### PR TITLE
fix: stream local file:// previews from the backend instead of Electron data URIs

### DIFF
--- a/packages/websocket/src/file-api.ts
+++ b/packages/websocket/src/file-api.ts
@@ -1,12 +1,22 @@
 /**
- * File browser API — T-WS-9 (binary download only).
+ * File browser API — binary download + local-file streaming.
  *
  * JSON operations (list, info) have been migrated to the tRPC `files` router.
- * This module retains only the binary download endpoint.
+ * This module retains the binary download endpoint plus a local-file streaming
+ * endpoint used to preview files referenced by `file://` URIs (local/desktop
+ * mode drops). The renderer can't load a raw `file://` URL under `webSecurity`,
+ * so it points media elements at `/api/files/local?path=…` and the backend
+ * streams the bytes off disk with HTTP Range support (needed for audio/video
+ * seeking) — no reading in Electron, no data URIs.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
+import {
+  corsHeaders,
+  nodeStreamToWebStream,
+  parseRangeHeader
+} from "./storage-api.js";
 
 export interface FileApiOptions {
   /** Root directory for the file browser sandbox. Defaults to user home. */
@@ -64,9 +74,155 @@ async function handleDownload(url: URL, rootDir: string): Promise<Response> {
   }
 }
 
+// ── Local-file streaming (/api/files/local) ─────────────────────────
+
+const LOCAL_MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".svg": "image/svg+xml",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".m4a": "audio/mp4",
+  ".flac": "audio/flac",
+  ".aac": "audio/aac",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".avi": "video/x-msvideo",
+  ".mkv": "video/x-matroska",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain",
+  ".json": "application/json"
+};
+
+// Files that are never a legitimate part of a preview flow — refuse them even
+// though this endpoint is dev/desktop-only. Mirrors the Electron main-process
+// denylist so the two file-read surfaces stay consistent.
+const SENSITIVE_HOME_ENTRIES = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".kube",
+  ".docker",
+  ".config/gcloud",
+  ".netrc",
+  ".pgpass",
+  ".npmrc"
+];
+
+function isDeniedPath(resolved: string): boolean {
+  const home = os.homedir();
+  for (const entry of SENSITIVE_HOME_ENTRIES) {
+    const forbidden = path.resolve(home, entry);
+    if (resolved === forbidden || resolved.startsWith(forbidden + path.sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function localMimeType(filePath: string): string {
+  return (
+    LOCAL_MIME_TYPES[path.extname(filePath).toLowerCase()] ??
+    "application/octet-stream"
+  );
+}
+
+async function handleLocalFileStream(
+  request: Request,
+  url: URL
+): Promise<Response> {
+  const userPath = url.searchParams.get("path");
+  if (!userPath) return errorResponse(400, "path parameter is required");
+  if (userPath.includes("\0")) return errorResponse(400, "Invalid path");
+
+  const resolved = path.resolve(userPath);
+  if (!path.isAbsolute(resolved)) {
+    return errorResponse(400, "Path must be absolute");
+  }
+  if (isDeniedPath(resolved)) {
+    return errorResponse(403, "Access to this path is not permitted");
+  }
+
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(resolved);
+  } catch {
+    return errorResponse(404, "File not found");
+  }
+  if (stat.isDirectory()) {
+    return errorResponse(400, "Cannot stream a directory");
+  }
+
+  const cors = corsHeaders(request);
+  const contentType = localMimeType(resolved);
+  const fileSize = stat.size;
+  const lastModified = stat.mtime.toUTCString();
+
+  if (request.method === "HEAD") {
+    return new Response(null, {
+      status: 200,
+      headers: {
+        ...cors,
+        "Content-Type": contentType,
+        "Content-Length": String(fileSize),
+        "Last-Modified": lastModified,
+        "Accept-Ranges": "bytes"
+      }
+    });
+  }
+
+  const rangeHeader = request.headers.get("Range");
+  if (rangeHeader) {
+    const range = parseRangeHeader(rangeHeader, fileSize);
+    if (!range) {
+      return new Response(JSON.stringify({ detail: "Range Not Satisfiable" }), {
+        status: 416,
+        headers: {
+          ...cors,
+          "content-type": "application/json",
+          "Content-Range": `bytes */${fileSize}`
+        }
+      });
+    }
+    const { start, end } = range;
+    const body = nodeStreamToWebStream(resolved, { start, end });
+    return new Response(body, {
+      status: 206,
+      headers: {
+        ...cors,
+        "Content-Type": contentType,
+        "Content-Length": String(end - start + 1),
+        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+        "Last-Modified": lastModified,
+        "Accept-Ranges": "bytes"
+      }
+    });
+  }
+
+  const body = nodeStreamToWebStream(resolved);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      ...cors,
+      "Content-Type": contentType,
+      "Content-Length": String(fileSize),
+      "Last-Modified": lastModified,
+      "Accept-Ranges": "bytes"
+    }
+  });
+}
+
 /**
- * Handle file browser binary download requests.
- * Route: /api/files/download
+ * Handle file browser binary requests.
+ * Routes:
+ *   /api/files/download — sandboxed binary download (octet-stream, no Range)
+ *   /api/files/local    — stream a local file by absolute path (Range-capable)
  *
  * JSON ops (list, info) have moved to the tRPC `files` router.
  */
@@ -79,16 +235,22 @@ export async function handleFileRequest(
     return errorResponse(403, "File browser is disabled in production");
   }
 
-  if (request.method !== "GET") {
-    return errorResponse(405, "Method not allowed");
-  }
-
   const rootDir = options.rootDir ?? os.homedir();
   const url = new URL(request.url);
   const pathname = url.pathname.replace(/\/+$/, "");
 
   if (pathname === "/api/files/download") {
+    if (request.method !== "GET") {
+      return errorResponse(405, "Method not allowed");
+    }
     return handleDownload(url, rootDir);
+  }
+
+  if (pathname === "/api/files/local") {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return errorResponse(405, "Method not allowed");
+    }
+    return handleLocalFileStream(request, url);
   }
 
   return errorResponse(404, "Not found");

--- a/packages/websocket/src/routes/files.ts
+++ b/packages/websocket/src/routes/files.ts
@@ -17,6 +17,13 @@ const filesRoutes: FastifyPluginAsync<RouteOptions> = async (app, _opts) => {
   app.all("/api/files/download", async (req, reply) => {
     await bridge(req, reply, (request) => handleFileRequest(request));
   });
+
+  // Stream a local file by absolute path (previews for `file://` URIs). GET/HEAD
+  // with Range support; the handler enforces the production guard and path
+  // denylist.
+  app.all("/api/files/local", async (req, reply) => {
+    await bridge(req, reply, (request) => handleFileRequest(request));
+  });
 };
 
 export default filesRoutes;

--- a/packages/websocket/src/storage-api.ts
+++ b/packages/websocket/src/storage-api.ts
@@ -51,7 +51,7 @@ const BASE_CORS_HEADERS: Record<string, string> = {
   Vary: "Origin"
 };
 
-function corsHeaders(request: Request): Record<string, string> {
+export function corsHeaders(request: Request): Record<string, string> {
   const headers: Record<string, string> = { ...BASE_CORS_HEADERS };
   const allowed = resolveAllowedOrigin(request.headers.get("Origin"));
   if (allowed) {
@@ -91,7 +91,7 @@ interface ParsedRange {
   end: number;
 }
 
-function parseRangeHeader(
+export function parseRangeHeader(
   rangeHeader: string,
   fileSize: number
 ): ParsedRange | null {
@@ -125,7 +125,7 @@ function parseRangeHeader(
 
 // ── Node.js ReadableStream wrapper around fs.createReadStream ─────
 
-function nodeStreamToWebStream(
+export function nodeStreamToWebStream(
   filePath: string,
   options?: { start?: number; end?: number }
 ): ReadableStream<Uint8Array> {

--- a/packages/websocket/tests/file-api.test.ts
+++ b/packages/websocket/tests/file-api.test.ts
@@ -121,6 +121,109 @@ describe("/api/files/download", () => {
 });
 
 // ---------------------------------------------------------------------------
+// /api/files/local (streaming by absolute path)
+// ---------------------------------------------------------------------------
+
+describe("/api/files/local", () => {
+  function localRequest(
+    absPath: string,
+    init?: { method?: string; headers?: Record<string, string> }
+  ): Request {
+    const url = `http://localhost/api/files/local?path=${encodeURIComponent(
+      absPath
+    )}`;
+    return new Request(url, {
+      method: init?.method ?? "GET",
+      headers: init?.headers
+    });
+  }
+
+  it("streams the full file with an inferred content type", async () => {
+    const file = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(file, "video-bytes");
+
+    const res = await handleFileRequest(localRequest(file));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("video/mp4");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(res.headers.get("Content-Length")).toBe("11");
+    expect(await res.text()).toBe("video-bytes");
+  });
+
+  it("serves a byte range as 206 Partial Content", async () => {
+    const file = path.join(tmpDir, "song.mp3");
+    await fs.writeFile(file, "0123456789");
+
+    const res = await handleFileRequest(
+      localRequest(file, { headers: { Range: "bytes=2-5" } })
+    );
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 2-5/10");
+    expect(res.headers.get("Content-Length")).toBe("4");
+    expect(await res.text()).toBe("2345");
+  });
+
+  it("returns 416 for an unsatisfiable range", async () => {
+    const file = path.join(tmpDir, "song.mp3");
+    await fs.writeFile(file, "0123456789");
+
+    const res = await handleFileRequest(
+      localRequest(file, { headers: { Range: "bytes=999-1000" } })
+    );
+    expect(res.status).toBe(416);
+    expect(res.headers.get("Content-Range")).toBe("bytes */10");
+  });
+
+  it("answers HEAD with metadata and no body", async () => {
+    const file = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(file, "video-bytes");
+
+    const res = await handleFileRequest(localRequest(file, { method: "HEAD" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Length")).toBe("11");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 404 for a missing file", async () => {
+    const res = await handleFileRequest(
+      localRequest(path.join(tmpDir, "nope.mp4"))
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a directory", async () => {
+    const dir = path.join(tmpDir, "adir");
+    await fs.mkdir(dir);
+    const res = await handleFileRequest(localRequest(dir));
+    expect(res.status).toBe(400);
+  });
+
+  it("denies sensitive home paths (e.g. ~/.ssh)", async () => {
+    const sshKey = path.join(os.homedir(), ".ssh", "id_rsa");
+    const res = await handleFileRequest(localRequest(sshKey));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects non-GET/HEAD methods", async () => {
+    const file = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(file, "x");
+    const res = await handleFileRequest(
+      localRequest(file, { method: "POST" })
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("is disabled in production", async () => {
+    process.env["NODETOOL_ENV"] = "production";
+    const res = await handleFileRequest(
+      localRequest(path.join(tmpDir, "clip.mp4"))
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unknown route
 // ---------------------------------------------------------------------------
 

--- a/web/src/components/node/ImageView.tsx
+++ b/web/src/components/node/ImageView.tsx
@@ -7,7 +7,7 @@ import DownloadIcon from "@mui/icons-material/Download";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import AssetViewer from "../assets/AssetViewer";
 import { createImageUrl } from "../../utils/imageUtils";
-import { useFileUriDataUrl } from "../../utils/localFile";
+import { fileUriToHttpUrl } from "../../utils/localFile";
 import BitmapCanvas from "./BitmapCanvas";
 import ImageDimensions from "./ImageDimensions";
 import { CopyAssetButton } from "../common/CopyAssetButton";
@@ -59,12 +59,13 @@ const ImageView: React.FC<ImageViewProps> = ({ source, bitmap }) => {
   const [displayedUrl, setDisplayedUrl] = useState<string>();
 
   // Local-mode `file://` sources can't be loaded by the renderer directly;
-  // resolve them to a data URL via the Electron bridge. Returns null for any
-  // other source, in which case the original `source` is used unchanged.
-  const fileDataUrl = useFileUriDataUrl(
+  // point them at the backend's `/api/files/local` streaming endpoint. Returns
+  // null for any other source, in which case the original `source` is used
+  // unchanged.
+  const fileHttpUrl = fileUriToHttpUrl(
     typeof source === "string" ? source : null
   );
-  const effectiveSource = fileDataUrl !== null ? fileDataUrl : source;
+  const effectiveSource = fileHttpUrl !== null ? fileHttpUrl : source;
 
   const nextUrl = useMemo(() => {
     // A newer source arrived before the previous preload committed — drop the

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -4,7 +4,7 @@ import { Asset } from "../../../stores/ApiTypes";
 import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
 import { bitmapToPngDataUrl } from "../../../lib/workflow/materializeBrowserOutputs";
-import { useFileUriDataUrl } from "../../../utils/localFile";
+import { fileUriToHttpUrl } from "../../../utils/localFile";
 
 /**
  * Base type for typed output values with a type discriminator
@@ -177,10 +177,11 @@ export function useSignedUrl(uri: string | undefined | null): string {
     { enabled: Boolean(key), staleTime: 6 * 24 * 60 * 60 * 1000 }
   );
   // `file://` URIs (local-mode assets) can't be loaded directly by the renderer
-  // under webSecurity — resolve them to a data URL via the Electron bridge.
-  const fileDataUrl = useFileUriDataUrl(uri);
-  if (fileDataUrl !== null) {
-    return fileDataUrl;
+  // under webSecurity — point them at the backend's `/api/files/local`
+  // streaming endpoint.
+  const fileHttpUrl = fileUriToHttpUrl(uri);
+  if (fileHttpUrl !== null) {
+    return fileHttpUrl;
   }
   return data?.url ?? resolveAssetUri(uri);
 }

--- a/web/src/serverState/__tests__/useAsset.test.tsx
+++ b/web/src/serverState/__tests__/useAsset.test.tsx
@@ -14,10 +14,18 @@ jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn()
 }));
 
+const mockFileUriToHttpUrl = jest.fn();
+jest.mock('../../utils/localFile', () => ({
+  __esModule: true,
+  fileUriToHttpUrl: (uri: string | null | undefined) =>
+    mockFileUriToHttpUrl(uri)
+}));
+
 describe('useAsset', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useQuery as jest.Mock).mockReturnValue({ data: mockAsset });
+    mockFileUriToHttpUrl.mockReturnValue(null);
   });
 
   it('returns asset and uri when audio asset provided', () => {
@@ -45,5 +53,20 @@ describe('useAsset', () => {
 
     expect(result.current.asset).toEqual(mockAsset);
     expect(result.current.uri).toBe(mockAsset.get_url);
+  });
+
+  it('resolves file:// URIs to the backend streaming URL instead of the raw path', () => {
+    mockFileUriToHttpUrl.mockReturnValue(
+      'http://localhost:7777/api/files/local?path=%2FUsers%2Fme%2Fsong.mp3'
+    );
+
+    const { result } = renderHook(() =>
+      useAsset({ audio: { asset_id: null, uri: 'file:///Users/me/song.mp3' } as any })
+    );
+
+    expect(mockFileUriToHttpUrl).toHaveBeenCalledWith('file:///Users/me/song.mp3');
+    expect(result.current.uri).toBe(
+      'http://localhost:7777/api/files/local?path=%2FUsers%2Fme%2Fsong.mp3'
+    );
   });
 });

--- a/web/src/serverState/useAsset.ts
+++ b/web/src/serverState/useAsset.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Asset, Video, Audio, Image, Document, Model3DRef } from "../stores/ApiTypes";
 import { useAssetStore } from "../stores/AssetStore";
 import { useQuery } from "@tanstack/react-query";
+import { fileUriToHttpUrl } from "../utils/localFile";
 
 type UseAssetProps = {
   audio?: Audio;
@@ -49,10 +50,16 @@ export function useAsset(props: UseAssetProps): {
   });
 
   const resourceUri = assetResource?.uri;
+  // `file://` URIs (local-mode drops in Electron) can't be loaded directly by
+  // the renderer under webSecurity — point them at the backend's
+  // `/api/files/local` streaming endpoint, same as the output-rendering path's
+  // `useSignedUrl`.
+  const fileHttpUrl = fileUriToHttpUrl(resourceUri);
   const uri =
-    !resourceUri || resourceUri.startsWith("asset://")
+    fileHttpUrl ??
+    (!resourceUri || resourceUri.startsWith("asset://")
       ? asset?.get_url || resourceUri || undefined
-      : resourceUri;
+      : resourceUri);
 
   return { asset, uri };
 }

--- a/web/src/utils/__tests__/localFile.test.ts
+++ b/web/src/utils/__tests__/localFile.test.ts
@@ -4,7 +4,8 @@ import {
   getLocalFilePath,
   pathToFileUri,
   fileUriToPath,
-  isFileUri
+  isFileUri,
+  fileUriToHttpUrl
 } from "../localFile";
 
 describe("pathToFileUri", () => {
@@ -47,6 +48,27 @@ describe("isFileUri", () => {
     expect(isFileUri("http://x/y.png")).toBe(false);
     expect(isFileUri(undefined)).toBe(false);
     expect(isFileUri(null)).toBe(false);
+  });
+});
+
+describe("fileUriToHttpUrl", () => {
+  it("maps a file:// URI to the backend streaming endpoint", () => {
+    expect(fileUriToHttpUrl("file:///Users/me/song.mp3")).toBe(
+      "http://localhost:7777/api/files/local?path=%2FUsers%2Fme%2Fsong.mp3"
+    );
+  });
+
+  it("encodes spaces and other unsafe characters in the path", () => {
+    expect(fileUriToHttpUrl("file:///Users/me/Kreuzberg%20Neon.mp3")).toBe(
+      "http://localhost:7777/api/files/local?path=%2FUsers%2Fme%2FKreuzberg%20Neon.mp3"
+    );
+  });
+
+  it("returns null for non-file URIs", () => {
+    expect(fileUriToHttpUrl("http://example.com/a.mp3")).toBeNull();
+    expect(fileUriToHttpUrl("asset://abc")).toBeNull();
+    expect(fileUriToHttpUrl(undefined)).toBeNull();
+    expect(fileUriToHttpUrl(null)).toBeNull();
   });
 });
 

--- a/web/src/utils/localFile.ts
+++ b/web/src/utils/localFile.ts
@@ -5,16 +5,17 @@
  * by a `file://` URI instead of being uploaded to the asset store. The backend
  * already resolves `file://` URIs from disk when a workflow runs; these helpers
  * cover the renderer side: getting a dropped file's path, building the URI, and
- * resolving the URI back to a previewable data URL (the renderer can't load a
- * raw `file://` URL under `webSecurity`, so previews go through the Electron
- * `readFileAsDataURL` bridge).
+ * resolving the URI to a previewable URL. The renderer can't load a raw
+ * `file://` URL under `webSecurity`, so previews point at the backend's
+ * `/api/files/local` endpoint, which streams the bytes off disk with HTTP Range
+ * support — no reading in Electron, no data URIs.
  *
  * None of this applies in a plain browser: a dropped `File` never exposes its
  * disk path there, so `getLocalFilePath` returns `null` and callers fall back
  * to uploading.
  */
 import { isElectron } from "./browser";
-import { useEffect, useState } from "react";
+import { BASE_URL } from "../stores/BASE_URL";
 
 /**
  * Resolve the absolute disk path of a dropped/selected file. Returns `null` in
@@ -70,72 +71,19 @@ export const fileUriToPath = (uri: string): string => {
 export const isFileUri = (uri: string | null | undefined): uri is string =>
   typeof uri === "string" && uri.startsWith("file://");
 
-// Cache resolved data URLs so a reloaded workflow doesn't re-read the same file
-// off disk on every render / for every node referencing it.
-const dataUrlCache = new Map<string, string>();
-const inflight = new Map<string, Promise<string>>();
-
 /**
- * Read a `file://` URI off disk (via the Electron bridge) and return it as a
- * data URL suitable for `<img>` / `<audio>` / `<iframe>`. Returns "" when not
- * in Electron or when the read fails. Results are cached per URI.
+ * Map a local `file://` URI to the backend endpoint that streams it over HTTP.
+ * Returns `null` for any non-`file://` URI, signalling callers to use their
+ * normal resolver. The backend reads the file off disk (with Range support for
+ * audio/video seeking), so the renderer never loads a raw `file://` URL and no
+ * bytes pass through Electron.
  */
-export const loadFileUriDataUrl = async (uri: string): Promise<string> => {
-  const cached = dataUrlCache.get(uri);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const existing = inflight.get(uri);
-  if (existing) {
-    return existing;
-  }
-  const read = window.api?.clipboard?.readFileAsDataURL;
-  if (!read) {
-    return "";
-  }
-  const promise = (async () => {
-    try {
-      const dataUrl = (await read(fileUriToPath(uri))) ?? "";
-      dataUrlCache.set(uri, dataUrl);
-      return dataUrl;
-    } catch {
-      dataUrlCache.set(uri, "");
-      return "";
-    } finally {
-      inflight.delete(uri);
-    }
-  })();
-  inflight.set(uri, promise);
-  return promise;
-};
-
-/**
- * Resolve a `file://` URI to a previewable data URL. Returns `null` when the
- * URI is not a `file://` URI (signalling callers to use their normal resolver),
- * or the data URL string (empty while the async read is in flight).
- */
-export const useFileUriDataUrl = (
+export const fileUriToHttpUrl = (
   uri: string | null | undefined
 ): string | null => {
-  const applicable = isFileUri(uri);
-  const [dataUrl, setDataUrl] = useState<string>(() =>
-    applicable ? dataUrlCache.get(uri) ?? "" : ""
-  );
-
-  useEffect(() => {
-    if (!applicable) {
-      return;
-    }
-    let cancelled = false;
-    void loadFileUriDataUrl(uri).then((resolved) => {
-      if (!cancelled) {
-        setDataUrl(resolved);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [applicable, uri]);
-
-  return applicable ? dataUrl : null;
+  if (!isFileUri(uri)) {
+    return null;
+  }
+  const encodedPath = encodeURIComponent(fileUriToPath(uri));
+  return `${BASE_URL}/api/files/local?path=${encodedPath}`;
 };


### PR DESCRIPTION
## Problem

Dropping a local audio/video file onto the canvas in the desktop app references it in place by a `file://` URI. The renderer can't load a raw `file://` URL under `webSecurity`, and the previous workaround read the whole file in the Electron main process and returned a base64 **data URI**. A data URI has no HTTP Range support, so `<video>` (and WaveSurfer's `fetch` probe) couldn't stream or seek — **dropping an mp4 failed** (`TypeError: Failed to fetch`).

## Fix

Serve local-file previews from the backend, streamed with Range support — no reading in Electron, no data URIs.

**Backend** — new `GET/HEAD /api/files/local?path=<abs>`:
- `file-api.ts`: streams a local file off disk with HTTP **Range** (206 partial content), content-type inference, `Accept-Ranges`, CORS, HEAD. Production-gated like the rest of `/api/files`. Sensitive-path denylist (`~/.ssh`, `.aws`, `.gnupg`, …) mirroring the Electron main process.
- `storage-api.ts`: exported the existing `parseRangeHeader` / `nodeStreamToWebStream` / `corsHeaders` so the new handler reuses them (no behavior change).
- `routes/files.ts`: registered the Fastify route.

**Frontend** — resolve `file://` URIs to that endpoint via a synchronous `fileUriToHttpUrl`, replacing the async Electron data-URI bridge (`useFileUriDataUrl`) in:
- `useAsset.ts` (property editor — audio/video/image/document)
- `output/hooks.ts` `useSignedUrl` (output previews)
- `ImageView.tsx`

Fixes audio, **video**, and image previews on the same path.

## Verification

Live smoke test against the wired server:
- Full GET → `200 video/mp4`, `Accept-Ranges: bytes`
- `Range: bytes=6-10` → `206`, `Content-Range: bytes 6-10/27`, exact slice returned
- HEAD → `200`, no body
- CORS reflects `http://localhost:3000` + `Cross-Origin-Resource-Policy: cross-origin`
- Denylist `~/.ssh/id_rsa` → `403`; missing → `404`; POST → `405`

Backend: 63 tests pass, websocket typecheck + lint clean. Web: 147 tests pass, typecheck clean.

> Note: the dev backend loads the websocket package from `dist`, so this needs `npm run build --workspace=packages/websocket` (a `dev:server` restart picks it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)