### PR TITLE
Optimize timeline editor performance: batch gestures, memoize handlers

### DIFF
--- a/docs/timeline-editor-performance-audit.md
+++ b/docs/timeline-editor-performance-audit.md
@@ -1,0 +1,460 @@
+# Timeline Editor Performance Audit
+
+_Audited 2026-07-02 at commit `6c3004e`. Scope: `web/src/components/timeline/`,
+`web/src/stores/timeline/`, `web/src/hooks/timeline/`, and the render/GPU layers
+they drive (~28k lines). Line numbers refer to that commit._
+
+## Verdict
+
+The core architecture is right, and the most expensive problem a timeline
+editor can have — React re-rendering at 60 fps during playback — is already
+solved. `TimelinePlaybackStore` pushes time through a transient non-React
+channel (`setTimeMs`/`subscribeTime`, `TimelinePlaybackStore.ts:55-118`), the
+playhead/timecode/karaoke highlight all consume it imperatively, and the
+compositor gates React updates behind a scene signature. Steady playback causes
+zero React renders.
+
+The real costs are elsewhere, in three clusters:
+
+1. **Gestures write to the reactive document store on every pointermove.**
+   Clip drag/trim, the transform gizmo, ~40 inspector/FX sliders, EQ and
+   compressor curves, scrubbing, and zoom all publish store updates at
+   pointer-event rate (60–240 Hz). Identity-preserving reducers keep most
+   *re-renders* in check, but every publish still runs every subscriber's
+   selector, and several wide subscriptions re-render the whole editor shell
+   per tick. Sliders and the gizmo also push one **undo entry per tick**,
+   so a two-second drag wipes the entire 100-entry undo history.
+2. **Per-frame playback work that scales with project size.** The rAF tick
+   re-derives the full scene model (sort + Map build + per-word caption
+   resolution) every frame just to detect "nothing changed", and the GPU
+   effects chain re-processes static layers 60×/s while any video plays.
+3. **Unbounded scaling.** No virtualization (every clip on every track is
+   always mounted, with thumbnail/waveform fetches), play-gesture audio
+   decoding of the entire timeline, and several unbounded or full-frame-sized
+   caches.
+
+Fixes are listed per finding; a priority table is at the end. The single
+highest-leverage theme: the repo already contains the right tools —
+`useTimelineHistoryBatch`, the transient time channel, stable
+`generatingClipIds` membership arrays — several hot paths just don't use them.
+
+---
+
+## Tier 1 — interactive gestures (highest user-visible impact)
+
+### 1.1 Inspector/FX sliders and curves: per-tick store writes, no history batching
+
+`NodeSlider` is a MUI Slider whose `onChange` fires per pointermove. Every
+call site pipes it straight into the zundo-wrapped `TimelineStore`:
+
+- `Inspector/InspectorPrimitives.tsx:641-643` (`InspectorSliderRow` — used by
+  all ~30 `ClipAdjustments` rows: opacity 167-169, color 441-444, blur 533,
+  anchor 338/348, radius 357-359)
+- `Tracks/TrackEffectsPanel.tsx:250` (`ParamRow` → `updateTrackEffect`,
+  `TimelineStore.ts:896-907`)
+- `Tracks/TrackEffectsPanel.tsx:520-540` and `985-1020` (EQ / compressor SVG
+  curve drags patch per pointermove; wheel handlers at 560-575, 1039-1054
+  patch per wheel tick)
+- `TimelineStore.ts:1498-1507` (`setClipPrompt` via
+  `DirectGenClipPanel.tsx:146-151` — one undo entry **per keystroke**)
+- Arrow-key nudge (`TracksRegion.tsx:504-518`) — one entry per key repeat
+
+Each tick: full `tracks.map`/`clips.map` allocation, zundo `partializedEqual`
+scan over all clips/tracks (`TimelineStore.ts:489-497`), one undo entry
+(limit is 100 — a single knob drag evicts all prior history), and a publish to
+every doc-store subscriber (compositor, tracks region, transcript panel,
+autosave, `attachUiPruning`).
+
+Clip drag/trim and track resize already solve this with
+`useTimelineHistoryBatch` (`Clip.tsx:496`, `TrackHeader.tsx:323`); nothing in
+the inspector or FX panel uses it.
+
+**Fix:** in the two shared choke points (`InspectorSliderRow`, `ParamRow`),
+render the drag from local state and commit on `onChangeCommitted`, or keep
+live writes for preview but wrap the gesture in
+`useTimelineHistoryBatch.begin()/mark()/end()` and rAF-throttle the writes.
+Same treatment for the EQ/compressor pointerdown/up handlers. Pause the
+temporal store during focused prompt typing; treat held key-repeat as one
+gesture.
+
+### 1.2 Transform gizmo: per-pointermove `patchClip`, no batching, forced layout
+
+`PreviewCompositor.tsx:928`:
+
+```tsx
+onChange={(id, next) => patchClip(id, { transform: next })}
+```
+
+Every gizmo move (60–240 Hz) allocates a new `clips` array
+(`TimelineStore.ts:1278-1282`), pushes an undo entry, and re-renders every
+`clips` subscriber — compositor scene memo, video-pool layout effect, tracks
+region, inspector. The pointer handler also calls `getBoundingClientRect()`
+per move (`TransformGizmoOverlay.tsx:330-333`).
+
+**Fix:** wire `useTimelineHistoryBatch` into the gizmo gesture, or drive the
+live transform from a ref straight into the compositor and commit one
+`patchClip` on pointerup. Cache the SVG rect at pointerdown (a ResizeObserver
+already invalidates on resize).
+
+### 1.3 Editor-root subscriptions re-render the whole shell per drag tick
+
+Three subscriptions sit at `TimelineEditorBody` — the root above TopBar,
+preview, inspector, tracks, and transcript:
+
+- **`useTimelineExport`** (`useTimelineExport.ts:57-66`, hosted at
+  `TimelineEditor.tsx:352-359`) reactively selects `tracks` + `clips` that are
+  only read inside the click-time `exportVideo` callback. `clips` gets a new
+  identity per drag/trim/gizmo/slider tick → whole-shell re-render per tick.
+  During export, `onProgress: setProgress` (line 119) re-renders the shell per
+  encoded frame. **Fix:** read `store.getState()` inside `exportVideo`;
+  throttle progress to ~4 Hz or move it to a leaf component.
+- **`useTimelineGenerationSubscriptions`** (`useGenerateClip.ts:318-354`,
+  hosted at `TimelineEditor.tsx:335`) selects the whole `clipJobs` record.
+  `updateJobProgress` (`TimelineGenerationStore.ts:347-365`) replaces the map
+  per WebSocket progress message, so the shell re-renders and the
+  subscription-reconcile effect re-runs per message for the entire life of
+  every generation. The store maintains progress-stable `generatingClipIds`
+  membership arrays for exactly this purpose (`TimelineGenerationStore.ts:51-63`)
+  — this hook bypasses them. **Fix:** key the effect on `generatingClipIds`
+  (or a `useShallow` projection of id/status/workflow) and read job details
+  via `getState()` inside the effect.
+- **`msPerPx`** (`TimelineEditor.tsx:338`) — every zoom tick re-renders the
+  shell; only `BottomStatusBar` needs it. The tracks-height resize drag
+  (`TimelineEditor.tsx:397-405`) sets React state per mousemove with the same
+  fanout. **Fix:** push the zoom wiring into a wrapper around
+  `BottomStatusBar`; apply resize height via ref during the drag, commit on
+  mouseup. Also stabilize `TopBar` props — `onOpenSettings={() => ...}` and
+  `activitySlot={<ActivityIndicator />}` (`TimelineEditor.tsx:495-498`) defeat
+  its memo every render.
+
+### 1.4 O(N²) selector churn during drags
+
+Every doc-store publish runs every subscriber's selector. During a drag that
+is per-pointermove:
+
+- Every mounted `Clip` selects `s.clips.find((c) => c.id === clipId)`
+  (`Clip.tsx:396-398`) — N clips × O(N) = O(N²) per tick. Same pattern in
+  `TimelineInspector.tsx:110`, `GeneratedClipPanel.tsx:88`,
+  `ClipVersionHistory.tsx:199`, `ClipActions.tsx:41`, `useGenerateClip.ts:375`.
+  At 300–500 clips this is tens of millions of comparisons/second mid-drag.
+- Every `TrackLane` re-filters all clips per lane (`TrackLane.tsx:113-122`);
+  the custom equality then discards the arrays.
+- `attachUiPruning` (`TimelineInstance.tsx:80-116`) builds
+  `new Set(state.clips.map(...))` per tick whenever a selection exists — and
+  dragging a selected clip is the common case.
+- `TracksRegion.contentEndMs` rescans all clips per tick
+  (`TracksRegion.tsx:204-223`; the cache key is `clips` identity).
+
+**Fix:** maintain a `Map<string, TimelineClip>` keyed on `clips` array
+identity (module-level `WeakMap<TimelineClip[], Map>` used inside selectors,
+or a `clipsById` field rebuilt in the same `set`). Turns every id lookup O(1).
+Defer `attachUiPruning` to a microtask/idle callback — pruning only matters
+after removals.
+
+### 1.5 Transcript projections rebuilt per drag tick, ×3 consumers
+
+`clips` identity changes per drag tick; three consumers rebuild the full
+transcript projection from it, each O(words · log):
+
+- `ScriptLane.tsx:126-136` — `buildTranscriptDoc(clips)` per tick, then
+  reconciles a `<span>` per word
+- `TranscriptPanel.tsx:41-42` — same rebuild plus a filler-count reduce
+- `TranscriptEditor.tsx` `SyncPlugin` (206, 233-240) — `transcriptSignature`
+  (80-87) runs `buildTranscriptDoc` **and** builds one giant joined string
+  over every word, per `clips` change, just to detect external edits
+
+With the script feature on, a drag pays this 3–5× per pointermove.
+Dragging a B-roll clip with no captions pays it too.
+
+**Fix:** share one projection via a module-level
+`WeakMap<TimelineClip[], TranscriptDoc>`, and gate on transcript-relevant
+change — select the caption-bearing clip subset with an equality that compares
+member identities, or bump a `transcriptRev` counter from caption-touching
+mutations and key the SyncPlugin check on it.
+
+### 1.6 Scrub fanout
+
+Ruler scrub and playhead drag write reactive `currentTimeMs` per pointermove
+(`TimeRuler.tsx:457-465`, `Playhead.tsx:200-214`). Repainting the preview per
+event is intended; the incidental subscribers are not:
+
+- `TimeRuler.tsx:266` subscribes to `currentTimeMs` solely for
+  `aria-valuenow` (482) — re-renders the ruler per tick. Set it imperatively
+  via `subscribeTime`, as `Playhead` already does.
+- `ScriptLane` re-renders every phrase chip and word span per tick
+  (`ScriptLane.tsx:130, 186-199`). Subscribe transiently and toggle classes.
+- While playing, each scrub tick bumps `seekNonce`, whose effect runs
+  `graph.stopAll()` + a full async `handlePlay()` — asset resolution, audio
+  re-scheduling, clock restart — per pixel (`PreviewArea.tsx:337-345`).
+  Debounce the restart (~100 ms trailing).
+- The paused one-shot composite runs twice per scrub tick — eagerly with a
+  stale frame and again on `seeked` (`PreviewCompositor.tsx:811-828`). Skip
+  the eager pass when all video layers are seeking.
+
+### 1.7 Zoom: per-wheel-event store publish, full re-layout, listener churn
+
+`TracksRegion.tsx:375-419`: every wheel/pinch event calls `setZoom` — one
+store publish per event (trackpads deliver 60–120+ Hz), re-rendering every
+clip (new `leftPx`/`widthPx`), lane, ruler, and scrollbar; the scroll
+correction (`444-465`) then triggers a second full region render via
+`setScrollLeftPx`. The effect re-attaches the wheel listener on every
+`msPerPx` change (dep at 419), so events landing before the next render
+compute from a stale scale (zoom skips). `getBoundingClientRect()` runs per
+event (389).
+
+**Fix:** rAF-coalesce `setZoom` with the latest wheel state in a ref; read
+`msPerPx` from a ref inside a stable listener; cache the container rect.
+For pinch smoothness, apply a temporary `transform: scaleX()` during the
+gesture and commit one re-layout at the end.
+
+---
+
+## Tier 2 — per-frame playback costs
+
+### 2.1 Scene model fully recomputed every rAF tick
+
+The playback loop (`PreviewCompositor.tsx:855-887`) calls
+`sceneSignature(liveMs)` per frame, which runs `computeActiveLayers`
+(`sceneModel.ts:226-312`): `[...tracks].sort`, a `Map` rebuild over all clips,
+per-track `filter().sort()`, a `ResolvedCaption` object per word of every
+captioned active clip, plus signature string concatenation — usually to
+conclude nothing changed. On a 6-track/200-clip timeline that is thousands of
+allocations per second of GC churn inside the playback loop. The scene is also
+computed twice per actual bump (signature + the `useMemo` at 434-509).
+
+**Fix:** compute a `nextChangeMs` horizon with each scene (min of active clip
+ends, upcoming starts, caption word boundaries) and skip signature work while
+`liveMs < nextChangeMs` — steady-state playback becomes one float compare per
+frame. Or cache `sortedTracks`/`clipsByTrackId` in a `WeakMap` keyed on the
+arrays.
+
+### 2.2 GPU effects re-process static layers every frame
+
+`gpu/compositor.ts:230-244` runs the full compute chain (chroma key → grade →
+2× blur → sharpen → vignette) unconditionally per `render()`. The rAF loop
+marks frames dirty whenever any video plays, so a static image with a heavy
+blur under a playing video is re-blurred 60×/s.
+
+**Fix:** cache the processed output per layer keyed on (source upload key,
+effects array identities — they are reference-stable until edited); return
+the cached texture on match. Videos self-invalidate via `currentTime`.
+
+### 2.3 WebGPU micro-churn per frame
+
+- `setLayers` re-sorts a copied array and rebuilds a prune `Set` every tick
+  while video plays (`gpu/compositor.ts:129-143`) — skip when layer ids and
+  order are unchanged.
+- `renderBlendPass` creates a fresh `GPUBindGroup` + three `createView()`
+  calls per layer per frame (`packages/gpu/src/compositor/compositor.ts:340-353`,
+  plus `blit` 367-370). Views are immutable per texture; cache them and key
+  bind groups on (source texture, ping-pong read texture).
+
+### 2.4 Playhead writes `style.left` and churns attributes per frame
+
+`Playhead.tsx:152-166`: `left` invalidates layout each frame where
+`transform: translateX()` would stay on the compositor; `aria-valuenow` and
+the pill `textContent` mutate 60×/s. Throttle both to ~10 Hz; switch to
+transform.
+
+### 2.5 Karaoke plugins re-query the word DOM per time tick
+
+`TranscriptEditor.tsx` — `ActiveWordPlugin` (330-355) and `ScriptCaretPlugin`
+(382-430) each run `querySelectorAll(".transcript-word")` + dataset string
+parsing + a linear scan per transient time tick (×2, 60 Hz), and the caret
+plugin interleaves style writes with `offsetLeft/offsetWidth` reads — forced
+reflow per frame. Both re-run their full setup on every `clips` identity
+change (deps at 354/430).
+
+**Fix:** build one shared sorted `{el, startMs, endMs, offsets}` cache per
+reseed (offsets refreshed on resize), binary-search the active word per tick,
+and reuse the cache in `SelectionHighlightPlugin` (445-455) and arrow-key
+stepping (621-637).
+
+---
+
+## Tier 3 — scaling limits (large projects)
+
+### 3.1 No virtualization
+
+`TrackLane.tsx:476-478` mounts every clip on every track regardless of the
+visible window. Each clip carries ~8–12 DOM nodes, three asset-URL effects
+(`Clip.tsx:963-1015`), a 24-frame thumbnail request per video URL
+(`useClipThumbnails.ts:12`), and a fetch+decode for audio waveforms — for
+clips hours off-screen. Every per-tick cost in Tier 1 scales with this total.
+
+**Fix:** window horizontally from `scrollLeftPx`/`msPerPx` (both already in
+the UI store — the visibility predicate is trivial from `startMs`/`durationMs`)
+with one viewport of overscan; window tracks vertically; gate thumbnail/peaks
+requests on visibility.
+
+### 3.2 Play gesture decodes every future audio clip before the clock starts
+
+`PreviewArea.tsx:261-304` filters all remaining audio clips and
+`scheduleClips` `Promise.all`s a fetch + `decodeAudioData` for each
+(`AudioGraph.ts:406-414`) before `clock.start`. Play latency grows with
+timeline length; peak memory is the whole timeline's decoded PCM; and with
+more than `BUFFER_CACHE_MAX = 16` distinct assets (`AudioGraph.ts:43`) the LRU
+evicts and re-decodes on every play/seek gesture. Seek-while-playing repeats
+everything.
+
+**Fix:** schedule only clips starting within a lookahead window (~30 s,
+matching `PRELOAD_LOOKAHEAD_MS`), top up as the playhead advances, and start
+the clock once the currently audible clips are ready.
+
+### 3.3 Caption raster cache: full-frame bitmaps, up to ~530 MB
+
+`captionRender.ts:19, 138-166`: each caption state rasterizes at full sequence
+resolution (a lower-third strip inside a 1920×1080 bitmap);
+`MAX_CACHE_ENTRIES = 64` × 8 MB ≈ 530 MB worst case (4K: ~2 GB). A new
+`OffscreenCanvas` is allocated per miss, and on the GPU side each new bitmap
+destroys and re-creates a full-frame texture per word change
+(`gpu/compositor.ts:155-160`) instead of re-uploading into the same-sized one.
+
+**Fix:** rasterize at the caption bounding box and position via the layer
+transform; reuse one `OffscreenCanvas`; re-upload into the existing texture
+when dimensions match; cap the cache by bytes.
+
+### 3.4 Unbounded caches and export memory
+
+- `clipThumbnails.ts:31, 197-215`: module-level Map of 24 base64 JPEGs per
+  video URL, never evicted; failed entries permanently poisoned. Use blob
+  URLs + LRU; allow retry.
+- `OffscreenVideoPool.ts:29, 92-113`: export accumulates one `<video>` per
+  video clip, never released until dispose — 50-clip exports risk hitting
+  browser media-element and hardware-decoder caps. Release entries behind the
+  export playhead.
+- `TimelineRenderer.ts:179-182, 303`: `BufferTarget` holds the whole MP4 in
+  memory. Fine today; a streaming target bounds it.
+- `ResultsStore.ts:704-722` (`setProgress`): growing string concat + whole
+  record spread per WebSocket chunk message. Accumulate chunks in an array;
+  coalesce progress writes to ~10 Hz.
+
+### 3.5 Export frame loop: serialized seeks, main-thread
+
+`TimelineRenderer.ts:248-266` awaits `videoPool.seek()` sequentially per
+layer; overlapping videos pay seek round-trips back-to-back. Issue seeks with
+`Promise.all`. Longer term, move the loop to a Worker with `OffscreenCanvas`.
+
+---
+
+## Tier 4 — smaller wins
+
+- **Filmstrip cells hash multi-KB data URLs through emotion per render**
+  (`Clip.tsx:337-345, 1090`): `css({ backgroundImage: url(<base64>) })` per
+  cell per render — emotion hashing is O(string length) and every distinct
+  URL inserts a permanent CSSOM rule. Runs per pointermove during trims.
+  Use `style={{ backgroundImage }}` exactly as the image path at 1060 does.
+- **`TracksRegion` subscribes to `scrollLeftPx` and `selectedClipIds`**
+  (`TracksRegion.tsx:227, 231`): whole-region re-render per pan frame and per
+  rubber-band selection change; selection is only used in event handlers —
+  read `getState()` there; let the memoized `TimelineScrollbar` subscribe to
+  scroll itself.
+- **Every `Clip` subscribes to the entire `ErrorStore.errors` record**
+  (`Clip.tsx:457-475`): any error anywhere re-renders every clip and re-scans
+  all error keys per clip. Narrow to a per-run derived lookup.
+- **Inspector sections stay mounted when folded**
+  (`CollapsibleSection.tsx:118-120`, MUI `Collapse` without `unmountOnExit`):
+  ~30 control rows render per inspector re-render regardless of fold state.
+  Add `unmountOnExit`/lazy children.
+- **`ClipAdjustments` passes fresh lambdas to every memoized row**
+  (`ClipAdjustments.tsx:167-169, 441-444` and the IIFE blocks at 252, 396,
+  501, 572): dragging one slider re-renders all rows. Give rows
+  `(clipId, field)` props or `useCallback` per field.
+- **`DirectGenClipPanel` subscribes to the whole `clips` array**
+  (`DirectGenClipPanel.tsx:78, 104-117`) to build a dropdown list; recomputed
+  per doc change even outside image-to-image mode. Select `{id,name}` pairs
+  with `useShallow`, gated on mode.
+- **`ClipListPopover` subscribes to `clips` while closed**
+  (`ActivityIndicator.tsx:83, 205-239`): during generation, every clip patch
+  re-renders two closed popovers. Render only when open.
+- **Right-edge drags churn `totalWidthPx`** (`TracksRegion.tsx:204-223,
+  320-323, 735`): dragging the last clip re-layouts the scroll area per move.
+  Quantize the width (e.g. 256-px steps) or freeze during gestures.
+- **`contentEndMs`/boundary work in `PreviewArea`** (`PreviewArea.tsx:201-207,
+  374-385`): re-render + O(n log n) boundary sort per drag tick; `clips` is
+  otherwise only used in click handlers. Select primitives; read
+  `getState()` in handlers.
+- **Cold-pool video preload never fires mid-clip** (`PreviewCompositor.tsx:
+  553-683`): the effect's time dep advances only on scene bumps, so the next
+  clip isn't preloaded until its boundary; `upcomingVideoClips` picks clips in
+  array order, not soonest-first; and activation reloads the element from
+  scratch, discarding the warm decoder. Re-evaluate on a coarse timer, sort by
+  `startMs`, and swap the cold element into the hot slot.
+- **Autosave can flush mid-gesture** (`useTimelineAutosave.ts:211-216`):
+  holding a drag still for >750 ms fires a wasted full-document PATCH (which
+  serializes every caption word). Gate the flush on "no history batch open".
+  Related: `useTimelineSave.ts:33-38` omits `transcript` from the manual-save
+  PATCH while autosave includes it — a correctness risk if the server replaces
+  the whole document.
+- **Rubber-band and gizmo read `getBoundingClientRect` per pointermove**
+  (`TrackLane.tsx:394`, `TransformGizmoOverlay.tsx:330-333`): cache at
+  pointerdown.
+- **`TimelineListPanel`**: inline `onCancelRename` defeats item memo
+  (`:572`); sort comparator allocates two `Date` objects per comparison
+  (`:374-376`). `useCallback` + precompute `getTime()`.
+- **`instanceStoreHook.ts:18-20` footgun**: the wrapper silently drops a
+  second (equality) argument — `useTimelineStore(sel, shallow)` compiles and
+  ignores `shallow`. Forward it.
+- **`el.src = ""` teardown** (`PreviewCompositor.tsx:307-308`) resolves to the
+  document URL and can fire a spurious request; use
+  `removeAttribute("src"); load()` as `OffscreenVideoPool.dispose` does.
+- **`AudioContext` instantiated on first play even with zero audio clips**
+  (`PreviewArea.tsx:257-258`). Gate on `activeAudioClips.length > 0`.
+
+---
+
+## What is already done well (do not "fix")
+
+- Transient playhead channel + `PlaybackClock`: zero React work per frame;
+  `Playhead`, control-bar timecode, and karaoke highlighting are imperative.
+- Store split (document / UI / playback, per-instance via `TimelineInstance`)
+  with a memoized provider bundle — disjoint subscriber sets, no context churn.
+- Identity-preserving reducers everywhere (`patchClip`/`patchById`/`moveClip`
+  return same state on no-ops; untouched clips keep identity) — memoized
+  siblings don't re-render during another clip's drag.
+- Undo: zundo `partialize` stores references (structural sharing, no deep
+  clones); `useTimelineHistoryBatch` collapses drag/trim/resize gestures.
+- Autosave: transient `store.subscribe`, O(1) reference dirty-check, 750 ms
+  debounce, single-flight — zero React renders.
+- `Clip.tsx` gesture internals: snap candidates snapshotted per gesture,
+  `elementsFromPoint` rAF-coalesced, waveform redraw rAF-coalesced with
+  whole-pixel gating; `TimeRuler` draws a viewport-sized canvas from a
+  latest-inputs ref.
+- Compositor: scene-signature gating, dirty-flag composite skip for static
+  scenes, stable clip→slot binding, LRU image cache, asset-URL cache with
+  failed states, caption bitmap `WeakMap` signature memo.
+- GPU: pipelines/samplers cached (no per-frame shader compilation anywhere),
+  uniform-buffer ring, effects intermediate-texture pooling, seek-guard
+  upload keying.
+- AudioGraph: in-place param updates when the chain shape matches, ref-equality
+  short-circuits, click-free ramps, in-flight decode dedupe.
+- `TimelineGenerationStore` deliberately keeps `generatingClipIds` stable
+  across progress ticks; `TrackEffectsPanel` mounts lazily; `AddClipMenu`
+  mounts on demand with `enabled`-gated queries.
+- No `JSON.parse(JSON.stringify)`, no polling loops, TanStack Query keys
+  stable with `enabled` guards throughout.
+
+---
+
+## Priority order
+
+| # | Fix | Files | Effort | Payoff |
+|---|-----|-------|--------|--------|
+| 1 | Commit-on-release / history-batch for `InspectorSliderRow` + `ParamRow` + EQ/compressor + gizmo | InspectorPrimitives, TrackEffectsPanel, TransformGizmoOverlay | S–M | Ends undo-history destruction; removes the densest store-write path |
+| 2 | `useTimelineExport` → `getState()` reads; throttle export progress | useTimelineExport | S | Stops whole-shell re-render per drag tick and per encoded frame |
+| 3 | `useTimelineGenerationSubscriptions` → key on `generatingClipIds` | useGenerateClip | S | Stops whole-shell re-render per progress message during generations |
+| 4 | `clipsById` map (WeakMap-keyed) for all id selectors | TimelineStore + call sites | S | O(N²)→O(N) selector work per drag tick |
+| 5 | Shared `WeakMap` transcript projection + transcript-relevant gating | ScriptLane, TranscriptPanel, TranscriptEditor | M | Removes O(words) rebuild ×3 per drag tick |
+| 6 | Scene `nextChangeMs` horizon in the rAF tick | PreviewCompositor, sceneModel | M | Removes per-frame scene recompute + GC churn during playback |
+| 7 | rAF-coalesced zoom with ref-read scale | TracksRegion | S | One React commit per displayed frame while zooming |
+| 8 | Scrub hygiene: ruler aria via `subscribeTime`, debounced `seekNonce` audio restart, ScriptLane transient highlight | TimeRuler, PreviewArea, ScriptLane | S–M | Cheap scrubbing, no audio-graph rebuild per pixel |
+| 9 | Windowed audio scheduling | PreviewArea, AudioGraph | M | Play latency stops scaling with timeline length |
+| 10 | Effects output cache for static layers | gpu/compositor, effectsProcessor | M | Removes 60 fps GPU work on static effected layers |
+| 11 | Caption strip-sized rasterization + texture reuse | captionRender, gpu/compositor | M | ~10–20× caption memory/upload reduction |
+| 12 | Clip virtualization + visibility-gated media fetches | TrackLane, TracksRegion, clipThumbnails | L | Caps all per-tick costs at viewport size; biggest ceiling |
+| 13 | Tier-4 batch (filmstrip inline style, selector narrowing, memo fixes, cache bounds) | various | S each | Broad small wins |
+
+Items 1–4 are small, independent, and remove the worst interactive behavior;
+they are the right first PR. Item 12 is the largest single ceiling-raiser for
+big projects but should land after 4 so the windowing predicate can reuse the
+id map.

--- a/web/src/components/timeline/ActivityIndicator.tsx
+++ b/web/src/components/timeline/ActivityIndicator.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -29,6 +30,7 @@ import {
   useFailedClipIds
 } from "../../stores/timeline/TimelineGenerationStore";
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { clipsById } from "../../stores/timeline/clipLookup";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
 
 // ── Styles ─────────────────────────────────────────────────────────────────
@@ -77,10 +79,16 @@ interface ClipListPopoverProps {
   onClose: () => void;
 }
 
+const EMPTY_AFFECTED_ENTRIES: readonly string[] = [];
+// Encodes id + SEP + name as one primitive per affected clip so the array
+// compares element-wise under useShallow instead of subscribing to the
+// entire `clips` array (only `id`/`name` for the handful of affected ids are
+// actually rendered).
+const AFFECTED_ENTRY_SEP = "\u0000";
+
 const ClipListPopover: React.FC<ClipListPopoverProps> = memo(
   ({ clipIds, title, anchorEl, onClose }) => {
     const theme = useTheme();
-    const clips = useTimelineStore((s) => s.clips);
     const selectClip = useTimelineUIStore((s) => s.selectClip);
 
     const handleSelectClip = useCallback(
@@ -91,10 +99,30 @@ const ClipListPopover: React.FC<ClipListPopoverProps> = memo(
       [selectClip, onClose]
     );
 
-    const affectedClips = useMemo(() => {
-      const idSet = new Set(clipIds);
-      return clips.filter((c) => idSet.has(c.id));
-    }, [clips, clipIds]);
+    const affectedEntries = useTimelineStore(
+      useShallow((s) => {
+        if (clipIds.length === 0) return EMPTY_AFFECTED_ENTRIES;
+        const byId = clipsById(s.clips);
+        const entries: string[] = [];
+        for (const id of clipIds) {
+          const c = byId.get(id);
+          if (c) entries.push(`${c.id}${AFFECTED_ENTRY_SEP}${c.name}`);
+        }
+        return entries;
+      })
+    );
+
+    const affectedClips = useMemo(
+      () =>
+        affectedEntries.map((entry) => {
+          const sepIndex = entry.indexOf(AFFECTED_ENTRY_SEP);
+          return {
+            id: entry.slice(0, sepIndex),
+            name: entry.slice(sepIndex + 1)
+          };
+        }),
+      [affectedEntries]
+    );
 
     return (
       <Popover
@@ -202,12 +230,14 @@ export const ActivityIndicator: React.FC = memo(() => {
             </Caption>
           </button>
 
-          <ClipListPopover
-            clipIds={generatingIds}
-            title={`${generatingCount} clip${generatingCount !== 1 ? "s" : ""} generating`}
-            anchorEl={generatingPopoverEl}
-            onClose={handleGeneratingClose}
-          />
+          {generatingPopoverEl && (
+            <ClipListPopover
+              clipIds={generatingIds}
+              title={`${generatingCount} clip${generatingCount !== 1 ? "s" : ""} generating`}
+              anchorEl={generatingPopoverEl}
+              onClose={handleGeneratingClose}
+            />
+          )}
         </>
       )}
 
@@ -231,12 +261,14 @@ export const ActivityIndicator: React.FC = memo(() => {
             </Caption>
           </button>
 
-          <ClipListPopover
-            clipIds={failedIds}
-            title={`${failedCount} clip${failedCount !== 1 ? "s" : ""} failed`}
-            anchorEl={failedPopoverEl}
-            onClose={handleFailedClose}
-          />
+          {failedPopoverEl && (
+            <ClipListPopover
+              clipIds={failedIds}
+              title={`${failedCount} clip${failedCount !== 1 ? "s" : ""} failed`}
+              anchorEl={failedPopoverEl}
+              onClose={handleFailedClose}
+            />
+          )}
         </>
       )}
     </FlexRow>

--- a/web/src/components/timeline/Inspector/ClipActions.tsx
+++ b/web/src/components/timeline/Inspector/ClipActions.tsx
@@ -14,6 +14,7 @@ import AutoAwesomeMotionIcon from "@mui/icons-material/AutoAwesomeMotion";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 import { ToolbarIconButton, FlexRow, Text, Dialog, TextInput, Toast } from "../../ui_primitives";
 
 // ── Styles ─────────────────────────────────────────────────────────────────
@@ -38,9 +39,7 @@ export const ClipActions: React.FC<ClipActionsProps> = memo(
     const theme = useTheme();
     const navigate = useNavigate();
 
-    const clip = useTimelineStore(
-      (s) => s.clips.find((c) => c.id === clipId)
-    );
+    const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
     const sequenceId = useTimelineStore((s) => s.sequenceId);
 
     const duplicateClip = useTimelineStore((s) => s.duplicateClip);

--- a/web/src/components/timeline/Inspector/ClipAdjustments.tsx
+++ b/web/src/components/timeline/Inspector/ClipAdjustments.tsx
@@ -14,7 +14,7 @@
  * so a panel stays open/closed across selections.
  */
 
-import React, { memo } from "react";
+import React, { memo, useCallback, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -30,7 +30,6 @@ import type {
   ClipColorEffect,
   ClipEffect,
   ClipTransform,
-  ClipTransition,
   TimelineClip
 } from "@nodetool-ai/timeline";
 import { BLEND_MODES } from "@nodetool-ai/gpu";
@@ -43,7 +42,8 @@ import {
   FlexRow,
   NodeSelect,
   NodeMenuItem,
-  Text
+  Text,
+  type SelectChangeEvent
 } from "../../ui_primitives";
 import { usePersistedFold } from "./usePersistedFold";
 import {
@@ -130,18 +130,305 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
     const isAudio = clip.mediaType === "audio";
     const isOverlay = clip.mediaType === "overlay";
 
-    const onPatchNumber = (
-      field: string,
-      raw: string,
-      min?: number,
-      max?: number
-    ) => {
-      const parsed = Number(raw);
-      if (!Number.isFinite(parsed)) return;
-      const value =
-        min != null && max != null ? clamp(parsed, min, max) : parsed;
-      patchClip(clip.id, { [field]: value });
-    };
+    // Latest-clip ref: lets the handlers below stay referentially stable
+    // across re-renders of the same clip (deps keyed on clip.id, not on
+    // `clip` itself) while still merging onto its current fields — otherwise
+    // every memoized row (InspectorSliderRow, InspectorPillInput…) would
+    // re-render on every keystroke in any other row, since a handler that
+    // closed over `clip` directly gets a new identity on every patch.
+    const clipRef = useRef(clip);
+    clipRef.current = clip;
+
+    const onPatchNumber = useCallback(
+      (field: string, raw: string, min?: number, max?: number) => {
+        const parsed = Number(raw);
+        if (!Number.isFinite(parsed)) return;
+        const value =
+          min != null && max != null ? clamp(parsed, min, max) : parsed;
+        patchClip(clipRef.current.id, { [field]: value });
+      },
+      [patchClip]
+    );
+
+    // ── Render section ─────────────────────────────────────────────────────
+
+    const handleOpacityChange = useCallback(
+      (value: number) => patchClip(clip.id, { opacity: value }),
+      [clip.id, patchClip]
+    );
+    const handleBlendModeChange = useCallback(
+      (e: SelectChangeEvent<unknown>) =>
+        patchClip(clip.id, { blendMode: e.target.value as BlendMode }),
+      [clip.id, patchClip]
+    );
+    const handleVolumeCommit = useCallback(
+      (raw: string) => onPatchNumber("volumeDb", raw, -60, 12),
+      [onPatchNumber]
+    );
+    const handleFadeInCommit = useCallback(
+      (raw: string) => {
+        const ms = parseSeconds(raw);
+        if (ms == null) return;
+        onPatchNumber(
+          "fadeInMs",
+          String(ms),
+          0,
+          Math.floor(clipRef.current.durationMs / 2)
+        );
+      },
+      [onPatchNumber]
+    );
+    const handleFadeOutCommit = useCallback(
+      (raw: string) => {
+        const ms = parseSeconds(raw);
+        if (ms == null) return;
+        onPatchNumber(
+          "fadeOutMs",
+          String(ms),
+          0,
+          Math.floor(clipRef.current.durationMs / 2)
+        );
+      },
+      [onPatchNumber]
+    );
+
+    // ── Transform section ──────────────────────────────────────────────────
+
+    const setTransform = useCallback(
+      (next: ClipTransform) => patchClip(clip.id, { transform: next }),
+      [clip.id, patchClip]
+    );
+    const handlePositionXCommit = useCallback(
+      (raw: string) => {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return;
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, position: { ...t.position, x: n } });
+      },
+      [setTransform]
+    );
+    const handlePositionYCommit = useCallback(
+      (raw: string) => {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return;
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, position: { ...t.position, y: n } });
+      },
+      [setTransform]
+    );
+    const handleScaleXCommit = useCallback(
+      (raw: string) => {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return;
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, scale: { ...t.scale, x: n } });
+      },
+      [setTransform]
+    );
+    const handleScaleYCommit = useCallback(
+      (raw: string) => {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return;
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, scale: { ...t.scale, y: n } });
+      },
+      [setTransform]
+    );
+    const handleRotationCommit = useCallback(
+      (raw: string) => {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return;
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, rotation: (n * Math.PI) / 180 });
+      },
+      [setTransform]
+    );
+    const handleAnchorXChange = useCallback(
+      (value: number) => {
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, anchor: { ...t.anchor, x: value } });
+      },
+      [setTransform]
+    );
+    const handleAnchorYChange = useCallback(
+      (value: number) => {
+        const t = clipRef.current.transform ?? IDENTITY_TRANSFORM;
+        setTransform({ ...t, anchor: { ...t.anchor, y: value } });
+      },
+      [setTransform]
+    );
+    const handleBorderRadiusChange = useCallback(
+      (value: number) => patchClip(clip.id, { borderRadius: value }),
+      [clip.id, patchClip]
+    );
+    const handleResetTransform = useCallback(
+      () =>
+        patchClip(clip.id, { transform: undefined, borderRadius: undefined }),
+      [clip.id, patchClip]
+    );
+
+    // ── Color section ──────────────────────────────────────────────────────
+
+    const updateColor = useCallback(
+      (patch: Partial<ClipColorEffect>): void => {
+        const current = findColorEffect(clipRef.current);
+        const next: ClipColorEffect = {
+          id: COLOR_EFFECT_ID,
+          type: "color",
+          enabled: current?.enabled ?? false,
+          brightness: current?.brightness,
+          contrast: current?.contrast,
+          saturation: current?.saturation,
+          hue: current?.hue,
+          temperature: current?.temperature,
+          tint: current?.tint,
+          shadows: current?.shadows,
+          highlights: current?.highlights,
+          ...patch
+        };
+        patchClip(clipRef.current.id, {
+          effects: upsertEffect(clipRef.current.effects, next)
+        });
+      },
+      [patchClip]
+    );
+    const handleColorEnabledChange = useCallback(
+      (next: boolean) => updateColor({ enabled: next }),
+      [updateColor]
+    );
+    const handleBrightnessChange = useCallback(
+      (value: number) => updateColor({ brightness: value }),
+      [updateColor]
+    );
+    const handleContrastChange = useCallback(
+      (value: number) => updateColor({ contrast: value }),
+      [updateColor]
+    );
+    const handleSaturationChange = useCallback(
+      (value: number) => updateColor({ saturation: value }),
+      [updateColor]
+    );
+    const handleHueChange = useCallback(
+      (value: number) => updateColor({ hue: value }),
+      [updateColor]
+    );
+    const handleTemperatureChange = useCallback(
+      (value: number) => updateColor({ temperature: value }),
+      [updateColor]
+    );
+    const handleTintChange = useCallback(
+      (value: number) => updateColor({ tint: value }),
+      [updateColor]
+    );
+    const handleShadowsChange = useCallback(
+      (value: number) => updateColor({ shadows: value }),
+      [updateColor]
+    );
+    const handleHighlightsChange = useCallback(
+      (value: number) => updateColor({ highlights: value }),
+      [updateColor]
+    );
+    const handleClearColor = useCallback(
+      () =>
+        patchClip(clipRef.current.id, {
+          effects: clipRef.current.effects?.filter(
+            (e) => e.id !== COLOR_EFFECT_ID
+          )
+        }),
+      [patchClip]
+    );
+
+    // ── Blur section ───────────────────────────────────────────────────────
+
+    const updateBlur = useCallback(
+      (patch: Partial<ClipBlurEffect>) => {
+        const current = findBlurEffect(clipRef.current);
+        const next: ClipBlurEffect = {
+          id: BLUR_EFFECT_ID,
+          type: "blur",
+          enabled: current?.enabled ?? false,
+          radius: current?.radius ?? 0,
+          sigma: current?.sigma,
+          ...patch
+        };
+        patchClip(clipRef.current.id, {
+          effects: upsertEffect(clipRef.current.effects, next)
+        });
+      },
+      [patchClip]
+    );
+    const handleBlurEnabledChange = useCallback(
+      (next: boolean) => updateBlur({ enabled: next }),
+      [updateBlur]
+    );
+    const handleBlurRadiusChange = useCallback(
+      (value: number) => updateBlur({ radius: value }),
+      [updateBlur]
+    );
+    const handleClearBlur = useCallback(
+      () =>
+        patchClip(clipRef.current.id, {
+          effects: clipRef.current.effects?.filter(
+            (e) => e.id !== BLUR_EFFECT_ID
+          )
+        }),
+      [patchClip]
+    );
+
+    // ── Transition section ─────────────────────────────────────────────────
+
+    const setTransitionMode = useCallback(
+      (next: "auto" | "crossfade" | "none") => {
+        if (next === "auto") {
+          patchClip(clipRef.current.id, { transitionIn: undefined });
+        } else if (next === "none") {
+          patchClip(clipRef.current.id, {
+            transitionIn: { type: "crossfade", durationMs: 0 }
+          });
+        } else {
+          const t = clipRef.current.transitionIn;
+          const duration = t && t.durationMs > 0 ? t.durationMs : 500;
+          patchClip(clipRef.current.id, {
+            transitionIn: { type: "crossfade", durationMs: duration }
+          });
+        }
+      },
+      [patchClip]
+    );
+    const handleTransitionModeChange = useCallback(
+      (e: SelectChangeEvent<unknown>) =>
+        setTransitionMode(e.target.value as "auto" | "crossfade" | "none"),
+      [setTransitionMode]
+    );
+    const handleTransitionDurationCommit = useCallback(
+      (raw: string) => {
+        const ms = parseSeconds(raw);
+        if (ms == null) return;
+        patchClip(clipRef.current.id, {
+          transitionIn: { type: "crossfade", durationMs: Math.max(0, ms) }
+        });
+      },
+      [patchClip]
+    );
+
+    // ── Derived display values ──────────────────────────────────────────────
+
+    const transform = clip.transform ?? IDENTITY_TRANSFORM;
+    const color = findColorEffect(clip);
+    const colorEnabled = color?.enabled ?? false;
+    const blur = findBlurEffect(clip);
+    const blurEnabled = blur?.enabled ?? false;
+    const blurRadius = blur?.radius ?? 0;
+    const transitionMode: "auto" | "crossfade" | "none" =
+      clip.transitionIn == null
+        ? "auto"
+        : clip.transitionIn.durationMs <= 0
+          ? "none"
+          : "crossfade";
+    const transitionDuration =
+      clip.transitionIn && clip.transitionIn.durationMs > 0
+        ? clip.transitionIn.durationMs
+        : 500;
 
     return (
       <>
@@ -155,6 +442,7 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
           }
           open={renderOpen}
           onToggle={setRenderOpen}
+          unmountOnExit
         >
           <FlexColumn css={sectionContentStyles(theme)}>
             {!isAudio && (
@@ -165,18 +453,14 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                 step={0.01}
                 value={clip.opacity ?? 1}
                 display={`${Math.round((clip.opacity ?? 1) * 100)}%`}
-                onChange={(value) => patchClip(clip.id, { opacity: value })}
+                onChange={handleOpacityChange}
               />
             )}
             {isOverlay && !isAudio && (
               <InspectorRow label="Blend">
                 <NodeSelect
                   value={clip.blendMode ?? "normal"}
-                  onChange={(e) =>
-                    patchClip(clip.id, {
-                      blendMode: e.target.value as BlendMode
-                    })
-                  }
+                  onChange={handleBlendModeChange}
                 >
                   {BLEND_MODES.map((mode) => (
                     <NodeMenuItem key={mode.value} value={mode.value}>
@@ -192,7 +476,7 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                   <InspectorPillInput
                     value={(clip.volumeDb ?? 0).toFixed(1)}
                     unit="dB"
-                    onCommit={(raw) => onPatchNumber("volumeDb", raw, -60, 12)}
+                    onCommit={handleVolumeCommit}
                     ariaLabel="Volume (dB)"
                   />
                 </InspectorRow>
@@ -200,16 +484,7 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                   <InspectorPillInput
                     value={((clip.fadeInMs ?? 0) / 1000).toFixed(2)}
                     unit="s"
-                    onCommit={(raw) => {
-                      const ms = parseSeconds(raw);
-                      if (ms == null) return;
-                      onPatchNumber(
-                        "fadeInMs",
-                        String(ms),
-                        0,
-                        Math.floor(clip.durationMs / 2)
-                      );
-                    }}
+                    onCommit={handleFadeInCommit}
                     ariaLabel="Fade in (seconds)"
                   />
                 </InspectorRow>
@@ -217,16 +492,7 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                   <InspectorPillInput
                     value={((clip.fadeOutMs ?? 0) / 1000).toFixed(2)}
                     unit="s"
-                    onCommit={(raw) => {
-                      const ms = parseSeconds(raw);
-                      if (ms == null) return;
-                      onPatchNumber(
-                        "fadeOutMs",
-                        String(ms),
-                        0,
-                        Math.floor(clip.durationMs / 2)
-                      );
-                    }}
+                    onCommit={handleFadeOutCommit}
                     ariaLabel="Fade out (seconds)"
                   />
                 </InspectorRow>
@@ -247,133 +513,83 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
               }
               open={transformOpen}
               onToggle={setTransformOpen}
+              unmountOnExit
             >
               <FlexColumn css={sectionContentStyles(theme)}>
-                {(() => {
-                  const t = clip.transform ?? IDENTITY_TRANSFORM;
-                  const setTransform = (next: ClipTransform) =>
-                    patchClip(clip.id, { transform: next });
-                  const setPos = (axis: "x" | "y", v: number) =>
-                    setTransform({
-                      ...t,
-                      position: { ...t.position, [axis]: v }
-                    });
-                  const setScale = (axis: "x" | "y", v: number) =>
-                    setTransform({
-                      ...t,
-                      scale: { ...t.scale, [axis]: v }
-                    });
-                  const setAnchor = (axis: "x" | "y", v: number) =>
-                    setTransform({
-                      ...t,
-                      anchor: { ...t.anchor, [axis]: v }
-                    });
-                  const setRotationDeg = (deg: number) =>
-                    setTransform({ ...t, rotation: (deg * Math.PI) / 180 });
-                  return (
-                    <>
-                      <InspectorRow label="Position">
-                        <InspectorPillInput
-                          value={t.position.x.toFixed(0)}
-                          unit="px"
-                          minWidth={72}
-                          onCommit={(raw) => {
-                            const n = Number(raw);
-                            if (Number.isFinite(n)) setPos("x", n);
-                          }}
-                          ariaLabel="Position X"
-                        />
-                        <InspectorPillInput
-                          value={t.position.y.toFixed(0)}
-                          unit="px"
-                          minWidth={72}
-                          onCommit={(raw) => {
-                            const n = Number(raw);
-                            if (Number.isFinite(n)) setPos("y", n);
-                          }}
-                          ariaLabel="Position Y"
-                        />
-                      </InspectorRow>
-                      <InspectorRow label="Scale">
-                        <InspectorPillInput
-                          value={t.scale.x.toFixed(2)}
-                          unit="×"
-                          minWidth={72}
-                          onCommit={(raw) => {
-                            const n = Number(raw);
-                            if (Number.isFinite(n)) setScale("x", n);
-                          }}
-                          ariaLabel="Scale X"
-                        />
-                        <InspectorPillInput
-                          value={t.scale.y.toFixed(2)}
-                          unit="×"
-                          minWidth={72}
-                          onCommit={(raw) => {
-                            const n = Number(raw);
-                            if (Number.isFinite(n)) setScale("y", n);
-                          }}
-                          ariaLabel="Scale Y"
-                        />
-                      </InspectorRow>
-                      <InspectorRow label="Rotation">
-                        <InspectorPillInput
-                          value={((t.rotation * 180) / Math.PI).toFixed(1)}
-                          unit="°"
-                          onCommit={(raw) => {
-                            const n = Number(raw);
-                            if (Number.isFinite(n)) setRotationDeg(n);
-                          }}
-                          ariaLabel="Rotation in degrees"
-                        />
-                      </InspectorRow>
-                      <InspectorSliderRow
-                        label="Anchor X"
-                        min={0}
-                        max={1}
-                        step={0.01}
-                        value={t.anchor.x}
-                        origin={0.5}
-                        display={t.anchor.x.toFixed(2)}
-                        onChange={(value) => setAnchor("x", value)}
-                      />
-                      <InspectorSliderRow
-                        label="Anchor Y"
-                        min={0}
-                        max={1}
-                        step={0.01}
-                        value={t.anchor.y}
-                        origin={0.5}
-                        display={t.anchor.y.toFixed(2)}
-                        onChange={(value) => setAnchor("y", value)}
-                      />
-                      <InspectorSliderRow
-                        label="Radius"
-                        min={0}
-                        max={500}
-                        step={1}
-                        value={clip.borderRadius ?? 0}
-                        display={`${(clip.borderRadius ?? 0).toFixed(0)}px`}
-                        onChange={(value) =>
-                          patchClip(clip.id, { borderRadius: value })
-                        }
-                      />
-                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                        <EditorButton
-                          size="small"
-                          onClick={() =>
-                            patchClip(clip.id, {
-                              transform: undefined,
-                              borderRadius: undefined
-                            })
-                          }
-                        >
-                          Reset transform
-                        </EditorButton>
-                      </FlexRow>
-                    </>
-                  );
-                })()}
+                <InspectorRow label="Position">
+                  <InspectorPillInput
+                    value={transform.position.x.toFixed(0)}
+                    unit="px"
+                    minWidth={72}
+                    onCommit={handlePositionXCommit}
+                    ariaLabel="Position X"
+                  />
+                  <InspectorPillInput
+                    value={transform.position.y.toFixed(0)}
+                    unit="px"
+                    minWidth={72}
+                    onCommit={handlePositionYCommit}
+                    ariaLabel="Position Y"
+                  />
+                </InspectorRow>
+                <InspectorRow label="Scale">
+                  <InspectorPillInput
+                    value={transform.scale.x.toFixed(2)}
+                    unit="×"
+                    minWidth={72}
+                    onCommit={handleScaleXCommit}
+                    ariaLabel="Scale X"
+                  />
+                  <InspectorPillInput
+                    value={transform.scale.y.toFixed(2)}
+                    unit="×"
+                    minWidth={72}
+                    onCommit={handleScaleYCommit}
+                    ariaLabel="Scale Y"
+                  />
+                </InspectorRow>
+                <InspectorRow label="Rotation">
+                  <InspectorPillInput
+                    value={((transform.rotation * 180) / Math.PI).toFixed(1)}
+                    unit="°"
+                    onCommit={handleRotationCommit}
+                    ariaLabel="Rotation in degrees"
+                  />
+                </InspectorRow>
+                <InspectorSliderRow
+                  label="Anchor X"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={transform.anchor.x}
+                  origin={0.5}
+                  display={transform.anchor.x.toFixed(2)}
+                  onChange={handleAnchorXChange}
+                />
+                <InspectorSliderRow
+                  label="Anchor Y"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={transform.anchor.y}
+                  origin={0.5}
+                  display={transform.anchor.y.toFixed(2)}
+                  onChange={handleAnchorYChange}
+                />
+                <InspectorSliderRow
+                  label="Radius"
+                  min={0}
+                  max={500}
+                  step={1}
+                  value={clip.borderRadius ?? 0}
+                  display={`${(clip.borderRadius ?? 0).toFixed(0)}px`}
+                  onChange={handleBorderRadiusChange}
+                />
+                <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                  <EditorButton size="small" onClick={handleResetTransform}>
+                    Reset transform
+                  </EditorButton>
+                </FlexRow>
               </FlexColumn>
             </CollapsibleSection>
           </>
@@ -391,94 +607,111 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
               }
               open={colorOpen}
               onToggle={setColorOpen}
+              unmountOnExit
             >
               <FlexColumn css={sectionContentStyles(theme)}>
-                {(() => {
-                  const color = findColorEffect(clip);
-                  const enabled = color?.enabled ?? false;
-                  const update = (patch: Partial<ClipColorEffect>): void => {
-                    const next: ClipColorEffect = {
-                      id: COLOR_EFFECT_ID,
-                      type: "color",
-                      enabled,
-                      brightness: color?.brightness,
-                      contrast: color?.contrast,
-                      saturation: color?.saturation,
-                      hue: color?.hue,
-                      temperature: color?.temperature,
-                      tint: color?.tint,
-                      shadows: color?.shadows,
-                      highlights: color?.highlights,
-                      ...patch
-                    };
-                    patchClip(clip.id, {
-                      effects: upsertEffect(clip.effects, next)
-                    });
-                  };
-                  const slider = (
-                    label: string,
-                    key: keyof Omit<
-                      ClipColorEffect,
-                      "id" | "type" | "enabled"
-                    >,
-                    min: number,
-                    max: number,
-                    step: number,
-                    defaultV: number,
-                    format: (v: number) => string = (v) => v.toFixed(2)
-                  ) => {
-                    const v = color?.[key] ?? defaultV;
-                    return (
-                      <InspectorSliderRow
-                        label={label}
-                        min={min}
-                        max={max}
-                        step={step}
-                        value={v}
-                        origin={defaultV}
-                        display={format(v)}
-                        disabled={!enabled}
-                        onChange={(value) =>
-                          update({ [key]: value } as Partial<ClipColorEffect>)
-                        }
-                      />
-                    );
-                  };
-                  return (
-                    <>
-                      <InspectorToggleRow
-                        label="Enabled"
-                        checked={enabled}
-                        onChange={(next) => update({ enabled: next })}
-                      />
-                      {slider("Brightness", "brightness", -1, 1, 0.01, 0)}
-                      {slider("Contrast", "contrast", 0, 4, 0.01, 1)}
-                      {slider("Saturation", "saturation", 0, 4, 0.01, 1)}
-                      {slider("Hue", "hue", -180, 180, 1, 0, (v) =>
-                        `${v.toFixed(0)}°`
-                      )}
-                      {slider("Temperature", "temperature", -1, 1, 0.01, 0)}
-                      {slider("Tint", "tint", -1, 1, 0.01, 0)}
-                      {slider("Shadows", "shadows", -1, 1, 0.01, 0)}
-                      {slider("Highlights", "highlights", -1, 1, 0.01, 0)}
-                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                        <EditorButton
-                          size="small"
-                          disabled={!color}
-                          onClick={() =>
-                            patchClip(clip.id, {
-                              effects: clip.effects?.filter(
-                                (e) => e.id !== COLOR_EFFECT_ID
-                              )
-                            })
-                          }
-                        >
-                          Clear color
-                        </EditorButton>
-                      </FlexRow>
-                    </>
-                  );
-                })()}
+                <InspectorToggleRow
+                  label="Enabled"
+                  checked={colorEnabled}
+                  onChange={handleColorEnabledChange}
+                />
+                <InspectorSliderRow
+                  label="Brightness"
+                  min={-1}
+                  max={1}
+                  step={0.01}
+                  value={color?.brightness ?? 0}
+                  origin={0}
+                  display={(color?.brightness ?? 0).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleBrightnessChange}
+                />
+                <InspectorSliderRow
+                  label="Contrast"
+                  min={0}
+                  max={4}
+                  step={0.01}
+                  value={color?.contrast ?? 1}
+                  origin={1}
+                  display={(color?.contrast ?? 1).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleContrastChange}
+                />
+                <InspectorSliderRow
+                  label="Saturation"
+                  min={0}
+                  max={4}
+                  step={0.01}
+                  value={color?.saturation ?? 1}
+                  origin={1}
+                  display={(color?.saturation ?? 1).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleSaturationChange}
+                />
+                <InspectorSliderRow
+                  label="Hue"
+                  min={-180}
+                  max={180}
+                  step={1}
+                  value={color?.hue ?? 0}
+                  origin={0}
+                  display={`${(color?.hue ?? 0).toFixed(0)}°`}
+                  disabled={!colorEnabled}
+                  onChange={handleHueChange}
+                />
+                <InspectorSliderRow
+                  label="Temperature"
+                  min={-1}
+                  max={1}
+                  step={0.01}
+                  value={color?.temperature ?? 0}
+                  origin={0}
+                  display={(color?.temperature ?? 0).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleTemperatureChange}
+                />
+                <InspectorSliderRow
+                  label="Tint"
+                  min={-1}
+                  max={1}
+                  step={0.01}
+                  value={color?.tint ?? 0}
+                  origin={0}
+                  display={(color?.tint ?? 0).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleTintChange}
+                />
+                <InspectorSliderRow
+                  label="Shadows"
+                  min={-1}
+                  max={1}
+                  step={0.01}
+                  value={color?.shadows ?? 0}
+                  origin={0}
+                  display={(color?.shadows ?? 0).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleShadowsChange}
+                />
+                <InspectorSliderRow
+                  label="Highlights"
+                  min={-1}
+                  max={1}
+                  step={0.01}
+                  value={color?.highlights ?? 0}
+                  origin={0}
+                  display={(color?.highlights ?? 0).toFixed(2)}
+                  disabled={!colorEnabled}
+                  onChange={handleHighlightsChange}
+                />
+                <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                  <EditorButton
+                    size="small"
+                    disabled={!color}
+                    onClick={handleClearColor}
+                  >
+                    Clear color
+                  </EditorButton>
+                </FlexRow>
               </FlexColumn>
             </CollapsibleSection>
           </>
@@ -496,60 +729,33 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
               }
               open={blurOpen}
               onToggle={setBlurOpen}
+              unmountOnExit
             >
               <FlexColumn css={sectionContentStyles(theme)}>
-                {(() => {
-                  const blur = findBlurEffect(clip);
-                  const enabled = blur?.enabled ?? false;
-                  const radius = blur?.radius ?? 0;
-                  const updateBlur = (patch: Partial<ClipBlurEffect>) => {
-                    const next: ClipBlurEffect = {
-                      id: BLUR_EFFECT_ID,
-                      type: "blur",
-                      enabled,
-                      radius,
-                      sigma: blur?.sigma,
-                      ...patch
-                    };
-                    patchClip(clip.id, {
-                      effects: upsertEffect(clip.effects, next)
-                    });
-                  };
-                  return (
-                    <>
-                      <InspectorToggleRow
-                        label="Enabled"
-                        checked={enabled}
-                        onChange={(next) => updateBlur({ enabled: next })}
-                      />
-                      <InspectorSliderRow
-                        label="Radius"
-                        min={0}
-                        max={20}
-                        step={0.5}
-                        value={radius}
-                        display={`${radius.toFixed(0)}px`}
-                        disabled={!enabled}
-                        onChange={(value) => updateBlur({ radius: value })}
-                      />
-                      <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
-                        <EditorButton
-                          size="small"
-                          disabled={!blur}
-                          onClick={() =>
-                            patchClip(clip.id, {
-                              effects: clip.effects?.filter(
-                                (e) => e.id !== BLUR_EFFECT_ID
-                              )
-                            })
-                          }
-                        >
-                          Clear blur
-                        </EditorButton>
-                      </FlexRow>
-                    </>
-                  );
-                })()}
+                <InspectorToggleRow
+                  label="Enabled"
+                  checked={blurEnabled}
+                  onChange={handleBlurEnabledChange}
+                />
+                <InspectorSliderRow
+                  label="Radius"
+                  min={0}
+                  max={20}
+                  step={0.5}
+                  value={blurRadius}
+                  display={`${blurRadius.toFixed(0)}px`}
+                  disabled={!blurEnabled}
+                  onChange={handleBlurRadiusChange}
+                />
+                <FlexRow justify="flex-end" sx={{ mt: 1, px: 0.5 }}>
+                  <EditorButton
+                    size="small"
+                    disabled={!blur}
+                    onClick={handleClearBlur}
+                  >
+                    Clear blur
+                  </EditorButton>
+                </FlexRow>
               </FlexColumn>
             </CollapsibleSection>
           </>
@@ -567,81 +773,39 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
               }
               open={transitionOpen}
               onToggle={setTransitionOpen}
+              unmountOnExit
             >
               <FlexColumn css={sectionContentStyles(theme)}>
-                {(() => {
-                  const t = clip.transitionIn;
-                  // Auto (default): cross-fade across any same-track overlap.
-                  // Crossfade: explicit duration. None: a zero-length cross-fade
-                  // — an opt-out that stays a hard cut even when clips overlap.
-                  const mode: "auto" | "crossfade" | "none" =
-                    t == null ? "auto" : t.durationMs <= 0 ? "none" : "crossfade";
-                  const duration = t && t.durationMs > 0 ? t.durationMs : 500;
-                  const setMode = (next: "auto" | "crossfade" | "none") => {
-                    if (next === "auto") {
-                      patchClip(clip.id, { transitionIn: undefined });
-                    } else if (next === "none") {
-                      patchClip(clip.id, {
-                        transitionIn: { type: "crossfade", durationMs: 0 }
-                      });
-                    } else {
-                      const transition: ClipTransition = {
-                        type: "crossfade",
-                        durationMs: duration
-                      };
-                      patchClip(clip.id, { transitionIn: transition });
-                    }
-                  };
-                  return (
-                    <>
-                      <InspectorRow label="Type">
-                        <NodeSelect
-                          value={mode}
-                          onChange={(e) =>
-                            setMode(
-                              e.target.value as "auto" | "crossfade" | "none"
-                            )
-                          }
-                        >
-                          <NodeMenuItem value="auto">Auto</NodeMenuItem>
-                          <NodeMenuItem value="crossfade">
-                            Crossfade
-                          </NodeMenuItem>
-                          <NodeMenuItem value="none">None</NodeMenuItem>
-                        </NodeSelect>
-                      </InspectorRow>
-                      {mode === "crossfade" && (
-                        <InspectorRow label="Duration">
-                          <InspectorPillInput
-                            value={(duration / 1000).toFixed(2)}
-                            unit="s"
-                            onCommit={(raw) => {
-                              const ms = parseSeconds(raw);
-                              if (ms == null) return;
-                              patchClip(clip.id, {
-                                transitionIn: {
-                                  type: "crossfade",
-                                  durationMs: Math.max(0, ms)
-                                }
-                              });
-                            }}
-                            ariaLabel="Transition duration"
-                          />
-                        </InspectorRow>
-                      )}
-                      <Text
-                        size="small"
-                        sx={{ px: 0.5, color: "text.secondary" }}
-                      >
-                        {mode === "auto"
-                          ? "Overlap this clip with the previous one on the same track to cross-fade."
-                          : mode === "crossfade"
-                            ? "Fixed cross-fade length, measured from this clip's start."
-                            : "Always a hard cut, even when clips overlap."}
-                      </Text>
-                    </>
-                  );
-                })()}
+                <InspectorRow label="Type">
+                  <NodeSelect
+                    value={transitionMode}
+                    onChange={handleTransitionModeChange}
+                  >
+                    <NodeMenuItem value="auto">Auto</NodeMenuItem>
+                    <NodeMenuItem value="crossfade">Crossfade</NodeMenuItem>
+                    <NodeMenuItem value="none">None</NodeMenuItem>
+                  </NodeSelect>
+                </InspectorRow>
+                {transitionMode === "crossfade" && (
+                  <InspectorRow label="Duration">
+                    <InspectorPillInput
+                      value={(transitionDuration / 1000).toFixed(2)}
+                      unit="s"
+                      onCommit={handleTransitionDurationCommit}
+                      ariaLabel="Transition duration"
+                    />
+                  </InspectorRow>
+                )}
+                <Text
+                  size="small"
+                  sx={{ px: 0.5, color: "text.secondary" }}
+                >
+                  {transitionMode === "auto"
+                    ? "Overlap this clip with the previous one on the same track to cross-fade."
+                    : transitionMode === "crossfade"
+                      ? "Fixed cross-fade length, measured from this clip's start."
+                      : "Always a hard cut, even when clips overlap."}
+                </Text>
               </FlexColumn>
             </CollapsibleSection>
           </>

--- a/web/src/components/timeline/Inspector/ClipVersionHistory.tsx
+++ b/web/src/components/timeline/Inspector/ClipVersionHistory.tsx
@@ -20,6 +20,7 @@ import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 
 import type { ClipVersion, TimelineClip } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
 import { relativeTime } from "../../../utils/formatDateAndTime";
@@ -196,7 +197,7 @@ export interface ClipVersionHistoryProps {
 export const ClipVersionHistory: React.FC<ClipVersionHistoryProps> = memo(
   ({ clipId }) => {
     const theme = useTheme();
-    const clip = useTimelineStore((s) => s.clips.find((c) => c.id === clipId));
+    const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
     const restoreVersion = useTimelineStore((s) => s.restoreVersion);
 
     const handleSelect = useCallback(

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -12,12 +12,15 @@
  * happens in `TimelineInspector`.
  */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
 import ImageModelSelect from "../../properties/ImageModelSelect";
@@ -69,13 +72,23 @@ const panelSx = {
   overflow: "auto"
 };
 
+// Source-clip dropdown is only rendered in image-to-image mode. Sharing one
+// empty array (rather than `[]` inline in the selector) keeps the selector's
+// result referentially stable outside that mode, so `useShallow` bails out
+// without a re-render.
+const EMPTY_SOURCE_ENTRIES: readonly string[] = [];
+// Encodes id + SEP + label as one primitive per eligible clip so the array
+// compares element-wise under useShallow (an array of fresh {value, label}
+// objects would never compare equal across renders). Clip ids never contain
+// this separator, so splitting on its first occurrence is unambiguous.
+const SOURCE_ENTRY_SEP = "\u0000";
+
 const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   clipId
 }) => {
   const theme = useTheme();
 
-  const clip = useTimelineStore((s) => s.clips.find((c) => c.id === clipId));
-  const clips = useTimelineStore((s) => s.clips);
+  const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
   const setClipPrompt = useTimelineStore((s) => s.setClipPrompt);
   const setClipDirectGenModel = useTimelineStore(
     (s) => s.setClipDirectGenModel
@@ -100,21 +113,36 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   const isImageToImage = clip?.bindingKind === "image-to-image";
 
   // Eligible image-to-image source clips: any other image/overlay clip with
-  // a rendered asset in the sequence.
-  const sourceOptions = useMemo(() => {
-    if (!clip) return [];
-    return clips
-      .filter(
-        (c) =>
-          c.id !== clip.id &&
-          (c.mediaType === "image" || c.mediaType === "overlay") &&
-          !!c.currentAssetId
-      )
-      .map((c) => ({
-        value: c.id,
-        label: c.name || c.id.slice(0, 8)
-      }));
-  }, [clips, clip]);
+  // a rendered asset in the sequence. Gated on `isImageToImage` so clips in
+  // every other mode never subscribe to the full `clips` array; the selector
+  // returns primitive strings (not fresh {value, label} objects) so
+  // `useShallow` can actually bail out the re-render when nothing eligible
+  // changed.
+  const sourceEntries = useTimelineStore(
+    useShallow((s) =>
+      isImageToImage
+        ? s.clips
+            .filter(
+              (c) =>
+                c.id !== clipId &&
+                (c.mediaType === "image" || c.mediaType === "overlay") &&
+                !!c.currentAssetId
+            )
+            .map(
+              (c) => `${c.id}${SOURCE_ENTRY_SEP}${c.name || c.id.slice(0, 8)}`
+            )
+        : EMPTY_SOURCE_ENTRIES
+    )
+  );
+
+  const sourceOptions = useMemo(
+    () =>
+      sourceEntries.map((entry) => {
+        const sepIndex = entry.indexOf(SOURCE_ENTRY_SEP);
+        return { value: entry.slice(0, sepIndex), label: entry.slice(sepIndex + 1) };
+      }),
+    [sourceEntries]
+  );
 
   const handleModelChange = useCallback(
     (v: ImageModelValue) => {
@@ -143,11 +171,31 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     [clipId, patchClipBinding]
   );
 
+  // Typing in the prompt field would otherwise push one undo entry per
+  // keystroke. Batch the whole focused-editing session into a single entry:
+  // begin on focus, mark per keystroke, end on blur (a stray unmount mid-edit
+  // is covered by useTimelineHistoryBatch's own unmount safety net).
+  const promptHistory = useTimelineHistoryBatch();
+  const promptGestureActiveRef = useRef(false);
+
+  const handlePromptFocus = useCallback(() => {
+    promptGestureActiveRef.current = true;
+    promptHistory.begin();
+  }, [promptHistory]);
+
+  const handlePromptBlur = useCallback(() => {
+    if (promptGestureActiveRef.current) {
+      promptGestureActiveRef.current = false;
+      promptHistory.end();
+    }
+  }, [promptHistory]);
+
   const handlePromptChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       setClipPrompt(clipId, e.target.value);
+      promptHistory.mark();
     },
-    [clipId, setClipPrompt]
+    [clipId, setClipPrompt, promptHistory]
   );
 
   const handleSourceChange = useCallback(
@@ -266,6 +314,8 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
             <TextInput
               value={clip.prompt ?? ""}
               onChange={handlePromptChange}
+              onFocus={handlePromptFocus}
+              onBlur={handlePromptBlur}
               placeholder={promptPlaceholder}
               multiline
               minRows={2}

--- a/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 import { useWorkflow } from "../../../serverState/useWorkflow";
 import { useWorkflowManager } from "../../../contexts/WorkflowManagerContext";
 import { NodeContext } from "../../../contexts/NodeContext";
@@ -47,6 +48,11 @@ import { ClipVersionHistory } from "./ClipVersionHistory";
 export interface GeneratedClipPanelProps {
   clipId: string;
 }
+
+// Stable identity so `clip.paramOverrides ?? EMPTY_PARAM_OVERRIDES` doesn't
+// hand MiniAppInputsForm a fresh object every render, which would defeat its
+// memoization for clips with no overrides.
+const EMPTY_PARAM_OVERRIDES: Record<string, unknown> = {};
 
 const panelSx = {
   width: "100%",
@@ -85,7 +91,7 @@ const inputsContainerStyles = (theme: Theme) =>
 export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
   ({ clipId }) => {
     const theme = useTheme();
-    const clip = useTimelineStore((s) => s.clips.find((c) => c.id === clipId));
+    const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
     const setParamOverride = useTimelineStore((s) => s.setParamOverride);
 
     const workflowId = clip?.workflowId ?? null;
@@ -155,7 +161,7 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
       return null;
     }
 
-    const paramOverrides = clip.paramOverrides ?? {};
+    const paramOverrides = clip.paramOverrides ?? EMPTY_PARAM_OVERRIDES;
     const generateLabel = clip.currentAssetId ? "Regenerate" : "Generate";
 
     return (

--- a/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
@@ -15,12 +15,14 @@ import React, {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState
 } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { NodeSlider, Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx, reducedMotion, Switch } from "../../ui_primitives";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 
 // ── Header ─────────────────────────────────────────────────────────────────
 
@@ -599,6 +601,68 @@ export const InspectorSliderRow: React.FC<InspectorSliderRowProps> = memo(
   ({ label, value, display, min, max, step, disabled, onChange, origin }) => {
     const theme = useTheme();
     const sliderSx = useMemo(() => precisionSliderSx(theme), [theme]);
+    const history = useTimelineHistoryBatch();
+
+    // Gesture state: pointermove/key-repeat onChange ticks are coalesced to
+    // one store write per animation frame; onChangeCommitted flushes the
+    // final value and closes the undo batch. See useTimelineHistoryBatch for
+    // why a single arrow-key press (onChange immediately followed by
+    // onChangeCommitted, both synchronous) still yields exactly one entry:
+    // the pending rAF write never fires because onChangeCommitted cancels it
+    // and applies the value itself before the frame runs.
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const gestureActiveRef = useRef(false);
+    const pendingValueRef = useRef<number | null>(null);
+    const rafIdRef = useRef<number | null>(null);
+
+    const flush = useCallback(() => {
+      rafIdRef.current = null;
+      if (pendingValueRef.current === null) return;
+      const next = pendingValueRef.current;
+      pendingValueRef.current = null;
+      onChangeRef.current(next);
+      history.mark();
+    }, [history]);
+
+    const handleChange = useCallback(
+      (_e: Event, next: number | number[]) => {
+        const value = Array.isArray(next) ? next[0] : next;
+        if (!gestureActiveRef.current) {
+          gestureActiveRef.current = true;
+          history.begin();
+        }
+        pendingValueRef.current = value;
+        if (rafIdRef.current === null) {
+          rafIdRef.current = requestAnimationFrame(flush);
+        }
+      },
+      [history, flush]
+    );
+
+    const handleChangeCommitted = useCallback(
+      (_e: React.SyntheticEvent | Event, next: number | number[]) => {
+        const value = Array.isArray(next) ? next[0] : next;
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        pendingValueRef.current = null;
+        onChangeRef.current(value);
+        history.mark();
+        history.end();
+        gestureActiveRef.current = false;
+      },
+      [history]
+    );
+
+    useEffect(() => {
+      return () => {
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+        }
+      };
+    }, []);
 
     const span = max - min || 1;
     const toPct = (v: number) =>
@@ -615,6 +679,7 @@ export const InspectorSliderRow: React.FC<InspectorSliderRowProps> = memo(
       "--fill-show-tick": showTick ? 1 : 0
     } as React.CSSProperties;
 
+    // Double-click reset is a single, discrete write — left un-batched.
     const handleReset = useCallback(() => {
       if (origin !== undefined) onChange(origin);
     }, [origin, onChange]);
@@ -638,9 +703,8 @@ export const InspectorSliderRow: React.FC<InspectorSliderRowProps> = memo(
             track={false}
             aria-label={label}
             sx={sliderSx}
-            onChange={(_e, next) =>
-              onChange(Array.isArray(next) ? next[0] : next)
-            }
+            onChange={handleChange}
+            onChangeCommitted={handleChangeCommitted}
           />
         </div>
         <span css={sliderValueStyles(theme)}>{display}</span>

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -11,6 +11,7 @@ import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelineInstance";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 import { usePersistedFold } from "./usePersistedFold";
 import {
   CollapsibleSection,
@@ -108,7 +109,7 @@ export const TimelineInspector: React.FC = memo(() => {
   const [timingOpen, setTimingOpen] = usePersistedFold("timing");
 
   const clip = useTimelineStore((s) =>
-    clipId ? s.clips.find((c) => c.id === clipId) : null
+    clipId ? (findClipById(s.clips, clipId) ?? null) : null
   );
   const track = useTimelineStore((s) =>
     clip ? s.tracks.find((t) => t.id === clip.trackId) : null
@@ -266,6 +267,7 @@ export const TimelineInspector: React.FC = memo(() => {
         }
         open={mediaOpen}
         onToggle={setMediaOpen}
+        unmountOnExit
       >
         <FlexColumn css={sectionContentStyles(theme)}>
           <InspectorRow label="Type">
@@ -288,6 +290,7 @@ export const TimelineInspector: React.FC = memo(() => {
         }
         open={timingOpen}
         onToggle={setTimingOpen}
+        unmountOnExit
       >
         <FlexColumn css={sectionContentStyles(theme)}>
           <InspectorRow label="Start">

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -159,7 +159,7 @@ const PreviewRegion: React.FC<{
   onCreateNewSequence?: () => void;
   createSequencePending?: boolean;
   createSequenceErrorMessage?: string | null;
-}> = ({
+}> = memo(({
   isLoading,
   sequenceUnavailable,
   onRetryFetch,
@@ -233,13 +233,22 @@ const PreviewRegion: React.FC<{
       )}
     </FlexColumn>
   );
-};
+});
+PreviewRegion.displayName = "PreviewRegion";
 
 type InspectorTab = "inspector" | "agent";
 
-const InspectorRegion: React.FC = () => {
+const InspectorRegion: React.FC = memo(() => {
   const theme = useTheme();
   const [tab, setTab] = useState<InspectorTab>("inspector");
+
+  const tabs = useMemo(
+    () => [
+      { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
+      { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> }
+    ],
+    []
+  );
 
   return (
     <FlexColumn
@@ -248,10 +257,7 @@ const InspectorRegion: React.FC = () => {
       sx={{ flex: "0 1 45%", minWidth: 0, minHeight: 0, width: 0 }}
     >
       <TabGroup
-        tabs={[
-          { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
-          { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> }
-        ]}
+        tabs={tabs}
         value={tab}
         onChange={(value) => setTab(value as InspectorTab)}
         size="small"
@@ -266,9 +272,10 @@ const InspectorRegion: React.FC = () => {
       </FlexColumn>
     </FlexColumn>
   );
-};
+});
+InspectorRegion.displayName = "InspectorRegion";
 
-const TranscriptRegion: React.FC = () => {
+const TranscriptRegion: React.FC = memo(() => {
   const theme = useTheme();
   const hasScript = useHasScript();
 
@@ -283,7 +290,40 @@ const TranscriptRegion: React.FC = () => {
       <TranscriptPanel />
     </FlexColumn>
   );
-};
+});
+TranscriptRegion.displayName = "TranscriptRegion";
+
+/**
+ * Zoom + generation-count status bar, isolated from the editor shell.
+ *
+ * Subscribes to `msPerPx` (changes per zoom tick) and the generation counts
+ * (change per WebSocket progress message) itself, so those high-frequency
+ * updates re-render only this leaf instead of the whole `TimelineEditorBody`.
+ */
+const TimelineStatusBar: React.FC = memo(() => {
+  const msPerPx = useTimelineUIStore((s) => s.msPerPx);
+  const setZoom = useTimelineUIStore((s) => s.setZoom);
+  // Convert msPerPx to a dimensionless ratio for ZoomControls (1 = default zoom)
+  const zoom = DEFAULT_MS_PER_PX / msPerPx;
+  const handleZoomChange = useCallback(
+    (nextZoom: number) => setZoom(DEFAULT_MS_PER_PX / nextZoom),
+    [setZoom]
+  );
+
+  const generatingCount = useGeneratingCount();
+  const failedCount = useFailedCount();
+
+  return (
+    <BottomStatusBar
+      mode="local"
+      zoom={zoom}
+      onZoomChange={handleZoomChange}
+      generatingCount={generatingCount}
+      failedCount={failedCount}
+    />
+  );
+});
+TimelineStatusBar.displayName = "TimelineStatusBar";
 
 // ── Main component ─────────────────────────────────────────────────────────
 
@@ -334,19 +374,9 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
   useWorkflowFreshnessCheck(sequenceId ?? null);
   useTimelineGenerationSubscriptions();
 
-  // Zoom ← wired to TimelineUIStore so TracksRegion + BottomStatusBar stay in sync
-  const msPerPx = useTimelineUIStore((s) => s.msPerPx);
-  const setZoom = useTimelineUIStore((s) => s.setZoom);
-  // Convert msPerPx to a dimensionless ratio for ZoomControls (1 = default zoom)
-  const zoom = DEFAULT_MS_PER_PX / msPerPx;
-  const handleZoomChange = useCallback(
-    (nextZoom: number) => setZoom(DEFAULT_MS_PER_PX / nextZoom),
-    [setZoom]
-  );
-
-  // Activity counts for BottomStatusBar
-  const generatingCount = useGeneratingCount();
-  const failedCount = useFailedCount();
+  // Zoom and generation counts moved to `TimelineStatusBar` (below): both
+  // change at high frequency (per zoom tick / per progress message) and
+  // previously re-rendered this whole shell via subscriptions hosted here.
 
   // Offline video export (frame-by-frame, 1:1 with the live preview).
   const {
@@ -363,6 +393,10 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
 
   // Project settings dialog (canvas size + fps) ────────────────────────────
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const handleOpenSettings = useCallback(() => setSettingsOpen(true), []);
+  const handleCloseSettings = useCallback(() => setSettingsOpen(false), []);
+  // Stable element so `activitySlot` doesn't defeat TopBar's memo every render.
+  const activitySlot = useMemo(() => <ActivityIndicator />, []);
 
   // Tracks resize ─────────────────────────────────────────────────────────
   const [tracksHeight, setTracksHeight] = useState(DEFAULT_TRACKS_HEIGHT_PX);
@@ -370,6 +404,9 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
   const dragStartYRef = useRef(0);
   const dragStartHeightRef = useRef(DEFAULT_TRACKS_HEIGHT_PX);
   const handleRef = useRef<HTMLDivElement>(null);
+  // Latest computed height + pending rAF id for the throttled resize below.
+  const pendingHeightRef = useRef<number | null>(null);
+  const resizeRafIdRef = useRef<number | null>(null);
 
   /** Begin mouse drag — capture start position and activate drag state. */
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -383,6 +420,11 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
    * Register / unregister window-level mouse listeners for the duration of a
    * drag. Cleanup runs on unmount, preventing listener leaks if the user
    * navigates away mid-drag.
+   *
+   * `onMouseMove` fires far more often than the display refreshes, so it only
+   * records the latest height in a ref and schedules at most one
+   * `setTracksHeight` per animation frame — otherwise every mousemove tick
+   * re-rendered the whole shell.
    */
   useEffect(() => {
     if (!isDragging) {
@@ -394,17 +436,35 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
     const handleEl = handleRef.current;
     handleEl?.classList.add("dragging");
 
+    const flushPendingHeight = () => {
+      resizeRafIdRef.current = null;
+      if (pendingHeightRef.current !== null) {
+        setTracksHeight(pendingHeightRef.current);
+      }
+    };
+
     const onMouseMove = (ev: MouseEvent) => {
       const deltaY = dragStartYRef.current - ev.clientY; // drag up → taller
-      setTracksHeight(
-        Math.min(
-          MAX_TRACKS_HEIGHT_PX,
-          Math.max(MIN_TRACKS_HEIGHT_PX, dragStartHeightRef.current + deltaY)
-        )
+      pendingHeightRef.current = Math.min(
+        MAX_TRACKS_HEIGHT_PX,
+        Math.max(MIN_TRACKS_HEIGHT_PX, dragStartHeightRef.current + deltaY)
       );
+      if (resizeRafIdRef.current === null) {
+        resizeRafIdRef.current = requestAnimationFrame(flushPendingHeight);
+      }
     };
 
     const onMouseUp = () => {
+      if (resizeRafIdRef.current !== null) {
+        cancelAnimationFrame(resizeRafIdRef.current);
+        resizeRafIdRef.current = null;
+      }
+      // Flush the final position synchronously so a mouseup landing between
+      // animation frames doesn't leave the panel at a stale height.
+      if (pendingHeightRef.current !== null) {
+        setTracksHeight(pendingHeightRef.current);
+        pendingHeightRef.current = null;
+      }
       setIsDragging(false);
     };
 
@@ -412,6 +472,10 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
     window.addEventListener("mouseup", onMouseUp);
 
     return () => {
+      if (resizeRafIdRef.current !== null) {
+        cancelAnimationFrame(resizeRafIdRef.current);
+        resizeRafIdRef.current = null;
+      }
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("mouseup", onMouseUp);
       document.body.style.userSelect = "";
@@ -484,6 +548,23 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
       ? createTimeline.error.message || "Could not create sequence."
       : null;
 
+  // Export dialog action button — memoized so re-renders unrelated to export
+  // state (e.g. the tracks-resize drag) don't allocate a fresh element that
+  // would defeat Dialog's memo.
+  const hasExportError = exportError != null;
+  const exportDialogActions = useMemo(
+    () => (
+      <EditorButton
+        variant={isExporting ? "outlined" : "contained"}
+        size="small"
+        onClick={isExporting ? cancelExport : clearExportError}
+      >
+        {isExporting ? "Cancel" : "Close"}
+      </EditorButton>
+    ),
+    [isExporting, hasExportError, cancelExport, clearExportError]
+  );
+
   return (
     <FlexColumn fullWidth fullHeight css={editorStyles(theme)}>
       {/* ── Top bar ───────────────────────────────────────────────── */}
@@ -492,10 +573,8 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
         isExporting={isExporting}
         onSave={sequenceUnavailable ? undefined : handleSave}
         isSaving={isSaving}
-        onOpenSettings={
-          sequenceUnavailable ? undefined : () => setSettingsOpen(true)
-        }
-        activitySlot={<ActivityIndicator />}
+        onOpenSettings={sequenceUnavailable ? undefined : handleOpenSettings}
+        activitySlot={activitySlot}
       />
 
       {/* ── Middle: assets + preview + inspector ──────────────────── */}
@@ -542,34 +621,20 @@ const TimelineEditorBody: React.FC<TimelineEditorProps> = memo(({
       <TracksRegion heightPx={tracksHeight} />
 
       {/* ── Bottom status bar ─────────────────────────────────────── */}
-      <BottomStatusBar
-        mode="local"
-        zoom={zoom}
-        onZoomChange={handleZoomChange}
-        generatingCount={generatingCount}
-        failedCount={failedCount}
-      />
+      <TimelineStatusBar />
 
       {/* ── Project settings dialog (canvas size + fps) ───────────── */}
       <ProjectSettingsDialog
         open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
+        onClose={handleCloseSettings}
       />
 
       {/* ── Export progress / error dialog ────────────────────────── */}
       <Dialog
-        open={isExporting || exportError != null}
+        open={isExporting || hasExportError}
         onClose={isExporting ? undefined : clearExportError}
-        title={exportError != null ? "Export failed" : "Exporting video"}
-        actions={
-          <EditorButton
-            variant={isExporting ? "outlined" : "contained"}
-            size="small"
-            onClick={isExporting ? cancelExport : clearExportError}
-          >
-            {isExporting ? "Cancel" : "Close"}
-          </EditorButton>
-        }
+        title={hasExportError ? "Export failed" : "Exporting video"}
+        actions={exportDialogActions}
       >
         {exportError != null ? (
           <Text size="small" sx={{ color: "error.main" }}>

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -371,9 +371,19 @@ const TimelineListPanel = () => {
     const filtered = needle
       ? all.filter((timeline) => timeline.name.toLowerCase().includes(needle))
       : all;
-    return [...filtered].sort(
-      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    );
+    const withTimestamps = filtered.map((timeline) => ({
+      ...timeline,
+      updatedAtMs: new Date(timeline.updatedAt).getTime()
+    }));
+    withTimestamps.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
+
+    let currentGroup = "";
+    return withTimestamps.map((timeline) => {
+      const group = groupByDate(timeline.updatedAt);
+      const showHeader = group !== currentGroup;
+      currentGroup = group;
+      return { ...timeline, group, showHeader };
+    });
   }, [data, filterValue]);
 
   const handleOpen = useCallback(
@@ -480,6 +490,8 @@ const TimelineListPanel = () => {
     setItemToDelete(item);
   }, []);
 
+  const handleCancelRename = useCallback(() => setEditingId(null), []);
+
   const handleConfirmDelete = useCallback(() => {
     if (itemToDelete) {
       deleteTimeline.mutate({ id: itemToDelete.id });
@@ -540,41 +552,33 @@ const TimelineListPanel = () => {
         </FlexColumn>
       ) : (
         <FlexColumn className="timeline-list" gap={0.5}>
-          {(() => {
-            let currentGroup = "";
-            return timelines.map((timeline) => {
-              const group = groupByDate(timeline.updatedAt);
-              const showHeader = group !== currentGroup;
-              currentGroup = group;
-              return (
-                <Fragment key={timeline.id}>
-                  {showHeader && (
-                    <div className="date-header-row">
-                      <Text
-                        className="date-header"
-                        size="small"
-                        color="secondary"
-                        weight={400}
-                      >
-                        {group}
-                      </Text>
-                    </div>
-                  )}
-                  <TimelineListItem
-                    id={timeline.id}
-                    name={timeline.name}
-                    updatedAt={timeline.updatedAt}
-                    active={timeline.id === activeTimelineId}
-                    editing={timeline.id === editingId}
-                    onOpen={handleOpen}
-                    onContextMenu={handleContextMenu}
-                    onCommitRename={handleCommitRename}
-                    onCancelRename={() => setEditingId(null)}
-                  />
-                </Fragment>
-              );
-            });
-          })()}
+          {timelines.map((timeline) => (
+            <Fragment key={timeline.id}>
+              {timeline.showHeader && (
+                <div className="date-header-row">
+                  <Text
+                    className="date-header"
+                    size="small"
+                    color="secondary"
+                    weight={400}
+                  >
+                    {timeline.group}
+                  </Text>
+                </div>
+              )}
+              <TimelineListItem
+                id={timeline.id}
+                name={timeline.name}
+                updatedAt={timeline.updatedAt}
+                active={timeline.id === activeTimelineId}
+                editing={timeline.id === editingId}
+                onOpen={handleOpen}
+                onContextMenu={handleContextMenu}
+                onCommitRename={handleCommitRename}
+                onCancelRename={handleCancelRename}
+              />
+            </Fragment>
+          ))}
         </FlexColumn>
       )}
     </FlexColumn>

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -24,6 +24,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 
 import type { TimelineClip, TimelineTrack, ClipStatus } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   useTimelineUIStore,
@@ -334,15 +335,16 @@ const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
 };
 WaveformCanvas.displayName = "WaveformCanvas";
 
-const filmstripCellStyles = (url: string) =>
-  css({
-    flex: 1,
-    height: "100%",
-    backgroundImage: `url(${url})`,
-    backgroundSize: "cover",
-    backgroundPosition: "center",
-    opacity: 0.78
-  });
+// Static (no per-URL variant): backgroundImage is set via inline `style`
+// instead, so a distinct thumbnail data URL per cell doesn't make emotion
+// hash a multi-KB string and insert a permanent CSSOM rule per render.
+const filmstripCellStyles = css({
+  flex: 1,
+  height: "100%",
+  backgroundSize: "cover",
+  backgroundPosition: "center",
+  opacity: 0.78
+});
 
 const trimHandleStyles = (
   theme: Theme,
@@ -392,10 +394,10 @@ export interface ClipProps {
 export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   const theme = useTheme();
 
-  // Selector: only this clip's fields
-  const clip = useTimelineStore(
-    (s) => s.clips.find((c) => c.id === clipId) as TimelineClip | undefined
-  );
+  // Selector: only this clip's fields. findClipById is O(1) via a WeakMap
+  // index keyed on `clips` identity, shared across every mounted Clip — vs.
+  // O(n) per clip per store publish (O(n²) aggregate during a drag).
+  const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
 
   const isSelected = useIsClipSelected(clipId);
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
@@ -453,26 +455,32 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   // Node-level errors from ErrorStore. Error keys are now scoped per run
   // (`${wf}:${jobId}:${node}`), so restrict the scan to the workflow's focused
   // run; with no focused run there's no error to surface.
+  //
+  // The scan lives INSIDE the selector so it returns this clip's own derived
+  // message (a primitive) rather than the whole `errors` record — every clip
+  // subscribing to the full record re-renders (and re-scans all keys) on any
+  // error anywhere; a primitive return only re-renders this clip when its own
+  // derived error actually changes.
   const workflowId = clip?.workflowId;
-  const errorEntries = useErrorStore((s) => s.errors);
   const focusedJobId = useWorkflowRunsStore((s) =>
     workflowId ? s.focusedJob[workflowId] : undefined
   );
-  const errorState: ClipErrorState | null = useMemo(() => {
+  const errorMessage = useErrorStore((s) => {
     if (!workflowId || !focusedJobId) {
       return null;
     }
     const prefix = `${workflowId}:${focusedJobId}:`;
-    for (const key of Object.keys(errorEntries) as NodeKey[]) {
-      if (key.startsWith(prefix) && hasNodeError(errorEntries[key])) {
-        return {
-          hasError: true,
-          message: nodeErrorToDisplayString(errorEntries[key])
-        };
+    for (const key of Object.keys(s.errors) as NodeKey[]) {
+      if (key.startsWith(prefix) && hasNodeError(s.errors[key])) {
+        return nodeErrorToDisplayString(s.errors[key]);
       }
     }
     return null;
-  }, [workflowId, focusedJobId, errorEntries]);
+  });
+  const errorState: ClipErrorState | null = useMemo(
+    () => (errorMessage !== null ? { hasError: true, message: errorMessage } : null),
+    [errorMessage]
+  );
 
   // Derive the displayed status badge.
   // For the "missing" check we trust clip.currentAssetId: if it's set,
@@ -1087,7 +1095,11 @@ const ClipBody: React.FC<ClipBodyProps> = memo(({
       {filmstripCells && (
         <div css={filmstripStyles}>
           {filmstripCells.map((cell, i) => (
-            <div key={i} css={filmstripCellStyles(cell.url)} />
+            <div
+              key={i}
+              css={filmstripCellStyles}
+              style={{ backgroundImage: `url(${cell.url})` }}
+            />
           ))}
         </div>
       )}

--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -13,9 +13,11 @@
  * Performance: the playhead position is driven imperatively. During playback
  * the live time advances ~60×/s through the playback store's TRANSIENT channel
  * (`subscribeTime`), which bypasses React. We subscribe once and set the DOM
- * `left` / pill text directly on refs — the component itself never re-renders
- * per frame. Reactive `currentTimeMs` is only read for the initial/resting
- * position (seek/scrub/pause), and zoom/scroll changes reposition via the same
+ * `transform` (not `left`, which would invalidate layout every frame) / pill
+ * text directly on refs — the component itself never re-renders per frame.
+ * `aria-valuenow` and the pill text are additionally throttled to ~10 Hz.
+ * Reactive `currentTimeMs` is only read for the initial/resting position
+ * (seek/scrub/pause), and zoom/scroll changes reposition via the same
  * imperative path.
  */
 
@@ -51,8 +53,13 @@ const hitAreaStyles = (theme: Theme, dragging: boolean) =>
     position: "absolute",
     top: 0,
     bottom: 0,
+    // Fixed base position — per-frame placement is done entirely via an
+    // imperative `transform: translateX()` (see applyTimeMs) so a moving
+    // playhead never invalidates layout the way animating `left` would. The
+    // half-width centering offset that used to live here as a static
+    // transform is folded into that same imperative translateX.
+    left: 0,
     width: HIT_AREA_WIDTH_PX,
-    transform: `translateX(-${HIT_AREA_WIDTH_PX / 2}px)`,
     cursor: dragging ? "grabbing" : "ew-resize",
     touchAction: "none",
     pointerEvents: "auto",
@@ -148,7 +155,18 @@ export const Playhead: React.FC<PlayheadProps> = memo(
     trackAreaOffsetRef.current = trackAreaOffsetPx;
     fpsRef.current = fps;
 
+    // Last-written aria bucket / pill text, so the throttled DOM writes below
+    // only fire when the displayed value actually changes.
+    const lastAriaBucketRef = useRef<number | null>(null);
+    const lastPillTextRef = useRef<string | null>(null);
+
     // Imperatively position the element + pill text from a time in ms.
+    // Position updates every call (needed every frame during playback) via
+    // `transform` (no layout invalidation, unlike animating `left`).
+    // aria-valuenow and the pill text are comparatively expensive DOM writes
+    // (attribute mutation / text reflow) that only need to change ~10×/s for
+    // a11y/readability, so they're gated behind a "did the rounded value
+    // actually change" check.
     const applyTimeMs = useCallback((timeMs: number) => {
       const leftPx =
         trackAreaOffsetRef.current +
@@ -156,12 +174,20 @@ export const Playhead: React.FC<PlayheadProps> = memo(
         scrollLeftRef.current;
       const el = hitAreaRef.current;
       if (el) {
-        el.style.left = `${leftPx}px`;
-        el.setAttribute("aria-valuenow", String(Math.round(timeMs)));
+        el.style.transform = `translateX(${leftPx - HIT_AREA_WIDTH_PX / 2}px)`;
+        const ariaBucket = Math.round(timeMs / 100);
+        if (ariaBucket !== lastAriaBucketRef.current) {
+          lastAriaBucketRef.current = ariaBucket;
+          el.setAttribute("aria-valuenow", String(Math.round(timeMs)));
+        }
       }
       const pill = pillRef.current;
       if (pill) {
-        pill.textContent = formatTimecode(timeMs, fpsRef.current);
+        const text = formatTimecode(timeMs, fpsRef.current);
+        if (text !== lastPillTextRef.current) {
+          lastPillTextRef.current = text;
+          pill.textContent = text;
+        }
       }
     }, []);
 

--- a/web/src/components/timeline/Tracks/ScriptLane.tsx
+++ b/web/src/components/timeline/Tracks/ScriptLane.tsx
@@ -10,15 +10,20 @@
  * highlights during playback. Read/navigate only — editing stays in the panel.
  */
 
-import React, { useMemo } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { styled } from "@mui/material/styles";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import { useShallow } from "zustand/react/shallow";
 import { MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx } from "../../ui_primitives";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
-import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
-import { buildTranscriptDoc } from "../../../stores/timeline/transcriptOps";
+import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelinePlaybackStore";
+import {
+  buildTranscriptDoc,
+  isTranscriptClip,
+  type TranscriptSegment
+} from "../../../stores/timeline/transcriptOps";
 import { TRACK_HEADER_WIDTH_PX } from "./TrackHeader";
 
 export const SCRIPT_LANE_HEIGHT_PX = 46;
@@ -37,7 +42,7 @@ const LaneRoot = styled("div")(({ theme }) => ({
   overflow: "hidden"
 }));
 
-const PhraseChip = styled("button")(({ theme }) => ({
+const PhraseChipRoot = styled("button")(({ theme }) => ({
   position: "absolute",
   top: 7,
   height: SCRIPT_LANE_HEIGHT_PX - 16,
@@ -120,88 +125,212 @@ export const ScriptLaneHeader: React.FC = () => (
   </HeaderCell>
 );
 
+// ── Imperative active-word/segment highlight ──────────────────────────────────
+
+/** A time span with a stable identity, sorted ascending and non-overlapping. */
+interface TimedKey {
+  key: string;
+  startMs: number;
+  endMs: number;
+}
+
+/** Binary-search the entry spanning `timeMs` (`start <= timeMs < end`), or null. */
+function findActiveRange<T extends TimedKey>(ranges: T[], timeMs: number): T | null {
+  let lo = 0;
+  let hi = ranges.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const r = ranges[mid];
+    if (timeMs < r.startMs) hi = mid - 1;
+    else if (timeMs >= r.endMs) lo = mid + 1;
+    else return r;
+  }
+  return null;
+}
+
+// ── Per-segment chip ───────────────────────────────────────────────────────────
+
+/** Precomputed per-segment render inputs (F5c: avoids recomputing `title` per render). */
+interface ScriptChipView {
+  segment: TranscriptSegment;
+  gapMs: number;
+  prevEndMs: number | undefined;
+  title: string;
+}
+
+interface PhraseChipProps {
+  view: ScriptChipView;
+  msPerPx: number;
+  isSelected: boolean;
+  onSelect: (segment: TranscriptSegment) => void;
+  registerChipEl: (id: string, el: HTMLButtonElement | null) => void;
+  registerWordEl: (key: string, el: HTMLElement | null) => void;
+}
+
+/**
+ * One phrase chip (plus its leading pause chip, if any). Memoized on the
+ * segment's own identity so an edit to one paragraph doesn't re-render every
+ * other chip — segments keep their identity across unrelated store publishes
+ * (`buildTranscriptDoc` is cached; `ScriptLane` only recomputes it when the
+ * transcript-relevant clip subset actually changes).
+ */
+const PhraseChip: React.FC<PhraseChipProps> = memo(function PhraseChip({
+  view,
+  msPerPx,
+  isSelected,
+  onSelect,
+  registerChipEl,
+  registerWordEl
+}) {
+  const { segment: seg, gapMs, prevEndMs, title } = view;
+  const left = seg.startMs / msPerPx;
+  const width = Math.max(10, (seg.endMs - seg.startMs) / msPerPx);
+
+  return (
+    <React.Fragment>
+      {gapMs >= PAUSE_MIN_MS && prevEndMs !== undefined && (
+        <PauseChip
+          style={{
+            left: prevEndMs / msPerPx,
+            width: gapMs / msPerPx
+          }}
+        >
+          {(gapMs / 1000).toFixed(1)}s
+        </PauseChip>
+      )}
+      <PhraseChipRoot
+        ref={(el) => registerChipEl(seg.id, el)}
+        type="button"
+        style={{ left, width }}
+        className={[isSelected ? "is-selected" : "", seg.isDraft ? "is-draft" : ""]
+          .filter(Boolean)
+          .join(" ")}
+        title={title}
+        data-testid="script-chip"
+        data-segment={seg.id}
+        onClick={() => onSelect(seg)}
+      >
+        <span className="phrase-text">
+          {seg.isDraft
+            ? seg.draftText || "…"
+            : seg.tokens.map((t, ti) => (
+                <React.Fragment key={t.wordIndex}>
+                  {ti > 0 ? " " : ""}
+                  <span
+                    ref={(el) => registerWordEl(`${seg.id}:${ti}`, el)}
+                    data-start={t.startMs}
+                    data-end={t.endMs}
+                  >
+                    {t.text}
+                  </span>
+                </React.Fragment>
+              ))}
+        </span>
+      </PhraseChipRoot>
+    </React.Fragment>
+  );
+});
+
 // ── Lane (for the scrollable lanes area) ──────────────────────────────────────
 
 export const ScriptLane: React.FC = () => {
-  const clips = useTimelineStore((s) => s.clips);
+  // Only the transcript/caption-bearing subset — untouched clips (B-roll,
+  // music) keep their identity across store publishes, so `useShallow`
+  // returns the SAME array reference for those publishes and the `segments`
+  // memo below skips recomputing entirely for a B-roll drag.
+  const clips = useTimelineStore(useShallow((s) => s.clips.filter(isTranscriptClip)));
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
   const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
   const setSelection = useTimelineUIStore((s) => s.setSelection);
-  const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
-  const seek = useTimelinePlaybackStore((s) => s.seek);
+  const playbackApi = useTimelinePlaybackStoreApi();
 
-  const segments = useMemo(
-    () => buildTranscriptDoc(clips).segments,
-    [clips]
+  // Chip view models plus the two sorted lookup tables the highlight effect
+  // binary-searches — all derived from `segments` in one pass so `title` and
+  // the ranges never redo the `buildTranscriptDoc` walk.
+  const { chipViews, segmentRanges, wordRanges } = useMemo(() => {
+    const segments = buildTranscriptDoc(clips).segments;
+    const chipViews: ScriptChipView[] = [];
+    const segmentRanges: TimedKey[] = [];
+    const wordRanges: TimedKey[] = [];
+
+    segments.forEach((seg, i) => {
+      const prev = segments[i - 1];
+      const gapMs = prev ? seg.startMs - prev.endMs : 0;
+      const title = seg.isDraft ? seg.draftText : seg.tokens.map((t) => t.text).join(" ");
+      chipViews.push({ segment: seg, gapMs, prevEndMs: prev?.endMs, title });
+      segmentRanges.push({ key: seg.id, startMs: seg.startMs, endMs: seg.endMs });
+      seg.tokens.forEach((t, ti) => {
+        wordRanges.push({ key: `${seg.id}:${ti}`, startMs: t.startMs, endMs: t.endMs });
+      });
+    });
+
+    return { chipViews, segmentRanges, wordRanges };
+  }, [clips]);
+
+  // DOM refs for the imperative highlight — populated by the chips' callback
+  // refs, so applying the highlight is a Map lookup, never a DOM query.
+  const chipElsRef = useRef(new Map<string, HTMLButtonElement>());
+  const wordElsRef = useRef(new Map<string, HTMLElement>());
+  const registerChipEl = useCallback((id: string, el: HTMLButtonElement | null) => {
+    if (el) chipElsRef.current.set(id, el);
+    else chipElsRef.current.delete(id);
+  }, []);
+  const registerWordEl = useCallback((key: string, el: HTMLElement | null) => {
+    if (el) wordElsRef.current.set(key, el);
+    else wordElsRef.current.delete(key);
+  }, []);
+
+  const onSelect = useCallback(
+    (segment: TranscriptSegment) => {
+      playbackApi.getState().seek(segment.startMs);
+      if (segment.clipIds.length > 0) setSelection(segment.clipIds);
+    },
+    [playbackApi, setSelection]
   );
+
+  // The active word/segment highlight, driven off the transient time channel
+  // instead of the reactive `currentTimeMs` (which is frozen during playback
+  // — it only updates on discrete seek/scrub/stop — so the old reactive
+  // version never lit up while actually playing). Subscribes once per
+  // `segmentRanges`/`wordRanges` identity change and toggles classes only when
+  // the active id changes, via the ref Maps above (no DOM query per tick).
+  useEffect(() => {
+    let lastSegmentId: string | null = null;
+    let lastWordKey: string | null = null;
+
+    const applyHighlight = (timeMs: number): void => {
+      const segId = findActiveRange(segmentRanges, timeMs)?.key ?? null;
+      if (segId !== lastSegmentId) {
+        if (lastSegmentId) chipElsRef.current.get(lastSegmentId)?.classList.remove("is-active");
+        if (segId) chipElsRef.current.get(segId)?.classList.add("is-active");
+        lastSegmentId = segId;
+      }
+
+      const wordKey = findActiveRange(wordRanges, timeMs)?.key ?? null;
+      if (wordKey !== lastWordKey) {
+        if (lastWordKey) wordElsRef.current.get(lastWordKey)?.classList.remove("w-active");
+        if (wordKey) wordElsRef.current.get(wordKey)?.classList.add("w-active");
+        lastWordKey = wordKey;
+      }
+    };
+
+    applyHighlight(playbackApi.getState().getTimeMs());
+    return playbackApi.getState().subscribeTime(applyHighlight);
+  }, [playbackApi, segmentRanges, wordRanges]);
 
   return (
     <LaneRoot style={{ width: "100%" }} data-testid="script-lane">
-      {segments.map((seg, i) => {
-        const prev = segments[i - 1];
-        const gapMs = prev ? seg.startMs - prev.endMs : 0;
-        const isSelected = seg.clipIds.some((id) => selectedClipIds.has(id));
-        const isActive =
-          currentTimeMs >= seg.startMs && currentTimeMs < seg.endMs;
-        const left = seg.startMs / msPerPx;
-        const width = Math.max(10, (seg.endMs - seg.startMs) / msPerPx);
-
-        return (
-          <React.Fragment key={seg.id}>
-            {gapMs >= PAUSE_MIN_MS && (
-              <PauseChip
-                style={{
-                  left: prev.endMs / msPerPx,
-                  width: gapMs / msPerPx
-                }}
-              >
-                {(gapMs / 1000).toFixed(1)}s
-              </PauseChip>
-            )}
-            <PhraseChip
-              type="button"
-              style={{ left, width }}
-              className={[
-                isSelected ? "is-selected" : "",
-                isActive ? "is-active" : "",
-                seg.isDraft ? "is-draft" : ""
-              ]
-                .filter(Boolean)
-                .join(" ")}
-              title={
-                seg.isDraft
-                  ? seg.draftText
-                  : seg.tokens.map((t) => t.text).join(" ")
-              }
-              data-testid="script-chip"
-              data-segment={seg.id}
-              onClick={() => {
-                seek(seg.startMs);
-                if (seg.clipIds.length > 0) setSelection(seg.clipIds);
-              }}
-            >
-              <span className="phrase-text">
-                {seg.isDraft
-                  ? seg.draftText || "…"
-                  : seg.tokens.map((t, ti) => (
-                      <React.Fragment key={t.wordIndex}>
-                        {ti > 0 ? " " : ""}
-                        <span
-                          className={
-                            currentTimeMs >= t.startMs && currentTimeMs < t.endMs
-                              ? "w-active"
-                              : undefined
-                          }
-                        >
-                          {t.text}
-                        </span>
-                      </React.Fragment>
-                    ))}
-              </span>
-            </PhraseChip>
-          </React.Fragment>
-        );
-      })}
+      {chipViews.map((view) => (
+        <PhraseChip
+          key={view.segment.id}
+          view={view}
+          msPerPx={msPerPx}
+          isSelected={view.segment.clipIds.some((id) => selectedClipIds.has(id))}
+          onSelect={onSelect}
+          registerChipEl={registerChipEl}
+          registerWordEl={registerWordEl}
+        />
+      ))}
     </LaneRoot>
   );
 };

--- a/web/src/components/timeline/Tracks/TimeRuler.tsx
+++ b/web/src/components/timeline/Tracks/TimeRuler.tsx
@@ -21,7 +21,10 @@ import { useColorScheme, useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import type { TimelineMarker } from "@nodetool-ai/timeline";
-import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import {
+  useTimelinePlaybackStore,
+  useTimelinePlaybackStoreApi
+} from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { BORDER_RADIUS, FONT_SIZE_MONO } from "../../ui_primitives";
@@ -137,7 +140,10 @@ interface MarkerOverlayProps {
   markers: TimelineMarker[];
   msPerPx: number;
   scrollLeftPx: number;
-  totalWidthPx: number;
+  /** Visible width of the ruler viewport (px) — NOT the scrollable content
+   *  width, which can be orders of magnitude larger and would make the
+   *  right-side cull effectively never fire. */
+  viewportWidthPx: number;
   headerWidthPx: number;
   onSeek: (timeMs: number) => void;
   onRemove: (id: string) => void;
@@ -147,7 +153,7 @@ const MarkerOverlayInner: React.FC<MarkerOverlayProps> = ({
   markers,
   msPerPx,
   scrollLeftPx,
-  totalWidthPx,
+  viewportWidthPx,
   headerWidthPx,
   onSeek,
   onRemove
@@ -163,9 +169,12 @@ const MarkerOverlayInner: React.FC<MarkerOverlayProps> = ({
     >
       {markers.map((m) => {
         const contentPx = m.timeMs / msPerPx;
-        // Cull markers outside the currently visible window.
-        const viewportPx = contentPx - scrollLeftPx;
-        if (viewportPx < 0 || viewportPx > totalWidthPx) {
+        // Cull markers outside the visible window (with a small overscan),
+        // in content space: [scrollLeftPx - 200, scrollLeftPx + viewport + 200].
+        if (
+          contentPx < scrollLeftPx - 200 ||
+          contentPx > scrollLeftPx + viewportWidthPx + 200
+        ) {
           return null;
         }
         return (
@@ -263,7 +272,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
     const msPerPx = useTimelineUIStore((s) => s.msPerPx);
     const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
     const seek = useTimelinePlaybackStore((s) => s.seek);
-    const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
+    const playbackStoreApi = useTimelinePlaybackStoreApi();
     const markers = useTimelineStore((s) => s.markers);
     const removeScene = useTimelineStore((s) => s.removeScene);
 
@@ -271,18 +280,49 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
     //
     // The canvas backing store is sized from offsetWidth/offsetHeight inside
     // the draw effect; bump a tick on container resize so the effect reruns
-    // and the ruler redraws at the new size.
+    // and the ruler redraws at the new size. Also track the canvas's visible
+    // width for the marker overlay's cull predicate (viewport, not content,
+    // width).
 
     const [resizeTick, setResizeTick] = useState(0);
+    const [viewportWidthPx, setViewportWidthPx] = useState(0);
     useEffect(() => {
       const canvas = canvasRef.current;
       if (!canvas) {
         return;
       }
-      const ro = new ResizeObserver(() => setResizeTick((t) => t + 1));
+      const ro = new ResizeObserver(() => {
+        setResizeTick((t) => t + 1);
+        setViewportWidthPx(canvas.offsetWidth);
+      });
       ro.observe(canvas);
       return () => ro.disconnect();
     }, []);
+
+    // ── Scrub/playhead aria value ────────────────────────────────────────────
+    //
+    // aria-valuenow only needs to reflect the position for a11y, not track it
+    // at full frame rate — subscribing to reactive `currentTimeMs` would
+    // re-render this memoized ruler (and redraw its canvas) on every
+    // scrub/playback tick. Write the attribute imperatively off the playback
+    // store's transient channel instead, throttled to ~10 Hz, mirroring
+    // Playhead's subscribeTime effect.
+    const lastAriaBucketRef = useRef<number | null>(null);
+    useEffect(() => {
+      const applyAriaValue = (timeMs: number) => {
+        const bucket = Math.round(timeMs / 100);
+        if (bucket === lastAriaBucketRef.current) {
+          return;
+        }
+        lastAriaBucketRef.current = bucket;
+        canvasRef.current?.setAttribute(
+          "aria-valuenow",
+          String(Math.round(timeMs))
+        );
+      };
+      applyAriaValue(playbackStoreApi.getState().getTimeMs());
+      return playbackStoreApi.getState().subscribeTime(applyAriaValue);
+    }, [playbackStoreApi]);
 
     // ── Draw ────────────────────────────────────────────────────────────────
     //
@@ -479,13 +519,12 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
           aria-label="Time ruler — click or drag to set playhead"
           role="slider"
           aria-valuemin={0}
-          aria-valuenow={Math.round(currentTimeMs)}
         />
         <MarkerOverlay
           markers={markers}
           msPerPx={msPerPx}
           scrollLeftPx={scrollLeftPx}
-          totalWidthPx={totalWidthPx}
+          viewportWidthPx={viewportWidthPx}
           headerWidthPx={headerWidthPx}
           onSeek={seek}
           onRemove={removeScene}

--- a/web/src/components/timeline/Tracks/TimelineScrollbar.tsx
+++ b/web/src/components/timeline/Tracks/TimelineScrollbar.tsx
@@ -18,6 +18,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { BORDER_RADIUS, MOTION } from "../../ui_primitives";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 
 export const TIMELINE_SCROLLBAR_HEIGHT_PX = 14;
 const MIN_THUMB_PX = 28;
@@ -107,8 +108,6 @@ export interface TimelineScrollbarProps {
   contentWidthPx: number;
   /** Visible viewport width of the lanes area (px). */
   viewportWidthPx: number;
-  /** Current horizontal scroll offset (px). */
-  scrollLeftPx: number;
   /** Left inset so the bar lines up with the lanes (track-header width). */
   leftInsetPx: number;
   /** Scroll the lanes to an absolute offset; the caller clamps via the DOM. */
@@ -116,8 +115,11 @@ export interface TimelineScrollbarProps {
 }
 
 export const TimelineScrollbar: React.FC<TimelineScrollbarProps> = memo(
-  ({ contentWidthPx, viewportWidthPx, scrollLeftPx, leftInsetPx, onScrollTo }) => {
+  ({ contentWidthPx, viewportWidthPx, leftInsetPx, onScrollTo }) => {
     const theme = useTheme();
+    // Subscribed here (rather than passed as a prop) so a pan frame only
+    // re-renders this scrollbar, not the whole TracksRegion.
+    const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
     const troughRef = useRef<HTMLDivElement>(null);
     const dragRef = useRef<{ startX: number; startScroll: number } | null>(null);
 

--- a/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
@@ -39,6 +39,7 @@ import type {
   TrackChromaKeyEffect
 } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   DEVICE_WIDTHS,
   EFFECT_LABELS,
@@ -225,38 +226,91 @@ interface ParamRowProps {
   disabled?: boolean;
 }
 
-const ParamRow: React.FC<ParamRowProps> = ({
-  label,
-  value,
-  min,
-  max,
-  step,
-  unit,
-  format,
-  onChange,
-  disabled
-}) => {
-  const theme = useTheme();
-  const display = format ? format(value) : value.toFixed(step < 1 ? 2 : 0);
-  return (
-    <FlexRow css={paramRowStyles}>
-      <span css={paramLabelStyles(theme)}>{label}</span>
-      <NodeSlider
-        value={value}
-        min={min}
-        max={max}
-        step={step}
-        disabled={disabled}
-        onChange={(_, v) => onChange(Array.isArray(v) ? v[0] : v)}
-        sx={{ flex: 1 }}
-      />
-      <span css={paramValueStyles(theme)}>
-        {display}
-        {unit ? ` ${unit}` : ""}
-      </span>
-    </FlexRow>
-  );
-};
+const ParamRow: React.FC<ParamRowProps> = memo(
+  ({ label, value, min, max, step, unit, format, onChange, disabled }) => {
+    const theme = useTheme();
+    const history = useTimelineHistoryBatch();
+
+    // Same rAF-coalesced, history-batched gesture as InspectorSliderRow: at
+    // most one store write per animation frame while dragging, one undo
+    // entry per gesture (or per key-repeat press) instead of one per tick.
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const gestureActiveRef = useRef(false);
+    const pendingValueRef = useRef<number | null>(null);
+    const rafIdRef = useRef<number | null>(null);
+
+    const flush = useCallback(() => {
+      rafIdRef.current = null;
+      if (pendingValueRef.current === null) return;
+      const next = pendingValueRef.current;
+      pendingValueRef.current = null;
+      onChangeRef.current(next);
+      history.mark();
+    }, [history]);
+
+    const handleChange = useCallback(
+      (_e: Event, v: number | number[]) => {
+        const next = Array.isArray(v) ? v[0] : v;
+        if (!gestureActiveRef.current) {
+          gestureActiveRef.current = true;
+          history.begin();
+        }
+        pendingValueRef.current = next;
+        if (rafIdRef.current === null) {
+          rafIdRef.current = requestAnimationFrame(flush);
+        }
+      },
+      [history, flush]
+    );
+
+    const handleChangeCommitted = useCallback(
+      (_e: React.SyntheticEvent | Event, v: number | number[]) => {
+        const next = Array.isArray(v) ? v[0] : v;
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        pendingValueRef.current = null;
+        onChangeRef.current(next);
+        history.mark();
+        history.end();
+        gestureActiveRef.current = false;
+      },
+      [history]
+    );
+
+    useEffect(() => {
+      return () => {
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+        }
+      };
+    }, []);
+
+    const display = format ? format(value) : value.toFixed(step < 1 ? 2 : 0);
+    return (
+      <FlexRow css={paramRowStyles}>
+        <span css={paramLabelStyles(theme)}>{label}</span>
+        <NodeSlider
+          value={value}
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          onChange={handleChange}
+          onChangeCommitted={handleChangeCommitted}
+          sx={{ flex: 1 }}
+        />
+        <span css={paramValueStyles(theme)}>
+          {display}
+          {unit ? ` ${unit}` : ""}
+        </span>
+      </FlexRow>
+    );
+  }
+);
+ParamRow.displayName = "ParamRow";
 
 // ── Per-effect editors ──────────────────────────────────────────────────────
 
@@ -449,6 +503,9 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [width, setWidth] = useState(600);
   const [dragBand, setDragBand] = useState<Band | null>(null);
+  const history = useTimelineHistoryBatch();
+  const onPatchRef = useRef(onPatch);
+  onPatchRef.current = onPatch;
 
   // Track SVG width to compute layout in user space.
   React.useEffect(() => {
@@ -507,14 +564,49 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
     );
   }, [curvePath, width, height]);
 
+  // Drag gestures are rAF-coalesced (one onPatch per frame) and wrapped in a
+  // single undo entry: begin() on pointerdown, mark() per flushed patch,
+  // end() on pointerup/pointercancel (flushing any not-yet-flushed patch
+  // synchronously first so the final position is never dropped).
+  const pendingPatchRef = useRef<Partial<TrackEq3Effect> | null>(null);
+  const dragRafIdRef = useRef<number | null>(null);
+
+  const flushPatch = useCallback(() => {
+    dragRafIdRef.current = null;
+    if (!pendingPatchRef.current) return;
+    const patch = pendingPatchRef.current;
+    pendingPatchRef.current = null;
+    onPatchRef.current(patch);
+    history.mark();
+  }, [history]);
+
+  const schedulePatch = useCallback(
+    (patch: Partial<TrackEq3Effect>) => {
+      pendingPatchRef.current = patch;
+      if (dragRafIdRef.current === null) {
+        dragRafIdRef.current = requestAnimationFrame(flushPatch);
+      }
+    },
+    [flushPatch]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (dragRafIdRef.current !== null) {
+        cancelAnimationFrame(dragRafIdRef.current);
+      }
+    };
+  }, []);
+
   const handlePointerDown = useCallback(
     (band: Band) => (e: React.PointerEvent<SVGElement>) => {
       if (disabled) return;
       (e.target as Element).setPointerCapture(e.pointerId);
       setDragBand(band);
+      history.begin();
       e.stopPropagation();
     },
-    [disabled]
+    [disabled, history]
   );
 
   const handlePointerMove = useCallback(
@@ -529,14 +621,14 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
       const clampedFreq = clamp(freq, fMin, fMax);
       const clampedDb = clamp(db, -EQ_DB_RANGE, EQ_DB_RANGE);
       if (dragBand === "low") {
-        onPatch({ lowFreq: clampedFreq, lowGainDb: clampedDb });
+        schedulePatch({ lowFreq: clampedFreq, lowGainDb: clampedDb });
       } else if (dragBand === "mid") {
-        onPatch({ midFreq: clampedFreq, midGainDb: clampedDb });
+        schedulePatch({ midFreq: clampedFreq, midGainDb: clampedDb });
       } else {
-        onPatch({ highFreq: clampedFreq, highGainDb: clampedDb });
+        schedulePatch({ highFreq: clampedFreq, highGainDb: clampedDb });
       }
     },
-    [dragBand, onPatch]
+    [dragBand, schedulePatch]
   );
 
   const handlePointerUp = useCallback(
@@ -547,32 +639,72 @@ const Eq3Curve: React.FC<Eq3CurveProps> = ({ effect, onPatch, disabled }) => {
         } catch {
           // ignore — capture may have already ended
         }
+        if (dragRafIdRef.current !== null) {
+          cancelAnimationFrame(dragRafIdRef.current);
+          dragRafIdRef.current = null;
+        }
+        if (pendingPatchRef.current) {
+          const patch = pendingPatchRef.current;
+          pendingPatchRef.current = null;
+          onPatchRef.current(patch);
+          history.mark();
+        }
+        history.end();
       }
       setDragBand(null);
     },
-    [dragBand]
+    [dragBand, history]
   );
 
   // Scroll-wheel on mid handle adjusts Q. Attached as a native non-passive
   // listener: React's onWheel is passive, so preventDefault() there can't
-  // stop the page from scrolling.
+  // stop the page from scrolling. `midQRef`/`disabledRef` keep the listener
+  // itself stable (attached once) instead of re-attaching on every value
+  // change; a burst of wheel ticks is batched into one undo entry, closed
+  // after 300 ms of inactivity.
   const midHandleRef = useRef<SVGCircleElement | null>(null);
+  const midQRef = useRef(effect.midQ);
+  midQRef.current = effect.midQ;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+  const wheelActiveRef = useRef(false);
+  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const el = midHandleRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent) => {
-      if (disabled) return;
+      if (disabledRef.current) return;
       e.preventDefault();
-      const next = clamp(
-        effect.midQ * (e.deltaY > 0 ? 0.9 : 1.1),
-        0.1,
-        10
-      );
-      onPatch({ midQ: parseFloat(next.toFixed(2)) });
+      if (!wheelActiveRef.current) {
+        wheelActiveRef.current = true;
+        history.begin();
+      }
+      const next = clamp(midQRef.current * (e.deltaY > 0 ? 0.9 : 1.1), 0.1, 10);
+      onPatchRef.current({ midQ: parseFloat(next.toFixed(2)) });
+      history.mark();
+      if (wheelTimeoutRef.current !== null) {
+        clearTimeout(wheelTimeoutRef.current);
+      }
+      wheelTimeoutRef.current = setTimeout(() => {
+        wheelTimeoutRef.current = null;
+        wheelActiveRef.current = false;
+        history.end();
+      }, 300);
     };
     el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [effect.midQ, onPatch, disabled]);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      if (wheelTimeoutRef.current !== null) {
+        clearTimeout(wheelTimeoutRef.current);
+        wheelTimeoutRef.current = null;
+        if (wheelActiveRef.current) {
+          wheelActiveRef.current = false;
+          history.end();
+        }
+      }
+    };
+  }, [history]);
 
   // Static grid: log decade lines + dB lines.
   const gridFreqs = [50, 100, 200, 500, 1000, 2000, 5000, 10000];
@@ -919,6 +1051,9 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [drag, setDrag] = useState<CompDrag>(null);
   const size = COMP_GRAPH_SIZE;
+  const history = useTimelineHistoryBatch();
+  const onPatchRef = useRef(onPatch);
+  onPatchRef.current = onPatch;
 
   const curvePath = useMemo(() => {
     const samples = 80;
@@ -972,14 +1107,47 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
   const ratioX = compXY(ratioRefInput, size);
   const ratioY = size - compXY(ratioOutDb, size);
 
+  // Drag gestures are rAF-coalesced (one onPatch per frame) and wrapped in a
+  // single undo entry, matching Eq3Curve's band handles.
+  const pendingPatchRef = useRef<Partial<TrackCompressorEffect> | null>(null);
+  const dragRafIdRef = useRef<number | null>(null);
+
+  const flushPatch = useCallback(() => {
+    dragRafIdRef.current = null;
+    if (!pendingPatchRef.current) return;
+    const patch = pendingPatchRef.current;
+    pendingPatchRef.current = null;
+    onPatchRef.current(patch);
+    history.mark();
+  }, [history]);
+
+  const schedulePatch = useCallback(
+    (patch: Partial<TrackCompressorEffect>) => {
+      pendingPatchRef.current = patch;
+      if (dragRafIdRef.current === null) {
+        dragRafIdRef.current = requestAnimationFrame(flushPatch);
+      }
+    },
+    [flushPatch]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (dragRafIdRef.current !== null) {
+        cancelAnimationFrame(dragRafIdRef.current);
+      }
+    };
+  }, []);
+
   const onDown = useCallback(
     (which: CompDrag) => (e: React.PointerEvent<SVGElement>) => {
       if (disabled) return;
       (e.target as Element).setPointerCapture(e.pointerId);
       setDrag(which);
+      history.begin();
       e.stopPropagation();
     },
-    [disabled]
+    [disabled, history]
   );
 
   const onMove = useCallback(
@@ -991,7 +1159,7 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
       if (drag === "threshold") {
         // Drag along the X axis primarily; clamp threshold.
         const t = clamp(compFromX(px * (size / rect.width), size), -60, 0);
-        onPatch({ thresholdDb: parseFloat(t.toFixed(1)) });
+        schedulePatch({ thresholdDb: parseFloat(t.toFixed(1)) });
       } else if (drag === "ratio") {
         // Vertical drag controls ratio. Output at ratioRefInput is the Y position.
         const outDb = compFromY(py * (size / rect.height), size);
@@ -1004,19 +1172,19 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
             1,
             20
           );
-          onPatch({ ratio: parseFloat(r.toFixed(2)) });
+          schedulePatch({ ratio: parseFloat(r.toFixed(2)) });
         } else {
           const compressedDelta = outDb - effect.thresholdDb;
           if (compressedDelta <= 0.01) {
-            onPatch({ ratio: 20 });
+            schedulePatch({ ratio: 20 });
           } else {
             const r = clamp(delta / compressedDelta, 1, 20);
-            onPatch({ ratio: parseFloat(r.toFixed(2)) });
+            schedulePatch({ ratio: parseFloat(r.toFixed(2)) });
           }
         }
       }
     },
-    [drag, onPatch, size, effect.thresholdDb]
+    [drag, schedulePatch, size, effect.thresholdDb]
   );
 
   const onUp = useCallback(
@@ -1027,31 +1195,71 @@ const CompressorCurve: React.FC<CompressorCurveProps> = ({
         } catch {
           // ignore
         }
+        if (dragRafIdRef.current !== null) {
+          cancelAnimationFrame(dragRafIdRef.current);
+          dragRafIdRef.current = null;
+        }
+        if (pendingPatchRef.current) {
+          const patch = pendingPatchRef.current;
+          pendingPatchRef.current = null;
+          onPatchRef.current(patch);
+          history.mark();
+        }
+        history.end();
       }
       setDrag(null);
     },
-    [drag]
+    [drag, history]
   );
 
   // Threshold-line wheel changes knee width. Native non-passive listener so
   // preventDefault() actually blocks scrolling (React's onWheel is passive).
+  // `kneeDbRef`/`disabledRef` keep the listener itself stable instead of
+  // re-attaching on every value change; a wheel burst batches into one undo
+  // entry, closed after 300 ms of inactivity.
   const threshHandleRef = useRef<SVGCircleElement | null>(null);
+  const kneeDbRef = useRef(effect.kneeDb);
+  kneeDbRef.current = effect.kneeDb;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+  const wheelActiveRef = useRef(false);
+  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const el = threshHandleRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent) => {
-      if (disabled) return;
+      if (disabledRef.current) return;
       e.preventDefault();
-      const next = clamp(
-        effect.kneeDb + (e.deltaY > 0 ? -1 : 1),
-        0,
-        40
-      );
-      onPatch({ kneeDb: parseFloat(next.toFixed(1)) });
+      if (!wheelActiveRef.current) {
+        wheelActiveRef.current = true;
+        history.begin();
+      }
+      const next = clamp(kneeDbRef.current + (e.deltaY > 0 ? -1 : 1), 0, 40);
+      onPatchRef.current({ kneeDb: parseFloat(next.toFixed(1)) });
+      history.mark();
+      if (wheelTimeoutRef.current !== null) {
+        clearTimeout(wheelTimeoutRef.current);
+      }
+      wheelTimeoutRef.current = setTimeout(() => {
+        wheelTimeoutRef.current = null;
+        wheelActiveRef.current = false;
+        history.end();
+      }, 300);
     };
     el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [effect.kneeDb, onPatch, disabled]);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      if (wheelTimeoutRef.current !== null) {
+        clearTimeout(wheelTimeoutRef.current);
+        wheelTimeoutRef.current = null;
+        if (wheelActiveRef.current) {
+          wheelActiveRef.current = false;
+          history.end();
+        }
+      }
+    };
+  }, [history]);
 
   const gridDbs = [-48, -36, -24, -12];
   const gridColor = theme.vars.palette.divider;

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -146,6 +146,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const rbLastAppliedRef = useRef<{ startMs: number; endMs: number } | null>(
     null
   );
+  /** Lane's bounding rect, captured once at pointerdown. The lane can't move
+   *  during a captured rubber-band gesture, so pointermove reuses this instead
+   *  of calling getBoundingClientRect() (forces layout) on every move. */
+  const rbLaneRectRef = useRef<DOMRect | null>(null);
   const [rubberBand, setRubberBand] = React.useState<RubberBandRect | null>(
     null
   );
@@ -344,6 +348,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
       e.currentTarget.setPointerCapture(e.pointerId);
       const rect = e.currentTarget.getBoundingClientRect();
+      rbLaneRectRef.current = rect;
       const localX = e.clientX - rect.left;
       rbStartRef.current = {
         x: localX,
@@ -391,7 +396,10 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       if (!isRubberBandingRef.current || e.buttons !== 1) {
         return;
       }
-      const rect = e.currentTarget.getBoundingClientRect();
+      const rect = rbLaneRectRef.current;
+      if (!rect) {
+        return;
+      }
       const curX = e.clientX - rect.left;
       const curY = e.clientY - rect.top;
 
@@ -416,6 +424,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     rbBaseSelectionRef.current = null;
     rbLastAppliedRef.current = null;
     rbTrackClipsRef.current = [];
+    rbLaneRectRef.current = null;
     setRubberBand(null);
   }, []);
 

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -45,10 +45,12 @@ import {
 } from "../../../stores/timeline/TimelineStore";
 import {
   useTimelineUIStore,
+  useTimelineUIStoreApi,
   MIN_MS_PER_PX,
   MAX_MS_PER_PX
 } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelinePlaybackStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   buildPastedClips,
   copyClipsToClipboard,
@@ -224,11 +226,8 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const hasScript = useHasScript();
 
     const msPerPx = useTimelineUIStore((s) => s.msPerPx);
-    const scrollLeftPx = useTimelineUIStore((s) => s.scrollLeftPx);
     const setScrollLeftPx = useTimelineUIStore((s) => s.setScrollLeftPx);
-    const setZoom = useTimelineUIStore((s) => s.setZoom);
 
-    const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
     const setActiveTool = useTimelineUIStore((s) => s.setActiveTool);
     const setSelection = useTimelineUIStore((s) => s.setSelection);
     const deleteSelected = useTimelineStore((s) => s.deleteSelected);
@@ -239,14 +238,17 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const moveSelectedClips = useTimelineStore((s) => s.moveSelectedClips);
     const addClips = useTimelineStore((s) => s.addClips);
     // Store handles for values read only inside event handlers (playhead
-    // time, fps, clip list). Subscribing reactively to currentTimeMs here
-    // would re-render every lane ~60×/s during playback.
+    // time, fps, clip list, selection, zoom). Subscribing reactively to these
+    // here would re-render the whole region ~60×/s during playback/zoom/pan
+    // and re-attach the keydown listener on every selection change.
     const docStore = useTimelineStoreApi();
     const playbackStore = useTimelinePlaybackStoreApi();
+    const uiStoreApi = useTimelineUIStoreApi();
 
     const addTrack = useTimelineStore((s) => s.addTrack);
     const addImportedClip = useTimelineStore((s) => s.addImportedClip);
     const importVideoWithAudio = useVideoAudioImport();
+    const arrowNudgeHistory = useTimelineHistoryBatch();
 
     const scrollableRef = useRef<HTMLDivElement>(null);
     const headerColumnRef = useRef<HTMLDivElement>(null);
@@ -285,12 +287,13 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         const trackType: "video" | "audio" =
           mediaType === "audio" ? "audio" : "video";
 
-        const rect = scrollableRef.current?.getBoundingClientRect();
-        if (!rect) return;
+        const scrollEl = scrollableRef.current;
+        if (!scrollEl) return;
+        const rect = scrollEl.getBoundingClientRect();
         const dropX = Math.max(0, e.clientX - rect.left);
         const startMs = Math.max(
           0,
-          Math.round((dropX + scrollLeftPx) * msPerPx)
+          Math.round((dropX + scrollEl.scrollLeft) * msPerPx)
         );
 
         addTrack(trackType);
@@ -305,20 +308,16 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           addImportedClip(asset, newTrack.id, startMs);
         }
       },
-      [
-        isAssetDrag,
-        scrollLeftPx,
-        msPerPx,
-        addTrack,
-        addImportedClip,
-        importVideoWithAudio
-      ]
+      [isAssetDrag, msPerPx, addTrack, addImportedClip, importVideoWithAudio]
     );
 
     // Total scrollable width from the real content extent, with a trailing pad
-    // so the last clip isn't flush against the edge.
+    // so the last clip isn't flush against the edge. Quantized to 256-px
+    // steps so dragging/trimming the right-most clip (which changes
+    // contentEndMs on every pointermove) only re-layouts the scroll area
+    // every 256px of content growth instead of every move.
     const totalWidthPx = Math.max(
-      contentEndMs / msPerPx + 200,
+      Math.ceil((contentEndMs / msPerPx + 200) / 256) * 256,
       1000
     );
 
@@ -372,26 +371,56 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     // keep the playhead pinned to the same viewport x as the lanes rescale.
     const prevMsPerPxRef = useRef(msPerPx);
 
+    // Zoom accumulation for the wheel listener below: a trackpad pinch
+    // delivers 60–120+ Hz of wheel events, so we accumulate the compounded
+    // factor from every event landing within one animation frame and apply a
+    // SINGLE `setZoom` per frame (trailing rAF) instead of one store publish
+    // (→ re-render of every clip/lane/ruler/scrollbar) per event.
+    const pendingZoomFactorRef = useRef(1);
+    const pendingZoomClientXRef = useRef(0);
+    const zoomRafIdRef = useRef<number | null>(null);
+
     useEffect(() => {
       const el = scrollableRef.current;
       if (!el) return;
+
+      const flushZoom = () => {
+        zoomRafIdRef.current = null;
+        const factor = pendingZoomFactorRef.current;
+        pendingZoomFactorRef.current = 1;
+        if (factor === 1) return;
+
+        // Read the live scale from the store (not a render closure) so
+        // consecutive rAF flushes compound on top of the zoom the previous
+        // flush actually applied, even though this listener never re-attaches.
+        const current = uiStoreApi.getState().msPerPx;
+        const next = Math.min(
+          MAX_MS_PER_PX,
+          Math.max(MIN_MS_PER_PX, current * factor)
+        );
+        if (next === current) return;
+
+        // The container rect is read at most once per flushed frame, not
+        // once per wheel event.
+        const rect = el.getBoundingClientRect();
+        const cursorPx = pendingZoomClientXRef.current - rect.left;
+        zoomAnchorRef.current = {
+          timeMs: (el.scrollLeft + cursorPx) * current,
+          cursorPx
+        };
+        uiStoreApi.getState().setZoom(next);
+      };
+
       const onWheel = (e: WheelEvent) => {
         const { zoomDelta, scrollDelta } = partitionTimelineWheel(e);
 
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
-          const factor = 1 + zoomDelta * ZOOM_SENSITIVITY;
-          const next = Math.min(
-            MAX_MS_PER_PX,
-            Math.max(MIN_MS_PER_PX, msPerPx * factor)
-          );
-          if (next === msPerPx) return;
-          const cursorPx = e.clientX - el.getBoundingClientRect().left;
-          zoomAnchorRef.current = {
-            timeMs: (el.scrollLeft + cursorPx) * msPerPx,
-            cursorPx
-          };
-          setZoom(next);
+          pendingZoomFactorRef.current *= 1 + zoomDelta * ZOOM_SENSITIVITY;
+          pendingZoomClientXRef.current = e.clientX;
+          if (zoomRafIdRef.current === null) {
+            zoomRafIdRef.current = requestAnimationFrame(flushZoom);
+          }
           return;
         }
 
@@ -414,9 +443,18 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           }
         }
       };
+      // Attached once with stable (empty) deps — msPerPx is read fresh from
+      // the store inside flushZoom, never from this closure, so events landing
+      // between renders always compute from the current scale.
       el.addEventListener("wheel", onWheel, { passive: false });
-      return () => el.removeEventListener("wheel", onWheel);
-    }, [msPerPx, setZoom]);
+      return () => {
+        el.removeEventListener("wheel", onWheel);
+        if (zoomRafIdRef.current !== null) {
+          cancelAnimationFrame(zoomRafIdRef.current);
+          zoomRafIdRef.current = null;
+        }
+      };
+    }, [uiStoreApi]);
 
     // The header column clips its overflow, so a wheel over it would otherwise
     // do nothing. Forward a vertical wheel to the lanes scroller (whose onScroll
@@ -479,6 +517,26 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         target instanceof HTMLTextAreaElement ||
         (target instanceof HTMLElement && target.isContentEditable);
 
+      // Arrow-key nudge undo batching: a held key repeats ~30×/s, each nudge
+      // mutating the store. Without batching that's one undo entry per
+      // repeat; begin() on the first nudge of a burst, mark() per nudge, and
+      // end() on keyup OR a 400ms trailing timeout (covers focus loss/OS key
+      // repeat quirks that swallow the keyup) so the whole burst collapses
+      // into a single undo entry.
+      let arrowNudgeOpen = false;
+      let arrowNudgeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      const endArrowNudgeBatch = () => {
+        if (arrowNudgeTimeoutId !== null) {
+          clearTimeout(arrowNudgeTimeoutId);
+          arrowNudgeTimeoutId = null;
+        }
+        if (arrowNudgeOpen) {
+          arrowNudgeOpen = false;
+          arrowNudgeHistory.end();
+        }
+      };
+
       const handleKeyDown = (e: KeyboardEvent) => {
         if (isEditableTarget(e.target)) {
           return;
@@ -490,6 +548,10 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         }
 
         const isCtrl = e.ctrlKey || e.metaKey;
+        // Read on demand instead of subscribing reactively — subscribing
+        // would re-render the region and re-attach this listener on every
+        // selection change (e.g. every rubber-band drag tick).
+        const { selectedClipIds } = uiStoreApi.getState();
 
         // Delete / Backspace → delete selected
         if (
@@ -509,11 +571,20 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           selectedClipIds.size > 0
         ) {
           e.preventDefault();
+          if (!arrowNudgeOpen) {
+            arrowNudgeOpen = true;
+            arrowNudgeHistory.begin();
+          }
           const fps = docStore.getState().fps;
           const stepMs = e.shiftKey ? 1000 : Math.round(1000 / Math.max(1, fps));
           const deltaMs = e.key === "ArrowLeft" ? -stepMs : stepMs;
           const primaryId: string = selectedClipIds.values().next().value!;
           moveSelectedClips(primaryId, selectedClipIds, deltaMs);
+          arrowNudgeHistory.mark();
+          if (arrowNudgeTimeoutId !== null) {
+            clearTimeout(arrowNudgeTimeoutId);
+          }
+          arrowNudgeTimeoutId = setTimeout(endArrowNudgeBatch, 400);
           return;
         }
 
@@ -600,10 +671,21 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         }
       };
 
+      const handleKeyUp = (e: KeyboardEvent) => {
+        if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+          endArrowNudgeBatch();
+        }
+      };
+
       window.addEventListener("keydown", handleKeyDown);
-      return () => window.removeEventListener("keydown", handleKeyDown);
+      window.addEventListener("keyup", handleKeyUp);
+      return () => {
+        window.removeEventListener("keydown", handleKeyDown);
+        window.removeEventListener("keyup", handleKeyUp);
+        endArrowNudgeBatch();
+      };
     }, [
-      selectedClipIds,
+      uiStoreApi,
       deleteSelected,
       duplicateSelected,
       setSelection,
@@ -612,7 +694,14 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       addClips,
       docStore,
       playbackStore,
-      setActiveTool
+      setActiveTool,
+      // useTimelineHistoryBatch() returns a fresh object per render, but
+      // begin/mark/end are individually stable (useCallback over a stable
+      // store api) — depend on those instead of the wrapper object so this
+      // listener doesn't re-attach every render.
+      arrowNudgeHistory.begin,
+      arrowNudgeHistory.mark,
+      arrowNudgeHistory.end
     ]);
 
     const expandedFxTrackId = useTimelineUIStore(
@@ -766,7 +855,6 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         <TimelineScrollbar
           contentWidthPx={totalWidthPx}
           viewportWidthPx={fxPanelWidth}
-          scrollLeftPx={scrollLeftPx}
           leftInsetPx={TRACK_HEADER_WIDTH_PX}
           onScrollTo={scrollToLeft}
         />

--- a/web/src/components/timeline/Tracks/__tests__/Playhead.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Playhead.test.tsx
@@ -3,8 +3,9 @@
  *
  * The playhead must update its DOM position from the playback store's TRANSIENT
  * channel (`setTimeMs` → `subscribeTime`) WITHOUT re-rendering the React tree.
- * These tests verify the element's `left` and the pill text track live time
- * pushes, and that those pushes don't trigger a component render.
+ * These tests verify the element's `transform` (compositor-only positioning;
+ * the -8px is the folded half-width centering offset) and the pill text track
+ * live time pushes, and that those pushes don't trigger a component render.
  */
 
 import React from "react";
@@ -35,17 +36,18 @@ describe("Playhead", () => {
 
     const el = screen.getByTestId("playhead");
 
-    // Push a live time of 1000ms → 1000 / 10 = 100px.
+    // Push a live time of 1000ms → 1000 / 10 = 100px, minus the 8px
+    // half-width centering offset.
     act(() => {
       useTimelinePlaybackStore.getState().setTimeMs(1000);
     });
-    expect(el.style.left).toBe("100px");
+    expect(el.style.transform).toBe("translateX(92px)");
 
     // A second push moves it again without remounting.
     act(() => {
       useTimelinePlaybackStore.getState().setTimeMs(2000);
     });
-    expect(el.style.left).toBe("200px");
+    expect(el.style.transform).toBe("translateX(192px)");
   });
 
   it("reflects the live position in the timecode pill", () => {

--- a/web/src/components/timeline/Tracks/clipThumbnails.ts
+++ b/web/src/components/timeline/Tracks/clipThumbnails.ts
@@ -26,10 +26,39 @@ interface CacheEntry {
   state: "pending" | "ready" | "failed";
   thumbnails?: ClipThumbnail[];
   promise?: Promise<ClipThumbnail[]>;
+  /** `Date.now()` when a "failed" entry was recorded; drives the retry window. */
+  failedAt?: number;
 }
+
+/** Cap on distinct video URLs held in `cache`, each worth up to 24 JPEG data
+ *  URLs. Insertion order in the Map doubles as recency order: every access
+ *  re-inserts its key (see `touch`), so the front of the Map is always the
+ *  least-recently-used entry. */
+const MAX_CACHE_ENTRIES = 32;
+/** How long a failed extraction stays poisoned before a fresh request for the
+ *  same URL is allowed to retry (e.g. a transient network blip). */
+const FAILURE_RETRY_MS = 30_000;
 
 const cache = new Map<string, CacheEntry>();
 const subscribers = new Map<string, Set<() => void>>();
+
+/** Re-insert `url` so it becomes the most-recently-used entry. */
+function touch(url: string, entry: CacheEntry): void {
+  cache.delete(url);
+  cache.set(url, entry);
+}
+
+/** Evict the least-recently-used entry once the cache exceeds its cap.
+ *  In-flight ("pending") entries are never evicted — losing track of a
+ *  running extraction would leak its concurrency slot. */
+function evictIfNeeded(): void {
+  if (cache.size <= MAX_CACHE_ENTRIES) return;
+  for (const [url, entry] of cache) {
+    if (entry.state === "pending") continue;
+    cache.delete(url);
+    return;
+  }
+}
 
 const MAX_CONCURRENT = 2;
 let active = 0;
@@ -180,13 +209,16 @@ export function extractVideoFrames(
 /** Get cached thumbnails synchronously (or null if not ready). */
 export function getThumbnails(url: string): ClipThumbnail[] | null {
   const entry = cache.get(url);
-  return entry?.state === "ready" ? entry.thumbnails ?? null : null;
+  if (entry?.state !== "ready") return null;
+  touch(url, entry);
+  return entry.thumbnails ?? null;
 }
 
 /**
  * Kick off thumbnail extraction for `url` if it hasn't started yet. Calls
  * to this function with the same URL share a single extraction. Notifies
- * subscribers when the result is ready.
+ * subscribers when the result is ready. A "failed" entry is retried once
+ * `FAILURE_RETRY_MS` has passed instead of staying poisoned forever.
  */
 export function requestThumbnails(
   url: string,
@@ -195,7 +227,15 @@ export function requestThumbnails(
 ): void {
   if (!url) return;
   const existing = cache.get(url);
-  if (existing) return; // already pending or ready/failed
+  if (existing) {
+    const retryDue =
+      existing.state === "failed" &&
+      Date.now() - (existing.failedAt ?? 0) >= FAILURE_RETRY_MS;
+    if (!retryDue) {
+      touch(url, existing);
+      return; // already pending, ready, or still within the failure cooldown
+    }
+  }
 
   const entry: CacheEntry = { state: "pending" };
   const promise = extract(url, count, width)
@@ -207,11 +247,13 @@ export function requestThumbnails(
     })
     .catch((err) => {
       entry.state = "failed";
+      entry.failedAt = Date.now();
       notify(url);
       throw err;
     });
   entry.promise = promise;
-  cache.set(url, entry);
+  touch(url, entry);
+  evictIfNeeded();
 }
 
 /** Subscribe to thumbnail-ready notifications for `url`. Returns unsubscribe. */

--- a/web/src/components/timeline/TranscriptPanel.tsx
+++ b/web/src/components/timeline/TranscriptPanel.tsx
@@ -15,6 +15,7 @@ import React, { memo, useCallback, useMemo, useRef, useState } from "react";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import CleaningServicesIcon from "@mui/icons-material/CleaningServices";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
+import { useShallow } from "zustand/react/shallow";
 
 import {
   Panel,
@@ -30,7 +31,7 @@ import {
 
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { useTimelineTranscriptStore } from "../../stores/timeline/TimelineTranscriptStore";
-import { buildTranscriptDoc } from "../../stores/timeline/transcriptOps";
+import { buildTranscriptDoc, isTranscriptClip } from "../../stores/timeline/transcriptOps";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useAssetStore } from "../../stores/AssetStore";
 import { TranscriptEditor } from "./transcript/TranscriptEditor";
@@ -38,9 +39,11 @@ import { TranscriptEditor } from "./transcript/TranscriptEditor";
 // ── Panel ────────────────────────────────────────────────────────────────────
 
 export const TranscriptPanel: React.FC = memo(() => {
-  const clips = useTimelineStore((s) => s.clips);
-  const doc = useMemo(() => buildTranscriptDoc(clips), [clips]);
-  const segments = doc.segments;
+  // Only the transcript/caption-bearing subset — untouched clips (B-roll,
+  // music) keep their identity across store publishes, so `useShallow`
+  // returns the SAME array reference for those publishes and the memo below
+  // skips recomputing the doc and filler count for a B-roll drag.
+  const clips = useTimelineStore(useShallow((s) => s.clips.filter(isTranscriptClip)));
 
   const removeFillers = useTimelineTranscriptStore((s) => s.removeFillers);
   const importMedia = useTimelineTranscriptStore((s) => s.importMedia);
@@ -50,14 +53,14 @@ export const TranscriptPanel: React.FC = memo(() => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importing, setImporting] = useState(false);
 
-  const fillerCount = useMemo(
-    () =>
-      doc.segments.reduce(
-        (n, s) => n + s.tokens.filter((t) => t.kind === "filler").length,
-        0
-      ),
-    [doc]
-  );
+  const { segments, fillerCount } = useMemo(() => {
+    const doc = buildTranscriptDoc(clips);
+    const fillerCount = doc.segments.reduce(
+      (n, s) => n + s.tokens.filter((t) => t.kind === "filler").length,
+      0
+    );
+    return { segments: doc.segments, fillerCount };
+  }, [clips]);
 
   const onImportFile = useCallback(
     async (file: File) => {

--- a/web/src/components/timeline/preview/AudioGraph.ts
+++ b/web/src/components/timeline/preview/AudioGraph.ts
@@ -374,13 +374,19 @@ export class AudioGraph {
     }
   }
 
+  /**
+   * Stop + schedule to exactly match `clips`: any currently-scheduled source
+   * whose clip isn't in the list is stopped first, then the new set is
+   * decoded and scheduled via `addClips`. Used for a play/seek gesture's
+   * initial window, where the caller wants playback to end up matching this
+   * set exactly (superseding whatever an older gesture left running).
+   */
   async scheduleClips(
     clips: ScheduledAudioClip[],
     tracks: TimelineTrack[],
     currentTimeMs: number,
     shouldCancel?: () => boolean
   ): Promise<void> {
-    const ctx = this.getContext();
     const activeIds = new Set(clips.map((c) => c.clip.id));
 
     for (const [id, src] of this.clipSources) {
@@ -401,6 +407,23 @@ export class AudioGraph {
       }
     }
 
+    await this.addClips(clips, tracks, currentTimeMs, shouldCancel);
+  }
+
+  /**
+   * Decode + schedule the subset of `clips` not already playing, without
+   * stopping any other currently-scheduled source. This is the primitive
+   * `scheduleClips` builds on; windowed audio top-up calls it directly so
+   * bringing newly-in-range clips in never disturbs sources already playing
+   * from an earlier `scheduleClips`/`addClips` call.
+   */
+  async addClips(
+    clips: ScheduledAudioClip[],
+    tracks: TimelineTrack[],
+    currentTimeMs: number,
+    shouldCancel?: () => boolean
+  ): Promise<void> {
+    const ctx = this.getContext();
     this.updateTracks(tracks);
 
     const bufferPromises = clips.map(async ({ clip, assetUrl }) => {

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -4,7 +4,6 @@ import React, {
   memo,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState
 } from "react";
@@ -12,6 +11,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { useShallow } from "zustand/react/shallow";
+import type { TimelineClip } from "@nodetool-ai/timeline";
 
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import PauseIcon from "@mui/icons-material/Pause";
@@ -58,6 +58,33 @@ function formatTimecode(timeMs: number, fps: number): string {
 
 function frameDeltaMs(fps: number): number {
   return 1000 / Math.max(1, fps);
+}
+
+/** Schedule/top-up audio clips whose start falls within this horizon of the
+ *  playhead — matches PreviewCompositor's PRELOAD_LOOKAHEAD_MS so video and
+ *  audio preload the same window. Bounds play-gesture decode latency and
+ *  resident PCM memory regardless of timeline length. */
+const AUDIO_LOOKAHEAD_MS = 30_000;
+/** How often the top-up interval re-scans for clips that entered the window
+ *  while playing. Must stay well under AUDIO_LOOKAHEAD_MS so every clip is
+ *  scheduled before the playhead reaches it. */
+const AUDIO_TOPUP_INTERVAL_MS = 5_000;
+/** Trailing debounce for the seek-while-playing audio restart. A ruler scrub
+ *  delivers pointermove-rate seeks; only the last one in a burst should pay
+ *  for asset resolution + decode + a fresh clock start. */
+const SEEK_RESTART_DEBOUNCE_MS = 120;
+
+/** True if `clip` is a schedulable audio clip that hasn't finished by `atMs`. */
+function isPendingAudioClip(clip: TimelineClip, atMs: number): boolean {
+  return (
+    clip.mediaType === "audio" &&
+    !clip.muted &&
+    !!clip.currentAssetId &&
+    (clip.status === "generated" ||
+      clip.status === "stale" ||
+      clip.status === "locked") &&
+    clip.startMs + clip.durationMs > atMs
+  );
 }
 
 const containerStyles = (theme: Theme) =>
@@ -198,12 +225,49 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       }))
     );
 
-    const { clips, tracks, durationMs } = useTimelineStore(
-      useShallow((s) => ({
-        clips: s.clips,
-        tracks: s.tracks,
-        durationMs: s.durationMs
-      }))
+    // `clips` is read imperatively via `useTimelineStore.getState()` inside
+    // handlers (handlePlay, the audio top-up) rather than subscribed here —
+    // it gets a new identity on every drag/trim/slider tick, which would
+    // otherwise re-render this whole control bar per pointermove for a value
+    // only ever read at click/gesture time. `tracks` stays a live
+    // subscription: it feeds the `graph.updateTracks` effect below so DSP/
+    // gain/solo/mute changes are audible immediately.
+    const tracks = useTimelineStore((s) => s.tracks);
+    const durationMs = useTimelineStore((s) => s.durationMs);
+
+    // `durationMs` is set only on load and is NOT recomputed when clips are
+    // added/moved (see TracksRegion, which derives its own content extent).
+    // For a new/unsaved sequence it stays 0, which would pin the scrubber's
+    // range to [0, 1] (max ≤ step → every drag snaps to the end). Derive the
+    // max from the actual clip extent, matching the ruler. Returning a
+    // primitive means the default equality skips re-renders for edits that
+    // don't move the content boundary (e.g. an opacity slider drag).
+    const contentEndMs = useTimelineStore((s) => {
+      let end = s.durationMs || 0;
+      for (const c of s.clips) {
+        end = Math.max(end, c.startMs + c.durationMs);
+      }
+      return end;
+    });
+
+    /** All unique clip boundary timestamps (start + end), sorted ascending.
+     *  `useShallow` keeps the returned array's identity stable across clip
+     *  edits that don't touch start/end (opacity, color, transform, ...), so
+     *  boundary-jump navigation doesn't re-render on every unrelated drag
+     *  tick. */
+    const clipBoundaries = useTimelineStore(
+      useShallow((s) => {
+        const pts = new Set<number>();
+        pts.add(0);
+        for (const c of s.clips) {
+          pts.add(c.startMs);
+          pts.add(c.startMs + c.durationMs);
+        }
+        if (s.durationMs) {
+          pts.add(s.durationMs);
+        }
+        return Array.from(pts).sort((a, b) => a - b);
+      })
     );
 
     const getAsset = useAssetStore((s) => s.get);
@@ -214,6 +278,44 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
      *  handlePlay compare against their captured value and bail when a later
      *  gesture has superseded them, so stale audio is never scheduled. */
     const playGenRef = useRef(0);
+    /** Clip ids scheduled in AudioGraph for the current play session. Reset
+     *  on every stop/restart so the top-up interval can tell which clips
+     *  still need scheduling. */
+    const scheduledClipIdsRef = useRef<Set<string>>(new Set());
+    /** Windowed-audio top-up interval id — started in handlePlay, cleared
+     *  with the rest of the session. */
+    const topUpIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+      null
+    );
+    /** Pending seek-while-playing restart — see the seekNonce effect. */
+    const seekDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
+
+    const clearTopUpInterval = useCallback(() => {
+      if (topUpIntervalRef.current !== null) {
+        clearInterval(topUpIntervalRef.current);
+        topUpIntervalRef.current = null;
+      }
+    }, []);
+
+    const clearSeekDebounce = useCallback(() => {
+      if (seekDebounceRef.current !== null) {
+        clearTimeout(seekDebounceRef.current);
+        seekDebounceRef.current = null;
+      }
+    }, []);
+
+    /** Tear down the windowed-audio session: stop the top-up interval,
+     *  cancel a pending seek-restart debounce, and forget which clips were
+     *  scheduled so the next play/seek starts a clean window. Called on
+     *  every path that stops or restarts audio — pause, stop, the
+     *  end-of-timeline auto-pause, seek, and the top of handlePlay itself. */
+    const stopAudioSession = useCallback(() => {
+      clearTopUpInterval();
+      clearSeekDebounce();
+      scheduledClipIdsRef.current.clear();
+    }, [clearTopUpInterval, clearSeekDebounce]);
 
     useEffect(() => {
       const clock = clockRef.current;
@@ -221,8 +323,9 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       return () => {
         clock.stop();
         graph.dispose();
+        stopAudioSession();
       };
-    }, []);
+    }, [stopAudioSession]);
 
     // Live-apply track gain/solo/mute and DSP chain changes so effect tweaks
     // are audible immediately without waiting for the next play/seek cycle.
@@ -231,6 +334,66 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       if (!graph.context) return;
       graph.updateTracks(tracks);
     }, [tracks]);
+
+    /**
+     * Re-scan for audio clips that entered the lookahead window since the
+     * last check and schedule only those, without touching clips already
+     * playing. Runs on a timer started in handlePlay so a long timeline's
+     * audio is brought in incrementally instead of decoding everything up
+     * front.
+     */
+    const topUpAudio = useCallback(
+      async (isStale: () => boolean) => {
+        if (isStale()) return;
+        const graph = graphRef.current;
+        const liveMs = getTimeMs();
+        const windowEndMs = liveMs + AUDIO_LOOKAHEAD_MS;
+        const clipsNow = useTimelineStore.getState().clips;
+
+        const newlyEnteredClips = clipsNow.filter(
+          (c) =>
+            isPendingAudioClip(c, liveMs) &&
+            c.startMs < windowEndMs &&
+            !scheduledClipIdsRef.current.has(c.id)
+        );
+        if (newlyEnteredClips.length === 0) return;
+
+        // Mark up front so an overlapping tick (a slow asset fetch outliving
+        // the 5 s interval) can't attempt the same clip twice.
+        for (const c of newlyEnteredClips) {
+          scheduledClipIdsRef.current.add(c.id);
+        }
+
+        const resolved = await Promise.all(
+          newlyEnteredClips.map(async (clip) => {
+            try {
+              const asset = await getAsset(clip.currentAssetId!);
+              const url = getAssetUrl(asset);
+              return url ? { clip, assetUrl: url } : null;
+            } catch {
+              return null;
+            }
+          })
+        );
+        if (isStale()) return;
+
+        const validClips = resolved.filter(
+          (c): c is NonNullable<typeof c> => c !== null
+        );
+        if (validClips.length === 0) return;
+
+        // `addClips` reuses scheduleClips' decode+schedule internals but
+        // skips its "stop sources not in this list" prune, so sources
+        // already playing from the initial window are left untouched.
+        await graph.addClips(
+          validClips,
+          useTimelineStore.getState().tracks,
+          getTimeMs(),
+          isStale
+        );
+      },
+      [getAsset, getTimeMs]
+    );
 
     const handlePlay = useCallback(async () => {
       const generation = ++playGenRef.current;
@@ -243,6 +406,9 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       // resume, asset fetches) a still-ticking clock would keep overwriting
       // currentTimeMs from its old start position, stomping a fresh seek.
       clock.stop();
+      // A fresh play/restart supersedes any top-up interval or debounced
+      // seek-restart left over from a previous session.
+      stopAudioSession();
 
       // Read fresh to avoid stale closure when the user scrubs before pressing play.
       let startMs = useTimelinePlaybackStore.getState().currentTimeMs;
@@ -254,23 +420,39 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
       play();
 
+      // Read fresh rather than closing over the reactive `clips` value so
+      // this component never needs to subscribe to (and re-render on) the
+      // clips array itself.
+      const clipsNow = useTimelineStore.getState().clips;
+      const remainingAudioClips = clipsNow.filter((c) =>
+        isPendingAudioClip(c, startMs)
+      );
+
+      if (remainingAudioClips.length === 0) {
+        // Nothing left to play — e.g. a seek landed past the last audio
+        // clip. Silence whatever an older gesture left running, but skip
+        // AudioContext creation/resume entirely rather than paying the
+        // autoplay-policy round trip for silence.
+        graph.stopAll();
+        clock.start(startMs, 1, null, durationMs || Infinity);
+        return;
+      }
+
       const ctx = graph.getContext();
       await ctx.resume();
       if (isStale()) return;
 
-      const activeAudioClips = clips.filter(
-        (c) =>
-          c.mediaType === "audio" &&
-          !c.muted &&
-          c.currentAssetId &&
-          (c.status === "generated" ||
-            c.status === "stale" ||
-            c.status === "locked") &&
-          c.startMs + c.durationMs > startMs
+      // Only decode/schedule what's audible now or about to become audible —
+      // not the rest of the timeline. The top-up interval below brings in
+      // the remaining clips as the playhead advances, so play latency and
+      // resident PCM memory stop scaling with timeline length.
+      const windowEndMs = startMs + AUDIO_LOOKAHEAD_MS;
+      const windowedClips = remainingAudioClips.filter(
+        (c) => c.startMs < windowEndMs
       );
 
       const scheduledClips = await Promise.all(
-        activeAudioClips.map(async (clip) => {
+        windowedClips.map(async (clip) => {
           try {
             const asset = await getAsset(clip.currentAssetId!);
             const url = getAssetUrl(asset);
@@ -295,13 +477,25 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       await graph.scheduleClips(validClips, tracks, startMs, isStale);
       if (isStale()) return;
 
-      clock.start(
-        startMs,
-        1,
-        validClips.length > 0 ? ctx : null,
-        durationMs || Infinity
-      );
-    }, [play, clips, tracks, durationMs, fps, getAsset, setCurrentTimeMs]);
+      for (const { clip } of validClips) {
+        scheduledClipIdsRef.current.add(clip.id);
+      }
+
+      clock.start(startMs, 1, ctx, durationMs || Infinity);
+
+      topUpIntervalRef.current = setInterval(() => {
+        void topUpAudio(isStale);
+      }, AUDIO_TOPUP_INTERVAL_MS);
+    }, [
+      play,
+      tracks,
+      durationMs,
+      fps,
+      getAsset,
+      setCurrentTimeMs,
+      stopAudioSession,
+      topUpAudio
+    ]);
 
     const handlePause = useCallback(() => {
       playGenRef.current++;
@@ -309,7 +503,8 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       clockRef.current.stop();
       graphRef.current.stopAll();
       graphRef.current.suspend();
-    }, [pause]);
+      stopAudioSession();
+    }, [pause, stopAudioSession]);
 
     const handleStop = useCallback(() => {
       playGenRef.current++;
@@ -317,7 +512,8 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       clockRef.current.stop();
       graphRef.current.stopAll();
       graphRef.current.suspend();
-    }, [stop]);
+      stopAudioSession();
+    }, [stop, stopAudioSession]);
 
     // The clock auto-pauses via the store when it hits the timeline end —
     // a path that bypasses handlePause. Mirror its teardown here so audio
@@ -328,18 +524,31 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       clockRef.current.stop();
       graphRef.current.stopAll();
       graphRef.current.suspend();
-    }, [isPlaying]);
+      stopAudioSession();
+    }, [isPlaying, stopAudioSession]);
 
     // On external seek while playing, restart audio scheduling + clock at the
     // new position so audio re-aligns with the playhead. We key on seekNonce
     // (bumped only by store.seek()) so frame-by-frame clock updates don't
-    // trigger a restart.
+    // trigger a restart. Silence immediately (`stopAll`), but debounce the
+    // actual restart: a ruler scrub delivers pointermove-rate seeks, and only
+    // the last one in a burst should pay for asset resolution, decode, and a
+    // fresh clock start. The effect cleanup cancels the pending restart when
+    // a newer seek supersedes it (or the component unmounts); `stopAudioSession`
+    // cancels it on pause/stop too.
     useEffect(() => {
       if (seekNonce === 0 || !isPlaying) {
         return;
       }
       graphRef.current.stopAll();
-      void handlePlay();
+      stopAudioSession();
+
+      seekDebounceRef.current = setTimeout(() => {
+        seekDebounceRef.current = null;
+        void handlePlay();
+      }, SEEK_RESTART_DEBOUNCE_MS);
+
+      return clearSeekDebounce;
       // handlePlay reads the latest currentTimeMs from the store.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [seekNonce]);
@@ -369,20 +578,6 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
     const stepBack = useCallback(() => stepFrame(-1), [stepFrame]);
     const stepForward = useCallback(() => stepFrame(1), [stepFrame]);
-
-    /** All unique clip boundary timestamps (start + end), sorted ascending. */
-    const clipBoundaries = useMemo(() => {
-      const pts = new Set<number>();
-      pts.add(0);
-      for (const c of clips) {
-        pts.add(c.startMs);
-        pts.add(c.startMs + c.durationMs);
-      }
-      if (durationMs) {
-        pts.add(durationMs);
-      }
-      return Array.from(pts).sort((a, b) => a - b);
-    }, [clips, durationMs]);
 
     const jumpToPrevBoundary = useCallback(() => {
       // Read the live playhead: while playing, `currentTimeMs` is frozen at the
@@ -447,18 +642,6 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       }
     }, []);
 
-    // `durationMs` is set only on load and is NOT recomputed when clips are
-    // added/moved (see TracksRegion, which derives its own content extent).
-    // For a new/unsaved sequence it stays 0, which would pin the scrubber's
-    // range to [0, 1] (max ≤ step → every drag snaps to the end). Derive the
-    // max from the actual clip extent, matching the ruler.
-    const contentEndMs = useMemo(() => {
-      let end = durationMs || 0;
-      for (const c of clips) {
-        end = Math.max(end, c.startMs + c.durationMs);
-      }
-      return end;
-    }, [clips, durationMs]);
     const scrubMax = Math.max(1, contentEndMs);
     const scrubValue = Math.min(scrubMax, scrubMs ?? currentTimeMs);
 

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -18,6 +18,7 @@ import type { TimelineClip, TrackEffect } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
 import {
@@ -37,6 +38,7 @@ import { TransformGizmoOverlay } from "./TransformGizmoOverlay";
 import {
   clipSourceTimeSec,
   computeActiveLayers,
+  computeActiveLayersWithHorizon,
   effectiveAssetId,
   isClipActive,
   trackZ,
@@ -211,6 +213,10 @@ export const PreviewCompositor: React.FC = memo(() => {
     s.selectedClipIds.size === 1 ? [...s.selectedClipIds][0] : null
   );
 
+  // Collapses a whole gizmo drag (60-240 Hz `onChange`) into a single undo
+  // entry instead of one per pointermove — see `onDragStart`/`onDragEnd` below.
+  const gizmoHistory = useTimelineHistoryBatch();
+
   const assetUrlCache = useRef<Map<string, AssetUrlEntry>>(new Map());
   const [urlCacheVersion, setUrlCacheVersion] = useState(0);
   const getAsset = useAssetStore((s) => s.get);
@@ -304,7 +310,10 @@ export const PreviewCompositor: React.FC = memo(() => {
     return () => {
       for (const el of pool) {
         el.pause();
-        el.src = "";
+        // Plain `el.src = ""` resolves to the document URL and can fire a
+        // spurious request; this is what actually clears the media element.
+        el.removeAttribute("src");
+        el.load();
         if (container.contains(el)) {
           container.removeChild(el);
         }
@@ -412,12 +421,17 @@ export const PreviewCompositor: React.FC = memo(() => {
   // Signature of the visible scene at a given time: the ordered active layer
   // ids plus, for captions, which word is currently spoken (so a highlight
   // change inside one clip still bumps the scene during playback). Used to
-  // decide when the rAF loop must re-render React / re-composite.
+  // decide when the rAF loop must re-render React / re-composite. Also
+  // returns the change horizon so the loop can skip recomputing this while
+  // the query time stays inside the current clip/word boundaries.
   const sceneSignature = useCallback(
-    (timeMs: number): string => {
-      const layers = computeActiveLayers(tracks, clips, timeMs, {
-        maxVideoLayers: HOT_POOL_SIZE
-      });
+    (timeMs: number): { signature: string; nextChangeMs: number } => {
+      const { layers, nextChangeMs } = computeActiveLayersWithHorizon(
+        tracks,
+        clips,
+        timeMs,
+        { maxVideoLayers: HOT_POOL_SIZE }
+      );
       let sig = "";
       for (const l of layers) {
         sig += `${l.kind}:${l.clipId}`;
@@ -426,7 +440,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         }
         sig += "|";
       }
-      return sig;
+      return { signature: sig, nextChangeMs };
     },
     [tracks, clips]
   );
@@ -547,6 +561,20 @@ export const PreviewCompositor: React.FC = memo(() => {
     urlCacheVersion
   ]);
 
+  // The pool effect below is keyed on `currentTimeMs` (React state), which
+  // only advances on scene bumps — so during one long clip, an upcoming
+  // clip's cold-pool preload would never fire before its boundary. This
+  // ticks a counter every 2s while playing purely to re-run that effect;
+  // every write inside it is already same-value-guarded (see the
+  // `data-asset` checks), so the extra evaluations are cheap no-ops for
+  // slots that are already correctly bound.
+  const [preloadTick, setPreloadTick] = useState(0);
+  useEffect(() => {
+    if (!isPlaying) return;
+    const id = window.setInterval(() => setPreloadTick((t) => t + 1), 2000);
+    return () => window.clearInterval(id);
+  }, [isPlaying]);
+
   // Drive the HTMLVideoElement pool (src/seek/play state). Same logic as
   // before, just without setting display/zIndex/blendMode — those are owned
   // by the GPU compositor now.
@@ -651,13 +679,16 @@ export const PreviewCompositor: React.FC = memo(() => {
       if (el && !el.paused) el.pause();
     }
 
-    // Preload upcoming clips into cold pool slots.
+    // Preload upcoming clips into cold pool slots. Sorted soonest-first so
+    // that with more than COLD_POOL_SIZE upcoming clips, the ones closest to
+    // the playhead win the slots (array order is otherwise arbitrary).
     const upcomingVideoClips = clips
       .filter(
         (c) =>
           (c.mediaType === "video" || c.mediaType === "overlay") &&
           isClipUpcoming(c, currentTimeMs)
       )
+      .sort((a, b) => a.startMs - b.startMs)
       .slice(0, COLD_POOL_SIZE);
 
     upcomingVideoClips.forEach((clip, i) => {
@@ -679,7 +710,10 @@ export const PreviewCompositor: React.FC = memo(() => {
     isPlaying,
     clips,
     clipById,
-    resolveUrl
+    resolveUrl,
+    // Not read directly — bumped every 2s during playback purely to
+    // re-evaluate cold-pool preloads mid-clip (see the effect above).
+    preloadTick
   ]);
 
   // Resolve / preload image elements for image layers.
@@ -834,6 +868,22 @@ export const PreviewCompositor: React.FC = memo(() => {
   const getTimeMsRef = useRef(getTimeMs);
   getTimeMsRef.current = getTimeMs;
 
+  // Latest `tracks`/`clips` identities, refreshed every render, so the rAF
+  // loop (whose closure is only recreated when `[gpuReady, isPlaying]`
+  // change) can detect a document mutation without re-subscribing.
+  const latestTracksRef = useRef(tracks);
+  latestTracksRef.current = tracks;
+  const latestClipsRef = useRef(clips);
+  latestClipsRef.current = clips;
+
+  // Change-horizon bookkeeping for the tick loop below: the `tracks`/`clips`
+  // identities and playhead position the last signature+horizon computation
+  // used, so steady-state frames can skip recomputing it entirely.
+  const lastComputeTracksRef = useRef(tracks);
+  const lastComputeClipsRef = useRef(clips);
+  const lastLiveMsRef = useRef(0);
+  const lastNextChangeMsRef = useRef(Number.NEGATIVE_INFINITY);
+
   // While playing, drive a rAF loop off the TRANSIENT playhead (`getTimeMs`),
   // not React state. It (a) bumps the React scene only when the active clip
   // set changes — so we re-bind the video pool / placeholders at boundaries
@@ -846,8 +896,15 @@ export const PreviewCompositor: React.FC = memo(() => {
 
     let raf = 0;
     // Seed with the current scene so the first playing frame doesn't trigger a
-    // spurious scene bump.
-    let lastSignature = sceneSignatureRef.current(getTimeMsRef.current());
+    // spurious scene bump. Also seeds the change horizon and the "last
+    // computed at" bookkeeping the skip-check below relies on.
+    const seedMs = getTimeMsRef.current();
+    const seed = sceneSignatureRef.current(seedMs);
+    let lastSignature = seed.signature;
+    lastLiveMsRef.current = seedMs;
+    lastNextChangeMsRef.current = seed.nextChangeMs;
+    lastComputeTracksRef.current = latestTracksRef.current;
+    lastComputeClipsRef.current = latestClipsRef.current;
     // Force a composite on the very first frame after play starts so any
     // pending texture uploads flush even before a video reports as playing.
     let forceRender = true;
@@ -855,13 +912,28 @@ export const PreviewCompositor: React.FC = memo(() => {
     const tick = () => {
       const liveMs = getTimeMsRef.current();
 
-      // Re-derive the active set; only push it into React when it changed.
-      const signature = sceneSignatureRef.current(liveMs);
-      const setChanged = signature !== lastSignature;
-      if (setChanged) {
-        lastSignature = signature;
-        setSceneTimeMs(liveMs);
+      // Steady-state frames (no clip/caption-word boundary crossed, no seek,
+      // no document mutation) skip re-deriving the scene entirely — the prior
+      // horizon already proves the active set can't have changed.
+      const needsRecompute =
+        liveMs >= lastNextChangeMsRef.current ||
+        liveMs < lastLiveMsRef.current ||
+        latestTracksRef.current !== lastComputeTracksRef.current ||
+        latestClipsRef.current !== lastComputeClipsRef.current;
+
+      let setChanged = false;
+      if (needsRecompute) {
+        const result = sceneSignatureRef.current(liveMs);
+        setChanged = result.signature !== lastSignature;
+        lastSignature = result.signature;
+        lastNextChangeMsRef.current = result.nextChangeMs;
+        lastComputeTracksRef.current = latestTracksRef.current;
+        lastComputeClipsRef.current = latestClipsRef.current;
+        if (setChanged) {
+          setSceneTimeMs(liveMs);
+        }
       }
+      lastLiveMsRef.current = liveMs;
 
       // A frame needs re-compositing when the active set just changed, or when
       // any active video is decoding new pixels (i.e. actually playing). Pure
@@ -895,8 +967,25 @@ export const PreviewCompositor: React.FC = memo(() => {
     activeImageLayers.length > 0 ||
     placeholderLayers.length > 0;
 
-  const generatingClips = clips.filter(
-    (c) => c.status === "generating" && isClipActive(c, currentTimeMs)
+  const generatingClips = useMemo(
+    () =>
+      clips.filter(
+        (c) => c.status === "generating" && isClipActive(c, currentTimeMs)
+      ),
+    [clips, currentTimeMs]
+  );
+
+  const staleActiveClips = useMemo(
+    () =>
+      clips.filter(
+        (c) =>
+          c.status === "stale" &&
+          isClipActive(c, currentTimeMs) &&
+          (c.mediaType === "video" ||
+            c.mediaType === "overlay" ||
+            c.mediaType === "image")
+      ),
+    [clips, currentTimeMs]
   );
 
   return (
@@ -925,7 +1014,12 @@ export const PreviewCompositor: React.FC = memo(() => {
             sequenceHeight={sequenceHeight}
             frameWidth={frameSize.w}
             frameHeight={frameSize.h}
-            onChange={(id, next) => patchClip(id, { transform: next })}
+            onChange={(id, next) => {
+              patchClip(id, { transform: next });
+              gizmoHistory.mark();
+            }}
+            onDragStart={gizmoHistory.begin}
+            onDragEnd={gizmoHistory.end}
           />
         )}
 
@@ -947,24 +1041,15 @@ export const PreviewCompositor: React.FC = memo(() => {
           </div>
         ))}
 
-        {clips
-          .filter(
-            (c) =>
-              c.status === "stale" &&
-              isClipActive(c, currentTimeMs) &&
-              (c.mediaType === "video" ||
-                c.mediaType === "overlay" ||
-                c.mediaType === "image")
-          )
-          .map((c) => (
-            <div
-              key={`stale-${c.id}`}
-              css={overlayBadgeStyles(theme, "#c08000")}
-              style={{ zIndex: 9999 }}
-            >
-              stale
-            </div>
-          ))}
+        {staleActiveClips.map((c) => (
+          <div
+            key={`stale-${c.id}`}
+            css={overlayBadgeStyles(theme, "#c08000")}
+            style={{ zIndex: 9999 }}
+          >
+            stale
+          </div>
+        ))}
 
         {generatingClips.length > 0 && (
           <div css={previewMagicOverlayStyles} aria-hidden>

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -90,6 +90,15 @@ export interface TransformGizmoOverlayProps {
   frameHeight: number;
   /** Commit a new transform for the clip. */
   onChange: (clipId: string, transform: ClipTransform) => void;
+  /**
+   * Fired once when any gizmo gesture begins (pointerdown on the body, a
+   * scale/rotate/pivot handle). Always paired with exactly one
+   * {@link onDragEnd} call. Lets the caller batch the gesture's `onChange`
+   * calls into a single undo entry.
+   */
+  onDragStart?: () => void;
+  /** Fired once when the active gesture ends (pointerup or pointercancel). */
+  onDragEnd?: () => void;
 }
 
 /** clip space [-1,1]² → frame CSS pixels (clip Y up → screen Y down). */
@@ -231,9 +240,17 @@ export function TransformGizmoOverlay({
   sequenceHeight,
   frameWidth,
   frameHeight,
-  onChange
+  onChange,
+  onDragStart,
+  onDragEnd
 }: TransformGizmoOverlayProps): React.ReactElement | null {
   const dragRef = useRef<DragSession | null>(null);
+  // Frame rect at gesture start. The frame cannot move while a drag holds
+  // pointer capture, so caching it here avoids a `getBoundingClientRect`
+  // (forced layout) on every pointermove. Cleared on drag end; non-drag
+  // geometry reads (resize) go through the frame-size ResizeObserver in
+  // PreviewCompositor, which is untouched by this cache.
+  const dragRectRef = useRef<DOMRect | null>(null);
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
 
   if (
@@ -328,7 +345,7 @@ export function TransformGizmoOverlay({
   };
 
   const pointerInFrame = (e: React.PointerEvent): Point => {
-    const rect = svgOf(e).getBoundingClientRect();
+    const rect = dragRectRef.current ?? svgOf(e).getBoundingClientRect();
     return { x: e.clientX - rect.left, y: e.clientY - rect.top };
   };
 
@@ -341,6 +358,9 @@ export function TransformGizmoOverlay({
     const svg = svgOf(e);
     svg.setPointerCapture?.(e.pointerId);
     svg.focus?.({ preventScroll: true });
+    // Cache once per gesture — read by `pointerInFrame` for every subsequent
+    // pointermove instead of re-querying layout each time.
+    dragRectRef.current = svg.getBoundingClientRect();
     const axisU = norm(sub(tr, tl));
     const axisV = norm(sub(bl, tl));
     const pointer = pointerInFrame(e);
@@ -375,6 +395,7 @@ export function TransformGizmoOverlay({
       widthU: len(sub(tr, tl)),
       heightV: len(sub(bl, tl))
     };
+    onDragStart?.();
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
@@ -471,6 +492,8 @@ export function TransformGizmoOverlay({
         svg.releasePointerCapture(e.pointerId);
       }
       dragRef.current = null;
+      dragRectRef.current = null;
+      onDragEnd?.();
     }
   };
 

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -207,9 +207,30 @@ export interface ComputeActiveLayersOptions {
 }
 
 /**
+ * Result of {@link computeActiveLayersWithHorizon}: the resolved layers plus
+ * the change horizon (see that function for what the horizon means).
+ */
+export interface ActiveLayersResult {
+  layers: ActiveLayer[];
+  /**
+   * The minimum time (ms), strictly greater than the query `currentTimeMs`,
+   * at which the resolved layer set OR any layer's active caption word could
+   * change. `Number.POSITIVE_INFINITY` when nothing upcoming would change it.
+   * Callers may treat `layers` as valid for any query time in
+   * `[currentTimeMs, nextChangeMs)` without recomputing.
+   */
+  nextChangeMs: number;
+}
+
+/**
  * Resolve every layer active at `currentTimeMs`, in the order the compositor
  * should blend them: media layers first (bottom track first, top track last),
- * then caption layers appended on top.
+ * then caption layers appended on top. Also computes the change horizon (see
+ * {@link ActiveLayersResult}), so a caller driving a per-frame loop (the live
+ * preview's rAF tick) can skip recomputation while the query time stays below
+ * it and the input arrays are unchanged — steady-state playback inside a
+ * clip's middle (no boundary crossed, no caption word transition) becomes a
+ * single float compare instead of re-deriving the whole scene.
  *
  * Captions are sourced from any active clip that carries word-level
  * `caption.words` — the voiceover audio clip or an imported audio/video clip —
@@ -223,12 +244,12 @@ export interface ComputeActiveLayersOptions {
  * the cap is applied in composite order (top tracks win, matching the preview
  * which fills slots while iterating top-to-bottom).
  */
-export function computeActiveLayers(
+export function computeActiveLayersWithHorizon(
   tracks: TimelineTrack[],
   clips: TimelineClip[],
   currentTimeMs: number,
   options: ComputeActiveLayersOptions = {}
-): ActiveLayer[] {
+): ActiveLayersResult {
   const maxVideoLayers = options.maxVideoLayers ?? MAX_VIDEO_LAYERS;
 
   const sortedTracks = [...tracks].sort((a, b) => a.index - b.index);
@@ -243,15 +264,35 @@ export function computeActiveLayers(
   const captionLayers: ActiveLayer[] = [];
   let videoCount = 0;
 
+  // Change horizon: the smallest upcoming time at which `isClipActive`,
+  // `resolveCaptionAtTime`'s active-word index, or the active-layer set could
+  // flip for ANY input considered below. Tracked alongside the existing scan
+  // so steady-state callers pay nothing extra beyond a few comparisons.
+  let nextChangeMs = Number.POSITIVE_INFINITY;
+  const considerBoundary = (ms: number): void => {
+    if (ms > currentTimeMs && ms < nextChangeMs) nextChangeMs = ms;
+  };
+
   for (const track of sortedTracks) {
     if (!track.visible) continue;
     const isVisual = track.type === "video" || track.type === "overlay";
+    const trackClips = clipsByTrackId.get(track.id) ?? [];
 
-    const activeClips = (clipsByTrackId.get(track.id) ?? [])
+    // Any clip starting on this track (active or not) can add a layer —
+    // mirrors `isClipActive`'s `>=` boundary at `startMs`.
+    for (const c of trackClips) {
+      considerBoundary(c.startMs);
+    }
+
+    const activeClips = trackClips
       .filter((c) => isClipActive(c, currentTimeMs))
       .sort((a, b) => a.startMs - b.startMs);
 
     for (const clip of activeClips) {
+      // Mirrors `isClipActive`'s `<` boundary: the clip stops being active
+      // (and its layer disappears) exactly at its end.
+      considerBoundary(clip.startMs + clip.durationMs);
+
       const baseOpacity = clip.opacity ?? 1;
       // During an overlap both clips are active, so `activeClips` already holds
       // the preceding clip the auto-crossfade ramps against.
@@ -261,6 +302,20 @@ export function computeActiveLayers(
       // Captions ride on their media clip and always render on top.
       const caption = resolveCaptionAtTime(clip, currentTimeMs);
       if (caption) {
+        if (clip.caption) {
+          // Mirrors `resolveCaptionAtTime`'s word boundaries: the active
+          // word's end and the next word's start each flip which word index
+          // is reported active.
+          const local = currentTimeMs - clip.startMs;
+          for (const w of clip.caption.words) {
+            if (local >= w.startMs && local < w.endMs) {
+              considerBoundary(clip.startMs + w.endMs);
+            } else if (w.startMs > local) {
+              considerBoundary(clip.startMs + w.startMs);
+            }
+          }
+        }
+
         captionLayers.push({
           kind: "caption",
           clip,
@@ -308,5 +363,21 @@ export function computeActiveLayers(
     }
   }
 
-  return [...mediaLayers, ...captionLayers];
+  return { layers: [...mediaLayers, ...captionLayers], nextChangeMs };
+}
+
+/**
+ * {@link computeActiveLayersWithHorizon}, discarding the change horizon. Kept
+ * as the stable entry point for callers that only need the layer set (the
+ * offline renderer, tests) — its signature must stay a plain `ActiveLayer[]`
+ * return.
+ */
+export function computeActiveLayers(
+  tracks: TimelineTrack[],
+  clips: TimelineClip[],
+  currentTimeMs: number,
+  options: ComputeActiveLayersOptions = {}
+): ActiveLayer[] {
+  return computeActiveLayersWithHorizon(tracks, clips, currentTimeMs, options)
+    .layers;
 }

--- a/web/src/components/timeline/render/OffscreenVideoPool.ts
+++ b/web/src/components/timeline/render/OffscreenVideoPool.ts
@@ -142,6 +142,23 @@ export class OffscreenVideoPool {
     });
   }
 
+  /**
+   * Tear down the element held for `clipId` immediately, ahead of `dispose()`.
+   * The render loop calls this once a clip's fixed time range has fully
+   * passed — each clip occupies a single contiguous span, so a released clip
+   * can never be seeked again. Without this, a many-clip export pins one live
+   * `<video>` element (and hardware decoder) per clip for the whole render,
+   * well past what browsers/decoders allow concurrently.
+   */
+  release(clipId: string): void {
+    const entry = this.entries.get(clipId);
+    if (!entry) return;
+    entry.el.pause();
+    entry.el.removeAttribute("src");
+    entry.el.load();
+    this.entries.delete(clipId);
+  }
+
   dispose(): void {
     for (const { el } of this.entries.values()) {
       el.pause();

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -131,15 +131,19 @@ export async function renderTimeline(
   const height = Math.max(2, Math.floor(opts.height / 2) * 2);
   const totalFrames = Math.max(1, Math.round((durationMs / 1000) * fps));
 
-  // Resolve each asset url at most once across the whole render.
-  const urlCache = new Map<string, string | undefined>();
-  const resolveCached = async (
-    assetId: string
-  ): Promise<string | undefined> => {
-    if (urlCache.has(assetId)) return urlCache.get(assetId);
-    const url = await resolveUrl(assetId);
-    urlCache.set(assetId, url);
-    return url;
+  // Resolve each asset url at most once across the whole render. Cached by
+  // the in-flight promise (not the resolved value) so the per-frame layer
+  // resolution below — which now resolves every layer of a frame
+  // concurrently — can't kick off a second `resolveUrl` for the same asset
+  // before the first one has settled.
+  const urlCache = new Map<string, Promise<string | undefined>>();
+  const resolveCached = (assetId: string): Promise<string | undefined> => {
+    let pending = urlCache.get(assetId);
+    if (!pending) {
+      pending = resolveUrl(assetId);
+      urlCache.set(assetId, pending);
+    }
+    return pending;
   };
 
   onProgress?.({ phase: "preparing", frame: 0, totalFrames, ratio: 0 });
@@ -214,60 +218,87 @@ export async function renderTimeline(
       audioSource.close();
     }
 
+    // Video/overlay clips release their pooled `<video>` element as soon as
+    // their fixed time range has fully passed. Each clip is a single
+    // contiguous span, so a released clip can never be seeked again — this
+    // caps live media elements at the overlap width instead of the whole
+    // export's clip count.
+    const videoClipsByEnd = clips
+      .filter((c) => c.mediaType === "video" || c.mediaType === "overlay")
+      .sort(
+        (a, b) => a.startMs + a.durationMs - (b.startMs + b.durationMs)
+      );
+    let releasePastIndex = 0;
+
     const frameDurationSec = 1 / fps;
     for (let frame = 0; frame < totalFrames; frame++) {
       throwIfAborted(signal);
       const timeMs = (frame * 1000) / fps;
 
+      while (
+        releasePastIndex < videoClipsByEnd.length &&
+        videoClipsByEnd[releasePastIndex].startMs +
+          videoClipsByEnd[releasePastIndex].durationMs <
+          timeMs
+      ) {
+        videoPool.release(videoClipsByEnd[releasePastIndex].id);
+        releasePastIndex++;
+      }
+
       const layers = computeActiveLayers(tracks, clips, timeMs);
-      const composite: CompositeLayer[] = [];
 
-      for (const layer of layers) {
-        if (layer.kind === "caption" && layer.caption) {
-          const bitmap = captionRasterizer.rasterize(
-            layer.caption,
-            width,
-            height
-          );
-          if (!bitmap) continue;
-          composite.push({
-            id: `c:${layer.clipId}`,
-            source: bitmap,
-            opacity: layer.opacity,
-            blendMode: layer.blendMode,
-            zIndex: trackZ(layer.trackIndex),
-            transform: layer.transform
-          });
-          continue;
-        }
+      // Resolve every layer's source concurrently — with several overlapping
+      // videos this turns N sequential seek round-trips into one. Promise.all
+      // preserves input order in its result array regardless of resolution
+      // order, so the composite below still assembles in the original
+      // (bottom-to-top) layer order.
+      const resolved = await Promise.all(
+        layers.map(async (layer): Promise<CompositeLayer | null> => {
+          if (layer.kind === "caption" && layer.caption) {
+            const bitmap = captionRasterizer.rasterize(
+              layer.caption,
+              width,
+              height
+            );
+            if (!bitmap) return null;
+            return {
+              id: `c:${layer.clipId}`,
+              source: bitmap,
+              opacity: layer.opacity,
+              blendMode: layer.blendMode,
+              zIndex: trackZ(layer.trackIndex),
+              transform: layer.transform
+            };
+          }
 
-        if (!layer.assetId) continue;
-        const url = await resolveCached(layer.assetId);
-        if (!url) continue;
+          if (!layer.assetId) return null;
+          const url = await resolveCached(layer.assetId);
+          if (!url) return null;
 
-        if (layer.kind === "video") {
-          const el = await videoPool.seek(
-            layer.clipId,
-            url,
-            clipSourceTimeSec(layer.clip, timeMs),
-            signal
-          );
-          if (el.videoWidth === 0) continue;
-          composite.push({
-            id: `v:${layer.clipId}`,
-            source: el,
-            opacity: layer.opacity,
-            blendMode: layer.blendMode,
-            zIndex: trackZ(layer.trackIndex),
-            transform: layer.transform,
-            borderRadius: layer.borderRadius,
-            effects: layer.effects,
-            trackEffects: layer.trackEffects
-          });
-        } else {
+          if (layer.kind === "video") {
+            const el = await videoPool.seek(
+              layer.clipId,
+              url,
+              clipSourceTimeSec(layer.clip, timeMs),
+              signal
+            );
+            if (el.videoWidth === 0) return null;
+            return {
+              id: `v:${layer.clipId}`,
+              source: el,
+              opacity: layer.opacity,
+              blendMode: layer.blendMode,
+              zIndex: trackZ(layer.trackIndex),
+              transform: layer.transform,
+              borderRadius: layer.borderRadius,
+              effects: layer.effects,
+              trackEffects: layer.trackEffects
+            };
+          }
+
           const img = await loadImage(url);
-          if (!img) continue;
-          composite.push({
+          if (!img) return null;
+          return {
             id: `i:${layer.clipId}`,
             source: img,
             opacity: layer.opacity,
@@ -277,9 +308,12 @@ export async function renderTimeline(
             borderRadius: layer.borderRadius,
             effects: layer.effects,
             trackEffects: layer.trackEffects
-          });
-        }
-      }
+          };
+        })
+      );
+      const composite: CompositeLayer[] = resolved.filter(
+        (layer): layer is CompositeLayer => layer !== null
+      );
 
       compositor.setLayers(composite);
       compositor.render();

--- a/web/src/components/timeline/transcript/TranscriptEditor.tsx
+++ b/web/src/components/timeline/transcript/TranscriptEditor.tsx
@@ -47,6 +47,8 @@ import {
   COMMAND_PRIORITY_LOW
 } from "lexical";
 
+import { useShallow } from "zustand/react/shallow";
+
 import { WordNode, $createWordNode, $isWordNode } from "./WordNode";
 import { DraftNode, $createDraftNode, $isDraftNode } from "./DraftNode";
 import {
@@ -60,6 +62,7 @@ import {
 import {
   applyEditorEdits,
   buildTranscriptDoc,
+  isTranscriptClip,
   type EditorEdits
 } from "../../../stores/timeline/transcriptOps";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
@@ -194,23 +197,150 @@ function $extractEdits(): EditorEdits {
   return { survivors, draftUpdates, newDraftTexts };
 }
 
+// ── Shared word index (F4: one DOM pass feeds every per-tick plugin) ─────────
+
+/** One rendered `.transcript-word` span, with its timing and cached layout. */
+interface TranscriptWordEntry {
+  el: HTMLElement;
+  clipId: string;
+  /** Absolute timeline start/end, parsed once from `data-start`/`data-end`. */
+  startMs: number;
+  endMs: number;
+  /** Layout relative to `.transcript-editor-area`, read once per rebuild so
+   *  per-tick consumers (the caret) never force a reflow. */
+  offsetLeft: number;
+  offsetTop: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}
+
+/**
+ * A sorted-by-time index over every `.transcript-word` span in the editor,
+ * rebuilt from a single `querySelectorAll` + one dataset/layout read pass.
+ * `ActiveWordPlugin`, `ScriptCaretPlugin`, `SelectionHighlightPlugin`, and the
+ * arrow-key word-stepping in `EditorBody` all read from one instance instead
+ * of each re-querying and re-parsing the whole word DOM on every 60 Hz time
+ * tick. `findActive`/`findNextStart` binary-search the sorted entries.
+ */
+class TranscriptWordIndex {
+  private entries: TranscriptWordEntry[] = [];
+  private listeners = new Set<() => void>();
+
+  /** Re-scan the DOM. Call after any change that can move or replace words. */
+  rebuild(root: HTMLElement | null): void {
+    if (!root) {
+      this.entries = [];
+    } else {
+      const next: TranscriptWordEntry[] = [];
+      // Document order out of `querySelectorAll` is already chronological
+      // (words render left-to-right, time-ordered), so no separate sort is
+      // needed.
+      root.querySelectorAll<HTMLElement>(".transcript-word").forEach((el) => {
+        const startMs = Number(el.dataset.start);
+        const endMs = Number(el.dataset.end);
+        if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return;
+        next.push({
+          el,
+          clipId: el.dataset.clip ?? "",
+          startMs,
+          endMs,
+          offsetLeft: el.offsetLeft,
+          offsetTop: el.offsetTop,
+          offsetWidth: el.offsetWidth,
+          offsetHeight: el.offsetHeight
+        });
+      });
+      this.entries = next;
+    }
+    this.listeners.forEach((cb) => cb());
+  }
+
+  /**
+   * Notified after every `rebuild()` (content or layout changed). Plugins that
+   * must reflect the words as soon as they appear — not just on the next time
+   * tick — subscribe here in addition to the playback time channel (mirrors
+   * why the pre-index code re-ran its whole effect on every `clips` change).
+   */
+  subscribe(cb: () => void): () => void {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  }
+
+  get size(): number {
+    return this.entries.length;
+  }
+
+  get all(): readonly TranscriptWordEntry[] {
+    return this.entries;
+  }
+
+  at(index: number): TranscriptWordEntry | null {
+    return this.entries[index] ?? null;
+  }
+
+  /** The word spanning `timeMs` (`start <= timeMs < end`), or null between words. */
+  findActive(timeMs: number): TranscriptWordEntry | null {
+    const entries = this.entries;
+    let lo = 0;
+    let hi = entries.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const entry = entries[mid];
+      if (timeMs < entry.startMs) hi = mid - 1;
+      else if (timeMs >= entry.endMs) lo = mid + 1;
+      else return entry;
+    }
+    return null;
+  }
+
+  /** The first word starting at or after `timeMs`, or null if none remain. */
+  findNextStart(timeMs: number): TranscriptWordEntry | null {
+    const entries = this.entries;
+    let lo = 0;
+    let hi = entries.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (entries[mid].startMs >= timeMs) hi = mid;
+      else lo = mid + 1;
+    }
+    return lo < entries.length ? entries[lo] : null;
+  }
+}
+
 // ── Plugins ──────────────────────────────────────────────────────────────────
+
+/** Cooldown window (ms) on the reseed signature check — see the effect below. */
+const RESEED_DEBOUNCE_MS = 150;
 
 /**
  * Owns the model↔editor sync. Re-seeds the editor from the clips when their
  * word content changes externally (and the editor is unfocused); reconciles the
  * editor back onto the clips on blur.
  */
-const SyncPlugin: React.FC = () => {
+const SyncPlugin: React.FC<{ wordIndex: TranscriptWordIndex }> = ({
+  wordIndex
+}) => {
   const [editor] = useLexicalComposerContext();
-  const clips = useTimelineStore((s) => s.clips);
+  // Only the transcript/caption-bearing subset — untouched clips (B-roll,
+  // music) keep their identity across store publishes, so `useShallow` returns
+  // the SAME array reference for those publishes and this effect below never
+  // re-runs for them. A B-roll drag no longer touches this plugin at all.
+  const clips = useTimelineStore(useShallow((s) => s.clips.filter(isTranscriptClip)));
   const markers = useTimelineStore((s) => s.markers);
   const setTranscriptAndClips = useTimelineStore((s) => s.setTranscriptAndClips);
 
   const focusedRef = useRef(false);
-  const seededClipsRef = useRef<TimelineClip[]>(clips);
   const seededSigRef = useRef<string>("");
   const seededMarkerSigRef = useRef<string>("");
+  const hasSeededRef = useRef(false);
+  // A "cooldown" window after each applied check: a change that lands inside
+  // it is remembered as `pendingCheckRef` instead of reseeding immediately, and
+  // is caught up in one trailing call when the window elapses. A change that
+  // lands outside any cooldown (mount, or a quiet period) applies immediately.
+  const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingCheckRef = useRef<(() => void) | null>(null);
 
   const reseed = useCallback(
     (nextClips: TimelineClip[], nextMarkers: TimelineMarker[]) => {
@@ -218,26 +348,70 @@ const SyncPlugin: React.FC = () => {
         () => $seedFromClips(nextClips, nextMarkers),
         { discrete: true }
       );
-      seededClipsRef.current = nextClips;
       seededSigRef.current = transcriptSignature(nextClips);
       seededMarkerSigRef.current = markerSignature(nextMarkers);
+      // `discrete: true` flushes the reconciliation synchronously, so the DOM
+      // already reflects the new words — rebuild the shared index right away
+      // rather than waiting for the next coalesced rebuild.
+      wordIndex.rebuild(editor.getRootElement());
     },
-    [editor]
+    [editor, wordIndex]
   );
 
-  // Re-seed when the model changes from outside the editor while it is unfocused
-  // — word content (generate / import / load / undo) or scene markers (a "/ New
-  // scene" command, or a removed break). The initial seed is done by
-  // `initialConfig.editorState`; this also fires on mount to capture
-  // `seededClipsRef` for the blur reconcile.
+  // Re-seed when the model changes from outside the editor while it is
+  // unfocused — word content (generate / import / load / undo) or scene
+  // markers (a "/ New scene" command, or a removed break). A single, isolated
+  // change (the common case: load / generate / undo, or a test asserting
+  // synchronously) applies immediately. A burst of changes within
+  // `RESEED_DEBOUNCE_MS` of each other (a caption-clip drag — identity churn
+  // on every pointermove) collapses into that first immediate check plus one
+  // trailing catch-up for the final state, instead of one reseed per tick.
+  // Reseeding only matters while unfocused, so neither the immediate nor the
+  // trailing path is user-visible as a delay.
   useEffect(() => {
-    if (focusedRef.current) return;
-    const sig = transcriptSignature(clips);
-    const msig = markerSignature(markers);
-    if (sig !== seededSigRef.current || msig !== seededMarkerSigRef.current) {
-      reseed(clips, markers);
+    const check = () => {
+      if (focusedRef.current) return;
+      const sig = transcriptSignature(clips);
+      const msig = markerSignature(markers);
+      if (sig !== seededSigRef.current || msig !== seededMarkerSigRef.current) {
+        reseed(clips, markers);
+      }
+    };
+
+    if (!hasSeededRef.current) {
+      hasSeededRef.current = true;
+      check();
+      return;
     }
+
+    if (cooldownTimerRef.current !== null) {
+      // Inside a cooldown from a recent check — remember this as the trailing
+      // call; the timer below picks it up with the latest clips/markers.
+      pendingCheckRef.current = check;
+      return;
+    }
+
+    check();
+    cooldownTimerRef.current = setTimeout(() => {
+      cooldownTimerRef.current = null;
+      const pending = pendingCheckRef.current;
+      pendingCheckRef.current = null;
+      pending?.();
+    }, RESEED_DEBOUNCE_MS);
   }, [clips, markers, reseed]);
+
+  // Cancel any cooldown timer and flush a still-pending trailing check on
+  // unmount, so the last queued change in a burst isn't silently dropped.
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current !== null) {
+        clearTimeout(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+      pendingCheckRef.current?.();
+      pendingCheckRef.current = null;
+    };
+  }, []);
 
   // Reconcile the edit on blur.
   useEffect(() => {
@@ -250,7 +424,11 @@ const SyncPlugin: React.FC = () => {
     const onBlur = () => {
       focusedRef.current = false;
       const edits = editor.getEditorState().read(() => $extractEdits());
-      const base = seededClipsRef.current;
+      // `applyEditorEdits` ripples cuts/moves across every track (B-roll
+      // included), so it needs the full clip list, not the transcript subset
+      // this plugin reacts to — read it fresh from the store here rather than
+      // widening the reactive selection above.
+      const base = useTimelineStore.getState().clips;
 
       // A brand-new line needs a voiceover track to land on.
       let audioTrackId =
@@ -316,30 +494,19 @@ const CaretSeekPlugin: React.FC = () => {
  * The playhead advances ~60×/s during playback through the transient time
  * channel, so this subscribes to {@link subscribeTime} and toggles the
  * `.is-active` class imperatively — never via React state, so it costs zero
- * re-renders per frame. The subscription also fires on discrete seek/scrub/stop
- * (they all emit on the same channel), and we apply once on mount / when the
- * word DOM changes (load / generate / reseed) so the highlight is correct at
- * rest too.
+ * re-renders per frame. It reads the shared `wordIndex` instead of querying
+ * the DOM itself, and only touches the DOM when the active word actually
+ * changes between ticks.
  */
-const ActiveWordPlugin: React.FC = () => {
-  const [editor] = useLexicalComposerContext();
+const ActiveWordPlugin: React.FC<{ wordIndex: TranscriptWordIndex }> = ({
+  wordIndex
+}) => {
   const playbackApi = useTimelinePlaybackStoreApi();
-  const clips = useTimelineStore((s) => s.clips);
   const lastActive = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     const apply = (timeMs: number): void => {
-      const root = editor.getRootElement();
-      if (!root) return;
-      let next: HTMLElement | null = null;
-      for (const el of root.querySelectorAll<HTMLElement>(".transcript-word")) {
-        const start = Number(el.dataset.start);
-        const end = Number(el.dataset.end);
-        if (timeMs >= start && timeMs < end) {
-          next = el;
-          break;
-        }
-      }
+      const next = wordIndex.findActive(timeMs)?.el ?? null;
       if (next === lastActive.current) return;
       lastActive.current?.classList.remove("is-active");
       if (next) {
@@ -350,8 +517,17 @@ const ActiveWordPlugin: React.FC = () => {
     };
 
     apply(playbackApi.getState().getTimeMs());
-    return playbackApi.getState().subscribeTime(apply);
-  }, [editor, playbackApi, clips]);
+    const unsubscribeTime = playbackApi.getState().subscribeTime(apply);
+    // Also re-apply whenever the word DOM is rebuilt (load / generate / reseed
+    // / resize) — otherwise the highlight wouldn't appear until the next tick.
+    const unsubscribeIndex = wordIndex.subscribe(() =>
+      apply(playbackApi.getState().getTimeMs())
+    );
+    return () => {
+      unsubscribeTime();
+      unsubscribeIndex();
+    };
+  }, [playbackApi, wordIndex]);
 
   return null;
 };
@@ -363,13 +539,17 @@ const ActiveWordPlugin: React.FC = () => {
  * moves the playhead — so there's always a cursor moving across the words. Word
  * offsets are relative to `.transcript-editor-area` (its `position: relative`
  * makes it the words' offsetParent), so the caret positions in the same space.
+ *
+ * All positioning comes from the shared `wordIndex`'s cached offsets — this
+ * plugin never reads `offsetLeft`/`offsetWidth` itself, so a tick never forces
+ * a layout reflow (it still writes `style.left` every tick while a word is
+ * active, since the caret genuinely sweeps across it).
  */
-const ScriptCaretPlugin: React.FC<{ visible: boolean }> = ({ visible }) => {
-  const [editor] = useLexicalComposerContext();
+const ScriptCaretPlugin: React.FC<{
+  visible: boolean;
+  wordIndex: TranscriptWordIndex;
+}> = ({ visible, wordIndex }) => {
   const playbackApi = useTimelinePlaybackStoreApi();
-  // Re-run when the projected words change (load / generate / reseed), not just
-  // when the playhead moves — otherwise the caret wouldn't appear until a seek.
-  const clips = useTimelineStore((s) => s.clips);
   const caretRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -380,43 +560,29 @@ const ScriptCaretPlugin: React.FC<{ visible: boolean }> = ({ visible }) => {
     // imperatively off the transient time channel (~60×/s during playback) and
     // off discrete seek/scrub — no React state, so zero per-frame re-renders.
     const apply = (timeMs: number): void => {
-      const root = editor.getRootElement();
-      if (!visible || !root) {
+      if (!visible || wordIndex.size === 0) {
         caret.style.display = "none";
         return;
       }
 
-      const words = [...root.querySelectorAll<HTMLElement>(".transcript-word")];
-      if (words.length === 0) {
-        caret.style.display = "none";
-        return;
-      }
-
-      let target: HTMLElement | null = null;
+      const active = wordIndex.findActive(timeMs);
+      let target = active;
       let fraction = 0;
-      for (const el of words) {
-        const start = Number(el.dataset.start);
-        const end = Number(el.dataset.end);
-        if (timeMs >= start && timeMs < end) {
-          target = el;
-          // The enclosing check guarantees start <= timeMs < end, so end > start
-          // and the denominator is always positive.
-          fraction = (timeMs - start) / (end - start);
-          break;
+      if (active) {
+        // The enclosing check guarantees start <= timeMs < end, so end > start
+        // and the denominator is always positive.
+        fraction = (timeMs - active.startMs) / (active.endMs - active.startMs);
+      } else {
+        // Between words / paused: sit at the next word's start, else after the last.
+        target = wordIndex.findNextStart(timeMs);
+        if (!target) {
+          target = wordIndex.at(wordIndex.size - 1);
+          fraction = 1; // offsetLeft + 1 * offsetWidth == right after the word.
         }
       }
-      // Between words / paused: sit at the next word's start, else after the last.
       if (!target) {
-        target =
-          words.find((el) => Number(el.dataset.start) >= timeMs) ?? null;
-        if (!target) {
-          const last = words[words.length - 1];
-          caret.style.display = "block";
-          caret.style.left = `${last.offsetLeft + last.offsetWidth}px`;
-          caret.style.top = `${last.offsetTop}px`;
-          caret.style.height = `${last.offsetHeight}px`;
-          return;
-        }
+        caret.style.display = "none";
+        return;
       }
 
       caret.style.display = "block";
@@ -426,8 +592,18 @@ const ScriptCaretPlugin: React.FC<{ visible: boolean }> = ({ visible }) => {
     };
 
     apply(playbackApi.getState().getTimeMs());
-    return playbackApi.getState().subscribeTime(apply);
-  }, [editor, playbackApi, visible, clips]);
+    const unsubscribeTime = playbackApi.getState().subscribeTime(apply);
+    // Re-run when the word DOM is rebuilt (load / generate / reseed / resize),
+    // not just when the playhead moves — otherwise the caret wouldn't appear
+    // (or would sit at stale offsets) until the next tick or seek.
+    const unsubscribeIndex = wordIndex.subscribe(() =>
+      apply(playbackApi.getState().getTimeMs())
+    );
+    return () => {
+      unsubscribeTime();
+      unsubscribeIndex();
+    };
+  }, [playbackApi, visible, wordIndex]);
 
   return <div ref={caretRef} className="script-caret" aria-hidden="true" />;
 };
@@ -436,22 +612,19 @@ const ScriptCaretPlugin: React.FC<{ visible: boolean }> = ({ visible }) => {
  * Mirrors the timeline's clip selection into the transcript: every word of a
  * selected clip gets `.is-selected`, so clicking a word (which selects its
  * clip) highlights here, and selecting a clip on the timeline highlights its
- * words. A DOM class toggle — no editor-state change.
+ * words. A DOM class toggle — no editor-state change. Reads the shared
+ * `wordIndex` instead of re-querying the word DOM.
  */
-const SelectionHighlightPlugin: React.FC = () => {
-  const [editor] = useLexicalComposerContext();
+const SelectionHighlightPlugin: React.FC<{ wordIndex: TranscriptWordIndex }> = ({
+  wordIndex
+}) => {
   const selectedClipIds = useTimelineUIStore((s) => s.selectedClipIds);
 
   useEffect(() => {
-    const root = editor.getRootElement();
-    if (!root) return;
-    for (const el of root.querySelectorAll<HTMLElement>(".transcript-word")) {
-      el.classList.toggle(
-        "is-selected",
-        selectedClipIds.has(el.dataset.clip ?? "")
-      );
+    for (const entry of wordIndex.all) {
+      entry.el.classList.toggle("is-selected", selectedClipIds.has(entry.clipId));
     }
-  }, [editor, selectedClipIds]);
+  }, [wordIndex, selectedClipIds]);
 
   return null;
 };
@@ -542,6 +715,14 @@ const EditorBody: React.FC<{
   const [editor] = useLexicalComposerContext();
   const writing = mode === "write";
 
+  // One shared index over the rendered `.transcript-word` DOM (F4): every
+  // per-tick plugin below reads it instead of each re-querying and
+  // re-parsing the whole word DOM 60×/s. Created once and never replaced —
+  // plugins receive the same instance for the component's lifetime.
+  const wordIndexRef = useRef<TranscriptWordIndex | null>(null);
+  if (!wordIndexRef.current) wordIndexRef.current = new TranscriptWordIndex();
+  const wordIndex = wordIndexRef.current;
+
   // Imperative handles to *this* instance's stores. We deliberately avoid the
   // `useTimelineStore.getState()` statics: those route to whichever timeline is
   // "active" on the activation stack, which is a *different* instance whenever a
@@ -559,6 +740,38 @@ const EditorBody: React.FC<{
     if (writing) root?.focus();
     else root?.blur();
   }, [editor, writing]);
+
+  // Keep the word index current. `registerUpdateListener` fires for every
+  // editor update (typing, node changes, and `SyncPlugin`'s reseeds); coalesce
+  // bursts of those into one rebuild per animation frame. The `ResizeObserver`
+  // catches layout-only changes (e.g. text wrapping shifts offsets without any
+  // editor update).
+  useEffect(() => {
+    wordIndex.rebuild(editor.getRootElement());
+
+    let rafId: number | null = null;
+    const scheduleRebuild = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        wordIndex.rebuild(editor.getRootElement());
+      });
+    };
+
+    const unregisterUpdateListener = editor.registerUpdateListener(() => {
+      scheduleRebuild();
+    });
+
+    const root = editor.getRootElement();
+    const resizeObserver = new ResizeObserver(() => scheduleRebuild());
+    if (root) resizeObserver.observe(root);
+
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      unregisterUpdateListener();
+      resizeObserver.disconnect();
+    };
+  }, [editor, wordIndex]);
 
   const togglePlay = useCallback(() => {
     const pb = playbackApi.getState();
@@ -620,13 +833,9 @@ const EditorBody: React.FC<{
         openSlashCommand();
       } else if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
         // Step the cursor word-by-word (the playhead follows, so the Script
-        // caret moves across words).
-        const root = editor.getRootElement();
-        if (!root) return;
-        const starts = [...root.querySelectorAll<HTMLElement>(".transcript-word")]
-          .map((el) => Number(el.dataset.start))
-          .filter((n) => Number.isFinite(n))
-          .sort((a, b) => a - b);
+        // caret moves across words). Reuses the shared word index — already
+        // sorted by time — instead of re-querying the word DOM.
+        const starts = wordIndex.all.map((entry) => entry.startMs);
         if (starts.length === 0) return;
         e.preventDefault();
         const t = playbackApi.getState().currentTimeMs;
@@ -640,7 +849,7 @@ const EditorBody: React.FC<{
 
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
-  }, [writing, togglePlay, openSlashCommand, editor, playbackApi]);
+  }, [writing, togglePlay, openSlashCommand, playbackApi, wordIndex]);
 
   // Write-mode keys ride the editor (it holds focus): ⌘S plays, Esc finishes,
   // and "/" at the start of a block opens the command menu (mid-text "/" stays
@@ -710,11 +919,11 @@ const EditorBody: React.FC<{
           ErrorBoundary={LexicalErrorBoundary}
         />
         <HistoryPlugin />
-        <SyncPlugin />
+        <SyncPlugin wordIndex={wordIndex} />
         <CaretSeekPlugin />
-        <ActiveWordPlugin />
-        <ScriptCaretPlugin visible={!writing} />
-        <SelectionHighlightPlugin />
+        <ActiveWordPlugin wordIndex={wordIndex} />
+        <ScriptCaretPlugin visible={!writing} wordIndex={wordIndex} />
+        <SelectionHighlightPlugin wordIndex={wordIndex} />
       </div>
     </EditorSurface>
   );

--- a/web/src/components/ui_primitives/CollapsibleSection.tsx
+++ b/web/src/components/ui_primitives/CollapsibleSection.tsx
@@ -26,6 +26,12 @@ export interface CollapsibleSectionProps extends Omit<BoxProps, "title" | "onTog
   hideIcon?: boolean;
   /** Compact mode with less padding */
   compact?: boolean;
+  /**
+   * Unmount children while collapsed instead of keeping them in the DOM
+   * (forwarded to MUI `Collapse`). Defaults to false so existing consumers
+   * that rely on folded content staying mounted are unaffected.
+   */
+  unmountOnExit?: boolean;
 }
 
 /**
@@ -61,6 +67,7 @@ const CollapsibleSectionInternal: React.FC<CollapsibleSectionProps> = ({
   timeout = 200,
   hideIcon = false,
   compact = false,
+  unmountOnExit = false,
   sx,
   children,
   ...props
@@ -115,7 +122,7 @@ const CollapsibleSectionInternal: React.FC<CollapsibleSectionProps> = ({
         )}
         <Box sx={{ flex: 1 }}>{title}</Box>
       </Box>
-      <Collapse in={isOpen} timeout={timeout}>
+      <Collapse in={isOpen} timeout={timeout} unmountOnExit={unmountOnExit}>
         {children}
       </Collapse>
     </Box>

--- a/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
+++ b/web/src/hooks/timeline/__tests__/useTimelineAutosave.test.ts
@@ -3,7 +3,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { makeTrack } from "@nodetool-ai/timeline";
 
-import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  getTimelineTemporal
+} from "../../../stores/timeline/TimelineStore";
 import {
   useTimelineAutosave,
   markTimelineLoadMigrated
@@ -437,5 +440,36 @@ describe("useTimelineAutosave", () => {
         notifications.some((n) => n.content.includes("autosave"))
       ).toBe(true);
     });
+  });
+
+  it("defers the flush while a gesture batch is open, then saves once it ends", async () => {
+    seedSequence();
+    renderHook(() => useTimelineAutosave({ debounceMs: 50 }));
+
+    // Simulate a drag/trim/slider gesture: useTimelineHistoryBatch pauses the
+    // temporal store for its duration.
+    act(() => {
+      getTimelineTemporal().pause();
+      useTimelineStore.getState().addTrack("video");
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    // The debounce elapsed, but the gesture is still open: the flush must
+    // re-arm instead of PATCHing the mid-gesture state.
+    expect(updateMutate).not.toHaveBeenCalled();
+
+    // Gesture ends (pointerup resumes tracking) with no further store write.
+    act(() => {
+      getTimelineTemporal().resume();
+    });
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const arg = updateMutate.mock.calls[0][0] as {
+      document: { tracks: unknown[] };
+    };
+    expect(arg.document.tracks).toHaveLength(1);
   });
 });

--- a/web/src/hooks/timeline/timelineDocumentPayload.ts
+++ b/web/src/hooks/timeline/timelineDocumentPayload.ts
@@ -1,0 +1,34 @@
+/**
+ * timelineDocumentPayload
+ *
+ * Single source of truth for the `document` object sent to
+ * `trpc.timeline.update` — shared by {@link useTimelineAutosave} and
+ * {@link useTimelineSave} so a manual "Save now" can never diverge from what
+ * autosave persists (previously the manual save omitted `transcript`, risking
+ * losing transcript state autosave hadn't flushed yet).
+ */
+import type { TimelineStoreState } from "../../stores/timeline/TimelineStore";
+
+export interface TimelineDocumentPayload {
+  tracks: TimelineStoreState["tracks"];
+  clips: TimelineStoreState["clips"];
+  markers: TimelineStoreState["markers"];
+  transcript: TimelineStoreState["transcript"];
+  scriptEnabled: TimelineStoreState["scriptEnabled"];
+}
+
+/** Build the `document` PATCH payload from any state slice carrying these fields. */
+export function buildTimelineDocumentPayload(
+  state: Pick<
+    TimelineStoreState,
+    "tracks" | "clips" | "markers" | "transcript" | "scriptEnabled"
+  >
+): TimelineDocumentPayload {
+  return {
+    tracks: state.tracks,
+    clips: state.clips,
+    markers: state.markers,
+    transcript: state.transcript,
+    scriptEnabled: state.scriptEnabled
+  };
+}

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { trpcClient } from "../../trpc/client";
 import { queryClient } from "../../queryClient";
 import { fetchWorkflowById, workflowQueryKey } from "../../serverState/useWorkflow";
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { useTimelineGenerationStore } from "../../stores/timeline/TimelineGenerationStore";
+import { findClipById } from "../../stores/timeline/clipLookup";
 import { getWorkflowRunnerStore } from "../../stores/WorkflowRunner";
 import { graphNodeToReactFlowNode } from "../../stores/graphNodeToReactFlowNode";
 import { graphEdgeToReactFlowEdge } from "../../stores/graphEdgeToReactFlowEdge";
@@ -274,9 +275,10 @@ export const handleJobMessage = async (jobId: string, message: WebSocketMessage)
 
   if (status === "cancelled") {
     generationStore.clearJob(context.clipId);
-    const clip = useTimelineStore
-      .getState()
-      .clips.find((candidate) => candidate.id === context.clipId);
+    const clip = findClipById(
+      useTimelineStore.getState().clips,
+      context.clipId
+    );
     if (clip) {
       useTimelineStore
         .getState()
@@ -316,22 +318,32 @@ const subscribeJob = async (
 };
 
 export const useTimelineGenerationSubscriptions = (): void => {
-  const clipJobs = useTimelineGenerationStore((state) => state.clipJobs);
+  // A sorted, comma-joined string of active job ids — a primitive, so it only
+  // changes identity when a job *enters or leaves* the active set, never on
+  // the progress-only updates `updateJobProgress` publishes per WebSocket
+  // message. That keeps this subscribe/unsubscribe effect from re-running
+  // (and re-rendering the shell that hosts this hook) per progress tick.
+  const activeJobIdsKey = useTimelineGenerationStore((state) =>
+    Object.values(state.clipJobs)
+      .filter((job) => isActiveStatus(job.status))
+      .map((job) => job.jobId)
+      .sort()
+      .join(",")
+  );
 
-  const activeJobs = useMemo(() => {
+  useEffect(() => {
+    const clipJobs = useTimelineGenerationStore.getState().clipJobs;
     const clips = useTimelineStore.getState().clips;
-    return Object.values(clipJobs)
+    const activeJobs = Object.values(clipJobs)
       .filter((job) => isActiveStatus(job.status))
       .map((job) => ({
         clipId: job.clipId,
         jobId: job.jobId,
         workflowId: job.workflowId,
-        selectedOutputNodeId: clips.find((c) => c.id === job.clipId)
+        selectedOutputNodeId: findClipById(clips, job.clipId)
           ?.selectedOutputNodeId
       }));
-  }, [clipJobs]);
 
-  useEffect(() => {
     const activeJobIdSet = new Set(activeJobs.map((job) => job.jobId));
 
     for (const [jobId] of jobSubscriptions) {
@@ -351,7 +363,7 @@ export const useTimelineGenerationSubscriptions = (): void => {
         true
       );
     }
-  }, [activeJobs]);
+  }, [activeJobIdsKey]);
 };
 
 interface UseGenerateClipResult {
@@ -372,9 +384,7 @@ interface UseGenerateClipResult {
 }
 
 export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
-  const clip = useTimelineStore((state) =>
-    state.clips.find((candidate) => candidate.id === clipId)
-  );
+  const clip = useTimelineStore((state) => findClipById(state.clips, clipId));
   const patchClip = useTimelineStore((state) => state.patchClip);
   const jobState = useTimelineGenerationStore((state) => state.clipJobs[clipId]);
 
@@ -494,9 +504,7 @@ export const useGenerateClip = (clipId: string): UseGenerateClipResult => {
     unsubscribeJob(jobState.jobId);
     clearJob(clipId);
 
-    const currentClip = useTimelineStore
-      .getState()
-      .clips.find((candidate) => candidate.id === clipId);
+    const currentClip = findClipById(useTimelineStore.getState().clips, clipId);
     if (currentClip) {
       patchClip(clipId, { status: deriveIdleClipStatus(currentClip) });
     }

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -126,7 +126,7 @@ function toClipNode(
 
 function toTrackNode(
   track: TimelineTrack,
-  clips: TimelineClip[]
+  clipCount: number
 ): TimelineTrackNode {
   return {
     id: track.id,
@@ -137,7 +137,7 @@ function toTrackNode(
     locked: track.locked,
     muted: !!track.muted,
     solo: !!track.solo,
-    clipCount: clips.reduce((n, c) => (c.trackId === track.id ? n + 1 : n), 0)
+    clipCount
   };
 }
 
@@ -203,6 +203,11 @@ export const useTimelineAgentBridge = (active: boolean): void => {
       getSnapshot(): TimelineSnapshot {
         const state = doc.getState();
         const tracks = state.tracks;
+        const map = trackMap();
+        const clipCountByTrack = new Map<string, number>();
+        for (const c of state.clips) {
+          clipCountByTrack.set(c.trackId, (clipCountByTrack.get(c.trackId) ?? 0) + 1);
+        }
         return {
           sequenceId: state.sequenceId,
           fps: state.fps,
@@ -211,15 +216,18 @@ export const useTimelineAgentBridge = (active: boolean): void => {
           durationMs: state.durationMs,
           playheadMs: Math.round(playback.getState().getTimeMs()),
           selectedClipIds: [...ui.getState().selectedClipIds],
-          tracks: tracks.map((t) => toTrackNode(t, state.clips)),
-          clips: state.clips.map((c) => toClipNode(c, trackMap()))
+          tracks: tracks.map((t) =>
+            toTrackNode(t, clipCountByTrack.get(t.id) ?? 0)
+          ),
+          clips: state.clips.map((c) => toClipNode(c, map))
         };
       },
 
       addTrack(type, name) {
         doc.getState().addTrack(type, name);
         const tracks = doc.getState().tracks;
-        return toTrackNode(tracks[tracks.length - 1], doc.getState().clips);
+        // A freshly added track has no clips yet.
+        return toTrackNode(tracks[tracks.length - 1], 0);
       },
 
       async generateClip(opts) {

--- a/web/src/hooks/timeline/useTimelineAutosave.ts
+++ b/web/src/hooks/timeline/useTimelineAutosave.ts
@@ -21,12 +21,22 @@
  *     save; the one exception is a load that migrated a legacy transcript,
  *     which is persisted once (see `markTimelineLoadMigrated`).
  *   - Pending edits are flushed on unmount.
+ *   - Gesture-aware: a drag/trim/slider gesture pauses the zundo temporal
+ *     store for its duration (`useTimelineHistoryBatch`). If the debounce
+ *     timer fires while a gesture is still open, the flush re-arms itself
+ *     instead of PATCHing the intermediate, mid-gesture state — pointerup
+ *     resumes tracking and the next flush attempt (scheduled or the one it
+ *     just re-armed) goes through.
  */
 import { useEffect, useRef } from "react";
 
-import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import {
+  useTimelineStoreApi,
+  timelineTemporalOf
+} from "../../stores/timeline/TimelineStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { trpcClient } from "../../trpc/client";
+import { buildTimelineDocumentPayload } from "./timelineDocumentPayload";
 
 import type { TimelineStoreState } from "../../stores/timeline/TimelineStore";
 
@@ -48,11 +58,7 @@ interface DocumentSnapshot {
 const pickSnapshot = (state: TimelineStoreState): DocumentSnapshot => ({
   sequenceId: state.sequenceId,
   baseUpdatedAt: state.baseUpdatedAt,
-  tracks: state.tracks,
-  clips: state.clips,
-  markers: state.markers,
-  transcript: state.transcript,
-  scriptEnabled: state.scriptEnabled
+  ...buildTimelineDocumentPayload(state)
 });
 
 // Sequence ids whose load migrated a legacy transcript onto clips. The
@@ -137,13 +143,7 @@ export function useTimelineAutosave(
         const response = await trpcClient.timeline.update.mutate({
           id: snapshot.sequenceId,
           baseUpdatedAt: baseUpdatedAt ?? undefined,
-          document: {
-            tracks: snapshot.tracks,
-            clips: snapshot.clips,
-            markers: snapshot.markers,
-            transcript: snapshot.transcript,
-            scriptEnabled: snapshot.scriptEnabled
-          }
+          document: buildTimelineDocumentPayload(snapshot)
         });
         const updatedAt = (response as { updatedAt?: unknown } | undefined)
           ?.updatedAt;
@@ -198,6 +198,15 @@ export function useTimelineAutosave(
         timeoutRef.current = null;
       }
       if (inFlightRef.current) return;
+      if (!timelineTemporalOf(store).isTracking) {
+        // A drag/trim/slider gesture is holding history paused
+        // (useTimelineHistoryBatch). Saving now would PATCH intermediate,
+        // mid-gesture state. Re-arm instead of clearing `pendingRef` — the
+        // gesture always ends on pointerup (which resumes tracking), so the
+        // re-armed timer's flush goes through with no cap needed.
+        scheduleFn();
+        return;
+      }
       const pending = pendingRef.current;
       pendingRef.current = null;
       if (!pending || !pending.sequenceId) return;

--- a/web/src/hooks/timeline/useTimelineExport.ts
+++ b/web/src/hooks/timeline/useTimelineExport.ts
@@ -8,9 +8,8 @@
  */
 
 import { useCallback, useRef, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 
-import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
 import { useAssetStore } from "../../stores/AssetStore";
 import { getAssetUrl } from "../../utils/assetHelpers";
 import {
@@ -53,17 +52,15 @@ function clipEndMs(clip: { startMs: number; durationMs: number }): number {
   return clip.startMs + clip.durationMs;
 }
 
+/** Minimum time between non-terminal progress state updates, in ms. */
+const PROGRESS_UPDATE_INTERVAL_MS = 250;
+
 export function useTimelineExport(): UseTimelineExportResult {
-  const { tracks, clips, width, height, fps, durationMs } = useTimelineStore(
-    useShallow((s) => ({
-      tracks: s.tracks,
-      clips: s.clips,
-      width: s.width,
-      height: s.height,
-      fps: s.fps,
-      durationMs: s.durationMs
-    }))
-  );
+  // `tracks`/`clips`/etc. are only read once, at click time, inside
+  // `exportVideo` — reading them via the store api (instead of a reactive
+  // selector) means drag/trim/slider ticks that replace `clips` no longer
+  // re-render this hook's owner (the whole editor shell).
+  const store = useTimelineStoreApi();
   const getAsset = useAssetStore((s) => s.get);
 
   const [isExporting, setIsExporting] = useState(false);
@@ -97,26 +94,47 @@ export function useTimelineExport(): UseTimelineExportResult {
         }
       };
 
+      // Coalesce per-frame progress into React state: at most one update per
+      // `PROGRESS_UPDATE_INTERVAL_MS`, plus every integer-percent change, plus
+      // the terminal update (ratio 1) so the dialog always reaches 100%.
+      let lastProgressPercent = -1;
+      let lastProgressAtMs = 0;
+      const handleProgress = (next: RenderProgress): void => {
+        const percent = Math.round(next.ratio * 100);
+        const now = Date.now();
+        const isTerminal = next.ratio >= 1;
+        if (
+          isTerminal ||
+          percent !== lastProgressPercent ||
+          now - lastProgressAtMs >= PROGRESS_UPDATE_INTERVAL_MS
+        ) {
+          lastProgressPercent = percent;
+          lastProgressAtMs = now;
+          setProgress(next);
+        }
+      };
+
       try {
-        const clipsDurationMs = clips.reduce(
+        const state = store.getState();
+        const clipsDurationMs = state.clips.reduce(
           (max, clip) => Math.max(max, clipEndMs(clip)),
           0
         );
-        const exportDurationMs = Math.max(durationMs, clipsDurationMs);
+        const exportDurationMs = Math.max(state.durationMs, clipsDurationMs);
         if (exportDurationMs <= 0) {
           throw new Error("Add a clip before exporting.");
         }
 
         const { bytes, mimeType } = await renderTimeline({
-          tracks,
-          clips,
-          width,
-          height,
-          fps,
+          tracks: state.tracks,
+          clips: state.clips,
+          width: state.width,
+          height: state.height,
+          fps: state.fps,
           durationMs: exportDurationMs,
           resolveUrl,
           signal: controller.signal,
-          onProgress: setProgress
+          onProgress: handleProgress
         });
         downloadBlob(bytes, mimeType, `${sanitizeFilename(filename ?? "timeline")}.mp4`);
       } catch (err) {
@@ -131,7 +149,7 @@ export function useTimelineExport(): UseTimelineExportResult {
         setProgress(null);
       }
     },
-    [tracks, clips, width, height, fps, durationMs, getAsset]
+    [store, getAsset]
   );
 
   return { exportVideo, cancel, clearError, isExporting, progress, error };

--- a/web/src/hooks/timeline/useTimelineSave.ts
+++ b/web/src/hooks/timeline/useTimelineSave.ts
@@ -4,13 +4,17 @@
  * Autosave ({@link useTimelineAutosave}) covers the common case, but the Save
  * button lets the user force an immediate PATCH of the current document and see
  * explicit feedback. Reads the live snapshot straight from the TimelineStore
- * and rolls `baseUpdatedAt` forward from the response, same as autosave.
+ * and rolls `baseUpdatedAt` forward from the response, same as autosave. The
+ * document payload itself comes from the shared `buildTimelineDocumentPayload`
+ * (see `timelineDocumentPayload.ts`) so this can never send a different field
+ * set than autosave does.
  */
 import { useCallback, useState } from "react";
 
 import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { trpcClient } from "../../trpc/client";
+import { buildTimelineDocumentPayload } from "./timelineDocumentPayload";
 
 export interface UseTimelineSaveResult {
   /** PATCH the current document immediately. Resolves when the save settles. */
@@ -30,12 +34,7 @@ export function useTimelineSave(): UseTimelineSaveResult {
       const response = await trpcClient.timeline.update.mutate({
         id: state.sequenceId,
         baseUpdatedAt: state.baseUpdatedAt ?? undefined,
-        document: {
-          tracks: state.tracks,
-          clips: state.clips,
-          markers: state.markers,
-          scriptEnabled: state.scriptEnabled
-        }
+        document: buildTimelineDocumentPayload(state)
       });
       const updatedAt = (response as { updatedAt?: unknown } | undefined)
         ?.updatedAt;

--- a/web/src/stores/instanceStoreHook.ts
+++ b/web/src/stores/instanceStoreHook.ts
@@ -7,18 +7,32 @@
  * currently active instance (`pickCurrent`). This keeps every existing call
  * site — both `useStore(selector)` and `useStore.getState()` — working without
  * edits while the underlying store is now created per editor instance.
+ *
+ * Returns `UseBoundStoreWithEqualityFn` (not plain `UseBoundStore`) and
+ * forwards the selector's equality-fn argument to `useStoreWithEqualityFn` —
+ * otherwise `useStore(selector, shallow)` would compile but silently ignore
+ * `shallow`, since a plain `UseBoundStore` call signature only takes the
+ * selector.
  */
 import type { StoreApi, UseBoundStore } from "zustand";
-import { useStoreWithEqualityFn } from "zustand/traditional";
+import {
+  useStoreWithEqualityFn,
+  type UseBoundStoreWithEqualityFn
+} from "zustand/traditional";
 
 export function createInstanceHook<S>(
   pickReactive: () => UseBoundStore<StoreApi<S>>,
   pickCurrent: () => UseBoundStore<StoreApi<S>>
-): UseBoundStore<StoreApi<S>> {
-  const hook = (<T,>(selector: (state: S) => T): T =>
-    useStoreWithEqualityFn(pickReactive(), selector)) as UseBoundStore<
-    StoreApi<S>
-  >;
+): UseBoundStoreWithEqualityFn<StoreApi<S>> {
+  const hook = (<T,>(
+    selector: (state: S) => T,
+    equalityFn?: (a: T, b: T) => boolean
+  ): T =>
+    useStoreWithEqualityFn(
+      pickReactive(),
+      selector,
+      equalityFn
+    )) as UseBoundStoreWithEqualityFn<StoreApi<S>>;
   hook.getState = () => pickCurrent().getState();
   hook.getInitialState = () => pickCurrent().getInitialState();
   hook.setState = ((partial: unknown, replace?: unknown) =>

--- a/web/src/stores/timeline/clipLookup.ts
+++ b/web/src/stores/timeline/clipLookup.ts
@@ -1,0 +1,34 @@
+/**
+ * O(1) clip lookup keyed on the clips array identity.
+ *
+ * TimelineStore reducers replace the `clips` array on every mutation, so a
+ * WeakMap keyed on the array gives each store publish exactly one index
+ * build, shared by every selector that needs an id lookup. Selectors like
+ * `s.clips.find((c) => c.id === id)` are O(n) per subscriber per publish —
+ * O(n²) aggregate during drags; `findClipById(s.clips, id)` is O(1) after
+ * the first call per publish.
+ */
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+const indexCache = new WeakMap<
+  readonly TimelineClip[],
+  Map<string, TimelineClip>
+>();
+
+export function clipsById(
+  clips: readonly TimelineClip[]
+): Map<string, TimelineClip> {
+  let index = indexCache.get(clips);
+  if (!index) {
+    index = new Map(clips.map((c) => [c.id, c]));
+    indexCache.set(clips, index);
+  }
+  return index;
+}
+
+export function findClipById(
+  clips: readonly TimelineClip[],
+  clipId: string
+): TimelineClip | undefined {
+  return clipsById(clips).get(clipId);
+}

--- a/web/src/stores/timeline/transcriptOps.ts
+++ b/web/src/stores/timeline/transcriptOps.ts
@@ -206,6 +206,18 @@ function buildSegment(key: string, members: TimelineClip[]): TranscriptSegment {
 }
 
 /**
+ * `buildTranscriptDoc` runs per store publish from three consumers
+ * (`ScriptLane`, `TranscriptPanel`, `TranscriptEditor`'s `SyncPlugin`) and its
+ * own recursive callers (`fillerRanges`, `reconcileTranscript`). Clips arrays
+ * are never mutated in place (every mutation in this module and in
+ * `TimelineStore` replaces the array), so the same array reference always
+ * projects to the same doc — safe to memoize by identity. A `WeakMap` lets
+ * both the array and its cached doc be collected together once the array is
+ * no longer referenced.
+ */
+const transcriptDocCache = new WeakMap<readonly TimelineClip[], TranscriptDoc>();
+
+/**
  * Project the editable transcript from the timeline's clips. Consecutive clips
  * sharing a `paragraphId` collapse into one paragraph (segment); each word
  * becomes an absolute-timed token tagged with its source clip. The result is
@@ -213,6 +225,9 @@ function buildSegment(key: string, members: TimelineClip[]): TranscriptSegment {
  * delete uses to translate text positions back to the timeline.
  */
 export function buildTranscriptDoc(clips: TimelineClip[]): TranscriptDoc {
+  const cached = transcriptDocCache.get(clips);
+  if (cached) return cached;
+
   const sorted = clips.filter(isTranscriptClip).sort(byTimeline);
   const segments: TranscriptSegment[] = [];
 
@@ -227,7 +242,9 @@ export function buildTranscriptDoc(clips: TimelineClip[]): TranscriptDoc {
     segments.push(buildSegment(key, members));
   }
 
-  return { segments, durationMs: maxEnd(sorted) };
+  const doc: TranscriptDoc = { segments, durationMs: maxEnd(sorted) };
+  transcriptDocCache.set(clips, doc);
+  return doc;
 }
 
 // ── Layout ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Performance audit of the timeline editor (~28k lines) plus fixes for the highest-impact findings. The audit report ships in this PR as `docs/timeline-editor-performance-audit.md` with file:line evidence for every finding, what was already well-optimized, and a prioritized follow-up list.

The architecture verdict: playback was already sound (transient time channel, zero React renders per frame). The real costs were **gestures writing to the undo-tracked store per pointermove**, **per-frame scene recomputation**, and **unbounded scaling** (audio decode, caches, media elements). Each commit fixes one area and was reviewed and tested independently.

## Changes

**Gesture batching (undo correctness + fanout)**
- All ~40 inspector/FX sliders and the EQ/compressor curves coalesce writes to one per animation frame and wrap gestures in `useTimelineHistoryBatch` — previously a two-second drag pushed ~120 undo entries, evicting the entire 100-entry undo history. Prompt typing batches focus→blur.
- The transform gizmo gets `onDragStart`/`onDragEnd` and batches the same way (one undo entry per drag, live preview unchanged); its pointermove handler reuses the rect cached at pointerdown.
- Arrow-key nudges batch per held-key burst.

**Wide-subscription fixes (whole-shell re-renders)**
- `useTimelineExport` selected `clips`/`tracks` reactively at the editor root but only read them at click time — every drag tick re-rendered the entire shell. Now reads `getState()` at export time; export progress coalesces to integer-percent/250 ms updates.
- `useTimelineGenerationSubscriptions` selected the whole `clipJobs` record, re-rendering the shell per WebSocket progress message. Now keyed on a sorted job-id string that only changes when a job enters/leaves the active set.
- Zoom (`msPerPx`) and generation counts moved into a status-bar leaf; TopBar/dialog props stabilized; tracks-resize drag rAF-throttled.

**Per-event hot paths**
- Clip-by-id selectors use a shared WeakMap-keyed `clipsById` index — O(1) per publish instead of N clips × O(N) `find` scans per drag tick.
- Wheel zoom coalesces to one `setZoom` per frame through a stable listener (also fixes stale-scale zoom skips); panning and rubber-band selection no longer re-render the tracks region; right-edge drags stop re-layouting the scroll area per move (256 px width quantization).
- Playhead positions via compositor-only `transform` instead of `style.left` (layout invalidation per frame); ruler `aria-valuenow` updates imperatively from the transient time channel.
- Filmstrip thumbnails apply data URLs via inline style instead of per-render emotion CSS (multi-KB string hashing per trim tick + permanent CSSOM growth).

**Playback loop**
- `computeActiveLayersWithHorizon` returns `nextChangeMs` (nearest clip boundary or caption word boundary); the compositor's rAF tick skips scene recomputation until the horizon is crossed, the playhead jumps backward, or the document changes — steady-state playback is one float compare per frame instead of a full scene derivation (tracks sort + Map build + per-word allocations at 60 fps).

**Transcript layer**
- `buildTranscriptDoc` memoizes by clips-array identity; all three consumers select only the caption-bearing clip subset, so B-roll drags no longer touch the transcript layer.
- A shared `TranscriptWordIndex` (one DOM scan per rebuild, binary search per tick) replaces per-tick `querySelectorAll` + offset reads in the karaoke/caret/selection plugins. Also fixes the ScriptLane highlight being frozen during playback.
- The editor reseed check runs on a leading+trailing 150 ms cooldown: caption-clip drags collapse from one Lexical rebuild per pointermove to two per burst.

**Audio & scaling**
- Play gesture schedules only clips within a 30 s lookahead (was: fetch + `decodeAudioData` for every remaining clip in the timeline before the clock starts); a 5 s top-up brings in clips as the window advances via a new `AudioGraph.addClips` that never disturbs playing sources. Seek-while-playing restarts are debounced 120 ms.
- Export releases pooled video elements once a clip's range has passed (live media elements cap at overlap width, not total clip count) and resolves each frame's layers concurrently, order-preserved.
- Thumbnail cache gains a 32-entry LRU and 30 s failure retry (was unbounded, failures permanently poisoned).

**Correctness fixes surfaced by the audit**
- Manual Save silently omitted `transcript` from its PATCH while autosave included it; both now build the document from one shared payload helper.
- Autosave no longer fires mid-gesture (flush re-arms while a history batch holds the temporal store paused). New test covers this.
- `createInstanceHook` silently dropped a second equality argument — `useStore(sel, shallow)` compiled but ignored `shallow`. Now forwarded and typed.

## Not included (follow-ups listed in the audit)

GPU-visual work (effects output caching, caption strip-sized rasterization) since compositing correctness needs visual verification; clip virtualization (structural change deserving its own PR); worker-thread export; `ResultsStore` chunk accumulation.

## Testing

- `tsc --noEmit` clean on the combined tree
- Full timeline test sweep: 58 suites / 626 tests pass, including a new autosave gesture-gating test and updated Playhead transform assertions
- Lint: 0 errors
- Each area was additionally verified by its focused suites before landing (historyBatching, TimelineEditor, TimelineGenerationStore, timelineWheel, TimelineScrollbar, transcriptOps, TimelinePlaybackStore, PreviewArea, AudioGraph, preview, sceneModel, useTimelineAutosave, useLoadTimelineIntoStore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyvdWq8oVQW4hivPQixKJk