### PR TITLE
[T-20260629-0002] Guard build host against NODE_ENV=production / wrong Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,12 @@
   "scripts": {
     "postinstall": "node -e \"try{require('fs').unlinkSync('node_modules/.electron-native-rebuild-stamp')}catch{}\"",
     "create:pack": "node scripts/create-pack.mjs",
+    "preflight": "node scripts/preflight.mjs",
+    "prebuild:packages": "node scripts/preflight.mjs",
     "build:packages": "turbo run build --filter=\"./packages/*\"",
+    "prebuild:packages:clean": "node scripts/preflight.mjs",
     "build:packages:clean": "turbo run build --filter=\"./packages/*\" --force",
+    "prebuild:packages:tsc": "node scripts/preflight.mjs",
     "build:packages:tsc": "tsc --build tsconfig.build.json && node scripts/copy-manifests.mjs",
     "build:web": "turbo run build --filter=web",
     "build": "turbo run build",

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Fast, network-free guard for the package build environment. Two failure
+// modes have historically produced cryptic errors that look like missing
+// dependencies:
+//
+//   1. NODE_ENV=production makes `npm install`/`npm ci` silently omit ALL
+//      devDependencies (typescript, turbo, node-gyp). The build then dies with
+//      "turbo: not found" / "Cannot find module 'typescript'" and sends you
+//      hunting for a dependency that was never missing.
+//   2. Running on a Node major other than the `.nvmrc` pin (e.g. Node 24 vs
+//      the pinned 22) drifts away from the version the packaged app embeds.
+//
+// This runs before `build:packages` so both fail loudly with the actual fix
+// instead of a downstream red herring.
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+
+function fail(message) {
+  process.stderr.write(`\n\x1b[31m✖ build preflight: ${message}\x1b[0m\n\n`);
+  process.exit(1);
+}
+
+function warn(message) {
+  process.stderr.write(`\x1b[33m⚠ build preflight: ${message}\x1b[0m\n`);
+}
+
+export function checkNodeEnv(env = process.env) {
+  if (env.NODE_ENV === "production") {
+    fail(
+      "NODE_ENV=production is set. npm omits ALL devDependencies (typescript, " +
+        "turbo, node-gyp) in this mode, so the build fails with misleading " +
+        '"module not found" / "turbo: not found" errors.\n' +
+        "  Fix: run `unset NODE_ENV` (or `NODE_ENV= npm run build:packages`), " +
+        "then reinstall with `npm install --include=dev` if devDeps were " +
+        "already pruned.\n" +
+        "  (This guards the build only — production runtime is unaffected.)"
+    );
+  }
+}
+
+export function checkNodeVersion(
+  running = process.versions.node,
+  root = repoRoot
+) {
+  let pinned;
+  try {
+    pinned = readFileSync(resolve(root, ".nvmrc"), "utf8").trim();
+  } catch {
+    // No .nvmrc — nothing to compare against.
+    return;
+  }
+  if (!pinned) {
+    return;
+  }
+
+  const runningMajor = running.split(".")[0];
+  const pinnedMajor = pinned.replace(/^v/, "").split(".")[0];
+
+  if (runningMajor !== pinnedMajor) {
+    warn(
+      `Node ${running} differs from the pinned major (.nvmrc: ${pinned}). ` +
+        "The packaged app embeds the pinned major; building on another can " +
+        "drift dev from prod.\n" +
+        "  Fix: `nvm use` (installs/activates the pinned Node)."
+    );
+  }
+}
+
+export function preflight(env = process.env) {
+  checkNodeEnv(env);
+  checkNodeVersion();
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  preflight();
+}


### PR DESCRIPTION
All acceptance criteria are met and committed.

## Summary

Added a fast, network-free build preflight that fails loudly on the two environment misconfigurations that previously produced cryptic errors: `NODE_ENV=production` (which makes npm silently drop all devDeps → misleading "turbo: not found" / "module not found") and a wrong Node major (Node 24 vs the pinned 22.22.1).

**Changed:**
- `scripts/preflight.mjs` (new) — `checkNodeEnv` hard-errors (exit 1) on `NODE_ENV=production` with the exact fix (`unset NODE_ENV` / `npm install --include=dev`); `checkNodeVersion` reads `.nvmrc` and warns on a Node-major mismatch with an `nvm use` hint. Runs in ~28ms, no network, silent on the happy path. Exports are individually testable.
- `package.json` — wired preflight as `prebuild:packages`, `prebuild:packages:clean`, and `prebuild:packages:tsc` npm pre-hooks (fires once before the whole build, not per-package), plus a standalone `preflight` script.

**Decisions (see task notes):**
- Node-major mismatch is a **warning**, not a hard error — this worktree and likely CI run on Node 24, so erroring would break legitimate builds. `NODE_ENV=production` is the hard error since it's the real breakage.
- **Skipped `engine-strict=true`** in `.npmrc`: with `engines <23` it would make `npm install` fail outright on any Node 24 host (CI included), which is worse than what it guards.

Verified: happy path silent (matching major), production → immediate exit 1 before turbo runs, version warn on Node 24, ~28ms timing, oxlint clean.

---

Closes task **T-20260629-0002**: Guard build host against NODE_ENV=production / wrong Node.


### Acceptance criteria
- [x] Running a package build with NODE_ENV=production fails immediately with a clear message naming the cause and the fix (unset NODE_ENV / --include=dev)
- [x] Building on a Node major other than the .nvmrc pin produces a clear warning or error with a `nvm use` hint
- [x] Preflight adds <100ms and makes no network calls
- [x] Normal build on Node 22 + unset NODE_ENV is unaffected (no new output noise on the happy path beyond a one-line OK at most)
- [x] lint + typecheck pass