### PR TITLE
Add ComfyUI worker proxy support (bridge protocol v3)

### DIFF
--- a/docs/python-bridge-protocol.md
+++ b/docs/python-bridge-protocol.md
@@ -151,6 +151,49 @@ simply does not expose them (see [Versioning](#versioning)).
 - `models.download` — download a model onto the worker cache, streaming ordered `progress` frames then a terminal `result`
 - `models.delete` — delete a cached model; returns whether it existed
 
+### `comfy.*`
+
+ComfyUI proxy. Introduced in bridge protocol **v3**, gated by `supportsComfy()`
+— a worker offers these only when it fronts a co-located, loopback-only ComfyUI
+server AND reports `worker.status.comfy.enabled: true`. Route `comfy.*` requests
+only to such workers. The full field-level reference lives in
+`docs/comfy-proxy.md` in nodetool-core.
+
+- `comfy.execute` — submit an API-format workflow; streams its lifecycle as
+  dedicated `comfy.event` frames (see below), then a terminal `result`/`error`.
+  Cancel with the standard `cancel` frame.
+- `comfy.queue` — `{queue_running, queue_pending}`
+- `comfy.interrupt` — global stop of the running job (admin-only)
+- `comfy.cancel` — best-effort per-prompt cancel (`{prompt_id}`); the safe
+  user-facing cancel
+- `comfy.upload` / `comfy.view` — stage a file into / fetch a file from ComfyUI's
+  input dir
+- `comfy.object_info` — full ComfyUI node catalog
+- `comfy.system_stats` / `comfy.status` — health/capacity; `comfy.status` adds
+  worker-level `{enabled, url, reachable}`
+- `comfy.free` — unload models from VRAM without a cold restart
+- `comfy.models.list` / `comfy.models.download` / `comfy.models.delete` — manage
+  model files on the worker's persistent volume. `comfy.models.download` streams
+  generic `progress` frames (NOT `comfy.event`) then a terminal `result`.
+
+#### `comfy.event`
+
+`comfy.execute` does **not** stream `progress` frames — ComfyUI's events don't
+fit the `{progress, total, message}` shape. Instead it emits a dedicated frame:
+
+```json
+{
+  "type": "comfy.event",
+  "request_id": "<the execute request's id>",
+  "data": { "event": "executing", "prompt_id": "p1", "node": "3" }
+}
+```
+
+`data.event` is the discriminator, in emission order: `queued` → `queue`
+(repeatable) → `started` / `cached` → `executing` (per node) → `progress` →
+`node_output` → `preview` (only if `previews: true`) → `completed` or
+`cancelled`. `result` is always the last frame.
+
 ## Result, error, chunk, and progress
 
 ### `result`
@@ -230,7 +273,7 @@ The JS runtime and Python worker each report a `BRIDGE_PROTOCOL_VERSION`. Two
 distinct numbers govern compatibility (see `packages/protocol/src/bridge-protocol.ts`):
 
 - **`BRIDGE_PROTOCOL_VERSION`** — the protocol the JS runtime currently speaks
-  (presently `2`).
+  (presently `3`).
 - **`MIN_BRIDGE_PROTOCOL_VERSION`** — the *hard floor* (presently `1`). The JS
   runtime rejects a worker only if it reports a protocol **below** this floor.
 
@@ -239,8 +282,9 @@ Compatibility rules:
 - **Older worker, at or above the floor** — connects normally. It does **not**
   fail startup. Additive features the worker predates are gated per-capability:
   a v1 worker connects fine and simply doesn't expose the `models.*` family
-  (gated by `supportsModelManagement()`, which requires v2+). Workers that
-  predate the `protocol_version` field are treated as v1.
+  (gated by `supportsModelManagement()`, which requires v2+) or `comfy.*`
+  (gated by `supportsComfy()`, which requires v3+ and `comfy.enabled`). Workers
+  that predate the `protocol_version` field are treated as v1.
 - **Worker below `MIN_BRIDGE_PROTOCOL_VERSION`** — rejected at `discover` with
   an actionable error (reinstall the Python environment). This is the only
   startup-failing case, reserved for genuine wire breaks.

--- a/docs/worker-deployment.md
+++ b/docs/worker-deployment.md
@@ -46,6 +46,20 @@ tables live in NodeTool's SQLite DB so the UI and CLI share one source of truth.
   built from a NodeTool Python package. It must run `python -m nodetool.worker`
   on port 7777 (msgpack RPC, bearer-token auth).
 
+### Worker images
+
+| Image | Contents | Use for |
+|-------|----------|---------|
+| `ghcr.io/nodetool-ai/nodetool-worker:latest` | The lean Python worker | Python nodes, HuggingFace pipelines, LLM providers |
+| `ghcr.io/nodetool-ai/nodetool-worker-comfy:latest` | Worker + a co-located, loopback-only ComfyUI | Everything above **plus** the **Run ComfyUI Workflow (Worker)** node |
+
+A worker started from the ComfyUI image fronts ComfyUI over the worker bridge
+(ComfyUI itself is never exposed outside the container) and reports
+`worker.status.comfy.enabled: true`. The **Run ComfyUI Workflow (Worker)** node
+runs an API-format ComfyUI workflow on such a worker. Pick the ComfyUI image
+from the **Worker image preset** dropdown in the Profiles editor, or pass
+`--image ghcr.io/nodetool-ai/nodetool-worker-comfy:latest` on the CLI.
+
 Store the API key in the secret store so the manager can read it:
 
 ```bash

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -697,6 +697,7 @@ export { GEMINI_NODES } from "@nodetool-ai/llm-nodes/nodes/gemini";
 export { APIFY_NODES } from "@nodetool-ai/integration-nodes/nodes/apify";
 export {
   ComfyWorkflowNode,
+  ComfyWorkerWorkflowNode,
   COMFY_NODES
 } from "@nodetool-ai/integration-nodes/nodes/comfy";
 export { MESSAGING_NODES } from "@nodetool-ai/integration-nodes/nodes/messaging";

--- a/packages/integration-nodes/src/nodes/comfy.ts
+++ b/packages/integration-nodes/src/nodes/comfy.ts
@@ -4,6 +4,10 @@ import {
   executeComfy,
   uploadComfyFile,
   loadMediaRefBytes,
+  WebsocketPythonBridge,
+  type PythonBridge,
+  type ComfyEvent,
+  type ComfyExecuteResult,
   type ProcessingContext,
   type MediaRefValue,
   type ComfyNodeOutputs,
@@ -346,4 +350,295 @@ export class ComfyWorkflowNode extends BaseNode {
   }
 }
 
-export const COMFY_NODES = tagAsServer([ComfyWorkflowNode]);
+/** Sniff a media kind + mime from the leading bytes of a ComfyUI output blob. */
+function sniffMedia(bytes: Uint8Array): {
+  kind: "image" | "audio" | "video";
+  mime: string;
+} {
+  const b = bytes;
+  // PNG
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return { kind: "image", mime: "image/png" };
+  }
+  // JPEG
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) {
+    return { kind: "image", mime: "image/jpeg" };
+  }
+  // GIF
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) {
+    return { kind: "image", mime: "image/gif" };
+  }
+  // RIFF container: WEBP (image) or WAV (audio)
+  if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46) {
+    if (b[8] === 0x57 && b[9] === 0x41 && b[10] === 0x56 && b[11] === 0x45) {
+      return { kind: "audio", mime: "audio/wav" };
+    }
+    return { kind: "image", mime: "image/webp" };
+  }
+  // ftyp box → MP4/MOV
+  if (b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70) {
+    return { kind: "video", mime: "video/mp4" };
+  }
+  // OGG
+  if (b[0] === 0x4f && b[1] === 0x67 && b[2] === 0x67 && b[3] === 0x53) {
+    return { kind: "audio", mime: "audio/ogg" };
+  }
+  // ID3 / MPEG audio
+  if (b[0] === 0x49 && b[1] === 0x44 && b[2] === 0x33) {
+    return { kind: "audio", mime: "audio/mpeg" };
+  }
+  return { kind: "image", mime: "image/png" };
+}
+
+/**
+ * Run a ComfyUI workflow on a NodeTool worker that fronts a co-located,
+ * loopback-only ComfyUI server (the `nodetool-worker-comfy` image), proxied
+ * over the worker bridge as `comfy.*` messages.
+ *
+ * Unlike {@link ComfyWorkflowNode} — which talks to a ComfyUI HTTP endpoint
+ * directly — this node connects to the worker's WebSocket bridge and calls
+ * `comfy.execute`. ComfyUI itself is never exposed outside the worker. Input
+ * media is sent as bridge blobs referenced from the workflow JSON via
+ * `"blob:<key>"` placeholders; the worker uploads them to ComfyUI before
+ * submitting. Generated files come back as output blobs and are emitted as
+ * typed media refs (kind sniffed from the bytes), one dynamic slot per file,
+ * plus a static `output` slot carrying the raw ComfyUI outputs.
+ */
+export class ComfyWorkerWorkflowNode extends BaseNode {
+  static readonly nodeType = "lib.comfy.RunWorkflowOnWorker";
+  static readonly title = "Run ComfyUI Workflow (Worker)";
+  static readonly description =
+    "Run a ComfyUI workflow on a NodeTool worker (nodetool-worker-comfy) over the worker bridge.\n    comfy, comfyui, workflow, worker, runpod, diffusion\n\n    Use cases:\n    - Run ComfyUI on a remote GPU worker without exposing ComfyUI directly\n    - Drive a RunPod ComfyUI worker from inside a NodeTool workflow";
+  static readonly supportsDynamicInputs = true;
+  static readonly supportsDynamicOutputs = true;
+  static readonly metadataOutputTypes = {
+    output: "dict[str, any]"
+  };
+
+  @prop({
+    type: "str",
+    default: "ws://127.0.0.1:7777/ws",
+    title: "Worker URL",
+    description:
+      "WebSocket URL of the NodeTool worker fronting ComfyUI, e.g. ws://host:7777/ws.",
+    required: true
+  })
+  declare worker_url: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Worker Token",
+    description: "Bearer token for the worker, if it requires authentication."
+  })
+  declare worker_token: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Workflow",
+    description:
+      "ComfyUI workflow in API (prompt) format, as a JSON string: a map of node id to { class_type, inputs }.",
+    required: true
+  })
+  declare workflow: any;
+
+  @prop({
+    type: "int",
+    default: 600,
+    title: "Timeout",
+    description: "Maximum seconds to wait for the workflow to finish.",
+    min: 1
+  })
+  declare timeout: any;
+
+  @prop({
+    type: "bool",
+    default: false,
+    title: "Previews",
+    description: "Stream ComfyUI preview images while the workflow runs."
+  })
+  declare previews: any;
+
+  /**
+   * Connect a bridge to the worker. Split out so tests can inject a fake
+   * bridge without standing up a real WebSocket worker.
+   */
+  protected async connectBridge(): Promise<PythonBridge> {
+    const url = String(this.worker_url ?? "").trim();
+    const token = String(this.worker_token ?? "").trim();
+    const bridge = new WebsocketPythonBridge({
+      wsUrl: url,
+      workerToken: token || undefined,
+      // One-shot per node run — never keep reconnecting after we close.
+      autoRestart: false
+    });
+    await bridge.connect();
+    return bridge;
+  }
+
+  private parseWorkflow(value: unknown): ComfyPrompt {
+    let parsed: unknown = value;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) return {};
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch (err) {
+        throw new Error(
+          `ComfyUI workflow is not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as ComfyPrompt;
+  }
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const url = String(this.worker_url ?? "").trim();
+    if (!url) {
+      throw new Error("Worker URL is required");
+    }
+
+    const source = this.parseWorkflow(this.workflow);
+    if (Object.keys(source).length === 0) {
+      throw new Error(
+        "ComfyUI workflow is required (API prompt format: { nodeId: { class_type, inputs } })"
+      );
+    }
+
+    // Deep clone so injected inputs never mutate the stored workflow prop.
+    const prompt = JSON.parse(JSON.stringify(source)) as ComfyPrompt;
+
+    // Inject dynamic inputs. Media refs are sent as bridge blobs referenced
+    // from the workflow via "blob:<key>" placeholders; scalars go in directly.
+    const blobs: Record<string, Uint8Array> = {};
+    for (const [handle, value] of this.dynamicProps) {
+      if (value === undefined || value === null) continue;
+      const sep = handle.indexOf(":");
+      if (sep <= 0) continue;
+      const nodeId = handle.slice(0, sep);
+      const field = handle.slice(sep + 1);
+      const node = prompt[nodeId];
+      if (!node || typeof node.inputs !== "object" || node.inputs === null) {
+        continue;
+      }
+      if (isMediaRef(value)) {
+        const bytes = await loadMediaRefBytes(value as MediaRefValue, context);
+        if (!bytes) continue;
+        const key = `${nodeId}_${field}`;
+        blobs[key] = bytes;
+        node.inputs[field] = `blob:${key}`;
+      } else {
+        node.inputs[field] = value;
+      }
+    }
+
+    const self = this as unknown as Record<string, unknown>;
+    const nodeId = String(self.__node_id ?? "");
+    const nodeName = String(self.__node_name ?? "Run ComfyUI Workflow (Worker)");
+    const logLine = (
+      content: string,
+      severity: "info" | "warning" | "error" = "info"
+    ): void => {
+      context?.postMessage({
+        type: "log_update",
+        node_id: nodeId,
+        node_name: nodeName,
+        content,
+        severity
+      });
+    };
+
+    const onEvent = (event: ComfyEvent): void => {
+      switch (event.event) {
+        case "started":
+          logLine("Execution started");
+          break;
+        case "cached":
+          if (event.nodes?.length) {
+            logLine(`Reused cache for ${event.nodes.length} node(s)`);
+          }
+          break;
+        case "executing":
+          if (event.node) {
+            const cls = prompt[event.node]?.class_type ?? event.node;
+            logLine(`Executing ${cls} (#${event.node})`);
+          }
+          break;
+        case "progress":
+          if (
+            typeof event.value === "number" &&
+            typeof event.max === "number" &&
+            event.max > 0
+          ) {
+            context?.postMessage({
+              type: "node_progress",
+              node_id: nodeId,
+              progress: event.value,
+              total: event.max
+            });
+          }
+          break;
+        default:
+          break;
+      }
+    };
+
+    const bridge = await this.connectBridge();
+    let result: ComfyExecuteResult;
+    try {
+      if (!bridge.supportsComfy()) {
+        throw new Error(
+          "The connected worker does not front a ComfyUI server " +
+            "(worker.status.comfy.enabled is not set). Deploy the " +
+            "nodetool-worker-comfy image."
+        );
+      }
+      const nodeCount = Object.keys(prompt).length;
+      logLine(`Running ComfyUI workflow (${nodeCount} nodes) on ${url}`);
+      result = await bridge.comfyExecute(
+        prompt as unknown as Record<string, unknown>,
+        {
+          blobs: Object.keys(blobs).length > 0 ? blobs : undefined,
+          previews: Boolean(this.previews),
+          timeout: Math.max(1, Number(this.timeout ?? 600))
+        },
+        onEvent
+      );
+    } finally {
+      bridge.close();
+    }
+
+    const outputs: Record<string, unknown> = {};
+    const resultBlobs = result.blobs ?? {};
+    let fileCount = 0;
+    for (const [key, bytes] of Object.entries(resultBlobs)) {
+      if (!(bytes instanceof Uint8Array)) continue;
+      const { kind, mime } = sniffMedia(bytes);
+      fileCount += 1;
+      outputs[key] = {
+        type: kind,
+        uri: "",
+        data: Buffer.from(bytes).toString("base64"),
+        mimeType: mime
+      };
+    }
+
+    logLine(
+      `ComfyUI workflow completed (${fileCount} file${fileCount === 1 ? "" : "s"})`
+    );
+
+    outputs.output = result.outputs ?? {};
+    return outputs;
+  }
+}
+
+export const COMFY_NODES = tagAsServer([
+  ComfyWorkflowNode,
+  ComfyWorkerWorkflowNode
+]);

--- a/packages/integration-nodes/src/nodes/comfy.ts
+++ b/packages/integration-nodes/src/nodes/comfy.ts
@@ -368,12 +368,22 @@ function sniffMedia(bytes: Uint8Array): {
   if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) {
     return { kind: "image", mime: "image/gif" };
   }
-  // RIFF container: WEBP (image) or WAV (audio)
+  // RIFF container — disambiguate by the form type in bytes 8-11. RIFF is
+  // generic (WEBP, WAVE, AVI, …), so only classify on an exact form match and
+  // fall through otherwise rather than assuming WebP.
   if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46) {
+    // "WEBP"
+    if (b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50) {
+      return { kind: "image", mime: "image/webp" };
+    }
+    // "WAVE"
     if (b[8] === 0x57 && b[9] === 0x41 && b[10] === 0x56 && b[11] === 0x45) {
       return { kind: "audio", mime: "audio/wav" };
     }
-    return { kind: "image", mime: "image/webp" };
+    // "AVI "
+    if (b[8] === 0x41 && b[9] === 0x56 && b[10] === 0x49 && b[11] === 0x20) {
+      return { kind: "video", mime: "video/x-msvideo" };
+    }
   }
   // ftyp box → MP4/MOV
   if (b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70) {

--- a/packages/integration-nodes/tests/comfy.test.ts
+++ b/packages/integration-nodes/tests/comfy.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { getNodeMetadata } from "@nodetool-ai/node-sdk";
-import { ComfyWorkflowNode, COMFY_NODES } from "@nodetool-ai/integration-nodes";
+import {
+  ComfyWorkflowNode,
+  ComfyWorkerWorkflowNode,
+  COMFY_NODES
+} from "@nodetool-ai/integration-nodes";
+import type {
+  PythonBridge,
+  ComfyEvent,
+  ComfyExecuteResult
+} from "@nodetool-ai/runtime";
 
 const samplePrompt = {
   "3": {
@@ -54,6 +63,109 @@ describe("ComfyWorkflowNode", () => {
   it("throws a helpful error when the workflow JSON is malformed", async () => {
     const node = makeNode({ workflow: "{not json" });
     await expect(drain(node)).rejects.toThrow(/not valid JSON/i);
+  });
+});
+
+/**
+ * A ComfyWorkerWorkflowNode wired to an injected fake bridge, so the happy path
+ * can be exercised without a real WebSocket worker.
+ */
+class TestWorkerNode extends ComfyWorkerWorkflowNode {
+  constructor(
+    private readonly fakeBridge: PythonBridge,
+    public readonly capturedEvents: ComfyEvent[] = []
+  ) {
+    super();
+  }
+  protected async connectBridge(): Promise<PythonBridge> {
+    return this.fakeBridge;
+  }
+}
+
+function makeFakeBridge(
+  overrides: Partial<PythonBridge> = {}
+): PythonBridge & { closed: boolean; lastExecuteArgs: unknown[] } {
+  const bridge = {
+    closed: false,
+    lastExecuteArgs: [] as unknown[],
+    supportsComfy: () => true,
+    comfyExecute: async (
+      prompt: Record<string, unknown>,
+      options?: unknown,
+      onEvent?: (e: ComfyEvent) => void
+    ): Promise<ComfyExecuteResult> => {
+      bridge.lastExecuteArgs = [prompt, options];
+      onEvent?.({ event: "started", prompt_id: "p1" });
+      onEvent?.({ event: "executing", prompt_id: "p1", node: "3" });
+      // A 1x1 PNG so sniffMedia classifies the output blob as an image.
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      return { prompt_id: "p1", outputs: { "9": { images: [] } }, blobs: { "9_image": png } };
+    },
+    close: () => {
+      bridge.closed = true;
+    },
+    ...overrides
+  } as unknown as PythonBridge & { closed: boolean; lastExecuteArgs: unknown[] };
+  return bridge;
+}
+
+describe("ComfyWorkerWorkflowNode", () => {
+  it("is registered as a server node", () => {
+    expect(COMFY_NODES).toContain(ComfyWorkerWorkflowNode);
+  });
+
+  it("declares worker + dynamic-schema metadata", () => {
+    const metadata = getNodeMetadata(ComfyWorkerWorkflowNode);
+    expect(metadata.node_type).toBe("lib.comfy.RunWorkflowOnWorker");
+    expect(metadata.supports_dynamic_inputs).toBe(true);
+    expect(metadata.supports_dynamic_outputs).toBe(true);
+    const propNames = metadata.properties.map((p) => p.name);
+    expect(propNames).toEqual(
+      expect.arrayContaining(["worker_url", "workflow", "timeout", "previews"])
+    );
+  });
+
+  it("throws when the worker URL is empty", async () => {
+    const node = new TestWorkerNode(makeFakeBridge());
+    (node as unknown as { assign: (p: Record<string, unknown>) => void }).assign({
+      worker_url: "  ",
+      workflow: JSON.stringify(samplePrompt)
+    });
+    await expect(node.process()).rejects.toThrow(/worker url is required/i);
+  });
+
+  it("errors when the worker does not front ComfyUI, and still closes the bridge", async () => {
+    const bridge = makeFakeBridge({ supportsComfy: () => false });
+    const node = new TestWorkerNode(bridge);
+    (node as unknown as { assign: (p: Record<string, unknown>) => void }).assign({
+      worker_url: "ws://host:7777/ws",
+      workflow: JSON.stringify(samplePrompt)
+    });
+    await expect(node.process()).rejects.toThrow(/does not front a ComfyUI/i);
+    expect(bridge.closed).toBe(true);
+  });
+
+  it("runs the workflow over the bridge and maps output blobs to media refs", async () => {
+    const bridge = makeFakeBridge();
+    const node = new TestWorkerNode(bridge);
+    (node as unknown as { assign: (p: Record<string, unknown>) => void }).assign({
+      worker_url: "ws://host:7777/ws",
+      workflow: JSON.stringify(samplePrompt),
+      timeout: 120,
+      previews: false
+    });
+
+    const result = await node.process();
+
+    expect(bridge.closed).toBe(true);
+    // The image blob was sniffed as PNG and wrapped as an image media ref.
+    expect(result["9_image"]).toMatchObject({ type: "image", mimeType: "image/png" });
+    expect(typeof (result["9_image"] as { data: string }).data).toBe("string");
+    // The raw ComfyUI outputs are on the static `output` slot.
+    expect(result.output).toEqual({ "9": { images: [] } });
+    // Options were forwarded (timeout in seconds).
+    const [, options] = bridge.lastExecuteArgs as [unknown, { timeout: number }];
+    expect(options.timeout).toBe(120);
   });
 });
 

--- a/packages/protocol/src/bridge-protocol.ts
+++ b/packages/protocol/src/bridge-protocol.ts
@@ -20,7 +20,7 @@
  *     genuinely backward-incompatible changes (framing changes, schema breaks,
  *     a removed/changed message). Additive changes (new message types the old
  *     worker simply never receives) MUST NOT move this floor — they are gated
- *     per-feature instead (see `supportsModelManagement`).
+ *     per-feature instead (see `supportsModelManagement`, `supportsComfy`).
  *
  * Coupling rules:
  *
@@ -46,14 +46,15 @@
  *   3. Update `MIN_NODETOOL_CORE_VERSION` to that new release.
  */
 
-export const BRIDGE_PROTOCOL_VERSION = 2;
+export const BRIDGE_PROTOCOL_VERSION = 3;
 
 /**
  * Hard floor: the JS runtime rejects (at `discover`) any worker reporting a
  * protocol below this. Stays at 1 because every protocol change so far has
- * been additive — `models.*` (v2) is negotiated via `supportsModelManagement`,
- * so a v1 worker still connects and runs every pre-v2 feature; it just doesn't
- * expose worker model management. Move this only for a real wire break.
+ * been additive — `models.*` (v2) is negotiated via `supportsModelManagement`
+ * and `comfy.*` (v3) via `supportsComfy`, so a v1 worker still connects and
+ * runs every pre-v2 feature; it just doesn't expose the newer families. Move
+ * this only for a real wire break.
  */
 export const MIN_BRIDGE_PROTOCOL_VERSION = 1;
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,14 @@ export { PythonBridgeBase };
 export type {
   UnifiedModelLike,
   ModelDownloadRequest,
-  ModelDownloadUpdate
+  ModelDownloadUpdate,
+  ComfyStatusInfo,
+  ComfyEvent,
+  ComfyExecuteOptions,
+  ComfyExecuteResult,
+  ComfyModelDownloadRequest,
+  ComfyModelDownloadUpdate,
+  ComfyModelInfo
 } from "./python-bridge-types.js";
 export {
   WebsocketPythonBridge,

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -69,6 +69,13 @@ import type {
   UnifiedModelLike,
   ModelDownloadRequest,
   ModelDownloadUpdate,
+  ComfyStatusInfo,
+  ComfyEvent,
+  ComfyExecuteOptions,
+  ComfyExecuteResult,
+  ComfyModelDownloadRequest,
+  ComfyModelDownloadUpdate,
+  ComfyModelInfo,
   PythonBridge
 } from "./python-bridge-types.js";
 
@@ -109,6 +116,13 @@ export abstract class PythonBridgeBase
   protected _workerStatus: PythonWorkerStatus | null = null;
   protected _pending = new Map<string, PendingRequest>();
   protected _pendingStream = new Map<string, PendingStreamRequest>();
+  /**
+   * `comfy.execute` event callbacks, keyed by request id. Separate from the
+   * pending maps because `comfy.event` frames are neither `progress` (wrong
+   * shape) nor terminal — they stream the ComfyUI lifecycle while the same
+   * request's terminal `result`/`error` settles via {@link _pendingStream}.
+   */
+  protected _pendingComfyEvents = new Map<string, (event: ComfyEvent) => void>();
   protected _options: PythonBridgeOptions;
   protected _connected = false;
   private _connectPromise: Promise<void> | null = null;
@@ -263,6 +277,14 @@ export abstract class PythonBridgeBase
         pending.onProgress({ request_id: requestId, ...data });
       }
       this.emit("progress", msg.data);
+    } else if (type === "comfy.event" && requestId) {
+      // Dedicated `comfy.execute` lifecycle frame. Distinct from `progress`
+      // because ComfyUI's events don't fit `{progress,total,message}`. Without
+      // this explicit case the frames would fall through and vanish silently.
+      const onEvent = this._pendingComfyEvents.get(requestId);
+      if (onEvent) {
+        onEvent(msg.data as ComfyEvent);
+      }
     }
   }
 
@@ -275,6 +297,7 @@ export abstract class PythonBridgeBase
       req.reject(error);
     }
     this._pendingStream.clear();
+    this._pendingComfyEvents.clear();
   }
 
   // ── Discover ───────────────────────────────────────────────────────
@@ -816,6 +839,28 @@ export abstract class PythonBridgeBase
     onProgress: (update: ModelDownloadUpdate) => void,
     requestId: string = randomUUID()
   ): Promise<void> {
+    return this._streamingDownload(
+      "models.download",
+      req as unknown as Record<string, unknown>,
+      (u) => onProgress(u as unknown as ModelDownloadUpdate),
+      requestId
+    );
+  }
+
+  /**
+   * Shared engine for the streaming-download RPCs (`models.download`,
+   * `comfy.models.download`): a request that emits ordered `progress` frames
+   * then a terminal `result`/`error`. Registers in BOTH pending maps and settles
+   * defensively — an inactivity watchdog (reset on every progress frame) and
+   * {@link cancel} both clear both maps so nothing leaks even if no terminal
+   * frame ever arrives. See {@link downloadModel} for the full rationale.
+   */
+  protected _streamingDownload(
+    type: string,
+    data: Record<string, unknown>,
+    onProgress: (update: Record<string, unknown>) => void,
+    requestId: string
+  ): Promise<void> {
     const idleTimeoutMs =
       this._options.downloadIdleTimeoutMs ?? DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS;
     return new Promise<void>((resolve, reject) => {
@@ -845,7 +890,7 @@ export abstract class PythonBridgeBase
           settle(() =>
             reject(
               new Error(
-                `Model download "${requestId}" stalled: no progress for ${idleTimeoutMs}ms.` +
+                `Download "${requestId}" stalled: no progress for ${idleTimeoutMs}ms.` +
                   (stderrHint ? ` Recent stderr: ${stderrHint}` : "")
               )
             )
@@ -857,7 +902,7 @@ export abstract class PythonBridgeBase
         reject: () => undefined,
         onProgress: (event) => {
           armIdleTimer();
-          onProgress(event as unknown as ModelDownloadUpdate);
+          onProgress(event as unknown as Record<string, unknown>);
         }
       });
       this._pendingStream.set(requestId, {
@@ -867,7 +912,7 @@ export abstract class PythonBridgeBase
       });
       armIdleTimer();
       try {
-        this._send({ type: "models.download", request_id: requestId, data: req });
+        this._send({ type, request_id: requestId, data });
       } catch (err) {
         settle(() => reject(err instanceof Error ? err : new Error(String(err))));
       }
@@ -907,6 +952,154 @@ export abstract class PythonBridgeBase
    */
   supportsModelManagement(): boolean {
     return (this._workerStatus?.protocol_version ?? 0) >= 2;
+  }
+
+  // ── ComfyUI proxy (bridge protocol v3+) ────────────────────────────────
+
+  /**
+   * Whether the attached worker fronts a ComfyUI server and speaks `comfy.*`.
+   * Requires protocol v3+ (the `comfy.*` family) AND a `worker.status.comfy`
+   * block reporting `enabled: true` — not every v3 worker has a ComfyUI, so
+   * route ComfyUI jobs only where this is true. Per-capability soft gate, like
+   * {@link supportsModelManagement}.
+   */
+  supportsComfy(): boolean {
+    const status = this._workerStatus;
+    return (
+      (status?.protocol_version ?? 0) >= 3 && status?.comfy?.enabled === true
+    );
+  }
+
+  /** The last-known `comfy` block from `worker.status`, or null. */
+  getComfyStatus(): ComfyStatusInfo | null {
+    return this._workerStatus?.comfy ?? null;
+  }
+
+  /**
+   * Submit a ComfyUI workflow and drain its `comfy.event` lifecycle.
+   *
+   * `comfy.execute` streams `queued → queue → started/cached → executing →
+   * progress → node_output → preview → completed/cancelled` as dedicated
+   * `comfy.event` frames (routed to {@link onEvent}), then settles with a
+   * terminal `result` (resolve) or `error` (reject) — `result` is always last.
+   * The event callback is registered in {@link _pendingComfyEvents} and the
+   * terminal frame in {@link _pendingStream}; both are cleared on settle.
+   *
+   * Cancellable via the standard {@link cancel}(requestId): pass a stable
+   * `requestId` (or reuse the returned default) to reach this exact run.
+   */
+  comfyExecute(
+    prompt: Record<string, unknown>,
+    options: ComfyExecuteOptions = {},
+    onEvent?: (event: ComfyEvent) => void,
+    requestId: string = randomUUID()
+  ): Promise<ComfyExecuteResult> {
+    const data: Record<string, unknown> = { prompt };
+    if (options.blobs) data.blobs = options.blobs;
+    if (options.previews) data.previews = true;
+    if (typeof options.timeout === "number") data.timeout = options.timeout;
+
+    return new Promise<ComfyExecuteResult>((resolve, reject) => {
+      let settled = false;
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        this._pendingStream.delete(requestId);
+        this._pendingComfyEvents.delete(requestId);
+        fn();
+      };
+      if (onEvent) this._pendingComfyEvents.set(requestId, onEvent);
+      this._pendingStream.set(requestId, {
+        resolve: (result) =>
+          settle(() => resolve(result as ComfyExecuteResult)),
+        reject: (err) => settle(() => reject(err)),
+        onChunk: () => {}
+      });
+      try {
+        this._send({ type: "comfy.execute", request_id: requestId, data });
+      } catch (err) {
+        settle(() =>
+          reject(err instanceof Error ? err : new Error(String(err)))
+        );
+      }
+    });
+  }
+
+  async comfyQueue(): Promise<Record<string, unknown>> {
+    return this._providerCall("comfy.queue", {});
+  }
+
+  async comfyInterrupt(): Promise<void> {
+    await this._providerCall("comfy.interrupt", {});
+  }
+
+  async comfyCancelPrompt(promptId: string): Promise<void> {
+    await this._providerCall("comfy.cancel", { prompt_id: promptId });
+  }
+
+  async comfyUpload(
+    filename: string,
+    bytes: Uint8Array,
+    options: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown>> {
+    return this._providerCall("comfy.upload", {
+      filename,
+      blob: bytes,
+      ...options
+    });
+  }
+
+  async comfyView(
+    filename: string,
+    options: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown>> {
+    return this._providerCall("comfy.view", { filename, ...options });
+  }
+
+  async comfyObjectInfo(): Promise<Record<string, unknown>> {
+    return this._providerCall("comfy.object_info", {});
+  }
+
+  async comfySystemStats(): Promise<Record<string, unknown>> {
+    return this._providerCall("comfy.system_stats", {});
+  }
+
+  async comfyStatus(): Promise<ComfyStatusInfo> {
+    const result = await this._providerCall("comfy.status", {});
+    return result as unknown as ComfyStatusInfo;
+  }
+
+  async comfyFree(options: Record<string, unknown> = {}): Promise<void> {
+    await this._providerCall("comfy.free", options);
+  }
+
+  async comfyModelsList(folder?: string): Promise<ComfyModelInfo[]> {
+    const result = await this._providerCall(
+      "comfy.models.list",
+      folder ? { folder } : {}
+    );
+    return (result as { models?: ComfyModelInfo[] }).models ?? [];
+  }
+
+  async comfyModelsDownload(
+    req: ComfyModelDownloadRequest,
+    onProgress: (update: ComfyModelDownloadUpdate) => void,
+    requestId: string = randomUUID()
+  ): Promise<void> {
+    return this._streamingDownload(
+      "comfy.models.download",
+      req as unknown as Record<string, unknown>,
+      (u) => onProgress(u as ComfyModelDownloadUpdate),
+      requestId
+    );
+  }
+
+  async comfyModelsDelete(folder: string, filename: string): Promise<boolean> {
+    const result = await this._providerCall("comfy.models.delete", {
+      folder,
+      filename
+    });
+    return Boolean((result as { deleted?: boolean }).deleted);
   }
 
   protected async _providerCall(

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -985,8 +985,11 @@ export abstract class PythonBridgeBase
    * The event callback is registered in {@link _pendingComfyEvents} and the
    * terminal frame in {@link _pendingStream}; both are cleared on settle.
    *
-   * Cancellable via the standard {@link cancel}(requestId): pass a stable
-   * `requestId` (or reuse the returned default) to reach this exact run.
+   * Cancellable via {@link cancelComfyExecute}(requestId): pass a stable
+   * `requestId` (or reuse the returned default) to reach this exact run. Prefer
+   * that over the bare {@link cancel} — a plain cancel frame does not settle the
+   * local promise, so if the worker never emits a terminal frame the promise
+   * would hang and the pending maps would leak.
    */
   comfyExecute(
     prompt: Record<string, unknown>,
@@ -1023,6 +1026,25 @@ export abstract class PythonBridgeBase
         );
       }
     });
+  }
+
+  /**
+   * Cancel an in-flight {@link comfyExecute} by request id. Sends the cancel
+   * frame AND settles the local promise by rejecting it — the worker may never
+   * emit a terminal `result`/`error` after a cancel (or may be hung), so we
+   * cannot rely on one to clean up. Rejecting through the pending-stream entry
+   * runs comfyExecute's settle(), clearing BOTH `_pendingStream` and
+   * `_pendingComfyEvents`. A no-op if the id is unknown. Mirrors
+   * {@link cancelModelDownload}.
+   */
+  cancelComfyExecute(requestId: string): void {
+    this.cancel(requestId);
+    const streamReq = this._pendingStream.get(requestId);
+    if (streamReq) {
+      streamReq.reject(
+        new Error(`ComfyUI execution "${requestId}" was cancelled.`)
+      );
+    }
   }
 
   async comfyQueue(): Promise<Record<string, unknown>> {

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -82,6 +82,116 @@ export interface ModelDownloadUpdate {
   error?: string;
 }
 
+// ── ComfyUI proxy (bridge protocol v3+) ───────────────────────────────────
+//
+// The worker can front a co-located, loopback-only ComfyUI server and proxy it
+// over the bridge as `comfy.*` messages. All shapes below mirror the worker's
+// `comfy_handler.py`; the authoritative field-level reference is
+// `docs/comfy-proxy.md` in nodetool-core. Events and results carry an index
+// signature so worker-side additions pass through untyped rather than being
+// dropped.
+
+/**
+ * The `comfy` block on `worker.status` (protocol v3+). Present only when the
+ * worker fronts a ComfyUI server; `enabled` is the routing signal — only send
+ * `comfy.*` to a worker whose last status reported `enabled: true`.
+ */
+export interface ComfyStatusInfo {
+  enabled: boolean;
+  /** Loopback URL the worker proxies to (e.g. http://127.0.0.1:8188). */
+  url?: string;
+  /** Whether the worker could reach ComfyUI at last check (comfy.status only). */
+  reachable?: boolean;
+}
+
+/**
+ * A `comfy.event` frame's `data`. `comfy.execute` streams its lifecycle as
+ * these dedicated frames — NOT as `progress` — because ComfyUI's events don't
+ * fit the `{progress,total,message}` shape. `event` is the discriminator, in
+ * emission order: queued → queue → started/cached → executing → progress →
+ * node_output → preview → completed/cancelled.
+ */
+export interface ComfyEvent {
+  event:
+    | "queued"
+    | "queue"
+    | "started"
+    | "cached"
+    | "executing"
+    | "progress"
+    | "node_output"
+    | "preview"
+    | "completed"
+    | "cancelled";
+  prompt_id?: string;
+  /** `executing`/`progress`/`node_output`/`preview`: the ComfyUI node id. */
+  node?: string | null;
+  /** `progress`: current step and total for the running node. */
+  value?: number;
+  max?: number;
+  /** `queue`: remaining queued prompts. */
+  queue_remaining?: number;
+  /** `cached`: node ids served from cache. */
+  nodes?: string[];
+  /** `node_output`: the raw ComfyUI output payload for that node. */
+  output?: Record<string, unknown>;
+  /** `preview`: raw preview image bytes (only when `previews: true`). */
+  blob?: Uint8Array;
+  mime_type?: string;
+  [key: string]: unknown;
+}
+
+/** Options for a {@link PythonBridge.comfyExecute} call. */
+export interface ComfyExecuteOptions {
+  /**
+   * Input files referenced from the workflow JSON via `"blob:<key>"`
+   * placeholders. The worker uploads them to ComfyUI and splices in the real
+   * filename before submitting.
+   */
+  blobs?: Record<string, Uint8Array>;
+  /** Request `preview` events (extra bandwidth); off by default. */
+  previews?: boolean;
+  /** Max seconds to wait for the ComfyUI run before the worker gives up. */
+  timeout?: number;
+}
+
+/** Terminal `result.data` of a {@link PythonBridge.comfyExecute} call. */
+export interface ComfyExecuteResult {
+  prompt_id?: string;
+  outputs?: Record<string, unknown>;
+  blobs?: Record<string, Uint8Array>;
+  [key: string]: unknown;
+}
+
+/** Request payload for {@link PythonBridge.comfyModelsDownload}. */
+export interface ComfyModelDownloadRequest {
+  /** Raw ComfyUI folder ("checkpoints", "loras", …) or a nodetool type string. */
+  folder: string;
+  /** Direct download URL, mutually exclusive with `repo_id`. */
+  url?: string;
+  /** HuggingFace repo id, mutually exclusive with `url`. */
+  repo_id?: string;
+  filename?: string;
+  [key: string]: unknown;
+}
+
+/** A `progress` frame from {@link PythonBridge.comfyModelsDownload}. */
+export interface ComfyModelDownloadUpdate {
+  status: "start" | "progress" | "completed" | "error" | "cancelled";
+  downloaded_bytes: number;
+  total_bytes: number;
+  error?: string;
+  [key: string]: unknown;
+}
+
+/** One file entry from {@link PythonBridge.comfyModelsList}. */
+export interface ComfyModelInfo {
+  folder: string;
+  filename: string;
+  size?: number;
+  [key: string]: unknown;
+}
+
 export interface PythonBridgeOptions {
   wsUrl?: string;
   /**
@@ -146,6 +256,11 @@ export interface PythonWorkerStatus {
   load_errors: PythonWorkerLoadError[];
   transport: string;
   max_frame_size: number;
+  /**
+   * ComfyUI proxy status (protocol v3+). Present only when the worker fronts a
+   * ComfyUI server; used to route `comfy.*` requests (see {@link ComfyStatusInfo}).
+   */
+  comfy?: ComfyStatusInfo;
 }
 
 /**
@@ -228,6 +343,64 @@ export interface PythonBridge extends EventEmitter {
   cancelModelDownload(requestId: string): void;
   deleteCachedModel(repoId: string): Promise<boolean>;
   supportsModelManagement(): boolean;
+
+  // ── ComfyUI proxy (protocol v3+, gated by supportsComfy) ─────────────────
+  /**
+   * Whether the attached worker fronts a ComfyUI server and speaks the
+   * `comfy.*` family (protocol v3+ AND `worker.status.comfy.enabled`). Route
+   * ComfyUI jobs only to workers where this is true.
+   */
+  supportsComfy(): boolean;
+  /** The last-known `comfy` block from `worker.status`, or null. */
+  getComfyStatus(): ComfyStatusInfo | null;
+  /**
+   * Submit a ComfyUI workflow (API-format prompt JSON) and drain its
+   * `comfy.event` lifecycle via `onEvent`. Resolves on the terminal `result`,
+   * rejects on `error`. Cancellable through the standard {@link cancel} with the
+   * returned/passed `requestId`.
+   */
+  comfyExecute(
+    prompt: Record<string, unknown>,
+    options?: ComfyExecuteOptions,
+    onEvent?: (event: ComfyEvent) => void,
+    requestId?: string
+  ): Promise<ComfyExecuteResult>;
+  /** `{queue_running, queue_pending}` — for a queue-position/ETA UI. */
+  comfyQueue(): Promise<Record<string, unknown>>;
+  /** Global interrupt: stops whatever ComfyUI is running. Admin-only. */
+  comfyInterrupt(): Promise<void>;
+  /** Best-effort per-prompt cancel — the safe user-facing cancel. */
+  comfyCancelPrompt(promptId: string): Promise<void>;
+  /** Stage a file into ComfyUI's input dir; returns the stored filename. */
+  comfyUpload(
+    filename: string,
+    bytes: Uint8Array,
+    options?: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  /** Fetch a file from ComfyUI by name. */
+  comfyView(
+    filename: string,
+    options?: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  /** Full ComfyUI node catalog. */
+  comfyObjectInfo(): Promise<Record<string, unknown>>;
+  /** ComfyUI system/VRAM stats. */
+  comfySystemStats(): Promise<Record<string, unknown>>;
+  /** Worker-level ComfyUI health: `{enabled, url, reachable}`. */
+  comfyStatus(): Promise<ComfyStatusInfo>;
+  /** Unload models from VRAM without a cold restart. */
+  comfyFree(options?: Record<string, unknown>): Promise<void>;
+  /** List model files on the worker's persistent volume. */
+  comfyModelsList(folder?: string): Promise<ComfyModelInfo[]>;
+  /** Download a model file onto the worker's volume, streaming progress. */
+  comfyModelsDownload(
+    req: ComfyModelDownloadRequest,
+    onProgress: (update: ComfyModelDownloadUpdate) => void,
+    requestId?: string
+  ): Promise<void>;
+  /** Remove a model file from the worker's volume. */
+  comfyModelsDelete(folder: string, filename: string): Promise<boolean>;
+
   getRecentStderrSummary(limit?: number): string | null;
   close(): void;
 }

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -365,6 +365,11 @@ export interface PythonBridge extends EventEmitter {
     onEvent?: (event: ComfyEvent) => void,
     requestId?: string
   ): Promise<ComfyExecuteResult>;
+  /**
+   * Cancel an in-flight {@link comfyExecute} by request id, settling its promise
+   * locally (does not rely on a terminal frame from the worker).
+   */
+  cancelComfyExecute(requestId: string): void;
   /** `{queue_running, queue_pending}` — for a queue-position/ETA UI. */
   comfyQueue(): Promise<Record<string, unknown>>;
   /** Global interrupt: stops whatever ComfyUI is running. Admin-only. */

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -261,6 +261,10 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     return this._target.comfyExecute(prompt, options, onEvent, requestId);
   }
 
+  cancelComfyExecute(requestId: string): void {
+    this._target.cancelComfyExecute(requestId);
+  }
+
   comfyQueue(): Promise<Record<string, unknown>> {
     return this._target.comfyQueue();
   }

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -22,7 +22,14 @@ import type {
   PythonProviderInfo,
   UnifiedModelLike,
   ModelDownloadRequest,
-  ModelDownloadUpdate
+  ModelDownloadUpdate,
+  ComfyStatusInfo,
+  ComfyEvent,
+  ComfyExecuteOptions,
+  ComfyExecuteResult,
+  ComfyModelDownloadRequest,
+  ComfyModelDownloadUpdate,
+  ComfyModelInfo
 } from "./python-bridge-types.js";
 import type { ASRResult } from "./providers/types.js";
 
@@ -235,6 +242,82 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
 
   supportsModelManagement(): boolean {
     return this._target.supportsModelManagement();
+  }
+
+  supportsComfy(): boolean {
+    return this._target.supportsComfy();
+  }
+
+  getComfyStatus(): ComfyStatusInfo | null {
+    return this._target.getComfyStatus();
+  }
+
+  comfyExecute(
+    prompt: Record<string, unknown>,
+    options?: ComfyExecuteOptions,
+    onEvent?: (event: ComfyEvent) => void,
+    requestId?: string
+  ): Promise<ComfyExecuteResult> {
+    return this._target.comfyExecute(prompt, options, onEvent, requestId);
+  }
+
+  comfyQueue(): Promise<Record<string, unknown>> {
+    return this._target.comfyQueue();
+  }
+
+  comfyInterrupt(): Promise<void> {
+    return this._target.comfyInterrupt();
+  }
+
+  comfyCancelPrompt(promptId: string): Promise<void> {
+    return this._target.comfyCancelPrompt(promptId);
+  }
+
+  comfyUpload(
+    filename: string,
+    bytes: Uint8Array,
+    options?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    return this._target.comfyUpload(filename, bytes, options);
+  }
+
+  comfyView(
+    filename: string,
+    options?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    return this._target.comfyView(filename, options);
+  }
+
+  comfyObjectInfo(): Promise<Record<string, unknown>> {
+    return this._target.comfyObjectInfo();
+  }
+
+  comfySystemStats(): Promise<Record<string, unknown>> {
+    return this._target.comfySystemStats();
+  }
+
+  comfyStatus(): Promise<ComfyStatusInfo> {
+    return this._target.comfyStatus();
+  }
+
+  comfyFree(options?: Record<string, unknown>): Promise<void> {
+    return this._target.comfyFree(options);
+  }
+
+  comfyModelsList(folder?: string): Promise<ComfyModelInfo[]> {
+    return this._target.comfyModelsList(folder);
+  }
+
+  comfyModelsDownload(
+    req: ComfyModelDownloadRequest,
+    onProgress: (update: ComfyModelDownloadUpdate) => void,
+    requestId?: string
+  ): Promise<void> {
+    return this._target.comfyModelsDownload(req, onProgress, requestId);
+  }
+
+  comfyModelsDelete(folder: string, filename: string): Promise<boolean> {
+    return this._target.comfyModelsDelete(folder, filename);
   }
 
   getRecentStderrSummary(limit?: number): string | null {

--- a/packages/runtime/tests/python-bridge-comfy.test.ts
+++ b/packages/runtime/tests/python-bridge-comfy.test.ts
@@ -133,14 +133,17 @@ describe("comfy.* bridge methods", () => {
     expect(pendingComfy.size).toBe(0);
   });
 
-  it("comfyExecute is cancellable via the standard cancel(requestId)", async () => {
+  it("cancelComfyExecute settles the promise and leaves no leaked entries", async () => {
+    // The worker hangs after `queued` — no terminal result/error ever arrives.
+    // cancelComfyExecute must reject the promise itself, not wait forever.
     const b = await connect({ comfyExecuteMode: "hang" });
 
     const events: ComfyEvent[] = [];
-    // The worker hangs after `queued`, so this run never settles on its own;
-    // swallow the rejection from the afterEach close() so it isn't unhandled.
-    b.comfyExecute({ "3": {} }, {}, (e) => events.push(e), "run-1").catch(
-      () => {}
+    const runPromise = b.comfyExecute(
+      { "3": {} },
+      {},
+      (e) => events.push(e),
+      "run-1"
     );
 
     // Wait for the first (queued) event to confirm the run is in flight.
@@ -150,7 +153,20 @@ describe("comfy.* bridge methods", () => {
     }
     expect(events[0]!.event).toBe("queued");
 
-    b.cancel("run-1");
+    b.cancelComfyExecute("run-1");
+    await expect(runPromise).rejects.toThrow(/cancelled/i);
+
+    // No leaked entries on either map after the local settle.
+    const pendingStream = (
+      bridge as unknown as { _pendingStream: Map<string, unknown> }
+    )._pendingStream;
+    const pendingComfy = (
+      bridge as unknown as { _pendingComfyEvents: Map<string, unknown> }
+    )._pendingComfyEvents;
+    expect(pendingStream.size).toBe(0);
+    expect(pendingComfy.size).toBe(0);
+
+    // A cancel frame reached the worker.
     const cancelStart = Date.now();
     while (
       worker!.received("cancel").length === 0 &&

--- a/packages/runtime/tests/python-bridge-comfy.test.ts
+++ b/packages/runtime/tests/python-bridge-comfy.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the ComfyUI proxy bridge methods (comfy.* RPC, bridge protocol v3):
+ * comfyExecute (with its dedicated comfy.event lifecycle frames), the simple
+ * comfy.* forwards, and the supportsComfy / getComfyStatus capability gate.
+ *
+ * Drives the real WebsocketPythonBridge against the shared fake worker, which
+ * fronts a fake ComfyUI and reports a `comfy` block on worker.status.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import {
+  startFakeWorker,
+  type FakeWorkerHandle
+} from "./python-websocket-bridge.test-helpers.js";
+import type { ComfyEvent } from "../src/python-bridge-types.js";
+
+describe("comfy.* bridge methods", () => {
+  let worker: FakeWorkerHandle | null = null;
+  let bridge: WebsocketPythonBridge | null = null;
+
+  afterEach(async () => {
+    if (bridge) {
+      bridge.close();
+      bridge = null;
+    }
+    if (worker) {
+      await worker.close();
+      worker = null;
+    }
+  });
+
+  const connect = async (
+    opts: Parameters<typeof startFakeWorker>[1] = {}
+  ): Promise<WebsocketPythonBridge> => {
+    worker = await startFakeWorker(0, { protocolVersion: 3, ...opts });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+    return bridge;
+  };
+
+  it("supportsComfy reflects protocol version and the comfy.enabled block", async () => {
+    const b = await connect();
+    expect(b.supportsComfy()).toBe(true);
+    expect(b.getComfyStatus()).toEqual({
+      enabled: true,
+      url: "http://127.0.0.1:8188"
+    });
+  });
+
+  it("supportsComfy is false when the worker reports no comfy block", async () => {
+    const b = await connect({ comfy: null });
+    expect(b.supportsComfy()).toBe(false);
+    expect(b.getComfyStatus()).toBeNull();
+  });
+
+  it("supportsComfy is false on a pre-v3 worker even if comfy is enabled", async () => {
+    // A v2 worker predates comfy.* — the family must not be offered regardless
+    // of what an (impossible) comfy block would say.
+    const b = await connect({ protocolVersion: 2 });
+    expect(b.supportsComfy()).toBe(false);
+    expect(b.supportsModelManagement()).toBe(true);
+  });
+
+  it("comfyExecute streams comfy.event frames then resolves on the terminal result", async () => {
+    const b = await connect();
+
+    const events: ComfyEvent[] = [];
+    const result = await b.comfyExecute(
+      { "3": { class_type: "KSampler", inputs: {} } },
+      { previews: false },
+      (e) => events.push(e)
+    );
+
+    // Events arrive in emission order; `queued` first (see comfy_handler.py).
+    expect(events.map((e) => e.event)).toEqual([
+      "queued",
+      "started",
+      "executing",
+      "progress",
+      "node_output",
+      "completed"
+    ]);
+    expect(events[0]!.prompt_id).toBe("p1");
+    expect(result.prompt_id).toBe("p1");
+    expect(result.outputs).toEqual({ "9": { images: ["out.png"] } });
+
+    // The prompt reached the worker verbatim on a comfy.execute frame.
+    const frames = worker!.received("comfy.execute");
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.data).toEqual({
+      prompt: { "3": { class_type: "KSampler", inputs: {} } }
+    });
+
+    // No leaked pending state on either map after settle.
+    const pendingStream = (
+      bridge as unknown as { _pendingStream: Map<string, unknown> }
+    )._pendingStream;
+    const pendingComfy = (
+      bridge as unknown as { _pendingComfyEvents: Map<string, unknown> }
+    )._pendingComfyEvents;
+    expect(pendingStream.size).toBe(0);
+    expect(pendingComfy.size).toBe(0);
+  });
+
+  it("comfyExecute forwards previews and timeout options", async () => {
+    const b = await connect();
+    await b.comfyExecute({ "3": {} }, { previews: true, timeout: 30 }, () => {});
+    const frames = worker!.received("comfy.execute");
+    expect(frames[0]!.data).toEqual({
+      prompt: { "3": {} },
+      previews: true,
+      timeout: 30
+    });
+  });
+
+  it("comfyExecute rejects on a terminal error frame and cleans up", async () => {
+    const b = await connect({ comfyExecuteMode: "error" });
+    await expect(
+      b.comfyExecute({ "3": {} }, {}, () => {})
+    ).rejects.toThrow(/comfy boom/);
+
+    const pendingStream = (
+      bridge as unknown as { _pendingStream: Map<string, unknown> }
+    )._pendingStream;
+    const pendingComfy = (
+      bridge as unknown as { _pendingComfyEvents: Map<string, unknown> }
+    )._pendingComfyEvents;
+    expect(pendingStream.size).toBe(0);
+    expect(pendingComfy.size).toBe(0);
+  });
+
+  it("comfyExecute is cancellable via the standard cancel(requestId)", async () => {
+    const b = await connect({ comfyExecuteMode: "hang" });
+
+    const events: ComfyEvent[] = [];
+    // The worker hangs after `queued`, so this run never settles on its own;
+    // swallow the rejection from the afterEach close() so it isn't unhandled.
+    b.comfyExecute({ "3": {} }, {}, (e) => events.push(e), "run-1").catch(
+      () => {}
+    );
+
+    // Wait for the first (queued) event to confirm the run is in flight.
+    const start = Date.now();
+    while (events.length === 0 && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(events[0]!.event).toBe("queued");
+
+    b.cancel("run-1");
+    const cancelStart = Date.now();
+    while (
+      worker!.received("cancel").length === 0 &&
+      Date.now() - cancelStart < 2000
+    ) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(worker!.received("cancel")[0]!.request_id).toBe("run-1");
+  });
+
+  it("comfyQueue / comfyCancelPrompt / comfyInterrupt issue the right frames", async () => {
+    const b = await connect();
+
+    expect(await b.comfyQueue()).toEqual({
+      queue_running: [],
+      queue_pending: []
+    });
+    await b.comfyCancelPrompt("p1");
+    await b.comfyInterrupt();
+
+    expect(worker!.received("comfy.queue")).toHaveLength(1);
+    expect(worker!.received("comfy.cancel")[0]!.data).toEqual({
+      prompt_id: "p1"
+    });
+    expect(worker!.received("comfy.interrupt")).toHaveLength(1);
+  });
+
+  it("comfyStatus / comfyModelsList / comfyModelsDelete forward and parse results", async () => {
+    const b = await connect();
+
+    expect(await b.comfyStatus()).toEqual({
+      enabled: true,
+      url: "http://127.0.0.1:8188",
+      reachable: true
+    });
+
+    const models = await b.comfyModelsList("checkpoints");
+    expect(models).toEqual([
+      { folder: "checkpoints", filename: "sd_xl_base.safetensors", size: 42 }
+    ]);
+    expect(worker!.received("comfy.models.list")[0]!.data).toEqual({
+      folder: "checkpoints"
+    });
+
+    expect(await b.comfyModelsDelete("checkpoints", "sd_xl_base.safetensors")).toBe(
+      true
+    );
+    expect(worker!.received("comfy.models.delete")[0]!.data).toEqual({
+      folder: "checkpoints",
+      filename: "sd_xl_base.safetensors"
+    });
+  });
+});

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -19,8 +19,8 @@ import {
 import type { ModelDownloadUpdate } from "../src/python-bridge-types.js";
 
 describe("bridge protocol version", () => {
-  it("is 2 (models.* support)", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(2);
+  it("is 3 (models.* + comfy.* support)", () => {
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(3);
   });
 });
 

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -57,6 +57,19 @@ export interface FakeWorkerOptions {
    *    worker)
    */
   downloadMode?: "progress" | "error" | "hang";
+  /**
+   * The `comfy` block echoed in the worker.status response. Defaults to an
+   * enabled block so comfy tests route correctly; pass `null` to omit it
+   * entirely (simulating a worker with no ComfyUI).
+   */
+  comfy?: { enabled: boolean; url?: string } | null;
+  /**
+   * comfy.execute behavior:
+   *  - "events": stream the full lifecycle then a terminal result (default)
+   *  - "error": emit a couple events then a terminal error frame
+   *  - "hang": emit `queued` then go silent (for cancel tests)
+   */
+  comfyExecuteMode?: "events" | "error" | "hang";
 }
 
 export interface FakeWorkerHandle {
@@ -123,7 +136,12 @@ export function startFakeWorker(
     answerExecute: initialOptions.answerExecute ?? true,
     streamMode: initialOptions.streamMode ?? "chunks",
     protocolVersion: initialOptions.protocolVersion ?? BRIDGE_PROTOCOL_VERSION,
-    downloadMode: initialOptions.downloadMode ?? "progress"
+    downloadMode: initialOptions.downloadMode ?? "progress",
+    comfy:
+      initialOptions.comfy === undefined
+        ? { enabled: true, url: "http://127.0.0.1:8188" }
+        : initialOptions.comfy,
+    comfyExecuteMode: initialOptions.comfyExecuteMode ?? "events"
   };
 
   wss.on("connection", (ws, request) => {
@@ -171,7 +189,8 @@ export function startFakeWorker(
               provider_count: 1,
               namespaces: ["fake"],
               load_errors: [],
-              max_frame_size: 256 * 1024 * 1024
+              max_frame_size: 256 * 1024 * 1024,
+              ...(opts.comfy ? { comfy: opts.comfy } : {})
             }
           });
           break;
@@ -330,6 +349,81 @@ export function startFakeWorker(
           });
           break;
         }
+        case "comfy.execute": {
+          const emitEvent = (data: Record<string, unknown>) =>
+            send({ type: "comfy.event", request_id: requestId, data });
+          emitEvent({ event: "queued", prompt_id: "p1" });
+          if (opts.comfyExecuteMode === "hang") break;
+          emitEvent({ event: "started", prompt_id: "p1" });
+          emitEvent({ event: "executing", prompt_id: "p1", node: "3" });
+          emitEvent({ event: "progress", prompt_id: "p1", node: "3", value: 1, max: 2 });
+          emitEvent({
+            event: "node_output",
+            prompt_id: "p1",
+            node: "9",
+            output: { images: [{ filename: "out.png" }] }
+          });
+          if (opts.comfyExecuteMode === "error") {
+            send({
+              type: "error",
+              request_id: requestId,
+              data: { error: "comfy boom", traceback: "Traceback ..." }
+            });
+            break;
+          }
+          emitEvent({ event: "completed", prompt_id: "p1" });
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              prompt_id: "p1",
+              outputs: { "9": { images: ["out.png"] } },
+              blobs: {}
+            }
+          });
+          break;
+        }
+        case "comfy.queue":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: { queue_running: [], queue_pending: [] }
+          });
+          break;
+        case "comfy.interrupt":
+        case "comfy.cancel":
+        case "comfy.free":
+          send({ type: "result", request_id: requestId, data: { ok: true } });
+          break;
+        case "comfy.status":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              enabled: opts.comfy?.enabled ?? false,
+              url: opts.comfy?.url,
+              reachable: true
+            }
+          });
+          break;
+        case "comfy.models.list":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: {
+              models: [
+                { folder: "checkpoints", filename: "sd_xl_base.safetensors", size: 42 }
+              ]
+            }
+          });
+          break;
+        case "comfy.models.delete":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: { deleted: true }
+          });
+          break;
         case "cancel":
           // no-op
           break;

--- a/packages/runtime/tests/swappable-python-bridge.test.ts
+++ b/packages/runtime/tests/swappable-python-bridge.test.ts
@@ -108,6 +108,7 @@ class FakeBridge extends EventEmitter {
   comfyExecute(): Promise<Record<string, unknown>> {
     return Promise.resolve({});
   }
+  cancelComfyExecute(): void {}
   comfyQueue(): Promise<Record<string, unknown>> {
     return Promise.resolve({});
   }

--- a/packages/runtime/tests/swappable-python-bridge.test.ts
+++ b/packages/runtime/tests/swappable-python-bridge.test.ts
@@ -99,6 +99,51 @@ class FakeBridge extends EventEmitter {
   supportsModelManagement(): boolean {
     return false;
   }
+  supportsComfy(): boolean {
+    return false;
+  }
+  getComfyStatus(): null {
+    return null;
+  }
+  comfyExecute(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfyQueue(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfyInterrupt(): Promise<void> {
+    return Promise.resolve();
+  }
+  comfyCancelPrompt(): Promise<void> {
+    return Promise.resolve();
+  }
+  comfyUpload(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfyView(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfyObjectInfo(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfySystemStats(): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
+  }
+  comfyStatus(): Promise<{ enabled: boolean }> {
+    return Promise.resolve({ enabled: false });
+  }
+  comfyFree(): Promise<void> {
+    return Promise.resolve();
+  }
+  comfyModelsList(): Promise<never[]> {
+    return Promise.resolve([]);
+  }
+  comfyModelsDownload(): Promise<void> {
+    return Promise.resolve();
+  }
+  comfyModelsDelete(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
   getRecentStderrSummary(): string | null {
     return null;
   }

--- a/web/src/components/workers/WorkerProfilesDialog.tsx
+++ b/web/src/components/workers/WorkerProfilesDialog.tsx
@@ -33,6 +33,17 @@ const API_KEY_BY_TARGET: Record<WorkerTarget, string> = {
 // The default NodeTool worker image. Editable — only override if you publish
 // your own build of `python -m nodetool.worker`.
 const DEFAULT_WORKER_IMAGE = "ghcr.io/nodetool-ai/nodetool-worker:latest";
+// Combined worker + ComfyUI image. A worker from this image fronts a
+// loopback-only ComfyUI and reports `worker.status.comfy.enabled: true`, so it
+// can run the "Run ComfyUI Workflow (Worker)" node.
+const COMFY_WORKER_IMAGE = "ghcr.io/nodetool-ai/nodetool-worker-comfy:latest";
+// Sentinel select value that keeps the free-text image field for a custom build.
+const CUSTOM_IMAGE = "__custom_image__";
+const IMAGE_PRESETS = [
+  { value: DEFAULT_WORKER_IMAGE, label: "NodeTool Worker" },
+  { value: COMFY_WORKER_IMAGE, label: "NodeTool Worker + ComfyUI" },
+  { value: CUSTOM_IMAGE, label: "Custom…" }
+] as const;
 const DEFAULT_IDLE_TIMEOUT = "30";
 // Persistent volume default — big enough for several HF image models. Models
 // download here and survive a stop/resume.
@@ -448,11 +459,26 @@ const WorkerProfilesDialog: React.FC<WorkerProfilesDialogProps> = ({
             defaultOpen={false}
           >
             <FlexColumn gap={2} sx={{ pt: 1 }}>
+              <SelectField
+                label="Worker image preset"
+                value={
+                  IMAGE_PRESETS.some((p) => p.value === image)
+                    ? image
+                    : CUSTOM_IMAGE
+                }
+                onChange={(value) => {
+                  if (value !== CUSTOM_IMAGE) setImage(value);
+                }}
+                options={IMAGE_PRESETS}
+                variant="outlined"
+                size="small"
+                description="ComfyUI worker fronts a co-located ComfyUI server for the “Run ComfyUI Workflow (Worker)” node."
+              />
               <TextInput
                 label="Worker image"
                 value={image}
                 onChange={(e) => setImage(e.target.value)}
-                helperText="Container image the provider runs. Keep the default unless you publish your own worker build."
+                helperText="Container image the provider runs. Pick a preset above, or set your own worker build."
                 fullWidth
                 compact
               />


### PR DESCRIPTION
## Summary

Adds a new `ComfyWorkerWorkflowNode` that runs ComfyUI workflows on a NodeTool worker fronting a co-located ComfyUI server, proxied over the worker bridge as `comfy.*` messages. This complements the existing `ComfyWorkflowNode` which talks directly to a ComfyUI HTTP endpoint.

## Key Changes

- **New node**: `ComfyWorkerWorkflowNode` (`lib.comfy.RunWorkflowOnWorker`)
  - Connects to a worker via WebSocket bridge and submits workflows via `comfy.execute`
  - Supports dynamic inputs (media refs sent as bridge blobs, scalars injected directly)
  - Emits output blobs as typed media refs (kind sniffed from file magic bytes)
  - Streams ComfyUI lifecycle events (`queued`, `started`, `executing`, `progress`, etc.) as log updates and progress messages
  - Includes `sniffMedia()` utility to detect image/audio/video MIME types from leading bytes (PNG, JPEG, GIF, WebP, WAV, MP4, OGG, MPEG)

- **Bridge protocol v3 support** (`packages/runtime/src/python-bridge-base.ts`)
  - New `comfy.*` RPC family: `comfyExecute`, `comfyQueue`, `comfyInterrupt`, `comfyCancelPrompt`, `comfyUpload`, `comfyView`, `comfyObjectInfo`, `comfySystemStats`, `comfyStatus`, `comfyFree`, `comfyModelsList`, `comfyModelsDownload`, `comfyModelsDelete`
  - Dedicated `comfy.event` frame handling (separate from `progress` frames) — ComfyUI events don't fit the `{progress, total, message}` shape
  - New `_pendingComfyEvents` map to route event callbacks while terminal `result`/`error` settles via `_pendingStream`
  - Capability gates: `supportsComfy()` checks protocol v3+ AND `worker.status.comfy.enabled`; `getComfyStatus()` returns the last-known comfy block
  - Refactored `downloadModel()` to use shared `_streamingDownload()` engine (reused by `comfyModelsDownload`)

- **Type definitions** (`packages/runtime/src/python-bridge-types.ts`)
  - `ComfyStatusInfo`: worker's comfy block (enabled, url, reachable)
  - `ComfyEvent`: lifecycle events (queued, started, executing, progress, node_output, preview, completed, cancelled)
  - `ComfyExecuteOptions`: blobs, previews, timeout
  - `ComfyExecuteResult`: prompt_id, outputs, blobs
  - `ComfyModelDownloadRequest/Update/Info`: model management shapes

- **Test coverage**
  - `python-bridge-comfy.test.ts`: full lifecycle tests (events, cancellation, error handling, model management)
  - `comfy.test.ts`: `ComfyWorkerWorkflowNode` happy path with fake bridge injection
  - Fake worker enhancements: `comfy.execute` simulation with event streaming, error/hang modes for cancel tests

- **UI updates**
  - Worker profile dialog now offers preset images: "NodeTool Worker", "NodeTool Worker + ComfyUI", "Custom…"
  - Documentation: bridge protocol v3 spec, worker image table, comfy-proxy reference

- **Exports**
  - `ComfyWorkerWorkflowNode` added to `COMFY_NODES` and re-exported from `base-nodes`
  - All comfy types exported from `@nodetool-ai/runtime`

## Implementation Details

- **Event streaming**: `comfy.execute` emits `comfy.event` frames (not `progress`) to `_pendingComfyEvents` callbacks while the same request's terminal `result`/`error` settles via `_pendingStream`. Both maps are cleared on settle to prevent leaks.
- **

https://claude.ai/code/session_01H3WiaeFhkYK3n4BeJTrYjg