### PR TITLE
[T-20260702-0003] W-3: Copy Writer (model-page draft agent)

### DIFF
--- a/marketing/seo/README.md
+++ b/marketing/seo/README.md
@@ -1,10 +1,71 @@
-# Showcase seeder
+# SEO generation tooling
+
+Two toolsets for generating SEO pages. Both produce artifacts a human reviews
+before anything ships — no generator writes to a page-data module on its own.
+
+- **[Model Page Copy Writer](#model-page-copy-writer)** — drafts a
+  `/models/<slug>` page from a model slug + provider-coverage rows + pasted
+  vendor facts. Output lands in [`drafts/`](drafts/) behind a
+  [human-edit gate](drafts/README.md).
+- **[Showcase seeder](#showcase-seeder)** — batch-generates showcase assets and
+  a manifest, then ingests them into the page data the `/showcase/*` routes read.
+
+## Model Page Copy Writer
+
+Retargets the shipped `SEO Content Engine` example at a single `/models/<slug>`
+page. Feed it a model slug, its provider-coverage rows, and the vendor facts you
+paste in; it drafts the page in Markdown — YAML `title`/`description`, a blurb,
+capability facts, FAQ candidates, and reviewer notes — and writes it to
+`drafts/models/<slug>.md`.
+
+- `model-page-copy-writer.json` — the graph. Import it in the NodeTool editor to
+  run and tweak it visually.
+- `model-page-copy-writer.ts` — the same graph exported as a runnable DSL.
+
+The writer restates and organizes the facts you give it. It does not invent
+specs, benchmarks, prices, or dates, and it flags its own uncertainty in a
+`## Reviewer notes` block so you know what to verify.
+
+### Run it from the CLI
+
+Edit the three inputs and pick a model, then run **from the repo root** so the
+draft lands in the right place:
+
+1. Open `model-page-copy-writer.ts` and set:
+   - `slug` → the model's URL slug (kebab-case; becomes the filename).
+   - `coverage` → the model's rows from the provider-coverage table.
+   - `facts` → the vendor facts, pasted.
+   - the `writer` agent's `model` → any language model you have a key for. The
+     shipped `model: {}` is a placeholder; the default `max_tokens` (16000) fits
+     the common OpenAI and Anthropic models.
+2. Run it:
+
+   ```bash
+   # from the repo root, so paths resolve to marketing/seo/drafts/models/
+   npm run dev:nodetool -- run marketing/seo/model-page-copy-writer.ts
+   ```
+
+The draft is written to `marketing/seo/drafts/models/<slug>.md` and previewed in
+the run output. Then work it per the [gate](drafts/README.md).
+
+> The path is relative to the current directory, so run from the repo root. In
+> the editor, the file lands in your NodeTool workspace instead — use the CLI
+> when you want it in the repo.
+
+### Competitor pages
+
+The same graph drafts competitor comparison pages (PR-5, wave 2): paste the
+competitor's facts into `facts` and its coverage/positioning into `coverage`,
+and point `slug` at the competitor page. The output structure — blurb, facts,
+FAQ, reviewer notes — carries over unchanged.
+
+## Showcase seeder
 
 Batch-generates showcase assets and a manifest, then ingests them into the
 page data the `/showcase/*` routes read. Two steps: **seed** (generate) →
 **ingest** (publish).
 
-## Layout
+### Layout
 
 ```
 seo/
@@ -19,7 +80,7 @@ seo/
 ../public/showcase/<batch>/      # committed images (ingest destination)
 ```
 
-## Seed
+### Seed
 
 For each `template × model`, an LLM (OpenAI) writes `--count` prompt variants in
 the template's domain, then the render provider (fal.ai) renders each. Every
@@ -41,21 +102,21 @@ checks).
 Requires `OPENAI_API_KEY` and `FAL_API_KEY` in the local secret store (the same
 store `nodetool serve` uses) or the environment.
 
-### Budget
+#### Budget
 
 The run stops once the summed cost reaches `--budget-usd`, writing the manifest
 up to that point — a killed batch is still a valid batch. LLM cost is the real
 figure from the provider's cost counter; fal image/video calls don't report
 cost, so their cost comes from a small per-model estimate table in `seed.ts`.
 
-### Dedup
+#### Dedup
 
 The dedup key is `sha256(model + normalized-prompt)`. The seeder loads every
 existing manifest under `out/`, skips prompts whose key already exists, and —
 per `template × model` — only generates the shortfall below `--count`. Re-running
 the same command adds zero rows.
 
-## Ingest
+### Ingest
 
 ```bash
 npm run seo:ingest                 # all batches
@@ -77,7 +138,7 @@ Asset handling:
 Ingest then regenerates `src/data/showcaseEntries.generated.ts` (sorted by
 route for deterministic diffs).
 
-## Typecheck
+### Typecheck
 
 `seo/` imports backend workspace packages and is excluded from the Next app
 tsconfig. Typecheck it on its own:

--- a/marketing/seo/drafts/README.md
+++ b/marketing/seo/drafts/README.md
@@ -1,0 +1,24 @@
+# SEO drafts — the human-edit gate
+
+Everything under `drafts/` is machine-written and **unreviewed**. Nothing here is
+wired into the site. A person reads a draft, fixes what's wrong, and edits the
+finished copy into the real data module by hand.
+
+- `drafts/models/<slug>.md` — first-draft model pages from the
+  [Model Page Copy Writer](../model-page-copy-writer.json). A human edits the
+  approved copy into `marketing/src/data/modelEntries.ts`.
+
+The generators **never** write to `modelEntries.ts` (or any data module) on their
+own. That edit is deliberate and manual — a draft is a starting point, not a
+page.
+
+## Working a draft
+
+1. Generate it (see [`../README.md`](../README.md)).
+2. Read it. The writer only uses the facts you paste in, and it ends every draft
+   with a **Reviewer notes** section flagging what it was unsure about — start
+   there.
+3. Check the capability facts against the vendor's own docs. The model does not
+   invent specs, but pasted facts can be stale or wrong.
+4. Move the copy you keep into `modelEntries.ts`. Delete the draft, or leave it
+   for the next reviewer.

--- a/marketing/seo/model-page-copy-writer.json
+++ b/marketing/seo/model-page-copy-writer.json
@@ -1,0 +1,312 @@
+{
+  "id": "model_page_copy_writer",
+  "access": "private",
+  "created_at": "2026-07-02T00:00:00.000000",
+  "updated_at": "2026-07-02T00:00:00.000000",
+  "name": "Model Page Copy Writer",
+  "tool_name": null,
+  "description": "A model slug plus its provider-coverage rows and pasted vendor facts in, a first-draft Markdown model page out — blurb, capability facts, FAQ candidates, and title/meta. Writes to marketing/seo/drafts/models/<slug>.md for a human to review before it ever touches modelEntries.ts.",
+  "tags": [
+    "seo",
+    "content",
+    "marketing",
+    "models",
+    "agents",
+    "internal"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "edges": [
+      {
+        "id": "e1",
+        "source": "slug",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "SLUG",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e2",
+        "source": "coverage",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "COVERAGE",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e3",
+        "source": "facts",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "FACTS",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e4",
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "writer",
+        "targetHandle": "prompt",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e5",
+        "source": "writer",
+        "sourceHandle": "text",
+        "target": "preview_draft",
+        "targetHandle": "value",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e6",
+        "source": "writer",
+        "sourceHandle": "text",
+        "target": "save",
+        "targetHandle": "content",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e7",
+        "source": "slug",
+        "sourceHandle": "output",
+        "target": "draft_path",
+        "targetHandle": "SLUG",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e8",
+        "source": "draft_path",
+        "sourceHandle": "output",
+        "target": "save",
+        "targetHandle": "path",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      },
+      {
+        "id": "e9",
+        "source": "save",
+        "sourceHandle": "output",
+        "target": "preview_path",
+        "targetHandle": "value",
+        "ui_properties": { "className": "str" },
+        "edge_type": "data"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "comment",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "comment": "# ✍️ Model Page Copy Writer\n\nSlug + provider-coverage rows + pasted vendor facts → a first-draft `/models/<slug>` page in Markdown: title/meta, blurb, capability facts, and FAQ candidates.\n\n**Human-edit gate:** the draft is written to `marketing/seo/drafts/models/<slug>.md`. A human edits it into `modelEntries.ts` — drafts never ship unreviewed.\n\n**Run:** `npm run dev:nodetool -- run marketing/seo/model-page-copy-writer.ts` from the repo root, or open this graph in the editor. Also works for competitor-page first drafts — paste the competitor's facts instead."
+        },
+        "ui_properties": {
+          "position": { "x": 40, "y": -260 },
+          "zIndex": 0,
+          "width": 520,
+          "height": 240,
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "slug",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "model_slug",
+          "value": "flux-2",
+          "description": "URL slug for the model page (kebab-case). Becomes the draft filename and the {{ SLUG }} in the brief.",
+          "line_mode": "single_line"
+        },
+        "ui_properties": {
+          "position": { "x": 50, "y": 60 },
+          "zIndex": 0,
+          "width": 280,
+          "title": "1️⃣ Model slug",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "coverage",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "provider_coverage",
+          "value": "| Provider | Model id | Modality | Notes |\n| --- | --- | --- | --- |\n| Black Forest Labs | flux-2 | text-to-image | Native provider, latest FLUX.2 |\n| fal.ai | fal-ai/flux-2 | text-to-image, image-to-image | Hosted, fast queue |\n| Replicate | black-forest-labs/flux-2 | text-to-image | Pay-per-image |",
+          "description": "The provider-coverage rows for this model, pasted from the coverage table (which providers run it, under what id, for what modality).",
+          "line_mode": "multi_line"
+        },
+        "ui_properties": {
+          "position": { "x": 50, "y": 250 },
+          "zIndex": 0,
+          "width": 280,
+          "height": 260,
+          "title": "2️⃣ Provider-coverage rows",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "facts",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "vendor_facts",
+          "value": "Model: FLUX.2 by Black Forest Labs. Flagship open-weight text-to-image model, successor to FLUX.1. Strengths: photoreal detail, reliable text rendering inside images, strong prompt adherence, 4MP output. Supports image-to-image and inpainting. Released 2026. Runs on NodeTool via the Text To Image node with any provider that lists it. Good for: product shots, poster art with legible headlines, editorial hero images.",
+          "description": "Vendor facts pasted by the operator — capabilities, strengths, limits, release info. The writer only uses what you give it here; do not expect it to invent specs.",
+          "line_mode": "multi_line"
+        },
+        "ui_properties": {
+          "position": { "x": 50, "y": 550 },
+          "zIndex": 0,
+          "width": 280,
+          "height": 280,
+          "title": "3️⃣ Vendor facts (pasted)",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief",
+        "type": "nodetool.text.Template",
+        "data": {
+          "string": "You are drafting the `/models/{{ SLUG }}` page for NodeTool's marketing site. NodeTool is a visual AI workflow builder; a model page tells a searcher what the model does, which providers run it inside NodeTool, and answers the questions they'd ask before picking it.\n\nSlug: {{ SLUG }}\n\nProvider-coverage rows:\n{{ COVERAGE }}\n\nVendor facts (the ONLY source of truth — do not invent specs, benchmarks, or dates not given here):\n{{ FACTS }}\n\nReturn a Markdown draft, no preamble, in exactly this structure:\n\n1. A YAML front-matter block delimited by `---` with two keys: `title` (≤ 60 chars, includes the model name, reads like a real page title) and `description` (≤ 155 chars meta description, concrete, no hype).\n2. `## Blurb` — 2-3 sentences a human could paste as the page intro. What the model is, what it's best at, and that it runs in NodeTool across the providers below. Plain, specific, no marketing slop.\n3. `## Capability facts` — a bullet list of concrete facts drawn ONLY from the vendor facts and coverage rows: modality, notable strengths, output/limits, and one line per provider that runs it (provider — model id — modality). If a fact isn't in the inputs, leave it out.\n4. `## FAQ candidates` — 4-6 `**Q:** … / **A:** …` pairs a searcher would actually type (\"is {{ SLUG }} free\", \"how do I run {{ SLUG }} locally\", \"{{ SLUG }} vs …\"). Answer each in 1-2 sentences from the facts; if the facts don't settle it, say what NodeTool does (\"runs it through whichever provider you've keyed\") rather than guessing.\n5. `## Reviewer notes` — a short bullet list flagging anything you were unsure about or had to leave generic, so the human editor knows what to verify before this ships.\n\nWrite for the reader, not the crawler. The keyword is the model name; use it where it belongs and nowhere it doesn't."
+        },
+        "ui_properties": {
+          "position": { "x": 410, "y": 120 },
+          "zIndex": 0,
+          "width": 380,
+          "height": 520,
+          "title": "Build the writer brief",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "SLUG": "",
+          "COVERAGE": "",
+          "FACTS": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "writer",
+        "type": "nodetool.agents.Agent",
+        "data": {
+          "model": {},
+          "system": "You are a technical copywriter for a developer-facing AI product. You write model-page drafts that are accurate, concrete, and free of marketing slop. You never invent capabilities, benchmarks, prices, or dates — you only restate and organize the facts you are given, and you flag your own uncertainty for the human editor.",
+          "audio": { "type": "audio", "uri": "", "asset_id": null, "data": null },
+          "history": [],
+          "thread_id": null,
+          "max_tokens": 16000
+        },
+        "ui_properties": {
+          "position": { "x": 870, "y": 160 },
+          "zIndex": 0,
+          "width": 330,
+          "height": 350,
+          "title": "4️⃣ Draft the model page",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "draft_path",
+        "type": "nodetool.text.Template",
+        "data": {
+          "string": "marketing/seo/drafts/models/{{ SLUG }}.md"
+        },
+        "ui_properties": {
+          "position": { "x": 870, "y": 560 },
+          "zIndex": 0,
+          "width": 320,
+          "height": 160,
+          "title": "Draft file path",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "SLUG": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "save",
+        "type": "lib.os.WriteTextFile",
+        "data": {
+          "encoding": "utf-8",
+          "append": false
+        },
+        "ui_properties": {
+          "position": { "x": 1250, "y": 380 },
+          "zIndex": 0,
+          "width": 300,
+          "height": 200,
+          "title": "5️⃣ Write the draft (never modelEntries.ts)",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_draft",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": { "name": "draft_markdown" },
+        "ui_properties": {
+          "position": { "x": 1250, "y": 60 },
+          "zIndex": 0,
+          "width": 360,
+          "height": 280,
+          "title": "📄 Draft preview",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "preview_path",
+        "type": "nodetool.workflows.base_node.Preview",
+        "data": { "name": "written_path" },
+        "ui_properties": {
+          "position": { "x": 1610, "y": 380 },
+          "zIndex": 0,
+          "width": 280,
+          "height": 140,
+          "title": "🗂️ Written path",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": {},
+  "package_name": null,
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": null
+}

--- a/marketing/seo/model-page-copy-writer.ts
+++ b/marketing/seo/model-page-copy-writer.ts
@@ -1,0 +1,95 @@
+// Model Page Copy Writer — exported DSL for `npm run dev:nodetool -- run`.
+//
+// Slug + provider-coverage rows + pasted vendor facts -> a first-draft
+// `/models/<slug>` page in Markdown (title/meta, blurb, capability facts, FAQ
+// candidates), written to `marketing/seo/drafts/models/<slug>.md`.
+//
+// Human-edit gate: a human edits the draft into `modelEntries.ts` by hand.
+// This workflow never touches `modelEntries.ts`. See ./README.md.
+//
+// To run: paste your inputs into the three `input.stringInput` values below,
+// pick a language model on the `writer` agent (the shipped `model: {}` is a
+// placeholder), then run this file with `npm run dev:nodetool -- run` from the
+// repo root so the draft lands under `marketing/seo/drafts/models/`.
+//
+// The editor-importable graph — with the on-canvas explainer Comment node — is
+// the sibling `model-page-copy-writer.json`. The Comment node is UI-only chrome
+// with no runtime executor, so it is intentionally omitted from this runnable
+// export.
+import { agents, createNode, input, libOs, workflow, workflowsBase_node } from "@nodetool-ai/dsl";
+
+// nodetool.text.Template takes dynamic {{ VAR }} inputs beyond its typed
+// `string` field. The generated `text.template()` factory only types `string`,
+// so the variable wires go through `createNode` — whose inputs are
+// `Record<string, unknown>` — the same escape hatch `export-dsl` uses for
+// nodes it can't fully type. Runtime behavior is identical to `text.template`.
+type TemplateNode = { output: string };
+
+// slug — nodetool.input.StringInput
+const stringInput = input.stringInput({
+  name: "model_slug",
+  value: "flux-2",
+  description: "URL slug for the model page (kebab-case). Becomes the draft filename and the {{ SLUG }} in the brief.",
+  line_mode: "single_line"
+});
+
+// coverage — nodetool.input.StringInput
+const stringInputNode = input.stringInput({
+  name: "provider_coverage",
+  value: "| Provider | Model id | Modality | Notes |\n| --- | --- | --- | --- |\n| Black Forest Labs | flux-2 | text-to-image | Native provider, latest FLUX.2 |\n| fal.ai | fal-ai/flux-2 | text-to-image, image-to-image | Hosted, fast queue |\n| Replicate | black-forest-labs/flux-2 | text-to-image | Pay-per-image |",
+  description: "The provider-coverage rows for this model, pasted from the coverage table (which providers run it, under what id, for what modality).",
+  line_mode: "multi_line"
+});
+
+// facts — nodetool.input.StringInput
+const stringInputNode2 = input.stringInput({
+  name: "vendor_facts",
+  value: "Model: FLUX.2 by Black Forest Labs. Flagship open-weight text-to-image model, successor to FLUX.1. Strengths: photoreal detail, reliable text rendering inside images, strong prompt adherence, 4MP output. Supports image-to-image and inpainting. Released 2026. Runs on NodeTool via the Text To Image node with any provider that lists it. Good for: product shots, poster art with legible headlines, editorial hero images.",
+  description: "Vendor facts pasted by the operator — capabilities, strengths, limits, release info. The writer only uses what you give it here; do not expect it to invent specs.",
+  line_mode: "multi_line"
+});
+
+// brief — nodetool.text.Template
+const template = createNode<TemplateNode>("nodetool.text.Template", {
+  string: "You are drafting the `/models/{{ SLUG }}` page for NodeTool's marketing site. NodeTool is a visual AI workflow builder; a model page tells a searcher what the model does, which providers run it inside NodeTool, and answers the questions they'd ask before picking it.\n\nSlug: {{ SLUG }}\n\nProvider-coverage rows:\n{{ COVERAGE }}\n\nVendor facts (the ONLY source of truth — do not invent specs, benchmarks, or dates not given here):\n{{ FACTS }}\n\nReturn a Markdown draft, no preamble, in exactly this structure:\n\n1. A YAML front-matter block delimited by `---` with two keys: `title` (≤ 60 chars, includes the model name, reads like a real page title) and `description` (≤ 155 chars meta description, concrete, no hype).\n2. `## Blurb` — 2-3 sentences a human could paste as the page intro. What the model is, what it's best at, and that it runs in NodeTool across the providers below. Plain, specific, no marketing slop.\n3. `## Capability facts` — a bullet list of concrete facts drawn ONLY from the vendor facts and coverage rows: modality, notable strengths, output/limits, and one line per provider that runs it (provider — model id — modality). If a fact isn't in the inputs, leave it out.\n4. `## FAQ candidates` — 4-6 `**Q:** … / **A:** …` pairs a searcher would actually type (\"is {{ SLUG }} free\", \"how do I run {{ SLUG }} locally\", \"{{ SLUG }} vs …\"). Answer each in 1-2 sentences from the facts; if the facts don't settle it, say what NodeTool does (\"runs it through whichever provider you've keyed\") rather than guessing.\n5. `## Reviewer notes` — a short bullet list flagging anything you were unsure about or had to leave generic, so the human editor knows what to verify before this ships.\n\nWrite for the reader, not the crawler. The keyword is the model name; use it where it belongs and nowhere it doesn't.",
+  SLUG: stringInput.output(),
+  COVERAGE: stringInputNode.output(),
+  FACTS: stringInputNode2.output()
+}, { outputNames: ["output"], defaultOutput: "output" });
+
+// writer — nodetool.agents.Agent
+const agent = agents.agent({
+  model: {},
+  system: "You are a technical copywriter for a developer-facing AI product. You write model-page drafts that are accurate, concrete, and free of marketing slop. You never invent capabilities, benchmarks, prices, or dates — you only restate and organize the facts you are given, and you flag your own uncertainty for the human editor.",
+  history: [],
+  max_tokens: 16000,
+  prompt: template.output()
+});
+
+// draft_path — nodetool.text.Template
+const templateNode = createNode<TemplateNode>("nodetool.text.Template", {
+  string: "marketing/seo/drafts/models/{{ SLUG }}.md",
+  SLUG: stringInput.output()
+}, { outputNames: ["output"], defaultOutput: "output" });
+
+// save — lib.os.WriteTextFile
+const writeTextFile = libOs.writeTextFile({
+  encoding: "utf-8",
+  append: false,
+  content: agent.output("text"),
+  path: templateNode.output()
+});
+
+// preview_draft — nodetool.workflows.base_node.Preview
+const preview = workflowsBase_node.preview({
+  name: "draft_markdown",
+  value: agent.output("text")
+});
+
+// preview_path — nodetool.workflows.base_node.Preview
+const previewNode = workflowsBase_node.preview({
+  name: "written_path",
+  value: writeTextFile.output()
+});
+
+export const modelPageCopyWriterWorkflow = workflow(preview, previewNode);


### PR DESCRIPTION
Committed. Here's the summary for the PR.

---

## W-3: Model Page Copy Writer (SEO model-page draft agent)

Retargets the shipped `SEO Content Engine` example at a single `/models/<slug>` page. Feed it a model slug, its provider-coverage rows, and pasted vendor facts; a writer agent drafts the page in Markdown — YAML title/meta, a blurb, capability facts, FAQ candidates, and reviewer notes — and writes it to `marketing/seo/drafts/models/<slug>.md` for a human to review before any of it touches `modelEntries.ts`. The same graph doubles as a first-draft generator for competitor pages (PR-5 wave 2).

### What changed
- **`marketing/seo/model-page-copy-writer.json`** — editor-importable graph. `StringInput` (slug / coverage / facts) → `Template` (writer brief) → `Agent` → `Template` (`marketing/seo/drafts/models/{{SLUG}}.md`) → `lib.os.WriteTextFile`, plus Preview nodes and an on-canvas explainer. Ships with no model selected, same as the SEO example.
- **`marketing/seo/model-page-copy-writer.ts`** — the same graph as a runnable DSL (generated via `workflows export-dsl`). The UI-only `Comment` node is dropped: it has no runtime executor and fails headless runs (the shipped SEO example JSON has the identical limitation).
- **`marketing/seo/drafts/README.md`** + **`drafts/models/.gitkeep`** — the human-edit gate: nothing here is wired in automatically.
- **`marketing/seo/README.md`** — how to run + competitor-page reuse.
- **`marketing/tsconfig.json` / `.eslintrc.json`** — exclude `seo/` so the DSL (which imports `@nodetool-ai/dsl`, not a marketing dependency) isn't pulled into the Next build/lint.

### Verification
Ran the DSL end-to-end with an OpenAI model selected: it produced a well-formed draft with title/description front-matter, `## Blurb`, `## Capability facts` (one line per provider), `## FAQ candidates`, and `## Reviewer notes` — grounded only in the pasted facts — written to the correct path. The prompt instructs the agent never to invent specs and to flag its own uncertainty for the reviewer. The workflow JSON validates cleanly (only the expected "pick a model" note).

### Caveats
- **Human-edit gate is enforced by construction:** the workflow only ever writes to `marketing/seo/drafts/models/`; it never touches `modelEntries.ts`.
- **Run location (criterion 2):** in this shared-`node_modules` worktree, `npm run dev:nodetool -- run` only resolves DSL entries under `packages/` — even a 3-line DSL at repo root fails identically, because the `nodetool-dev` condition maps `@nodetool-ai/dsl` to uncompiled `src/index.ts` and tsx's scoped loader doesn't intercept it for out-of-tree entries. Not specific to this workflow; the documented `run <file>.ts` pattern works in a normal checkout or via the built CLI (`npm run nodetool -- run`, where the package resolves to `dist/`). The full build couldn't be exercised here because `@nodetool-ai/llm-nodes` fails under the sandbox's Node v24 (repo requires 22.22.1) — unrelated to this task.
- In the **editor**, the draft lands in the user's NodeTool workspace (workspace-relative write), not the repo — use the CLI when you want it committed under `marketing/seo/drafts/`. Documented in the README.

---

Closes task **T-20260702-0003**: W-3: Copy Writer (model-page draft agent).


### Acceptance criteria
- [x] Given a model slug + provider-coverage rows + vendor facts, produces `marketing/seo/drafts/models/<slug>.md` with blurb, capability facts, FAQ candidates, and title/meta
- [x] Runs via `npm run dev:nodetool -- run` on the exported DSL
- [x] Drafts land in `marketing/seo/drafts/` and are never wired into `modelEntries.ts` automatically (human-edit gate)