### PR TITLE
Include rebuild-native.mjs in Docker image for postinstall

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@ web/node_modules
 .git
 .deploy
 electron
+# The root postinstall runs this script during `npm ci` in the image, so it
+# must be re-included from the otherwise-excluded electron/ tree.
+!electron/scripts/rebuild-native.mjs
 mobile
 workflow_runner
 docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY --parents packages/*/package.json ./
 COPY web/package.json web/
+# The root postinstall rebuilds better-sqlite3 via this script (see the root
+# package.json); it's re-included from the ignored electron/ tree in .dockerignore.
+COPY electron/scripts/rebuild-native.mjs electron/scripts/rebuild-native.mjs
 
 RUN npm ci
 


### PR DESCRIPTION
## Summary
Ensures the native module rebuild script (`electron/scripts/rebuild-native.mjs`) is available in the Docker image during `npm ci`, even though the `electron/` directory is otherwise excluded.

## Changes
- **`.dockerignore`**: Added negation pattern `!electron/scripts/rebuild-native.mjs` to re-include the rebuild script from the otherwise-excluded `electron/` tree
- **`Dockerfile`**: Added explicit `COPY` instruction for `electron/scripts/rebuild-native.mjs` before `RUN npm ci`

## Details
The root `postinstall` script (defined in root `package.json`) invokes `electron/scripts/rebuild-native.mjs` to rebuild `better-sqlite3` against Node.js headers during installation. Since the entire `electron/` directory is excluded in `.dockerignore` to reduce image size, this critical script was missing from the build context. The fix re-includes only the necessary script file while keeping the rest of `electron/` excluded.

This aligns with the architecture documented in CLAUDE.md: `better-sqlite3` is the one source-built native module that must be rebuilt against Node 22.22.1 headers during both dev and production builds.

https://claude.ai/code/session_01CMw3jF5FsdXWoyMjDk43tu