### PR TITLE
Add native image generation support to OpenAI Responses provider

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -206,6 +206,7 @@ export {
   TranscribeAudioTool,
   EmbedTextTool
 } from "./tools/media-tools.js";
+export { ImageGenerationTool } from "./tools/image-generation-tool.js";
 export {
   persistOutput,
   workspaceDir as workspaceDirFromContext,

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -36,6 +36,7 @@ import {
   GoogleGroundedSearchTool,
   GoogleImageGenerationTool
 } from "./google-tools.js";
+import { ImageGenerationTool } from "./image-generation-tool.js";
 import {
   DataForSEOSearchTool,
   DataForSEONewsTool,
@@ -104,6 +105,7 @@ export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   DataForSEOImagesTool,
 
   // Generation
+  ImageGenerationTool,
   GoogleImageGenerationTool,
   OpenAIImageGenerationTool,
   OpenAITextToSpeechTool,

--- a/packages/agents/src/tools/image-generation-tool.ts
+++ b/packages/agents/src/tools/image-generation-tool.ts
@@ -1,0 +1,60 @@
+/**
+ * `image_generation` — the cross-provider image tool.
+ *
+ * Providers that expose a native server-side image generator
+ * (`supportsNativeImageGeneration`, e.g. OpenAI's Responses API) render a tool
+ * of this name as their own built-in and never call `process()` — the image
+ * arrives directly on the assistant message. Providers without one fall back to
+ * this implementation, which generates via a default provider+model and saves
+ * the result as an asset, mirroring `GenerateImageTool`.
+ */
+
+import { IMAGE_GENERATION_TOOL_NAME } from "@nodetool-ai/runtime";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+import { GenerateImageTool } from "./media-tools.js";
+
+// Fallback target when the active provider has no native image tool.
+const FALLBACK_PROVIDER = "openai";
+const FALLBACK_MODEL = "gpt-image-1";
+
+export class ImageGenerationTool extends Tool {
+  readonly name = IMAGE_GENERATION_TOOL_NAME;
+  readonly description =
+    "Generate or edit an image from a text prompt. On providers with a native " +
+    "image tool this runs server-side; elsewhere it falls back to a default " +
+    "image model and returns the result as an asset.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      prompt: {
+        type: "string" as const,
+        description: "A text description of the desired image."
+      }
+    },
+    required: ["prompt"]
+  };
+
+  private readonly delegate = new GenerateImageTool();
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const prompt = params["prompt"];
+    if (typeof prompt !== "string" || !prompt)
+      return { error: "prompt is required" };
+
+    return this.delegate.process(context, {
+      provider: FALLBACK_PROVIDER,
+      model: FALLBACK_MODEL,
+      prompt
+    });
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const prompt = String(params["prompt"] ?? "an image");
+    const msg = `Generating ${prompt}`;
+    return msg.length > 80 ? "Generating an image" : msg;
+  }
+}

--- a/packages/agents/tests/image-generation-tool.test.ts
+++ b/packages/agents/tests/image-generation-tool.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { IMAGE_GENERATION_TOOL_NAME } from "@nodetool-ai/runtime";
+import { ImageGenerationTool } from "../src/tools/image-generation-tool.js";
+
+describe("ImageGenerationTool", () => {
+  const tool = new ImageGenerationTool();
+
+  it("uses the canonical image_generation name and a minimal schema", () => {
+    expect(tool.name).toBe(IMAGE_GENERATION_TOOL_NAME);
+    expect(tool.inputSchema.required).toEqual(["prompt"]);
+    expect(Object.keys(tool.inputSchema.properties as object)).toEqual([
+      "prompt"
+    ]);
+  });
+
+  it("returns an error when prompt is missing", async () => {
+    const result = (await tool.process({} as never, {})) as {
+      error?: string;
+    };
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns an error when prompt is empty", async () => {
+    const result = (await tool.process({} as never, {
+      prompt: ""
+    })) as { error?: string };
+    expect(result.error).toBeDefined();
+  });
+
+  it("falls back to a default provider+model and persists an asset", async () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const runProviderPrediction = vi.fn().mockResolvedValue(pngBytes);
+    const createAsset = vi
+      .fn()
+      .mockResolvedValue({ id: "asset-123" });
+    const context = {
+      runProviderPrediction,
+      createAsset
+    } as never;
+
+    const result = (await tool.process(context, {
+      prompt: "a red fox in snow"
+    })) as { type?: string; asset_id?: string; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.type).toBe("image");
+    expect(result.asset_id).toBe("asset-123");
+    expect(runProviderPrediction).toHaveBeenCalledTimes(1);
+    const call = runProviderPrediction.mock.calls[0][0];
+    expect(call.provider).toBe("openai");
+    expect(call.model).toBe("gpt-image-1");
+    expect(call.capability).toBe("text_to_image");
+    expect(call.params.prompt).toBe("a red fox in snow");
+  });
+
+  it("userMessage stays within the length budget", () => {
+    const msg = tool.userMessage({ prompt: "a".repeat(200) });
+    expect(msg.length).toBeLessThanOrEqual(80);
+  });
+});

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -248,6 +248,18 @@ export abstract class BaseProvider {
     return false;
   }
 
+  /**
+   * Whether this provider has a built-in, server-side image generator (e.g.
+   * the OpenAI Responses `image_generation` tool). When `true`, a tool named
+   * {@link IMAGE_GENERATION_TOOL_NAME} is rendered as the provider's native
+   * tool — its result arrives as image content on the assistant message, not
+   * as a function-call round-trip. Default `false` (use the fallback function
+   * tool).
+   */
+  get supportsNativeImageGeneration(): boolean {
+    return false;
+  }
+
   setMessageEmitter(fn: (msg: unknown) => void): void {
     this._emitMessage = fn;
   }

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -190,7 +190,8 @@ export type {
 export {
   isProviderSessionUpdate,
   isProviderMessageEvent,
-  WEB_SEARCH_TOOL_NAME
+  WEB_SEARCH_TOOL_NAME,
+  IMAGE_GENERATION_TOOL_NAME
 } from "./types.js";
 
 // Register hosted providers with the secret key NAME each one needs but no

--- a/packages/runtime/src/providers/openai-responses-provider.ts
+++ b/packages/runtime/src/providers/openai-responses-provider.ts
@@ -100,6 +100,38 @@ function systemPrompt(messages: Message[]): string {
     .join("\n\n");
 }
 
+/**
+ * A native image_generation result surfaced by the stream parser as an image
+ * chunk. Returns the content block to attach to the assistant message, or
+ * null for any other stream item. The multi-megabyte base64 blob must be
+ * absorbed here, never yielded onward as a chunk.
+ */
+function imageContentFromChunk(item: unknown): MessageImageContent | null {
+  if (
+    !isRecord(item) ||
+    item.type !== "chunk" ||
+    item.content_type !== "image" ||
+    typeof item.content !== "string"
+  ) {
+    return null;
+  }
+  const metadata = isRecord(item.content_metadata) ? item.content_metadata : {};
+  const mimeType =
+    typeof metadata.mimeType === "string" ? metadata.mimeType : "image/png";
+  return { type: "image_url", image: { data: item.content, mimeType } };
+}
+
+/** Text block (when non-empty) followed by generated-image blocks. */
+function assistantContentWithImages(
+  text: string,
+  images: MessageImageContent[]
+): MessageContent[] {
+  const blocks: MessageContent[] = [];
+  if (text) blocks.push({ type: "text", text });
+  blocks.push(...images);
+  return blocks;
+}
+
 export class OpenAIResponsesProvider extends OpenAIProvider {
   static override requiredSecrets(): string[] {
     return ["OPENAI_API_KEY"];
@@ -184,16 +216,10 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
       this.buildToolCall.bind(this)
     );
     const images = extractResponsesImages(response.output);
-
-    let content: string | MessageContent[] | null;
-    if (images.length > 0) {
-      const blocks: MessageContent[] = [];
-      if (outputText) blocks.push({ type: "text", text: outputText });
-      blocks.push(...images);
-      content = blocks;
-    } else {
-      content = outputText || null;
-    }
+    const content: string | MessageContent[] | null =
+      images.length > 0
+        ? assistantContentWithImages(outputText, images)
+        : outputText || null;
 
     return {
       role: "assistant",
@@ -213,7 +239,36 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
       stream: true,
       store: false
     });
-    yield* this.streamResponsesRequest(args, request);
+    // Absorb native image results here too — this non-loop path must uphold
+    // the same invariant as collectModelTurn: the base64 blob never leaks
+    // outward as a chunk. The image rides a trailing assistant message event.
+    const images: MessageImageContent[] = [];
+    let assistantText = "";
+    for await (const item of this.streamResponsesRequest(args, request)) {
+      const image = imageContentFromChunk(item);
+      if (image) {
+        images.push(image);
+        continue;
+      }
+      if (
+        isRecord(item) &&
+        item.type === "chunk" &&
+        typeof item.content === "string" &&
+        !item.thinking
+      ) {
+        assistantText += item.content;
+      }
+      yield item;
+    }
+    if (images.length > 0) {
+      yield {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: assistantContentWithImages(assistantText, images)
+        }
+      };
+    }
   }
 
   override async *generateLoop(
@@ -376,19 +431,11 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
 
       previousResponseId = state.responseId;
       // Native image_generation results ride the assistant message as image
-      // content (a multi-megabyte base64 blob must not hit the text stream) and
-      // don't affect pending-tool semantics.
-      let assistantContent: string | MessageContent[] | null;
-      if (state.images.length > 0) {
-        const blocks: MessageContent[] = [];
-        if (state.assistantText) {
-          blocks.push({ type: "text", text: state.assistantText });
-        }
-        blocks.push(...state.images);
-        assistantContent = blocks;
-      } else {
-        assistantContent = state.assistantText || null;
-      }
+      // content and don't affect pending-tool semantics.
+      const assistantContent: string | MessageContent[] | null =
+        state.images.length > 0
+          ? assistantContentWithImages(state.assistantText, state.images)
+          : state.assistantText || null;
       const assistantMsg: Message = {
         role: "assistant",
         content: assistantContent,
@@ -508,20 +555,9 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
         continue;
       }
       if (isRecord(item) && item.type === "chunk") {
-        if (item.content_type === "image" && typeof item.content === "string") {
-          // Absorb the native image into the assistant message rather than
-          // leaking a base64 blob into the outward text-chunk stream.
-          const metadata = isRecord(item.content_metadata)
-            ? item.content_metadata
-            : {};
-          const mimeType =
-            typeof metadata.mimeType === "string"
-              ? metadata.mimeType
-              : "image/png";
-          state.images.push({
-            type: "image_url",
-            image: { data: item.content, mimeType }
-          });
+        const image = imageContentFromChunk(item);
+        if (image) {
+          state.images.push(image);
           state.emittedContent = true;
           continue;
         }

--- a/packages/runtime/src/providers/openai-responses-provider.ts
+++ b/packages/runtime/src/providers/openai-responses-provider.ts
@@ -4,6 +4,7 @@ import { BaseProvider, splitToolResultImages } from "./base-provider.js";
 import { OpenAIProvider } from "./openai-provider.js";
 import { hashSystemPrompt } from "./provider-session.js";
 import {
+  extractResponsesImages,
   extractResponsesText,
   extractResponsesToolCalls,
   isRecord,
@@ -16,10 +17,12 @@ import {
 import {
   isProviderMessageEvent,
   isProviderSessionUpdate,
+  IMAGE_GENERATION_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME,
   type LanguageModel,
   type Message,
   type MessageContent,
+  type MessageImageContent,
   type ProviderSession,
   type ProviderStreamItem,
   type ProviderTool,
@@ -30,6 +33,10 @@ const log = createLogger("nodetool.runtime.providers.openai-responses");
 
 const RESPONSE_WEB_SEARCH_TOOL: Record<string, unknown> = {
   type: "web_search"
+};
+
+const RESPONSE_IMAGE_GENERATION_TOOL: Record<string, unknown> = {
+  type: "image_generation"
 };
 
 const OPENAI_RESPONSES_FALLBACK_MODELS: LanguageModel[] = [
@@ -69,6 +76,7 @@ type ResponsesCreate = (
 
 interface StreamTurnState {
   assistantText: string;
+  images: MessageImageContent[];
   pending: ToolCall[];
   responseId: string | null;
   emittedContent: boolean;
@@ -111,6 +119,10 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
     return true;
   }
 
+  override get supportsNativeImageGeneration(): boolean {
+    return true;
+  }
+
   override async hasToolSupport(model: string): Promise<boolean> {
     return isOpenAIResponsesModel(model);
   }
@@ -131,6 +143,10 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
     for (const tool of tools) {
       if (tool.name === WEB_SEARCH_TOOL_NAME) {
         formatted.push(RESPONSE_WEB_SEARCH_TOOL);
+        continue;
+      }
+      if (tool.name === IMAGE_GENERATION_TOOL_NAME) {
+        formatted.push(RESPONSE_IMAGE_GENERATION_TOOL);
         continue;
       }
       const [functionTool] = responseTools([tool]);
@@ -167,10 +183,21 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
       response.output,
       this.buildToolCall.bind(this)
     );
+    const images = extractResponsesImages(response.output);
+
+    let content: string | MessageContent[] | null;
+    if (images.length > 0) {
+      const blocks: MessageContent[] = [];
+      if (outputText) blocks.push({ type: "text", text: outputText });
+      blocks.push(...images);
+      content = blocks;
+    } else {
+      content = outputText || null;
+    }
 
     return {
       role: "assistant",
-      content: outputText || null,
+      content,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined
     };
   }
@@ -278,7 +305,8 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
     if (tools.length > 0) {
       request.tools = tools;
       request.tool_choice =
-        args.toolChoice === WEB_SEARCH_TOOL_NAME
+        args.toolChoice === WEB_SEARCH_TOOL_NAME ||
+        args.toolChoice === IMAGE_GENERATION_TOOL_NAME
           ? "auto"
           : responseToolChoice(args.toolChoice) ?? "auto";
     }
@@ -309,6 +337,7 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
   private createTurnState(responseId: string | null): StreamTurnState {
     return {
       assistantText: "",
+      images: [],
       pending: [],
       responseId,
       emittedContent: false
@@ -346,9 +375,23 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
       yield* this.collectModelTurn(config.args, request, config.systemHash, state);
 
       previousResponseId = state.responseId;
+      // Native image_generation results ride the assistant message as image
+      // content (a multi-megabyte base64 blob must not hit the text stream) and
+      // don't affect pending-tool semantics.
+      let assistantContent: string | MessageContent[] | null;
+      if (state.images.length > 0) {
+        const blocks: MessageContent[] = [];
+        if (state.assistantText) {
+          blocks.push({ type: "text", text: state.assistantText });
+        }
+        blocks.push(...state.images);
+        assistantContent = blocks;
+      } else {
+        assistantContent = state.assistantText || null;
+      }
       const assistantMsg: Message = {
         role: "assistant",
-        content: state.assistantText || null,
+        content: assistantContent,
         toolCalls: state.pending.length > 0 ? state.pending : null
       };
       yield { type: "message", message: assistantMsg };
@@ -465,6 +508,23 @@ export class OpenAIResponsesProvider extends OpenAIProvider {
         continue;
       }
       if (isRecord(item) && item.type === "chunk") {
+        if (item.content_type === "image" && typeof item.content === "string") {
+          // Absorb the native image into the assistant message rather than
+          // leaking a base64 blob into the outward text-chunk stream.
+          const metadata = isRecord(item.content_metadata)
+            ? item.content_metadata
+            : {};
+          const mimeType =
+            typeof metadata.mimeType === "string"
+              ? metadata.mimeType
+              : "image/png";
+          state.images.push({
+            type: "image_url",
+            image: { data: item.content, mimeType }
+          });
+          state.emittedContent = true;
+          continue;
+        }
         if (typeof item.content === "string" && !item.thinking) {
           state.assistantText += item.content;
           if (item.content) state.emittedContent = true;

--- a/packages/runtime/src/providers/responses-api.ts
+++ b/packages/runtime/src/providers/responses-api.ts
@@ -69,12 +69,41 @@ export async function messagesToResponsesInput(
     }
 
     if (message.role === "assistant") {
-      const text = stringifyContent(message.content);
-      if (text) {
+      const outputParts: Array<Record<string, unknown>> = [];
+      // The Responses input schema doesn't accept images in assistant output,
+      // so a previously generated image is re-presented as a user input_image
+      // after the assistant turn. Preserves multi-turn edit context on a fresh
+      // replay (no previous_response_id to resume from / expired session).
+      const trailingImages: Array<Record<string, unknown>> = [];
+      if (typeof message.content === "string") {
+        if (message.content) {
+          outputParts.push({ type: "output_text", text: message.content });
+        }
+      } else if (Array.isArray(message.content)) {
+        const textParts: string[] = [];
+        for (const part of message.content) {
+          if (part.type === "text") {
+            textParts.push(part.text);
+          } else if (part.type === "image_url") {
+            const converted = await responseInputContent(part, resolveUri);
+            if (converted) {
+              trailingImages.push({
+                type: "message",
+                role: "user",
+                content: [converted]
+              });
+            }
+          }
+        }
+        const text = textParts.join("");
+        if (text) outputParts.push({ type: "output_text", text });
+      }
+
+      if (outputParts.length > 0) {
         input.push({
           type: "message",
           role: "assistant",
-          content: [{ type: "output_text", text }]
+          content: outputParts
         });
       }
       for (const toolCall of message.toolCalls ?? []) {
@@ -86,6 +115,7 @@ export async function messagesToResponsesInput(
           arguments: JSON.stringify(toolCall.args ?? {})
         });
       }
+      for (const imageItem of trailingImages) input.push(imageItem);
       continue;
     }
 
@@ -158,6 +188,27 @@ export function extractResponsesToolCalls(
     );
   }
   return toolCalls;
+}
+
+export function extractResponsesImages(output: unknown): MessageImageContent[] {
+  if (!Array.isArray(output)) return [];
+  const images: MessageImageContent[] = [];
+  for (const item of output) {
+    if (
+      !isRecord(item) ||
+      item.type !== "image_generation_call" ||
+      typeof item.result !== "string"
+    ) {
+      continue;
+    }
+    const format =
+      typeof item.output_format === "string" ? item.output_format : "png";
+    images.push({
+      type: "image_url",
+      image: { data: item.result, mimeType: `image/${format}` }
+    });
+  }
+  return images;
 }
 
 export function responseUsage(response: Record<string, unknown>): UsageInfo {
@@ -253,6 +304,37 @@ export async function* streamResponsesEvents(
         String(event.name ?? current?.name ?? ""),
         argsText
       );
+      continue;
+    }
+
+    if (type === "response.output_item.done") {
+      // The `image_generation` tool is a server-side tool: the image arrives as
+      // a completed output item, with no function_call_output round trip, so it
+      // must never enter the pending tool-call set. Surface it as an image chunk.
+      const item = event.item;
+      if (
+        isRecord(item) &&
+        item.type === "image_generation_call" &&
+        typeof item.result === "string"
+      ) {
+        const format =
+          typeof item.output_format === "string" ? item.output_format : "png";
+        const chunk: Chunk = {
+          type: "chunk",
+          content: item.result,
+          content_type: "image",
+          content_metadata: {
+            mimeType: `image/${format}`,
+            itemId: typeof item.id === "string" ? item.id : undefined,
+            revisedPrompt:
+              typeof item.revised_prompt === "string"
+                ? item.revised_prompt
+                : undefined
+          },
+          done: false
+        };
+        yield chunk;
+      }
       continue;
     }
 

--- a/packages/runtime/src/providers/responses-api.ts
+++ b/packages/runtime/src/providers/responses-api.ts
@@ -57,8 +57,21 @@ export async function messagesToResponsesInput(
   resolveUri: (uri: string) => Promise<string>
 ): Promise<Array<Record<string, unknown>>> {
   const input: Array<Record<string, unknown>> = [];
+  // Images generated on a prior assistant turn, awaiting re-presentation. The
+  // Responses input schema doesn't accept images in assistant output, so each
+  // one is re-presented as a user input_image — but only AFTER the turn's tool
+  // block: a function_call and its function_call_output must stay adjacent,
+  // so the flush waits for the first non-tool message (or end of history).
+  // Preserves multi-turn edit context on a fresh replay (no
+  // previous_response_id to resume from / expired session).
+  let pendingImages: Array<Record<string, unknown>> = [];
 
   for (const message of messages) {
+    if (message.role !== "tool" && pendingImages.length > 0) {
+      input.push(...pendingImages);
+      pendingImages = [];
+    }
+
     if (message.role === "tool") {
       input.push({
         type: "function_call_output",
@@ -70,11 +83,6 @@ export async function messagesToResponsesInput(
 
     if (message.role === "assistant") {
       const outputParts: Array<Record<string, unknown>> = [];
-      // The Responses input schema doesn't accept images in assistant output,
-      // so a previously generated image is re-presented as a user input_image
-      // after the assistant turn. Preserves multi-turn edit context on a fresh
-      // replay (no previous_response_id to resume from / expired session).
-      const trailingImages: Array<Record<string, unknown>> = [];
       if (typeof message.content === "string") {
         if (message.content) {
           outputParts.push({ type: "output_text", text: message.content });
@@ -87,7 +95,7 @@ export async function messagesToResponsesInput(
           } else if (part.type === "image_url") {
             const converted = await responseInputContent(part, resolveUri);
             if (converted) {
-              trailingImages.push({
+              pendingImages.push({
                 type: "message",
                 role: "user",
                 content: [converted]
@@ -115,7 +123,6 @@ export async function messagesToResponsesInput(
           arguments: JSON.stringify(toolCall.args ?? {})
         });
       }
-      for (const imageItem of trailingImages) input.push(imageItem);
       continue;
     }
 
@@ -133,6 +140,7 @@ export async function messagesToResponsesInput(
     input.push({ role: message.role, content });
   }
 
+  input.push(...pendingImages);
   return input;
 }
 

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -102,6 +102,18 @@ export interface ToolCall {
  */
 export const WEB_SEARCH_TOOL_NAME = "web_search";
 
+/**
+ * Canonical name for the image-generation tool. Providers with a built-in,
+ * server-side image generator (`supportsNativeImageGeneration`, e.g. the
+ * OpenAI Responses `image_generation` tool) render a tool with this name as
+ * their native tool: the generated image arrives inside the model turn as an
+ * `image_generation_call` output item — there is no function-call round-trip —
+ * and the provider surfaces it as image content on the assistant message.
+ * Providers without native support fall back to a function tool that calls
+ * `textToImage`/`imageToImage`.
+ */
+export const IMAGE_GENERATION_TOOL_NAME = "image_generation";
+
 export interface ProviderTool {
   name: string;
   description?: string;

--- a/packages/runtime/tests/providers/openai-responses-provider.test.ts
+++ b/packages/runtime/tests/providers/openai-responses-provider.test.ts
@@ -393,6 +393,103 @@ describe("OpenAIResponsesProvider", () => {
     ]);
   });
 
+  it("keeps function_call/function_call_output adjacent when replaying an image+tool turn", async () => {
+    const b64 = "aGVsbG8=";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "image and a lookup" },
+          { type: "image_url", image: { data: b64, mimeType: "image/png" } }
+        ] as MessageContent[],
+        toolCalls: [{ id: "call_1", name: "lookup", args: { q: "fox" } }]
+      },
+      { role: "tool", toolCallId: "call_1", content: "result" },
+      { role: "user", content: "make it blue" }
+    ];
+
+    const input = await messagesToResponsesInput(messages, async (uri) => uri);
+
+    // The re-presented image must NOT split the call/output pair; it flushes
+    // after the tool block, before the next user turn.
+    expect(input.map((item) => item.type ?? (item.role as string))).toEqual([
+      "message", // assistant text
+      "function_call",
+      "function_call_output",
+      "message", // re-presented user input_image
+      "user" // next user turn
+    ]);
+    expect(input[3]).toEqual({
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_image", image_url: `data:image/png;base64,${b64}` }
+      ]
+    });
+  });
+
+  it("re-presents a trailing assistant image even when history ends on a tool message", async () => {
+    const b64 = "aGVsbG8=";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "image_url", image: { data: b64, mimeType: "image/png" } }
+        ] as MessageContent[],
+        toolCalls: [{ id: "call_1", name: "lookup", args: {} }]
+      },
+      { role: "tool", toolCallId: "call_1", content: "result" }
+    ];
+
+    const input = await messagesToResponsesInput(messages, async (uri) => uri);
+
+    expect(input.map((item) => item.type)).toEqual([
+      "function_call",
+      "function_call_output",
+      "message"
+    ]);
+  });
+
+  it("absorbs native image chunks on the non-loop generateMessages path", async () => {
+    const b64 = "aGVsbG8=";
+    const create = vi.fn().mockResolvedValue(
+      makeAsyncIterable([
+        { type: "response.created", response: { id: "resp_img" } },
+        { type: "response.output_text.delta", delta: "Sure" },
+        {
+          type: "response.output_item.done",
+          item: { type: "image_generation_call", id: "ig_1", result: b64 }
+        },
+        { type: "response.completed", response: { id: "resp_img" } }
+      ])
+    );
+    const provider = providerWithCreate(create);
+
+    const items = await collect(
+      provider.generateMessages({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "draw" }],
+        tools: [{ name: IMAGE_GENERATION_TOOL_NAME }]
+      })
+    );
+
+    const chunks = items.filter(
+      (item): item is Extract<ProviderStreamItem, { type: "chunk" }> =>
+        "type" in item && item.type === "chunk"
+    );
+    expect(chunks.every((c) => c.content !== b64)).toBe(true);
+
+    const messages = items.filter(
+      (item): item is Extract<ProviderStreamItem, { type: "message" }> =>
+        "type" in item && item.type === "message"
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message.content).toEqual([
+      { type: "text", text: "Sure" },
+      { type: "image_url", image: { data: b64, mimeType: "image/png" } }
+    ]);
+  });
+
   it("extractResponsesImages pulls image_generation_call items", () => {
     const b64 = "aGVsbG8=";
     const images = extractResponsesImages([

--- a/packages/runtime/tests/providers/openai-responses-provider.test.ts
+++ b/packages/runtime/tests/providers/openai-responses-provider.test.ts
@@ -3,9 +3,16 @@ import { PROVIDER_IDS } from "@nodetool-ai/protocol";
 import type OpenAI from "openai";
 import { OpenAIProvider } from "../../src/providers/openai-provider.js";
 import { OpenAIResponsesProvider } from "../../src/providers/openai-responses-provider.js";
-import type {
-  Message,
-  ProviderStreamItem
+import {
+  extractResponsesImages,
+  messagesToResponsesInput
+} from "../../src/providers/responses-api.js";
+import {
+  IMAGE_GENERATION_TOOL_NAME,
+  type Message,
+  type MessageContent,
+  type MessageImageContent,
+  type ProviderStreamItem
 } from "../../src/providers/types.js";
 
 function makeAsyncIterable(
@@ -50,6 +57,10 @@ describe("OpenAIResponsesProvider", () => {
     expect(new OpenAIProvider({ OPENAI_API_KEY: "k" }).supportsNativeWebSearch).toBe(
       false
     );
+    expect(provider.supportsNativeImageGeneration).toBe(true);
+    expect(
+      new OpenAIProvider({ OPENAI_API_KEY: "k" }).supportsNativeImageGeneration
+    ).toBe(false);
     await expect(provider.hasToolSupport("o3-mini")).resolves.toBe(true);
     await expect(provider.hasToolSupport("text-embedding-3-small")).resolves.toBe(
       false
@@ -288,6 +299,116 @@ describe("OpenAIResponsesProvider", () => {
       "assistant",
       "tool",
       "assistant"
+    ]);
+  });
+
+  it("maps the image_generation tool to a hosted Responses tool", () => {
+    const provider = providerWithCreate(vi.fn());
+
+    expect(
+      provider.formatTools([{ name: IMAGE_GENERATION_TOOL_NAME }])
+    ).toEqual([{ type: "image_generation" }]);
+  });
+
+  it("surfaces a native image_generation_call as assistant image content", async () => {
+    const b64 = "aGVsbG8="; // "hello"
+    const create = vi.fn().mockResolvedValue(
+      makeAsyncIterable([
+        { type: "response.created", response: { id: "resp_img" } },
+        { type: "response.output_text.delta", delta: "Here you go" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "image_generation_call",
+            id: "ig_1",
+            result: b64,
+            output_format: "webp",
+            revised_prompt: "a red fox"
+          }
+        },
+        { type: "response.completed", response: { id: "resp_img" } }
+      ])
+    );
+    const provider = providerWithCreate(create);
+
+    const items = await collect(
+      provider.generateLoop({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "draw a fox" }],
+        tools: [{ name: IMAGE_GENERATION_TOOL_NAME }]
+      })
+    );
+
+    // Only one request — the server-side tool must not trigger a tool round.
+    expect(create).toHaveBeenCalledTimes(1);
+
+    const chunks = items.filter(
+      (item): item is Extract<ProviderStreamItem, { type: "chunk" }> =>
+        "type" in item && item.type === "chunk"
+    );
+    // The base64 blob must never leak into the outward chunk stream.
+    expect(chunks.every((c) => c.content !== b64)).toBe(true);
+    expect(chunks.some((c) => c.content === "Here you go")).toBe(true);
+
+    const messages = items.filter(
+      (item): item is Extract<ProviderStreamItem, { type: "message" }> =>
+        "type" in item && item.type === "message"
+    );
+    expect(messages).toHaveLength(1);
+    const content = messages[0].message.content as MessageContent[];
+    expect(content).toEqual([
+      { type: "text", text: "Here you go" },
+      { type: "image_url", image: { data: b64, mimeType: "image/webp" } }
+    ]);
+    expect(messages[0].message.toolCalls).toBeNull();
+  });
+
+  it("re-presents an assistant image as a user input_image in replay input", async () => {
+    const b64 = "aGVsbG8=";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "here is your image" },
+          { type: "image_url", image: { data: b64, mimeType: "image/png" } }
+        ] as MessageContent[]
+      }
+    ];
+
+    const input = await messagesToResponsesInput(messages, async (uri) => uri);
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "here is your image" }]
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_image", image_url: `data:image/png;base64,${b64}` }
+        ]
+      }
+    ]);
+  });
+
+  it("extractResponsesImages pulls image_generation_call items", () => {
+    const b64 = "aGVsbG8=";
+    const images = extractResponsesImages([
+      { type: "message", content: [{ type: "output_text", text: "x" }] },
+      {
+        type: "image_generation_call",
+        id: "ig_1",
+        result: b64,
+        output_format: "jpeg"
+      },
+      { type: "image_generation_call", id: "ig_2", result: b64 }
+    ]);
+
+    expect(images).toEqual<MessageImageContent[]>([
+      { type: "image_url", image: { data: b64, mimeType: "image/jpeg" } },
+      { type: "image_url", image: { data: b64, mimeType: "image/png" } }
     ]);
   });
 });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2658,24 +2658,38 @@ export class UnifiedWebSocketRunner {
       const mimeType =
         typeof image.mimeType === "string" ? image.mimeType : "image/png";
       const ext = IMAGE_MIME_TO_EXT[mimeType] ?? "png";
-      const asset = new Asset({
-        user_id: userId,
-        workflow_id: workflowId ?? null,
-        name: `image_${Date.now()}`,
-        content_type: mimeType,
-        parent_id: null
-      });
-      const fileName = `${asset.id}.${ext}`;
-      await storeAssetWithThumbnail(asset.id, fileName, bytes, mimeType);
-      asset.size = bytes.length;
-      await asset.save();
-      // The DB / wire shape mirrors handleMediaGenerationMessage: an asset_id
-      // reference (never raw bytes). resolveContentUrls / resolveContentForProvider
-      // dereference asset_id on the way out and on the next turn.
-      out.push({
-        type: "image_url",
-        image: { type: "image", asset_id: asset.id, mimeType }
-      });
+      // Per-block isolation: a storage failure must not abort the whole turn —
+      // the image is already generated (and billed), and the assistant text
+      // plus any sibling images should still reach the user. Degrade the
+      // failed block to a text notice; never fall back to raw base64.
+      try {
+        const asset = new Asset({
+          user_id: userId,
+          workflow_id: workflowId ?? null,
+          name: `image_${Date.now()}`,
+          content_type: mimeType,
+          parent_id: null
+        });
+        const fileName = `${asset.id}.${ext}`;
+        await storeAssetWithThumbnail(asset.id, fileName, bytes, mimeType);
+        asset.size = bytes.length;
+        await asset.save();
+        // The DB / wire shape mirrors handleMediaGenerationMessage: an asset_id
+        // reference (never raw bytes). resolveContentUrls / resolveContentForProvider
+        // dereference asset_id on the way out and on the next turn.
+        out.push({
+          type: "image_url",
+          image: { type: "image", asset_id: asset.id, mimeType }
+        });
+      } catch (err) {
+        log.error("Failed to store generated image as asset", {
+          error: err instanceof Error ? err.message : String(err)
+        });
+        out.push({
+          type: "text",
+          text: "[a generated image could not be saved]"
+        });
+      }
     }
     return out;
   }

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2624,6 +2624,63 @@ export class UnifiedWebSocketRunner {
   }
 
   /**
+   * Persist raw image bytes carried on an assistant message (native providers
+   * that run a server-side image tool emit them inline) as real assets, and
+   * rewrite each such block to the wire shape `{ type: "image_url", image: {
+   * type: "image", asset_id, mimeType } }`. Blocks that already reference an
+   * asset (uri / asset_id, no raw data) and non-image blocks pass through
+   * untouched. Raw base64 is never persisted or sent.
+   */
+  private async materializeAssistantImageContent(
+    content: MessageContent[],
+    userId: string,
+    workflowId: string | null
+  ): Promise<Array<Record<string, unknown>>> {
+    const out: Array<Record<string, unknown>> = [];
+    for (const block of content) {
+      if (block.type !== "image_url") {
+        out.push(block as unknown as Record<string, unknown>);
+        continue;
+      }
+      const image = block.image;
+      const rawData = image.data;
+      let bytes: Uint8Array | null = null;
+      if (rawData instanceof Uint8Array) {
+        bytes = rawData;
+      } else if (typeof rawData === "string" && rawData) {
+        bytes = new Uint8Array(Buffer.from(rawData, "base64"));
+      }
+      if (!bytes) {
+        // Already an asset/uri reference (or empty) — leave as-is.
+        out.push(block as unknown as Record<string, unknown>);
+        continue;
+      }
+      const mimeType =
+        typeof image.mimeType === "string" ? image.mimeType : "image/png";
+      const ext = IMAGE_MIME_TO_EXT[mimeType] ?? "png";
+      const asset = new Asset({
+        user_id: userId,
+        workflow_id: workflowId ?? null,
+        name: `image_${Date.now()}`,
+        content_type: mimeType,
+        parent_id: null
+      });
+      const fileName = `${asset.id}.${ext}`;
+      await storeAssetWithThumbnail(asset.id, fileName, bytes, mimeType);
+      asset.size = bytes.length;
+      await asset.save();
+      // The DB / wire shape mirrors handleMediaGenerationMessage: an asset_id
+      // reference (never raw bytes). resolveContentUrls / resolveContentForProvider
+      // dereference asset_id on the way out and on the next turn.
+      out.push({
+        type: "image_url",
+        image: { type: "image", asset_id: asset.id, mimeType }
+      });
+    }
+    return out;
+  }
+
+  /**
    * Recursively process tool results, handling asset-like objects.
    * Mirrors Python's RegularChatProcessor._process_tool_result().
    *
@@ -3624,7 +3681,27 @@ export class UnifiedWebSocketRunner {
         if (isProviderMessageEvent(item)) {
           const m = item.message;
           if (m.role === "assistant") {
-            if (typeof m.content === "string") content = m.content;
+            // Content may be a plain string or a MessageContent[] carrying
+            // native-image blocks. Raw image bytes are turned into real assets
+            // here so base64 never lands in the DB or on the wire.
+            let persistedContent: unknown = m.content ?? null;
+            if (typeof m.content === "string") {
+              content = m.content;
+            } else if (Array.isArray(m.content)) {
+              const materialized = await this.materializeAssistantImageContent(
+                m.content,
+                userId,
+                workflowId
+              );
+              persistedContent = materialized;
+              content = materialized
+                .filter(
+                  (c) =>
+                    c.type === "text" && typeof c.text === "string"
+                )
+                .map((c) => c.text as string)
+                .join("");
+            }
             const toolCalls = Array.isArray(m.toolCalls)
               ? m.toolCalls.map((tc) => ({
                   id: tc.id,
@@ -3636,7 +3713,7 @@ export class UnifiedWebSocketRunner {
             const assistantMsgData: Record<string, unknown> = {
               type: "message",
               role: "assistant",
-              content: m.content ?? null,
+              content: persistedContent,
               ...(toolCalls ? { tool_calls: toolCalls } : {}),
               thread_id: threadId,
               workflow_id: workflowId,

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1008,6 +1008,11 @@ with the \`ToolSearch\` tool.
 
 # Image and media
 When tools return media URLs, embed them as markdown image / link tags.
+Image URIs often use the \`asset://<id>.<ext>\` scheme (e.g.
+\`asset://b7953a3877e2437bbc1bc51792fcd222.png\`) — embed these verbatim as
+markdown images: \`![](asset://<id>.<ext>)\`. The chat UI resolves \`asset://\`
+to a fetchable URL and renders the image inline; do not rewrite it to an HTTP
+URL or wrap it in a code block.
 
 # File types
 References to documents, images, videos, or audio files have the shape:
@@ -3334,11 +3339,18 @@ export class UnifiedWebSocketRunner {
         this.runSingleNode(nodeType, inputs, userId, threadId)
       )
     ];
+    // When the active provider generates images natively (OpenAI Responses
+    // `image_generation` tool), drop the redundant provider-specific
+    // `openai_image_generation` tool — the native `image_generation` covers it
+    // and avoids offering two overlapping image tools.
+    const dropOpenAIImageTool = provider.supportsNativeImageGeneration;
     // De-duplicate by name (builtins / mcp / extras may overlap); first wins.
     const dedupedToolbelt: Tool[] = [];
     const seenToolNames = new Set<string>();
     for (const tool of rawToolbelt) {
       if (seenToolNames.has(tool.name)) continue;
+      if (dropOpenAIImageTool && tool.name === "openai_image_generation")
+        continue;
       seenToolNames.add(tool.name);
       dedupedToolbelt.push(tool);
     }

--- a/packages/websocket/tests/assistant-image-materialize.test.ts
+++ b/packages/websocket/tests/assistant-image-materialize.test.ts
@@ -96,6 +96,43 @@ describe("materializeAssistantImageContent", () => {
     expect(out).toEqual(content);
   });
 
+  it("isolates a storage failure to its block and keeps the rest of the turn", async () => {
+    const b64ok = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    const b64bad = Buffer.from([0xff, 0xd8]).toString("base64");
+    storeMock
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValueOnce(undefined);
+    const content: MessageContent[] = [
+      { type: "text", text: "two images" },
+      {
+        type: "image_url",
+        image: { type: "image", data: b64bad, mimeType: "image/jpeg" }
+      },
+      {
+        type: "image_url",
+        image: { type: "image", data: b64ok, mimeType: "image/png" }
+      }
+    ];
+
+    const out = await (
+      runner as unknown as MaterializeRunner
+    ).materializeAssistantImageContent(content, "user-9", "wf-1");
+
+    // The failed block degrades to a text notice; the sibling image and the
+    // assistant text still make it through, and no base64 leaks.
+    expect(out[0]).toEqual({ type: "text", text: "two images" });
+    expect(out[1]).toEqual({
+      type: "text",
+      text: "[a generated image could not be saved]"
+    });
+    expect(out[2]).toEqual({
+      type: "image_url",
+      image: { type: "image", asset_id: "asset-2", mimeType: "image/png" }
+    });
+    expect(JSON.stringify(out)).not.toContain(b64bad);
+    expect(JSON.stringify(out)).not.toContain(b64ok);
+  });
+
   it("decodes Uint8Array image data as well", async () => {
     const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
     const content: MessageContent[] = [

--- a/packages/websocket/tests/assistant-image-materialize.test.ts
+++ b/packages/websocket/tests/assistant-image-materialize.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit test for materializing native-image assistant content into assets.
+ *
+ * Native providers (e.g. OpenAI Responses) emit an assistant message whose
+ * content array carries raw base64 image bytes. The runner must persist those
+ * as real assets and rewrite each block to an `asset_id` reference so raw
+ * base64 never lands in the DB or on the wire. Blocks that already reference an
+ * asset, and non-image blocks, pass through untouched.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { UnifiedWebSocketRunner } from "../src/unified-websocket-runner.js";
+import type { MessageContent } from "@nodetool-ai/protocol";
+
+const storeMock = vi.fn(async () => undefined);
+vi.mock("../src/lib/thumbnail.js", () => ({
+  storeAssetWithThumbnail: (...args: unknown[]) => storeMock(...args)
+}));
+
+let assetSeq = 0;
+vi.mock("@nodetool-ai/models", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/models")>();
+  class FakeAsset {
+    id = `asset-${++assetSeq}`;
+    size = 0;
+    constructor(public readonly props: Record<string, unknown>) {}
+    async save(): Promise<void> {}
+  }
+  return { ...actual, Asset: FakeAsset };
+});
+
+interface MaterializeRunner {
+  materializeAssistantImageContent(
+    content: MessageContent[],
+    userId: string,
+    workflowId: string | null
+  ): Promise<Array<Record<string, unknown>>>;
+}
+
+describe("materializeAssistantImageContent", () => {
+  let runner: UnifiedWebSocketRunner;
+
+  beforeEach(() => {
+    assetSeq = 0;
+    storeMock.mockClear();
+    runner = new UnifiedWebSocketRunner({
+      resolveExecutor: () => ({
+        async process() {
+          return {};
+        }
+      })
+    });
+  });
+
+  it("persists raw base64 image blocks as assets and rewrites them", async () => {
+    const b64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    const content: MessageContent[] = [
+      { type: "text", text: "Here is your image" },
+      {
+        type: "image_url",
+        image: { type: "image", data: b64, mimeType: "image/png" }
+      }
+    ];
+
+    const out = await (
+      runner as unknown as MaterializeRunner
+    ).materializeAssistantImageContent(content, "user-9", "wf-1");
+
+    expect(storeMock).toHaveBeenCalledTimes(1);
+    expect(out[0]).toEqual({ type: "text", text: "Here is your image" });
+    expect(out[1]).toEqual({
+      type: "image_url",
+      image: { type: "image", asset_id: "asset-1", mimeType: "image/png" }
+    });
+    // The raw base64 must not survive into the persisted block.
+    expect(JSON.stringify(out)).not.toContain(b64);
+  });
+
+  it("leaves already-referenced and non-image blocks untouched", async () => {
+    const content: MessageContent[] = [
+      { type: "text", text: "note" },
+      {
+        type: "image_url",
+        image: { type: "image", asset_id: "existing-42", mimeType: "image/png" }
+      },
+      {
+        type: "image_url",
+        image: { type: "image", uri: "asset://existing-7.png" }
+      }
+    ];
+
+    const out = await (
+      runner as unknown as MaterializeRunner
+    ).materializeAssistantImageContent(content, "user-9", null);
+
+    expect(storeMock).not.toHaveBeenCalled();
+    expect(out).toEqual(content);
+  });
+
+  it("decodes Uint8Array image data as well", async () => {
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+    const content: MessageContent[] = [
+      {
+        type: "image_url",
+        image: { type: "image", data: bytes, mimeType: "image/jpeg" }
+      }
+    ];
+
+    const out = await (
+      runner as unknown as MaterializeRunner
+    ).materializeAssistantImageContent(content, "user-9", "wf-2");
+
+    expect(storeMock).toHaveBeenCalledTimes(1);
+    expect(out[0]).toEqual({
+      type: "image_url",
+      image: { type: "image", asset_id: "asset-1", mimeType: "image/jpeg" }
+    });
+  });
+});

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -9,7 +9,15 @@ import { SPACING, getSpacingPx } from "../../ui_primitives/spacing";
 import { CodeBlock } from "./markdown_elements/CodeBlock";
 import { PreRenderer } from "./markdown_elements/PreRenderer";
 import { BORDER_RADIUS } from "../../ui_primitives";
+import { resolveUri } from "../../../utils/imageUtils";
 import "../../../styles/markdown/github-markdown.css";
+
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".avif"];
+
+const isImageHref = (href: string): boolean => {
+  const lower = href.toLowerCase().split(/[?#]/)[0];
+  return IMAGE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+};
 
 interface ChatMarkdownProps {
   content: string;
@@ -51,6 +59,7 @@ const REHYPE_PLUGINS: Options["rehypePlugins"] = [rehypeRaw];
 
 const audioSpanCss = css({ display: "inline-flex", alignItems: "center", gap: getSpacingPx(SPACING.md), verticalAlign: "middle" });
 const audioCss = css({ height: "32px" });
+const imageCss = css({ maxWidth: "100%", height: "auto", borderRadius: BORDER_RADIUS.md });
 
 const ChatMarkdown: React.FC<ChatMarkdownProps> = React.memo(({
   content,
@@ -60,8 +69,24 @@ const ChatMarkdown: React.FC<ChatMarkdownProps> = React.memo(({
     () => ({
       code: (props: React.ComponentPropsWithoutRef<"code">) => <CodeBlock {...props} onInsert={onInsertCode} />,
       pre: (props: React.ComponentPropsWithoutRef<"pre">) => <PreRenderer {...props} onInsert={onInsertCode} />,
+      img: ({ node: _node, src, alt, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"img">) => (
+        <img
+          {...props}
+          src={typeof src === "string" ? resolveUri(src) : src}
+          alt={alt ?? ""}
+          css={imageCss}
+          loading="lazy"
+        />
+      ),
       a: ({ node: _node, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"a">) => {
         const { href, children } = props;
+        if (href && isImageHref(href)) {
+          return (
+            <a href={resolveUri(href)} target="_blank" rel="noopener noreferrer">
+              <img src={resolveUri(href)} alt={String(children ?? "")} css={imageCss} loading="lazy" />
+            </a>
+          );
+        }
         const isAudio =
           href &&
           (href.toLowerCase().endsWith(".mp3") ||

--- a/web/src/utils/imageUtils.ts
+++ b/web/src/utils/imageUtils.ts
@@ -19,7 +19,7 @@ export interface ImageSource {
  * - `/api/...` → prefixed with `BASE_URL`.
  * - Other absolute URIs (`data:`, `blob:`, `http:`, `https:`) returned as-is.
  */
-const resolveUri = (uri: string): string => {
+export const resolveUri = (uri: string): string => {
   if (uri.startsWith("asset://")) {
     const assetId = uri.slice("asset://".length);
     return `${BASE_URL}/api/storage/${assetId}`;


### PR DESCRIPTION
## Summary

Adds support for native server-side image generation via the OpenAI Responses API. When a provider supports native image generation (`supportsNativeImageGeneration`), the `image_generation` tool is rendered as the provider's built-in tool—images arrive directly on the assistant message as `image_generation_call` output items, not through a function-call round-trip. Raw base64 image data is persisted as real assets before being sent to clients, ensuring binary data never leaks into the database or over the wire.

## Key Changes

- **OpenAI Responses Provider**
  - Added `supportsNativeImageGeneration` property (returns `true`)
  - Maps `IMAGE_GENERATION_TOOL_NAME` tool to Responses API `image_generation` type
  - Extracts `image_generation_call` items from response output and surfaces them as `MessageImageContent` on assistant messages
  - Absorbs native image chunks in both `generateMessages()` and `generateLoop()` paths, preventing raw base64 from leaking as chunks
  - Handles image content in message replay via `messagesToResponsesInput()`

- **Responses API Utilities**
  - Added `extractResponsesImages()` to pull `image_generation_call` items from response output and convert to `MessageImageContent`
  - Enhanced `messagesToResponsesInput()` to re-present assistant-generated images as user `input_image` messages during replay, with proper ordering to keep function_call/function_call_output pairs adjacent
  - Added `response.output_item.done` event handling in `streamResponsesEvents()` to surface native image results as image chunks

- **WebSocket Runner**
  - Added `materializeAssistantImageContent()` to persist raw image bytes (base64 or Uint8Array) as real assets and rewrite blocks to asset references
  - Per-block error isolation: storage failures degrade to text notices without aborting the turn
  - Integrated materialization into message event handling so raw base64 never reaches the database or clients

- **Base Provider & Types**
  - Added `supportsNativeImageGeneration` property to `BaseProvider` (default `false`)
  - Exported `IMAGE_GENERATION_TOOL_NAME` constant for cross-provider use

- **Fallback Image Generation Tool**
  - New `ImageGenerationTool` in `packages/agents/` for providers without native support
  - Delegates to default provider (OpenAI) + model (gpt-image-1) and persists result as asset
  - Registered in builtin tools

- **Tests**
  - Added comprehensive test coverage for native image handling in `OpenAIResponsesProvider`
  - Added `assistant-image-materialize.test.ts` covering asset persistence, error isolation, and Uint8Array handling
  - Added `image-generation-tool.test.ts` for fallback tool behavior

https://claude.ai/code/session_01VR8vL3jgYMosz4b3JBQsg5