### PR TITLE
Add retry logic to GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -47,10 +47,24 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment-retry.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # The Pages "syncing_files" backend step fails intermittently with a
+      # generic "Deployment failed, try again later." GitHub offers no
+      # server-side retry, so the first attempt is allowed to fail and a second
+      # attempt runs only when it does. Each call creates a fresh deployment.
       - name: Deploy to GitHub Pages
         id: deployment
+        continue-on-error: true
+        uses: actions/deploy-pages@v5
+
+      - name: Wait before retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment-retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Adds automatic retry logic to the GitHub Pages deployment step to handle intermittent failures from GitHub's "syncing_files" backend, which occasionally fails with a generic "Deployment failed, try again later." error.

## Changes
- Modified the deployment environment URL to fall back to the retry step's output if the initial deployment fails
- Added `continue-on-error: true` to the initial deployment step to allow the workflow to proceed even on failure
- Added a 30-second wait step between deployment attempts to give GitHub's backend time to recover
- Added a retry deployment step that only runs if the initial deployment fails
- Added explanatory comment documenting why the retry logic is necessary

## Implementation Details
- The initial deployment step (`steps.deployment`) now allows failures without stopping the workflow
- A conditional wait step (`if: steps.deployment.outcome == 'failure'`) pauses for 30 seconds before retrying
- The retry step (`steps.deployment-retry`) only executes when the first attempt fails
- The environment URL uses a conditional expression to prefer the initial deployment output, falling back to the retry output if needed
- Both deployment steps use the same action (`actions/deploy-pages@v5`) and create fresh deployments on each attempt

https://claude.ai/code/session_01TxuCK5gfHmT7sauF4bXrtY