### PR TITLE
Add plan approval gate and timeline UI for agent execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -50242,7 +50242,7 @@
     },
     "packages/agents": {
       "name": "@nodetool-ai/agents",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
@@ -50274,7 +50274,7 @@
     },
     "packages/atlascloud-nodes": {
       "name": "@nodetool-ai/atlascloud-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -50291,7 +50291,7 @@
     },
     "packages/audio-nodes": {
       "name": "@nodetool-ai/audio-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@k13engineering/rubberband": "^0.0.8",
@@ -50313,7 +50313,7 @@
     },
     "packages/auth": {
       "name": "@nodetool-ai/auth",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.98.0",
@@ -50331,7 +50331,7 @@
     },
     "packages/automation-nodes": {
       "name": "@nodetool-ai/automation-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -50372,7 +50372,7 @@
     },
     "packages/base-nodes": {
       "name": "@nodetool-ai/base-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -50402,7 +50402,7 @@
     },
     "packages/chat": {
       "name": "@nodetool-ai/chat",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -50419,7 +50419,7 @@
     },
     "packages/cli": {
       "name": "@nodetool-ai/cli",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.0.0",
@@ -50489,7 +50489,7 @@
     },
     "packages/code-nodes": {
       "name": "@nodetool-ai/code-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -50514,7 +50514,7 @@
     },
     "packages/code-runners": {
       "name": "@nodetool-ai/code-runners",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -50532,7 +50532,7 @@
     },
     "packages/compute": {
       "name": "@nodetool-ai/compute",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -50546,7 +50546,7 @@
     },
     "packages/config": {
       "name": "@nodetool-ai/config",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.0"
@@ -50563,7 +50563,7 @@
     },
     "packages/core-nodes": {
       "name": "@nodetool-ai/core-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -50585,7 +50585,7 @@
     },
     "packages/data-nodes": {
       "name": "@nodetool-ai/data-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^0.1.65",
@@ -50609,7 +50609,7 @@
     },
     "packages/deploy": {
       "name": "@nodetool-ai/deploy",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -50636,7 +50636,7 @@
     },
     "packages/document-nodes": {
       "name": "@nodetool-ai/document-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@hyzyla/pdfium": "^2.1.12",
@@ -50665,7 +50665,7 @@
     },
     "packages/dsl": {
       "name": "@nodetool-ai/dsl",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/base-nodes": "*",
@@ -50691,7 +50691,7 @@
     },
     "packages/elevenlabs-nodes": {
       "name": "@nodetool-ai/elevenlabs-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.0.0",
@@ -50725,7 +50725,7 @@
     },
     "packages/fal-nodes": {
       "name": "@nodetool-ai/fal-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@fal-ai/client": "^1.9.4",
@@ -50743,7 +50743,7 @@
     },
     "packages/gpu": {
       "name": "@nodetool-ai/gpu",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "typegpu": "^0.11.6"
@@ -50762,7 +50762,7 @@
     },
     "packages/huggingface": {
       "name": "@nodetool-ai/huggingface",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@huggingface/hub": "^2.11.0",
@@ -50779,7 +50779,7 @@
     },
     "packages/huggingface-nodes": {
       "name": "@nodetool-ai/huggingface-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -50795,7 +50795,7 @@
     },
     "packages/image-editor": {
       "name": "@nodetool-ai/image-editor",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -50807,7 +50807,7 @@
     },
     "packages/image-nodes": {
       "name": "@nodetool-ai/image-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -50831,7 +50831,7 @@
     },
     "packages/integration-nodes": {
       "name": "@nodetool-ai/integration-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -50892,7 +50892,7 @@
     },
     "packages/kernel": {
       "name": "@nodetool-ai/kernel",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -50931,7 +50931,7 @@
     },
     "packages/kie-nodes": {
       "name": "@nodetool-ai/kie-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -50948,7 +50948,7 @@
     },
     "packages/llm-nodes": {
       "name": "@nodetool-ai/llm-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -50969,7 +50969,7 @@
     },
     "packages/minimax-nodes": {
       "name": "@nodetool-ai/minimax-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -50986,7 +50986,7 @@
     },
     "packages/models": {
       "name": "@nodetool-ai/models",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51010,7 +51010,7 @@
     },
     "packages/node-sdk": {
       "name": "@nodetool-ai/node-sdk",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51031,7 +51031,7 @@
     },
     "packages/nodes-utils": {
       "name": "@nodetool-ai/nodes-utils",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -51048,7 +51048,7 @@
     },
     "packages/protocol": {
       "name": "@nodetool-ai/protocol",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*",
@@ -51078,7 +51078,7 @@
     },
     "packages/replicate-nodes": {
       "name": "@nodetool-ai/replicate-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -51096,7 +51096,7 @@
     },
     "packages/reve-nodes": {
       "name": "@nodetool-ai/reve-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -51112,7 +51112,7 @@
     },
     "packages/runtime": {
       "name": "@nodetool-ai/runtime",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@aki-io/aki-io": "^1.0.1",
@@ -51155,7 +51155,7 @@
     },
     "packages/sandbox": {
       "name": "@nodetool-ai/sandbox",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51174,7 +51174,7 @@
     },
     "packages/sandbox-agent": {
       "name": "@nodetool-ai/sandbox-agent",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^9.0.0",
@@ -51197,7 +51197,7 @@
     },
     "packages/sandbox-tools": {
       "name": "@nodetool-ai/sandbox-tools",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51266,7 +51266,7 @@
     },
     "packages/sdk": {
       "name": "@nodetool-ai/sdk",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/protocol": "*",
@@ -51294,7 +51294,7 @@
     },
     "packages/security": {
       "name": "@nodetool-ai/security",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1029.0",
@@ -51313,7 +51313,7 @@
     },
     "packages/storage": {
       "name": "@nodetool-ai/storage",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -51335,7 +51335,7 @@
     },
     "packages/text-nodes": {
       "name": "@nodetool-ai/text-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
@@ -51365,7 +51365,7 @@
     },
     "packages/timeline": {
       "name": "@nodetool-ai/timeline",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*"
@@ -51380,7 +51380,7 @@
     },
     "packages/together-nodes": {
       "name": "@nodetool-ai/together-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -51397,7 +51397,7 @@
     },
     "packages/topaz-nodes": {
       "name": "@nodetool-ai/topaz-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -51413,7 +51413,7 @@
     },
     "packages/transformers-js-nodes": {
       "name": "@nodetool-ai/transformers-js-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -51435,7 +51435,7 @@
     },
     "packages/transformers-js-provider": {
       "name": "@nodetool-ai/transformers-js-provider",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51454,7 +51454,7 @@
     },
     "packages/vectorstore": {
       "name": "@nodetool-ai/vectorstore",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51475,7 +51475,7 @@
     },
     "packages/video-nodes": {
       "name": "@nodetool-ai/video-nodes",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@gltf-transform/core": "^4.3.0",
@@ -51500,7 +51500,7 @@
     },
     "packages/websocket": {
       "name": "@nodetool-ai/websocket",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
@@ -51560,7 +51560,7 @@
     },
     "packages/workflow-runner": {
       "name": "@nodetool-ai/workflow-runner",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -52144,7 +52144,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.7.0-rc.28",
+      "version": "0.7.0-rc.29",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -167,6 +167,36 @@ for await (const msg of agent.execute(ctx)) {
 const result = agent.getResults();
 ```
 
+## Plan Approval Gate
+
+`Agent` can pause after planning and present the plan for user approval before
+executing it. Wire a callback either as the `requestPlanApproval` option or on
+the ProcessingContext under `PLAN_APPROVAL_CONTEXT_KEY` (the websocket runner
+sets the context variable for chat-triggered runs, so Agent nodes in plan mode
+gate without explicit wiring):
+
+```typescript
+const agent = new Agent({
+  ...,
+  requestPlanApproval: async (plan) =>
+    userSaysYes(plan) ? { decision: "approve" } : { decision: "reject", feedback: "..." }
+});
+```
+
+- **approve** — execution proceeds.
+- **reject with feedback** — the planner re-runs with the feedback appended to
+  the objective (bounded by `MAX_PLAN_REVISIONS`, 3) and the revised plan is
+  presented again.
+- **reject without feedback** — the run ends; `getResults()` returns a
+  rejection notice.
+
+The gate emits `planning_update` events with phase `awaiting_approval`
+(status Running/Success/Failed) and `revision` so UIs can show state. Over the
+websocket this round-trips as `plan_approval_request` / `plan_approval_response`
+messages; the web chat renders a `PlanApprovalCard` with approve/reject and a
+feedback field. Without a callback, planning flows straight into execution as
+before. Tests: `packages/agents/tests/plan-approval.test.ts`.
+
 ## Parallel Task Execution
 
 The Agent class automatically decomposes objectives into parallel tasks via `TaskPlanner.planMultiTask()`. Tasks form a DAG — independent tasks run concurrently.

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -21,6 +21,7 @@ import type {
   ProcessingMessage,
   StepResult,
   LogUpdate,
+  PlanningUpdate,
   TaskUpdate,
   Chunk
 } from "@nodetool-ai/protocol";
@@ -37,7 +38,13 @@ import {
   SecurityMonitor,
   createSecurityMonitorConsult
 } from "./security-monitor.js";
-import type { Task, TaskPlan } from "./types.js";
+import type {
+  PlanApprovalDecision,
+  RequestPlanApproval,
+  Task,
+  TaskPlan
+} from "./types.js";
+import { PLAN_APPROVAL_CONTEXT_KEY } from "./types.js";
 import type { PlanCache, CheckpointStore } from "./checkpoint-store.js";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import {
@@ -289,7 +296,19 @@ export interface AgentOptions {
   checkpointStore?: CheckpointStore;
   /** Run identifier the checkpoint is keyed by. Required for checkpointing. */
   runId?: string;
+  /**
+   * Opt-in plan approval gate. When supplied (or found on the
+   * ProcessingContext under {@link PLAN_APPROVAL_CONTEXT_KEY}), the agent
+   * pauses after planning and presents the plan for approval. A rejection
+   * with feedback triggers a bounded replan; a plain rejection aborts the
+   * run with a rejection notice as the result. Omit to keep the original
+   * plan-then-execute behavior.
+   */
+  requestPlanApproval?: RequestPlanApproval;
 }
+
+/** Maximum replan rounds a rejection-with-feedback can trigger. */
+const MAX_PLAN_REVISIONS = 3;
 
 export class Agent {
   readonly name: string;
@@ -323,6 +342,7 @@ export class Agent {
   private readonly planCache?: PlanCache;
   private readonly checkpointStore?: CheckpointStore;
   private readonly runId?: string;
+  private readonly requestPlanApproval?: RequestPlanApproval;
   /** The multi-task plan, set after planning. */
   taskPlan: TaskPlan | null = null;
 
@@ -357,6 +377,7 @@ export class Agent {
     this.planCache = opts.planCache;
     this.checkpointStore = opts.checkpointStore;
     this.runId = opts.runId;
+    this.requestPlanApproval = opts.requestPlanApproval;
     if (opts.task) {
       this.task = opts.task;
     }
@@ -663,7 +684,7 @@ export class Agent {
       yield planResult.value;
       planResult = await planGen.next();
     }
-    const taskPlan = planResult.value;
+    let taskPlan = planResult.value;
 
     if (!taskPlan) {
       log.error("Agent failed", {
@@ -671,6 +692,29 @@ export class Agent {
         error: "TaskPlanner failed to create a multi-task plan."
       });
       throw new Error("TaskPlanner failed to create a task plan.");
+    }
+
+    // Plan approval gate: when a host wired in a callback (option or context
+    // variable), pause here and present the plan. Rejection with feedback
+    // replans; plain rejection ends the run with a rejection notice.
+    const requestApproval =
+      this.requestPlanApproval ??
+      context.get<RequestPlanApproval>(PLAN_APPROVAL_CONTEXT_KEY);
+    if (typeof requestApproval === "function") {
+      const approved = yield* this.awaitPlanApproval(
+        requestApproval,
+        taskPlan,
+        planner,
+        context,
+        effectiveObjective
+      );
+      if (!approved) {
+        log.info("Plan rejected by user — execution aborted", {
+          name: this.name
+        });
+        return;
+      }
+      taskPlan = approved;
     }
 
     this.taskPlan = taskPlan;
@@ -763,6 +807,104 @@ export class Agent {
 
     log.info("Agent completed", { name: this.name });
     this.persistAgentRunMemory();
+  }
+
+  /**
+   * Present a plan for user approval, replanning on rejection-with-feedback
+   * (bounded by {@link MAX_PLAN_REVISIONS}). Returns the approved plan, or
+   * null when the user rejected it — in that case `this.results` carries a
+   * rejection notice and the caller must end the run.
+   */
+  private async *awaitPlanApproval(
+    requestApproval: RequestPlanApproval,
+    initialPlan: TaskPlan,
+    planner: TaskPlanner,
+    context: ProcessingContext,
+    objective: string
+  ): AsyncGenerator<ProcessingMessage, TaskPlan | null> {
+    let plan = initialPlan;
+    for (let revision = 0; ; revision++) {
+      yield {
+        type: "planning_update",
+        node_id: "agent_planner",
+        phase: "awaiting_approval",
+        status: "Running",
+        content: `Waiting for approval: ${plan.title} (${plan.tasks.length} tasks)`
+      } satisfies PlanningUpdate;
+
+      let decision: PlanApprovalDecision;
+      try {
+        decision = await requestApproval(structuredClone(plan));
+      } catch (err) {
+        log.warn("Plan approval request failed — treating as rejection", {
+          name: this.name,
+          error: err instanceof Error ? err.message : String(err)
+        });
+        decision = { decision: "reject" };
+      }
+
+      if (decision.decision === "approve") {
+        yield {
+          type: "planning_update",
+          node_id: "agent_planner",
+          phase: "awaiting_approval",
+          status: "Success",
+          content: `Plan approved: ${plan.title}`
+        } satisfies PlanningUpdate;
+        return plan;
+      }
+
+      const feedback = decision.feedback?.trim() ?? "";
+      if (!feedback || revision >= MAX_PLAN_REVISIONS) {
+        yield {
+          type: "planning_update",
+          node_id: "agent_planner",
+          phase: "awaiting_approval",
+          status: "Failed",
+          content: feedback
+            ? `Plan rejected after ${revision} revision(s).`
+            : "Plan rejected by user."
+        } satisfies PlanningUpdate;
+        this.results = feedback
+          ? `Plan rejected by user. Feedback: ${feedback}`
+          : "Plan rejected by user.";
+        return null;
+      }
+
+      yield {
+        type: "planning_update",
+        node_id: "agent_planner",
+        phase: "revision",
+        status: "Running",
+        content: `Revising plan with feedback: ${feedback.slice(0, 200)}`
+      } satisfies PlanningUpdate;
+
+      const revisedObjective = [
+        objective,
+        "",
+        `A previous plan titled "${plan.title}" was rejected by the user.`,
+        `User feedback: ${feedback}`,
+        "Create a revised plan that addresses this feedback."
+      ].join("\n");
+
+      const planGen = planner.planMultiTask(revisedObjective, context);
+      let next = await planGen.next();
+      while (!next.done) {
+        yield next.value;
+        next = await planGen.next();
+      }
+      if (!next.value) {
+        yield {
+          type: "planning_update",
+          node_id: "agent_planner",
+          phase: "awaiting_approval",
+          status: "Failed",
+          content: "Replanning after feedback failed."
+        } satisfies PlanningUpdate;
+        throw new Error("TaskPlanner failed to create a revised plan.");
+      }
+      plan = next.value;
+    }
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -3,7 +3,14 @@
  */
 
 // Types
-export type { Step, Task, TaskPlan } from "./types.js";
+export type {
+  Step,
+  Task,
+  TaskPlan,
+  PlanApprovalDecision,
+  RequestPlanApproval
+} from "./types.js";
+export { PLAN_APPROVAL_CONTEXT_KEY } from "./types.js";
 
 // Tools
 export { Tool } from "./tools/base-tool.js";

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -40,3 +40,29 @@ export interface TaskPlan {
   title: string;
   tasks: Task[];
 }
+
+/**
+ * User decision on a proposed {@link TaskPlan}. A rejection may carry
+ * feedback; the agent replans with it (bounded) instead of aborting.
+ */
+export type PlanApprovalDecision =
+  | { decision: "approve" }
+  | { decision: "reject"; feedback?: string };
+
+/**
+ * Callback a host wires in to gate execution on user plan approval.
+ * Called after planning with the proposed plan; execution proceeds only on
+ * an approve decision.
+ */
+export type RequestPlanApproval = (
+  plan: TaskPlan
+) => Promise<PlanApprovalDecision>;
+
+/**
+ * ProcessingContext variable key under which hosts (e.g. the websocket
+ * runner) expose a {@link RequestPlanApproval} callback. `Agent.execute`
+ * falls back to this when no `requestPlanApproval` option was passed, so
+ * plan gating reaches agents buried inside workflow nodes without explicit
+ * wiring at every construction site.
+ */
+export const PLAN_APPROVAL_CONTEXT_KEY = "request_plan_approval";

--- a/packages/agents/tests/plan-approval.test.ts
+++ b/packages/agents/tests/plan-approval.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the plan-approval gate in Agent.execute: rejection aborts the
+ * run, rejection-with-feedback triggers a replan, and the callback is picked
+ * up from the ProcessingContext when not passed as an option.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "../src/agent.js";
+import {
+  PLAN_APPROVAL_CONTEXT_KEY,
+  type PlanApprovalDecision,
+  type TaskPlan
+} from "../src/types.js";
+import type {
+  BaseProvider as BaseProviderType,
+  ProcessingContext,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { ProcessingMessage, PlanningUpdate } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const OBJECTIVE = "Research and write outreach";
+
+function scriptedPlanCalls(): ToolCall[] {
+  return [
+    {
+      id: "tc_add_1",
+      name: "add_task",
+      args: {
+        id: "task_research",
+        title: "Research the prospect",
+        depends_on: [],
+        steps: [
+          {
+            id: "task_research_s1",
+            instructions: "Search the web",
+            depends_on: []
+          }
+        ]
+      }
+    },
+    { id: "tc_finish", name: "finish_plan", args: { title: "Outreach Plan" } }
+  ];
+}
+
+/** Provider that replays the plan script on every generateLoop invocation. */
+function createLoopProvider(script: ToolCall[]): {
+  provider: BaseProviderType;
+  getLoopCalls: () => number;
+} {
+  let loopCalls = 0;
+  const provider = {
+    provider: "sdk_loop",
+    hasToolSupport: async () => true,
+    async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+      yield { type: "chunk", content: "", done: true };
+    },
+    async *generateMessagesTraced(): AsyncGenerator<ProviderStreamItem> {
+      yield { type: "chunk", content: "", done: true };
+    },
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+        terminal?: boolean;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      loopCalls++;
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const tc of script) {
+        if (args.signal?.aborted) break;
+        yield tc;
+        const tool = toolMap.get(tc.name);
+        const content = tool?.execute ? await tool.execute(tc.args) : "";
+        yield {
+          type: "message",
+          message: {
+            role: "tool",
+            toolCallId: tc.id,
+            content:
+              typeof content === "string" ? content : JSON.stringify(content)
+          }
+        };
+        if (tool?.terminal) break;
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProviderType;
+  return { provider, getLoopCalls: () => loopCalls };
+}
+
+function makeAgent(
+  provider: BaseProviderType,
+  requestPlanApproval?: (plan: TaskPlan) => Promise<PlanApprovalDecision>
+): Agent {
+  return new Agent({
+    name: "plan-approval-test",
+    objective: OBJECTIVE,
+    provider,
+    model: "opus",
+    workspace: join(tmpdir(), `plan-approval-test-${Date.now()}`),
+    requestPlanApproval
+  });
+}
+
+async function drain(
+  gen: AsyncGenerator<ProcessingMessage>
+): Promise<ProcessingMessage[]> {
+  const messages: ProcessingMessage[] = [];
+  for await (const msg of gen) {
+    messages.push(msg);
+  }
+  return messages;
+}
+
+function approvalUpdates(messages: ProcessingMessage[]): PlanningUpdate[] {
+  return messages.filter(
+    (m): m is PlanningUpdate =>
+      m.type === "planning_update" &&
+      (m as PlanningUpdate).phase === "awaiting_approval"
+  );
+}
+
+describe("Agent plan approval gate", () => {
+  it("aborts the run with a rejection notice when the plan is rejected", async () => {
+    const { provider, getLoopCalls } = createLoopProvider(scriptedPlanCalls());
+    const requestApproval = vi.fn(
+      async (): Promise<PlanApprovalDecision> => ({ decision: "reject" })
+    );
+    const agent = makeAgent(provider, requestApproval);
+
+    const messages = await drain(
+      agent.execute(createMockContext() as ProcessingContext)
+    );
+
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+    // Only the planning loop ran — no step execution, no compiler.
+    expect(getLoopCalls()).toBe(1);
+    expect(agent.getResults()).toBe("Plan rejected by user.");
+
+    const updates = approvalUpdates(messages);
+    expect(updates.some((u) => u.status === "Running")).toBe(true);
+    expect(updates.some((u) => u.status === "Failed")).toBe(true);
+  });
+
+  it("replans when rejected with feedback, presenting the revised plan", async () => {
+    const { provider, getLoopCalls } = createLoopProvider(scriptedPlanCalls());
+    const decisions: PlanApprovalDecision[] = [
+      { decision: "reject", feedback: "Add a verification task" },
+      { decision: "reject" }
+    ];
+    const seenPlans: TaskPlan[] = [];
+    const requestApproval = vi.fn(
+      async (plan: TaskPlan): Promise<PlanApprovalDecision> => {
+        seenPlans.push(plan);
+        return decisions.shift() ?? { decision: "reject" };
+      }
+    );
+    const agent = makeAgent(provider, requestApproval);
+
+    await drain(agent.execute(createMockContext() as ProcessingContext));
+
+    // Two approval round-trips: original plan, then the revised plan built by
+    // a second planning loop.
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+    expect(getLoopCalls()).toBe(2);
+    expect(seenPlans).toHaveLength(2);
+    expect(agent.getResults()).toBe("Plan rejected by user.");
+  });
+
+  it("proceeds without gating when no callback is configured", async () => {
+    const { provider } = createLoopProvider(scriptedPlanCalls());
+    const agent = makeAgent(provider);
+
+    const messages = await drain(
+      agent.execute(createMockContext() as ProcessingContext)
+    );
+
+    expect(approvalUpdates(messages)).toHaveLength(0);
+    // Execution went past planning (the plan is set and tasks ran).
+    expect(agent.taskPlan?.title).toBe("Outreach Plan");
+  });
+
+  it("picks up the approval callback from the ProcessingContext", async () => {
+    const { provider, getLoopCalls } = createLoopProvider(scriptedPlanCalls());
+    const requestApproval = vi.fn(
+      async (): Promise<PlanApprovalDecision> => ({ decision: "reject" })
+    );
+    const agent = makeAgent(provider);
+
+    const context = createMockContext();
+    context.set(PLAN_APPROVAL_CONTEXT_KEY, requestApproval);
+
+    await drain(agent.execute(context as ProcessingContext));
+
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+    expect(getLoopCalls()).toBe(1);
+    expect(agent.getResults()).toBe("Plan rejected by user.");
+  });
+});

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -86,9 +86,13 @@ import {
   QueryCollectionTool,
   gateTools,
   extractInjectableImages,
+  PLAN_APPROVAL_CONTEXT_KEY,
   type PermissionMode,
   type ApprovalDecision,
-  type ApprovalRequest
+  type ApprovalRequest,
+  type PlanApprovalDecision,
+  type RequestPlanApproval,
+  type TaskPlan
 } from "@nodetool-ai/agents";
 import {
   createDefaultLongTermMemory,
@@ -1926,6 +1930,9 @@ export class UnifiedWebSocketRunner {
       workspaceDir,
       assetOutputMode: this.mode === "text" ? "data_uri" : "temp_url"
     });
+    // Agents planning inside this run pause for user approval over this
+    // socket before executing their plan.
+    this.attachPlanApproval(context, null);
 
     // Expose executor/node-type resolution on the context so that
     // sub-workflow nodes (WorkflowNode) can create child runners.
@@ -2807,6 +2814,67 @@ export class UnifiedWebSocketRunner {
   }
 
   /**
+   * Round-trip a plan approval to the client and resolve with the user's
+   * decision. Emits a `plan_approval_request` carrying the serialized plan,
+   * then waits for the matching `plan_approval_response` (resolved via
+   * {@link approvalBridge}). A cancelled wait (stop) is treated as a
+   * rejection without feedback, which aborts the agent run.
+   */
+  private async requestPlanApproval(
+    threadId: string | null,
+    plan: TaskPlan
+  ): Promise<PlanApprovalDecision> {
+    const approvalId = `plan_${randomUUID()}`;
+    await this.sendMessage({
+      type: "plan_approval_request",
+      thread_id: threadId,
+      approval_id: approvalId,
+      plan: {
+        title: plan.title,
+        tasks: plan.tasks.map((t) => ({
+          id: t.id,
+          title: t.title,
+          depends_on: t.dependsOn ?? [],
+          steps: t.steps.map((s) => ({
+            id: s.id,
+            instructions: s.instructions
+          }))
+        }))
+      }
+    });
+    try {
+      // No timeout — the user may take a while; `stop` cancels via cancelAll.
+      const response = await this.approvalBridge.createWaiter(approvalId, 0);
+      if (response.decision === "approve") {
+        return { decision: "approve" };
+      }
+      const feedback =
+        typeof response.feedback === "string" && response.feedback.trim()
+          ? response.feedback.trim()
+          : undefined;
+      return { decision: "reject", feedback };
+    } catch {
+      // Cancelled (generation stopped) — treat as a rejection.
+      return { decision: "reject" };
+    }
+  }
+
+  /**
+   * Expose the plan-approval round-trip on a processing context so any Agent
+   * that plans inside this run (e.g. an Agent node in plan mode) pauses for
+   * user approval before executing. See PLAN_APPROVAL_CONTEXT_KEY in
+   * `@nodetool-ai/agents`.
+   */
+  private attachPlanApproval(
+    context: RuntimeProcessingContext,
+    threadId: string | null
+  ): void {
+    const request: RequestPlanApproval = (plan) =>
+      this.requestPlanApproval(threadId, plan);
+    context.set(PLAN_APPROVAL_CONTEXT_KEY, request);
+  }
+
+  /**
    * Execute a single node by type and return its output. Builds a one-node
    * graph and runs it through a fresh {@link WorkflowRunner}, then returns the
    * node's completed result. Backs the `run_node` chat tool.
@@ -2814,7 +2882,8 @@ export class UnifiedWebSocketRunner {
   private async runSingleNode(
     nodeType: string,
     inputs: Record<string, unknown>,
-    userId: string
+    userId: string,
+    threadId: string | null = null
   ): Promise<unknown> {
     const jobId = randomUUID();
     const nodeId = "node_0";
@@ -2853,6 +2922,7 @@ export class UnifiedWebSocketRunner {
       workspaceDir: tmpdir(),
       assetOutputMode: this.mode === "text" ? "data_uri" : "temp_url"
     });
+    this.attachPlanApproval(context, threadId);
     context.setResolveExecutor((node) => this.resolveExecutor(node));
     if (this.resolveNodeType) {
       const resolverObj =
@@ -3121,7 +3191,7 @@ export class UnifiedWebSocketRunner {
       new ListCollectionsTool(),
       new QueryCollectionTool(),
       new RunNodeTool((nodeType, inputs) =>
-        this.runSingleNode(nodeType, inputs, userId)
+        this.runSingleNode(nodeType, inputs, userId, threadId)
       )
     ];
     // De-duplicate by name (builtins / mcp / extras may overlap); first wins.
@@ -3255,6 +3325,9 @@ export class UnifiedWebSocketRunner {
       userId,
       workspaceDir: chatWorkspaceDir
     });
+    // Any agent planning inside this turn (e.g. via run_node spawning an
+    // Agent node in plan mode) pauses for user plan approval.
+    this.attachPlanApproval(ctx, threadId || null);
 
     // Prepend system prompt if first message isn't system role — matches Python
     if (chatHistory.length === 0 || chatHistory[0].role !== "system") {
@@ -5981,6 +6054,15 @@ export class UnifiedWebSocketRunner {
       }
 
       if (msgType === "tool_approval_response") {
+        const approvalId =
+          typeof data.approval_id === "string" ? data.approval_id : null;
+        if (approvalId) {
+          this.approvalBridge.resolveResult(approvalId, data);
+        }
+        continue;
+      }
+
+      if (msgType === "plan_approval_response") {
         const approvalId =
           typeof data.approval_id === "string" ? data.approval_id : null;
         if (approvalId) {

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -129,6 +129,9 @@ const ToolCallCard: React.FC<{
 
   const hasArgs = !!displayArgs && Object.keys(displayArgs).length > 0;
   const resultContent = result?.content;
+  // The call is complete once a result arrived; expandable details only show
+  // when the result actually has content.
+  const isCompleted = result !== undefined;
   const hasResult =
     resultContent != null &&
     !(typeof resultContent === "string" && resultContent.trim().length === 0);
@@ -214,7 +217,7 @@ const ToolCallCard: React.FC<{
           {isRunning ? (
             <LoadingSpinner size="small" />
           ) : (
-            hasResult && (
+            isCompleted && (
               <CheckCircleRoundedIcon
                 className="tool-status-icon done"
                 aria-label="completed"
@@ -325,13 +328,11 @@ const ToolCallGroup: React.FC<{
   const isRunning = toolCalls.some(
     (tc) => tc.id && runningToolCallId === tc.id
   );
-  const completedCount = toolCalls.filter((tc) => {
-    const content = durationFor(tc).toolResult?.content;
-    return (
-      content != null &&
-      !(typeof content === "string" && content.trim().length === 0)
-    );
-  }).length;
+  // A call is completed once a result message arrived — tools may
+  // legitimately return empty/null content.
+  const completedCount = toolCalls.filter(
+    (tc) => durationFor(tc).toolResult !== undefined
+  ).length;
   // Per-call durations are measured from the message start, so the chain's
   // total wall-clock time is the longest one.
   const totalDurationMs = toolCalls.reduce<number | null>((max, tc) => {

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -25,17 +25,15 @@ import {
   Text,
   FlexRow,
   FlexColumn,
-  ToolbarIconButton,
   LoadingSpinner,
-  Collapse,
-  SPACING,
-  getSpacingPx
+  Collapse
 } from "../../ui_primitives";
 import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 import PersonOutlineRoundedIcon from "@mui/icons-material/PersonOutlineRounded";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
+import { getToolVisual } from "./toolCallIcon";
 
 
 import AgentExecutionView from "./AgentExecutionView";
@@ -142,6 +140,12 @@ const ToolCallCard: React.FC<{
   const handleToggleOpen = useCallback(() => {
     setOpen((v) => !v);
   }, []);
+  const handleHeaderKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setOpen((v) => !v);
+    }
+  }, []);
 
   // For subtasks we keep the title + "Subtask" badge as the headline. For
   // regular tool calls we drop the tool name entirely and let the LLM-authored
@@ -154,6 +158,7 @@ const ToolCallCard: React.FC<{
     : liveMessage || fallbackName;
   const showSeparateMessage = isSubtask && !!liveMessage;
   const headlineLabel = isSubtask ? "Subtask" : null;
+  const { Icon: ToolIcon, accent } = getToolVisual(tc.name);
 
   return (
     <div
@@ -161,15 +166,21 @@ const ToolCallCard: React.FC<{
         isSubtask ? " run-subtask" : ""
       }`}
     >
-      <FlexRow className="tool-call-header" align="center" justify="space-between" fullWidth gap={0.5}>
-        <FlexRow align="center" gap={0.5} sx={{ minWidth: 0 }}>
-          {isSubtask && (
-            <AccountTreeOutlinedIcon
-              fontSize="small"
-              className="subtask-icon"
-              aria-hidden
-            />
-          )}
+      <FlexRow
+        className={`tool-call-header${hasDetails ? " expandable" : ""}`}
+        align="center"
+        fullWidth
+        gap={1}
+        role={hasDetails ? "button" : undefined}
+        tabIndex={hasDetails ? 0 : undefined}
+        aria-expanded={hasDetails ? open : undefined}
+        onClick={hasDetails ? handleToggleOpen : undefined}
+        onKeyDown={hasDetails ? handleHeaderKeyDown : undefined}
+      >
+        <span className={`tool-icon-tile accent-${accent}`} aria-hidden>
+          <ToolIcon />
+        </span>
+        <FlexRow align="center" gap={1} sx={{ minWidth: 0, flex: 1 }}>
           {headlineLabel && (
             <Text
               component="span"
@@ -183,7 +194,7 @@ const ToolCallCard: React.FC<{
           <Text
             component="span"
             size="small"
-            weight={isSubtask ? 500 : 400}
+            weight={500}
             className="tool-call-name"
             truncate
           >
@@ -194,31 +205,32 @@ const ToolCallCard: React.FC<{
               {liveMessage}
             </Text>
           )}
-          {isRunning && <LoadingSpinner size="small" />}
+          {!isSubtask && <span className="tool-call-id">{tc.name}</span>}
         </FlexRow>
-        <FlexRow align="center" gap={0.5} sx={{ flexShrink: 0 }}>
+        <FlexRow align="center" gap={1} sx={{ flexShrink: 0 }}>
           {durationLabel && (
-            <Text
-              component="span"
-              size="small"
-              className="tool-call-duration"
-              sx={{ color: "text.disabled", whiteSpace: "nowrap" }}
-            >
-              {durationLabel}
-            </Text>
+            <span className="tool-call-duration">{durationLabel}</span>
+          )}
+          {isRunning ? (
+            <LoadingSpinner size="small" />
+          ) : (
+            hasResult && (
+              <CheckCircleRoundedIcon
+                className="tool-status-icon done"
+                aria-label="completed"
+              />
+            )
           )}
           {hasDetails && (
-            <ToolbarIconButton
-              tooltip={open ? "Hide details" : "Show details"}
-              onClick={handleToggleOpen}
-              icon={<ExpandMoreIcon className={`expand-icon${open ? " expanded" : ""}`} />}
-              className="tool-expand-button"
+            <ExpandMoreIcon
+              className={`expand-icon${open ? " expanded" : ""}`}
+              aria-hidden
             />
           )}
         </FlexRow>
       </FlexRow>
       <Collapse in={open} timeout="auto" unmountOnExit>
-        <FlexColumn gap={0.5} sx={{ marginTop: getSpacingPx(SPACING.xs) }}>
+        <FlexColumn className="tool-call-details" gap={0.5}>
           {isSubtask && subtaskInstructions && (
             <FlexColumn gap={0.5}>
               <Caption className="tool-section-title">Instructions</Caption>
@@ -254,16 +266,17 @@ type ToolResultLookup = Record<
 >;
 
 /**
- * ToolCallGroup - Collapses a message's tool calls behind a single
- * "N tools called" line that unfolds to reveal each ToolCallCard. A lone
- * tool call renders directly with no extra chrome.
+ * ToolCallGroup - Renders a message's tool calls as a "tool execution chain":
+ * a tiny uppercase section label with a hairline rule, one bordered card per
+ * call, and a completion summary bar. The section header collapses the chain
+ * for dense threads. A lone tool call renders as a single card with no chrome.
  */
 const ToolCallGroup: React.FC<{
   toolCalls: ToolCall[];
   toolResultsByCallId?: ToolResultLookup;
   messageCreatedAt?: string | null;
 }> = React.memo(({ toolCalls, toolResultsByCallId, messageCreatedAt }) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const runningToolCallId = useGlobalChatStore((s) => s.currentRunningToolCallId);
   const handleToggleOpen = useCallback(() => setOpen((v) => !v), []);
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -273,8 +286,8 @@ const ToolCallGroup: React.FC<{
     }
   }, []);
 
-  const renderCard = useCallback(
-    (tc: ToolCall, i: number) => {
+  const durationFor = useCallback(
+    (tc: ToolCall) => {
       const toolResult =
         tc.id && toolResultsByCallId
           ? toolResultsByCallId[String(tc.id)]
@@ -284,6 +297,14 @@ const ToolCallGroup: React.FC<{
           ? new Date(toolResult.createdAt).getTime() -
             new Date(messageCreatedAt).getTime()
           : null;
+      return { toolResult, durationMs };
+    },
+    [toolResultsByCallId, messageCreatedAt]
+  );
+
+  const renderCard = useCallback(
+    (tc: ToolCall, i: number) => {
+      const { toolResult, durationMs } = durationFor(tc);
       return (
         <ToolCallCard
           key={tc.id || i}
@@ -293,7 +314,7 @@ const ToolCallGroup: React.FC<{
         />
       );
     },
-    [toolResultsByCallId, messageCreatedAt]
+    [durationFor]
   );
 
   // A single tool call keeps the original inline card — no group wrapper.
@@ -304,13 +325,31 @@ const ToolCallGroup: React.FC<{
   const isRunning = toolCalls.some(
     (tc) => tc.id && runningToolCallId === tc.id
   );
+  const completedCount = toolCalls.filter((tc) => {
+    const content = durationFor(tc).toolResult?.content;
+    return (
+      content != null &&
+      !(typeof content === "string" && content.trim().length === 0)
+    );
+  }).length;
+  // Per-call durations are measured from the message start, so the chain's
+  // total wall-clock time is the longest one.
+  const totalDurationMs = toolCalls.reduce<number | null>((max, tc) => {
+    const { durationMs } = durationFor(tc);
+    if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) {
+      return max;
+    }
+    return max === null ? durationMs : Math.max(max, durationMs);
+  }, null);
+  const totalDurationLabel =
+    totalDurationMs !== null ? formatDuration(totalDurationMs) : null;
 
   return (
     <div className="tool-call-group">
       <FlexRow
         className="tool-call-group-header"
         align="center"
-        gap={0.5}
+        gap={1}
         role="button"
         tabIndex={0}
         aria-expanded={open}
@@ -319,12 +358,13 @@ const ToolCallGroup: React.FC<{
       >
         <Text
           component="span"
-          size="small"
+          size="smaller"
           weight={500}
           className="tool-call-group-label"
         >
-          {toolCalls.length} tools called
+          Tool execution chain
         </Text>
+        <span className="tool-call-group-rule" aria-hidden />
         {isRunning && <LoadingSpinner size="small" />}
         <ExpandMoreIcon
           className={`expand-icon${open ? " expanded" : ""}`}
@@ -332,12 +372,23 @@ const ToolCallGroup: React.FC<{
         />
       </FlexRow>
       <Collapse in={open} timeout="auto" unmountOnExit>
-        <FlexColumn
-          className="tool-call-group-body"
-          gap={0.1}
-          sx={{ marginTop: getSpacingPx(SPACING.xs) }}
-        >
+        <FlexColumn className="tool-call-chain" gap={1}>
           {toolCalls.map(renderCard)}
+          <FlexRow className="tool-call-summary" align="center" gap={1.5}>
+            <span className="tool-call-summary-count">
+              {completedCount}/{toolCalls.length} completed
+            </span>
+            {totalDurationLabel && (
+              <>
+                <span className="tool-call-summary-divider" aria-hidden>
+                  |
+                </span>
+                <span className="tool-call-summary-duration">
+                  {totalDurationLabel}
+                </span>
+              </>
+            )}
+          </FlexRow>
         </FlexColumn>
       </Collapse>
     </div>

--- a/web/src/components/chat/message/PlanApprovalCard.tsx
+++ b/web/src/components/chat/message/PlanApprovalCard.tsx
@@ -1,0 +1,208 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { EditorButton } from "../../editor_ui";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  TextInput,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import type {
+  PendingPlanApproval,
+  PlanDecision
+} from "../../../stores/GlobalChatStore";
+
+interface PlanApprovalCardProps {
+  approvalId: string;
+  approval: PendingPlanApproval;
+  onResolve: (
+    approvalId: string,
+    decision: PlanDecision,
+    feedback?: string
+  ) => void;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    border: `1px solid ${theme.vars.palette.divider}`,
+    borderRadius: BORDER_RADIUS.lg,
+    overflow: "hidden",
+    ".plan-approval-header": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(2),
+      padding: theme.spacing(1.5, 2),
+      borderBottom: `1px solid ${theme.vars.palette.divider}`
+    },
+    ".plan-approval-counts": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      fontVariantNumeric: "tabular-nums",
+      whiteSpace: "nowrap",
+      marginLeft: "auto"
+    },
+    ".plan-approval-tasks": {
+      padding: theme.spacing(1.5, 2)
+    },
+    ".plan-task-index": {
+      width: 20,
+      height: 20,
+      borderRadius: BORDER_RADIUS.circle,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmaller)",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0
+    },
+    ".plan-task + .plan-task": {
+      marginTop: theme.spacing(1.5)
+    },
+    ".plan-task-deps": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      whiteSpace: "nowrap"
+    },
+    ".plan-step": {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: theme.spacing(1),
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmall)",
+      lineHeight: 1.45,
+      "&::before": {
+        content: '""',
+        width: 4,
+        height: 4,
+        borderRadius: BORDER_RADIUS.circle,
+        background: theme.vars.palette.text.disabled,
+        flexShrink: 0,
+        marginTop: "0.5em"
+      }
+    },
+    ".plan-approval-footer": {
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.spacing(1.5),
+      padding: theme.spacing(1.5, 2),
+      borderTop: `1px solid ${theme.vars.palette.divider}`
+    }
+  });
+
+/**
+ * Inline approval prompt for an agent's proposed execution plan. Shows the
+ * plan title and its tasks/steps, with an optional feedback field. Approve
+ * starts execution; Reject with feedback asks the agent to revise the plan;
+ * Reject without feedback aborts the run.
+ */
+const PlanApprovalCard: React.FC<PlanApprovalCardProps> = ({
+  approvalId,
+  approval,
+  onResolve
+}) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+  const [feedback, setFeedback] = useState("");
+
+  const { plan } = approval;
+  const totalSteps = plan.tasks.reduce((sum, t) => sum + t.steps.length, 0);
+
+  const handleApprove = useCallback(
+    () => onResolve(approvalId, "approve"),
+    [approvalId, onResolve]
+  );
+  const handleReject = useCallback(
+    () => onResolve(approvalId, "reject", feedback.trim() || undefined),
+    [approvalId, feedback, onResolve]
+  );
+  const handleFeedbackChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setFeedback(e.target.value),
+    []
+  );
+
+  const hasFeedback = feedback.trim().length > 0;
+
+  return (
+    <div css={cssStyles} className="plan-approval-card" role="group">
+      <div className="plan-approval-header">
+        <FlexColumn gap={0}>
+          <Text size="small" weight={500}>
+            Execution plan
+          </Text>
+          <Text size="smaller" color="secondary">
+            {plan.title}
+          </Text>
+        </FlexColumn>
+        <span className="plan-approval-counts">
+          {plan.tasks.length} tasks · {totalSteps} steps
+        </span>
+      </div>
+      <div className="plan-approval-tasks">
+        {plan.tasks.map((task, i) => (
+          <FlexColumn key={task.id} className="plan-task" gap={0.5}>
+            <FlexRow align="center" gap={1}>
+              <span className="plan-task-index">{i + 1}</span>
+              <Text size="small" weight={500} sx={{ minWidth: 0 }}>
+                {task.title}
+              </Text>
+              {task.depends_on.length > 0 && (
+                <span className="plan-task-deps">
+                  after {task.depends_on.join(", ")}
+                </span>
+              )}
+            </FlexRow>
+            <FlexColumn gap={0.25} sx={{ pl: 3.5 }}>
+              {task.steps.map((step) => (
+                <span key={step.id} className="plan-step">
+                  {step.instructions}
+                </span>
+              ))}
+            </FlexColumn>
+          </FlexColumn>
+        ))}
+      </div>
+      <div className="plan-approval-footer">
+        <TextInput
+          size="small"
+          compact
+          placeholder="Request changes (optional) — sent to the agent on reject"
+          value={feedback}
+          onChange={handleFeedbackChange}
+          multiline
+          maxRows={3}
+        />
+        <FlexRow gap={1} align="center" justify="flex-end">
+          <EditorButton
+            variant="outlined"
+            color="error"
+            density="normal"
+            onClick={handleReject}
+            startIcon={<CloseRoundedIcon />}
+          >
+            {hasFeedback ? "Reject with feedback" : "Reject"}
+          </EditorButton>
+          <EditorButton
+            variant="contained"
+            color="primary"
+            density="normal"
+            onClick={handleApprove}
+            startIcon={<PlayArrowRoundedIcon />}
+          >
+            Approve & run
+          </EditorButton>
+        </FlexRow>
+      </div>
+    </div>
+  );
+};
+
+export default memo(PlanApprovalCard);

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import { MessageView } from "../MessageView";
@@ -41,7 +41,7 @@ const toolCall = (id: string, name: string): ToolCall => ({
 });
 
 describe("MessageView tool-call grouping", () => {
-  it("collapses multiple tool calls behind a single 'N tools called' line", () => {
+  it("renders multiple tool calls as an expanded execution chain with a summary", () => {
     renderView({
       id: "m1",
       role: "assistant",
@@ -53,12 +53,14 @@ describe("MessageView tool-call grouping", () => {
       ]
     } as Message);
 
-    expect(screen.getByText("4 tools called")).toBeInTheDocument();
-    // Collapsed by default: individual tool names are not shown yet.
-    expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
+    expect(screen.getByText("Tool execution chain")).toBeInTheDocument();
+    // Expanded by default: every card is visible along with the summary bar.
+    expect(screen.getByText("Run Tests")).toBeInTheDocument();
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(screen.getByText("0/4 completed")).toBeInTheDocument();
   });
 
-  it("unfolds to reveal the individual tool calls when toggled", async () => {
+  it("collapses the chain when the section header is toggled", async () => {
     const user = userEvent.setup();
     renderView({
       id: "m2",
@@ -66,10 +68,17 @@ describe("MessageView tool-call grouping", () => {
       tool_calls: [toolCall("a", "search"), toolCall("b", "run_tests")]
     } as Message);
 
-    await user.click(screen.getByRole("button", { name: /2 tools called/i }));
-
     expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    expect(screen.getByText("Search")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /tool execution chain/i })
+    );
+
+    // Collapse unmounts its children once the exit transition finishes.
+    await waitFor(() => {
+      expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
   });
 
   it("renders a single tool call inline without the group wrapper", () => {
@@ -79,7 +88,9 @@ describe("MessageView tool-call grouping", () => {
       tool_calls: [toolCall("a", "search")]
     } as Message);
 
-    expect(screen.queryByText(/tools called/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/tool execution chain/i)
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Search")).toBeInTheDocument();
   });
 });

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -81,6 +81,30 @@ describe("MessageView tool-call grouping", () => {
     expect(screen.queryByText("Search")).not.toBeInTheDocument();
   });
 
+  it("counts a call with an empty result as completed in the summary", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <MessageView
+          message={
+            {
+              id: "m4",
+              role: "assistant",
+              tool_calls: [toolCall("a", "search"), toolCall("b", "run_tests")]
+            } as Message
+          }
+          isThoughtExpanded={() => false}
+          onToggleThought={() => {}}
+          toolResultsByCallId={{
+            // Empty-string content still means the tool responded.
+            a: { name: "search", content: "" }
+          }}
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText("1/2 completed")).toBeInTheDocument();
+  });
+
   it("renders a single tool call inline without the group wrapper", () => {
     renderView({
       id: "m3",

--- a/web/src/components/chat/message/toolCallIcon.tsx
+++ b/web/src/components/chat/message/toolCallIcon.tsx
@@ -1,0 +1,75 @@
+/**
+ * toolCallIcon — maps a tool name to a category icon + accent color for the
+ * tool execution chain. Categories are keyword-driven so any provider's tool
+ * naming (snake_case, MCP `mcp__server__tool`, `ui_*`) lands in a sensible
+ * bucket; unknown tools fall back to a neutral wrench.
+ */
+
+import type { SvgIconComponent } from "@mui/icons-material";
+import StorageRoundedIcon from "@mui/icons-material/StorageRounded";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import PublicRoundedIcon from "@mui/icons-material/PublicRounded";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import TerminalRoundedIcon from "@mui/icons-material/TerminalRounded";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
+
+/** Accent keys resolve to theme palette colors in the chat styles. */
+export type ToolAccent =
+  | "info"
+  | "warning"
+  | "success"
+  | "primary"
+  | "secondary"
+  | "neutral";
+
+export interface ToolVisual {
+  Icon: SvgIconComponent;
+  accent: ToolAccent;
+}
+
+const CATEGORIES: Array<{ pattern: RegExp; visual: ToolVisual }> = [
+  {
+    pattern: /subtask|agent|task/,
+    visual: { Icon: AccountTreeOutlinedIcon, accent: "primary" }
+  },
+  {
+    pattern: /database|query|sql|collection|vector|index|table|record/,
+    visual: { Icon: StorageRoundedIcon, accent: "info" }
+  },
+  {
+    pattern: /search|find|grep|glob|lookup|list/,
+    visual: { Icon: SearchRoundedIcon, accent: "warning" }
+  },
+  {
+    pattern: /file|read|write|edit|directory|folder|asset|document|save|open/,
+    visual: { Icon: DescriptionOutlinedIcon, accent: "warning" }
+  },
+  {
+    pattern: /http|web|fetch|url|browser|download|upload|request|api|notif|send|mail|message/,
+    visual: { Icon: PublicRoundedIcon, accent: "success" }
+  },
+  {
+    pattern: /image|video|audio|speech|generate|render|draw|media/,
+    visual: { Icon: ImageOutlinedIcon, accent: "secondary" }
+  },
+  {
+    pattern: /shell|bash|terminal|command|exec|run|code|script|node|workflow/,
+    visual: { Icon: TerminalRoundedIcon, accent: "primary" }
+  }
+];
+
+const DEFAULT_VISUAL: ToolVisual = {
+  Icon: BuildOutlinedIcon,
+  accent: "neutral"
+};
+
+export function getToolVisual(name?: string | null): ToolVisual {
+  if (!name) return DEFAULT_VISUAL;
+  const normalized = name.toLowerCase();
+  for (const { pattern, visual } of CATEGORIES) {
+    if (pattern.test(normalized)) return visual;
+  }
+  return DEFAULT_VISUAL;
+}

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -337,25 +337,19 @@ export const createStyles = (theme: Theme) => ({
       overflowWrap: "anywhere"
     },
 
-    ".tool-call-card": {
-      border: "none",
-      borderRadius: BORDER_RADIUS.sm,
-      background: "transparent",
-      padding: "0",
-      marginBottom: 0
+    // ── Tool execution chain ────────────────────────────────────────────────
+    // A message's tool calls render as a chain: tiny uppercase section label
+    // with a hairline rule, one bordered card per call, and a summary bar.
+    ".tool-call-group": {
+      width: "100%",
+      margin: theme.spacing(0.5, 0)
     },
 
-    // A message with several tool calls collapses them behind one
-    // "N tools called" line that unfolds to reveal each card.
     ".tool-call-group-header": {
       cursor: "pointer",
       userSelect: "none",
       borderRadius: BORDER_RADIUS.sm,
-      padding: theme.spacing(0.25, 0.5),
-      margin: theme.spacing(0, -0.5),
-      "&:hover": {
-        background: theme.vars.palette.action.hover
-      },
+      padding: theme.spacing(0.25, 0),
       "&:focus-visible": {
         outline: `2px solid ${theme.vars.palette.primary.main}`,
         outlineOffset: 1
@@ -363,15 +357,110 @@ export const createStyles = (theme: Theme) => ({
     },
 
     ".tool-call-group-label": {
-      color: theme.vars.palette.text.secondary
+      color: theme.vars.palette.text.secondary,
+      textTransform: "uppercase",
+      letterSpacing: "0.08em",
+      whiteSpace: "nowrap"
     },
 
-    ".tool-call-group-body": {
-      paddingLeft: theme.spacing(1)
+    ".tool-call-group-rule": {
+      height: 1,
+      flex: 1,
+      background: theme.vars.palette.divider
     },
 
-    ".tool-call-group-body .tool-call-card + .tool-call-card": {
-      marginTop: "0.05em"
+    ".tool-call-chain": {
+      marginTop: theme.spacing(1)
+    },
+
+    ".tool-call-summary": {
+      background: theme.vars.palette.action.hover,
+      borderRadius: BORDER_RADIUS.sm,
+      padding: theme.spacing(0.5, 1.5),
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmaller)"
+    },
+
+    ".tool-call-summary-divider": {
+      opacity: 0.3
+    },
+
+    ".tool-call-summary-duration": {
+      fontFamily: theme.fontFamily2,
+      fontVariantNumeric: "tabular-nums"
+    },
+
+    ".tool-call-card": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.md,
+      background: "transparent",
+      overflow: "hidden",
+      marginBottom: 0
+    },
+
+    ".tool-icon-tile": {
+      width: 24,
+      height: 24,
+      borderRadius: BORDER_RADIUS.sm,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      color: theme.vars.palette.text.secondary,
+      background: theme.vars.palette.action.hover,
+      "& svg": { fontSize: 15 }
+    },
+
+    ".tool-icon-tile.accent-info": {
+      color: theme.vars.palette.info.main,
+      background: `rgb(${theme.vars.palette.info.mainChannel} / 0.12)`
+    },
+    ".tool-icon-tile.accent-warning": {
+      color: theme.vars.palette.warning.main,
+      background: `rgb(${theme.vars.palette.warning.mainChannel} / 0.12)`
+    },
+    ".tool-icon-tile.accent-success": {
+      color: theme.vars.palette.success.main,
+      background: `rgb(${theme.vars.palette.success.mainChannel} / 0.12)`
+    },
+    ".tool-icon-tile.accent-primary": {
+      color: theme.vars.palette.primary.main,
+      background: `rgb(${theme.vars.palette.primary.mainChannel} / 0.12)`
+    },
+    ".tool-icon-tile.accent-secondary": {
+      color: theme.vars.palette.secondary.main,
+      background: `rgb(${theme.vars.palette.secondary.mainChannel} / 0.12)`
+    },
+
+    ".tool-call-id": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis"
+    },
+
+    ".tool-call-duration": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      fontVariantNumeric: "tabular-nums",
+      whiteSpace: "nowrap"
+    },
+
+    ".tool-status-icon": {
+      fontSize: 15,
+      flexShrink: 0
+    },
+
+    ".tool-status-icon.done": {
+      color: theme.vars.palette.success.main
+    },
+
+    ".tool-call-details": {
+      padding: theme.spacing(1, 1.5, 1.25),
+      borderTop: `1px solid ${theme.vars.palette.divider}`
     },
 
     ".tool-call-card.running .tool-call-name": {
@@ -381,18 +470,9 @@ export const createStyles = (theme: Theme) => ({
     // `run_subtask` cards stand apart from generic tool calls — a light
     // accent border + soft background marks them as a deeper sub-execution.
     ".tool-call-card.run-subtask": {
-      border: `1px solid ${theme.vars.palette.divider}`,
       borderLeft: `2px solid ${theme.vars.palette.primary.main}`,
-      borderRadius: BORDER_RADIUS.md,
-      padding: theme.spacing(0.5, 1),
-      background: `${theme.vars.palette.primary.main}0a`,
+      background: `rgb(${theme.vars.palette.primary.mainChannel} / 0.04)`,
       marginBottom: theme.spacing(0.5)
-    },
-
-    ".tool-call-card.run-subtask .subtask-icon": {
-      fontSize: 14,
-      color: theme.vars.palette.primary.main,
-      flexShrink: 0
     },
 
     ".tool-call-card.run-subtask .tool-call-badge": {
@@ -443,7 +523,7 @@ export const createStyles = (theme: Theme) => ({
     },
 
     ".chat-message.has-tool-calls .tool-call-card + .tool-call-card": {
-      marginTop: "0.05em"
+      marginTop: theme.spacing(1)
     },
 
     ".chat-message.has-tool-calls .markdown": {
@@ -476,12 +556,26 @@ export const createStyles = (theme: Theme) => ({
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      lineHeight: 1.25
+      lineHeight: 1.25,
+      padding: theme.spacing(1.25, 1.5)
+    },
+
+    ".tool-call-header.expandable": {
+      cursor: "pointer",
+      userSelect: "none",
+      transition: MOTION.background,
+      "&:hover": {
+        background: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
+      }
     },
 
     ".tool-call-name": {
       fontSize: "var(--fontSizeSmall)",
-      fontWeight: 600,
+      fontWeight: 500,
       color: theme.vars.palette.text.primary,
       whiteSpace: "nowrap"
     },
@@ -489,11 +583,6 @@ export const createStyles = (theme: Theme) => ({
     ".tool-message": {
       fontSize: "var(--fontSizeSmall)",
       color: theme.vars.palette.text.secondary
-    },
-
-    ".tool-expand-button": {
-      padding: theme.spacing(0.5),
-      marginRight: -2
     },
 
     ".expand-icon": {

--- a/web/src/components/chat/thread/ChatThreadView.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.tsx
@@ -24,6 +24,7 @@ import { MessageView } from "../message/MessageView";
 import MediaOutputGroup from "../message/MediaOutputGroup";
 import type { MediaGenerationRequest } from "../../../stores/MediaGenerationStore";
 import ToolApprovalCard from "../message/ToolApprovalCard";
+import PlanApprovalCard from "../message/PlanApprovalCard";
 import { ScrollToBottomButton } from "../controls/ScrollToBottomButton";
 import { createStyles } from "./ChatThreadView.styles";
 import PlanningUpdateDisplay from "../../node/PlanningUpdateDisplay";
@@ -261,6 +262,22 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
         ([, approval]) => approval.thread_id === currentThreadId
       ),
     [pendingApprovals, currentThreadId]
+  );
+
+  // Pending plan-approval prompts. Plans from runs not bound to a thread
+  // (thread_id null, e.g. editor workflow runs) show on the active thread.
+  const pendingPlanApprovals = useGlobalChatStore(
+    (s) => s.pendingPlanApprovals
+  );
+  const resolvePlanApproval = useGlobalChatStore((s) => s.resolvePlanApproval);
+  const threadPlanApprovals = useMemo(
+    () =>
+      Object.entries(pendingPlanApprovals).filter(
+        ([, approval]) =>
+          approval.thread_id === null ||
+          approval.thread_id === currentThreadId
+      ),
+    [pendingPlanApprovals, currentThreadId]
   );
 
   // The generating turn's own outgoing message carries `media_generation` —
@@ -656,6 +673,27 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
                     message={approval.message}
                     args={approval.args}
                     onResolve={resolveApproval}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {threadPlanApprovals.length > 0 && (
+            <div className="chat-message-list-item">
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: getSpacingPx(SPACING.md)
+                }}
+              >
+                {threadPlanApprovals.map(([approvalId, approval]) => (
+                  <PlanApprovalCard
+                    key={approvalId}
+                    approvalId={approvalId}
+                    approval={approval}
+                    onResolve={resolvePlanApproval}
                   />
                 ))}
               </div>

--- a/web/src/components/execution/ExecutionTree.tsx
+++ b/web/src/components/execution/ExecutionTree.tsx
@@ -1,44 +1,38 @@
 /** @jsxImportSource @emotion/react */
 /**
- * ExecutionTree — Web port of the CLI tree execution view.
+ * ExecutionTree — Agent plan/execution timeline.
  *
- * Renders agent task/step hierarchy as an interactive tree:
- *
- * ◆ Plan  (2/3 tasks)
- * ├─ ✓ Task 1: Search for sources              3.2s (3 steps)
- * ├─ ◐ Task 2: Analyze findings
- * │  ├─ ✓ google_search("topic")
- * │  │    → Found 5 results
- * │  └─ ◐ llm_call
- * │       → The key themes emerging from...
- * └─ ○ Task 3: Write summary                   waiting
+ * Renders the agent task/step hierarchy as a vertical status timeline:
+ * a plan header with progress bar and per-status dot counts, then one
+ * timeline node per task (check / spinner / waiting circle / failed) joined
+ * by status-colored connector lines, with the task's steps nested inside.
  */
 
 import React, { memo, useMemo, useState, useCallback } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Text, FlexRow, FlexColumn, BORDER_RADIUS, MOTION } from "../ui_primitives";
+import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import AutorenewRoundedIcon from "@mui/icons-material/AutorenewRounded";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import {
+  FlexRow,
+  FlexColumn,
+  BORDER_RADIUS,
+  MOTION,
+  reducedMotion
+} from "../ui_primitives";
 import type {
   ExecutionTreeState,
   TaskState,
   StepState,
   StepToolCallEntry,
-  PlanningEntry,
-  LogEntry
+  PlanningEntry
 } from "../../hooks/useExecutionTreeState";
 
-// ---------------------------------------------------------------------------
-// Icons (matching CLI)
-// ---------------------------------------------------------------------------
-
-const ICONS = {
-  waiting: "○",
-  running: "◐",
-  completed: "✓",
-  failed: "✗",
-  plan: "◆"
-} as const;
+type NodeStatus = "waiting" | "running" | "completed" | "failed";
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -46,168 +40,324 @@ const ICONS = {
 
 const treeStyles = (theme: Theme) =>
   css({
-    fontFamily: theme.fontFamily2 || "monospace",
+    fontFamily: theme.fontFamily1,
     fontSize: "var(--fontSizeSmall)",
-    lineHeight: 1.6,
-    padding: "0.75rem 0",
+    lineHeight: 1.5,
     userSelect: "text",
 
-    ".tree-plan-header": {
+    "@keyframes tlSpin": {
+      from: { transform: "rotate(0deg)" },
+      to: { transform: "rotate(360deg)" }
+    },
+
+    "@keyframes tlPulse": {
+      "0%, 100%": { opacity: 1 },
+      "50%": { opacity: 0.4 }
+    },
+
+    ".plan-card": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      overflow: "hidden",
+      background: "transparent"
+    },
+
+    ".plan-header": {
       display: "flex",
       alignItems: "center",
-      gap: "0.35rem",
-      marginBottom: "0.25rem"
+      gap: theme.spacing(2),
+      padding: theme.spacing(1.25, 2),
+      borderBottom: `1px solid ${theme.vars.palette.divider}`
     },
 
-    ".tree-plan-icon": {
-      color: theme.vars.palette.primary.main,
-      fontWeight: 600
-    },
-
-    ".tree-plan-label": {
-      color: theme.vars.palette.primary.main,
-      fontWeight: 600,
-      fontSize: "var(--fontSizeNormal)"
-    },
-
-    ".tree-plan-count": {
-      color: theme.vars.palette.text.secondary,
+    ".plan-title": {
       fontSize: "var(--fontSizeSmall)",
-      marginLeft: "0.25rem"
+      fontWeight: 500,
+      color: theme.vars.palette.text.primary,
+      whiteSpace: "nowrap"
     },
 
-    ".tree-task": {
-      cursor: "pointer",
-      "&:hover .tree-task-name": {
-        textDecoration: "underline",
-        textDecorationColor: theme.vars.palette.text.secondary,
-        textUnderlineOffset: "2px"
+    ".plan-progress-track": {
+      flex: 1,
+      height: 6,
+      borderRadius: BORDER_RADIUS.pill,
+      background: theme.vars.palette.action.hover,
+      overflow: "hidden"
+    },
+
+    ".plan-progress-fill": {
+      height: "100%",
+      borderRadius: BORDER_RADIUS.pill,
+      background: theme.vars.palette.text.primary,
+      transition: `width ${MOTION.slow}`,
+      ...reducedMotion({ transition: MOTION.none })
+    },
+
+    ".plan-count": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      fontVariantNumeric: "tabular-nums",
+      whiteSpace: "nowrap"
+    },
+
+    ".plan-dots": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1.5)
+    },
+
+    ".plan-dot": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(0.5),
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      whiteSpace: "nowrap",
+      "&::before": {
+        content: '""',
+        width: 6,
+        height: 6,
+        borderRadius: BORDER_RADIUS.circle,
+        background: "currentColor"
       }
     },
 
-    ".tree-branch": {
-      color: theme.vars.palette.text.disabled,
-      whiteSpace: "pre"
+    ".plan-dot.completed::before": { background: theme.vars.palette.success.main },
+    ".plan-dot.running::before": { background: theme.vars.palette.info.main },
+    ".plan-dot.failed::before": { background: theme.vars.palette.error.main },
+    ".plan-dot.waiting::before": {
+      background: theme.vars.palette.action.disabled
     },
 
-    "@keyframes gradientShift": {
-      "0%": { color: theme.vars.palette.warning.main },
-      "50%": { color: theme.vars.palette.primary.main },
-      "100%": { color: theme.vars.palette.warning.main }
+    ".plan-body": {
+      padding: theme.spacing(2)
     },
 
-    "@keyframes treeItemEnter": {
-      "0%": { opacity: 0, transform: "translateY(-4px)" },
-      "100%": { opacity: 1, transform: "translateY(0)" }
-    },
-
-    "@media (prefers-reduced-motion: no-preference)": {
-      ".tree-planning-entry, .tree-task, .tree-step, .tree-plan-header": {
-        animation: `treeItemEnter ${MOTION.normal} both`
-      }
-    },
-
-    ".tree-icon-waiting": { color: theme.vars.palette.text.disabled },
-    ".tree-icon-running": {
-      animation: "gradientShift 2s ease-in-out infinite"
-    },
-    ".tree-icon-completed": { color: theme.vars.palette.success.main },
-    ".tree-icon-failed": { color: theme.vars.palette.error.main },
-
-    ".tree-task-name": {
-      fontWeight: 600,
-      marginLeft: "0.2rem"
-    },
-
-    ".tree-task-meta": {
-      color: theme.vars.palette.text.secondary,
-      fontSize: "var(--fontSizeSmall)",
-      marginLeft: "0.5rem"
-    },
-
-    ".tree-step-name": {
-      marginLeft: "0.2rem"
-    },
-
-    ".tree-step-output": {
-      color: theme.vars.palette.text.secondary,
-      fontSize: "var(--fontSizeSmall)"
-    },
-
-    ".tree-step-error": {
-      color: theme.vars.palette.error.main,
-      fontSize: "var(--fontSizeSmall)"
-    },
-
-    ".tree-planning": {
+    // ── Timeline nodes ─────────────────────────────────────────────────────
+    ".tl-item": {
       display: "flex",
-      alignItems: "center",
-      gap: "0.35rem",
-      fontFamily: theme.fontFamily1,
-      color: theme.vars.palette.warning.main
+      gap: theme.spacing(1.5),
+      position: "relative"
     },
 
-    ".tree-planning-text": {
-      fontFamily: theme.fontFamily1,
-      color: theme.vars.palette.text.secondary,
-      fontSize: "var(--fontSizeSmall)",
-      marginLeft: "0.25rem"
-    },
-
-    ".tree-planning-log": {
+    ".tl-rail": {
       display: "flex",
       flexDirection: "column",
-      gap: "0.2rem",
-      marginBottom: "0.5rem",
-      fontFamily: theme.fontFamily1
-    },
-
-    ".tree-planning-entry": {
-      display: "flex",
-      alignItems: "baseline",
-      gap: "0.5rem",
-      fontFamily: theme.fontFamily1
-    },
-
-    ".tree-planning-phase": {
-      fontFamily: theme.fontFamily1,
-      fontSize: "var(--fontSizeSmall)",
-      fontWeight: 600,
-      textTransform: "capitalize",
-      letterSpacing: 0,
-      minWidth: "5.5rem",
+      alignItems: "center",
       flexShrink: 0
     },
 
-    ".tree-planning-content": {
-      fontFamily: theme.fontFamily1,
-      color: theme.vars.palette.text.secondary,
+    ".tl-badge": {
+      width: 24,
+      height: 24,
+      borderRadius: BORDER_RADIUS.circle,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      zIndex: 1,
+      transition: MOTION.all,
+      ...reducedMotion({ transition: MOTION.none }),
+      "& svg": { fontSize: 14 }
+    },
+
+    ".tl-badge.completed": {
+      background: theme.vars.palette.success.main,
+      color: theme.vars.palette.success.contrastText
+    },
+
+    ".tl-badge.failed": {
+      background: theme.vars.palette.error.main,
+      color: theme.vars.palette.error.contrastText
+    },
+
+    ".tl-badge.running": {
+      background: theme.vars.palette.info.main,
+      color: theme.vars.palette.info.contrastText,
+      boxShadow: `0 0 0 4px rgb(${theme.vars.palette.info.mainChannel} / 0.2)`,
+      "& svg": {
+        animation: "tlSpin 1.4s linear infinite",
+        ...reducedMotion({ animation: "none" })
+      }
+    },
+
+    ".tl-badge.waiting": {
+      background: theme.vars.palette.action.hover,
+      color: theme.vars.palette.text.disabled,
+      "&::after": {
+        content: '""',
+        width: 8,
+        height: 8,
+        borderRadius: BORDER_RADIUS.circle,
+        border: `2px solid currentColor`
+      }
+    },
+
+    ".tl-connector": {
+      width: 2,
+      flex: 1,
+      minHeight: theme.spacing(1.5),
+      background: theme.vars.palette.divider
+    },
+
+    ".tl-connector.completed": {
+      background: `rgb(${theme.vars.palette.success.mainChannel} / 0.4)`
+    },
+    ".tl-connector.running": {
+      background: `rgb(${theme.vars.palette.info.mainChannel} / 0.4)`
+    },
+    ".tl-connector.failed": {
+      background: `rgb(${theme.vars.palette.error.mainChannel} / 0.4)`
+    },
+
+    ".tl-content": {
+      flex: 1,
+      minWidth: 0,
+      paddingBottom: theme.spacing(2.5)
+    },
+
+    ".tl-item.last > .tl-content": {
+      paddingBottom: 0
+    },
+
+    ".tl-row": {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: theme.spacing(1),
+      minHeight: 24
+    },
+
+    ".tl-row-main": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(1),
+      flex: 1,
+      minWidth: 0,
+      textAlign: "left"
+    },
+
+    ".tl-row-main.clickable": {
+      cursor: "pointer",
+      "&:hover .tl-name": {
+        textDecoration: "underline",
+        textDecorationColor: theme.vars.palette.text.secondary,
+        textUnderlineOffset: "2px"
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 2,
+        borderRadius: BORDER_RADIUS.xs
+      }
+    },
+
+    ".tl-name": {
       fontSize: "var(--fontSizeSmall)",
-      lineHeight: 1.45,
+      color: theme.vars.palette.text.secondary,
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap"
     },
 
-    ".tree-log-entry": {
-      color: theme.vars.palette.text.disabled,
-      fontSize: "var(--fontSizeSmaller)",
-      paddingLeft: "1.5rem"
+    ".tl-name.running": {
+      color: theme.vars.palette.text.primary,
+      fontWeight: 500
     },
 
-    ".tree-step-row": {
-      cursor: "pointer",
-      "&:hover .tree-step-name": {
-        textDecoration: "underline",
-        textDecorationColor: theme.vars.palette.text.secondary,
-        textUnderlineOffset: "2px"
+    ".tl-name.waiting": {
+      color: theme.vars.palette.text.disabled
+    },
+
+    ".tl-name.failed": {
+      color: theme.vars.palette.error.main
+    },
+
+    ".tl-chevron": {
+      fontSize: 14,
+      color: theme.vars.palette.text.disabled,
+      flexShrink: 0,
+      transition: MOTION.transform,
+      ...reducedMotion({ transition: MOTION.none }),
+      "&.collapsed": { transform: "rotate(-90deg)" }
+    },
+
+    ".tl-meta": {
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(0.5),
+      flexShrink: 0,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      fontVariantNumeric: "tabular-nums",
+      whiteSpace: "nowrap",
+      "& svg": { fontSize: 11 }
+    },
+
+    ".tl-meta.running": {
+      fontFamily: theme.fontFamily1,
+      color: theme.vars.palette.info.main,
+      "&::before": {
+        content: '""',
+        width: 6,
+        height: 6,
+        borderRadius: BORDER_RADIUS.circle,
+        background: "currentColor",
+        animation: "tlPulse 1.6s ease-in-out infinite",
+        ...reducedMotion({ animation: "none" })
       }
     },
 
-    ".tree-step-inspector": {
-      marginTop: "0.25rem",
-      marginBottom: "0.4rem",
-      padding: "0.5rem 0.75rem",
+    ".tl-meta.waiting": {
+      fontFamily: theme.fontFamily1,
+      color: theme.vars.palette.text.disabled
+    },
+
+    ".tl-detail": {
+      marginTop: theme.spacing(0.25),
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      lineHeight: 1.6,
+      color: theme.vars.palette.text.secondary,
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word"
+    },
+
+    ".tl-detail.error": {
+      color: theme.vars.palette.error.main
+    },
+
+    ".tl-children": {
+      marginTop: theme.spacing(1.5)
+    },
+
+    // ── Planning trace ─────────────────────────────────────────────────────
+    ".planning-log": {
+      display: "flex",
+      flexDirection: "column",
+      marginBottom: theme.spacing(1)
+    },
+
+    ".planning-phase": {
+      fontSize: "var(--fontSizeSmall)",
+      fontWeight: 500,
+      textTransform: "capitalize",
+      color: theme.vars.palette.text.primary,
+      whiteSpace: "nowrap"
+    },
+
+    ".planning-content": {
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.secondary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+
+    // ── Step inspector ─────────────────────────────────────────────────────
+    ".tl-inspector": {
+      marginTop: theme.spacing(1),
+      padding: theme.spacing(1, 1.5),
       borderLeft: `2px solid ${theme.vars.palette.divider}`,
       background: `${theme.vars.palette.action.hover}`,
       borderRadius: `0 ${BORDER_RADIUS.sm} ${BORDER_RADIUS.sm} 0`,
@@ -215,16 +365,16 @@ const treeStyles = (theme: Theme) =>
       lineHeight: 1.5,
       display: "flex",
       flexDirection: "column",
-      gap: "0.4rem"
+      gap: theme.spacing(1)
     },
 
-    ".tree-step-inspector-section": {
+    ".tl-inspector-section": {
       display: "flex",
       flexDirection: "column",
-      gap: "0.15rem"
+      gap: theme.spacing(0.25)
     },
 
-    ".tree-step-inspector-label": {
+    ".tl-inspector-label": {
       color: theme.vars.palette.text.secondary,
       fontWeight: 600,
       textTransform: "uppercase",
@@ -232,37 +382,38 @@ const treeStyles = (theme: Theme) =>
       fontSize: "var(--fontSizeSmaller)"
     },
 
-    ".tree-step-inspector-body": {
+    ".tl-inspector-body": {
       color: theme.vars.palette.text.primary,
       whiteSpace: "pre-wrap",
       wordBreak: "break-word",
-      fontFamily: theme.fontFamily2 || "monospace",
+      fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmall)"
     },
 
-    ".tree-step-inspector-code": {
+    ".tl-inspector-code": {
+      margin: 0,
       color: theme.vars.palette.text.primary,
       whiteSpace: "pre-wrap",
       wordBreak: "break-word",
-      fontFamily: theme.fontFamily2 || "monospace",
+      fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmall)",
       background: theme.vars.palette.background.default,
-      padding: "0.35rem 0.5rem",
+      padding: theme.spacing(0.75, 1),
       borderRadius: BORDER_RADIUS.sm,
       maxHeight: "20rem",
       overflow: "auto"
     },
 
-    ".tree-step-inspector-tool": {
+    ".tl-inspector-tool": {
       display: "flex",
       flexDirection: "column",
-      gap: "0.15rem",
-      padding: "0.25rem 0",
+      gap: theme.spacing(0.25),
+      padding: theme.spacing(0.5, 0),
       borderTop: `1px dashed ${theme.vars.palette.divider}`,
       "&:first-of-type": { borderTop: "none" }
     },
 
-    ".tree-step-inspector-error": {
+    ".tl-inspector-error": {
       color: theme.vars.palette.error.main
     }
   });
@@ -289,10 +440,6 @@ function truncateOutput(output: string, maxLines: number = 2): string {
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Step rendering
-// ---------------------------------------------------------------------------
-
 function stringifyResult(v: unknown): string {
   if (v === undefined || v === null) return "";
   if (typeof v === "string") return v;
@@ -303,43 +450,57 @@ function stringifyResult(v: unknown): string {
   }
 }
 
+const StatusBadge: React.FC<{ status: NodeStatus }> = memo(({ status }) => (
+  <div className={`tl-badge ${status}`} aria-hidden>
+    {status === "completed" && <CheckRoundedIcon />}
+    {status === "failed" && <CloseRoundedIcon />}
+    {status === "running" && <AutorenewRoundedIcon />}
+  </div>
+));
+
+StatusBadge.displayName = "StatusBadge";
+
+// ---------------------------------------------------------------------------
+// Step inspector
+// ---------------------------------------------------------------------------
+
 const StepInspector: React.FC<{ step: StepState }> = memo(({ step }) => {
   const resultText = useMemo(() => stringifyResult(step.rawResult), [step.rawResult]);
 
   return (
-    <div className="tree-step-inspector">
+    <div className="tl-inspector">
       {step.instructions ? (
-        <div className="tree-step-inspector-section">
-          <span className="tree-step-inspector-label">Instructions</span>
-          <span className="tree-step-inspector-body">{step.instructions}</span>
+        <div className="tl-inspector-section">
+          <span className="tl-inspector-label">Instructions</span>
+          <span className="tl-inspector-body">{step.instructions}</span>
         </div>
       ) : null}
 
       {step.duration !== undefined ? (
-        <div className="tree-step-inspector-section">
-          <span className="tree-step-inspector-label">Duration</span>
-          <span className="tree-step-inspector-body">
+        <div className="tl-inspector-section">
+          <span className="tl-inspector-label">Duration</span>
+          <span className="tl-inspector-body">
             {formatDuration(step.duration)}
           </span>
         </div>
       ) : null}
 
       {step.toolCalls.length > 0 ? (
-        <div className="tree-step-inspector-section">
-          <span className="tree-step-inspector-label">
+        <div className="tl-inspector-section">
+          <span className="tl-inspector-label">
             Tool calls ({step.toolCalls.length})
           </span>
           {step.toolCalls.map((call: StepToolCallEntry, i: number) => (
             <div
               key={call.id ?? `${call.name}-${i}`}
-              className="tree-step-inspector-tool"
+              className="tl-inspector-tool"
             >
-              <span className="tree-step-inspector-body">
+              <span className="tl-inspector-body">
                 <strong>{call.name || "tool"}</strong>
                 {call.message ? `  ${call.message}` : ""}
               </span>
               {Object.keys(call.args ?? {}).length > 0 ? (
-                <pre className="tree-step-inspector-code">
+                <pre className="tl-inspector-code">
                   {JSON.stringify(call.args, null, 2)}
                 </pre>
               ) : null}
@@ -349,18 +510,16 @@ const StepInspector: React.FC<{ step: StepState }> = memo(({ step }) => {
       ) : null}
 
       {resultText ? (
-        <div className="tree-step-inspector-section">
-          <span className="tree-step-inspector-label">Result</span>
-          <pre className="tree-step-inspector-code">{resultText}</pre>
+        <div className="tl-inspector-section">
+          <span className="tl-inspector-label">Result</span>
+          <pre className="tl-inspector-code">{resultText}</pre>
         </div>
       ) : null}
 
       {step.error ? (
-        <div className="tree-step-inspector-section">
-          <span className="tree-step-inspector-label tree-step-inspector-error">
-            Error
-          </span>
-          <pre className="tree-step-inspector-code tree-step-inspector-error">
+        <div className="tl-inspector-section">
+          <span className="tl-inspector-label tl-inspector-error">Error</span>
+          <pre className="tl-inspector-code tl-inspector-error">
             {step.error}
           </pre>
         </div>
@@ -371,28 +530,24 @@ const StepInspector: React.FC<{ step: StepState }> = memo(({ step }) => {
 
 StepInspector.displayName = "StepInspector";
 
+// ---------------------------------------------------------------------------
+// Step node
+// ---------------------------------------------------------------------------
+
 const StepNode: React.FC<{
   step: StepState;
   isLast: boolean;
-  parentPrefix: string;
-}> = memo(({ step, isLast, parentPrefix }) => {
+}> = memo(({ step, isLast }) => {
   const [expanded, setExpanded] = useState(false);
-  const branch = isLast ? "└─ " : "├─ ";
-  const cont = isLast ? "   " : "│  ";
-  const iconClass = `tree-icon-${step.status}`;
-  const icon = ICONS[step.status];
 
   const displayName = step.toolName
     ? step.toolArgs
       ? `${step.toolName}(${step.toolArgs.slice(0, 50)})`
       : step.toolName
-    : step.name.slice(0, 60);
+    : step.name.slice(0, 80);
 
-  const duration =
-    step.duration !== undefined ? ` ${formatDuration(step.duration)}` : "";
   const outputPreview = truncateOutput(step.output);
-  const errorText =
-    typeof step.error === "string" ? step.error : "";
+  const errorText = typeof step.error === "string" ? step.error : "";
   const errorPreview = errorText.slice(0, 120);
 
   const hasInspector =
@@ -405,46 +560,61 @@ const StepNode: React.FC<{
     if (hasInspector) setExpanded((v) => !v);
   }, [hasInspector]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (hasInspector && (e.key === "Enter" || e.key === " ")) {
+        e.preventDefault();
+        setExpanded((v) => !v);
+      }
+    },
+    [hasInspector]
+  );
+
   return (
-    <FlexColumn className="tree-step">
-      <FlexRow
-        align="center"
-        className={hasInspector ? "tree-step-row" : undefined}
-        onClick={hasInspector ? handleToggle : undefined}
-      >
-        <span className="tree-branch">
-          {parentPrefix}
-          {branch}
-        </span>
-        <span className={iconClass}>{icon}</span>
-        <span className={`tree-step-name ${iconClass}`}>{displayName}</span>
-        {duration && <span className="tree-task-meta">{duration}</span>}
-      </FlexRow>
-      {outputPreview && step.status === "running" && !expanded ? (
-        <span className="tree-step-output">
-          {parentPrefix}
-          {cont}
-          {"   → "}
-          {outputPreview}
-        </span>
-      ) : null}
-      {errorPreview && !expanded ? (
-        <span className="tree-step-error">
-          {parentPrefix}
-          {cont}
-          {"   ✗ "}
-          {errorPreview}
-        </span>
-      ) : null}
-      {expanded && hasInspector ? <StepInspector step={step} /> : null}
-    </FlexColumn>
+    <div className={`tl-item${isLast ? " last" : ""}`}>
+      <div className="tl-rail">
+        <StatusBadge status={step.status} />
+        {!isLast && <div className={`tl-connector ${step.status}`} aria-hidden />}
+      </div>
+      <div className="tl-content">
+        <div className="tl-row">
+          <FlexRow
+            className={`tl-row-main${hasInspector ? " clickable" : ""}`}
+            align="center"
+            gap={1}
+            role={hasInspector ? "button" : undefined}
+            tabIndex={hasInspector ? 0 : undefined}
+            aria-expanded={hasInspector ? expanded : undefined}
+            onClick={hasInspector ? handleToggle : undefined}
+            onKeyDown={hasInspector ? handleKeyDown : undefined}
+          >
+            <span className={`tl-name ${step.status}`}>{displayName}</span>
+          </FlexRow>
+          {step.status === "running" ? (
+            <span className="tl-meta running">In progress</span>
+          ) : step.duration !== undefined ? (
+            <span className="tl-meta">
+              <AccessTimeRoundedIcon aria-hidden />
+              {formatDuration(step.duration)}
+            </span>
+          ) : null}
+        </div>
+        {outputPreview && !expanded ? (
+          <div className="tl-detail">{outputPreview}</div>
+        ) : null}
+        {errorPreview && !expanded ? (
+          <div className="tl-detail error">{errorPreview}</div>
+        ) : null}
+        {expanded && hasInspector ? <StepInspector step={step} /> : null}
+      </div>
+    </div>
   );
 });
 
 StepNode.displayName = "StepNode";
 
 // ---------------------------------------------------------------------------
-// Task rendering
+// Task node
 // ---------------------------------------------------------------------------
 
 const TaskNode: React.FC<{
@@ -452,51 +622,79 @@ const TaskNode: React.FC<{
   isLast: boolean;
   onToggle: () => void;
 }> = memo(({ task, isLast, onToggle }) => {
-  const branch = isLast ? "└─ " : "├─ ";
-  const cont = isLast ? "   " : "│  ";
-  const iconClass = `tree-icon-${task.status}`;
-  const icon = ICONS[task.status];
-
-  const duration =
-    task.duration !== undefined ? formatDuration(task.duration) : "";
   const stepCount = task.steps.length;
   const completedSteps = task.steps.filter(
     (s) => s.status === "completed"
   ).length;
+  const duration =
+    task.duration !== undefined ? formatDuration(task.duration) : "";
+  const hasSteps = stepCount > 0;
 
-  if (!task.expanded) {
-    return (
-      <FlexRow align="center" className="tree-task" onClick={onToggle}>
-        <span className="tree-branch">{branch}</span>
-        <span className={iconClass}>{icon}</span>
-        <span className={`tree-task-name ${iconClass}`}>{task.name}</span>
-        {duration && <span className="tree-task-meta">{duration}</span>}
-        <span className="tree-task-meta">
-          ({completedSteps}/{stepCount} steps)
-        </span>
-      </FlexRow>
-    );
-  }
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onToggle();
+      }
+    },
+    [onToggle]
+  );
 
   return (
-    <FlexColumn>
-      <FlexRow align="center" className="tree-task" onClick={onToggle}>
-        <span className="tree-branch">{branch}</span>
-        <span className={iconClass}>{icon}</span>
-        <span className={`tree-task-name ${iconClass}`}>{task.name}</span>
-        {task.status === "waiting" && (
-          <span className="tree-task-meta">waiting</span>
-        )}
-      </FlexRow>
-      {task.steps.map((step, i) => (
-        <StepNode
-          key={step.id}
-          step={step}
-          isLast={i === task.steps.length - 1}
-          parentPrefix={cont}
-        />
-      ))}
-    </FlexColumn>
+    <div className={`tl-item${isLast ? " last" : ""}`}>
+      <div className="tl-rail">
+        <StatusBadge status={task.status} />
+        {!isLast && <div className={`tl-connector ${task.status}`} aria-hidden />}
+      </div>
+      <div className="tl-content">
+        <div className="tl-row">
+          <FlexRow
+            className={`tl-row-main${hasSteps ? " clickable" : ""}`}
+            align="center"
+            gap={1}
+            role={hasSteps ? "button" : undefined}
+            tabIndex={hasSteps ? 0 : undefined}
+            aria-expanded={hasSteps ? task.expanded : undefined}
+            onClick={hasSteps ? onToggle : undefined}
+            onKeyDown={hasSteps ? handleKeyDown : undefined}
+          >
+            <span className={`tl-name ${task.status}`}>{task.name}</span>
+            {hasSteps && (
+              <ExpandMoreIcon
+                className={`tl-chevron${task.expanded ? "" : " collapsed"}`}
+                aria-hidden
+              />
+            )}
+          </FlexRow>
+          {task.status === "running" ? (
+            <span className="tl-meta running">In progress</span>
+          ) : task.status === "waiting" ? (
+            <span className="tl-meta waiting">waiting</span>
+          ) : (
+            <span className="tl-meta">
+              {duration && (
+                <>
+                  <AccessTimeRoundedIcon aria-hidden />
+                  {duration}
+                </>
+              )}
+              {hasSteps ? ` ${completedSteps}/${stepCount} steps` : null}
+            </span>
+          )}
+        </div>
+        {task.expanded && hasSteps ? (
+          <div className="tl-children">
+            {task.steps.map((step, i) => (
+              <StepNode
+                key={step.id}
+                step={step}
+                isLast={i === task.steps.length - 1}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 });
 
@@ -506,62 +704,61 @@ TaskNode.displayName = "TaskNode";
 // Planning log
 // ---------------------------------------------------------------------------
 
-const PHASE_ICONS_DONE: Record<string, string> = {
-  initialization: "✓",
-  generation: "✓",
-  validation: "✗",
-  complete: "✓"
-};
-
-const PHASE_ICONS_ACTIVE: Record<string, string> = {
-  initialization: "◐",
-  generation: "◐",
-  validation: "✗",
-  complete: "✓"
-};
-
 const PlanningLog: React.FC<{
   entries: PlanningEntry[];
-  logs: LogEntry[];
   isActive: boolean;
-}> = memo(({ entries, logs, isActive }) => {
-  if (entries.length === 0 && logs.length === 0) {
+}> = memo(({ entries, isActive }) => {
+  if (entries.length === 0) {
     if (isActive) {
       return (
-        <FlexRow align="center" className="tree-planning">
-          <span className="tree-icon-running">{ICONS.running}</span>
-          <Text>planning</Text>
-        </FlexRow>
+        <div className="planning-log">
+          <div className="tl-item last">
+            <div className="tl-rail">
+              <StatusBadge status="running" />
+            </div>
+            <div className="tl-content">
+              <div className="tl-row">
+                <span className="planning-phase">Planning</span>
+                <span className="tl-meta running">In progress</span>
+              </div>
+            </div>
+          </div>
+        </div>
       );
     }
     return null;
   }
 
   return (
-    <div className="tree-planning-log">
+    <div className="planning-log">
       {entries.map((entry, i) => {
         const isLast = i === entries.length - 1;
         const isRunning = isLast && isActive;
-        const statusClass =
+        const status: NodeStatus =
           entry.status === "failed"
-            ? "tree-icon-failed"
-            : entry.status === "success"
-            ? "tree-icon-completed"
+            ? "failed"
             : isRunning
-            ? "tree-icon-running"
-            : "tree-icon-completed";
-        const icons = isRunning ? PHASE_ICONS_ACTIVE : PHASE_ICONS_DONE;
-        const icon = icons[entry.phase] ?? "○";
+              ? "running"
+              : "completed";
 
         return (
-          <div key={`${entry.phase}-${i}`} className="tree-planning-entry">
-            <span className={statusClass}>{icon}</span>
-            <span className={`tree-planning-phase ${statusClass}`}>
-              {entry.phase}
-            </span>
-            <span className="tree-planning-content">
-              {entry.content}
-            </span>
+          <div
+            key={`${entry.phase}-${i}`}
+            className={`tl-item${isLast ? " last" : ""}`}
+          >
+            <div className="tl-rail">
+              <StatusBadge status={status} />
+              {!isLast && <div className={`tl-connector ${status}`} aria-hidden />}
+            </div>
+            <div className="tl-content">
+              <div className="tl-row">
+                <span className="planning-phase">{entry.phase}</span>
+                {isRunning && <span className="tl-meta running">In progress</span>}
+              </div>
+              {entry.content ? (
+                <div className="planning-content">{entry.content}</div>
+              ) : null}
+            </div>
           </div>
         );
       })}
@@ -583,43 +780,62 @@ interface ExecutionTreeProps {
 const ExecutionTree: React.FC<ExecutionTreeProps> = ({ state, onToggleTask }) => {
   const theme = useTheme();
 
-  const completedCount = useMemo(
-    () => state.tasks.filter((t) => t.status === "completed").length,
-    [state.tasks]
-  );
+  const counts = useMemo(() => {
+    const c = { completed: 0, running: 0, waiting: 0, failed: 0 };
+    for (const t of state.tasks) c[t.status] += 1;
+    return c;
+  }, [state.tasks]);
 
   if (state.phase === "idle") return null;
 
   const hasTasks = state.tasks.length > 0;
+  const total = state.tasks.length;
+  const progressPct = total > 0 ? (counts.completed / total) * 100 : 0;
 
   return (
     <div css={treeStyles(theme)}>
       {/* Planning trace is a live indicator — only keep it on screen while
           planning is still running. Once planning is complete, the plan
-          tree below is the durable representation. */}
-      {state.phase === "planning" && state.planningLog.length > 0 && (
-        <PlanningLog
-          entries={state.planningLog}
-          logs={state.logs}
-          isActive={true}
-        />
-      )}
-      {state.phase === "planning" && state.planningLog.length === 0 && (
-        <FlexRow align="center" className="tree-planning">
-          <span className="tree-icon-running">{ICONS.running}</span>
-          <Text>planning</Text>
-        </FlexRow>
+          timeline below is the durable representation. */}
+      {state.phase === "planning" && (
+        <PlanningLog entries={state.planningLog} isActive={true} />
       )}
       {hasTasks && (
-        <>
-          <FlexRow align="center" className="tree-plan-header">
-            <span className="tree-plan-icon">{ICONS.plan}</span>
-            <span className="tree-plan-label">Plan</span>
-            <span className="tree-plan-count">
-              ({completedCount}/{state.tasks.length} tasks)
+        <div className="plan-card">
+          <FlexRow className="plan-header" align="center" gap={2}>
+            <span className="plan-title">Execution plan</span>
+            <div
+              className="plan-progress-track"
+              role="progressbar"
+              aria-valuenow={counts.completed}
+              aria-valuemin={0}
+              aria-valuemax={total}
+              aria-label="Completed tasks"
+            >
+              <div
+                className="plan-progress-fill"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <span className="plan-count">
+              {counts.completed}/{total}
             </span>
+            <div className="plan-dots">
+              {counts.completed > 0 && (
+                <span className="plan-dot completed">{counts.completed}</span>
+              )}
+              {counts.running > 0 && (
+                <span className="plan-dot running">{counts.running}</span>
+              )}
+              {counts.failed > 0 && (
+                <span className="plan-dot failed">{counts.failed}</span>
+              )}
+              {counts.waiting > 0 && (
+                <span className="plan-dot waiting">{counts.waiting}</span>
+              )}
+            </div>
           </FlexRow>
-          <FlexColumn>
+          <FlexColumn className="plan-body" gap={0}>
             {state.tasks.map((task, i) => (
               <TaskNode
                 key={task.id}
@@ -629,7 +845,7 @@ const ExecutionTree: React.FC<ExecutionTreeProps> = ({ state, onToggleTask }) =>
               />
             ))}
           </FlexColumn>
-        </>
+        </div>
       )}
     </div>
   );

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -100,6 +100,7 @@ import { FrontendToolRegistry } from "../../lib/tools/frontendTools";
 import { getFrontendToolRuntimeState } from "../../lib/tools/frontendToolRuntimeState";
 import type {
   GlobalChatState,
+  ProposedPlan,
   StepToolCall
 } from "../../stores/GlobalChatStore";
 import { globalWebSocketManager, type WebSocketMessage } from "../../lib/websocket/GlobalWebSocketManager";
@@ -139,6 +140,18 @@ export interface ToolApprovalRequestMessage {
   args: Record<string, unknown>;
 }
 
+/**
+ * Server → client request to approve a proposed agent plan. Routed to the
+ * GlobalChatStore as a pending plan approval; the user resolves it via the
+ * inline PlanApprovalCard, which sends a `plan_approval_response` back.
+ */
+export interface PlanApprovalRequestMessage {
+  type: "plan_approval_request";
+  thread_id: string | null;
+  approval_id: string;
+  plan: ProposedPlan;
+}
+
 export interface ToolCallMessage {
   type: "tool_call";
   tool_call_id: string;
@@ -167,6 +180,7 @@ export type MsgpackData =
   | ToolCallMessage
   | ToolResultMessage
   | ToolApprovalRequestMessage
+  | PlanApprovalRequestMessage
   | ErrorMessage;
 
 export interface ToolResultMessage {
@@ -1217,6 +1231,28 @@ export async function sendToolApprovalResponse(
   }
 }
 
+/**
+ * Send the user's decision on a proposed agent plan back to the server,
+ * resuming the paused agent. An approve starts execution; a reject with
+ * feedback triggers a replan; a plain reject aborts the run.
+ */
+export async function sendPlanApprovalResponse(
+  approvalId: string,
+  decision: "approve" | "reject",
+  feedback?: string
+): Promise<void> {
+  try {
+    await globalWebSocketManager.send({
+      type: "plan_approval_response",
+      approval_id: approvalId,
+      decision,
+      ...(feedback ? { feedback } : {})
+    });
+  } catch (error) {
+    console.error("Failed to send plan_approval_response:", error);
+  }
+}
+
 export async function handleChatWebSocketMessage(
   msg: WebSocketMessage,
   set: ChatStateSetter,
@@ -1329,6 +1365,8 @@ export async function handleChatWebSocketMessage(
     void executeToolCall(data, get, set, globalWebSocketManager);
   } else if (data.type === "tool_approval_request") {
     get().addPendingApproval(data);
+  } else if (data.type === "plan_approval_request") {
+    get().addPendingPlanApproval(data);
   } else if (data.type === "generation_stopped") {
     // Clear the safety timeout when generation is stopped
     const timeoutId = get().sendMessageTimeoutId;

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -1337,6 +1337,11 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
         // Stopping cancels the run, so drop any pending tool/plan-approval
         // prompts for the current thread — they belong to the cancelled run.
+        // Null-thread plan approvals go too: the server's stop command calls
+        // approvalBridge.cancelAll(), which cancels every waiter on this
+        // socket (including ones from non-thread-bound workflow runs), so
+        // keeping their cards would leave orphaned prompts whose responses
+        // resolve nothing.
         if (currentThreadId) {
           set((state) => {
             const remaining = Object.fromEntries(

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -25,7 +25,10 @@ import {
   TodoItem,
   PermissionMode
 } from "./ApiTypes";
-import { sendToolApprovalResponse } from "../core/chat/chatProtocol";
+import {
+  sendPlanApprovalResponse,
+  sendToolApprovalResponse
+} from "../core/chat/chatProtocol";
 import { isLocalhost } from "../lib/env";
 import { trpcClient } from "../trpc/client";
 import {
@@ -102,6 +105,48 @@ interface ToolApprovalRequest {
   args: Record<string, unknown>;
 }
 
+/** A step of a proposed agent plan, as serialized on the wire. */
+export interface ProposedPlanStep {
+  id: string;
+  instructions: string;
+}
+
+/** A task of a proposed agent plan, as serialized on the wire. */
+export interface ProposedPlanTask {
+  id: string;
+  title: string;
+  depends_on: string[];
+  steps: ProposedPlanStep[];
+}
+
+/** The plan an agent proposes before executing. */
+export interface ProposedPlan {
+  title: string;
+  tasks: ProposedPlanTask[];
+}
+
+/** Decision a user can make on a proposed agent plan. */
+export type PlanDecision = "approve" | "reject";
+
+/**
+ * A pending plan-approval request awaiting a user decision. Keyed by
+ * `approval_id` in `pendingPlanApprovals`. `thread_id` is null when the plan
+ * comes from a run not bound to a thread (e.g. an editor workflow run) — the
+ * card then shows on the active thread.
+ */
+export interface PendingPlanApproval {
+  thread_id: string | null;
+  plan: ProposedPlan;
+}
+
+/** Server → client plan-approval request payload. */
+interface PlanApprovalRequest {
+  type: "plan_approval_request";
+  thread_id: string | null;
+  approval_id: string;
+  plan: ProposedPlan;
+}
+
 export interface GlobalChatState extends ChatPiSlice {
   // Connection state
   status: ChatStatus;
@@ -175,6 +220,15 @@ export interface GlobalChatState extends ChatPiSlice {
   pendingApprovals: Record<string, PendingApproval>;
   addPendingApproval: (req: ToolApprovalRequest) => void;
   resolveApproval: (approvalId: string, decision: ApprovalDecision) => void;
+
+  // Inline plan-approval prompts awaiting a user decision, keyed by approval_id.
+  pendingPlanApprovals: Record<string, PendingPlanApproval>;
+  addPendingPlanApproval: (req: PlanApprovalRequest) => void;
+  resolvePlanApproval: (
+    approvalId: string,
+    decision: PlanDecision,
+    feedback?: string
+  ) => void;
 
   // Planning updates
   currentPlanningUpdate: PlanningUpdate | null;
@@ -395,6 +449,32 @@ const useGlobalChatStore = create<GlobalChatState>()(
         set((state) => {
           const { [approvalId]: _resolved, ...rest } = state.pendingApprovals;
           return { pendingApprovals: rest };
+        });
+      },
+
+      // Inline plan-approval prompts
+      pendingPlanApprovals: {},
+      addPendingPlanApproval: (req: PlanApprovalRequest) =>
+        set((state) => ({
+          pendingPlanApprovals: {
+            ...state.pendingPlanApprovals,
+            [req.approval_id]: {
+              thread_id: req.thread_id ?? null,
+              plan: req.plan
+            }
+          }
+        })),
+      resolvePlanApproval: (
+        approvalId: string,
+        decision: PlanDecision,
+        feedback?: string
+      ) => {
+        if (!get().pendingPlanApprovals[approvalId]) return;
+        void sendPlanApprovalResponse(approvalId, decision, feedback);
+        set((state) => {
+          const { [approvalId]: _resolved, ...rest } =
+            state.pendingPlanApprovals;
+          return { pendingPlanApprovals: rest };
         });
       },
 
@@ -1255,8 +1335,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // Abort any active frontend tools
         FrontendToolRegistry.abortAll();
 
-        // Stopping cancels the run, so drop any pending tool-approval prompts
-        // for the current thread — they belong to the now-cancelled run.
+        // Stopping cancels the run, so drop any pending tool/plan-approval
+        // prompts for the current thread — they belong to the cancelled run.
         if (currentThreadId) {
           set((state) => {
             const remaining = Object.fromEntries(
@@ -1264,7 +1344,17 @@ const useGlobalChatStore = create<GlobalChatState>()(
                 ([, approval]) => approval.thread_id !== currentThreadId
               )
             );
-            return { pendingApprovals: remaining };
+            const remainingPlans = Object.fromEntries(
+              Object.entries(state.pendingPlanApprovals).filter(
+                ([, approval]) =>
+                  approval.thread_id !== null &&
+                  approval.thread_id !== currentThreadId
+              )
+            );
+            return {
+              pendingApprovals: remaining,
+              pendingPlanApprovals: remainingPlans
+            };
           });
         }
 
@@ -1435,6 +1525,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
           }
           if (!state.pendingApprovals) {
             state.pendingApprovals = {};
+          }
+          if (!state.pendingPlanApprovals) {
+            state.pendingPlanApprovals = {};
           }
           if (!state.selectedModel) {
             state.selectedModel = buildDefaultLanguageModel();

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -493,11 +493,11 @@
   }
 
   .mobile .chat-messages-list .tool-call-card {
-    padding: var(--spacing-micro) var(--spacing-sm) !important;
     font-size: 0.875em !important;
   }
 
   .mobile .chat-messages-list .tool-call-header {
+    padding: var(--spacing-micro) var(--spacing-sm) !important;
     gap: var(--spacing-xs) !important;
   }
 


### PR DESCRIPTION
## Summary

Adds a user-facing plan approval gate to the agent execution flow, allowing users to review and approve (or reject with feedback) proposed task plans before execution. Includes a new timeline-based execution view and plan approval card UI component.

## Key Changes

### Agent Planning & Approval (`packages/agents/`)
- **Plan approval gate**: Agent now pauses after planning if `requestPlanApproval` callback is provided (via option or ProcessingContext). Users can approve, reject, or reject with feedback to trigger bounded replanning (max 3 revisions).
- **New types**: `PlanApprovalDecision`, `RequestPlanApproval`, and `PLAN_APPROVAL_CONTEXT_KEY` exported from `@nodetool-ai/agents`.
- **Replan logic**: Rejection with feedback re-invokes the planner with user feedback; plain rejection aborts with "Plan rejected by user." message.

### WebSocket Runner (`packages/websocket/`)
- **Plan approval round-trip**: `requestPlanApproval()` method emits `plan_approval_request` to client, waits for matching `plan_approval_response` via approval bridge. Cancelled waits (stop) treated as rejection without feedback.
- **Context attachment**: Automatically attaches plan approval callback to ProcessingContext for runs, enabling Agent nodes to gate without explicit wiring.

### Web UI Components
- **ExecutionTree redesign** (`web/src/components/execution/ExecutionTree.tsx`): Complete rewrite from tree-style ASCII art to vertical timeline layout with:
  - Plan header card with progress bar and per-status dot counts
  - Timeline nodes per task (status badges: check/spinner/waiting/failed) joined by status-colored connector lines
  - Nested steps inside each task with collapsible inspector
  - Improved animations and accessibility (keyboard navigation, ARIA labels)
  
- **PlanApprovalCard** (new): Inline approval prompt showing plan title, task/step counts, task list with dependencies, and approve/reject buttons. Reject with optional feedback field.

- **Tool call chain UI** (`ChatThreadView.styles.ts`): Refactored tool execution display with uppercase section labels, hairline dividers, bordered cards, and summary bar.

- **Tool icon mapping** (`toolCallIcon.tsx`, new): Keyword-driven categorization of tool names to icons (database, search, subtask, etc.) with accent colors.

- **MessageView updates**: Integrated plan approval card rendering alongside tool approval cards; updated tool call card header with icon tiles and improved keyboard interaction.

### Chat Protocol & Store
- **Plan approval messages**: New `PlanApprovalRequestMessage` and response handling in `chatProtocol.ts`.
- **GlobalChatStore**: Added `pendingPlanApprovals` map, `addPendingPlanApproval()`, and `resolvePlanApproval()` methods to track and resolve plan approvals.

### Tests
- **plan-approval.test.ts** (new): Comprehensive tests for rejection (aborts run), rejection with feedback (replans), and callback resolution from ProcessingContext.

## Implementation Details

- **Timeline styling**: Uses MUI theme tokens, CSS Grid for layout, and status-colored connectors. Respects `prefers-reduced-motion` for animations.
- **Plan serialization**: Tasks/steps serialized on wire with `depends_on` (snake_case) for protocol compatibility.
- **Backward compatible**: Plan approval is opt-in; omitting the callback preserves original plan-then-execute behavior.
- **Max revisions**: Bounded to 3 replan rounds to prevent infinite loops on user feedback.

https://claude.ai/code/session_01L6fcWMWwsaKCYeVtYd1zbH