### PR TITLE
Add comprehensive README files and package metadata to all packages

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -81,5 +81,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-agents",
+    "agent",
+    "planning",
+    "task-planner",
+    "autonomous-agents",
+    "llm-agents"
   ]
 }

--- a/packages/atlascloud-nodes/README.md
+++ b/packages/atlascloud-nodes/README.md
@@ -1,0 +1,39 @@
+# @nodetool-ai/atlascloud-nodes
+
+AtlasCloud.ai nodes for [NodeTool](https://nodetool.ai).
+
+Run [AtlasCloud](https://atlascloud.ai) models inside NodeTool workflows: ByteDance Seedance 2.0 video generation (text-to-video, image-to-video, reference-to-video) with native audio, plus GPT Image 2, Nano Banana 2, and Nano Banana Pro image generation and editing.
+
+## Install
+
+```bash
+npm install @nodetool-ai/atlascloud-nodes
+```
+
+## Nodes
+
+| Node | Type | Description |
+| --- | --- | --- |
+| Seedance 2.0 — Text to Video | `atlascloud.video.Seedance2TextToVideo` | Generate video from text with native audio. |
+| Seedance 2.0 — Image to Video | `atlascloud.video.Seedance2ImageToVideo` | Animate a still image into video. |
+| Seedance 2.0 — Reference to Video | `atlascloud.video.Seedance2ReferenceToVideo` | Generate video from reference frames. |
+| Seedance 2.0 Fast — Text to Video | `atlascloud.video.Seedance2FastTextToVideo` | Faster text-to-video. |
+| Seedance 2.0 Fast — Image to Video | `atlascloud.video.Seedance2FastImageToVideo` | Faster image-to-video. |
+| Seedance 2.0 Fast — Reference to Video | `atlascloud.video.Seedance2FastReferenceToVideo` | Faster reference-to-video. |
+| GPT Image 2 — Text to Image | `atlascloud.image.GPTImage2TextToImage` | Generate images from text. |
+| GPT Image 2 — Edit | `atlascloud.image.GPTImage2Edit` | Edit an image from a prompt. |
+| Nano Banana 2 — Text to Image | `atlascloud.image.NanoBanana2TextToImage` | Generate images from text. |
+| Nano Banana 2 — Edit | `atlascloud.image.NanoBanana2Edit` | Edit an image from a prompt. |
+| Nano Banana Pro — Text to Image | `atlascloud.image.NanoBananaProTextToImage` | Generate images from text. |
+| Nano Banana Pro — Edit | `atlascloud.image.NanoBananaProEdit` | Edit an image from a prompt. |
+| Nano Banana Pro — Text to Image (Ultra) | `atlascloud.image.NanoBananaProTextToImageUltra` | Higher-quality text-to-image. |
+| Nano Banana Pro — Edit (Ultra) | `atlascloud.image.NanoBananaProEditUltra` | Higher-quality image edit. |
+
+## Configuration
+
+Set `ATLASCLOUD_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/atlascloud-nodes/package.json
+++ b/packages/atlascloud-nodes/package.json
@@ -46,5 +46,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "atlascloud",
+    "video-generation",
+    "image-generation",
+    "seedance",
+    "nano-banana"
   ]
 }

--- a/packages/audio-nodes/README.md
+++ b/packages/audio-nodes/README.md
@@ -1,0 +1,62 @@
+# @nodetool-ai/audio-nodes
+
+Audio I/O, DSP, and effects nodes for [NodeTool](https://nodetool.ai).
+
+A pack of audio-processing nodes for NodeTool workflows: load and save audio,
+edit and mix clips, run DSP effects, synthesize sound with a modular-synth graph,
+and stream audio in real time. Also includes text-to-speech and text-to-music
+generation.
+
+## Install
+
+```bash
+npm install @nodetool-ai/audio-nodes
+```
+
+## Nodes
+
+### I/O
+
+Load and save audio, inspect format details.
+
+- `nodetool.audio.LoadAudioFile`, `nodetool.audio.LoadAudioFolder`, `nodetool.audio.LoadAudioAssets`
+- `nodetool.audio.SaveAudio`, `nodetool.audio.SaveAudioFile`
+- `nodetool.audio.GetAudioInfo`
+
+### Editing and mixing
+
+Cut, join, and combine clips.
+
+- `nodetool.audio.Trim`, `nodetool.audio.SliceAudio`, `nodetool.audio.Concat`, `nodetool.audio.ConcatList`
+- `nodetool.audio.Repeat`, `nodetool.audio.Reverse`, `nodetool.audio.CreateSilence`, `nodetool.audio.RemoveSilence`
+- `nodetool.audio.OverlayAudio`, `nodetool.audio.AudioMixer`
+- `nodetool.audio.MonoToStereo`, `nodetool.audio.StereoToMono`, `nodetool.audio.ChunkToAudio`
+
+### DSP and effects
+
+- `nodetool.audio.Normalize`, `nodetool.audio.FadeIn`, `nodetool.audio.FadeOut`
+
+### Generation
+
+- `nodetool.audio.TextToSpeech` — synthesize speech from text.
+- `nodetool.audio.TextToMusic` — generate music from a prompt.
+
+### Realtime streaming
+
+Chunk-based streaming filters and gain for live audio.
+
+- `nodetool.audio.realtime.AudioToChunks`, `nodetool.audio.realtime.ChunksToAudio`, `nodetool.audio.realtime.AudioOutput`
+- `nodetool.audio.realtime.StreamingGain`, `nodetool.audio.realtime.StreamingLowPass`, `nodetool.audio.realtime.StreamingHighPass`
+
+### Modular synthesis
+
+A patchable, Eurorack-style synth built from control-voltage nodes.
+
+- `nodetool.audio.synth.Oscillator`, `nodetool.audio.synth.LFO`, `nodetool.audio.synth.ADSR`
+- `nodetool.audio.synth.VCA`, `nodetool.audio.synth.VCF`, `nodetool.audio.synth.Mixer`
+- `nodetool.audio.synth.Gate`, `nodetool.audio.synth.SampleHold`, `nodetool.audio.synth.Attenuverter`
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/audio-nodes/package.json
+++ b/packages/audio-nodes/package.json
@@ -61,5 +61,20 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "audio",
+    "dsp",
+    "audio-effects",
+    "audio-processing"
+  ]
 }

--- a/packages/audio-nodes/package.json
+++ b/packages/audio-nodes/package.json
@@ -49,5 +49,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/audio-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,58 @@
+# @nodetool-ai/auth
+
+Authentication and authorization for [NodeTool](https://nodetool.ai) — pluggable auth providers (local, static token, Supabase), user management, and Fastify HTTP middleware.
+
+This package owns the auth surface for the NodeTool backend: token verification, user records, admin/role checks, and the request middleware that gates the HTTP and WebSocket API. Providers are swappable, so the same server runs single-user local, static-token, or multi-user Supabase auth.
+
+## Install
+
+```bash
+npm install @nodetool-ai/auth
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `AuthProvider` | class | Base contract every auth provider implements |
+| `AuthResult` | type | Result of a token verification attempt |
+| `TokenType` | enum | Distinguishes access, refresh, and static tokens |
+| `LocalAuthProvider` | class | Single-user local auth (no external service) |
+| `StaticTokenProvider` | class | Shared static bearer token |
+| `MultiUserAuthProvider` | class | Multi-user auth backed by a user store |
+| `SupabaseAuthProvider` | class | Verifies Supabase-issued JWTs |
+| `createAuthMiddleware` | function | Builds request middleware returning an `AuthenticatedUser` |
+| `getUserId` | function | Reads the authenticated user id off a request |
+| `authenticateRequest` | function | Low-level request authentication |
+| `requireAuth` | function | Guard that rejects unauthenticated requests |
+| `extractBearerToken` | function | Pulls the bearer token from request headers |
+| `HttpError` | class | Error carrying an HTTP status code |
+| `isAdmin` | function | Role check for `{ role: "admin" }` users |
+| `UserManager` | class | In-memory user management |
+| `FileUserManager` | class | File-backed user store |
+| `User` / `ManagedUser` / `UserRecord` | interface | User record shapes |
+
+## Usage
+
+```ts
+import {
+  StaticTokenProvider,
+  MultiUserAuthProvider,
+  createAuthMiddleware
+} from "@nodetool-ai/auth";
+
+const authenticate = createAuthMiddleware({
+  staticProvider: new StaticTokenProvider(process.env.NODETOOL_TOKEN!),
+  userProvider: new MultiUserAuthProvider({ /* ... */ }),
+  enforceAuth: true
+});
+
+// In a request handler:
+const user = await authenticate(request);
+console.log(user.id);
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -47,5 +47,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "Authentication and authorization for NodeTool — pluggable auth providers (local, static token, Supabase), user management, and Fastify HTTP middleware",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "authentication",
+    "authorization",
+    "middleware",
+    "fastify"
   ]
 }

--- a/packages/automation-nodes/README.md
+++ b/packages/automation-nodes/README.md
@@ -1,0 +1,49 @@
+# @nodetool-ai/automation-nodes
+
+Browser, OS, filesystem, and automation nodes for [NodeTool](https://nodetool.ai).
+
+Automate the local system from visual AI workflows: fetch and crawl web pages,
+read and write files, run SQLite queries, read and write Excel workbooks, OCR
+images, classify and detect objects with TensorFlow.js, schedule triggers, and
+drive macOS apps via AppleScript.
+
+## Install
+
+```bash
+npm install @nodetool-ai/automation-nodes
+```
+
+## Nodes
+
+**Browser** (`lib.browser.*`) — `WebFetch`, `DownloadFile`, `Browser`,
+`Screenshot`, `SpiderCrawl`.
+
+**OS / filesystem** (`lib.os.*`) — file operations (`ListFiles`, `CopyFile`,
+`MoveFile`, `CreateDirectory`, `FileExists`, `GetFileSize`), read/write
+(`ReadTextFile`, `WriteTextFile`, `ReadBinaryFile`, `WriteBinaryFile`), path
+helpers (`JoinPaths`, `Basename`, `Dirname`, `SplitPath`, `NormalizePath`,
+`RelativePath`), timestamps, and `ShowNotification`.
+
+**SQLite** (`lib.sqlite.*`) — `CreateTable`, `Insert`, `Query`, `Update`,
+`Delete`, `ExecuteSQL`, `GetDatabasePath`.
+
+**Excel** (`lib.excel.*`) — `CreateWorkbook`, `ExcelToDataFrame`,
+`DataFrameToExcel`, `FormatCells`, `AutoFitColumns`, `SaveWorkbook`.
+
+**OCR** (`lib.ocr.*`) — Tesseract-backed `ExtractText`, `ExtractData`.
+
+**TensorFlow.js** (`lib.tensorflow.*`) — `MobileNetClassify`,
+`MobileNetEmbedding`, `CocoSsdDetect`, `Qna`.
+
+**Triggers** (`nodetool.triggers.*`) — `Wait`, `ManualTrigger`,
+`IntervalTrigger`, `WebhookTrigger`, `FileWatchTrigger`.
+
+**Apple** (`lib.apple.*`) — macOS automation via AppleScript: Calendar, Notes,
+Reminders, Messages, Mail, Contacts, Safari control, clipboard, and
+notifications (`CreateCalendarEvent`, `CreateNote`, `SendMessage`,
+`SearchContacts`, `OpenSafariURL`, `SetClipboardText`, `SayText`, …).
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/automation-nodes/package.json
+++ b/packages/automation-nodes/package.json
@@ -69,5 +69,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/automation-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/automation-nodes/package.json
+++ b/packages/automation-nodes/package.json
@@ -81,5 +81,23 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "automation",
+    "browser-automation",
+    "os",
+    "filesystem",
+    "sqlite",
+    "ocr",
+    "excel"
+  ]
 }

--- a/packages/base-nodes/package.json
+++ b/packages/base-nodes/package.json
@@ -68,5 +68,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "nodes",
+    "text",
+    "image",
+    "llm",
+    "agents"
   ]
 }

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -1,0 +1,46 @@
+# @nodetool-ai/chat
+
+Chat message processing for [NodeTool](https://nodetool.ai) — tool-call orchestration, streaming responses, and token counting.
+
+This package drives a chat turn end to end: it streams a provider response, runs any tool calls the model emits, loops until the turn settles, and reports progress through callbacks. It also counts tokens for text and message arrays so callers can enforce context budgets.
+
+## Install
+
+```bash
+npm install @nodetool-ai/chat
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `processChat` | function | Runs a full chat turn: stream, execute tool calls, loop to completion |
+| `runTool` | function | Executes a single tool call against a tool list |
+| `ChatCallbacks` | interface | Hooks for chunks, tool calls, tool results, and session updates |
+| `countTextTokens` | function | Token count for a text string |
+| `countMessageTokens` | function | Token count for a single message |
+| `countMessagesTokens` | function | Token count for a message array |
+
+## Usage
+
+```ts
+import { processChat } from "@nodetool-ai/chat";
+
+await processChat({
+  userInput: "Summarize the attached report",
+  messages,
+  model: "claude-sonnet-4-6",
+  provider,
+  context,
+  tools,
+  callbacks: {
+    onChunk: (text) => process.stdout.write(text),
+    onToolCall: (call) => console.log("tool:", call.name)
+  }
+});
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -45,5 +45,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "Chat message processing for NodeTool — tool-call orchestration, streaming responses, and token counting",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "chat",
+    "llm-chat",
+    "streaming",
+    "token-counting",
+    "tool-calls"
   ]
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,80 @@
+# @nodetool-ai/cli
+
+Command-line tools for [NodeTool](https://nodetool.ai) — interactive AI chat with agent mode and workflow management from the terminal.
+
+Ships two executables: `nodetool` for managing workflows, jobs, assets, models, secrets, and servers, and `nodetool-chat` for an interactive multi-provider LLM chat with agent mode and tool support.
+
+## Install
+
+```bash
+npm install -g @nodetool-ai/cli
+```
+
+## Executables
+
+| Command | Description |
+|---|---|
+| `nodetool` | Management CLI — serve, run workflows, jobs, assets, models, secrets, settings, MCP install |
+| `nodetool-chat` | Interactive terminal chat with agent mode across providers |
+
+## `nodetool`
+
+```bash
+nodetool info                       # System and environment info, API-key status
+nodetool serve --host 0.0.0.0 --port 7777   # Start the WebSocket + HTTP server
+nodetool run workflow.ts            # Run a TypeScript/JavaScript DSL workflow file
+
+# Workflows (needs a running server for id-based commands)
+nodetool workflows list
+nodetool workflows get <id>
+nodetool workflows run <id|file.json|file.ts> --params '{"key":"value"}'
+nodetool workflows export-dsl <id> -o out.ts       # Export as TypeScript DSL
+nodetool workflows export-bundle <id> -o pack.nodetool   # Portable zip with assets
+nodetool workflows import-bundle pack.nodetool
+
+# Jobs and assets
+nodetool jobs list --workflow-id <id>
+nodetool jobs get <job_id>
+nodetool assets list --query "photo" --content-type image/png
+
+# Models
+nodetool models list
+nodetool models providers
+nodetool models by-provider anthropic --kind llm
+
+# Secrets (encrypted local store)
+nodetool secrets list
+nodetool secrets store OPENAI_API_KEY
+nodetool secrets get OPENAI_API_KEY
+
+# Settings and MCP
+nodetool settings show
+nodetool mcp install                # Register the MCP server for Claude Code, Codex, OpenCode
+nodetool mcp status
+```
+
+Server-calling commands accept `--api-url <url>` (default `http://localhost:7777`, env `NODETOOL_API_URL`) and `--json` for machine-readable output.
+
+## `nodetool-chat`
+
+```bash
+nodetool-chat                           # Saved / auto-detected settings
+nodetool-chat --provider anthropic --model claude-sonnet-4-6
+nodetool-chat --agent                   # Start in agent mode
+nodetool-chat --workspace /path/to/dir  # Set the workspace for file tools
+nodetool-chat --url ws://localhost:7777/ws   # Connect to a running server
+echo "research 5 AI topics" | nodetool-chat --agent   # Piped, non-interactive
+```
+
+Chat flags: `-p, --provider`, `-m, --model`, `-a, --agent`, `-u, --url`, `-w, --workspace`, `--tools <list>`.
+
+Providers include anthropic, openai, gemini, xai, groq, mistral, deepseek, ollama, lmstudio, and other registry providers.
+
+## Tracing
+
+Both executables accept `--trace-file <path>` (append LLM/agent/workflow spans as JSONL) and `--trace-stdout <pretty|json>`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,5 +88,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "cli",
+    "command-line",
+    "terminal",
+    "agent-mode",
+    "chat-cli"
   ]
 }

--- a/packages/code-nodes/README.md
+++ b/packages/code-nodes/README.md
@@ -1,0 +1,35 @@
+# @nodetool-ai/code-nodes
+
+Code-execution and agent-tool nodes for [NodeTool](https://nodetool.ai).
+
+Run Python, JavaScript, Bash, Ruby, and Lua inside visual AI workflows — in a
+subprocess, a sandbox, or a Docker container — and drive single-purpose LLM
+tool agents for shell, browser, filesystem, git, media, and document tasks.
+
+## Install
+
+```bash
+npm install @nodetool-ai/code-nodes
+```
+
+## Nodes
+
+**Code execution** (`nodetool.code.*`) — run a script and capture its output:
+`ExecutePython`, `ExecuteJavaScript`, `ExecuteBash`, `ExecuteRuby`,
+`ExecuteLua`, `ExecuteCommand`. Command variants (`RunPythonCommand`,
+`RunBashCommand`, `RunShellCommand`, …) and Docker-isolated variants
+(`RunPythonCommandDocker`, `RunBashCommandDocker`, …).
+
+**Sandbox** (`nodetool.sandbox.*`) — `SandboxShell`, `SandboxFile`.
+
+**Tool agents** (`nodetool.agents.*`) — LLM agents scoped to one toolset:
+`ShellAgent`, `BrowserAgent`, `LiveBrowserAgent`, `FilesystemAgent`, `GitAgent`,
+`HttpApiAgent`, `HtmlAgent`, `ImageAgent`, `MediaAgent`, `FfmpegAgent`,
+`DocumentAgent`, `DocxAgent`, `PdfLibAgent`, `PptxAgent`, `SpreadsheetAgent`,
+`EmailAgent`, `SQLiteAgent`, `SupabaseAgent`, `VectorStoreAgent`,
+`YtDlpDownloaderAgent`, and `ClaudeCodeAgent`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/code-nodes/package.json
+++ b/packages/code-nodes/package.json
@@ -52,5 +52,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/code-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/code-nodes/package.json
+++ b/packages/code-nodes/package.json
@@ -64,5 +64,20 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "code-execution",
+    "javascript",
+    "sandbox",
+    "agent-tools"
+  ]
 }

--- a/packages/code-runners/README.md
+++ b/packages/code-runners/README.md
@@ -1,0 +1,56 @@
+# @nodetool-ai/code-runners
+
+Streaming code runners for [NodeTool](https://nodetool.ai) — execute Python, JavaScript, Bash, Ruby, and Lua in Docker containers or local subprocesses.
+
+Each runner streams `stdout`/`stderr` line by line as an async generator, with configurable image, memory, CPU, and network limits. A 1:1 TypeScript port of the Python `nodetool-core` code runners.
+
+## Install
+
+```bash
+npm install @nodetool-ai/code-runners
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+|---|---|---|
+| `StreamRunnerBase` | class | Base runner — Docker or local subprocess, streaming output |
+| `PythonDockerRunner` | class | Run Python in a container |
+| `JavaScriptDockerRunner` | class | Run JavaScript in a container |
+| `BashDockerRunner` | class | Run Bash in a container |
+| `RubyDockerRunner` | class | Run Ruby in a container |
+| `LuaRunner` / `LuaSubprocessRunner` | class | Run Lua in a container or local subprocess |
+| `CommandDockerRunner` | class | Run an arbitrary command in a container |
+| `ServerDockerRunner` / `ServerSubprocessRunner` | class | Long-lived server processes |
+| `DockerHijackMultiplexDemuxer` | class | Demultiplex Docker's multiplexed attach stream |
+| `ContainerFailureError` | class | Thrown when a container or subprocess exits non-zero |
+| `StreamRunnerOptions`, `StreamOptions`, `Slot` | type | Runner configuration and output-slot types |
+
+## Usage
+
+Runners expose `stream(userCode, envLocals, options?)`, an async generator yielding `[slot, text]` pairs where `slot` is `"stdout"` or `"stderr"`.
+
+```ts
+import { PythonDockerRunner } from "@nodetool-ai/code-runners";
+
+const runner = new PythonDockerRunner({
+  image: "python:3.12-slim",
+  timeoutSeconds: 30,
+  memLimit: "256m",
+  networkDisabled: true
+});
+
+for await (const [slot, text] of runner.stream(
+  "print('hello from', name)",
+  { name: "nodetool" }
+)) {
+  process[slot === "stderr" ? "stderr" : "stdout"].write(text + "\n");
+}
+```
+
+Call `runner.stop()` to cooperatively cancel an active run. Docker execution requires a reachable Docker daemon (via `dockerode`).
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/code-runners/package.json
+++ b/packages/code-runners/package.json
@@ -48,5 +48,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "code-execution",
+    "docker",
+    "subprocess",
+    "python",
+    "javascript",
+    "sandbox"
   ]
 }

--- a/packages/compute/README.md
+++ b/packages/compute/README.md
@@ -1,0 +1,46 @@
+# @nodetool-ai/compute
+
+Remote compute orchestration for [NodeTool](https://nodetool.ai) — provisions and reaps GPU workers on RunPod and Vast.ai.
+
+This package manages the lifecycle of remote GPU workers: it provisions instances from worker profiles, tracks their connections, reconciles desired against actual state, and runs a reaper that tears down idle or orphaned instances. Providers for RunPod and Vast.ai sit behind a common `WorkerProvider` interface.
+
+## Install
+
+```bash
+npm install @nodetool-ai/compute
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `WorkerManager` | class | Manages worker profiles, provisioning, and reconciliation |
+| `WorkerManagerDeps` | type | Injectable dependencies for `WorkerManager` |
+| `ReconcileSummary` | type | Result of a reconcile pass |
+| `WorkerConnection` / `WorkerOrphan` | type | Tracked worker and orphaned-instance shapes |
+| `startReaper` | function | Starts the background loop that reaps idle/orphaned workers |
+| `runReaperOnce` | function | Runs a single reaper pass |
+| `ReaperDeps` / `ReaperHandle` / `ReaperManager` | type | Reaper wiring and control handle |
+| `RunpodPodProvider` | class | `WorkerProvider` implementation for RunPod |
+| `VastProvider` | class | `WorkerProvider` implementation for Vast.ai |
+| `WorkerProvider` | interface | Provision/status/terminate contract for a compute backend |
+| `WorkerSpec` / `WorkerTarget` / `WorkerStatus` | type | Worker specification and status shapes |
+| `ProviderInstance` / `ProvisionResult` | type | Provider-level instance and provisioning results |
+
+## Usage
+
+```ts
+import { WorkerManager, startReaper } from "@nodetool-ai/compute";
+
+const manager = new WorkerManager();
+const summary = await manager.reconcile();
+
+const reaper = startReaper({ manager });
+// ... later
+reaper.stop();
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -43,5 +43,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "Remote compute orchestration for NodeTool — provisions and reaps GPU workers on RunPod and Vast.ai",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "gpu",
+    "runpod",
+    "vast-ai",
+    "compute",
+    "gpu-workers",
+    "orchestration"
   ]
 }

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,51 @@
+# @nodetool-ai/config
+
+Configuration and environment loading for [NodeTool](https://nodetool.ai) — settings, paths, logging, byte limits, and cross-runtime module loading.
+
+This is the base dependency for the backend: it loads and reads environment variables, resolves data/asset/database paths, registers typed settings, configures logging, and diagnoses the running environment. It also provides cross-runtime helpers for importing Node built-ins and optional modules from code that also runs in the browser.
+
+## Install
+
+```bash
+npm install @nodetool-ai/config
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `loadEnvironment` / `resetEnvironment` | function | Load and reset the process environment (dotenv) |
+| `getEnv` / `requireEnv` | function | Read an env var, optionally throwing if missing |
+| `getByteLimitEnv` | function | Parse a byte-size limit from an env var |
+| `registerSetting` / `getSettings` / `clearSettings` | function | Register and read typed settings |
+| `SettingDefinition` / `SettingStatus` | type | Setting registration and status shapes |
+| `configureLogging` / `getLogLevel` / `createLogger` | function | Configure logging and create named loggers |
+| `LogLevel` / `LoggingOptions` / `Logger` | type | Logging types |
+| `diagnoseEnvironment` / `maskSecret` | function | Environment diagnostics and secret masking |
+| `getNodetoolDataDir` / `getDefaultDbPath` / `getDefaultAssetsPath` | function | Resolve standard data, database, and asset paths |
+| `getPostgresDatabaseUrl` / `getDefaultVectorstoreDbPath` | function | Resolve Postgres and vectorstore locations |
+| `getAssetFilePath` / `buildAssetUrl` | function | Map asset keys to file paths and URLs |
+| `loadAssetStorageConfig` / `loadTempStorageConfig` | function | Load storage configuration from the environment |
+| `StorageConfig` / `SIGNED_URL_TTL` | type / const | Storage config shape and signed-URL lifetime |
+| `IS_NODE` / `importNodeBuiltin` / `importHidden` / `importOptionalModule` | const / function | Cross-runtime module loading helpers |
+
+## Usage
+
+```ts
+import {
+  loadEnvironment,
+  requireEnv,
+  createLogger,
+  getDefaultDbPath
+} from "@nodetool-ai/config";
+
+loadEnvironment();
+const log = createLogger("server");
+log.info("db path", getDefaultDbPath());
+const token = requireEnv("NODETOOL_TOKEN");
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -46,5 +46,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "Configuration and environment loading for NodeTool — settings, paths, logging, byte limits, and cross-runtime module loading",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "configuration",
+    "settings",
+    "environment",
+    "logging"
   ]
 }

--- a/packages/core-nodes/README.md
+++ b/packages/core-nodes/README.md
@@ -1,0 +1,53 @@
+# @nodetool-ai/core-nodes
+
+Core logic, control-flow, and input nodes for [NodeTool](https://nodetool.ai).
+
+The base building blocks for visual AI workflows: constants, control flow (if,
+switch, loops), list operations, workflow inputs, variables, subgraphs, vector
+store indexing and search, date/time, and validation. Pure-JS, no API keys.
+
+## Install
+
+```bash
+npm install @nodetool-ai/core-nodes
+```
+
+## Nodes
+
+**Control flow** (`nodetool.control.*`) — branching and iteration: `If`,
+`Switch`, `ForEach`, `Collect`, `RepeatCount`, `RepeatValue`, `Take`,
+`TakeWhile`, `DropWhile`, `Drop`, `TryCatch`, `Zip`, `Cross`, `Chunk`,
+`Distinct`, `Count`, `Last`, `FilterEqual`, `FilterCode`, `Tap`, `Reroute`.
+
+**Constants** (`nodetool.constant.*`) — typed literal values: `String`,
+`Integer`, `Float`, `Bool`, `List`, `Dict`, `JSON`, `Image`, `Audio`, `Video`,
+`Document`, `DataFrame`, `Date`, `DateTime`, and model constants
+(`LanguageModelConstant`, `ImageModelConstant`, `TTSModelConstant`, and more).
+
+**Inputs** (`nodetool.input.*`) — workflow entry points: `StringInput`,
+`IntegerInput`, `FloatInput`, `BooleanInput`, `SelectInput`, `ImageInput`,
+`AudioInput`, `VideoInput`, `DocumentInput`, `DataframeInput`, `MessageInput`,
+model pickers (`LanguageModelInput`, `ImageModelInput`, `ASRModelInput`, …), and
+list variants.
+
+**Lists** (`nodetool.list.*`) — `Range`, `Tile`, `RepeatEach`, `RepeatValue`.
+
+**Variables** (`nodetool.variable.*`) — `SetVariable`, `GetVariable`.
+
+**Vector store** (`vector.*`) — index and query embeddings: `Collection`,
+`IndexEmbedding`, `IndexTextChunk`, `IndexString`, `IndexImage`, `QueryText`,
+`QueryImage`, `HybridSearch`, `GetDocuments`, `Count`, `Peek`, `RemoveOverlap`.
+
+**Workflow** — `nodetool.workflows.subgraph.Subgraph`,
+`nodetool.workflows.workflow_node.Workflow`.
+
+**Date/time** (`lib.datetime.*`) — `Now`, `Format`, `Add`, `Diff`, `StartEnd`.
+
+**Validation** (`lib.validate.*`) — `Email`, `URL`, `IP`, `String`, `Sanitize`.
+
+**Compare** — `nodetool.compare.CompareImages`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/core-nodes/package.json
+++ b/packages/core-nodes/package.json
@@ -61,5 +61,21 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "control-flow",
+    "logic",
+    "constants",
+    "list",
+    "input"
+  ]
 }

--- a/packages/core-nodes/package.json
+++ b/packages/core-nodes/package.json
@@ -49,5 +49,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/core-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/data-nodes/README.md
+++ b/packages/data-nodes/README.md
@@ -1,0 +1,33 @@
+# @nodetool-ai/data-nodes
+
+Dataframe, CSV, RSS, and chart nodes for [NodeTool](https://nodetool.ai).
+
+Load, transform, and save tabular data in visual AI workflows: parse CSV, run
+dataframe operations (filter, join, aggregate, pivot), fetch RSS feeds, and
+render charts to images.
+
+## Install
+
+```bash
+npm install @nodetool-ai/data-nodes
+```
+
+## Nodes
+
+**Dataframe** (`nodetool.data.*`) — load and shape tabular data: `ImportCSV`,
+`LoadCSVFile`, `LoadCSVURL`, `LoadCSVAssets`, `JSONToDataframe`, `FromList`,
+`ToList`, `SaveDataframe`, `SaveCSVDataframeFile`. Column operations:
+`SelectColumn`, `ExtractColumn`, `AddColumn`, `Rename`. Rows and filtering:
+`Filter`, `FilterNone`, `Slice`, `FindRow`, `SortByColumn`, `DropDuplicates`,
+`DropNA`, `FillNA`, `ForEachRow`. Combine and reshape: `Merge`, `Append`,
+`Join`, `Aggregate`, `Pivot`. Inspect: `Schema`, `Describe`.
+
+**RSS** (`lib.rss.*`) — `FetchRSSFeed`, `ExtractFeedMetadata`.
+
+**Charts** (`lib.charts.ChartRenderer`) — render a Chart.js chart definition to
+a PNG image.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/data-nodes/package.json
+++ b/packages/data-nodes/package.json
@@ -51,5 +51,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/data-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/data-nodes/package.json
+++ b/packages/data-nodes/package.json
@@ -63,5 +63,21 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "data",
+    "dataframe",
+    "csv",
+    "rss",
+    "charts"
+  ]
 }

--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -1,0 +1,41 @@
+# @nodetool-ai/deploy
+
+NodeTool deployment toolkit — Docker image builds, SSH/compose provisioning, and self-hosted server management for [NodeTool](https://nodetool.ai).
+
+This package builds Docker images, provisions self-hosted servers over SSH with generated Compose files, and manages deployment state, progress, remote users, and admin operations. It exposes framework-agnostic route handlers so the same deploy logic backs both the CLI and the API.
+
+## Install
+
+```bash
+npm install @nodetool-ai/deploy
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `DeploymentManager` | class | Lists, runs, and tracks deployments via pluggable deployer factories |
+| `DeploymentConfig` | type | Loaded deployment configuration (from `deployment.yaml`) |
+| `StateManager` | class | Persists and reads deployment state |
+| Progress helpers | function | Progress tracking for long-running deploys |
+| SSH / Docker utilities | function | SSH sessions, image builds, `docker run`, image specs |
+| `SelfHostedDeployer` | class | Deploys to a self-hosted server over SSH + Compose |
+| Compose generation | function | Generates `docker-compose` files for a deployment |
+| Auth / user helpers | function | Remote user management and API user manager |
+| Admin client / operations / routes | function | Admin API client, operations, and route handlers |
+| Sync / workflow syncer | function | Syncs workflows and assets to a deployed server |
+| Storage / collection routes | function | Framework-agnostic route handlers |
+
+## Usage
+
+```ts
+import { DeploymentManager, StateManager } from "@nodetool-ai/deploy";
+
+const manager = new DeploymentManager(config, new StateManager(), deployerFactories);
+const deployments = await manager.listDeployments();
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -56,5 +56,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "NodeTool deployment toolkit — Docker image builds, SSH/compose provisioning, and self-hosted server management",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "deployment",
+    "docker",
+    "ssh",
+    "self-hosted",
+    "devops"
   ]
 }

--- a/packages/document-nodes/README.md
+++ b/packages/document-nodes/README.md
@@ -1,0 +1,41 @@
+# @nodetool-ai/document-nodes
+
+PDF, DOCX, EPUB, and PPTX document nodes for [NodeTool](https://nodetool.ai).
+
+Read, write, split, and convert documents in visual AI workflows: extract text,
+tables, and Markdown from PDFs, build Word documents, parse EPUB chapters and
+PowerPoint slides, and chunk text for RAG pipelines.
+
+## Install
+
+```bash
+npm install @nodetool-ai/document-nodes
+```
+
+## Nodes
+
+**Document** (`nodetool.document.*`) — load and save documents
+(`LoadDocumentFile`, `SaveDocumentFile`, `ListDocuments`) and split text into
+chunks for indexing: `SplitDocument`, `SplitRecursively`, `SplitMarkdown`,
+`SplitHTML`, `SplitJSON`.
+
+**PDF** (`lib.pdf.*`) — `PageCount`, `PageMetadata`, `ExtractText`,
+`ExtractMarkdown`, `ExtractStyledText`, `ExtractTextBlocks`, `ExtractTables`,
+`ExtractOcr`, `SearchText`, `Screenshot`, `Pdftoppm`.
+
+**DOCX** (`lib.docx.*`) — build and read Word documents: `CreateDocument`,
+`LoadWordDocument`, `AddHeading`, `AddParagraph`, `AddTable`, `AddImage`,
+`AddPageBreak`, `SetDocumentProperties`, `SaveDocument`.
+
+**EPUB** (`lib.epub.*`) — `Metadata`, `TableOfContents`, `ExtractText`,
+`ExtractChapters`.
+
+**PPTX** (`lib.pptx.*`) — `ExtractText`, `ExtractSlides`.
+
+**Convert** (`lib.convert.*`) — `ConvertToMarkdown`, plus pandoc-backed
+`pandoc.ConvertText` and `pandoc.ConvertFile`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/document-nodes/package.json
+++ b/packages/document-nodes/package.json
@@ -56,5 +56,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/document-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/document-nodes/package.json
+++ b/packages/document-nodes/package.json
@@ -68,5 +68,21 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "documents",
+    "pdf",
+    "docx",
+    "epub",
+    "pptx"
+  ]
 }

--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -1,0 +1,52 @@
+# @nodetool-ai/dsl
+
+Type-safe TypeScript DSL for defining [NodeTool](https://nodetool.ai) workflows.
+
+Build a workflow graph in code — nodes, edges, and typed output handles — then run it or export it. Node factories are generated from the registry, so connections are checked at compile time.
+
+## Install
+
+```bash
+npm install @nodetool-ai/dsl
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+|---|---|---|
+| `createNode` | function | Create a graph node from a node type, inputs, and options |
+| `workflow` | function | Assemble a `Workflow` from terminal (output) nodes |
+| `run` | function | Execute a workflow and return its outputs |
+| `workflowToDsl` | function | Generate DSL source from a workflow graph (used by `export-dsl`) |
+| `OutputHandle`, `Connectable`, `SingleOutput` | type | Typed wiring between node outputs and inputs |
+| `DslNode`, `Workflow`, `WorkflowNode`, `WorkflowEdge` | type | Graph value types |
+| `RunOptions`, `WorkflowResult`, `SecretResolver` | type | Execution configuration and results |
+| generated namespaces (`text`, `agents`, `geminiImage`, …) | module | Typed factories for every registered node, grouped by namespace |
+
+## Usage
+
+```ts
+import { workflow, run, text } from "@nodetool-ai/dsl";
+import { getSecret } from "@nodetool-ai/models";
+
+const chunks = text.chunk({ text: "...long document...", length: 1000, overlap: 200 });
+
+const wf = workflow(chunks);
+const result = await run(wf, {
+  secretResolver: (key, userId) => getSecret(key, userId)
+});
+console.log(result); // { output: string[] }
+```
+
+`createNode(nodeType, inputs, opts)` is the low-level primitive behind the generated factories; `opts` covers `streaming`, `multiOutput`, `outputNames`, and `defaultOutput`. Pass an output handle (`node.output()`) as another node's input to wire an edge. Graphs with Python nodes connect a worker bridge automatically (via `RunOptions.bridgeOptions` or the `NODETOOL_WORKER_URL` environment).
+
+Regenerate the node factories after node changes:
+
+```bash
+npm run codegen
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -58,5 +58,16 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "dsl",
+    "typescript-dsl",
+    "workflow-dsl",
+    "type-safe"
   ]
 }

--- a/packages/elevenlabs-nodes/README.md
+++ b/packages/elevenlabs-nodes/README.md
@@ -1,0 +1,30 @@
+# @nodetool-ai/elevenlabs-nodes
+
+ElevenLabs AI nodes for [NodeTool](https://nodetool.ai).
+
+Run the [ElevenLabs](https://elevenlabs.io) API inside NodeTool workflows: text-to-speech and voice generation, speech-to-text transcription, and realtime streaming TTS and STT over WebSocket.
+
+## Install
+
+```bash
+npm install @nodetool-ai/elevenlabs-nodes
+```
+
+## Nodes
+
+| Node | Type | Description |
+| --- | --- | --- |
+| Text to Speech | `elevenlabs.TextToSpeech` | Synthesize speech with a chosen voice, model, stability, similarity, and style. |
+| Speech to Text | `elevenlabs.SpeechToText` | Transcribe audio with timestamps, diarization, and audio-event tagging. |
+| Realtime Text to Speech | `elevenlabs.RealtimeTextToSpeech` | Stream synthesized speech over WebSocket. |
+| Realtime Speech to Text | `elevenlabs.RealtimeSpeechToText` | Stream transcription from audio chunks over WebSocket. |
+| Standard Voice | `elevenlabs.StandardVoice` | Pick an ElevenLabs system voice and output its voice ID. |
+
+## Configuration
+
+Set `ELEVENLABS_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/elevenlabs-nodes/package.json
+++ b/packages/elevenlabs-nodes/package.json
@@ -49,5 +49,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "elevenlabs",
+    "text-to-speech",
+    "tts",
+    "voice",
+    "audio"
   ]
 }

--- a/packages/fal-nodes/README.md
+++ b/packages/fal-nodes/README.md
@@ -1,0 +1,40 @@
+# @nodetool-ai/fal-nodes
+
+FAL AI nodes for [NodeTool](https://nodetool.ai).
+
+Run [fal.ai](https://fal.ai) models inside NodeTool workflows: FLUX and other text-to-image and image-to-image models, text-to-video and image-to-video, text-to-speech, speech-to-text, audio generation, and image-to-3D. The pack generates every node from a bundled manifest, so it tracks the fal.ai endpoint catalog.
+
+## Install
+
+```bash
+npm install @nodetool-ai/fal-nodes
+```
+
+## Nodes
+
+Over 1,000 nodes, one per fal.ai endpoint, named `fal.<category>.<Model>`.
+
+| Category | Node type prefix | Example |
+| --- | --- | --- |
+| Text to image | `fal.text_to_image.*` | `fal.text_to_image.FluxDev` |
+| Image to image | `fal.image_to_image.*` | `fal.image_to_image.FluxSchnellRedux` |
+| Text to video | `fal.text_to_video.*` | `fal.text_to_video.HunyuanVideo` |
+| Image to video | `fal.image_to_video.*` | `fal.image_to_video.PixverseV56ImageToVideo` |
+| Video to video | `fal.video_to_video.*` | `fal.video_to_video.AMTInterpolation` |
+| Text to audio | `fal.text_to_audio.*` | `fal.text_to_audio.ACEStepPromptToAudio` |
+| Text to speech | `fal.text_to_speech.*` | `fal.text_to_speech.Qwen3TtsTextToSpeech17B` |
+| Speech to text | `fal.speech_to_text.*` | `fal.speech_to_text.ElevenLabsSpeechToText` |
+| Vision | `fal.vision.*` | `fal.vision.ArbiterImageText` |
+| Image to 3D | `fal.image_to_3d.*` | `fal.image_to_3d.Trellis2` |
+| Training | `fal.training.*` | `fal.training.ZImageBaseTrainer` |
+
+Remaining categories: `audio_to_audio`, `audio_to_video`, `video_to_audio`, `video_to_text`, `text_to_3d`, `3d_to_3d`, `llm`, `text_to_json`, and more.
+
+## Configuration
+
+Set `FAL_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/fal-nodes/package.json
+++ b/packages/fal-nodes/package.json
@@ -48,5 +48,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "fal",
+    "fal-ai",
+    "image-generation",
+    "flux",
+    "text-to-image"
   ]
 }

--- a/packages/gpu/README.md
+++ b/packages/gpu/README.md
@@ -1,0 +1,52 @@
+# @nodetool-ai/gpu
+
+Canonical blend-mode catalog and shared WGSL blend functions for NodeTool compositors (sketch, timeline, Compositor node) for [NodeTool](https://nodetool.ai).
+
+The single source of truth for the `BlendMode` union, its stable numeric GPU ids, the Canvas2D and Sharp/libvips mappings, and the shared WGSL `applyBlendMode` shader math. The package root is pure — no WebGPU runtime — so Node consumers can pull in the catalog without the GPU stack. The TypeGPU shader pool lives behind `./pool` and the browser layer-compositing engine behind `./webgpu`.
+
+## Install
+
+```bash
+npm install @nodetool-ai/gpu
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `BlendMode` | type | Union of the 13 canonical blend modes (`normal`, `multiply`, `add`, …) |
+| `BLEND_MODE_TUPLE` | const | Ordered `const` tuple of mode names — drives the union and Zod enums |
+| `BLEND_MODE_INFOS` | const | Full table: value, label, `gpuId`, Canvas2D op, Sharp blend |
+| `BLEND_MODES` | const | `{ value, label }[]` for UI dropdowns |
+| `BLEND_MODE_VALUES` | const | Alias of `BLEND_MODE_TUPLE` |
+| `BlendModeInfo` | interface | One catalog row |
+| `CanvasCompositeOp` | type | Literal union of the Canvas2D `globalCompositeOperation` values used |
+| `coerceBlendMode` | function | Coerce unknown input to a valid `BlendMode` (falls back to `normal`) |
+| `blendModeGpuId` | function | Map a mode to its stable numeric shader id |
+| `blendModeToCanvasOp` | function | Map a mode to its Canvas2D composite op |
+| `blendModeToSharpBlend` | function | Map a mode to its Sharp/libvips `blend` string |
+| `WGSL_BLEND_FUNCTIONS` | const | WGSL source for `applyBlendMode(src, dst, mode)`, injected into fragment shaders |
+
+## Usage
+
+```ts
+import {
+  BLEND_MODES,
+  blendModeToCanvasOp,
+  WGSL_BLEND_FUNCTIONS
+} from "@nodetool-ai/gpu";
+
+// Populate a UI dropdown
+BLEND_MODES.forEach(({ value, label }) => addOption(value, label));
+
+// Canvas2D compositing
+ctx.globalCompositeOperation = blendModeToCanvasOp("multiply") as GlobalCompositeOperation;
+
+// Inject the shared blend math into a WGSL fragment shader
+const fragment = `${WGSL_BLEND_FUNCTIONS}\n@fragment fn fs(...) { ... }`;
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/gpu/package.json
+++ b/packages/gpu/package.json
@@ -67,5 +67,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "gpu",
+    "webgpu",
+    "wgsl",
+    "blend-modes",
+    "compositor",
+    "shaders"
   ]
 }

--- a/packages/huggingface-nodes/package.json
+++ b/packages/huggingface-nodes/package.json
@@ -45,5 +45,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "huggingface",
+    "model-nodes",
+    "inference"
   ]
 }

--- a/packages/huggingface/README.md
+++ b/packages/huggingface/README.md
@@ -1,0 +1,57 @@
+# @nodetool-ai/huggingface
+
+HuggingFace integration for [NodeTool](https://nodetool.ai) — cache scanning, model discovery, artifact inspection, and downloads.
+
+Scan the local HuggingFace cache, search the Hub, inspect safetensors layouts to classify model types, and download repos or GGUF files for llama.cpp with progress reporting.
+
+## Install
+
+```bash
+npm install @nodetool-ai/huggingface
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+|---|---|---|
+| `getHfToken`, `resolveHfToken`, `clearHfTokenCache` | function | Resolve the HuggingFace access token from the secret store / env |
+| `HfFastCache`, `getDefaultHfCacheDir` | class / function | Fast scan of the local HF cache |
+| `readCachedHfModels`, `searchCachedHfModels`, `getModelsByHfType`, `filterModelsByHfType`, `deleteCachedHfModel` | function | Query and prune cached models |
+| `getLlamaCppModelsFromCache`, `detectRepoPackaging` | function | Detect GGUF / repo packaging |
+| `searchHfHub`, `listAllHfModels` | function | Search and list models on the Hub |
+| `detectModel`, `summarizeSafetensor`, `classifySafetensorSet` | function | Inspect safetensors and classify model type |
+| `inspectPaths` | function | Detect model artifacts under given paths |
+| `getHuggingfaceFileInfos` | function | Fetch file metadata for repo files |
+| `asyncHfDownload`, `hfHubFileUrl`, `hfCacheRoot`, `hfRepoCacheDir` | function | Download repos and resolve cache paths |
+| `DownloadManager`, `getDownloadManager` | class / function | Track and report download progress |
+| `downloadLlamaCppModel`, `getLlamaCppModelPath`, `isLlamaCppModelCached` | function | Manage GGUF models for llama.cpp |
+| `UnifiedModel`, `HfHubModel`, `DetectionResult`, `SafetensorSummary`, `DownloadUpdate` | type | Model and inspection value types |
+
+## Usage
+
+```ts
+import {
+  readCachedHfModels,
+  searchHfHub,
+  getDownloadManager
+} from "@nodetool-ai/huggingface";
+
+// List models already in the local cache
+const cached = await readCachedHfModels();
+
+// Search the Hub
+const results = await searchHfHub({ query: "flux", limit: 10 });
+
+// Download with progress
+const manager = getDownloadManager();
+await manager.startDownload("black-forest-labs/FLUX.1-schnell", {
+  onProgress: (update) => console.log(`${update.repoId}: ${update.status}`)
+});
+```
+
+Cache paths follow the standard `HF_HOME` / `~/.cache/huggingface` layout. Authenticated calls use the token resolved by `resolveHfToken` (secret store, then `HF_TOKEN`).
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -46,5 +46,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "huggingface",
+    "models",
+    "model-discovery",
+    "downloads",
+    "hub"
   ]
 }

--- a/packages/image-editor/README.md
+++ b/packages/image-editor/README.md
@@ -1,0 +1,54 @@
+# @nodetool-ai/image-editor
+
+Shared image-editor types, dependency hashing, and seeded layer templates for [NodeTool](https://nodetool.ai).
+
+The pure type layer behind NodeTool's layered sketch editor: the persisted document shape, per-layer generation bindings (workflow-bound and direct text-to-image / image-to-image / inpaint), version history, and the content hash that detects when a layer is stale. Kept free of the web editor implementation so both the browser and server can depend on it.
+
+## Install
+
+```bash
+npm install @nodetool-ai/image-editor
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `ImageDocument` | interface | Top-level persisted image document (sketch + layer bindings) |
+| `SketchDocumentLike` | interface | Minimal sketch-compatible document payload |
+| `SketchLayerLike` | interface | One layer (raster / mask / group) |
+| `SketchViewportLike` | interface | Zoom + pan state |
+| `LayerWorkflowBinding` | interface | How a layer's pixels are generated (unified binding) |
+| `LayerBinding` | type | Clearer alias of `LayerWorkflowBinding` for new code |
+| `LayerBindingKind` | type | `"workflow" \| "text-to-image" \| "image-to-image" \| "inpaint"` |
+| `LayerStatus` | type | `draft`, `queued`, `generating`, `generated`, `stale`, `failed`, … |
+| `LayerVersion` | interface | One recorded generation of a layer |
+| `PersistedHistoryEntryLike` | interface | Undo/redo history entry shape |
+| `LayerTemplateKind` | type | `"text-to-image" \| "inpaint" \| "background-remove"` |
+| `LayerTemplateDefinition` | interface | Seeded workflow template for a new layer |
+
+The Node-only `computeDependencyHash` (and its `DependencyHashInput`) is not re-exported from the root because it pulls in `node:crypto`. Import it from the subpath on the server:
+
+```ts
+import { computeDependencyHash } from "@nodetool-ai/image-editor/dependencyHash";
+```
+
+## Usage
+
+```ts
+import type { ImageDocument, LayerBinding } from "@nodetool-ai/image-editor";
+
+const doc: ImageDocument = loadDocument(id);
+const binding: LayerBinding | undefined = doc.layerBindings.find(
+  (b) => b.layerId === activeLayerId
+);
+
+if (binding?.status === "stale") {
+  regenerate(binding);
+}
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/image-editor/package.json
+++ b/packages/image-editor/package.json
@@ -49,5 +49,16 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "image-editor",
+    "layers",
+    "canvas",
+    "editor"
   ]
 }

--- a/packages/image-nodes/README.md
+++ b/packages/image-nodes/README.md
@@ -1,0 +1,91 @@
+# @nodetool-ai/image-nodes
+
+Image-processing nodes for [NodeTool](https://nodetool.ai).
+
+A pack of image nodes for NodeTool workflows: resize, crop, and composite images;
+color-grade and filter with a Sharp-based and WebGPU-shader pipeline; draw
+gradients and text; warp, mask, and key; and run AI image generation, upscaling,
+and background removal.
+
+## Install
+
+```bash
+npm install @nodetool-ai/image-nodes
+```
+
+## Nodes
+
+### I/O
+
+- `nodetool.image.LoadImageFile`, `nodetool.image.LoadImageFolder`, `nodetool.image.LoadImageAssets`
+- `nodetool.image.SaveImage`, `nodetool.image.SaveImageFile`, `nodetool.image.GetMetadata`
+
+### Transform and composite
+
+- `nodetool.image.Resize`, `nodetool.image.ResizeImage`, `nodetool.image.Scale`, `nodetool.image.Fit`, `nodetool.image.CanvasResize`
+- `nodetool.image.Crop`, `nodetool.image.RotateAndFlip`, `nodetool.image.Paste`, `nodetool.image.Compositor`
+- `nodetool.image.BatchToList`, `nodetool.image.ImagesToList`
+
+### AI
+
+- `nodetool.image.TextToImage`, `nodetool.image.ImageToImage`, `nodetool.image.Upscale`
+- `nodetool.image.RemoveBackground`, `nodetool.image.Relight`, `nodetool.image.Vectorize`
+
+### Paint and sketch
+
+- `nodetool.image.Painter`
+- `nodetool.sketch.CreateSketch`, `nodetool.sketch.RenderSketch`, `nodetool.sketch.SketchLayers`
+
+### Color and grading
+
+Basic color plus a full grading suite.
+
+- Color: `lib.image.color.BrightnessContrast`, `lib.image.color.HSB`, `lib.image.color.Exposure`, `lib.image.color.Invert`, `lib.image.color.Posterize`, `lib.image.color.ChannelSplit`, `lib.image.color.Grade`
+- Grading: `lib.image.color_grading.Curves`, `lib.image.color_grading.LiftGammaGain`, `lib.image.color_grading.ColorBalance`, `lib.image.color_grading.CDL`, `lib.image.color_grading.FilmLook`, `lib.image.color_grading.HSLAdjust`, `lib.image.color_grading.SaturationVibrance`, `lib.image.color_grading.SplitToning`, `lib.image.color_grading.Vignette`
+- Also: `nodetool.image.Levels`, `nodetool.image.Channels`
+
+### Filters
+
+`lib.image.filter.GaussianBlur`, `lib.image.filter.Canny`, `lib.image.filter.FindEdges`,
+`lib.image.filter.Emboss`, `lib.image.filter.Contour`, `lib.image.filter.Pixelate`,
+`lib.image.filter.Solarize`, `lib.image.filter.Threshold`, `lib.image.filter.UnsharpMask`,
+`lib.image.filter.Smooth`, `lib.image.filter.ConvertToGrayscale`, `nodetool.image.Blur`.
+
+### Enhance
+
+`lib.image.enhance.AutoContrast`, `lib.image.enhance.AdaptiveContrast`,
+`lib.image.enhance.EdgeEnhance`, `lib.image.enhance.Detail`,
+`lib.image.enhance.Equalize`, `lib.image.enhance.RankFilter`.
+
+### Effects
+
+`lib.image.effects.Glow`, `lib.image.effects.DropShadow`, `lib.image.effects.Outline`,
+`lib.image.effects.ColorOverlay`, `lib.image.effects.Add`.
+
+### Draw and generators
+
+`lib.image.draw.LinearGradient`, `lib.image.draw.RadialGradient`,
+`lib.image.draw.AngularGradient`, `lib.image.draw.DiamondGradient`,
+`lib.image.draw.Checkerboard`, `lib.image.draw.GaussianNoise`,
+`lib.image.draw.Background`, `lib.image.draw.RenderText`.
+
+### Warp
+
+`lib.image.warp.Affine`, `lib.image.warp.CornerPin`, `lib.image.warp.Displace`,
+`lib.image.warp.Offset`, `lib.image.warp.Pad`, `lib.image.warp.PolarRemap`,
+`lib.image.warp.Spherize`, `lib.image.warp.Tile`.
+
+### Mask, channel, and keyer
+
+- Mask: `lib.image.mask.FromImage`, `lib.image.mask.Apply`, `lib.image.mask.Invert`, `lib.image.Mask`
+- Channel: `lib.image.channel.Merge`, `lib.image.channel.Shuffle`
+- Keyer: `lib.image.keyer.ChromaKey`, `lib.image.keyer.LumaKey`
+
+### Grid
+
+`lib.grid.SliceImageGrid`, `lib.grid.CombineImageGrid`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/image-nodes/package.json
+++ b/packages/image-nodes/package.json
@@ -51,5 +51,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/image-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/image-nodes/package.json
+++ b/packages/image-nodes/package.json
@@ -63,5 +63,21 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "image",
+    "image-processing",
+    "sharp",
+    "webgpu",
+    "shaders"
+  ]
 }

--- a/packages/integration-nodes/README.md
+++ b/packages/integration-nodes/README.md
@@ -1,0 +1,72 @@
+# @nodetool-ai/integration-nodes
+
+External-API integration nodes for [NodeTool](https://nodetool.ai).
+
+Connect visual AI workflows to the outside world: HTTP and GraphQL requests, AWS
+S3, Supabase, Notion, Twilio, email, Discord and Telegram, Google search via
+SerpApi, Apify web scrapers, and ComfyUI workflows.
+
+## Install
+
+```bash
+npm install @nodetool-ai/integration-nodes
+```
+
+## Nodes
+
+**HTTP** (`lib.http.*`) — `GetText`, `GetJSON`, `GetBytes`, `Post`, `Put`,
+`Patch`, `Delete`.
+
+**GraphQL** (`lib.graphql.*`) — `Query`, `QueryWithAuth`, `Introspection`,
+`BatchQuery`.
+
+**S3** (`lib.s3.*`) — `ListBuckets`, `ListObjects`, `GetObject`, `PutObject`,
+`DeleteObject`, `CopyObject`, `GetPresignedUrl`.
+
+**Supabase** (`lib.supabase.*`) — `Select`, `Insert`, `Update`, `Delete`,
+`Upsert`, `RPC`.
+
+**Notion** (`lib.notion.*`) — `Search`, `GetPage`, `GetPageContent`,
+`CreatePage`, `UpdatePage`, `QueryDatabase`.
+
+**Twilio** (`lib.twilio.*`) — `SendSMS`, `SendWhatsApp`, `GetMessages`,
+`Lookup`.
+
+**Mail** (`lib.mail.*`) — `SendEmail`, `GmailSearch`, `AddLabel`,
+`MoveToArchive`.
+
+**Messaging** (`messaging.*`) — Discord and Telegram bot triggers and senders:
+`discord.DiscordBotTrigger`, `discord.DiscordSendMessage`,
+`telegram.TelegramBotTrigger`, `telegram.TelegramSendMessage`.
+
+**Search** (`search.google.*`) — SerpApi-backed Google search:
+`GoogleSearch`, `GoogleNews`, `GoogleImages`, `GoogleFinance`, `GoogleJobs`,
+`GoogleLens`, `GoogleMaps`, `GoogleShopping`.
+
+**Apify** (`apify.scraping.*`) — `ApifyWebScraper`,
+`ApifyGoogleSearchScraper`, `ApifyInstagramScraper`, `ApifyAmazonScraper`,
+`ApifyYouTubeScraper`, `ApifyTwitterScraper`, `ApifyLinkedInScraper`.
+
+**Other** — `lib.comfy.RunWorkflow`, `lib.comfy.RunWorkflowOnWorker`,
+`kie.dynamic_schema.KieAI`, `lib.secret.GetSecret`.
+
+## Configuration
+
+Set the keys for the services you use in NodeTool's secret store (Settings → API
+Keys) or as environment variables:
+
+- S3: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- Supabase: `SUPABASE_URL`, `SUPABASE_KEY`
+- Notion: `NOTION_API_KEY`
+- Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`
+- Mail: `GOOGLE_APP_PASSWORD`
+- Search: `SERPAPI_API_KEY`
+- Apify: `APIFY_API_TOKEN`
+- KIE: `KIE_API_KEY`
+- Discord: `DISCORD_BOT_TOKEN`
+- Telegram: `TELEGRAM_BOT_TOKEN`
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/integration-nodes/package.json
+++ b/packages/integration-nodes/package.json
@@ -69,5 +69,24 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "http",
+    "graphql",
+    "s3",
+    "notion",
+    "twilio",
+    "apify",
+    "integrations",
+    "api"
+  ]
 }

--- a/packages/integration-nodes/package.json
+++ b/packages/integration-nodes/package.json
@@ -57,5 +57,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/integration-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -51,5 +51,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "workflow-engine",
+    "actor-model",
+    "dag",
+    "graph",
+    "workflow-runner"
   ]
 }

--- a/packages/kie-nodes/README.md
+++ b/packages/kie-nodes/README.md
@@ -1,0 +1,32 @@
+# @nodetool-ai/kie-nodes
+
+Kie.ai model nodes for [NodeTool](https://nodetool.ai).
+
+Run [Kie.ai](https://kie.ai) models inside NodeTool workflows: text-to-image and image editing, text-to-video and image-to-video, and audio generation including Suno music. The pack generates every node from a bundled manifest, so it tracks the Kie.ai model catalog.
+
+## Install
+
+```bash
+npm install @nodetool-ai/kie-nodes
+```
+
+## Nodes
+
+Over 120 nodes, one per Kie.ai model, named `kie.<category>.<Model>`.
+
+| Category | Node type prefix | Example |
+| --- | --- | --- |
+| Image | `kie.image.*` | `kie.image.BytedanceSeedream` |
+| Video | `kie.video.*` | `kie.video.GrokImagineTextToVideo` |
+| Audio | `kie.audio.*` | `kie.audio.ElevenlabsAudioIsolation` |
+
+Includes Seedream, Grok Imagine, Veo, Runway, and Suno music nodes.
+
+## Configuration
+
+Set `KIE_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/kie-nodes/package.json
+++ b/packages/kie-nodes/package.json
@@ -52,5 +52,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "kie",
+    "kie-ai",
+    "model-nodes"
   ]
 }

--- a/packages/llm-nodes/README.md
+++ b/packages/llm-nodes/README.md
@@ -1,0 +1,52 @@
+# @nodetool-ai/llm-nodes
+
+LLM provider and agent nodes for [NodeTool](https://nodetool.ai).
+
+Call OpenAI, Google Gemini, Mistral, and xAI directly from visual AI workflows —
+chat, embeddings, image generation, speech, transcription, web search — plus
+NodeTool agent nodes for summarizing, extracting, classifying, and generating
+structured output.
+
+## Install
+
+```bash
+npm install @nodetool-ai/llm-nodes
+```
+
+## Nodes
+
+**OpenAI** (`openai.*`) — `text.Embedding`, `text.WebSearch`, `text.Moderation`,
+`image.CreateImage`, `image.EditImage`, `image.ImageVariation`,
+`audio.TextToSpeech`, `audio.Transcribe`, `audio.Translate`,
+`agents.RealtimeAgent`, `agents.RealtimeTranscription`.
+
+**Gemini** (`gemini.*`) — `text.GroundedSearch`, `text.Embedding`,
+`image.ImageGeneration`, `video.TextToVideo`, `video.ImageToVideo`,
+`audio.TextToSpeech`, `audio.Transcribe`.
+
+**Mistral** (`mistral.*`) — `text.ChatComplete`, `text.CodeComplete`,
+`embeddings.Embedding`, `vision.ImageToText`, `vision.OCR`.
+
+**xAI** (`xai.*`) — `text.ChatComplete`, `text.WebSearch`, `vision.ImageToText`,
+`image.GenerateImage`.
+
+**Agents** (`nodetool.agents.*`) — `Summarizer`, `Extractor`, `Classifier`,
+`EnhancePrompt`, `CreateThread`.
+
+**Generators** (`nodetool.generators.*`) — `StructuredOutputGenerator`,
+`DataGenerator`, `ListGenerator`, `ChartGenerator`, `SVGGenerator`.
+
+## Configuration
+
+Set the provider keys you use in NodeTool's secret store (Settings → API Keys)
+or as environment variables:
+
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+- `MISTRAL_API_KEY`
+- `XAI_API_KEY`
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/llm-nodes/package.json
+++ b/packages/llm-nodes/package.json
@@ -90,5 +90,22 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "llm",
+    "openai",
+    "anthropic",
+    "gemini",
+    "mistral",
+    "agents"
+  ]
 }

--- a/packages/llm-nodes/package.json
+++ b/packages/llm-nodes/package.json
@@ -78,5 +78,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/llm-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/minimax-nodes/package.json
+++ b/packages/minimax-nodes/package.json
@@ -46,5 +46,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "minimax",
+    "text-to-speech",
+    "text-to-image",
+    "text-to-video",
+    "music-generation"
   ]
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -58,5 +58,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "database",
+    "sqlite",
+    "drizzle",
+    "orm",
+    "data-models"
   ]
 }

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -52,5 +52,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "sdk",
+    "node-sdk",
+    "basenode",
+    "node-registry",
+    "type-system"
   ]
 }

--- a/packages/nodes-utils/README.md
+++ b/packages/nodes-utils/README.md
@@ -1,0 +1,54 @@
+# @nodetool-ai/nodes-utils
+
+Shared helpers for node packages: platform tags and lazy Node-only module loaders for [NodeTool](https://nodetool.ai).
+
+A small utility crate every `*-nodes` package depends on instead of duplicating helpers or pulling the whole base-nodes barrel: platform-tagging helpers that stamp `static platforms` onto node arrays, lazy loaders for `node:` built-ins so non-portable paths don't block module init on non-Node runtimes, template variable substitution, and Buffer-free base64.
+
+## Install
+
+```bash
+npm install @nodetool-ai/nodes-utils
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `tagAsServer` | function | Mark a `_NODES` array as server-only |
+| `tagAsNode` | function | Mark nodes as requiring the Node runtime |
+| `tagAsHybrid` | function | Mark nodes as running on server or browser |
+| `tagAsBrowserGpu` | function | Mark nodes as needing browser WebGPU |
+| `tagAsUniversal` | function | Mark nodes as runnable on any platform |
+| `tagAsContentCard` | function | Tag nodes surfaced as content cards |
+| `loadNodeFsPromises` | function | Lazily import `node:fs/promises` |
+| `loadNodeFsSync` | function | Lazily import `node:fs` |
+| `loadNodePath` | function | Lazily import `node:path` |
+| `loadNodeOs` | function | Lazily import `node:os` |
+| `loadNodeUrl` | function | Lazily import `node:url` |
+| `renderTemplate` | function | Substitute `{{ variable }}` / `{variable}` placeholders |
+| `referencedVariables` | function | List variable names referenced in a template |
+| `base64ToBytes` | function | Decode base64 to `Uint8Array` (Node + browser) |
+| `bytesToBase64` | function | Encode bytes to base64 (Node + browser) |
+
+## Usage
+
+```ts
+import {
+  tagAsServer,
+  renderTemplate,
+  loadNodePath
+} from "@nodetool-ai/nodes-utils";
+
+tagAsServer(_NODES);
+
+const text = renderTemplate("Hello {{ name }}", { name: "world" });
+
+// Only touches node:path when this path actually runs
+const path = await loadNodePath();
+const full = path.join(dir, "file.txt");
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/nodes-utils/package.json
+++ b/packages/nodes-utils/package.json
@@ -43,5 +43,9 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  }
 }

--- a/packages/nodes-utils/package.json
+++ b/packages/nodes-utils/package.json
@@ -47,5 +47,15 @@
   "homepage": "https://nodetool.ai",
   "bugs": {
     "url": "https://github.com/nodetool-ai/nodetool/issues"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "utilities",
+    "helpers",
+    "platform"
+  ]
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -70,5 +70,16 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "message-types",
+    "msgpack",
+    "protocol",
+    "websocket"
   ]
 }

--- a/packages/replicate-nodes/README.md
+++ b/packages/replicate-nodes/README.md
@@ -1,0 +1,40 @@
+# @nodetool-ai/replicate-nodes
+
+Replicate model nodes for [NodeTool](https://nodetool.ai).
+
+Run [Replicate](https://replicate.com) models inside NodeTool workflows: image generation and upscaling, video generation, text generation, speech and transcription, embeddings, background removal, face processing, and OCR. The pack generates every node from a bundled manifest, so it tracks the Replicate model catalog.
+
+## Install
+
+```bash
+npm install @nodetool-ai/replicate-nodes
+```
+
+## Nodes
+
+Over 400 nodes, one per Replicate model, named `replicate.<category>.<Model>`.
+
+| Category | Node type prefix | Example |
+| --- | --- | --- |
+| Image generation | `replicate.image.generate.*` | `replicate.image.generate.AdInpaint` |
+| Image upscaling | `replicate.image.upscale.*` | `replicate.image.upscale.RealEsrGan` |
+| Image enhancement | `replicate.image.enhance.*` | `replicate.image.enhance.CodeFormer` |
+| Image analysis | `replicate.image.analyze.*` | `replicate.image.analyze.SDXLClipInterrogator` |
+| Background removal | `replicate.image.background.*` | — |
+| Video generation | `replicate.video.generate.*` | — |
+| Video face swap | `replicate.video.face.*` | — |
+| Text generation | `replicate.text.generate.*` | — |
+| Speech / audio | `replicate.audio.speech.*` | — |
+| Transcription | `replicate.audio.transcribe.*` | — |
+| Embeddings | `replicate.embedding.*` | — |
+
+Also covers image-to-3D, OCR, face-to-many, and audio generation.
+
+## Configuration
+
+Set `REPLICATE_API_TOKEN` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/replicate-nodes/package.json
+++ b/packages/replicate-nodes/package.json
@@ -48,5 +48,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "replicate",
+    "image-generation",
+    "model-nodes"
   ]
 }

--- a/packages/reve-nodes/package.json
+++ b/packages/reve-nodes/package.json
@@ -45,5 +45,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "reve",
+    "image-generation"
   ]
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -109,5 +109,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "llm",
+    "llm-providers",
+    "openai",
+    "anthropic",
+    "gemini",
+    "ollama",
+    "inference"
   ]
 }

--- a/packages/sandbox-agent/README.md
+++ b/packages/sandbox-agent/README.md
@@ -1,0 +1,36 @@
+# @nodetool-ai/sandbox-agent
+
+In-container tool server: a Fastify HTTP service exposing file, shell, browser, and desktop tools to the host sandbox for [NodeTool](https://nodetool.ai).
+
+The server that runs *inside* a NodeTool sandbox container. It is baked into the sandbox Docker image and started by the container entrypoint; the host side (`@nodetool-ai/sandbox`) drives it over HTTP through `ToolClient`. Routes are validated against the shared Zod schemas in `@nodetool-ai/sandbox/schemas`, so host and container never drift.
+
+This package is infrastructure — you normally interact with it through `@nodetool-ai/sandbox`, not directly.
+
+## Install
+
+```bash
+npm install @nodetool-ai/sandbox-agent
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `buildServer` | function | Build the Fastify instance exposing the file / shell / browser / desktop tool routes |
+| `BuildServerOptions` | interface | Server options |
+| `SANDBOX_AGENT_VERSION` | const | Version string reported by the tool server |
+
+## Usage
+
+```ts
+import { buildServer } from "@nodetool-ai/sandbox-agent";
+
+// Runs inside the sandbox container (via the image entrypoint)
+const server = buildServer();
+await server.listen({ host: "0.0.0.0", port: 8000 });
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/sandbox-agent/package.json
+++ b/packages/sandbox-agent/package.json
@@ -56,5 +56,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "sandbox",
+    "fastify",
+    "tool-server",
+    "agent-tools",
+    "docker"
   ]
 }

--- a/packages/sandbox-tools/README.md
+++ b/packages/sandbox-tools/README.md
@@ -1,0 +1,50 @@
+# @nodetool-ai/sandbox-tools
+
+Agent tool adapter: exposes a sandbox's `ToolClient` as a set of `@nodetool-ai/agents` Tool instances for [NodeTool](https://nodetool.ai).
+
+Bridges `@nodetool-ai/sandbox` and `@nodetool-ai/agents`: `createSandboxTools` turns a sandbox `ToolClient` into ready-to-use agent tools — file, shell, browser, desktop, screen, mouse, keyboard, and web-search operations — each backed by the shared Zod schemas so the agent sees precise input contracts.
+
+## Install
+
+```bash
+npm install @nodetool-ai/sandbox-tools
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `createSandboxTools` | function | Build the full set of agent `Tool` instances from a `ToolClient` |
+| `CreateSandboxToolsOptions` | interface | Options controlling which tools are created |
+| `listSandboxToolNames` | function | List the names of every sandbox tool |
+| `SandboxTool` | class | One agent tool that invokes a `ToolClient` method |
+| `SandboxToolDefinition` | type | Definition of a sandbox tool (name, description, schema, method) |
+| `toJsonSchema` | function | Convert a tool's Zod input schema to JSON Schema |
+
+## Usage
+
+```ts
+import { DockerSandboxProvider, SessionStore } from "@nodetool-ai/sandbox";
+import { createSandboxTools } from "@nodetool-ai/sandbox-tools";
+import { Agent } from "@nodetool-ai/agents";
+
+const provider = new DockerSandboxProvider();
+const store = new SessionStore({ provider });
+const sandbox = await store.acquire("chat-123");
+
+const agent = new Agent({
+  name: "researcher",
+  objective: "Investigate the codebase in /workspace",
+  provider,
+  model,
+  tools: createSandboxTools(sandbox.client)
+});
+
+// ...run the agent...
+await sandbox.release();
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/sandbox-tools/package.json
+++ b/packages/sandbox-tools/package.json
@@ -50,5 +50,15 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "sandbox",
+    "agent-tools",
+    "tool-adapter"
   ]
 }

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,52 @@
+# @nodetool-ai/sandbox
+
+Host-side sandbox provisioning: Docker-backed isolated Linux computers for agents, with shell, file, browser, and desktop tools, for [NodeTool](https://nodetool.ai).
+
+Provisions isolated Linux environments an agent can drive. The current backend is Docker; future backends (gVisor, Firecracker, E2B, Daytona) implement the same `SandboxProvider` interface. A typed `ToolClient` talks over HTTP to the in-container tool server (`@nodetool-ai/sandbox-agent`), and a `SessionStore` keeps one sandbox per session. Request/response schemas are shared Zod schemas under the `./schemas` subpath, so host and container never drift.
+
+## Install
+
+```bash
+npm install @nodetool-ai/sandbox
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `SandboxProvider` | interface | Backend contract — provision and manage sandboxes |
+| `Sandbox` | interface | A running sandbox with its `client` and endpoints |
+| `SandboxOptions` | interface | Provisioning options (image, memory, etc.) |
+| `SandboxEndpoint` | interface | An exposed endpoint (URL + port) |
+| `DockerSandbox` | class | A single Docker-backed sandbox |
+| `DockerSandboxProvider` | class | Docker implementation of `SandboxProvider` |
+| `ToolClient` | class | Typed HTTP client for the in-container tool server |
+| `ToolClientOptions` | interface | Client options (endpoint URL, timeouts) |
+| `ToolInvocationError` | class | Thrown when a tool call fails |
+| `SessionStore` | class | Acquire / release one sandbox per session key |
+| `SessionStoreOptions` | interface | Store options (provider, idle timeout) |
+| `DEFAULT_SANDBOX_IMAGE` / `TOOL_SERVER_PORT` / `VNC_WS_PORT` | const | Image tag and port constants |
+| `parseMemLimit` | function | Parse a memory-limit string to bytes |
+| `./schemas` (subpath) | module | Shared Zod input/output schemas for every sandbox tool |
+
+## Usage
+
+```ts
+import { DockerSandboxProvider, SessionStore } from "@nodetool-ai/sandbox";
+
+const provider = new DockerSandboxProvider();
+const store = new SessionStore({ provider });
+
+const sandbox = await store.acquire("chat-123");
+
+const { id } = await sandbox.client.shellExec({ command: "ls -la /workspace" });
+const view = await sandbox.client.shellView({ id });
+console.log(view.output);
+
+await sandbox.release();
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -56,5 +56,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "sandbox",
+    "docker",
+    "isolation",
+    "agent-tools",
+    "browser-automation",
+    "desktop"
   ]
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -53,5 +53,9 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -57,5 +57,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "sdk",
+    "trpc",
+    "client",
+    "websocket",
+    "api-client"
   ]
 }

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -1,0 +1,44 @@
+# @nodetool-ai/security
+
+Secret storage and encryption for [NodeTool](https://nodetool.ai) — master-key management, crypto helpers, and startup security checks.
+
+This package owns encryption at rest for the NodeTool backend. It derives and stores a master key (OS keychain via keytar, environment variable, or AWS Secrets Manager), encrypts and decrypts secrets (including Fernet-compatible payloads), and runs startup checks that verify the security configuration before the server accepts traffic.
+
+## Install
+
+```bash
+npm install @nodetool-ai/security
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `generateMasterKey` | function | Generate a new random master key |
+| `deriveKey` | function | Derive an encryption key from a passphrase |
+| `encrypt` / `decrypt` | function | Encrypt and decrypt payloads with the master key |
+| `encryptFernet` / `decryptFernet` | function | Fernet-compatible encryption for cross-runtime secrets |
+| `isValidMasterKey` | function | Validate a master-key string |
+| `getMasterKey` / `initMasterKey` | function | Read or initialize the active master key |
+| `setMasterKey` / `setMasterKeyPersistent` / `deleteMasterKey` | function | Set (optionally persist to keychain) or delete the master key |
+| `clearMasterKeyCache` | function | Clear the in-memory key cache |
+| `isUsingEnvKey` / `isUsingAwsKey` | function | Report which key source is active |
+| `setKeytarLoader` / `resetKeytarLoader` | function | Override the keytar loader (for tests) |
+| `KeychainAccessError` | class | Error thrown when the OS keychain is unreachable |
+| `runStartupChecks` | function | Verify security configuration at startup |
+| `StartupCheckResult` | type | Result of a startup check |
+
+## Usage
+
+```ts
+import { initMasterKey, encrypt, decrypt } from "@nodetool-ai/security";
+
+await initMasterKey();
+const sealed = encrypt("sk-secret-value");
+const plain = decrypt(sealed);
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -48,5 +48,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "description": "Secret storage and encryption for NodeTool — master-key management, crypto helpers, and startup security checks",
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "encryption",
+    "secrets",
+    "secret-storage",
+    "crypto",
+    "security"
   ]
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -50,5 +50,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "storage",
+    "s3",
+    "file-storage",
+    "supabase",
+    "object-storage"
   ]
 }

--- a/packages/text-nodes/README.md
+++ b/packages/text-nodes/README.md
@@ -1,0 +1,72 @@
+# @nodetool-ai/text-nodes
+
+Text-processing nodes for [NodeTool](https://nodetool.ai).
+
+A pack of text nodes for NodeTool workflows: manipulate and template strings,
+match and replace with regex, tokenize and embed, run NLP (tokenizing, stemming,
+sentiment, entity extraction), parse HTML and Markdown, and build SVG.
+
+## Install
+
+```bash
+npm install @nodetool-ai/text-nodes
+```
+
+## Nodes
+
+### Manipulation
+
+- `nodetool.text.Concat`, `nodetool.text.Join`, `nodetool.text.Split`, `nodetool.text.Slice`, `nodetool.text.Replace`
+- `nodetool.text.Template`, `nodetool.text.Prompt`, `nodetool.text.PadText`, `nodetool.text.SurroundWith`, `nodetool.text.TruncateText`
+- `nodetool.text.CollapseWhitespace`, `nodetool.text.TrimWhitespace`, `nodetool.text.RemovePunctuation`, `nodetool.text.Slugify`, `nodetool.text.StripAccents`
+- Case: `nodetool.text.ToLowercase`, `nodetool.text.ToUppercase`, `nodetool.text.ToTitlecase`, `nodetool.text.CapitalizeText`, `nodetool.text.ToString`
+
+### Compare and predicates
+
+- `nodetool.text.Compare`, `nodetool.text.Equals`, `nodetool.text.Contains`, `nodetool.text.StartsWith`, `nodetool.text.EndsWith`
+- `nodetool.text.IsEmpty`, `nodetool.text.HasLength`, `nodetool.text.IndexOf`, `nodetool.text.Length`
+
+### Regex
+
+- `nodetool.text.RegexMatch`, `nodetool.text.RegexReplace`, `nodetool.text.RegexSplit`, `nodetool.text.RegexValidate`
+- `nodetool.text.FindAllRegex`, `nodetool.text.ExtractRegex`, `nodetool.text.FilterRegexString`, `nodetool.text.FilterString`
+
+### Extract and parse
+
+- `nodetool.text.Extract`, `nodetool.text.ExtractJSON`, `nodetool.text.ParseJSON`, `nodetool.text.Chunk`, `nodetool.text.Collect`
+
+### Tokens and embeddings
+
+- `nodetool.text.CountTokens`, `nodetool.text.Embedding`
+- `nodetool.text.AutomaticSpeechRecognition`
+
+### I/O
+
+- `nodetool.text.LoadTextAssets`, `nodetool.text.LoadTextFolder`, `nodetool.text.SaveText`, `nodetool.text.SaveTextFile`
+
+### NLP
+
+`lib.nlp.Tokenize`, `lib.nlp.Stem`, `lib.nlp.ClassifyText`, `lib.nlp.ExtractEntities`,
+`lib.nlp.SentimentAnalysis`, `lib.nlp.TfIdf`, `lib.nlp.PhoneticMatch`.
+
+### Markdown
+
+`lib.markdown.ExtractHeaders`, `lib.markdown.ExtractLinks`, `lib.markdown.ExtractBulletLists`,
+`lib.markdown.ExtractNumberedLists`, `lib.markdown.ExtractCodeBlocks`, `lib.markdown.ExtractTables`.
+
+### HTML
+
+`lib.html.HTMLToText`, `lib.html.WebsiteContentExtractor`, `lib.html.ExtractLinks`,
+`lib.html.ExtractImages`, `lib.html.ExtractVideos`, `lib.html.ExtractAudio`,
+`lib.html.ExtractMetadata`, `lib.html.BaseUrl`. Also `nodetool.text.HtmlToText`.
+
+### SVG
+
+`lib.svg.Document`, `lib.svg.Rect`, `lib.svg.Circle`, `lib.svg.Ellipse`, `lib.svg.Line`,
+`lib.svg.Path`, `lib.svg.Polygon`, `lib.svg.Text`, `lib.svg.Gradient`, `lib.svg.Transform`,
+`lib.svg.ClipPath`, `lib.svg.DropShadow`, `lib.svg.GaussianBlur`, `lib.svg.SVGToImage`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/text-nodes/package.json
+++ b/packages/text-nodes/package.json
@@ -57,5 +57,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/text-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/text-nodes/package.json
+++ b/packages/text-nodes/package.json
@@ -69,5 +69,22 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "text",
+    "text-processing",
+    "nlp",
+    "markdown",
+    "html",
+    "svg"
+  ]
 }

--- a/packages/timeline/README.md
+++ b/packages/timeline/README.md
@@ -1,0 +1,50 @@
+# @nodetool-ai/timeline
+
+Core timeline types and status models for the NodeTool timeline feature for [NodeTool](https://nodetool.ai).
+
+The canonical type layer plus pure editing math for NodeTool's video timeline: sequences, tracks, clips, markers, versions, and status values, along with framework-free helpers for splitting, trimming, snapping, placement, and staleness detection. Blend modes are re-exported from `@nodetool-ai/gpu` so the timeline preview compositor agrees with the sketch editor and Compositor node.
+
+## Install
+
+```bash
+npm install @nodetool-ai/timeline
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `TimelineSequence` | interface | Top-level sequence (tracks, clips, markers, transcript) |
+| `TimelineTrack` | interface | A track within a sequence |
+| `TimelineClip` | interface | A clip placed on a track |
+| `TimelineMarker` | interface | A timeline marker |
+| `ClipStatus` | type | `draft`, `queued`, `generating`, `generated`, `stale`, … |
+| `BlendMode` | type | Re-exported from `@nodetool-ai/gpu` |
+| `makeSequence` / `makeTrack` / `makeClip` / `makeMarker` | function | Factories for default sequence, track, clip, and marker |
+| `makeClipVersion` / `makeTrackEffect` | function | Factories for a clip version and a track effect |
+| `createTimeOrderedUuid` | function | Time-ordered UUID for stable ids |
+| `splitClip` | function | Split a clip at a time into two clips |
+| `trimClip` | function | Trim a clip's in/out points |
+| `snap` | function | Snap a time value to nearby points |
+| `sourceRate` | function | Compute a clip's source playback rate |
+| `resolveSnap` / `buildSnapPoints` | function | Snapping resolution and snap-point construction |
+| `resolveTrackPlacement` | function | Resolve where a clip lands across tracks |
+| `computeStaleSet` | function | Determine which clips are stale |
+
+The Node-only `computeDependencyHash` lives at the `@nodetool-ai/timeline/dependencyHash` subpath (it depends on `node:crypto`).
+
+## Usage
+
+```ts
+import { makeSequence, makeClip, splitClip } from "@nodetool-ai/timeline";
+
+const sequence = makeSequence({ name: "Intro", fps: 30 });
+const clip = makeClip({ startMs: 0, durationMs: 5000 });
+
+const [head, tail] = splitClip(clip, 2000);
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -51,5 +51,15 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "timeline",
+    "video-editing",
+    "types"
   ]
 }

--- a/packages/together-nodes/README.md
+++ b/packages/together-nodes/README.md
@@ -1,7 +1,8 @@
 # @nodetool-ai/together-nodes
 
-Together AI media nodes for NodeTool — one workflow node per Together
-[serverless model](https://docs.together.ai/docs/serverless/models), covering:
+Together AI media nodes for [NodeTool](https://nodetool.ai) — one workflow node
+per Together [serverless model](https://docs.together.ai/docs/serverless/models),
+covering:
 
 | Modality | Models | Nodes |
 | --- | --- | --- |
@@ -15,6 +16,17 @@ Together AI media nodes for NodeTool — one workflow node per Together
 **56 nodes total.** Chat / LLM and embedding capabilities are not surfaced as
 per-model nodes here — they are served by the generic Agent / Embedding nodes
 through `TogetherProvider` in `@nodetool-ai/runtime`.
+
+## Install
+
+```bash
+npm install @nodetool-ai/together-nodes
+```
+
+## Configuration
+
+Set `TOGETHER_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an
+environment variable.
 
 ## Architecture
 
@@ -51,3 +63,8 @@ npm test
 
 Edit the catalog (model ids / names / supported tasks) or the per-modality field
 templates in that script, then re-run `gen:manifest`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/together-nodes/package.json
+++ b/packages/together-nodes/package.json
@@ -47,5 +47,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "together-ai",
+    "llm",
+    "model-nodes"
   ]
 }

--- a/packages/topaz-nodes/README.md
+++ b/packages/topaz-nodes/README.md
@@ -1,0 +1,36 @@
+# @nodetool-ai/topaz-nodes
+
+Topaz Labs image and video enhancement nodes for [NodeTool](https://nodetool.ai).
+
+Run the [Topaz Labs](https://www.topazlabs.com) API inside NodeTool workflows: upscale, sharpen, denoise, restore, and matte images, plus enhance and frame-interpolate video.
+
+## Install
+
+```bash
+npm install @nodetool-ai/topaz-nodes
+```
+
+## Nodes
+
+| Node | Type | Description |
+| --- | --- | --- |
+| Topaz Enhance Image | `topaz.image.EnhanceImage` | Precision upscale and enhance with Topaz models. |
+| Topaz Enhance Image (Generative) | `topaz.image.EnhanceImageGenerative` | Generative upscale and enhance. |
+| Topaz Sharpen Image | `topaz.image.SharpenImage` | Sharpen and deblur. |
+| Topaz Sharpen Image (Generative) | `topaz.image.SharpenImageGenerative` | Generative sharpen. |
+| Topaz Denoise Image | `topaz.image.DenoiseImage` | Remove noise. |
+| Topaz Denoise Image (Generative) | `topaz.image.DenoiseImageGenerative` | Generative denoise. |
+| Topaz Adjust Lighting | `topaz.image.AdjustLighting` | Adjust image lighting. |
+| Topaz Restore Image | `topaz.image.RestoreImage` | Restore degraded images. |
+| Topaz Matte Image | `topaz.image.MatteImage` | Generate a subject matte. |
+| Topaz Enhance Video | `topaz.video.EnhanceVideo` | Upscale and enhance video. |
+| Topaz Interpolate Video | `topaz.video.InterpolateVideo` | Interpolate frames for higher frame rate. |
+
+## Configuration
+
+Set `TOPAZ_API_KEY` in NodeTool's secret store (Settings → API Keys) or as an environment variable.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/topaz-nodes/package.json
+++ b/packages/topaz-nodes/package.json
@@ -45,5 +45,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "topaz",
+    "topaz-labs",
+    "image-enhancement",
+    "video-enhancement",
+    "upscaling"
   ]
 }

--- a/packages/transformers-js-nodes/README.md
+++ b/packages/transformers-js-nodes/README.md
@@ -1,0 +1,32 @@
+# @nodetool-ai/transformers-js-nodes
+
+Hugging Face Transformers.js nodes for [NodeTool](https://nodetool.ai).
+
+Run NLP, vision, and audio models locally in visual AI workflows via
+Transformers.js and ONNX Runtime — no API keys, no cloud. Models download from
+the Hugging Face Hub on first use and are cached on disk.
+
+## Install
+
+```bash
+npm install @nodetool-ai/transformers-js-nodes
+```
+
+## Nodes
+
+All node types are under the `transformers.*` namespace.
+
+**Text** — `TextClassification`, `TokenClassification`, `QuestionAnswering`,
+`Summarization`, `Translation`, `TextGeneration`, `FillMask`,
+`FeatureExtraction`, `ZeroShotClassification`.
+
+**Vision** — `ImageClassification`, `ObjectDetection`, `ImageToText`,
+`ZeroShotImageClassification`.
+
+**Audio** — `AutomaticSpeechRecognition`, `AudioClassification`,
+`TextToSpeech`.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/transformers-js-nodes/package.json
+++ b/packages/transformers-js-nodes/package.json
@@ -51,5 +51,21 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "transformers-js",
+    "onnx",
+    "local-inference",
+    "nlp",
+    "vision"
   ]
 }

--- a/packages/transformers-js-provider/README.md
+++ b/packages/transformers-js-provider/README.md
@@ -1,0 +1,40 @@
+# @nodetool-ai/transformers-js-provider
+
+Local-models BaseProvider backed by @huggingface/transformers and kokoro-js (chat, TTS, ASR, embeddings) for [NodeTool](https://nodetool.ai).
+
+Runs models locally in-process — no API keys, no network — via ONNX through `@huggingface/transformers`, with kokoro-js for text-to-speech. Registers a `transformers_js` provider on the NodeTool runtime registry, so chat, TTS, ASR, and embedding calls route to local inference like any other provider.
+
+## Install
+
+```bash
+npm install @nodetool-ai/transformers-js-provider
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `TransformersJsProvider` | class | Local-models `BaseProvider` (chat, TTS, ASR, embeddings) |
+| `registerTransformersJsProvider` | function | Register the provider as `transformers_js` on the runtime registry (idempotent) |
+| `discoverLanguageModels` | function | Discover available local chat models |
+| `discoverTTSModels` | function | Discover available local text-to-speech models |
+| `discoverASRModels` | function | Discover available local speech-recognition models |
+| `discoverEmbeddingModels` | function | Discover available local embedding models |
+
+## Usage
+
+```ts
+import { registerTransformersJsProvider } from "@nodetool-ai/transformers-js-provider";
+import { getRegisteredProvider } from "@nodetool-ai/runtime";
+
+// During server bootstrap
+registerTransformersJsProvider();
+
+// Later, resolve the provider class from the registry and use it like any other
+const ProviderClass = getRegisteredProvider("transformers_js");
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/transformers-js-provider/package.json
+++ b/packages/transformers-js-provider/package.json
@@ -48,5 +48,19 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "transformers-js",
+    "local-models",
+    "onnx",
+    "tts",
+    "asr",
+    "embeddings",
+    "kokoro"
   ]
 }

--- a/packages/vectorstore/README.md
+++ b/packages/vectorstore/README.md
@@ -1,0 +1,62 @@
+# @nodetool-ai/vectorstore
+
+SQLite-vec vector store for [NodeTool](https://nodetool.ai) — embeddings, collections, and semantic search for RAG.
+
+A backend-agnostic vector provider abstraction with a local SQLite-vec implementation (plus Pinecone and Supabase providers), document chunking, and embedding functions for OpenAI, Ollama, Gemini, Mistral, Cohere, Voyage, and Jina.
+
+## Install
+
+```bash
+npm install @nodetool-ai/vectorstore
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+|---|---|---|
+| `VectorProvider`, `VectorCollection` | interface | Backend-agnostic vector store contract |
+| `SqliteVecProvider` | class | Local SQLite-vec provider |
+| `PineconeProvider` | class | Pinecone-backed provider |
+| `SupabaseProvider` | class | Supabase (pgvector) provider |
+| `createVectorProviderFromEnv`, `getDefaultVectorProvider`, `setDefaultVectorProvider` | function | Resolve / configure the default provider |
+| `createSqliteVecProvider` | function | Construct a local provider directly |
+| `resolveCollection` | function | Get a collection through the default provider, inferring its embedding function |
+| `getProviderEmbeddingFunction` | function | Build an embedding function for a model / provider |
+| `OpenAIEmbeddingFunction`, `OllamaEmbeddingFunction`, `GeminiEmbeddingFunction`, `MistralEmbeddingFunction`, `CohereEmbeddingFunction`, `VoyageEmbeddingFunction`, `JinaEmbeddingFunction` | class | Provider-specific embedding functions |
+| `splitDocument` | function | Chunk a document into overlapping text segments |
+| `SqliteVecStore`, `VecCollection`, `getDefaultStore` | class / function | Low-level SQLite-vec handle (prefer `VectorProvider`) |
+| `VectorRecord`, `VectorMatch`, `VectorQuery`, `DistanceMetric`, `RecordMetadata` | type | Query and record value types |
+| `CollectionNotFoundError`, `ProviderConfigError`, `UnsupportedFilterError` | class | Error types |
+
+## Usage
+
+```ts
+import {
+  getDefaultVectorProvider,
+  getProviderEmbeddingFunction,
+  splitDocument
+} from "@nodetool-ai/vectorstore";
+
+const provider = getDefaultVectorProvider();
+const ef = getProviderEmbeddingFunction("text-embedding-3-small", "openai");
+
+const collection = await provider.getOrCreateCollection({
+  name: "docs",
+  embeddingFunction: ef,
+  metadata: { embedding_model: "text-embedding-3-small", embedding_provider: "openai" }
+});
+
+const chunks = splitDocument("...long document...", "doc-1", 1000, 200);
+await collection.upsert(
+  chunks.map((c, i) => ({ id: `doc-1:${i}`, document: c.text }))
+);
+
+const results = await collection.query({ text: "what is nodetool?", topK: 5 });
+```
+
+The default provider is chosen from the environment (`createVectorProviderFromEnv`), defaulting to local SQLite-vec at `VECTORSTORE_DB_PATH`. When a collection stores `embedding_model` / `embedding_provider` metadata, `resolveCollection` reattaches the right embedding function for you.
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/vectorstore/package.json
+++ b/packages/vectorstore/package.json
@@ -51,5 +51,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "vector-store",
+    "rag",
+    "embeddings",
+    "sqlite-vec",
+    "semantic-search"
   ]
 }

--- a/packages/video-nodes/README.md
+++ b/packages/video-nodes/README.md
@@ -1,0 +1,58 @@
+# @nodetool-ai/video-nodes
+
+Video and 3D-model nodes for [NodeTool](https://nodetool.ai).
+
+A pack of video-processing and 3D-mesh nodes for NodeTool workflows: trim, concat,
+and transform video; apply color and effects; run AI video generation and lip-sync;
+edit timelines; and load, repair, and convert 3D models.
+
+## Install
+
+```bash
+npm install @nodetool-ai/video-nodes
+```
+
+## Nodes
+
+### Video I/O
+
+- `nodetool.video.LoadVideoFile`, `nodetool.video.LoadVideoAssets`
+- `nodetool.video.SaveVideo`, `nodetool.video.SaveVideoFile`
+- `nodetool.video.GetVideoInfo`
+
+### Editing and transform
+
+- `nodetool.video.Trim`, `nodetool.video.Concat`, `nodetool.video.Reverse`, `nodetool.video.SetSpeed`, `nodetool.video.Fps`
+- `nodetool.video.Resize`, `nodetool.video.Rotate`, `nodetool.video.Overlay`, `nodetool.video.Transition`
+- `nodetool.video.ExtractFrame`, `nodetool.video.FrameToVideo`, `nodetool.video.ForEachFrame`
+- `nodetool.video.AddAudio`, `nodetool.video.ExtractAudio`, `nodetool.video.AddSubtitles`
+
+### Color and effects
+
+- `nodetool.video.Blur`, `nodetool.video.Sharpness`, `nodetool.video.Denoise`, `nodetool.video.Stabilize`
+- `nodetool.video.ChromaKey`, `nodetool.video.ColorBalance`, `nodetool.video.Saturation`
+
+### AI generation
+
+- `nodetool.video.TextToVideo`, `nodetool.video.ImageToVideo`, `nodetool.video.VideoToVideo`
+- `nodetool.video.LipSync`
+
+### Timeline
+
+Assemble clips and render a multi-track timeline.
+
+- `nodetool.timeline.AddClips`, `nodetool.timeline.RenderTimeline`, `nodetool.timeline.Transcript`
+
+### 3D models
+
+Load, generate, transform, and repair meshes.
+
+- I/O and metadata: `nodetool.model3d.LoadModel3DFile`, `nodetool.model3d.SaveModel3D`, `nodetool.model3d.SaveModel3DFile`, `nodetool.model3d.FormatConverter`, `nodetool.model3d.GetModel3DMetadata`
+- Generation: `nodetool.model3d.TextTo3D`, `nodetool.model3d.ImageTo3D`
+- Transform: `nodetool.model3d.Transform3D`, `nodetool.model3d.CenterMesh`, `nodetool.model3d.NormalizeModel3D`
+- Mesh ops: `nodetool.model3d.Decimate`, `nodetool.model3d.RepairMesh`, `nodetool.model3d.MergeMeshes`, `nodetool.model3d.Boolean3D`, `nodetool.model3d.FlipNormals`, `nodetool.model3d.RecalculateNormals`, `nodetool.model3d.ExtractLargestComponent`
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/video-nodes/package.json
+++ b/packages/video-nodes/package.json
@@ -52,5 +52,17 @@
   "files": [
     "dist",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/video-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/video-nodes/package.json
+++ b/packages/video-nodes/package.json
@@ -64,5 +64,20 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "video",
+    "video-processing",
+    "3d",
+    "3d-models"
+  ]
 }

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -102,5 +102,17 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "websocket",
+    "fastify",
+    "server",
+    "api",
+    "realtime"
   ]
 }

--- a/packages/workflow-runner/README.md
+++ b/packages/workflow-runner/README.md
@@ -1,0 +1,57 @@
+# @nodetool-ai/workflow-runner
+
+Portable workflow runner — turns a graph + NodeRegistry into a `(Request) => Response` handler for Vercel, Cloudflare Workers, or any Web-standard runtime, for [NodeTool](https://nodetool.ai).
+
+Wraps the kernel `WorkflowRunner` with a transport- and runtime-agnostic surface: an async-generator streaming API and a Server-Sent-Events HTTP handler built on Web-standard `Request`/`Response`/`ReadableStream`. Runs on Vercel (Node + Edge), Cloudflare Workers, Bun, and Deno. A `./browser` entry runs graphs entirely in-browser.
+
+## Install
+
+```bash
+npm install @nodetool-ai/workflow-runner
+```
+
+## Exported symbols
+
+| Symbol | Kind | Description |
+| --- | --- | --- |
+| `runWorkflow` | function | Run a graph against a `NodeRegistry`, yielding live `ProcessingMessage`s |
+| `RunWorkflowOptions` | interface | Options: graph, registry, params, context, storage, secrets, signal |
+| `GraphData` | type | `{ nodes, edges }` graph shape |
+| `createWorkflowHandler` | function | Build a `(Request) => Response` SSE handler from a registry |
+| `CreateWorkflowHandlerOptions` | interface | Handler options: registry, `createContext`, `beforeRun`, platform |
+| `WorkflowRequestBody` | interface | Parsed request body (`graph`, `params`, `workflow_id`, `job_id`) |
+| `envSecretResolver` | function | Secret resolver backed by environment variables |
+| `createBrowserRegistry` | function | Build a `NodeRegistry` of browser-runnable nodes (`./browser`) |
+| `runBrowserWorkflow` | function | Run a graph in the browser (`./browser`) |
+| `graphRunsInRegistry` | function | Check whether a graph's nodes are all present in a registry (`./browser`) |
+
+## Usage
+
+```ts
+import { createWorkflowHandler, envSecretResolver } from "@nodetool-ai/workflow-runner";
+import { NodeRegistry } from "@nodetool-ai/node-sdk";
+
+const registry = new NodeRegistry();
+// ...register the nodes available in this deployment
+
+// A Web-standard fetch handler — export it from a Vercel / Cloudflare route
+export const POST = createWorkflowHandler({
+  registry,
+  createContext: () => ({ secretResolver: envSecretResolver }) as never
+});
+```
+
+Or drive the run directly and stream messages:
+
+```ts
+import { runWorkflow } from "@nodetool-ai/workflow-runner";
+
+for await (const message of runWorkflow({ graph, registry, params })) {
+  console.log(message.type, message);
+}
+```
+
+## Links
+
+- [NodeTool](https://nodetool.ai)
+- [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/workflow-runner/package.json
+++ b/packages/workflow-runner/package.json
@@ -62,5 +62,18 @@
   "files": [
     "dist",
     "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "workflow-runner",
+    "serverless",
+    "vercel",
+    "cloudflare-workers",
+    "edge",
+    "web-standard"
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive README documentation and standardized package metadata (repository, homepage, bugs, keywords, publishConfig) to all 55 npm workspace packages. Each README documents the package's purpose, installation, exported symbols/nodes, and usage patterns.

## Key Changes

- **README files**: Added detailed `README.md` to every package, covering:
  - Package purpose and key features
  - Installation instructions
  - Exported symbols/API surface with descriptions
  - Node listings (for node packages) organized by category
  - Usage examples where applicable

- **Package metadata**: Updated `package.json` in all packages with:
  - `repository` field pointing to the monorepo with package-specific directory
  - `homepage` linking to https://nodetool.ai
  - `bugs` URL for issue tracking
  - `publishConfig.access: "public"` for npm publishing
  - `keywords` array with consistent tags (`nodetool`, `ai`, `workflow`, `workflow-automation`, `typescript`, plus package-specific terms)
  - `files` array (where missing) to include `dist/` and `README.md`

## Notable Details

- READMEs follow a consistent structure across all 55 packages for discoverability
- Node packages (image-nodes, audio-nodes, text-nodes, etc.) list all available nodes organized by category
- Core infrastructure packages (config, security, auth, kernel, etc.) document their exported symbols and interfaces
- Keywords enable better npm search and discovery
- Repository metadata enables direct links from npm.js to the source code

https://claude.ai/code/session_0138MpJvpTkRgzetAM4gnXBp