### PR TITLE
Upgrade @pydantic/genai-prices to 0.0.69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16841,9 +16841,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@pydantic/genai-prices": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/@pydantic/genai-prices/-/genai-prices-0.0.62.tgz",
-      "integrity": "sha512-n7pX9Xkrt8Hx+ztUU1qXdFTv2DYyiK3PwuWyIZiYpPWvCkKkb2c+oENmF+/iLitbNWQNANAhBs9aSKOg36obzQ==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@pydantic/genai-prices/-/genai-prices-0.0.69.tgz",
+      "integrity": "sha512-IkeJG4bZSj78k6OfQp/zqy/iS05czr3m6Ts/UgKZ0fS44v+BMUp8fITlKEZyJl6px8bFTQbETINvvJp4YY11/Q==",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"
@@ -51125,7 +51125,7 @@
         "@opentelemetry/sdk-node": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.6.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@pydantic/genai-prices": "^0.0.62",
+        "@pydantic/genai-prices": "^0.0.69",
         "js-tiktoken": "^1.0.21",
         "msgpackr": "^1.11.2",
         "openai": "^6.35.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,7 +25,7 @@
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/sdk-trace-base": "^2.6.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "@pydantic/genai-prices": "^0.0.62",
+    "@pydantic/genai-prices": "^0.0.69",
     "js-tiktoken": "^1.0.21",
     "openai": "^6.35.0",
     "replicate": "^1.4.0",


### PR DESCRIPTION
## Summary
Updates the `@pydantic/genai-prices` dependency in the runtime package from `0.0.62` to `0.0.69`.

## Changes
- Bumped `@pydantic/genai-prices` from `^0.0.62` to `^0.0.69` in `packages/runtime/package.json`

## Notes
This is a patch-level dependency update that brings in the latest pricing data and any bug fixes from the genai-prices library. The lockfile has been updated accordingly.

https://claude.ai/code/session_01PF5AZGk2DMDySthQ9SD3JN