### PR TITLE
Optimize rendering and serialization performance

### DIFF
--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -71,7 +71,9 @@ export interface LayerItemProps {
   isMask: boolean;
   isIsolated: boolean;
   dropPosition: DropPosition;
-  editingLayerId: string | null;
+  /** True only for the row being renamed — keeps other rows' memo stable while typing. */
+  isEditing: boolean;
+  /** Live rename input value; empty string for rows not being edited. */
   editName: string;
   onLayerRowPointerDown: (e: React.PointerEvent, layerId: string) => void;
   onLayerRowClick: (e: React.MouseEvent, layerId: string) => void;
@@ -122,7 +124,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
   isMask,
   isIsolated,
   dropPosition,
-  editingLayerId,
+  isEditing,
   editName,
   onLayerRowPointerDown,
   onLayerRowClick,
@@ -327,7 +329,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
           </Tooltip>
         )}
 
-        {editingLayerId === layer.id ? (
+        {isEditing ? (
           <input
             aria-label="Layer name"
             value={editName}

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -14,7 +14,6 @@
 import React, {
   useCallback,
   useEffect,
-  useState,
   useMemo,
   useRef,
   forwardRef
@@ -409,10 +408,11 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
 
     // ─── Document-space cursor tracking ─────────────────────────────────
 
-    const [cursorDocPos, setCursorDocPos] = useState<Point | null>(null);
-    // Mirror the document-space cursor into the store so the (standalone)
-    // status bar can read it without prop-drilling. Local state still drives
-    // the floating info pill used by the in-node modal.
+    // The document-space cursor lives in the store only (`cursorDocPos`), not
+    // in local state: pointer moves fire at 60–120+ Hz and a local setState
+    // here would re-render the whole canvas subtree per event. The store
+    // setter dedupes same-cell writes, and only the tiny readout components
+    // (status bar / info pill) subscribe to it.
     const setStoreCursorDocPos = useSketchStore((s) => s.setCursorDocPos);
     // The standalone editor (bound document) shows the full-width status bar,
     // which subsumes the floating info pill — hide the pill there. The in-node
@@ -429,9 +429,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
               x: ((clientX - rect.left) / rect.width) * doc.canvas.width,
               y: ((clientY - rect.top) / rect.height) * doc.canvas.height
             };
-            const next = { x: Math.floor(p.x), y: Math.floor(p.y) };
-            setCursorDocPos(next);
-            setStoreCursorDocPos(next);
+            setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
             return;
           }
         }
@@ -448,9 +446,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
             doc.canvas.width,
             doc.canvas.height
           );
-          const next = { x: Math.floor(p.x), y: Math.floor(p.y) };
-          setCursorDocPos(next);
-          setStoreCursorDocPos(next);
+          setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
         }
       },
       [
@@ -483,7 +479,6 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
 
     const handleMouseLeaveWithCoords = useCallback(() => {
       pointerHandlers.handleMouseLeave();
-      setCursorDocPos(null);
       setStoreCursorDocPos(null);
     }, [pointerHandlers, setStoreCursorDocPos]);
 
@@ -515,7 +510,6 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         interactionTool={interactionTool}
         bootstrapPhaseActive={compositing.bootstrapPhaseActive}
         backend={compositing.backend}
-        cursorDocPos={cursorDocPos}
         showInfoBar={!standaloneDocumentId}
         containerCursor={pointerHandlers.containerCursor}
         onPointerDown={handlePointerDownWithClient}

--- a/web/src/components/sketch/SketchCanvasPresentation.tsx
+++ b/web/src/components/sketch/SketchCanvasPresentation.tsx
@@ -14,6 +14,7 @@ import React, { memo } from "react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
 import { FlexRow, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { useSketchStore } from "./state";
 import type { Point, SketchTool } from "./types";
 import SketchCanvasResizeHandles from "./SketchCanvasResizeHandles";
 import { SKETCH_Z_INDEX, SKETCH_FONT } from "./sketchStyles";
@@ -93,7 +94,6 @@ export interface SketchCanvasPresentationProps {
   backend: "webgpu" | "canvas2d";
 
   // ── Info bar data ──────────────────────────────────────────────────
-  cursorDocPos: Point | null;
   /**
    * Floating bottom-center info pill (dimensions / zoom / cursor). Defaults to
    * true; the standalone editor hides it because its full-width status bar
@@ -128,6 +128,24 @@ export interface SketchCanvasPresentationProps {
   docOverlay?: React.ReactNode;
 }
 
+// ─── Cursor readout ──────────────────────────────────────────────────────────
+
+/**
+ * Subscribes to the store cursor position itself so pointer moves re-render
+ * only this span — not the canvas component tree.
+ */
+const CursorPosReadout = memo(function CursorPosReadout() {
+  const cursorDocPos = useSketchStore((s) => s.cursorDocPos);
+  if (cursorDocPos === null) {
+    return null;
+  }
+  return (
+    <span style={{ fontSize: SKETCH_FONT.sm, minWidth: 65 }}>
+      {cursorDocPos.x}, {cursorDocPos.y}
+    </span>
+  );
+});
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
@@ -149,7 +167,6 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
       containerCursor,
       bootstrapPhaseActive,
       backend,
-      cursorDocPos,
       showInfoBar = true,
       onPointerDown,
       onPointerMove,
@@ -317,11 +334,7 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
               {canvasWidth} × {canvasHeight}
             </span>
             <span>{Math.round(zoom * 100)}%</span>
-            {cursorDocPos !== null && (
-              <span style={{ fontSize: SKETCH_FONT.sm, minWidth: 65 }}>
-                {cursorDocPos.x}, {cursorDocPos.y}
-              </span>
-            )}
+            <CursorPosReadout />
           </FlexRow>
         )}
       </div>

--- a/web/src/components/sketch/SketchLayersPanel.tsx
+++ b/web/src/components/sketch/SketchLayersPanel.tsx
@@ -69,6 +69,8 @@ import {
 } from "./types";
 import LayerItem from "./LayerItem";
 import type { DropPosition } from "./LayerItem";
+import type { LayerStatus } from "@nodetool-ai/image-editor";
+import { shallow } from "zustand/shallow";
 import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
 import { getRememberedModel } from "../../stores/lastModelStore";
 import { useSketchStore } from "./state/useSketchStore";
@@ -488,9 +490,17 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
   const dragSourceIndex = useRef<number | null>(null);
 
   // ─── Per-layer generation status (for status badges) ──────────────
-  // Subscribe to the bindings dictionary so each row picks up status flips
-  // (draft → stale → generated → failed) without manual prop drilling.
-  const layerBindings = useSketchSessionStore((s) => s.bindings);
+  // Derive only the per-layer statuses (shallow-compared) instead of
+  // subscribing to the whole bindings dictionary: binding edits that don't
+  // flip a status (prompt keystrokes, param overrides, version appends)
+  // must not re-render the panel.
+  const layerBindingStatuses = useSketchSessionStore((s) => {
+    const statuses: Record<string, LayerStatus> = {};
+    for (const layerId in s.bindings) {
+      statuses[layerId] = s.bindings[layerId].status;
+    }
+    return statuses;
+  }, shallow);
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false);
 
   // ─── Direct-generation layers (text-to-image, image-to-image) ─────
@@ -1149,8 +1159,8 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
               dropPosition={
                 dropTarget?.realIdx === realIdx ? dropTarget.position : null
               }
-              editingLayerId={editingLayerId}
-              editName={editName}
+              isEditing={editingLayerId === layer.id}
+              editName={editingLayerId === layer.id ? editName : ""}
               onLayerRowPointerDown={handleLayerRowPointerDown}
               onLayerRowClick={handleLayerRowClick}
               onVisibilityButtonMouseDown={handleVisibilityButtonMouseDown}
@@ -1170,7 +1180,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
               onDrop={handleDrop}
               onDragEnd={handleDragEnd}
               onToggleGroupCollapsed={onToggleGroupCollapsed}
-              bindingStatus={layerBindings[layer.id]?.status}
+              bindingStatus={layerBindingStatuses[layer.id]}
             />
           );
         })}

--- a/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
+++ b/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
@@ -6,9 +6,10 @@
  * info bar content, and resize handle rendering.
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import SketchCanvasPresentation from "../SketchCanvasPresentation";
 import type { SketchCanvasPresentationProps } from "../SketchCanvasPresentation";
+import { useSketchStore } from "../state";
 import { cursorStyleForTool } from "../sketchCursorStyle";
 import { canvasTransformStyle } from "../sketchCanvasPresentation.helpers";
 import { TransformTool } from "../tools/TransformTool";
@@ -64,7 +65,6 @@ function makeProps(
     containerCursor: cursorStyleForTool("brush"),
     bootstrapPhaseActive: false,
     backend: "canvas2d",
-    cursorDocPos: null,
     onPointerDown: jest.fn(),
     onPointerMove: jest.fn(),
     onPointerUp: jest.fn(),
@@ -162,15 +162,22 @@ describe("SketchCanvasPresentation", () => {
     expect(infoBar!.textContent).toContain("200%");
   });
 
-  it("shows cursor position when cursorDocPos is provided", () => {
-    const { container } = render(
-      <SketchCanvasPresentation
-        {...makeProps({ cursorDocPos: { x: 42, y: 17 } })}
-      />
-    );
-    const infoBar = container.querySelector(".sketch-canvas__info-bar");
-    expect(infoBar!.textContent).toContain("42");
-    expect(infoBar!.textContent).toContain("17");
+  it("shows cursor position when the store cursorDocPos is set", () => {
+    act(() => {
+      useSketchStore.setState({ cursorDocPos: { x: 42, y: 17 } });
+    });
+    try {
+      const { container } = render(
+        <SketchCanvasPresentation {...makeProps()} />
+      );
+      const infoBar = container.querySelector(".sketch-canvas__info-bar");
+      expect(infoBar!.textContent).toContain("42");
+      expect(infoBar!.textContent).toContain("17");
+    } finally {
+      act(() => {
+        useSketchStore.setState({ cursorDocPos: null });
+      });
+    }
   });
 
   it("does NOT render resize handles when onCanvasResize is not provided", () => {

--- a/web/src/components/sketch/sketchCanvasHooks/useLayerHydration.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useLayerHydration.ts
@@ -6,7 +6,7 @@
  * signatures used by the compositing trigger effects.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { SketchDocument } from "../types";
 import type { SketchRuntime } from "../rendering";
 import { resolveAssetUri } from "../../node/output/hooks";
@@ -71,35 +71,71 @@ export function useLayerHydration({
   >(new Map());
 
   /**
+   * Per-layer data-identity versions. `layer.data` is a serialized raster
+   * (often a multi-MB base64 string), so signatures must never embed it —
+   * concatenating it on every layers change is O(total raster bytes). Instead
+   * each distinct data value per layer gets a small monotonic version number;
+   * `===` on the unchanged case compares by reference in O(1).
+   */
+  const layerDataVersionRef = useRef<
+    Map<string, { data: string | null; version: number }>
+  >(new Map());
+  const dataVersionCounterRef = useRef(0);
+
+  const getLayerDataVersion = (
+    layerId: string,
+    data: string | null
+  ): number => {
+    const versions = layerDataVersionRef.current;
+    const prev = versions.get(layerId);
+    if (prev && prev.data === data) {
+      return prev.version;
+    }
+    const version = ++dataVersionCounterRef.current;
+    versions.set(layerId, { data, version });
+    return version;
+  };
+
+  /**
    * Stable hydration key: must NOT include doc canvas size when width/height
    * are inferred from the document (resize would re-run setLayerData and stretch
    * pixels into a larger backing store).
    */
-  const layerHydrationSignature = doc.layers
-    .map((layer) => {
-      const ref = layer.imageReference;
-      const refKey = ref
-        ? `${ref.uri}|${ref.objectFit}|${ref.naturalWidth}x${ref.naturalHeight}|${ref.sourceCrop ? `${ref.sourceCrop.x},${ref.sourceCrop.y},${ref.sourceCrop.width},${ref.sourceCrop.height}` : ""}`
-        : "";
-      const w =
-        layer.contentBounds?.width != null
-          ? String(layer.contentBounds.width)
-          : "";
-      const h =
-        layer.contentBounds?.height != null
-          ? String(layer.contentBounds.height)
-          : "";
-      return `${layer.id}:${layer.data ?? ""}:${refKey}:${layer.contentBounds?.x ?? 0}:${layer.contentBounds?.y ?? 0}:${w}:${h}`;
-    })
-    .join("|");
+  const layerHydrationSignature = useMemo(
+    () =>
+      doc.layers
+        .map((layer) => {
+          const ref = layer.imageReference;
+          const refKey = ref
+            ? `${ref.uri}|${ref.objectFit}|${ref.naturalWidth}x${ref.naturalHeight}|${ref.sourceCrop ? `${ref.sourceCrop.x},${ref.sourceCrop.y},${ref.sourceCrop.width},${ref.sourceCrop.height}` : ""}`
+            : "";
+          const w =
+            layer.contentBounds?.width != null
+              ? String(layer.contentBounds.width)
+              : "";
+          const h =
+            layer.contentBounds?.height != null
+              ? String(layer.contentBounds.height)
+              : "";
+          const dataVersion = getLayerDataVersion(layer.id, layer.data ?? null);
+          return `${layer.id}:${dataVersion}:${refKey}:${layer.contentBounds?.x ?? 0}:${layer.contentBounds?.y ?? 0}:${w}:${h}`;
+        })
+        .join("|"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- getLayerDataVersion reads refs only
+    [doc.layers]
+  );
 
   /** Visibility / opacity / blend / type / order — drives display recomposite. */
-  const layerDisplayStackSignature = doc.layers
-    .map(
-      (l) =>
-        `${l.id}:${l.visible ? 1 : 0}:${l.opacity}:${String(l.blendMode ?? "normal")}:${l.type}`
-    )
-    .join("|");
+  const layerDisplayStackSignature = useMemo(
+    () =>
+      doc.layers
+        .map(
+          (l) =>
+            `${l.id}:${l.visible ? 1 : 0}:${l.opacity}:${String(l.blendMode ?? "normal")}:${l.type}`
+        )
+        .join("|"),
+    [doc.layers]
+  );
 
   // ─── Initialize layer canvases from document data ───────────────────
 
@@ -112,6 +148,7 @@ export function useLayerHydration({
         runtime.deleteLayerCanvas(id);
         hydratedLayerStateRef.current.delete(id);
         layerStableRasterSizeRef.current.delete(id);
+        layerDataVersionRef.current.delete(id);
       }
     }
 
@@ -151,7 +188,8 @@ export function useLayerHydration({
       const refKey = ref
         ? `${ref.uri}|${ref.objectFit}|${ref.naturalWidth}x${ref.naturalHeight}|${ref.sourceCrop ? `${ref.sourceCrop.x},${ref.sourceCrop.y},${ref.sourceCrop.width},${ref.sourceCrop.height}` : ""}`
         : "";
-      const hydrationKey = `${layer.data ?? ""}:${refKey}:${defaultBounds.x}:${defaultBounds.y}:${defaultBounds.width}:${defaultBounds.height}`;
+      const dataVersion = getLayerDataVersion(layer.id, layer.data ?? null);
+      const hydrationKey = `${dataVersion}:${refKey}:${defaultBounds.x}:${defaultBounds.y}:${defaultBounds.width}:${defaultBounds.height}`;
       if (hydratedLayerStateRef.current.get(layer.id) === hydrationKey) {
         const ex = layerCanvasesRef.current.get(layer.id);
         if (ex != null && ex.width > 0 && ex.height > 0) {

--- a/web/src/components/sketch/state/slices/historySlice.ts
+++ b/web/src/components/sketch/state/slices/historySlice.ts
@@ -101,6 +101,39 @@ function captureDocumentCanvas(
 }
 
 /**
+ * Serialize layer structure for equality comparison without cloning.
+ * JSON.stringify only reads its input, so the per-layer `structuredClone`
+ * that `captureLayerStructure` performs (needed for snapshot immutability)
+ * is pure overhead on the compare path. Both sides of a comparison must go
+ * through this same mapper so key order is identical.
+ */
+function serializeStructureForCompare(
+  layers: readonly Layer[] | readonly LayerStructureSnapshot[]
+): string {
+  return JSON.stringify(
+    layers.map((l) => ({
+      id: l.id,
+      name: l.name,
+      type: l.type,
+      visible: l.visible,
+      opacity: l.opacity,
+      locked: l.locked,
+      alphaLock: l.alphaLock,
+      blendMode: l.blendMode,
+      transform: l.transform,
+      contentBounds: l.contentBounds,
+      exposedAsInput: l.exposedAsInput,
+      exposedAsOutput: l.exposedAsOutput,
+      imageReference: l.imageReference,
+      parentId: l.parentId,
+      collapsed: l.collapsed,
+      segmentationMeta: l.segmentationMeta,
+      effects: l.effects
+    }))
+  );
+}
+
+/**
  * Whether the live document is *ahead* of the snapshot stored at `index` —
  * i.e. there are uncommitted edits since that checkpoint.
  *
@@ -151,11 +184,39 @@ function isLiveStateAhead(
   // visibility, etc. Selection isn't compared: selection edits always commit
   // via a push, so they never leave an uncommitted tip.
   const storedStructure = resolveLayerStructure(history, index);
-  const liveStructure = captureLayerStructure(document.layers);
-  if (storedStructure.length !== liveStructure.length) {
+  if (storedStructure.length !== document.layers.length) {
     return true;
   }
-  return JSON.stringify(liveStructure) !== JSON.stringify(storedStructure);
+  return (
+    serializeStructureForCompare(document.layers) !==
+    serializeStructureForCompare(storedStructure)
+  );
+}
+
+/**
+ * Identity-keyed cache for {@link isLiveStateAhead}. `canUndo()` is evaluated
+ * inside component selectors, which re-run on every store write (including
+ * high-frequency cursor-position updates). Document, history array, and index
+ * are immutable snapshots, so the last answer can be reused until any of them
+ * changes identity.
+ */
+const liveStateAheadCache = new WeakMap<
+  SketchDocument,
+  { history: HistoryEntry[]; index: number; result: boolean }
+>();
+
+function isLiveStateAheadCached(
+  document: SketchDocument,
+  history: HistoryEntry[],
+  index: number
+): boolean {
+  const cached = liveStateAheadCache.get(document);
+  if (cached && cached.history === history && cached.index === index) {
+    return cached.result;
+  }
+  const result = isLiveStateAhead(document, history, index);
+  liveStateAheadCache.set(document, { history, index, result });
+  return result;
 }
 
 /**
@@ -289,7 +350,7 @@ export const createHistorySlice: StateCreator<
     // always leave the live state equal to the entry at `historyIndex`.
     const dirtyTip =
       state.historyIndex === state.history.length - 1 &&
-      isLiveStateAhead(state.document, state.history, state.historyIndex);
+      isLiveStateAheadCached(state.document, state.history, state.historyIndex);
 
     let history = state.history;
     let newIndex: number;
@@ -436,7 +497,7 @@ export const createHistorySlice: StateCreator<
     return (
       state.historyIndex === 0 &&
       state.historyIndex === state.history.length - 1 &&
-      isLiveStateAhead(state.document, state.history, 0)
+      isLiveStateAheadCached(state.document, state.history, 0)
     );
   },
   canRedo: () => get().historyIndex < get().history.length - 1

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -141,5 +141,14 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
   setCropPreviewBounds: (bounds) => set({ cropPreviewBounds: bounds }),
 
   cursorDocPos: null,
-  setCursorDocPos: (pos) => set({ cursorDocPos: pos })
+  setCursorDocPos: (pos) =>
+    set((state) => {
+      // Written on every pointer move — skip the notify when the integer
+      // position is unchanged so subscribers don't re-render per event.
+      const prev = state.cursorDocPos;
+      if (prev === pos || (prev && pos && prev.x === pos.x && prev.y === pos.y)) {
+        return state;
+      }
+      return { ...state, cursorDocPos: pos };
+    })
 });

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -685,8 +685,18 @@ async function externalizeOversizedBitmaps(
 
   const candidates = buildCandidates();
 
+  // Serializing the whole document is O(total bytes); do it once and track the
+  // running total as candidates are externalized instead of re-serializing per
+  // iteration. The estimate is conservative (each replacement also adds a
+  // small imageReference / uri payload, padded below), and `saveSnapshot`
+  // re-checks the exact size after externalization.
+  const REPLACEMENT_PADDING_BYTES = 512;
+  let totalBytes =
+    candidates.length > 0
+      ? getImageDocumentByteLength(nextSketch, layerBindings)
+      : 0;
+
   for (const candidate of candidates) {
-    const totalBytes = getImageDocumentByteLength(nextSketch, layerBindings);
     if (
       candidate.bytes <= MAX_INLINE_LAYER_BYTES &&
       totalBytes <= MAX_PERSISTED_IMAGE_DOCUMENT_BYTES
@@ -709,6 +719,10 @@ async function externalizeOversizedBitmaps(
     }
 
     candidate.replace(uri);
+    totalBytes -= Math.max(
+      0,
+      sourceData.length - uri.length - REPLACEMENT_PADDING_BYTES
+    );
     if (candidate.layerId) {
       externalizedLayerIds.add(candidate.layerId);
     }
@@ -849,7 +863,10 @@ export function useStandaloneSketchDocument(
   const editorStore = instance.editor;
   const sessionStore = instance.session;
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingHashRef = useRef<string | null>(null);
+  // Whether editor/binding state changed since the last save attempt. Store
+  // mutations only flip this flag — the expensive serialize/hash runs once
+  // inside the debounced save (`saveSnapshot`), never on the mutation path.
+  const pendingDirtyRef = useRef(false);
   // Keep the latest trpc utils available to the autosave callback. Reassign
   // on every render so the closure inside `saveSnapshot` sees the current
   // utils object even though it lives outside any React effect.
@@ -873,7 +890,7 @@ export function useStandaloneSketchDocument(
       toPersistedSketchEditorState(initialState),
       response.document.layerBindings ?? []
     );
-    pendingHashRef.current = serverHash;
+    pendingDirtyRef.current = false;
     const session = sessionStore.getState();
     session.setLoadedDocument(
       {
@@ -903,25 +920,21 @@ export function useStandaloneSketchDocument(
       const store = sessionStore.getState();
       if (inFlightRef.current || !store.documentId) {
         // A manual save may be in flight (shared guard). Re-arm the debounce
-        // so a pending hash isn't dropped if that save fails — but never
+        // so a pending change isn't dropped if that save fails — but never
         // after unmount (cleanup also calls flush()).
-        if (
-          alive &&
-          inFlightRef.current &&
-          pendingHashRef.current &&
-          pendingHashRef.current !== store.lastServerHash
-        ) {
+        if (alive && inFlightRef.current && pendingDirtyRef.current) {
           schedule();
         }
         return;
       }
-      const nextHash = pendingHashRef.current;
-      if (!nextHash || nextHash === store.lastServerHash) {
+      if (!pendingDirtyRef.current) {
         return;
       }
-      pendingHashRef.current = null;
+      pendingDirtyRef.current = false;
       inFlightRef.current = true;
       const documentId = store.documentId;
+      // `saveSnapshot` serializes + hashes once here and skips the network
+      // call when the document matches the last server hash.
       void saveSnapshot(instance, documentId, store.name, (saved) => {
         utilsRef.current.sketch.get.setData({ id: documentId }, saved);
       }).finally(() => {
@@ -929,11 +942,7 @@ export function useStandaloneSketchDocument(
         if (!alive) {
           return;
         }
-        const currentStore = sessionStore.getState();
-        if (
-          pendingHashRef.current &&
-          pendingHashRef.current !== currentStore.lastServerHash
-        ) {
+        if (pendingDirtyRef.current) {
           schedule();
         }
       });
@@ -974,38 +983,18 @@ export function useStandaloneSketchDocument(
         return;
       }
       prevSelected = nextSelected;
-
-      const nextHash = computeImageDocumentHash(
-        toPersistedSketchEditorState({
-          document: state.document,
-          activeTool: state.activeTool ?? DEFAULT_SKETCH_ACTIVE_TOOL,
-          zoom: state.zoom,
-          pan: state.pan,
-          history: stripHistoryCanvasSnapshots(state.history),
-          historyIndex: state.historyIndex
-        }),
-        Object.values(sessionStore.getState().bindings)
-      );
-      pendingHashRef.current = nextHash;
-      if (nextHash !== sessionStore.getState().lastServerHash) {
-        schedule();
-      }
+      pendingDirtyRef.current = true;
+      schedule();
     });
 
     // Subscribe to the merged session store too — bindings live here now,
-    // and a binding change still needs to bump the pending hash.
+    // and a binding change still needs to trigger a save.
     let prevBindings = sessionStore.getState().bindings;
     const unsubscribeSession = sessionStore.subscribe((state) => {
       if (state.bindings === prevBindings) return;
       prevBindings = state.bindings;
-      const nextHash = computeImageDocumentHash(
-        toPersistedSketchEditorState(buildSnapshot(editorStore)),
-        Object.values(state.bindings)
-      );
-      pendingHashRef.current = nextHash;
-      if (nextHash !== sessionStore.getState().lastServerHash) {
-        schedule();
-      }
+      pendingDirtyRef.current = true;
+      schedule();
     });
 
     return () => {

--- a/web/src/stores/sketch/persistence.ts
+++ b/web/src/stores/sketch/persistence.ts
@@ -40,25 +40,34 @@ function cloneValue<T>(value: T): T {
   return structuredClone(value);
 }
 
+/**
+ * Drop the non-serializable `layerCanvasSnapshots` from each entry. Shallow —
+ * the returned entries share all other fields with the store's history, so
+ * treat the result as read-only.
+ */
 export function stripHistoryCanvasSnapshots(
   history: readonly HistoryEntry[]
 ): PersistedHistoryEntry[] {
-  return history.map(({ layerCanvasSnapshots: _ignored, ...entry }) =>
-    cloneValue(entry)
-  );
+  return history.map(({ layerCanvasSnapshots: _ignored, ...entry }) => entry);
 }
 
+/**
+ * Assemble the persisted shape without deep-cloning. Layer data URLs and
+ * history entries can total many MB, so this must stay allocation-light: the
+ * result shares `document` and `history` references with the store. Treat it
+ * as read-only — mutating paths (`externalizeOversizedBitmaps`) clone first.
+ */
 export function toPersistedSketchEditorState(
   snapshot: SketchPersistenceSnapshot
 ): PersistedSketchEditorState {
   return {
-    ...cloneValue(snapshot.document),
+    ...snapshot.document,
     activeTool: snapshot.activeTool,
     viewport: {
       zoom: snapshot.zoom,
-      pan: cloneValue(snapshot.pan)
+      pan: { x: snapshot.pan.x, y: snapshot.pan.y }
     },
-    history: cloneValue(snapshot.history),
+    history: snapshot.history,
     historyIndex: snapshot.historyIndex
   };
 }


### PR DESCRIPTION
## Summary

This PR reduces unnecessary re-renders and serialization overhead across the sketch editor by deferring expensive computations, deduplicating state updates, and avoiding deep clones of large data structures.

## Key Changes

### Layer Hydration & Rendering (`useLayerHydration.ts`)
- Wrap `layerHydrationSignature` and `layerDisplayStackSignature` in `useMemo` to prevent recomputation on every render
- Replace direct embedding of `layer.data` (often multi-MB base64 strings) with small monotonic version numbers in signatures
- Add `getLayerDataVersion()` helper that tracks per-layer data identity and returns cached version numbers, reducing signature string concatenation from O(total raster bytes) to O(1) on unchanged data
- Clean up `layerDataVersionRef` when layers are deleted

### Autosave & Document Hashing (`SketchSessionStore.ts`)
- Replace hash-based dirty tracking with a simple boolean flag (`pendingDirtyRef`)
- Remove expensive `computeImageDocumentHash()` calls from store subscription paths — hash is now computed once inside the debounced `saveSnapshot()` callback
- Optimize `externalizeOversizedBitmaps()` to track running byte total instead of re-serializing the entire document on each candidate iteration
- Add conservative padding estimate for replacement URIs to avoid redundant serialization checks

### History & Undo/Redo (`historySlice.ts`)
- Add `serializeStructureForCompare()` to serialize layer structure without cloning, avoiding per-comparison allocations
- Implement `isLiveStateAheadCached()` with a `WeakMap` identity cache for `isLiveStateAhead()` results
- Cache key is the document snapshot itself (immutable), so the last answer is reused until document/history/index identity changes
- Eliminates redundant comparisons during high-frequency store writes (e.g., cursor position updates that trigger selector re-evaluation)

### Persistence (`persistence.ts`)
- Remove unnecessary deep clones in `stripHistoryCanvasSnapshots()` and `toPersistedSketchEditorState()`
- Return shallow references to document and history arrays instead of cloning — treat results as read-only
- Mutating paths (`externalizeOversizedBitmaps`) clone first as needed

### Cursor Position Tracking (`SketchCanvas.tsx`, `SketchCanvasPresentation.tsx`, `uiSlice.ts`)
- Move cursor position from local component state to Zustand store only
- Add deduplication in `setCursorDocPos()` — skip notify when integer position is unchanged
- Extract `CursorPosReadout` component that subscribes directly to store, so pointer moves (60–120+ Hz) only re-render the tiny readout, not the entire canvas subtree
- Remove `cursorDocPos` prop from `SketchCanvasPresentation` — read from store instead

### Layer Panel Rendering (`SketchLayersPanel.tsx`)
- Derive only per-layer statuses (shallow-compared) instead of subscribing to entire bindings dictionary
- Binding edits that don't flip status (prompt keystrokes, param overrides) no longer trigger panel re-renders
- Simplify `LayerItem` props: replace `editingLayerId` with boolean `isEditing` and always-empty-or-live `editName` to keep non-editing rows' memos stable during rename

### Tests (`sketchCanvasPresentation.test.tsx`)
- Update test to set cursor position via store instead of prop
- Use `act()` wrapper for store mutations and cleanup

## Implementation Details

- **Data versioning**: Each distinct `layer.data` value per layer gets a unique version number. Unchanged data returns the cached version in O(1), avoiding string concatenation of multi-MB payloads.
- **Deduplication**: `setCursorDocPos()` compares integer coordinates before notifying subscribers, preventing re-renders when the cursor stays in the same cell.
- **Caching**: `isLiveStateAheadCached()` uses `WeakMap` keyed by document snapshot identity — no manual cache invalidation needed.
- **Shallow references**: Persisted state shares document/history

https://claude.ai/code/session_01QZHC6BjanRyNFLKy6p9LYd