### PR TITLE
Optimize waveform rendering with peak cache and external playhead store

### DIFF
--- a/web/src/components/audio_editor/AudioSampleEditor.tsx
+++ b/web/src/components/audio_editor/AudioSampleEditor.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from "react";
 
 import {
   Box,
@@ -14,6 +21,7 @@ import { useSaveAudioToAsset } from "../../hooks/audio/useSaveAudioToAsset";
 import WaveformView, { type Selection } from "./WaveformView";
 import AudioEditorToolbar from "./AudioEditorToolbar";
 import { useEditHistory } from "./useEditHistory";
+import { createPlayheadStore, type PlayheadStore } from "./playheadStore";
 import {
   applyGain,
   audioBufferToSample,
@@ -63,11 +71,36 @@ const formatTime = (seconds: number): string => {
   return `${m}:${String(s).padStart(2, "0")}.${String(ms).padStart(3, "0")}`;
 };
 
+/** Clock in the footer — the only editor text that updates during playback. */
+const PlaybackClock = memo(function PlaybackClock({
+  playhead,
+  duration
+}: {
+  playhead: PlayheadStore;
+  duration: number;
+}) {
+  const seconds = useSyncExternalStore(
+    playhead.subscribe,
+    playhead.get,
+    playhead.get
+  );
+  return (
+    <Caption>
+      {formatTime(seconds)} / {formatTime(duration)}
+    </Caption>
+  );
+});
+
 /**
  * In-browser audio sample editor (Audacity-style): decode an asset into PCM,
  * select a region on the waveform, apply destructive edits (trim, delete,
  * silence, fade, normalize, reverse, gain) with undo/redo, audition with the
  * transport, and save the result back to the asset as WAV.
+ *
+ * The playhead advances every animation frame during playback, so it lives in
+ * an external store (`playheadStore`) rather than state here — only the
+ * playhead line and the clock subscribe, and this component doesn't re-render
+ * per frame.
  */
 const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
   const history = useEditHistory<AudioSample>();
@@ -82,12 +115,7 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
   const selectionRef = useRef<Selection | null>(null);
   selectionRef.current = selection;
 
-  const [playhead, setPlayheadState] = useState(0);
-  const playheadRef = useRef(0);
-  const setPlayhead = useCallback((value: number) => {
-    playheadRef.current = value;
-    setPlayheadState(value);
-  }, []);
+  const [playhead] = useState(createPlayheadStore);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [loop, setLoop] = useState(false);
@@ -97,6 +125,10 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
 
   const audioCtxRef = useRef<AudioContext | null>(null);
   const sourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const playBufferRef = useRef<{
+    sample: AudioSample;
+    buffer: AudioBuffer;
+  } | null>(null);
   const rafRef = useRef<number | null>(null);
   const startCtxTimeRef = useRef(0);
   const startOffsetRef = useRef(0);
@@ -146,12 +178,20 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
     const useLoop = loopRef.current;
     const begin = Math.max(
       0,
-      Math.min(sel ? sel.start : playheadRef.current, duration)
+      Math.min(sel ? sel.start : playhead.get(), duration)
     );
     const end = sel ? sel.end : duration;
 
     const src = ctx.createBufferSource();
-    src.buffer = sampleToAudioBuffer(current, ctx);
+    // Building the AudioBuffer copies every channel, so reuse it while the
+    // sample is unchanged (replay, loop, seek-and-play).
+    if (playBufferRef.current?.sample !== current) {
+      playBufferRef.current = {
+        sample: current,
+        buffer: sampleToAudioBuffer(current, ctx)
+      };
+    }
+    src.buffer = playBufferRef.current.buffer;
     src.connect(ctx.destination);
     if (useLoop) {
       src.loop = true;
@@ -169,7 +209,7 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
       if (loopRef.current) return;
       teardownSource();
       setIsPlaying(false);
-      setPlayhead(selectionRef.current ? selectionRef.current.start : begin);
+      playhead.set(selectionRef.current ? selectionRef.current.start : begin);
     };
     sourceRef.current = src;
     setIsPlaying(true);
@@ -183,11 +223,11 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
       } else if (t > endRef.current) {
         t = endRef.current;
       }
-      setPlayhead(t);
+      playhead.set(t);
       rafRef.current = requestAnimationFrame(tick);
     };
     rafRef.current = requestAnimationFrame(tick);
-  }, [getCtx, teardownSource, setPlayhead]);
+  }, [getCtx, teardownSource, playhead]);
 
   const pause = useCallback(() => {
     teardownSource();
@@ -197,8 +237,8 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
   const stop = useCallback(() => {
     teardownSource();
     setIsPlaying(false);
-    setPlayhead(selectionRef.current ? selectionRef.current.start : 0);
-  }, [teardownSource, setPlayhead]);
+    playhead.set(selectionRef.current ? selectionRef.current.start : 0);
+  }, [teardownSource, playhead]);
 
   const togglePlay = useCallback(() => {
     if (isPlaying) pause();
@@ -252,10 +292,10 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
       const end = Math.min(sel.end, duration);
       return end > start ? { start, end } : null;
     });
-    if (playheadRef.current > duration) {
-      setPlayhead(duration);
+    if (playhead.get() > duration) {
+      playhead.set(duration);
     }
-  }, [sample, teardownSource, setPlayhead]);
+  }, [sample, teardownSource, playhead]);
 
   useEffect(
     () => () => {
@@ -268,17 +308,18 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
     [teardownSource]
   );
 
-  const waveAreaRef = useRef<HTMLDivElement>(null);
+  // Element state (not a ref) so the observer attaches when the wave area
+  // mounts — it only appears after loading finishes, past the mount effect.
+  const [waveArea, setWaveArea] = useState<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   useEffect(() => {
-    const el = waveAreaRef.current;
-    if (!el) return;
+    if (!waveArea) return;
     const observer = new ResizeObserver((entries) => {
       setContainerWidth(entries[0]?.contentRect.width ?? 0);
     });
-    observer.observe(el);
+    observer.observe(waveArea);
     return () => observer.disconnect();
-  }, []);
+  }, [waveArea]);
 
   const duration = sample ? sampleDuration(sample) : 0;
   const fitPps =
@@ -300,16 +341,16 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
     if (!selection) return;
     commitEdit((s) => cropToRange(s, selection.start, selection.end));
     setSelection(null);
-    setPlayhead(0);
-  }, [selection, commitEdit, setPlayhead]);
+    playhead.set(0);
+  }, [selection, commitEdit, playhead]);
 
   const handleDelete = useCallback(() => {
     if (!selection) return;
     const start = selection.start;
     commitEdit((s) => deleteRange(s, selection.start, selection.end));
     setSelection(null);
-    setPlayhead(start);
-  }, [selection, commitEdit, setPlayhead]);
+    playhead.set(start);
+  }, [selection, commitEdit, playhead]);
 
   const handleSilence = useCallback(() => {
     if (!selection) return;
@@ -418,14 +459,14 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
         onDone={onClose}
       />
 
-      <Box ref={waveAreaRef} sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+      <Box ref={setWaveArea} sx={{ flex: 1, minHeight: 0, position: "relative" }}>
         <WaveformView
           sample={sample}
           pixelsPerSecond={pixelsPerSecond}
           selection={selection}
-          playheadSec={playhead}
+          playhead={playhead}
           onSelectionChange={setSelection}
-          onSeek={setPlayhead}
+          onSeek={playhead.set}
         />
       </Box>
 
@@ -446,9 +487,7 @@ const AudioSampleEditor = ({ asset, onClose }: AudioSampleEditorProps) => {
               )} (${formatTime(selection.end - selection.start)})`
             : "Drag to select · Click to seek"}
         </Caption>
-        <Caption>
-          {formatTime(playhead)} / {formatTime(duration)}
-        </Caption>
+        <PlaybackClock playhead={playhead} duration={duration} />
       </FlexRow>
     </FlexColumn>
   );

--- a/web/src/components/audio_editor/WaveformView.tsx
+++ b/web/src/components/audio_editor/WaveformView.tsx
@@ -2,7 +2,14 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore
+} from "react";
 
 import {
   numChannels,
@@ -10,6 +17,8 @@ import {
   sampleDuration,
   type AudioSample
 } from "./audioSample";
+import { buildChannelPeaks, peakRange } from "./waveformPeaks";
+import type { PlayheadStore } from "./playheadStore";
 
 export interface Selection {
   start: number;
@@ -21,7 +30,7 @@ interface WaveformViewProps {
   /** Horizontal scale; total content width is `duration * pixelsPerSecond`. */
   pixelsPerSecond: number;
   selection: Selection | null;
-  playheadSec: number;
+  playhead: PlayheadStore;
   onSelectionChange: (selection: Selection | null) => void;
   onSeek: (seconds: number) => void;
 }
@@ -42,10 +51,11 @@ const styles = (theme: Theme) =>
       cursor: "text"
     },
     "& canvas": {
-      position: "absolute",
+      position: "sticky",
       top: 0,
       left: 0,
-      display: "block"
+      display: "block",
+      pointerEvents: "none"
     },
     "& .selection": {
       position: "absolute",
@@ -118,20 +128,47 @@ const formatRulerTime = (seconds: number, interval: number): string => {
   return `${minutes}:${String(secs).padStart(2, "0")}`;
 };
 
+/** Positioned line that tracks the playhead store without re-rendering the view. */
+const PlayheadLine = memo(function PlayheadLine({
+  playhead,
+  pixelsPerSecond
+}: {
+  playhead: PlayheadStore;
+  pixelsPerSecond: number;
+}) {
+  const seconds = useSyncExternalStore(
+    playhead.subscribe,
+    playhead.get,
+    playhead.get
+  );
+  return (
+    <div
+      className="playhead"
+      style={{ left: `${seconds * pixelsPerSecond}px` }}
+    />
+  );
+});
+
 /**
  * Canvas waveform with click-to-seek and drag-to-select. Channels are drawn as
- * stacked min/max lanes. The waveform canvas only repaints when the sample,
- * zoom, or size changes; the selection band and playhead are positioned DOM
- * nodes so seeking and playback don't trigger a redraw.
+ * stacked min/max lanes.
+ *
+ * The canvas is viewport-sized and sticky inside a wide scrollable inner div:
+ * only the visible slice is ever painted, and per-column min/max comes from a
+ * peak cache built once per sample. Redraws (scroll, zoom, resize) therefore
+ * cost O(visible pixels), not O(total frames), and the canvas never hits the
+ * browser's per-dimension size limit at high zoom. The selection band and
+ * playhead are positioned DOM nodes, so selecting and playback don't repaint
+ * the canvas at all.
  */
-const WaveformView = ({
+const WaveformView = memo(function WaveformView({
   sample,
   pixelsPerSecond,
   selection,
-  playheadSec,
+  playhead,
   onSelectionChange,
   onSeek
-}: WaveformViewProps) => {
+}: WaveformViewProps) {
   const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -141,28 +178,44 @@ const WaveformView = ({
   const duration = sampleDuration(sample);
   const width = Math.max(1, Math.ceil(duration * pixelsPerSecond));
 
+  const peaks = useMemo(
+    () => sample.channels.map((channel) => buildChannelPeaks(channel)),
+    [sample]
+  );
+
   const waveColor = theme.palette.grey[300];
   const midColor = theme.palette.grey[700];
   const rulerColor = theme.palette.text.secondary;
   const rulerLineColor = theme.palette.divider;
 
-  useEffect(() => {
+  const draw = useCallback(() => {
     const canvas = canvasRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
 
+    const viewportWidth = container.clientWidth;
     const height = container.clientHeight;
-    const waveformHeight = Math.max(1, height - RULER_HEIGHT);
+    if (viewportWidth === 0 || height === 0) return;
+
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = Math.floor(width * dpr);
-    canvas.height = Math.floor(height * dpr);
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
+    const deviceWidth = Math.floor(viewportWidth * dpr);
+    const deviceHeight = Math.floor(height * dpr);
+    if (canvas.width !== deviceWidth) canvas.width = deviceWidth;
+    if (canvas.height !== deviceHeight) canvas.height = deviceHeight;
+    const cssWidth = `${viewportWidth}px`;
+    const cssHeight = `${height}px`;
+    if (canvas.style.width !== cssWidth) canvas.style.width = cssWidth;
+    if (canvas.style.height !== cssHeight) canvas.style.height = cssHeight;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    ctx.scale(dpr, dpr);
-    ctx.clearRect(0, 0, width, height);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, viewportWidth, height);
+
+    const scrollX = Math.max(0, Math.round(container.scrollLeft));
+    const contentWidth = Math.max(1, Math.ceil(duration * pixelsPerSecond));
+    const drawWidth = Math.max(0, Math.min(viewportWidth, contentWidth - scrollX));
+    const waveformHeight = Math.max(1, height - RULER_HEIGHT);
 
     const tickInterval = chooseTickInterval(pixelsPerSecond);
     ctx.strokeStyle = rulerLineColor;
@@ -171,9 +224,18 @@ const WaveformView = ({
     ctx.textBaseline = "top";
     ctx.beginPath();
     ctx.moveTo(0, RULER_HEIGHT - 0.5);
-    ctx.lineTo(width, RULER_HEIGHT - 0.5);
-    for (let t = 0; t <= duration; t += tickInterval) {
-      const x = Math.round(t * pixelsPerSecond) + 0.5;
+    ctx.lineTo(viewportWidth, RULER_HEIGHT - 0.5);
+    // Start one tick early so a label whose tick sits just left of the
+    // viewport still renders its visible text.
+    const firstTick =
+      Math.max(0, Math.floor(scrollX / pixelsPerSecond / tickInterval) - 1) *
+      tickInterval;
+    const lastVisibleSec = Math.min(
+      duration,
+      (scrollX + viewportWidth) / pixelsPerSecond
+    );
+    for (let t = firstTick; t <= lastVisibleSec; t += tickInterval) {
+      const x = Math.round(t * pixelsPerSecond - scrollX) + 0.5;
       ctx.moveTo(x, RULER_HEIGHT - 8);
       ctx.lineTo(x, RULER_HEIGHT);
       ctx.fillText(formatRulerTime(t, tickInterval), x + 4, 4);
@@ -184,41 +246,42 @@ const WaveformView = ({
     const lanes = numChannels(sample);
     const laneHeight = waveformHeight / lanes;
     const frames = numFrames(sample);
-    const samplesPerPx = frames / width;
+    const framesPerPx = sample.sampleRate / pixelsPerSecond;
 
     for (let c = 0; c < lanes; c += 1) {
       const data = channels[c];
+      const channelPeaks = peaks[c];
       const mid = RULER_HEIGHT + laneHeight * c + laneHeight / 2;
       const amp = (laneHeight / 2) * 0.92;
 
       ctx.fillStyle = midColor;
-      ctx.fillRect(0, Math.round(mid), width, 1);
+      ctx.fillRect(0, Math.round(mid), drawWidth, 1);
 
       ctx.fillStyle = waveColor;
-      for (let x = 0; x < width; x += 1) {
-        const startI = Math.floor(x * samplesPerPx);
-        const endI = Math.min(frames, Math.floor((x + 1) * samplesPerPx));
-        let min = 1;
-        let max = -1;
+      for (let px = 0; px < drawWidth; px += 1) {
+        const contentX = scrollX + px;
+        const startI = Math.floor(contentX * framesPerPx);
+        const endI = Math.min(frames, Math.floor((contentX + 1) * framesPerPx));
+        let min: number;
+        let max: number;
         if (endI <= startI) {
           const v = data[Math.min(startI, frames - 1)] ?? 0;
           min = v;
           max = v;
         } else {
-          for (let i = startI; i < endI; i += 1) {
-            const v = data[i];
-            if (v < min) min = v;
-            if (v > max) max = v;
-          }
+          const peak = peakRange(data, channelPeaks, startI, endI);
+          if (!peak) continue;
+          min = peak.min;
+          max = peak.max;
         }
         const yMax = mid - max * amp;
         const yMin = mid - min * amp;
-        ctx.fillRect(x, yMax, 1, Math.max(1, yMin - yMax));
+        ctx.fillRect(px, yMax, 1, Math.max(1, yMin - yMax));
       }
     }
   }, [
     sample,
-    width,
+    peaks,
     duration,
     pixelsPerSecond,
     waveColor,
@@ -228,6 +291,36 @@ const WaveformView = ({
     theme.fontSizeTiny,
     theme.fontFamily2
   ]);
+
+  const drawRef = useRef(draw);
+  drawRef.current = draw;
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  // Repaint the visible slice on scroll and container resize, at most once per
+  // animation frame.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let raf: number | null = null;
+    const schedule = () => {
+      if (raf != null) return;
+      raf = requestAnimationFrame(() => {
+        raf = null;
+        drawRef.current();
+      });
+    };
+    container.addEventListener("scroll", schedule, { passive: true });
+    const observer = new ResizeObserver(schedule);
+    observer.observe(container);
+    return () => {
+      container.removeEventListener("scroll", schedule);
+      observer.disconnect();
+      if (raf != null) cancelAnimationFrame(raf);
+    };
+  }, []);
 
   const secondsFromEvent = useCallback(
     (clientX: number): number => {
@@ -289,8 +382,10 @@ const WaveformView = ({
     };
   }, [selection, pixelsPerSecond]);
 
+  const containerStyles = useMemo(() => styles(theme), [theme]);
+
   return (
-    <div ref={containerRef} css={styles(theme)} className="waveform-view">
+    <div ref={containerRef} css={containerStyles} className="waveform-view">
       <div
         ref={innerRef}
         className="waveform-inner"
@@ -301,13 +396,10 @@ const WaveformView = ({
       >
         <canvas ref={canvasRef} />
         {selectionStyle && <div className="selection" style={selectionStyle} />}
-        <div
-          className="playhead"
-          style={{ left: `${playheadSec * pixelsPerSecond}px` }}
-        />
+        <PlayheadLine playhead={playhead} pixelsPerSecond={pixelsPerSecond} />
       </div>
     </div>
   );
-};
+});
 
 export default WaveformView;

--- a/web/src/components/audio_editor/__tests__/audioSample.test.ts
+++ b/web/src/components/audio_editor/__tests__/audioSample.test.ts
@@ -51,6 +51,14 @@ describe("audioSample frame helpers", () => {
   });
 });
 
+describe("makeAudioSample", () => {
+  it("hides channel data from enumeration (React dev-mode prop walks)", () => {
+    const result = cropToRange(makeSample([[0, 1, 2, 3]], 4), 0, 0.5);
+    expect(Object.keys(result)).toEqual(["sampleRate"]);
+    expect(Array.from(result.channels[0])).toEqual([0, 1]);
+  });
+});
+
 describe("cropToRange", () => {
   it("keeps only the selected range", () => {
     const sample = makeSample([[0, 1, 2, 3, 4, 5, 6, 7]], 8);

--- a/web/src/components/audio_editor/__tests__/playheadStore.test.ts
+++ b/web/src/components/audio_editor/__tests__/playheadStore.test.ts
@@ -1,0 +1,35 @@
+import { createPlayheadStore } from "../playheadStore";
+
+describe("createPlayheadStore", () => {
+  it("gets and sets the value", () => {
+    const store = createPlayheadStore();
+    expect(store.get()).toBe(0);
+    store.set(1.5);
+    expect(store.get()).toBe(1.5);
+  });
+
+  it("notifies subscribers on change", () => {
+    const store = createPlayheadStore();
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.set(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when the value is unchanged", () => {
+    const store = createPlayheadStore(3);
+    const listener = jest.fn();
+    store.subscribe(listener);
+    store.set(3);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const store = createPlayheadStore();
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+    unsubscribe();
+    store.set(4);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/audio_editor/__tests__/waveformPeaks.test.ts
+++ b/web/src/components/audio_editor/__tests__/waveformPeaks.test.ts
@@ -1,0 +1,80 @@
+import { buildChannelPeaks, peakRange } from "../waveformPeaks";
+
+const bruteForce = (
+  data: Float32Array,
+  start: number,
+  end: number
+): { min: number; max: number } | null => {
+  const lo = Math.max(0, start);
+  const hi = Math.min(data.length, end);
+  if (hi <= lo) return null;
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = lo; i < hi; i += 1) {
+    if (data[i] < min) min = data[i];
+    if (data[i] > max) max = data[i];
+  }
+  return { min, max };
+};
+
+/** Deterministic pseudo-random signal so ranges hit varied values. */
+const makeSignal = (length: number): Float32Array => {
+  const data = new Float32Array(length);
+  let x = 42;
+  for (let i = 0; i < length; i += 1) {
+    x = (x * 1103515245 + 12345) % 2147483648;
+    data[i] = (x / 2147483648) * 2 - 1;
+  }
+  return data;
+};
+
+describe("buildChannelPeaks", () => {
+  it("stores per-block min/max", () => {
+    const data = Float32Array.from([0.1, -0.5, 0.3, 0.9, -0.2, 0.0]);
+    const peaks = buildChannelPeaks(data, 3);
+    expect(peaks.min[0]).toBeCloseTo(-0.5);
+    expect(peaks.max[0]).toBeCloseTo(0.3);
+    expect(peaks.min[1]).toBeCloseTo(-0.2);
+    expect(peaks.max[1]).toBeCloseTo(0.9);
+  });
+
+  it("handles a trailing partial block", () => {
+    const data = Float32Array.from([1, -1, 0.5]);
+    const peaks = buildChannelPeaks(data, 2);
+    expect(peaks.min.length).toBe(2);
+    expect(peaks.min[1]).toBeCloseTo(0.5);
+    expect(peaks.max[1]).toBeCloseTo(0.5);
+  });
+});
+
+describe("peakRange", () => {
+  const data = makeSignal(1000);
+  const peaks = buildChannelPeaks(data, 32);
+
+  it.each([
+    ["whole signal", 0, 1000],
+    ["block-aligned", 64, 320],
+    ["partial edges", 5, 995],
+    ["within one block", 40, 50],
+    ["single sample", 40, 41],
+    ["straddling one boundary", 30, 40],
+    ["start on boundary", 32, 45],
+    ["end on boundary", 45, 64]
+  ])("matches a raw scan (%s)", (_label, start, end) => {
+    expect(peakRange(data, peaks, start, end)).toEqual(
+      bruteForce(data, start, end)
+    );
+  });
+
+  it("clamps out-of-bounds ranges", () => {
+    expect(peakRange(data, peaks, -10, 2000)).toEqual(
+      bruteForce(data, 0, 1000)
+    );
+  });
+
+  it("returns null for empty ranges", () => {
+    expect(peakRange(data, peaks, 10, 10)).toBeNull();
+    expect(peakRange(data, peaks, 50, 40)).toBeNull();
+    expect(peakRange(data, peaks, 1000, 1200)).toBeNull();
+  });
+});

--- a/web/src/components/audio_editor/audioSample.ts
+++ b/web/src/components/audio_editor/audioSample.ts
@@ -17,6 +17,29 @@ export interface AudioSample {
   readonly channels: Float32Array[];
 }
 
+/**
+ * Build an AudioSample with `channels` non-enumerable. Samples are passed as
+ * React props, and React 19's dev-mode performance instrumentation deep-walks
+ * the enumerable properties of any prop whose identity changed — a Float32Array
+ * exposes every frame as an enumerable index, which freezes the tab for tens of
+ * seconds per edit on long files. Hiding the frames from enumeration keeps dev
+ * edits instant; direct `.channels` access is unaffected.
+ */
+export const makeAudioSample = (
+  sampleRate: number,
+  channels: Float32Array[]
+): AudioSample => {
+  const sample = { sampleRate } as {
+    sampleRate: number;
+    channels: Float32Array[];
+  };
+  Object.defineProperty(sample, "channels", {
+    value: channels,
+    enumerable: false
+  });
+  return sample;
+};
+
 export type FadeDirection = "in" | "out";
 
 export const numFrames = (sample: AudioSample): number =>
@@ -64,10 +87,7 @@ const resolveRange = (
 const mapChannels = (
   sample: AudioSample,
   fn: (channel: Float32Array) => Float32Array
-): AudioSample => ({
-  sampleRate: sample.sampleRate,
-  channels: sample.channels.map(fn)
-});
+): AudioSample => makeAudioSample(sample.sampleRate, sample.channels.map(fn));
 
 /** Keep only the selected range (trim/crop). */
 export const cropToRange = (
@@ -267,12 +287,13 @@ export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
 export const audioBufferToSample = (buffer: AudioBuffer): AudioSample => {
   const channels: Float32Array[] = [];
   for (let c = 0; c < buffer.numberOfChannels; c += 1) {
-    channels.push(Float32Array.from(buffer.getChannelData(c)));
+    // slice() is a memcpy; Float32Array.from() iterates element by element.
+    channels.push(buffer.getChannelData(c).slice());
   }
   if (channels.length === 0) {
     channels.push(new Float32Array(buffer.length));
   }
-  return { sampleRate: buffer.sampleRate, channels };
+  return makeAudioSample(buffer.sampleRate, channels);
 };
 
 /** Build a playable AudioBuffer from a sample (length forced to at least 1). */

--- a/web/src/components/audio_editor/playheadStore.ts
+++ b/web/src/components/audio_editor/playheadStore.ts
@@ -1,0 +1,33 @@
+/**
+ * Playhead position shared between the playback loop and the UI.
+ *
+ * Playback advances the playhead ~60×/s. Holding it in React state at the top
+ * of the editor would re-render the whole tree every frame, so it lives in
+ * this tiny external store instead; only the leaf components that display it
+ * (playhead line, clock) subscribe via `useSyncExternalStore`.
+ */
+
+export interface PlayheadStore {
+  get: () => number;
+  set: (seconds: number) => void;
+  subscribe: (listener: () => void) => () => void;
+}
+
+export const createPlayheadStore = (initial = 0): PlayheadStore => {
+  let value = initial;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => value,
+    set: (seconds: number) => {
+      if (seconds === value) return;
+      value = seconds;
+      listeners.forEach((listener) => listener());
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+};

--- a/web/src/components/audio_editor/waveformPeaks.ts
+++ b/web/src/components/audio_editor/waveformPeaks.ts
@@ -1,0 +1,79 @@
+/**
+ * Precomputed min/max peaks for waveform rendering.
+ *
+ * Each pixel column of the waveform shows the min/max of the samples under it.
+ * Scanning raw samples per redraw is O(total frames) — too slow to repeat on
+ * every zoom, scroll, or resize. Instead each channel is bucketed into
+ * fixed-size blocks once per edit; a column query combines whole blocks plus
+ * raw samples at the partial edges, so redraw cost scales with visible pixels
+ * instead of duration.
+ */
+
+export const PEAK_BLOCK_SIZE = 256;
+
+export interface ChannelPeaks {
+  readonly blockSize: number;
+  readonly min: Float32Array;
+  readonly max: Float32Array;
+}
+
+export const buildChannelPeaks = (
+  data: Float32Array,
+  blockSize: number = PEAK_BLOCK_SIZE
+): ChannelPeaks => {
+  const blockCount = Math.ceil(data.length / blockSize);
+  const min = new Float32Array(blockCount);
+  const max = new Float32Array(blockCount);
+  for (let b = 0; b < blockCount; b += 1) {
+    const start = b * blockSize;
+    const end = Math.min(data.length, start + blockSize);
+    let mn = Infinity;
+    let mx = -Infinity;
+    for (let i = start; i < end; i += 1) {
+      const v = data[i];
+      if (v < mn) mn = v;
+      if (v > mx) mx = v;
+    }
+    min[b] = mn;
+    max[b] = mx;
+  }
+  return { blockSize, min, max };
+};
+
+/**
+ * Min/max over `[startFrame, endFrame)`, reading whole blocks where possible
+ * and raw samples at the partial edges. Returns null for an empty range.
+ */
+export const peakRange = (
+  data: Float32Array,
+  peaks: ChannelPeaks,
+  startFrame: number,
+  endFrame: number
+): { min: number; max: number } | null => {
+  const start = Math.max(0, startFrame);
+  const end = Math.min(data.length, endFrame);
+  if (end <= start) return null;
+
+  const { blockSize } = peaks;
+  const firstFullBlock = Math.ceil(start / blockSize);
+  const lastFullBlock = Math.floor(end / blockSize);
+  let mn = Infinity;
+  let mx = -Infinity;
+
+  const headEnd = Math.min(end, firstFullBlock * blockSize);
+  for (let i = start; i < headEnd; i += 1) {
+    const v = data[i];
+    if (v < mn) mn = v;
+    if (v > mx) mx = v;
+  }
+  for (let b = firstFullBlock; b < lastFullBlock; b += 1) {
+    if (peaks.min[b] < mn) mn = peaks.min[b];
+    if (peaks.max[b] > mx) mx = peaks.max[b];
+  }
+  for (let i = Math.max(headEnd, lastFullBlock * blockSize); i < end; i += 1) {
+    const v = data[i];
+    if (v < mn) mn = v;
+    if (v > mx) mx = v;
+  }
+  return { min: mn, max: mx };
+};


### PR DESCRIPTION
## Summary

Refactors the audio waveform editor to eliminate per-frame re-renders during playback and optimize canvas redraws during zoom/scroll. Introduces a peak-cache system for O(visible pixels) rendering cost instead of O(total frames), and moves playhead state to an external store so only leaf components (playhead line, clock) update during playback.

## Key Changes

- **Peak cache system** (`waveformPeaks.ts`): Pre-computes min/max values in fixed-size blocks (256 samples) per channel. Waveform rendering now queries the cache instead of scanning raw samples, reducing redraw cost from O(total frames) to O(visible pixels). Includes comprehensive tests covering block-aligned ranges, partial edges, and boundary conditions.

- **External playhead store** (`playheadStore.ts`): Playhead position now lives in a tiny external store with `get()`, `set()`, and `subscribe()` methods. The playback loop updates it ~60×/s without triggering React re-renders. Only `PlayheadLine` and `PlaybackClock` components subscribe via `useSyncExternalStore`, eliminating full-tree re-renders during playback.

- **Viewport-sized sticky canvas**: Canvas is now viewport-sized and sticky-positioned inside a wide scrollable inner div. Only the visible slice is painted per frame. Scroll and resize events trigger redraws via `requestAnimationFrame` throttling, not React state updates.

- **Memoized components**: `WaveformView` and `PlaybackClock` wrapped with `memo()` to prevent unnecessary re-renders when props haven't changed.

- **AudioSample optimization** (`audioSample.ts`): Added `makeAudioSample()` helper that hides channel data from enumeration. Prevents React 19's dev-mode prop-walking instrumentation from deep-scanning Float32Array indices (which freezes the tab for tens of seconds on long files).

- **Playback buffer caching**: Reuses the same `AudioBuffer` across replays/loops/seeks while the sample is unchanged, avoiding redundant channel copies.

- **Ruler rendering optimization**: Only renders tick marks and labels visible in the current viewport, not the entire duration.

## Implementation Details

- Peak cache is built once per sample edit via `useMemo` in `WaveformView`.
- Canvas redraws are scheduled via `requestAnimationFrame` on scroll/resize to avoid thrashing.
- `PlayheadLine` uses `useSyncExternalStore` to subscribe to playhead changes without re-rendering the parent `WaveformView`.
- `AudioSampleEditor` no longer holds playhead in state; it passes the store to `WaveformView` and uses `playhead.set()` for seeking/playback control.
- All changes maintain backward compatibility with existing selection and seek APIs.

https://claude.ai/code/session_01ACZ4kXEYZXybCrCKocMMeR