### PR TITLE
Kernel & runner review: analysis doc + fixes for 9 findings

### DIFF
--- a/docs/KERNEL_RUNNER_ANALYSIS.md
+++ b/docs/KERNEL_RUNNER_ANALYSIS.md
@@ -2,7 +2,15 @@
 
 Review of `packages/kernel/` (runner, actor, inbox, graph, io, correlation
 analysis, triggers, durable inbox) as of 2026-07-04. Findings are ordered by
-severity within each section. Line references are against the current source.
+severity within each section. Line references are against the source at the
+time of review (commit 21230c7).
+
+**Fix status (this PR):** findings #1, #2, #3, #4, #6, #9, #13, #16, #17 are
+fixed; #7, #11, #12 now emit warnings instead of failing silently (see the
+follow-up commits on this branch). Still open, pending a design decision:
+#5 (control-response attribution needs an event id echoed through the
+actor), #8 (`RunResult.outputs` accumulation semantics), #10 (backpressure
+defaults), #14, #15, and the smaller issues.
 
 ## Bugs
 

--- a/docs/KERNEL_RUNNER_ANALYSIS.md
+++ b/docs/KERNEL_RUNNER_ANALYSIS.md
@@ -1,0 +1,280 @@
+# Kernel & WorkflowRunner review — bugs, issues, design flaws
+
+Review of `packages/kernel/` (runner, actor, inbox, graph, io, correlation
+analysis, triggers, durable inbox) as of 2026-07-04. Findings are ordered by
+severity within each section. Line references are against the current source.
+
+## Bugs
+
+### 1. Edge status regresses from `completed` back to `active` at run end
+
+`_incrementEdgeCounter` throttles `edge_update` emissions and marks throttled
+edges dirty (`runner.ts:1623-1625`). `_sendEOS` emits the terminal
+`status: "completed"` update (`runner.ts:1473-1479`) but never clears the
+edge from `_edgeCounterDirty`. At run end, `_drainActiveEdges` calls
+`_flushEdgeCounters` (`runner.ts:1643-1654`), which re-emits
+`status: "active"` for every dirty edge — including edges already reported
+completed. Any edge that received a message within the last
+`EDGE_UPDATE_MIN_INTERVAL_MS` before its source finished ends the run with
+`completed` followed by `active` as its final message. Fix: clear the edge
+from `_edgeCounterDirty` (and stamp `_edgeCounterLastEmitMs`) inside
+`_sendEOS`, or have `_flushEdgeCounters` skip edges whose EOS was already
+emitted (`_eosSentEdges` is available).
+
+### 2. Behavior-flag hydration is OR-based, so stale saved `true` flags can never be corrected
+
+`Graph.loadFromDict` computes
+`is_streaming_input: descriptorDefaults.is_streaming_input || node.is_streaming_input || false`
+(`graph.ts:437-457`), same for `is_streaming_output`, `is_controlled`,
+`is_join_node`. The comments claim the registry is the source of truth and
+saved JSON is "a cache that gets overwritten", and `input_mode` /
+`output_correlation` really are overwritten — but the boolean flags are ORed.
+If a node type migrates from streaming to buffered (or stops being a join
+node), every saved workflow keeps the stale `true` and runs the wrong
+execution mode, with no way to fix it short of re-saving the graph. The
+actor trusts these flags to pick `run()` vs `process()` vs `_runControlled`,
+so this silently changes execution semantics. Fix: treat the registry value
+as authoritative when the resolver returned a descriptor
+(`descriptorDefaults.is_streaming_input ?? node.is_streaming_input ?? false`
+is still wrong; it should be
+`descriptorDefaults.is_streaming_input ?? false` when the registry resolved,
+falling back to the saved value only for unresolved/dynamic types).
+
+### 3. `pushInputValue` bypasses the input node's `process()`
+
+`_dispatchInputs` runs the input node's executor so transforming inputs
+(StringInput `max_length`, DocumentFileInput building a `DocumentRef`,
+MessageDeconstructor splitting) emit their declared per-handle outputs
+(`runner.ts:938-951`). `pushInputValue` (`runner.ts:337-367`) puts the raw
+value straight onto outgoing edges. The same input node behaves differently
+depending on whether the value arrived as a start param or was streamed in —
+streamed values skip validation/transformation entirely and leak the raw
+value to every edge regardless of `sourceHandle` semantics. It also stamps a
+different `source_edge_id` (`external:...` vs the real edge id), which will
+not match the per-edge lineage-done/closed bookkeeping keyed by real edge
+ids.
+
+### 4. Controlled-node wait can deadlock the whole run
+
+`_runControlled` refuses to process any control event until *every* data
+handle has produced at least one value (`actor.ts:1301-1303`,
+`_waitForDataInputs` at `actor.ts:1341-1377`). The wait loop only exits when
+all handles are satisfied or the inbox is fully drained — and "fully
+drained" includes `__control__`, which stays open while the controller is
+alive. Two realistic shapes hang forever:
+
+- An upstream node completes without emitting on the controlled node's data
+  handle (filter/conditional output). The handle closes but `pending` never
+  empties, control events are held aside indefinitely, and a controller
+  awaiting `sendControlEvent` never resolves → `_processGraph`'s
+  `Promise.all` never settles. No timeout exists anywhere on this path.
+- An agent both controls the node and (directly or transitively) produces
+  its data input: the agent awaits the control response before emitting
+  data; the controlled node awaits data before answering.
+
+The runner already rejects pending control responses when the *controlled*
+actor finishes, but here the controlled actor never finishes. At minimum the
+wait should give up when all data handles are closed (drop `pending` handles
+whose upstream count reached zero), mirroring how `_runCorrelatedImpl`
+treats closed empty-scope handles as "use defaults".
+
+### 5. `sendControlEvent` responses are matched to the wrong output when event sources mix
+
+`_sendMessages` resolves the oldest pending `sendControlEvent` waiter on
+*any* output emission from the target node (`runner.ts:1357-1364`). The FIFO
+assumption holds only when `sendControlEvent` is the sole source of control
+events. If the same node is also driven by a control *edge*
+(`__control_output__` routing) or by `dispatchControlEvent`, an edge-driven
+firing's outputs resolve a `sendControlEvent` waiter that belongs to a
+different event. The agent then receives another invocation's result. The
+response should be correlated to the event (e.g. stamp an event id on the
+ControlEvent and echo it through the actor), not inferred from global output
+order.
+
+### 6. `_dispatchInputs` falls back to leaking the raw value on missing handles
+
+`handleValue = nodeOutputs[edge.sourceHandle] !== undefined ? ... : value`
+(`runner.ts:958-961`). The fallback exists for test doubles returning `{}`,
+but it applies per-edge: a real input node with several declared outputs
+that legitimately omits one (e.g. "no attachments") gets the raw input value
+delivered on that edge instead of nothing. Downstream receives a value of
+the wrong type/shape. The fallback should trigger only when `process()`
+returned an entirely empty record, not per-handle.
+
+### 7. Streaming-input node without `run()` silently ignores all its inputs
+
+The legacy fallback (`actor.ts:388-399`) calls `process()` once with only
+the node's own properties. Data queued on its inbox is never read; it is
+reported only as a post-run "pending inbox work" warning. A misdeclared node
+(registry says `is_streaming_input`, implementation has no `run`) drops all
+upstream data while the run still reports `completed`. This should be a node
+error, not a silent fallback.
+
+### 8. `RunResult.outputs` keeps only the last firing of multi-fire terminal nodes
+
+Output collection stores `result.outputs`, which is the actor's
+`_latestResult` — the last invocation's record (`runner.ts:1099-1110`,
+`actor.ts:473`). A terminal node fired once per streamed item contributes
+only its final values to `RunResult.outputs`; earlier firings survive only
+as `output_update` messages. The `Record<string, unknown[]>` shape suggests
+accumulation was intended. Also, `Object.values(result.outputs)` flattens
+multiple output handles into one array, losing handle names, and
+`_isOutputNode` is "no outgoing data edges" (`runner.ts:1717-1721`), so a
+controller agent with only a control edge out also lands in workflow
+outputs, and two terminal nodes sharing a `name` merge into one bucket.
+
+### 9. `TriggerWakeupService` defeats `DurableInbox`'s append serialization
+
+`DurableInbox.append` chains appends per *instance* because
+getMaxSeq→save is a read-modify-write (`durable-inbox.ts:196-222`). But
+`deliverTriggerInput` constructs a fresh `DurableInbox` per call over the
+shared store (`trigger-wakeup.ts:88-89`), so concurrent deliveries for the
+same (run, node) each get their own no-op chain, read the same `maxSeq`, and
+persist duplicate `seq` values — corrupting the ordering that `findPending`
+sorts by. The service should cache one `DurableInbox` per (runId, nodeId).
+
+## Design flaws / risks
+
+### 10. No backpressure in production, and the correlated scheduler can't be backpressured at all
+
+No production caller passes `bufferLimit`, so every inbox is unbounded
+(`runner.ts:771`). Independently, `_runCorrelatedImpl` eagerly drains the
+inbox into actor-local buckets (`maxBuckets`, sticky maps), so even with a
+`bufferLimit`, buffered nodes release inbox backpressure immediately and
+buffering just moves into the actor. The only guards are
+`maxPendingKeys`/`maxPendingMessagesPerKey` (10k × 10k envelopes). A fast
+producer feeding a slow consumer grows the heap without bound; audio-rate
+streams make this practical, not theoretical.
+
+### 11. Unmigrated streaming producers silently collapse to last-value-wins downstream
+
+The analyzer defaults missing `output_correlation` to `single` with
+`repeats: false` (`correlation-analysis.ts:480`). A custom/legacy node that
+emits many values on one slot (without declaring `chunk`/`iteration`) feeds
+a downstream buffered handle classified `empty`-scope sticky
+(`actor.ts:568-579`), where each arrival overwrites the previous
+(`actor.ts:813-816`) and the node fires once at close with only the last
+value. Pre-correlation semantics fired per message. Correctness of every
+third-party node now hinges on correlation metadata being declared; the
+failure mode is silent data loss. There is no warning when multiple
+envelopes overwrite an empty-scope sticky slot — emitting one would make the
+migration gap visible.
+
+### 12. Non-driver duplicate keys are silently dropped inside the actor
+
+In `_runCorrelatedImpl` with no repeating driver, a key fires once
+(`fired` set, `actor.ts:727-738`); a second envelope arriving for the same
+key on a max-scope handle stays in the actor-local bucket forever. Unlike
+inbox-stranded data, `_checkPendingInboxWork` cannot see it (the envelope
+was already popped), so the loss is completely silent.
+
+### 13. `Graph` mutates caller-owned node descriptors
+
+`_detectControlledNodes` writes `is_controlled = true` onto the node objects
+passed in (`graph.ts:515-525`), and the runner passes the caller's
+`graphData.nodes` through (bypass rewrite preserves object identity). A
+`WorkflowRunner.run()` therefore mutates the caller's graph data despite the
+`readonly` typing. Harmless today, but it leaks state across runs and
+violates the descriptor contract.
+
+### 14. Control context exposes every property value to the LLM
+
+`_buildControlContext` embeds all non-underscore property values of
+controlled nodes as tool-schema defaults (`runner.ts:1810-1900`). If a
+controlled node carries a sensitive string property (token, endpoint,
+prompt containing PII), it is shipped into the controller LLM's tool
+definitions. Similarly, `generation_complete` rides all scalar resolved
+inputs into persisted asset metadata (`actor.ts:149-164`). Both need a
+notion of secret/sensitive properties to redact.
+
+### 15. Trigger watchdog restarts forever with no backoff
+
+`_watchdogCheck` restarts `failed`/`completed` jobs every tick
+(`trigger-manager.ts:337-374`). A workflow that fails at startup restarts
+every 30 s indefinitely — no backoff, no retry cap, no circuit breaker.
+`getInstance` also silently ignores differing `opts` on subsequent calls,
+and only the latest watchdog check is awaited by `shutdown`
+(`_watchdogCheckInFlight` is overwritten per tick), so an older,
+still-running check can theoretically revive a job after shutdown's await.
+
+### 16. Two job ids per run
+
+`edge_update` messages use `this.jobId` from the constructor while
+`job_update` uses `request.job_id` (`runner.ts:1629-1635` vs 473-478).
+Callers that pass different values get edge updates that clients cannot
+associate with the job. One of the two should win (or the constructor id
+should be dropped).
+
+### 17. Runner instance lifecycle races
+
+`_resetRunState()` runs at the top of `_runImpl`, so `cancel()` called
+between construction and `run()` is silently lost (`_cancelled` reset,
+fresh `AbortController`). A second `run()` on the same instance while the
+first is in flight clobbers all shared state. Cheap fix: latch a
+"cancelled before start" flag and reject concurrent `run()`.
+
+## Smaller issues
+
+- **Inbox arrival queue is O(n²)** — `_arrival` is a plain array;
+  `_removeFromArrival` does `indexOf`+`splice` per consumed envelope and
+  `prepend` does `unshift` (`inbox.ts:113`, `579-585`). With deep backlogs
+  (audio-rate streams, list aggregation) this degrades quadratically. A
+  per-handle counter or linked list removes the scans.
+- **`_notifyWaiters` / `_notifyPutWaiters` wake every waiter** while their
+  doc comments say "wake one" (`inbox.ts:552-566`) — thundering herd on hot
+  streams; each `put` wakes all consumers and all blocked producers.
+- **`put()` on a closed inbox silently drops data** and returns normally
+  (`inbox.ts:202`); fine for cancellation, but producers cannot distinguish
+  delivered from dropped.
+- **`_emitNodeStatus("running")` fires at actor start**, before any input
+  arrives (`actor.ts:303`), so every node in the graph shows "running"
+  immediately; there is no "waiting for inputs" state.
+- **`getInputSchema`/`getOutputSchema` classify nodes by
+  `type.includes("Input")`** (`graph.ts:772-783`) while the runner uses
+  `type.startsWith("nodetool.input.")` — the two predicates disagree for
+  types like `...InputSanitizer`, and every schema property is marked
+  `required` even when a default exists.
+- **A node that is both `is_streaming_input` and `is_controlled`** takes the
+  streaming branch and its control events are never consumed
+  (`actor.ts:310-401` branch order); combinations of behavior flags are not
+  validated.
+- **`_runControlled` ignores `_listInputHandles` and lineage** — multi-edge
+  list inputs to controlled nodes keep only the latest value
+  (`actor.ts:1384-1395`).
+- **Duplicate `__control_output__` routing is possible by edge shape**: the
+  runner routes `__control_output__` to all control edges, then the edge
+  loop routes `outputs[edge.sourceHandle]` again (`runner.ts:1154-1227`).
+  Convention (`sourceHandle: "__control__"`) prevents overlap today, but an
+  edge saved with `sourceHandle: "__control_output__"` would deliver the
+  event twice; nothing validates control-edge source handles.
+- **`MemoryDurableInboxStore` is O(n) per operation** over one flat array —
+  acceptable for tests, but it is also the default store used by
+  `TriggerWakeupService` in production paths, and `TriggerInput` records
+  accumulate until an explicit `cleanupProcessed` call.
+
+## What is solid
+
+Cycle handling is sound end-to-end (data cycles rejected by the
+correlation topo sort, self-loops by `validateEdgeEndpoints`, control
+cycles by DFS). The double-EOS guard (`_eosSentEdges`), per-unique-controller
+`__control__` counting, the FIFO queue for control responses replacing the
+old single-slot resolver, the held-control-events fix in
+`_waitForDataInputs`, and the pending-start dedup in
+`TriggerWorkflowManager` all show earlier races were found and fixed with
+regression tests. The message-retention cap and audio-chunk exclusion in
+`_emit` are well reasoned. The Stryker annotations indicate real mutation
+coverage.
+
+## Suggested priority
+
+1. Flag hydration OR-logic (#2) — silent wrong execution mode on saved
+   graphs.
+2. Controlled-node deadlock (#4) and control-response attribution (#5) —
+   hangs and wrong agent results at runtime.
+3. Streaming-migration last-value collapse (#11) + duplicate-key silent drop
+   (#12) — silent data loss; at minimum emit warnings.
+4. `pushInputValue` transformation bypass (#3) and dispatch fallback leak
+   (#6).
+5. Edge status regression (#1) — small, contained UI fix.
+6. Backpressure story (#10) — decide on a default `bufferLimit` and a
+   bucket-level cap that actually applies to buffered nodes.

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -385,7 +385,27 @@ export class NodeActor {
         } else {
           // Legacy fallback: call process() once with the node's own
           // property values, matching the defaults merge every other
-          // execution path applies.
+          // execution path applies. process() reads no inbox data, so any
+          // value queued on a connected data handle is dropped. Surface that
+          // instead of completing silently: the node is misdeclared (registry
+          // says is_streaming_input, implementation has no run()). Downgraded
+          // to a warning rather than a hard error because existing fixtures
+          // rely on the fallback firing with connected inputs.
+          const droppedHandles = this.inbox
+            .handles()
+            .filter((h) => h !== "__control__");
+          if (droppedHandles.length > 0) {
+            const warning =
+              `streaming-input node ${this.node.type} has no run() ` +
+              `implementation but has connected inputs ` +
+              `(${droppedHandles.join(", ")}); data would be silently dropped`;
+            // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+            log.warn(warning, {
+              nodeId: this.node.id,
+              type: this.node.type
+            });
+            this._emitNodeStatus("warning", undefined, warning);
+          }
           const outputs = await this._executor.process(
             {
               ...(this.node.properties ?? {}),
@@ -591,6 +611,10 @@ export class NodeActor {
     const maxBuckets = new Map<string, Map<string, MessageEnvelope[]>>();
     const prefixSticky = new Map<string, Map<string, MessageEnvelope>>();
     const emptySticky = new Map<string, MessageEnvelope>();
+    // Handles already warned about empty-scope overwrite (§11): warn once per
+    // handle per run so an unmigrated stream collapsing to last-value-wins is
+    // visible without flooding the log.
+    const emptyStickyWarned = new Set<string>();
     // Multi-edge list inputs accumulate every envelope instead of
     // overwriting; drained as an array when the node fires.
     const emptyListEnvelopes = new Map<string, MessageEnvelope[]>();
@@ -813,6 +837,17 @@ export class NodeActor {
         if (isListInput(handle)) {
           emptyListEnvelopes.get(handle)!.push(envelope);
         } else {
+          if (emptySticky.has(handle) && !emptyStickyWarned.has(handle)) {
+            emptyStickyWarned.add(handle);
+            // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+            log.warn(
+              `Node "${this.node.id}" handle "${handle}" received multiple ` +
+                `values at empty scope; only the last is kept. Declare ` +
+                `output_correlation (chunk/iteration) on the upstream output ` +
+                `to preserve the stream.`,
+              { nodeId: this.node.id, handle }
+            );
+          }
           emptySticky.set(handle, envelope);
         }
         // Empty-scope arrival can unblock any pending max-scope key.
@@ -879,6 +914,36 @@ export class NodeActor {
         this._lastEnvelopes = envelopes;
         await this._executeWithInputs(values);
         fired.add("");
+      }
+    }
+
+    // Envelopes still stranded in actor-local buckets at close are invisible to
+    // the runner's post-run pending-inbox check (they were already popped). §12.
+    // With no repeating driver a key fires at most once, so a second max-scope
+    // envelope for an already-fired key is dropped silently; a key that never
+    // reached readiness keeps its envelopes too. Warn for both so the loss is
+    // not silent. Scheduling is unchanged.
+    for (const [handle, buckets] of maxBuckets) {
+      for (const [key, bucket] of buckets) {
+        if (bucket.length === 0) continue;
+        if (fired.has(key)) {
+          // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+          log.warn(
+            `Node "${this.node.id}" dropped ${bucket.length} envelope(s) on ` +
+              `handle "${handle}" for key "${key}" already fired without a ` +
+              `repeating driver; declare output_correlation to fan out per ` +
+              `item.`,
+            { nodeId: this.node.id, handle, key, count: bucket.length }
+          );
+        } else {
+          // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+          log.warn(
+            `Node "${this.node.id}" left ${bucket.length} envelope(s) on ` +
+              `handle "${handle}" for key "${key}" unfired at close; its ` +
+              `inputs never completed for this key.`,
+            { nodeId: this.node.id, handle, key, count: bucket.length }
+          );
+        }
       }
     }
   }
@@ -1352,22 +1417,46 @@ export class NodeActor {
       return;
     }
 
-    // Drain items until all data handles have at least one value.
-    // Control events that arrive first are held aside and re-queued after
-    // the wait: prepending them back while still iterating would make the
-    // very next tryPopAny() pop the same event again — an unbounded
-    // microtask spin that starves the event loop and blocks the upstream
-    // data put() forever.
+    // Drain items until every data handle has a value. A handle whose upstream
+    // sources have all closed with nothing buffered can never be satisfied, so
+    // drop it from `pending` and let the node's declared default apply —
+    // mirroring how `_runCorrelatedImpl` treats a closed empty-scope handle.
+    // Without this the wait blocks forever whenever an upstream completes
+    // without emitting on a data handle (filter/conditional output), stranding
+    // held control events and hanging any controller awaiting sendControlEvent.
+    //
+    // A close wakes the inbox's internal waiters but yields no envelope, so this
+    // is a manual loop over `tryPopAnyWithEnvelope()` + `waitForActivity()`
+    // rather than a for-await: the pruning below must re-run on a closure that
+    // arrives while blocked.
+    //
+    // Control events that arrive first are held aside and re-queued after the
+    // wait: prepending them back while still iterating would make the very next
+    // pop return the same event again — an unbounded microtask spin that
+    // starves the event loop and blocks the upstream data put() forever.
     const heldControlEvents: MessageEnvelope[] = [];
-    for await (const [handle, envelope] of this.inbox.iterAnyWithEnvelope()) {
-      if (handle === "__control__") {
-        heldControlEvents.push(envelope);
+    for (;;) {
+      for (const handle of [...pending]) {
+        if (!this.inbox.isOpen(handle) && !this.inbox.hasBuffered(handle)) {
+          pending.delete(handle);
+        }
+      }
+      if (pending.size === 0) break;
+
+      const popped = this.inbox.tryPopAnyWithEnvelope();
+      if (popped) {
+        const [handle, envelope] = popped;
+        if (handle === "__control__") {
+          heldControlEvents.push(envelope);
+          continue;
+        }
+        if (!this._cachedInputs) this._cachedInputs = {};
+        this._cachedInputs[handle] = envelope.data;
+        pending.delete(handle);
         continue;
       }
-      if (!this._cachedInputs) this._cachedInputs = {};
-      this._cachedInputs[handle] = envelope.data;
-      pending.delete(handle);
-      if (pending.size === 0) break;
+
+      await this.inbox.waitForActivity();
     }
     // Re-queue held control events at the front, preserving arrival order,
     // so iterInput("__control__") consumes them next.

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -170,16 +170,17 @@ export class Graph {
   private _streamingUpstream: Set<string> | null = null;
 
   constructor(data: GraphData) {
-    this.nodes = data.nodes;
+    // Auto-detect is_controlled from incoming control edges (Python parity:
+    // BaseNode.is_controlled() checks graph edges at runtime). Affected nodes
+    // are replaced with shallow copies rather than mutated in place, so a
+    // WorkflowRunner.run() never writes back onto the caller's graph data.
+    this.nodes = Graph._withControlledFlags(data.nodes, data.edges);
     this.edges = data.edges;
     this._nodeIndex = new Map();
     this._incomingEdges = new Map();
     this._outgoingEdges = new Map();
     this._outgoingByHandle = new Map();
     this._buildIndices();
-    // Auto-detect is_controlled from incoming control edges (Python parity:
-    // BaseNode.is_controlled() checks graph edges at runtime).
-    this._detectControlledNodes();
   }
 
   /**
@@ -432,15 +433,18 @@ export class Graph {
           ...(node.outputs ?? {})
         },
         // Streaming/control flags: registry metadata (descriptorDefaults) is
-        // the source of truth.  Saved graph data may have stale or missing
-        // values, so always prefer the registry if it declares true.
+        // authoritative when it speaks. An explicit registry boolean — true OR
+        // false — wins; the saved value applies only when the resolver omits
+        // the flag (undefined), e.g. for unresolved/dynamic types. OR-ing here
+        // would let a stale saved `true` survive a registry that migrated the
+        // type to buffered/uncontrolled, silently running the wrong mode.
         is_streaming_input:
-          descriptorDefaults.is_streaming_input ||
-          node.is_streaming_input ||
+          descriptorDefaults.is_streaming_input ??
+          node.is_streaming_input ??
           false,
         is_streaming_output:
-          descriptorDefaults.is_streaming_output ||
-          node.is_streaming_output ||
+          descriptorDefaults.is_streaming_output ??
+          node.is_streaming_output ??
           false,
         // Correlation metadata is authoritative from the registry. Saved JSON
         // is treated as a cache and overwritten — including when the resolver
@@ -449,12 +453,9 @@ export class Graph {
         input_mode: descriptorDefaults.input_mode,
         output_correlation: descriptorDefaults.output_correlation,
         is_controlled:
-          descriptorDefaults.is_controlled || node.is_controlled || false,
-        // Correlation metadata is registry-authoritative; saved JSON is a
-        // cache that gets overwritten — matching `input_mode` /
-        // `output_correlation` above. See docs/correlation-design.md §1.
+          descriptorDefaults.is_controlled ?? node.is_controlled ?? false,
         is_join_node:
-          descriptorDefaults.is_join_node || node.is_join_node || false
+          descriptorDefaults.is_join_node ?? node.is_join_node ?? false
       };
 
       resolvedNodes.push(hydratedNode);
@@ -507,21 +508,29 @@ export class Graph {
   }
 
   /**
-   * Auto-detect is_controlled from incoming control edges.
-   * In Python, BaseNode.is_controlled() is a runtime method that checks
-   * the graph context. In TS, we set the flag on the descriptor so that
-   * the actor knows to use _runControlled().
+   * Return the node list with is_controlled set on every control-edge target.
+   * In Python, BaseNode.is_controlled() is a runtime method that checks the
+   * graph context; in TS we set the flag on the descriptor so the actor knows
+   * to use _runControlled(). Node objects are caller-owned (the runner passes
+   * `graphData.nodes` straight through), so a target lacking the flag is
+   * replaced with a shallow copy — the original is left untouched. Every other
+   * node keeps its identity.
    */
-  private _detectControlledNodes(): void {
-    for (const edge of this.edges) {
-      if (!isControlEdge(edge)) continue;
-      const target = this._nodeIndex.get(edge.target);
-      // Stryker disable next-line ConditionalExpression,LogicalOperator,BooleanLiteral: equivalent — control edges always have a known target here, and re-setting an already-true flag is a no-op; the guard is a micro-optimization
-      if (target && !target.is_controlled) {
-        // NodeDescriptor is readonly in the type, but we own the instances
-        (target as { is_controlled?: boolean }).is_controlled = true;
-      }
+  private static _withControlledFlags(
+    nodes: ReadonlyArray<NodeDescriptor>,
+    edges: ReadonlyArray<Edge>
+  ): ReadonlyArray<NodeDescriptor> {
+    const controlledIds = new Set<string>();
+    for (const edge of edges) {
+      if (isControlEdge(edge)) controlledIds.add(edge.target);
     }
+    if (controlledIds.size === 0) return nodes;
+    return nodes.map((node) =>
+      // Stryker disable next-line ConditionalExpression,LogicalOperator,BooleanLiteral: equivalent — re-copying an already-controlled node yields the same is_controlled value; the guard only preserves object identity (a micro-optimization)
+      controlledIds.has(node.id) && !node.is_controlled
+        ? { ...node, is_controlled: true }
+        : node
+    );
   }
 
   // -----------------------------------------------------------------------

--- a/packages/kernel/src/inbox.ts
+++ b/packages/kernel/src/inbox.ts
@@ -573,6 +573,17 @@ export class NodeInbox {
   }
 
   /**
+   * Resolve when the inbox is next notified of activity — a `put`, `prepend`,
+   * lineage signal, `markSourceDone`, or `closeAll`. Yields nothing: unlike the
+   * iterators, a close that produces no envelope still wakes the caller. Used by
+   * consumers that manage their own draining (the controlled-node wait) and must
+   * re-check handle state after an upstream close arrives while blocked.
+   */
+  async waitForActivity(): Promise<void> {
+    await this._waitForData();
+  }
+
+  /**
    * Remove the first occurrence of `handle` from the arrival queue.
    * Called after consuming from a specific handle.
    */

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -63,7 +63,7 @@ import { Graph, GraphValidationError } from "./graph.js";
 import { rewriteBypassedNodes } from "./graph-utils.js";
 import { NodeInbox } from "./inbox.js";
 import { NodeActor, type NodeExecutor } from "./actor.js";
-import { externalEdgeId, syntheticEdgeId } from "./edge-ids.js";
+import { syntheticEdgeId } from "./edge-ids.js";
 import type { CorrelationLineage } from "@nodetool-ai/protocol";
 import {
   analyzeCorrelation,
@@ -260,6 +260,29 @@ export class WorkflowRunner {
   /** Cancellation flag. */
   private _cancelled = false;
 
+  /**
+   * Latch set by `cancel()` and never cleared by `_resetRunState`. A cancel
+   * that lands between construction and `run()` would otherwise be dropped —
+   * the reset clears `_cancelled` and swaps the AbortController. `_runImpl`
+   * re-applies this latch after the reset so such a run terminates as
+   * "cancelled". §17.
+   */
+  private _cancelRequested = false;
+
+  /**
+   * True while a run is in flight. A second concurrent `run()` on the same
+   * instance would clobber all shared run state, so `_runImpl` rejects it. §17.
+   */
+  private _running = false;
+
+  /**
+   * Job id used for `edge_update` emissions during a run. Captured from
+   * `request.job_id` at the start of `_runImpl` so edge updates and
+   * `job_update` messages carry the same id; before a run starts it defaults
+   * to the constructor id. §16.
+   */
+  private _effectiveJobId: string;
+
   /** Run-level cancellation signal source; aborted by `cancel()`. */
   private _abortController = new AbortController();
 
@@ -323,6 +346,7 @@ export class WorkflowRunner {
 
   constructor(jobId: string, options: WorkflowRunnerOptions) {
     this.jobId = jobId;
+    this._effectiveJobId = jobId;
     this._options = options;
   }
 
@@ -349,6 +373,34 @@ export class WorkflowRunner {
     }
 
     for (const node of inputNodes) {
+      // Run the node's own process() so streamed values transform exactly like
+      // start params do in _dispatchInputs (StringInput max_length,
+      // DocumentFileInput building a DocumentRef, MessageDeconstructor
+      // splitting). Otherwise the same input node behaves differently depending
+      // on whether the value arrived as a param or was streamed in. This is a
+      // live-stream path, so a process() failure throws rather than silently
+      // dropping the value.
+      const executor = this._resolveExecutor(node);
+      let nodeOutputs: Record<string, unknown>;
+      try {
+        nodeOutputs = await executor.process(
+          { value },
+          this._options.executionContext
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Input node "${node.name ?? node.id}" (${node.type}) failed: ${message}`
+        );
+      }
+
+      // Same fallback semantics as _dispatchInputs: raw-value dispatch only
+      // when process() produced no defined output at all (the test-double
+      // case). Once the record carries any real output, a handle it omits
+      // stays silent rather than leaking the raw input value onto it.
+      const outputsEmpty = !Object.values(nodeOutputs).some(
+        (v) => v !== undefined
+      );
       const outgoing = this._graph
         .findOutgoingEdges(node.id)
         .filter(isDataEdge);
@@ -356,10 +408,22 @@ export class WorkflowRunner {
         if (sourceHandle && edge.sourceHandle !== sourceHandle) {
           continue;
         }
+        const hasHandleValue = nodeOutputs[edge.sourceHandle] !== undefined;
+        if (!outputsEmpty && !hasHandleValue) continue;
         const targetInbox = this._inboxes.get(edge.target);
         if (!targetInbox) continue;
-        await targetInbox.put(edge.targetHandle, value, {
-          source_edge_id: externalEdgeId(inputName, edge.sourceHandle)
+        const handleValue = hasHandleValue
+          ? nodeOutputs[edge.sourceHandle]
+          : value;
+        await targetInbox.put(edge.targetHandle, handleValue, {
+          source_edge_id:
+            edge.id ??
+            syntheticEdgeId(
+              edge.source,
+              edge.sourceHandle,
+              edge.target,
+              edge.targetHandle
+            )
         });
         this._incrementEdgeCounter(edge);
       }
@@ -422,7 +486,27 @@ export class WorkflowRunner {
     request: RunJobRequest,
     graphData: HydratedGraphData
   ): Promise<RunResult> {
+    // Reject a second concurrent run before touching any shared state — a reset
+    // here would wipe the in-flight run's inboxes/outputs/messages. §17.
+    if (this._running) {
+      throw new Error(
+        `WorkflowRunner "${this.jobId}" is already running; ` +
+          "create a new runner instance per job"
+      );
+    }
+    this._running = true;
+
     this._resetRunState();
+    this._effectiveJobId = request.job_id ?? this.jobId;
+
+    // A cancel() that landed before this run started set the latch but was
+    // undone by _resetRunState (fresh controller, _cancelled cleared). Re-apply
+    // it so the run terminates as "cancelled" rather than silently ignoring the
+    // request. §17.
+    if (this._cancelRequested) {
+      this._cancelled = true;
+      this._abortController.abort();
+    }
 
     try {
       log.info("Workflow started", {
@@ -602,6 +686,8 @@ export class WorkflowRunner {
         status: "failed",
         error: message
       };
+    } finally {
+      this._running = false;
     }
   }
 
@@ -646,6 +732,8 @@ export class WorkflowRunner {
 
   cancel(): void {
     log.info("Job cancelled", { jobId: this.jobId });
+    // Latch the request so a cancel before run() survives _resetRunState. §17.
+    this._cancelRequested = true;
     this._cancelled = true;
     // Stop producing loops (generators, pacers) that never wait on inputs —
     // closing inboxes only unblocks consumers. Nodes observe this via
@@ -949,16 +1037,27 @@ export class WorkflowRunner {
         );
       }
 
+      // Raw-value fallback only when process() produced no defined output at
+      // all (the documented test-double case, incl. `{}`). Once the record
+      // carries any real output, a handle it legitimately omits (e.g. an input
+      // with no attachments) stays silent instead of leaking the raw input
+      // value onto that edge. §6. Keyed on `!== undefined` to match the
+      // per-handle check below. The EOS pass below still closes every edge so
+      // downstream nodes complete.
+      const outputsEmpty = !Object.values(nodeOutputs).some(
+        (v) => v !== undefined
+      );
       const outgoing = this._graph
         .findOutgoingEdges(node.id)
         .filter(isDataEdge);
       for (const edge of outgoing) {
+        const hasHandleValue = nodeOutputs[edge.sourceHandle] !== undefined;
+        if (!outputsEmpty && !hasHandleValue) continue;
         const targetInbox = this._inboxes.get(edge.target);
         if (targetInbox) {
-          const handleValue =
-            nodeOutputs[edge.sourceHandle] !== undefined
-              ? nodeOutputs[edge.sourceHandle]
-              : value;
+          const handleValue = hasHandleValue
+            ? nodeOutputs[edge.sourceHandle]
+            : value;
           await targetInbox.put(edge.targetHandle, handleValue, {
             source_edge_id:
               edge.id ??
@@ -1470,9 +1569,14 @@ export class WorkflowRunner {
         }
       }
 
+      // This terminal update carries the exact final counter, so clear any
+      // dirty mark: otherwise _flushEdgeCounters at run end would re-emit
+      // status "active" after "completed" for an edge whose counter advanced
+      // within the throttle window just before its source finished. §1.
+      this._edgeCounterDirty.delete(edgeId);
       this._emit({
         type: "edge_update",
-        job_id: this.jobId,
+        job_id: this._effectiveJobId,
         edge_id: edgeId,
         status: "completed",
         counter: this._edgeCounters.get(edgeId) ?? null
@@ -1628,7 +1732,7 @@ export class WorkflowRunner {
     this._edgeCounterDirty.delete(id);
     this._emit({
       type: "edge_update",
-      job_id: this.jobId,
+      job_id: this._effectiveJobId,
       edge_id: id,
       status: "active",
       counter
@@ -1644,7 +1748,7 @@ export class WorkflowRunner {
     for (const id of this._edgeCounterDirty) {
       this._emit({
         type: "edge_update",
-        job_id: this.jobId,
+        job_id: this._effectiveJobId,
         edge_id: id,
         status: "active",
         counter: this._edgeCounters.get(id) ?? null
@@ -1686,7 +1790,7 @@ export class WorkflowRunner {
         ) {
           this._emit({
             type: "edge_update",
-            job_id: this.jobId,
+            job_id: this._effectiveJobId,
             edge_id: edgeId,
             status: "drained",
             counter: this._edgeCounters.get(edgeId) ?? null

--- a/packages/kernel/src/trigger-wakeup.ts
+++ b/packages/kernel/src/trigger-wakeup.ts
@@ -36,9 +36,28 @@ export class TriggerWakeupService {
   // Stryker disable next-line ArrayDeclaration: a non-empty seed is equivalent — a bogus entry matches no runId/nodeId/inputId and is excluded by every query/filter
   private _inputs: TriggerInput[] = [];
   private _inboxStore: DurableInboxStore;
+  /**
+   * One DurableInbox per (runId, nodeId). DurableInbox.append() serializes its
+   * read-modify-write (getMaxSeq → save) per *instance* via a promise chain, so
+   * concurrent deliveries for the same (run, node) must share one instance or
+   * they each read the same maxSeq and persist duplicate seq values. The key is
+   * `JSON.stringify([runId, nodeId])` because runId/nodeId are arbitrary
+   * strings — a plain `:` join would let ("a:b","c") collide with ("a","b:c").
+   */
+  private _inboxes = new Map<string, DurableInbox>();
 
   constructor(inboxStore?: DurableInboxStore) {
     this._inboxStore = inboxStore ?? new MemoryDurableInboxStore();
+  }
+
+  private _inboxFor(runId: string, nodeId: string): DurableInbox {
+    const key = JSON.stringify([runId, nodeId]);
+    let inbox = this._inboxes.get(key);
+    if (!inbox) {
+      inbox = new DurableInbox(runId, nodeId, this._inboxStore);
+      this._inboxes.set(key, inbox);
+    }
+    return inbox;
   }
 
   /**
@@ -84,8 +103,10 @@ export class TriggerWakeupService {
       ...(opts.cursor ? { cursor: opts.cursor } : {})
     });
 
-    // Also append as inbox message
-    const inbox = new DurableInbox(opts.runId, opts.nodeId, this._inboxStore);
+    // Also append as inbox message. Reuse a cached DurableInbox per (run, node)
+    // so its per-instance append serialization applies across concurrent
+    // deliveries — a fresh instance per call would defeat it (see finding #9).
+    const inbox = this._inboxFor(opts.runId, opts.nodeId);
     await inbox.append("trigger", opts.payload, `trigger-${opts.inputId}`);
 
     return true;

--- a/packages/kernel/tests/actor.test.ts
+++ b/packages/kernel/tests/actor.test.ts
@@ -382,6 +382,77 @@ describe("NodeActor – controlled mode", () => {
     expect(calls[0]).toEqual({ x: 100, threshold: 0.5 });
     expect(sentOutputs).toHaveLength(1);
   });
+
+  // #4: an upstream that closes a data handle without ever emitting must not
+  // deadlock the controlled-node wait. The controller stays open (sendControlEvent
+  // shape), so the old for-await over iterAnyWithEnvelope never ended and the run
+  // hung. The vitest timeout guards the regression.
+  it(
+    "processes a control event after an upstream closes a data handle without emitting, while the controller stays open (#4)",
+    async () => {
+      const node = makeNode({ is_controlled: true });
+      const inbox = new NodeInbox();
+      inbox.addUpstream("__control__", 1);
+      inbox.addUpstream("x", 1);
+
+      const { executor, calls } = trackingExecutor(() => ({ out: 1 }));
+      const { actor, sentOutputs } = createActor(node, inbox, executor);
+
+      const runP = actor.run();
+      // Let the actor reach the data wait (x open, nothing buffered).
+      await new Promise((r) => setTimeout(r, 5));
+
+      // Upstream for x closes without emitting; controller is still open.
+      inbox.markSourceDone("x");
+      await inbox.put("__control__", {
+        event_type: "run" as const,
+        properties: { threshold: 0.5 }
+      });
+
+      // The run event is processed with x absent (node defaults apply).
+      await new Promise((r) => setTimeout(r, 5));
+      expect(calls).toEqual([{ threshold: 0.5 }]);
+      expect(sentOutputs).toHaveLength(1);
+
+      // Close the controller to let the actor finish.
+      await inbox.put("__control__", { event_type: "stop" as const });
+      inbox.markSourceDone("__control__");
+      await runP;
+    },
+    2000
+  );
+
+  it(
+    "still caches data that arrives while blocked before the control event (#4)",
+    async () => {
+      const node = makeNode({ is_controlled: true });
+      const inbox = new NodeInbox();
+      inbox.addUpstream("__control__", 1);
+      inbox.addUpstream("x", 1);
+
+      const { executor, calls } = trackingExecutor((inputs) => ({
+        out: inputs.x
+      }));
+      const { actor } = createActor(node, inbox, executor);
+
+      const runP = actor.run();
+      await new Promise((r) => setTimeout(r, 5));
+
+      // Data arrives after the actor is already blocked in the wait.
+      await inbox.put("x", 42);
+      await inbox.put("__control__", {
+        event_type: "run" as const,
+        properties: {}
+      });
+      await inbox.put("__control__", { event_type: "stop" as const });
+      inbox.markSourceDone("x");
+      inbox.markSourceDone("__control__");
+      await runP;
+
+      expect(calls).toEqual([{ x: 42 }]);
+    },
+    2000
+  );
 });
 
 describe("NodeActor – error handling", () => {

--- a/packages/kernel/tests/bug-fixes-actor.test.ts
+++ b/packages/kernel/tests/bug-fixes-actor.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Regression tests for kernel-actor bug fixes (docs/KERNEL_RUNNER_ANALYSIS.md):
+ *   #7  streaming-input node without run() + connected inputs → warn, not silent
+ *   #11 empty-scope sticky overwrite → warn once per handle per run
+ *   #12 non-driver duplicate max-scope key dropped → warn at close
+ *
+ * The controlled-node deadlock (#4) lives in actor.test.ts alongside the other
+ * controlled-mode coverage.
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import { NodeActor, type NodeExecutor } from "../src/actor.js";
+import { NodeInbox } from "../src/inbox.js";
+import type { NodeAnalysis } from "../src/correlation-analysis.js";
+import type { NodeDescriptor, NodeUpdate } from "@nodetool-ai/protocol";
+import { configureLogging } from "@nodetool-ai/config";
+
+const EMPTY_ANALYSIS: NodeAnalysis = {
+  invocationScope: [],
+  inputs: new Map(),
+  outputs: new Map()
+};
+
+function analysis(
+  invocationScope: string[],
+  inputs: Record<string, [string[], boolean?]>
+): NodeAnalysis {
+  return {
+    invocationScope,
+    inputs: new Map(
+      Object.entries(inputs).map(([h, [scope, repeats]]) => [
+        h,
+        {
+          scope,
+          repeatsPerKey: repeats ?? false,
+          isMultiEdge: false,
+          possibleChildRoots: new Set<string>()
+        }
+      ])
+    ),
+    outputs: new Map()
+  };
+}
+
+function makeNode(overrides: Partial<NodeDescriptor> = {}): NodeDescriptor {
+  return { id: "n1", type: "test.Node", ...overrides };
+}
+
+interface SentOutput {
+  nodeId: string;
+  outputs: Record<string, unknown>;
+}
+
+function createActor(
+  node: NodeDescriptor,
+  inbox: NodeInbox,
+  executor: NodeExecutor,
+  correlation: NodeAnalysis = EMPTY_ANALYSIS
+): { actor: NodeActor; sentOutputs: SentOutput[]; messages: unknown[] } {
+  const sentOutputs: SentOutput[] = [];
+  const messages: unknown[] = [];
+  const actor = new NodeActor({
+    node,
+    inbox,
+    executor,
+    correlation,
+    sendOutputs: async (nodeId, outputs) => {
+      sentOutputs.push({ nodeId, outputs });
+    },
+    emitMessage: (msg) => messages.push(msg)
+  });
+  return { actor, sentOutputs, messages };
+}
+
+function trackingExecutor(
+  processFn: (i: Record<string, unknown>) => Record<string, unknown>
+): { executor: NodeExecutor; calls: Array<Record<string, unknown>> } {
+  const calls: Array<Record<string, unknown>> = [];
+  return {
+    executor: {
+      async process(inputs) {
+        calls.push(inputs);
+        return processFn(inputs);
+      }
+    },
+    calls
+  };
+}
+
+let originalLogLevel: string | undefined;
+
+beforeEach(() => {
+  originalLogLevel = process.env["NODETOOL_LOG_LEVEL"];
+  process.env["NODETOOL_LOG_LEVEL"] = "info";
+  configureLogging();
+});
+
+afterEach(() => {
+  if (originalLogLevel === undefined) {
+    delete process.env["NODETOOL_LOG_LEVEL"];
+  } else {
+    process.env["NODETOOL_LOG_LEVEL"] = originalLogLevel;
+  }
+  configureLogging();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// #7 — streaming-input node without run()
+// ---------------------------------------------------------------------------
+
+describe("NodeActor – streaming-input legacy fallback (#7)", () => {
+  it("warns (log + node_update) when connected inputs would be dropped", async () => {
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const { executor, calls } = trackingExecutor(() => ({ legacy: true }));
+    const { actor, sentOutputs, messages } = createActor(node, inbox, executor);
+
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await inbox.put("a", 1);
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    // Fallback still fires process({}) — behavior unchanged, but surfaced.
+    expect(calls).toEqual([{}]);
+    expect(sentOutputs.map((s) => s.outputs)).toEqual([{ legacy: true }]);
+
+    const warn = messages.find(
+      (m) =>
+        (m as NodeUpdate).type === "node_update" &&
+        (m as NodeUpdate).status === "warning"
+    ) as NodeUpdate | undefined;
+    expect(warn).toBeDefined();
+    expect(warn?.error).toContain("data would be silently dropped");
+
+    const logged = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(logged).toContain("no run() implementation");
+  });
+
+  it("does not warn when no data handles are connected", async () => {
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+
+    const { executor, calls } = trackingExecutor(() => ({ legacy: true }));
+    const { actor, messages } = createActor(node, inbox, executor);
+
+    await actor.run();
+
+    expect(calls).toEqual([{}]);
+    const warn = messages.find(
+      (m) =>
+        (m as NodeUpdate).type === "node_update" &&
+        (m as NodeUpdate).status === "warning"
+    );
+    expect(warn).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #11 — empty-scope sticky overwrite
+// ---------------------------------------------------------------------------
+
+describe("NodeActor – empty-scope sticky overwrite (#11)", () => {
+  it("warns once per handle when a stream collapses to last-value-wins", async () => {
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const { executor, calls } = trackingExecutor((i) => ({ out: i.a }));
+    const { actor } = createActor(
+      node,
+      inbox,
+      executor,
+      analysis([], { a: [[], false] })
+    );
+
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await inbox.put("a", "first");
+    await inbox.put("a", "second");
+    await inbox.put("a", "third");
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    // Node fires once with the last value (unchanged scheduling).
+    expect(calls).toEqual([{ a: "third" }]);
+
+    const logged = stderr.mock.calls.map((c) => String(c[0])).join("");
+    const occurrences = logged.split("only the last is kept").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #12 — non-driver duplicate max-scope key dropped
+// ---------------------------------------------------------------------------
+
+describe("NodeActor – duplicate max-scope key drop (#12)", () => {
+  it("warns when a second envelope for an already-fired key is stranded", async () => {
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+
+    const { executor, calls } = trackingExecutor((i) => ({ out: i.a }));
+    const { actor } = createActor(
+      node,
+      inbox,
+      executor,
+      analysis(["r"], { a: [["r"], false] })
+    );
+
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const lineage = { r: { index: 0 } };
+    await inbox.put("a", "first", { correlation_lineage: lineage });
+    await inbox.put("a", "second", { correlation_lineage: lineage });
+    inbox.markSourceDone("a");
+    await actor.run();
+
+    // The key fires once; the duplicate is dropped (unchanged scheduling).
+    expect(calls).toEqual([{ a: "first" }]);
+
+    const logged = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(logged).toContain("already fired without a repeating driver");
+    expect(logged).toContain("dropped 1 envelope");
+  });
+});

--- a/packages/kernel/tests/bug-fixes-runner.test.ts
+++ b/packages/kernel/tests/bug-fixes-runner.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Regression tests for five confirmed WorkflowRunner bugs
+ * (docs/KERNEL_RUNNER_ANALYSIS.md findings #1, #6, #3, #16, #17).
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner } from "../src/runner.js";
+import type {
+  NodeDescriptor,
+  Edge,
+  EdgeUpdate,
+  JobUpdate
+} from "@nodetool-ai/protocol";
+import type { NodeExecutor } from "../src/actor.js";
+
+function simpleExecutor(
+  fn: (inputs: Record<string, unknown>) => Record<string, unknown>
+): NodeExecutor {
+  return {
+    async process(inputs) {
+      return fn(inputs);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// #1 — edge status must not regress from "completed" back to "active"
+// ---------------------------------------------------------------------------
+
+describe("bug #1: edge status does not regress to active after completed", () => {
+  it("last edge_update on a throttled edge is completed, not active", async () => {
+    // A streaming-output node emits two values back-to-back (well inside the
+    // 1s throttle window), so the edge's counter advances to 2 with only the
+    // first update emitted — the edge is left dirty. When the node finishes,
+    // _sendEOS emits "completed" (counter 2); the run-end flush must NOT
+    // re-emit "active" for that already-completed edge.
+    const nodes: NodeDescriptor[] = [
+      { id: "trig", type: "test.Input", name: "trig" },
+      { id: "streamer", type: "test.Streamer", is_streaming_output: true },
+      { id: "sink", type: "test.Sink", name: "sink" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e-trig",
+        source: "trig",
+        sourceHandle: "value",
+        target: "streamer",
+        targetHandle: "start"
+      },
+      {
+        id: "e-stream",
+        source: "streamer",
+        sourceHandle: "value",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-edge-status", {
+      resolveExecutor: (node) => {
+        if (node.type === "test.Streamer") {
+          return {
+            async *genProcess() {
+              yield { value: 1 };
+              yield { value: 2 };
+            }
+          };
+        }
+        return simpleExecutor((inputs) => ({ value: inputs.value }));
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "job-edge-status", params: { trig: 0 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+
+    const streamEdge = result.messages.filter(
+      (m) => m.type === "edge_update" && (m as EdgeUpdate).edge_id === "e-stream"
+    ) as EdgeUpdate[];
+    expect(streamEdge.length).toBeGreaterThanOrEqual(1);
+    const last = streamEdge[streamEdge.length - 1];
+    expect(last.status).toBe("completed");
+    expect(last.counter).toBe(2);
+    // And no "active" update appears after the "completed" one.
+    const completedIdx = streamEdge.findIndex((m) => m.status === "completed");
+    expect(
+      streamEdge.slice(completedIdx + 1).some((m) => m.status === "active")
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #6 — _dispatchInputs must not leak the raw value onto omitted handles
+// ---------------------------------------------------------------------------
+
+describe("bug #6: dispatch fallback does not leak raw value per handle", () => {
+  it("an input that emits only handle 'a' leaves handle 'b' silent", async () => {
+    const received: Record<string, Array<Record<string, unknown>>> = {
+      targetA: [],
+      targetB: []
+    };
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "targetA", type: "test.Sink", name: "a" },
+      { id: "targetB", type: "test.Sink", name: "b" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "ea",
+        source: "in",
+        sourceHandle: "a",
+        target: "targetA",
+        targetHandle: "in"
+      },
+      {
+        id: "eb",
+        source: "in",
+        sourceHandle: "b",
+        target: "targetB",
+        targetHandle: "in"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-dispatch-leak", {
+      resolveExecutor: (node) => {
+        if (node.type === "test.Input") {
+          // Emits only handle "a"; "b" is legitimately omitted.
+          return simpleExecutor(() => ({ a: 1 }));
+        }
+        return {
+          async process(inputs) {
+            received[node.id].push({ ...inputs });
+            return {};
+          }
+        };
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "job-dispatch-leak", params: { x: 99 } },
+      { nodes, edges }
+    );
+
+    // The run still completes: handle "b" closes (EOS) even though no value
+    // was delivered, so targetB does not hang.
+    expect(result.status).toBe("completed");
+    // targetA received the real handle value.
+    expect(received.targetA.some((r) => r.in === 1)).toBe(true);
+    // targetB never received the raw input value (99) or anything on "in".
+    expect(received.targetB.some((r) => r.in !== undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3 — pushInputValue runs the input node's process()
+// ---------------------------------------------------------------------------
+
+describe("bug #3: pushInputValue routes through the node's process()", () => {
+  it("delivers the transformed value, not the raw streamed value", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "stream_in", type: "test.Input", name: "stream_in" },
+      { id: "sink", type: "test.Sink", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "stream_in",
+        sourceHandle: "output",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-push-transform", {
+      resolveExecutor: (node) => {
+        if (node.type === "test.Input") {
+          // Transform: double the value and emit it on the "output" handle.
+          return simpleExecutor((inputs) => ({
+            output: (inputs.value as number) * 2
+          }));
+        }
+        return simpleExecutor((inputs) => ({ value: inputs.value }));
+      }
+    });
+
+    const runPromise = runner.run(
+      { job_id: "job-push-transform", params: {} },
+      { nodes, edges }
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    await runner.pushInputValue("stream_in", 5);
+    runner.finishInputStream("stream_in");
+
+    const result = await runPromise;
+    expect(result.status).toBe("completed");
+    // 5 → process() doubles → 10 (not the raw 5).
+    expect(result.outputs.result).toContain(10);
+    expect(result.outputs.result).not.toContain(5);
+  });
+
+  it("does not leak the raw value onto handles the process() omits", async () => {
+    const received: Record<string, Array<Record<string, unknown>>> = {
+      sinkA: [],
+      sinkB: []
+    };
+    const nodes: NodeDescriptor[] = [
+      { id: "stream_in", type: "test.Input", name: "stream_in" },
+      { id: "sinkA", type: "test.Sink", name: "a" },
+      { id: "sinkB", type: "test.Sink", name: "b" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "ea",
+        source: "stream_in",
+        sourceHandle: "a",
+        target: "sinkA",
+        targetHandle: "in"
+      },
+      {
+        id: "eb",
+        source: "stream_in",
+        sourceHandle: "b",
+        target: "sinkB",
+        targetHandle: "in"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-push-omit", {
+      resolveExecutor: (node) => {
+        if (node.type === "test.Input") {
+          return simpleExecutor((inputs) => ({ a: inputs.value }));
+        }
+        return {
+          async process(inputs) {
+            received[node.id].push({ ...inputs });
+            return {};
+          }
+        };
+      }
+    });
+
+    const runPromise = runner.run(
+      { job_id: "job-push-omit", params: {} },
+      { nodes, edges }
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    await runner.pushInputValue("stream_in", 7);
+    runner.finishInputStream("stream_in");
+
+    const result = await runPromise;
+    expect(result.status).toBe("completed");
+    expect(received.sinkA.some((r) => r.in === 7)).toBe(true);
+    expect(received.sinkB.some((r) => r.in !== undefined)).toBe(false);
+  });
+
+  it("throws a wrapped error when the input node's process() fails", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "stream_in", type: "test.Input", name: "stream_in" },
+      { id: "sink", type: "test.Sink", name: "sink" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "stream_in",
+        sourceHandle: "output",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-push-error", {
+      resolveExecutor: (node) => {
+        if (node.type === "test.Input") {
+          return {
+            async process() {
+              throw new Error("boom in input");
+            }
+          };
+        }
+        return simpleExecutor((inputs) => ({ value: inputs.value }));
+      }
+    });
+
+    const runPromise = runner.run(
+      { job_id: "job-push-error", params: {} },
+      { nodes, edges }
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    await expect(runner.pushInputValue("stream_in", 1)).rejects.toThrow(
+      /stream_in.*test\.Input.*boom in input/
+    );
+
+    // Close the stream so the still-running graph terminates.
+    runner.finishInputStream("stream_in");
+    const result = await runPromise;
+    expect(result.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #16 — edge_update and job_update carry the same (request) job id
+// ---------------------------------------------------------------------------
+
+describe("bug #16: one job id per run for both message kinds", () => {
+  it("edge_update messages use request.job_id, not the constructor id", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "proc", type: "test.Proc" },
+      { id: "out", type: "test.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "in",
+        sourceHandle: "value",
+        target: "proc",
+        targetHandle: "a"
+      },
+      {
+        id: "e2",
+        source: "proc",
+        sourceHandle: "result",
+        target: "out",
+        targetHandle: "value"
+      }
+    ];
+
+    // Constructor id differs from the request id on purpose.
+    const runner = new WorkflowRunner("ctor-job-id", {
+      resolveExecutor: (node) =>
+        node.type === "test.Proc"
+          ? simpleExecutor((inputs) => ({ result: inputs.a }))
+          : simpleExecutor((inputs) => ({ value: inputs.value }))
+    });
+
+    const result = await runner.run(
+      { job_id: "request-job-id", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+
+    const edgeUpdates = result.messages.filter(
+      (m) => m.type === "edge_update"
+    ) as EdgeUpdate[];
+    const jobUpdates = result.messages.filter(
+      (m) => m.type === "job_update"
+    ) as JobUpdate[];
+
+    expect(edgeUpdates.length).toBeGreaterThanOrEqual(1);
+    // Every edge_update carries the request job id — the same one job_update
+    // uses — so clients can associate them.
+    expect(edgeUpdates.every((m) => m.job_id === "request-job-id")).toBe(true);
+    expect(jobUpdates.every((m) => m.job_id === "request-job-id")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #17 — runner lifecycle: cancel-before-run + concurrent-run guard
+// ---------------------------------------------------------------------------
+
+describe("bug #17: runner lifecycle races", () => {
+  it("a cancel() before run() still terminates the run as cancelled", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "out", type: "test.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "in",
+        sourceHandle: "value",
+        target: "out",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-cancel-early", {
+      resolveExecutor: () => simpleExecutor((inputs) => ({ value: inputs.value }))
+    });
+
+    // Cancel lands between construction and run().
+    runner.cancel();
+
+    const result = await runner.run(
+      { job_id: "job-cancel-early", params: { x: 1 } },
+      { nodes, edges }
+    );
+    expect(result.status).toBe("cancelled");
+  });
+
+  it("a second concurrent run() is rejected", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "slow", type: "test.Slow" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "in",
+        sourceHandle: "value",
+        target: "slow",
+        targetHandle: "a"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-concurrent", {
+      resolveExecutor: (node) =>
+        node.type === "test.Slow"
+          ? {
+              async process() {
+                await new Promise((r) => setTimeout(r, 150));
+                return { result: 1 };
+              }
+            }
+          : simpleExecutor((inputs) => ({ value: inputs.value }))
+    });
+
+    const first = runner.run(
+      { job_id: "job-concurrent-1", params: { x: 1 } },
+      { nodes, edges }
+    );
+    // Let the first run enter _runImpl and mark itself in-flight.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await expect(
+      runner.run({ job_id: "job-concurrent-2", params: { x: 2 } }, { nodes, edges })
+    ).rejects.toThrow(/already running/);
+
+    const result = await first;
+    expect(result.status).toBe("completed");
+  });
+});

--- a/packages/kernel/tests/e2e/actor-modes.test.ts
+++ b/packages/kernel/tests/e2e/actor-modes.test.ts
@@ -115,20 +115,18 @@ describe("ACTOR-003: Streaming output node yields multiple values", () => {
     );
 
     expect(result.status).toBe("completed");
-    // 3 values emitted from counter. edge_update is throttled (first
-    // message immediately, then at most one per interval, exact final
-    // counter flushed at run end) — assert the final counter, not the
-    // message count.
+    // 3 values emitted from counter. edge_update is throttled (first message
+    // immediately, then coalesced). The terminal "completed" update carries
+    // the exact final counter; §1 guarantees no "active" update trails it.
     const edgeUpdates = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
-        (m as { edge_id: string }).edge_id === "e-counter-sink" &&
-        (m as { status: string }).status === "active"
-    );
-    expect(edgeUpdates.length).toBeGreaterThanOrEqual(1);
-    expect(
-      (edgeUpdates[edgeUpdates.length - 1] as { counter?: number }).counter
-    ).toBe(3);
+        (m as { edge_id: string }).edge_id === "e-counter-sink"
+    ) as Array<{ status: string; counter?: number }>;
+    const completed = edgeUpdates.filter((m) => m.status === "completed");
+    expect(completed.length).toBeGreaterThanOrEqual(1);
+    expect(completed[completed.length - 1].counter).toBe(3);
+    expect(edgeUpdates[edgeUpdates.length - 1].status).toBe("completed");
   });
 });
 
@@ -267,17 +265,17 @@ describe("ACTOR-007: Sticky input semantics with streaming upstream", () => {
 
     expect(result.status).toBe("completed");
     // 3 values from counter (1,2,3) + sticky b=10 → 3 executions: 11, 12, 13.
-    // edge_update is throttled; the last active update carries the total.
+    // edge_update is throttled; the terminal "completed" update carries the
+    // total, with no trailing "active" (§1).
     const edgeUpdates = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
-        (m as { edge_id: string }).edge_id === "e-add" &&
-        (m as { status: string }).status === "active"
-    );
-    expect(edgeUpdates.length).toBeGreaterThanOrEqual(1);
-    expect(
-      (edgeUpdates[edgeUpdates.length - 1] as { counter?: number }).counter
-    ).toBe(3);
+        (m as { edge_id: string }).edge_id === "e-add"
+    ) as Array<{ status: string; counter?: number }>;
+    const completed = edgeUpdates.filter((m) => m.status === "completed");
+    expect(completed.length).toBeGreaterThanOrEqual(1);
+    expect(completed[completed.length - 1].counter).toBe(3);
+    expect(edgeUpdates[edgeUpdates.length - 1].status).toBe("completed");
   });
 });
 

--- a/packages/kernel/tests/e2e/complex-topologies.test.ts
+++ b/packages/kernel/tests/e2e/complex-topologies.test.ts
@@ -292,16 +292,18 @@ describe("COMPLEX-010: Static constant + streaming counter feeds Add", () => {
     );
 
     expect(result.status).toBe("completed");
-    // 3 values (10,11,12) + b=1 → Add fires 3 times. edge_update is
-    // throttled; the last active update carries the total.
-    const active = result.messages.filter(
+    // 3 values (10,11,12) + b=1 → Add fires 3 times. edge_update is throttled;
+    // the terminal "completed" update carries the total, with no trailing
+    // "active" (§1).
+    const edgeUpdates = result.messages.filter(
       (m) =>
         m.type === "edge_update" &&
-        (m as EdgeUpdate).edge_id === "e-sc-add" &&
-        (m as EdgeUpdate).status === "active"
-    );
-    expect(active.length).toBeGreaterThanOrEqual(1);
-    expect((active[active.length - 1] as EdgeUpdate).counter).toBe(3);
+        (m as EdgeUpdate).edge_id === "e-sc-add"
+    ) as EdgeUpdate[];
+    const completed = edgeUpdates.filter((m) => m.status === "completed");
+    expect(completed.length).toBeGreaterThanOrEqual(1);
+    expect(completed[completed.length - 1].counter).toBe(3);
+    expect(edgeUpdates[edgeUpdates.length - 1].status).toBe("completed");
   });
 });
 

--- a/packages/kernel/tests/e2e/runner-lifecycle.test.ts
+++ b/packages/kernel/tests/e2e/runner-lifecycle.test.ts
@@ -320,16 +320,16 @@ describe("RUNNER-019: Streaming output node propagates streaming flag downstream
     );
 
     expect(result.status).toBe("completed");
-    // 4 items emitted on e1. edge_update is throttled; the last active
-    // update carries the total.
-    const active = result.messages.filter(
+    // 4 items emitted on e1. edge_update is throttled; the terminal "completed"
+    // update carries the total, with no trailing "active" (§1).
+    const edgeUpdates = result.messages.filter(
       (m) =>
-        m.type === "edge_update" &&
-        (m as EdgeUpdate).edge_id === "e1" &&
-        (m as EdgeUpdate).status === "active"
-    );
-    expect(active.length).toBeGreaterThanOrEqual(1);
-    expect((active[active.length - 1] as EdgeUpdate).counter).toBe(4);
+        m.type === "edge_update" && (m as EdgeUpdate).edge_id === "e1"
+    ) as EdgeUpdate[];
+    const completed = edgeUpdates.filter((m) => m.status === "completed");
+    expect(completed.length).toBeGreaterThanOrEqual(1);
+    expect(completed[completed.length - 1].counter).toBe(4);
+    expect(edgeUpdates[edgeUpdates.length - 1].status).toBe("completed");
   });
 });
 

--- a/packages/kernel/tests/graph-mutation.test.ts
+++ b/packages/kernel/tests/graph-mutation.test.ts
@@ -241,6 +241,42 @@ describe("Graph.loadFromDict – hydration", () => {
     expect(node.is_controlled).toBe(true);
   });
 
+  it("lets an explicit registry false override a stale saved true flag", async () => {
+    // A node type migrated from streaming to buffered: the registry now
+    // declares is_streaming_input false, so the stale saved true must lose.
+    const resolver = resolverFor({
+      descriptorDefaults: { is_streaming_input: false }
+    });
+    const g = await Graph.loadFromDict(
+      {
+        nodes: [{ id: "a", type: "t", is_streaming_input: true }],
+        edges: []
+      },
+      { resolver }
+    );
+    expect(g.findNode("a")!.is_streaming_input).toBe(false);
+  });
+
+  it("keeps the saved flag when the registry omits it", async () => {
+    // Resolver returns no behavior flag (undefined) — the saved value survives.
+    const g = await Graph.loadFromDict(
+      {
+        nodes: [{ id: "a", type: "t", is_streaming_output: true }],
+        edges: []
+      },
+      { resolver: resolverFor({ descriptorDefaults: { name: "T" } }) }
+    );
+    expect(g.findNode("a")!.is_streaming_output).toBe(true);
+  });
+
+  it("uses the registry flag when the saved node omits it", async () => {
+    const g = await Graph.loadFromDict(
+      { nodes: [{ id: "a", type: "t" }], edges: [] },
+      { resolver: resolverFor({ descriptorDefaults: { is_streaming_input: true } }) }
+    );
+    expect(g.findNode("a")!.is_streaming_input).toBe(true);
+  });
+
   it("falls back to saved node flags, then to false", async () => {
     const fromNode = await Graph.loadFromDict(
       { nodes: [{ id: "a", type: "t", is_streaming_output: true }], edges: [] },
@@ -329,6 +365,19 @@ describe("Graph – control detection & lookups", () => {
     const g = new Graph({ nodes, edges: [ctrl("a", "b")] });
     expect(g.findNode("b")!.is_controlled).toBe(true);
     expect(g.findNode("a")!.is_controlled).toBeFalsy();
+  });
+
+  it("does not mutate the caller's node objects when marking controlled", () => {
+    const target = n("b", "t");
+    const nodes = [n("a", "t"), target];
+    const g = new Graph({ nodes, edges: [ctrl("a", "b")] });
+    // The Graph carries a copy with the flag set...
+    expect(g.findNode("b")!.is_controlled).toBe(true);
+    expect(g.findNode("b")).not.toBe(target);
+    // ...while the caller-owned original is left untouched.
+    expect(target.is_controlled).toBeUndefined();
+    // Unaffected nodes keep their identity (no whole-graph copy).
+    expect(g.findNode("a")).toBe(nodes[0]);
   });
 
   it("findEdges / findDataEdges narrow by handle and edge type", () => {

--- a/packages/kernel/tests/runner-coverage.test.ts
+++ b/packages/kernel/tests/runner-coverage.test.ts
@@ -577,6 +577,13 @@ describe("WorkflowRunner – external workflow inputs", () => {
             value: Number(inputs.a ?? 0) + Number(inputs.b ?? 0)
           }));
         }
+        // IntegerInput emits on its "output" handle — the handle the outgoing
+        // edges read. Emitting there (not "value") keeps the double honest now
+        // that the runner no longer leaks the raw input value onto edges whose
+        // sourceHandle the process() record omits.
+        if (node.type === "nodetool.input.IntegerInput") {
+          return simpleExecutor((inputs) => ({ output: inputs.value }));
+        }
         return simpleExecutor((inputs) => ({ value: inputs.value }));
       }
     });
@@ -634,6 +641,11 @@ describe("WorkflowRunner – external workflow inputs", () => {
           return simpleExecutor((inputs) => ({
             value: Number(inputs.a ?? 0) + Number(inputs.b ?? 0)
           }));
+        }
+        // IntegerInput emits on its "output" handle (see the note in the
+        // sibling test) so the outgoing edges receive its value.
+        if (node.type === "nodetool.input.IntegerInput") {
+          return simpleExecutor((inputs) => ({ output: inputs.value }));
         }
         return simpleExecutor((inputs) => ({ value: inputs.value }));
       }

--- a/packages/kernel/tests/trigger-wakeup.test.ts
+++ b/packages/kernel/tests/trigger-wakeup.test.ts
@@ -162,6 +162,69 @@ describe("TriggerWakeupService — durable store delivery", () => {
   });
 });
 
+describe("TriggerWakeupService — concurrent delivery sequencing (finding #9)", () => {
+  it("assigns strictly increasing, duplicate-free seq under concurrent deliveries for the same (run, node)", async () => {
+    const store = new MemoryDurableInboxStore();
+    const svc = new TriggerWakeupService(store);
+
+    const N = 50;
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        svc.deliverTriggerInput({
+          runId: "r1",
+          nodeId: "n1",
+          inputId: `input-${i}`,
+          payload: { i }
+        })
+      )
+    );
+
+    // Every distinct inputId is a new delivery.
+    expect(results.every((r) => r === true)).toBe(true);
+
+    const persisted = await store.findPending("r1", "n1", "trigger", N * 2);
+    expect(persisted).toHaveLength(N);
+
+    const seqs = persisted.map((m) => m.seq);
+    // Duplicate-free.
+    expect(new Set(seqs).size).toBe(N);
+    // Strictly increasing 1..N (findPending sorts by seq).
+    expect(seqs).toEqual(Array.from({ length: N }, (_, i) => i + 1));
+  });
+
+  it("keeps sequences independent across distinct (run, node) pairs", async () => {
+    const store = new MemoryDurableInboxStore();
+    const svc = new TriggerWakeupService(store);
+
+    await Promise.all([
+      svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "a",
+        payload: {}
+      }),
+      svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n2",
+        inputId: "b",
+        payload: {}
+      }),
+      // A colliding plain-":" join of these two would be "r1:n2:x" vs
+      // "r1:n2x" — JSON keying keeps them apart.
+      svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n2x",
+        inputId: "c",
+        payload: {}
+      })
+    ]);
+
+    expect(await store.findPending("r1", "n1", "trigger", 10)).toHaveLength(1);
+    expect(await store.findPending("r1", "n2", "trigger", 10)).toHaveLength(1);
+    expect(await store.findPending("r1", "n2x", "trigger", 10)).toHaveLength(1);
+  });
+});
+
 describe("TriggerWakeupService — getPendingInputs filtering", () => {
   it("respects the limit", async () => {
     const svc = new TriggerWakeupService();

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -371,25 +371,30 @@ export function hydrateGraphNodeFlags(
     const meta = cls ? undefined : registry.resolveMetadata(node.type);
     return {
       ...node,
+      // `??`, not `||`: a registered class always carries explicit booleans
+      // (BaseNode defaults them to false), so the registry corrects a stale
+      // saved `true` when a node type migrates away from streaming/control.
+      // OR let the saved value win forever. Saved flags apply only when the
+      // registry has no opinion (unknown type, or metadata omitting the flag).
       is_streaming_input:
-        (cls ? cls.isStreamingInput : meta?.is_streaming_input) ||
-        node.is_streaming_input ||
+        (cls ? cls.isStreamingInput : meta?.is_streaming_input) ??
+        node.is_streaming_input ??
         false,
       is_streaming_output:
-        (cls ? hasStreamingOutput(cls) : meta?.is_streaming_output) ||
-        node.is_streaming_output ||
+        (cls ? hasStreamingOutput(cls) : meta?.is_streaming_output) ??
+        node.is_streaming_output ??
         false,
       is_controlled:
-        (cls ? cls.isControlled : meta?.is_controlled) ||
-        node.is_controlled ||
+        (cls ? cls.isControlled : meta?.is_controlled) ??
+        node.is_controlled ??
         false,
       is_join_node:
-        (cls ? cls.isJoinNode : meta?.is_join_node) ||
-        node.is_join_node ||
+        (cls ? cls.isJoinNode : meta?.is_join_node) ??
+        node.is_join_node ??
         false,
       always_emit_output_updates:
-        (cls ? cls.alwaysEmitOutputUpdates : meta?.always_emit_output_updates) ||
-        node.always_emit_output_updates ||
+        (cls ? cls.alwaysEmitOutputUpdates : meta?.always_emit_output_updates) ??
+        node.always_emit_output_updates ??
         false,
       input_mode: (cls ? cls.inputMode : meta?.input_mode) ?? node.input_mode,
       output_correlation:
@@ -458,14 +463,19 @@ export function createGraphNodeTypeResolver(
         supportsDynamicInputs: metadata.supports_dynamic_inputs ?? false,
         descriptorDefaults: {
           name: metadata.title,
-          ...(metadata.is_streaming_input && { is_streaming_input: true }),
-          ...(metadata.is_streaming_output && { is_streaming_output: true }),
+          // Explicit booleans, never omitted: Graph.loadFromDict resolves each
+          // flag as `descriptorDefaults.flag ?? saved ?? false`, so an omitted
+          // false here would let a stale saved `true` survive a node type's
+          // migration away from streaming/control. Metadata is built from the
+          // class statics (BaseNode defaults false), so absent means false.
+          is_streaming_input: metadata.is_streaming_input ?? false,
+          is_streaming_output: metadata.is_streaming_output ?? false,
+          is_controlled: metadata.is_controlled ?? false,
+          is_join_node: metadata.is_join_node ?? false,
           ...(metadata.input_mode && { input_mode: metadata.input_mode }),
           ...(metadata.output_correlation && {
             output_correlation: metadata.output_correlation
           }),
-          ...(metadata.is_controlled && { is_controlled: true }),
-          ...(metadata.is_join_node && { is_join_node: true }),
           ...(metadata.always_emit_output_updates && {
             always_emit_output_updates: true
           }),

--- a/packages/node-sdk/tests/graph-resolver.test.ts
+++ b/packages/node-sdk/tests/graph-resolver.test.ts
@@ -61,7 +61,12 @@ describe("createGraphNodeTypeResolver", () => {
       supportsDynamicInputs: false,
       descriptorDefaults: {
         name: "Strict Node",
+        // Behavior flags are always explicit booleans so a stale saved `true`
+        // is corrected by the registry (Graph.loadFromDict uses `??`).
+        is_streaming_input: false,
         is_streaming_output: true,
+        is_controlled: false,
+        is_join_node: false,
         input_mode: "buffered",
         output_correlation: {
           output: { kind: "single", source: "__execution__" }
@@ -125,7 +130,10 @@ describe("createGraphNodeTypeResolver", () => {
     const resolved = await resolver.resolveNodeType("test.zip.Node");
     expect(resolved?.descriptorDefaults).toEqual({
       name: "Zip Node",
+      is_streaming_input: false,
       is_streaming_output: true,
+      is_controlled: false,
+      is_join_node: false,
       input_mode: "buffered",
       output_correlation: {
         output: { kind: "single", source: "__execution__" }

--- a/packages/node-sdk/tests/hydrate-graph-flags.test.ts
+++ b/packages/node-sdk/tests/hydrate-graph-flags.test.ts
@@ -78,4 +78,65 @@ describe("hydrateGraphNodeFlags", () => {
 
     expect(hydrated.nodes[0].is_streaming_output).toBe(true);
   });
+
+  it("corrects a stale saved true when the registered class declares false", () => {
+    // A node type that migrated away from streaming: the class statics say
+    // false, but a workflow saved before the migration still carries
+    // is_streaming_input: true. The registry must win (?? precedence), or the
+    // kernel actor keeps picking run() for a node that no longer streams.
+    class BufferedNode extends BaseNode {
+      static readonly nodeType = "test.MigratedBuffered";
+      static readonly title = "Migrated Buffered";
+      static readonly description = "";
+
+      async process() {
+        return {};
+      }
+    }
+    const registry = new NodeRegistry();
+    registry.register(BufferedNode);
+
+    const hydrated = hydrateGraphNodeFlags(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.MigratedBuffered",
+            properties: {},
+            is_streaming_input: true,
+            is_streaming_output: true,
+            is_controlled: true,
+            is_join_node: true
+          }
+        ],
+        edges: []
+      } as never,
+      registry
+    );
+
+    expect(hydrated.nodes[0].is_streaming_input).toBe(false);
+    expect(hydrated.nodes[0].is_streaming_output).toBe(false);
+    expect(hydrated.nodes[0].is_controlled).toBe(false);
+    expect(hydrated.nodes[0].is_join_node).toBe(false);
+  });
+
+  it("keeps saved flags for node types the registry does not know", () => {
+    const registry = new NodeRegistry();
+    const hydrated = hydrateGraphNodeFlags(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "unknown.pkg.Node",
+            properties: {},
+            is_streaming_input: true
+          }
+        ],
+        edges: []
+      } as never,
+      registry
+    );
+
+    expect(hydrated.nodes[0].is_streaming_input).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Two things in one PR: a technical review of `packages/kernel/` (runner, actor, inbox, graph, correlation analysis, triggers, durable inbox), and fixes for the findings that were clear-cut bugs. The review document is `docs/KERNEL_RUNNER_ANALYSIS.md` — 17 numbered findings plus smaller issues, each with file/line references, a concrete failure scenario, and a fix suggestion.

## Fixes in this PR

**`NodeActor` / `NodeInbox`** (findings #4, #7, #11, #12)
- Controlled-node wait deadlock: `_waitForDataInputs` no longer hangs forever when an upstream closes a data handle without emitting (filter/conditional output). Closed-and-empty handles fall back to node defaults, via a new `NodeInbox.waitForActivity()` that wakes on EOS notifications, not just envelope arrivals. Previously a controller awaiting `sendControlEvent` on such a node deadlocked the whole run.
- Streaming-input nodes without `run()` emit a warning `node_update` when connected inputs would be silently dropped by the legacy `process()` fallback.
- The correlated scheduler warns on both silent-data-loss shapes: an empty-scope sticky handle overwriting a previous envelope (unmigrated streaming producer collapsing to last-value-wins), and envelopes stranded in max-scope buckets at close.

**`Graph` / node-sdk hydration** (findings #2, #13)
- Behavior flags (`is_streaming_input/output`, `is_controlled`, `is_join_node`) were hydrated with `||`, so a stale saved `true` could never be corrected when a node type migrated away from streaming/control — the actor then picked the wrong execution mode forever. `Graph.loadFromDict` and `hydrateGraphNodeFlags` now resolve `registry ?? saved ?? false`, and the node-sdk resolver emits explicit booleans instead of omitting the false case. Saved flags still apply for node types the registry doesn't know.
- `Graph`'s constructor no longer mutates caller-owned node descriptors when stamping `is_controlled`; control-edge targets are replaced by shallow copies.

**`WorkflowRunner`** (findings #1, #3, #6, #16, #17)
- Edge status no longer regresses `completed` → `active` at run end (`_sendEOS` clears the throttled-counter dirty flag).
- `_dispatchInputs` no longer leaks the raw input value onto edges whose handle the input node's `process()` intentionally omitted; the fallback applies only when `process()` produced no defined output at all.
- `pushInputValue` now runs the input node's `process()` like start params do (streamed values were skipping transformation/validation entirely), stamps real edge ids as `source_edge_id`, and wraps `process()` failures with the node id/type.
- `edge_update` carries the same job id as `job_update` (`request.job_id`).
- `cancel()` before `run()` is honored, and a second concurrent `run()` on the same instance throws instead of clobbering in-flight state.

**`TriggerWakeupService`** (finding #9)
- Concurrent trigger deliveries for the same (run, node) could persist duplicate `seq` values because each call built a fresh `DurableInbox`, defeating its per-instance append serialization. The service now caches one inbox per (run, node).

## Test plan

- Every fix has regression tests (several verified to fail without the fix). New: `bug-fixes-actor.test.ts`, `bug-fixes-runner.test.ts`, `trigger-wakeup.test.ts`, plus additions to `actor.test.ts`, `graph-mutation.test.ts`, `graph-resolver.test.ts`, `hydrate-graph-flags.test.ts`.
- Existing tests that encoded the buggy behavior (trailing `active` edge flush, raw-value input leak) were updated to the corrected semantics.
- Kernel suite: 817 passed / 3 skipped / 6 todo. node-sdk suite: 564 passed. core-nodes: 167 passed. Lint/typecheck (`tsc --noEmit`) clean on both touched packages.

## Deliberately not fixed here (design decisions, see doc)

- **#5** `sendControlEvent` response attribution — needs an event id threaded through `ControlEvent` and echoed by the actor (small protocol change).
- **#8** `RunResult.outputs` keeps only the last firing of multi-fire terminal nodes — accumulating changes the observable output shape for existing consumers.
- **#10** backpressure defaults — no production caller sets `bufferLimit`, and the correlated scheduler drains into unbounded actor-local buckets regardless; needs a deliberate default + bucket cap.
- **#14, #15** and the smaller issues listed in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JncheB97V8B5btyJCpGbi1