### PR TITLE
Security hardening: replace dynamic code evaluation with safe parser

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -124,13 +124,16 @@ async function loadSkillFromFile(
 
   if (!content.startsWith("---")) return null;
 
-  const parts = content.split("---", 3);
+  // Frontmatter is delimited by the first two `---` fences. Rejoin everything
+  // after the second fence so a `---` horizontal rule inside the skill body is
+  // preserved rather than truncated (a limited `split` would discard the tail).
+  const parts = content.split("---");
   if (parts.length < 3) return null;
 
   const metadata = parseFrontmatter(parts[1]);
   const name = (metadata["name"] ?? "").trim();
   const description = (metadata["description"] ?? "").trim();
-  const instructions = parts[2].trim();
+  const instructions = parts.slice(2).join("---").trim();
 
   if (!isValidSkillName(name)) return null;
   if (!isValidSkillDescription(description)) return null;

--- a/packages/agents/src/checkpoint-store.ts
+++ b/packages/agents/src/checkpoint-store.ts
@@ -91,6 +91,50 @@ export function hashPlanKey(input: PlanKeyInput): string {
 }
 
 // ---------------------------------------------------------------------------
+// Shared file persistence helpers (read-merge-write, atomic write)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tolerant read of a `{ [key]: T }` JSON object from disk. A missing or
+ * corrupt file yields an empty map rather than throwing — callers treat a
+ * cache/store file as best-effort.
+ */
+async function readDiskEntries<T>(
+  fs: typeof import("node:fs/promises"),
+  filePath: string
+): Promise<Map<string, T>> {
+  const disk = new Map<string, T>();
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, T>;
+    for (const [k, v] of Object.entries(parsed)) {
+      disk.set(k, v);
+    }
+  } catch {
+    // Missing or corrupt file — treat as empty.
+  }
+  return disk;
+}
+
+/**
+ * Write `contents` to `filePath` atomically: write to a uniquely-named temp
+ * file in the same directory, then `rename` over the target. A reader never
+ * observes a half-written file, and a crash mid-write leaves the previous
+ * contents intact.
+ */
+async function writeAtomic(
+  fs: typeof import("node:fs/promises"),
+  filePath: string,
+  contents: string
+): Promise<void> {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(36)
+    .slice(2)}.tmp`;
+  await fs.writeFile(tmpPath, contents, "utf-8");
+  await fs.rename(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
 // PlanCache
 // ---------------------------------------------------------------------------
 
@@ -117,10 +161,19 @@ export class InMemoryPlanCache implements PlanCache {
  * `{ [key]: TaskPlan }` loaded lazily on first access and written on every
  * `set`. All I/O degrades gracefully: a missing/corrupt file starts empty and a
  * failed write is logged, never thrown.
+ *
+ * Persistence is read-merge-write and serialized through {@link persistQueue}:
+ * every `set()` schedules a step that re-reads the current file, layers the
+ * in-memory map on top (so a `set()` from an instance that never loaded prior
+ * entries — or entries written by another process in the meantime — doesn't
+ * wipe them), and writes the result atomically (temp file + rename). Steps run
+ * strictly one after another, so concurrent `set()` calls never interleave
+ * writes or let an out-of-order completion persist a stale snapshot last.
  */
 export class FilePlanCache implements PlanCache {
   private readonly filePath: string;
   private cache: Map<string, TaskPlan> | null = null;
+  private persistQueue: Promise<void> = Promise.resolve();
 
   constructor(filePath: string) {
     this.filePath = filePath;
@@ -133,26 +186,44 @@ export class FilePlanCache implements PlanCache {
       "node:fs/promises"
     );
     if (!fs) return this.cache;
-    try {
-      const raw = await fs.readFile(this.filePath, "utf-8");
-      const parsed = JSON.parse(raw) as Record<string, TaskPlan>;
-      for (const [k, v] of Object.entries(parsed)) {
-        this.cache.set(k, v);
-      }
-    } catch {
-      // Missing or corrupt cache file — start empty.
+    for (const [k, v] of await readDiskEntries<TaskPlan>(fs, this.filePath)) {
+      this.cache.set(k, v);
     }
     return this.cache;
   }
 
-  private async persist(): Promise<void> {
+  /**
+   * Queue a read-merge-write persist step behind any already-scheduled ones.
+   * Never throws — write failures are logged and the queue continues.
+   */
+  private schedulePersist(): void {
+    this.persistQueue = this.persistQueue.then(() => this.persistOnce());
+  }
+
+  private async persistOnce(): Promise<void> {
     const fs = await importNodeBuiltin<typeof import("node:fs/promises")>(
       "node:fs/promises"
     );
     if (!fs || !this.cache) return;
     try {
-      const obj = Object.fromEntries(this.cache.entries());
-      await fs.writeFile(this.filePath, JSON.stringify(obj), "utf-8");
+      const disk = await readDiskEntries<TaskPlan>(fs, this.filePath);
+      // In-memory entries win over disk on conflicting keys; disk-only keys
+      // (from another instance/process, or entries this instance never
+      // loaded) are preserved instead of being wiped by the write.
+      const merged = new Map(disk);
+      for (const [k, v] of this.cache) {
+        merged.set(k, v);
+      }
+      await writeAtomic(
+        fs,
+        this.filePath,
+        JSON.stringify(Object.fromEntries(merged))
+      );
+      // Absorb disk-only keys into the in-memory mirror so a subsequent sync
+      // `get()` can observe entries persisted elsewhere.
+      for (const [k, v] of merged) {
+        if (!this.cache.has(k)) this.cache.set(k, v);
+      }
     } catch (err) {
       log.warn("FilePlanCache persist failed", {
         filePath: this.filePath,
@@ -169,11 +240,11 @@ export class FilePlanCache implements PlanCache {
     return this.cache?.get(key);
   }
 
-  /** Mutates the in-memory mirror and persists asynchronously (fire-and-forget). */
+  /** Mutates the in-memory mirror and queues an async read-merge-write persist. */
   set(key: string, plan: TaskPlan): void {
     if (!this.cache) this.cache = new Map();
     this.cache.set(key, plan);
-    void this.persist();
+    this.schedulePersist();
   }
 
   /** Eagerly load the file into memory so `get` returns persisted entries. */
@@ -217,10 +288,14 @@ export class InMemoryCheckpointStore implements CheckpointStore {
  * File-backed checkpoint store. The whole store is a single JSON object
  * `{ [runId]: Checkpoint }`. Same graceful-degradation contract as
  * {@link FilePlanCache}: read failures start empty, write failures are logged.
+ *
+ * Persistence follows the same read-merge-write, atomic-write, serialized-queue
+ * scheme as {@link FilePlanCache} — see its class doc for the rationale.
  */
 export class FileCheckpointStore implements CheckpointStore {
   private readonly filePath: string;
   private store: Map<string, Checkpoint> | null = null;
+  private persistQueue: Promise<void> = Promise.resolve();
 
   constructor(filePath: string) {
     this.filePath = filePath;
@@ -233,26 +308,47 @@ export class FileCheckpointStore implements CheckpointStore {
       "node:fs/promises"
     );
     if (!fs) return this.store;
-    try {
-      const raw = await fs.readFile(this.filePath, "utf-8");
-      const parsed = JSON.parse(raw) as Record<string, Checkpoint>;
-      for (const [k, v] of Object.entries(parsed)) {
-        this.store.set(k, v);
-      }
-    } catch {
-      // Missing or corrupt checkpoint file — start empty.
+    for (const [k, v] of await readDiskEntries<Checkpoint>(
+      fs,
+      this.filePath
+    )) {
+      this.store.set(k, v);
     }
     return this.store;
   }
 
-  private async persist(): Promise<void> {
+  /**
+   * Queue a read-merge-write persist step behind any already-scheduled ones.
+   * Never throws — write failures are logged and the queue continues.
+   */
+  private schedulePersist(): void {
+    this.persistQueue = this.persistQueue.then(() => this.persistOnce());
+  }
+
+  private async persistOnce(): Promise<void> {
     const fs = await importNodeBuiltin<typeof import("node:fs/promises")>(
       "node:fs/promises"
     );
     if (!fs || !this.store) return;
     try {
-      const obj = Object.fromEntries(this.store.entries());
-      await fs.writeFile(this.filePath, JSON.stringify(obj), "utf-8");
+      const disk = await readDiskEntries<Checkpoint>(fs, this.filePath);
+      // In-memory entries win over disk on conflicting keys; disk-only keys
+      // (from another instance/process, or entries this instance never
+      // loaded) are preserved instead of being wiped by the write.
+      const merged = new Map(disk);
+      for (const [k, v] of this.store) {
+        merged.set(k, v);
+      }
+      await writeAtomic(
+        fs,
+        this.filePath,
+        JSON.stringify(Object.fromEntries(merged))
+      );
+      // Absorb disk-only keys into the in-memory mirror so a subsequent sync
+      // `load()` can observe entries persisted elsewhere.
+      for (const [k, v] of merged) {
+        if (!this.store.has(k)) this.store.set(k, v);
+      }
     } catch (err) {
       log.warn("FileCheckpointStore persist failed", {
         filePath: this.filePath,
@@ -268,7 +364,7 @@ export class FileCheckpointStore implements CheckpointStore {
   save(runId: string, checkpoint: Checkpoint): void {
     if (!this.store) this.store = new Map();
     this.store.set(runId, checkpoint);
-    void this.persist();
+    this.schedulePersist();
   }
 
   /** Eagerly load the file into memory so `load` returns persisted entries. */

--- a/packages/agents/src/compiler-agent.ts
+++ b/packages/agents/src/compiler-agent.ts
@@ -253,7 +253,26 @@ export class CompilerAgent {
     const finishStepExecute = async (
       args: Record<string, unknown>
     ): Promise<string> => {
-      const resultPayload = (args?.["result"] as unknown) ?? args;
+      const rawResult = args?.["result"] as unknown;
+      // Fall back to the whole args object when `result` is absent, but strip
+      // the injected `_message` protocol field so it can't leak into the result.
+      let resultPayload: unknown =
+        rawResult !== undefined && rawResult !== null
+          ? rawResult
+          : Tool.stripMessage(args ?? {});
+      // Array-output schemas are wrapped as `{ result: { items: <array> } }`
+      // for the tool parameter schema; unwrap `{ items: [...] }` back to the
+      // array. Gate on the declared schema type so a legitimate object result
+      // with an `items` key is not misinterpreted.
+      if (
+        this.outputSchema?.["type"] === "array" &&
+        resultPayload !== null &&
+        typeof resultPayload === "object" &&
+        !Array.isArray(resultPayload) &&
+        Array.isArray((resultPayload as Record<string, unknown>)["items"])
+      ) {
+        resultPayload = (resultPayload as Record<string, unknown>)["items"];
+      }
       if (resultPayload === undefined || resultPayload === null) {
         return '{"error": "Missing result in finish_step call"}';
       }

--- a/packages/agents/src/graph-builder.ts
+++ b/packages/agents/src/graph-builder.ts
@@ -112,6 +112,17 @@ export class GraphBuilder {
     }
     if (errors.length > 0) return errors;
 
+    // Reject an edge that would introduce a cycle: if `source` is already
+    // reachable from `target`, adding source→target closes a loop
+    // (target→…→source→target). Caught here so the model gets an actionable
+    // error at the moment it adds the edge, not only at finish_graph.
+    if (this.isReachable(target, source)) {
+      errors.push(
+        `Edge ${source}.${sourceHandle} → ${target}.${targetHandle} would create a cycle: '${source}' is already reachable from '${target}'.`
+      );
+      return errors;
+    }
+
     // Check for duplicate edge
     const isDuplicate = this._edges.some(
       (e) =>
@@ -129,6 +140,27 @@ export class GraphBuilder {
 
     this._edges.push({ source, sourceHandle, target, targetHandle });
     return errors;
+  }
+
+  /**
+   * Whether `to` is reachable from `from` following the current directed edges.
+   * A node is trivially reachable from itself. Used by {@link addEdge} for a
+   * cheap incremental cycle check.
+   */
+  private isReachable(from: string, to: string): boolean {
+    if (from === to) return true;
+    const visited = new Set<string>([from]);
+    const stack = [from];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const edge of this._edges) {
+        if (edge.source !== current || visited.has(edge.target)) continue;
+        if (edge.target === to) return true;
+        visited.add(edge.target);
+        stack.push(edge.target);
+      }
+    }
+    return false;
   }
 
   /**

--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -294,10 +294,15 @@ export class GraphPlanner {
 
     // The provider drives the tool loop, so backends that run their own agent
     // loop (e.g. the Claude Agent SDK) work. Each graph tool carries its own
-    // `execute` closure that mutates the shared builder; `finish_graph` is
-    // `terminal`, so the loop ends once it runs. The AbortController only
-    // short-circuits the loop when the per-turn tool-call budget is spent (an
-    // early-stop that is not a terminal tool).
+    // `execute` closure that mutates the shared builder.
+    //
+    // `finish_graph` is only *conditionally* terminal: on a valid graph it
+    // finalizes and aborts the loop; on a validation failure it returns the
+    // errors as the tool result and does NOT abort, so the model iterates and
+    // fixes the graph within the tool-call budget. The static `terminal` flag
+    // can't express that, so the AbortController stops the loop on a successful
+    // finish. It also short-circuits when the per-turn tool-call budget is
+    // spent (an early-stop that is not a terminal tool).
     const abort = new AbortController();
     let exhausted = false;
 
@@ -334,6 +339,10 @@ export class GraphPlanner {
             nodes: finishGraphTool.graph.nodes.length,
             edges: finishGraphTool.graph.edges.length
           });
+          // Valid graph captured — end the loop promptly. A failed finish_graph
+          // returns its errors as the tool result (no abort) so the model can
+          // fix and call finish_graph again within the budget.
+          abort.abort();
         } else if (totalToolCalls >= MAX_TOOL_CALLS_PER_TURN) {
           exhausted = true;
           abort.abort();
@@ -342,16 +351,10 @@ export class GraphPlanner {
         return resultStr;
       };
 
-    const providerTools = allTools.map((tool) => {
-      if (tool === finishGraphTool) {
-        return {
-          ...tool.toProviderTool(),
-          execute: makeExecute(tool),
-          terminal: true
-        };
-      }
-      return { ...tool.toProviderTool(), execute: makeExecute(tool) };
-    });
+    const providerTools = allTools.map((tool) => ({
+      ...tool.toProviderTool(),
+      execute: makeExecute(tool)
+    }));
 
     const stream = this.provider.generateLoop({
       messages,

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -80,6 +80,14 @@ export class ParallelTaskExecutor {
   private readonly checkpointStore?: CheckpointStore;
   private readonly runId?: string;
   private readonly planTools?: string[];
+  /**
+   * IDs of tasks that ran but did not genuinely succeed (budget exhausted,
+   * unsatisfiable dependency, or an error result). Tracked separately from
+   * `task.completed` so a failed task is never checkpointed as success nor
+   * counted as a satisfied dependency, while still terminating the scheduler
+   * loop instead of being re-dispatched forever.
+   */
+  private readonly failedTaskIds = new Set<string>();
 
   constructor(opts: ParallelTaskExecutorOptions) {
     this.provider = opts.provider;
@@ -332,6 +340,28 @@ export class ParallelTaskExecutor {
       }
     }
 
+    // A TaskExecutor returns without throwing even when its steps failed
+    // (StepExecutor writes an `{ error }` result and emits an error
+    // step_result rather than raising). Decide whether the task actually
+    // succeeded before recording it as complete or checkpointing it.
+    const failureReason = this.detectTaskFailure(task, taskResult);
+    if (failureReason) {
+      this.failedTaskIds.add(task.id);
+      log.warn("Task failed", {
+        taskId: task.id,
+        title: task.title,
+        reason: failureReason
+      });
+      yield {
+        type: "log_update",
+        node_id: "parallel_task_executor",
+        node_name: "ParallelTaskExecutor",
+        content: `Task "${task.title}" (${task.id}) failed: ${failureReason}`,
+        severity: "error"
+      } satisfies LogUpdate;
+      return;
+    }
+
     if (taskResult !== null && taskResult !== undefined) {
       // Idempotent: only write if StepExecutor didn't already persist it.
       if (!this.context.memory.has(memoryKeys.task(task.id))) {
@@ -369,10 +399,41 @@ export class ParallelTaskExecutor {
   }
 
   /**
-   * Check if all tasks have been completed.
+   * Decide whether a task that just returned actually failed. Detects:
+   *  - steps that never completed (round/step budget exhausted, or an
+   *    unsatisfiable dependency left executable steps at zero), and
+   *  - steps (or the resolved task result) whose value is an `{ error }`
+   *    payload written by StepExecutor's failure path.
+   * Returns a human-readable reason on failure, or `null` on success.
+   */
+  private detectTaskFailure(task: Task, taskResult: unknown): string | null {
+    const incomplete = task.steps.filter((s) => !s.completed);
+    if (incomplete.length > 0) {
+      return `${incomplete.length} of ${task.steps.length} step(s) did not complete (budget exhausted or unsatisfiable dependency)`;
+    }
+    for (const step of task.steps) {
+      const value = this.context.memory.getValue(memoryKeys.step(step.id));
+      if (isErrorResult(value)) {
+        return `step ${step.id}: ${value.error}`;
+      }
+    }
+    if (isErrorResult(taskResult)) {
+      return taskResult.error;
+    }
+    return null;
+  }
+
+  /**
+   * Check if the scheduler is done: every task has either completed
+   * successfully or been recorded as failed. A failed task blocks its
+   * dependents (their deps are never satisfied), so those remain pending and
+   * the scheduler exits via the "no executable tasks" path rather than
+   * spinning until the iteration cap.
    */
   private allTasksComplete(): boolean {
-    return this.taskPlan.tasks.every((task) => task.completed);
+    return this.taskPlan.tasks.every(
+      (task) => task.completed || this.failedTaskIds.has(task.id)
+    );
   }
 
   /**
@@ -392,6 +453,7 @@ export class ParallelTaskExecutor {
     return this.taskPlan.tasks.filter(
       (task) =>
         !task.completed &&
+        !this.failedTaskIds.has(task.id) &&
         (task.dependsOn ?? []).every((dep) => completedIds.has(dep))
     );
   }
@@ -419,6 +481,21 @@ export class ParallelTaskExecutor {
     const lastTask = this.taskPlan.tasks[this.taskPlan.tasks.length - 1];
     return this.context.memory.getValue(memoryKeys.task(lastTask.id)) ?? null;
   }
+}
+
+/**
+ * A value is treated as a failure marker when it is a plain object carrying a
+ * non-empty string `error` field — the shape StepExecutor writes on its failure
+ * path (`{ error: "Step failed: ..." }`).
+ */
+function isErrorResult(value: unknown): value is { error: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).error === "string" &&
+    ((value as Record<string, unknown>).error as string).length > 0
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -459,22 +536,33 @@ async function* mergeAsyncGenerators<T>(
     }
   });
 
-  while (activeCount > 0 || queue.length > 0) {
-    if (queue.length > 0) {
-      yield queue.shift()!;
-    } else if (activeCount > 0) {
-      const waitPromise = new Promise<void>((r) => {
-        resolve = r;
-      });
+  // The try/finally guarantees that if the downstream consumer stops early
+  // (its `for await` breaks or throws, injecting `.return()` into this merge
+  // generator), we terminate the child generators instead of leaving the
+  // producer tasks driving them to completion in the background (e.g. LLM
+  // calls firing after cancellation).
+  try {
+    while (activeCount > 0 || queue.length > 0) {
       if (queue.length > 0) {
-        resolve = null;
-        continue;
+        yield queue.shift()!;
+      } else if (activeCount > 0) {
+        const waitPromise = new Promise<void>((r) => {
+          resolve = r;
+        });
+        if (queue.length > 0) {
+          resolve = null;
+          continue;
+        }
+        await waitPromise;
       }
-      await waitPromise;
     }
+  } finally {
+    // Stop every child generator so its producer `for await` loop terminates
+    // (a generator may already be done — allSettled swallows those). Then wait
+    // for all producer promises to settle before returning.
+    await Promise.allSettled(generators.map((gen) => gen.return(undefined)));
+    await Promise.allSettled(tasks);
   }
-
-  await Promise.allSettled(tasks);
 
   if (hasError) {
     throw firstError instanceof Error

--- a/packages/agents/src/security-monitor.ts
+++ b/packages/agents/src/security-monitor.ts
@@ -183,8 +183,12 @@ export function parseVerdict(text: string): SecurityVerdict | null {
   if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
     const obj = parsed as Record<string, unknown>;
     if ("block" in obj || "tier" in obj) {
-      const block = coerceBlock(obj["block"]);
       const tier = coerceTier(obj["tier"]);
+      // `block` is authoritative when present. When the judge omits it but
+      // gives a tier, a non-"none" tier implies a block — otherwise a
+      // `{tier:"hard"}` verdict would silently fail open (see module header).
+      const block =
+        "block" in obj ? coerceBlock(obj["block"]) : tier !== "none";
       return {
         block,
         tier,
@@ -196,10 +200,12 @@ export function parseVerdict(text: string): SecurityVerdict | null {
 
   // Strategy 2: tag form, e.g. <block>yes</block><reason>…</reason>.
   const blockTag = tagBody(trimmed, "block");
-  if (blockTag !== null) {
+  const tierTag = tagBody(trimmed, "tier");
+  if (blockTag !== null || tierTag !== null) {
+    const tier = coerceTier(tierTag);
     return {
-      block: coerceBlock(blockTag),
-      tier: coerceTier(tagBody(trimmed, "tier")),
+      block: blockTag !== null ? coerceBlock(blockTag) : tier !== "none",
+      tier,
       severity: coerceSeverity(tagBody(trimmed, "severity")),
       reason: tagBody(trimmed, "reason") ?? ""
     };

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -873,6 +873,10 @@ export class StepExecutor {
     const abort = new AbortController();
     const uiEvents: ProcessingMessage[] = [];
     let lastAssistant: Message | null = null;
+    // Captures a real exception thrown by the provider loop (401, rate limit,
+    // network, tool-schema error) so the failure path reports the actual cause
+    // instead of misattributing it to iteration exhaustion.
+    let generationError: Error | null = null;
 
     const emitCompletion = (normalizedResult: unknown): void => {
       this.storeCompletionResult(normalizedResult);
@@ -895,7 +899,27 @@ export class StepExecutor {
     const finishStepExecute = async (
       args: Record<string, unknown>
     ): Promise<string | MessageContent[]> => {
-      const resultPayload = args?.["result"] ?? args;
+      const rawResult = args?.["result"];
+      // Fall back to the whole args object when `result` is absent, but strip
+      // the injected `_message` protocol field so it can't leak into the result.
+      let resultPayload: unknown =
+        rawResult !== undefined && rawResult !== null
+          ? rawResult
+          : Tool.stripMessage(args ?? {});
+      // Array-output steps are wrapped as `{ result: { items: <array> } }` for
+      // the tool parameter schema (OpenAI requires an object top-level). Unwrap
+      // `{ items: [...] }` back to the array before validating against the
+      // original array schema. Gate on the declared schema type so a legitimate
+      // object result with an `items` key is not misinterpreted.
+      if (
+        this.resultSchema?.["type"] === "array" &&
+        resultPayload !== null &&
+        typeof resultPayload === "object" &&
+        !Array.isArray(resultPayload) &&
+        Array.isArray((resultPayload as Record<string, unknown>)["items"])
+      ) {
+        resultPayload = (resultPayload as Record<string, unknown>)["items"];
+      }
       if (resultPayload === undefined || resultPayload === null) {
         return '{"error": "Missing result in finish_step call"}';
       }
@@ -1037,9 +1061,10 @@ export class StepExecutor {
         yield* drainUi();
       }
     } catch (e) {
+      generationError = e instanceof Error ? e : new Error(String(e));
       log.error("Step generation failed", {
         stepId: this.step.id,
-        error: String(e)
+        error: generationError.message
       });
     }
 
@@ -1055,14 +1080,18 @@ export class StepExecutor {
       }
     }
 
-    // If we exhausted iterations without completing, yield a failure event
-    // and a step_result so downstream steps see an explicit error rather than undefined.
+    // If we didn't complete, yield a failure event and a step_result so
+    // downstream steps see an explicit error rather than undefined. When the
+    // provider loop threw, report the real cause; otherwise the step genuinely
+    // ran out of iterations (or an unstructured step produced no final text).
     if (!this.step.completed) {
       this.step.completed = true;
       this.step.endTime = Date.now();
 
       const errorResult = {
-        error: `Step failed: exceeded ${this.maxIterations} iterations without completion`
+        error: generationError
+          ? `Step failed: ${generationError.message}`
+          : `Step failed: exceeded ${this.maxIterations} iterations without completion`
       };
       this.result = errorResult;
       this.context.memory.set({

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -442,28 +442,37 @@ async function* mergeAsyncGenerators<T>(
     }
   });
 
-  // Yield items as they arrive
-  while (activeCount > 0 || queue.length > 0) {
-    if (queue.length > 0) {
-      yield queue.shift()!;
-    } else if (activeCount > 0) {
-      // Set resolve BEFORE checking queue again to avoid race condition
-      // where an item is pushed between the check and the await.
-      const waitPromise = new Promise<void>((r) => {
-        resolve = r;
-      });
-      // Re-check after setting resolve — item may have arrived between
-      // the outer check and setting resolve.
+  // Yield items as they arrive. The try/finally guarantees that if the
+  // downstream consumer stops early (its `for await` breaks or throws, which
+  // injects `.return()` into this merge generator), we terminate the child
+  // generators instead of leaving the producer tasks driving them to
+  // completion in the background (e.g. LLM calls firing after cancellation).
+  try {
+    while (activeCount > 0 || queue.length > 0) {
       if (queue.length > 0) {
-        resolve = null;
-        continue;
+        yield queue.shift()!;
+      } else if (activeCount > 0) {
+        // Set resolve BEFORE checking queue again to avoid race condition
+        // where an item is pushed between the check and the await.
+        const waitPromise = new Promise<void>((r) => {
+          resolve = r;
+        });
+        // Re-check after setting resolve — item may have arrived between
+        // the outer check and setting resolve.
+        if (queue.length > 0) {
+          resolve = null;
+          continue;
+        }
+        await waitPromise;
       }
-      await waitPromise;
     }
+  } finally {
+    // Stop every child generator so its producer `for await` loop terminates
+    // (a generator may already be done — allSettled swallows those). Then wait
+    // for all producer promises to settle before returning.
+    await Promise.allSettled(generators.map((gen) => gen.return(undefined)));
+    await Promise.allSettled(tasks);
   }
-
-  // Wait for all producer promises to settle
-  await Promise.allSettled(tasks);
 
   if (hasError) {
     throw firstError instanceof Error

--- a/packages/agents/src/task-planner.ts
+++ b/packages/agents/src/task-planner.ts
@@ -417,9 +417,15 @@ export class TaskPlanner {
     // agent loop (e.g. the Claude Agent SDK) work. Each plan tool carries its
     // own `execute` closure that mutates the shared builder and buffers the UI
     // events its result implies; the stream consumer below drains that buffer
-    // in order. `finish_plan` is `terminal`, so the loop ends after it runs.
-    // The AbortController only short-circuits the loop when a single task fails
-    // validation too many times (an early-stop that is not a terminal tool).
+    // in order.
+    //
+    // `finish_plan` is only *conditionally* terminal: on a valid plan it
+    // commits and aborts the loop; on a validation failure it returns the
+    // errors as the tool result and does NOT abort, so the model iterates and
+    // fixes the plan within the call budget. The static `terminal` flag can't
+    // express that, so the AbortController stops the loop on a successful
+    // finish. It also short-circuits when a single task fails validation too
+    // many times (an early-stop that is not a terminal tool).
     const abort = new AbortController();
     const uiEvents: ProcessingMessage[] = [];
     let finished = false;
@@ -516,6 +522,7 @@ export class TaskPlanner {
           content: `Plan created: ${plan.title} (${plan.tasks.length} tasks, ${totalSteps} steps, ${independent} parallelizable)`
         } satisfies PlanningUpdate);
         finished = true;
+        abort.abort();
       } else if (status === "validation_failed") {
         const errors = (result["errors"] as string[]) ?? [];
         uiEvents.push({
@@ -533,8 +540,7 @@ export class TaskPlanner {
       { ...removeTaskTool.toProviderTool(), execute: removeTaskExecute },
       {
         ...finishPlanTool.toProviderTool(),
-        execute: finishPlanExecute,
-        terminal: true
+        execute: finishPlanExecute
       }
     ];
 

--- a/packages/agents/src/tools/calculator-tool.ts
+++ b/packages/agents/src/tools/calculator-tool.ts
@@ -6,10 +6,11 @@
  * IMPORTANT: `expression` is model-supplied and must never reach a dynamic
  * code sink (`eval`, `new Function`, `with`, `vm`). This file implements a
  * small self-contained tokenizer and recursive-descent parser/evaluator that
- * only understands numeric literals, the four arithmetic operators, `**`,
- * parentheses, and a fixed whitelist of function/constant identifiers. Any
- * other identifier (e.g. `constructor`, `process`, `require`, `globalThis`)
- * is rejected as "unknown" rather than resolved through the prototype chain.
+ * only understands numeric literals, the arithmetic operators (`+ - * / %` and
+ * `**`), parentheses, comma-separated function arguments, and a fixed whitelist
+ * of function/constant identifiers. Any other identifier (e.g. `constructor`,
+ * `process`, `require`, `globalThis`) is rejected as "unknown" rather than
+ * resolved through the prototype chain.
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";

--- a/packages/agents/src/tools/calculator-tool.ts
+++ b/packages/agents/src/tools/calculator-tool.ts
@@ -2,13 +2,32 @@
  * Calculator tool for safe mathematical expression evaluation.
  *
  * Port of src/nodetool/agents/tools/math_tools.py (CalculatorTool)
+ *
+ * IMPORTANT: `expression` is model-supplied and must never reach a dynamic
+ * code sink (`eval`, `new Function`, `with`, `vm`). This file implements a
+ * small self-contained tokenizer and recursive-descent parser/evaluator that
+ * only understands numeric literals, the four arithmetic operators, `**`,
+ * parentheses, and a fixed whitelist of function/constant identifiers. Any
+ * other identifier (e.g. `constructor`, `process`, `require`, `globalThis`)
+ * is rejected as "unknown" rather than resolved through the prototype chain.
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { z } from "zod";
 import { Tool } from "./base-tool.js";
 
-const MATH_SCOPE: Record<string, unknown> = {
+/**
+ * Build a lookup object with a `null` prototype so bracket access can never
+ * resolve to an inherited `Object.prototype` member (`constructor`,
+ * `toString`, `__proto__`, ...). Combined with the tokenizer never emitting a
+ * `.` (member access) token, this closes the prototype-chain escape that the
+ * old `with(scope)` evaluator was vulnerable to.
+ */
+function createLookup<T>(entries: Record<string, T>): Record<string, T> {
+  return Object.assign(Object.create(null) as Record<string, T>, entries);
+}
+
+const FUNCTIONS: Record<string, (...args: number[]) => number> = createLookup({
   sqrt: Math.sqrt,
   abs: Math.abs,
   sin: Math.sin,
@@ -20,14 +39,279 @@ const MATH_SCOPE: Record<string, unknown> = {
   floor: Math.floor,
   ceil: Math.ceil,
   round: Math.round,
-  min: Math.min,
-  max: Math.max,
-  pow: Math.pow,
+  min: (...args: number[]) => Math.min(...args),
+  max: (...args: number[]) => Math.max(...args),
+  pow: (base: number, exponent: number) => Math.pow(base, exponent)
+});
+
+const CONSTANTS: Record<string, number> = createLookup({
   PI: Math.PI,
   E: Math.E,
   pi: Math.PI,
   e: Math.E
-};
+});
+
+type TokenType = "number" | "ident" | "op" | "lparen" | "rparen" | "comma" | "eof";
+
+interface Token {
+  type: TokenType;
+  value: string;
+}
+
+function isDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= "0" && ch <= "9";
+}
+
+function isIdentStart(ch: string | undefined): boolean {
+  return ch !== undefined && /[A-Za-z_]/.test(ch);
+}
+
+function isIdentPart(ch: string | undefined): boolean {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+/**
+ * Split a math expression into tokens. Only characters that are part of a
+ * recognized number, identifier, operator, or grouping/separator are
+ * accepted — anything else (including `.` used for member access, quotes,
+ * semicolons, brackets, etc.) throws immediately.
+ */
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  const n = input.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = input[i];
+
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+
+    if (isDigit(ch) || (ch === "." && isDigit(input[i + 1]))) {
+      let j = i;
+      while (isDigit(input[j])) j++;
+      if (input[j] === ".") {
+        j++;
+        while (isDigit(input[j])) j++;
+      }
+      if (input[j] === "e" || input[j] === "E") {
+        let k = j + 1;
+        if (input[k] === "+" || input[k] === "-") k++;
+        if (isDigit(input[k])) {
+          j = k;
+          while (isDigit(input[j])) j++;
+        }
+      }
+      tokens.push({ type: "number", value: input.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if (isIdentStart(ch)) {
+      let j = i + 1;
+      while (isIdentPart(input[j])) j++;
+      tokens.push({ type: "ident", value: input.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if (ch === "*" && input[i + 1] === "*") {
+      tokens.push({ type: "op", value: "**" });
+      i += 2;
+      continue;
+    }
+    if (ch === "+" || ch === "-" || ch === "*" || ch === "/" || ch === "%") {
+      tokens.push({ type: "op", value: ch });
+      i++;
+      continue;
+    }
+    if (ch === "(") {
+      tokens.push({ type: "lparen", value: ch });
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      tokens.push({ type: "rparen", value: ch });
+      i++;
+      continue;
+    }
+    if (ch === ",") {
+      tokens.push({ type: "comma", value: ch });
+      i++;
+      continue;
+    }
+
+    throw new Error(`Unexpected character: ${ch}`);
+  }
+
+  tokens.push({ type: "eof", value: "" });
+  return tokens;
+}
+
+/**
+ * Recursive-descent parser/evaluator. Precedence (high to low): `**`
+ * (right-assoc) > unary +/- > `* / %` > binary `+ -`. Grammar:
+ *
+ * ```
+ * additive       := multiplicative (('+' | '-') multiplicative)*
+ * multiplicative := unary (('*' | '/' | '%') unary)*
+ * unary          := ('-' | '+') unary | power
+ * power          := primary ('**' unary)?
+ * primary        := NUMBER
+ *                 | IDENT ('(' (additive (',' additive)*)? ')')?
+ *                 | '(' additive ')'
+ * ```
+ *
+ * Identifiers are resolved only against the {@link FUNCTIONS} / {@link
+ * CONSTANTS} whitelists — there is no fallback to any host object, so an
+ * unrecognized name is a parse error, not a lookup into `globalThis` or a
+ * prototype chain.
+ */
+class ExpressionParser {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parse(): number {
+    const value = this.parseAdditive();
+    if (this.peek().type !== "eof") {
+      throw new Error(`Unexpected trailing input: '${this.peek().value}'`);
+    }
+    return value;
+  }
+
+  private peek(): Token {
+    return this.tokens[this.pos];
+  }
+
+  private advance(): Token {
+    return this.tokens[this.pos++];
+  }
+
+  private expect(type: TokenType): void {
+    const token = this.advance();
+    if (token.type !== type) {
+      throw new Error(
+        `Expected '${type}' but got '${token.value || token.type}'`
+      );
+    }
+  }
+
+  private parseAdditive(): number {
+    let value = this.parseMultiplicative();
+    for (;;) {
+      const token = this.peek();
+      if (token.type === "op" && (token.value === "+" || token.value === "-")) {
+        this.advance();
+        const rhs = this.parseMultiplicative();
+        value = token.value === "+" ? value + rhs : value - rhs;
+      } else {
+        return value;
+      }
+    }
+  }
+
+  private parseMultiplicative(): number {
+    let value = this.parseUnary();
+    for (;;) {
+      const token = this.peek();
+      if (
+        token.type === "op" &&
+        (token.value === "*" || token.value === "/" || token.value === "%")
+      ) {
+        this.advance();
+        const rhs = this.parseUnary();
+        if (token.value === "*") value *= rhs;
+        else if (token.value === "/") value /= rhs;
+        else value %= rhs;
+      } else {
+        return value;
+      }
+    }
+  }
+
+  private parseUnary(): number {
+    const token = this.peek();
+    if (token.type === "op" && (token.value === "-" || token.value === "+")) {
+      this.advance();
+      const value = this.parseUnary();
+      return token.value === "-" ? -value : value;
+    }
+    return this.parsePower();
+  }
+
+  private parsePower(): number {
+    const base = this.parsePrimary();
+    const token = this.peek();
+    if (token.type === "op" && token.value === "**") {
+      this.advance();
+      const exponent = this.parseUnary();
+      return Math.pow(base, exponent);
+    }
+    return base;
+  }
+
+  private parsePrimary(): number {
+    const token = this.peek();
+
+    if (token.type === "number") {
+      this.advance();
+      return Number(token.value);
+    }
+
+    if (token.type === "lparen") {
+      this.advance();
+      const value = this.parseAdditive();
+      this.expect("rparen");
+      return value;
+    }
+
+    if (token.type === "ident") {
+      this.advance();
+      const name = token.value;
+
+      if (this.peek().type === "lparen") {
+        this.advance();
+        const args: number[] = [];
+        if (this.peek().type !== "rparen") {
+          args.push(this.parseAdditive());
+          while (this.peek().type === "comma") {
+            this.advance();
+            args.push(this.parseAdditive());
+          }
+        }
+        this.expect("rparen");
+
+        const fn = FUNCTIONS[name];
+        if (typeof fn !== "function") {
+          throw new Error(`Unknown function: ${name}`);
+        }
+        return fn(...args);
+      }
+
+      const constant = CONSTANTS[name];
+      if (typeof constant !== "number") {
+        throw new Error(`Unknown identifier: ${name}`);
+      }
+      return constant;
+    }
+
+    throw new Error(`Unexpected token: '${token.value || token.type}'`);
+  }
+}
+
+/**
+ * Evaluate a whitelisted-syntax math expression. Never executes
+ * model-supplied code — parsing and evaluation only walk the token stream
+ * against {@link FUNCTIONS} / {@link CONSTANTS}.
+ */
+function evaluateExpression(expression: string): number {
+  const tokens = tokenize(expression);
+  const parser = new ExpressionParser(tokens);
+  return parser.parse();
+}
 
 const CALCULATOR_SCHEMA = z
   .object({
@@ -53,13 +337,7 @@ export class CalculatorTool extends Tool {
     }
 
     try {
-      // Use Function constructor with a restricted scope
-
-      const fn = new Function(
-        "scope",
-        `with(scope) { return (${expression}) }`
-      );
-      const result: unknown = fn(MATH_SCOPE);
+      const result = evaluateExpression(expression);
       if (typeof result !== "number" || !isFinite(result)) {
         return {
           error: `Expression did not evaluate to a finite number: ${String(result)}`

--- a/packages/agents/src/tools/plan-builder-tools.ts
+++ b/packages/agents/src/tools/plan-builder-tools.ts
@@ -57,17 +57,32 @@ export class PlanBuilder {
     const errors = this.validateNewTask(task);
     if (errors.length > 0) return { ok: false, errors };
 
-    applySchemaOverrides(task.steps);
+    const schemaErrors = applySchemaOverrides(task.steps);
+    if (schemaErrors.length > 0) return { ok: false, errors: schemaErrors };
+
     this.tasks.push(task);
     return { ok: true, task };
   }
 
-  removeTask(id: string): { ok: boolean; error?: string } {
+  removeTask(id: string): { ok: boolean; error?: string; warning?: string } {
     const idx = this.tasks.findIndex((t) => t.id === id);
     if (idx === -1) {
       return { ok: false, error: `Task '${id}' is not in the plan.` };
     }
     this.tasks.splice(idx, 1);
+    // Warn about tasks left depending on the removed id — a dangling
+    // dependency stalls execution and is rejected by finish_plan.
+    const dependents = this.tasks
+      .filter((t) => (t.dependsOn ?? []).includes(id))
+      .map((t) => t.id);
+    if (dependents.length > 0) {
+      return {
+        ok: true,
+        warning: `Task '${id}' was removed but still referenced by depends_on of: ${dependents.join(
+          ", "
+        )}. Update or remove those tasks before finish_plan.`
+      };
+    }
     return { ok: true };
   }
 
@@ -196,6 +211,21 @@ export class PlanBuilder {
       errors.push("Plan must contain at least one task.");
       return errors;
     }
+
+    // Every task-level dependency must reference a task still in the plan.
+    // remove_task can leave a dangling `depends_on` (the dependent would then
+    // never become executable), so re-check the whole set at finish time.
+    const taskIds = new Set(this.tasks.map((t) => t.id));
+    for (const task of this.tasks) {
+      for (const dep of task.dependsOn ?? []) {
+        if (!taskIds.has(dep)) {
+          errors.push(
+            `Task '${task.id}' depends on task '${dep}' which is not in the plan. Add it back or remove the dependency.`
+          );
+        }
+      }
+    }
+
     if (!checkTaskCycles(this.tasks)) {
       errors.push("Circular dependency detected among tasks.");
     }
@@ -261,7 +291,14 @@ function checkTaskCycles(tasks: readonly Task[]): boolean {
   return true;
 }
 
-function applySchemaOverrides(steps: Step[]): void {
+/**
+ * Normalize each step's `output_schema` (default the top-level `type` to
+ * "object"). Returns validation errors for any step whose `output_schema` is
+ * not valid JSON — the caller surfaces them so the model can fix the schema
+ * instead of the malformed schema being silently dropped.
+ */
+function applySchemaOverrides(steps: Step[]): string[] {
+  const errors: string[] = [];
   for (const step of steps) {
     if (!step.outputSchema) continue;
     try {
@@ -275,10 +312,15 @@ function applySchemaOverrides(steps: Step[]): void {
           step.outputSchema = JSON.stringify(parsed);
         }
       }
-    } catch {
-      step.outputSchema = undefined;
+    } catch (e) {
+      errors.push(
+        `Step '${step.id}': output_schema is not valid JSON (${
+          e instanceof Error ? e.message : String(e)
+        }). Provide a valid JSON schema string or omit output_schema.`
+      );
     }
   }
+  return errors;
 }
 
 // ---------------------------------------------------------------------------
@@ -389,7 +431,12 @@ export class RemoveTaskTool extends Tool {
     if (!result.ok) {
       return { status: "error", error: result.error };
     }
-    return { status: "task_removed", id, tasksSoFar: this.builder.taskCount };
+    return {
+      status: "task_removed",
+      id,
+      tasksSoFar: this.builder.taskCount,
+      ...(result.warning ? { warning: result.warning } : {})
+    };
   }
 
   userMessage(params: Record<string, unknown>): string {

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -67,6 +67,8 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   extract_pdf_text: "read",
   extract_pdf_tables: "read",
   convert_pdf_to_markdown: "read",
+  view_image: "read",
+  list_images: "read",
   // --- read: nodetool inspection (REST + local) ---
   list_workflows: "read",
   get_workflow: "read",

--- a/packages/agents/tests/add-node-tool.test.ts
+++ b/packages/agents/tests/add-node-tool.test.ts
@@ -182,12 +182,16 @@ describe("FinishGraphTool", () => {
     expect(tool.graph!.nodes).toHaveLength(2);
   });
 
-  it("returns validation errors for cycles", async () => {
+  it("rejects a cycle-forming edge at add time", async () => {
     const builder = new GraphBuilder();
     builder.addNode("a", "test.Node");
     builder.addNode("b", "test.Node");
-    builder.addEdge("a", "out", "b", "in");
-    builder.addEdge("b", "out", "a", "in");
+    expect(builder.addEdge("a", "out", "b", "in")).toHaveLength(0);
+
+    // The closing edge b→a is rejected here, so the cycle never enters the
+    // graph and finish_graph finalizes the acyclic remainder.
+    const cycleErrors = builder.addEdge("b", "out", "a", "in");
+    expect(cycleErrors.some((e) => e.includes("cycle"))).toBe(true);
 
     const tool = new FinishGraphTool(builder);
     const result = (await tool.process(
@@ -195,10 +199,7 @@ describe("FinishGraphTool", () => {
       {}
     )) as Record<string, unknown>;
 
-    expect(result.status).toBe("validation_failed");
-    expect((result.errors as string[]).some((e) => e.includes("cycle"))).toBe(
-      true
-    );
-    expect(tool.graph).toBeNull();
+    expect(result.status).toBe("graph_finalized");
+    expect(result.edges).toBe(1);
   });
 });

--- a/packages/agents/tests/graph-builder.test.ts
+++ b/packages/agents/tests/graph-builder.test.ts
@@ -39,16 +39,17 @@ describe("GraphBuilder", () => {
     expect(errors[0]).toContain("Self-loops");
   });
 
-  it("detects cycles", () => {
+  it("rejects an edge that would close a cycle", () => {
     const builder = new GraphBuilder();
     builder.addNode("a", "test.Node");
     builder.addNode("b", "test.Node");
     builder.addNode("c", "test.Node");
-    builder.addEdge("a", "out", "b", "in");
-    builder.addEdge("b", "out", "c", "in");
-    builder.addEdge("c", "out", "a", "in");
+    expect(builder.addEdge("a", "out", "b", "in")).toHaveLength(0);
+    expect(builder.addEdge("b", "out", "c", "in")).toHaveLength(0);
 
-    const errors = builder.validate();
+    // The closing edge c→a is rejected at add time (a is reachable from c),
+    // so the cycle never enters the graph.
+    const errors = builder.addEdge("c", "out", "a", "in");
     expect(errors.some((e) => e.includes("cycle"))).toBe(true);
   });
 

--- a/packages/agents/tests/tools/calculator-tool-hardening.test.ts
+++ b/packages/agents/tests/tools/calculator-tool-hardening.test.ts
@@ -1,6 +1,14 @@
 /**
- * Mutation-hardening tests for CalculatorTool: the input-schema shape and the
- * non-number result branch that line coverage left unverified.
+ * Mutation-hardening tests for CalculatorTool: the input-schema shape, the
+ * non-number result branch, and — critically — the parser/evaluator's
+ * refusal to execute anything but whitelisted arithmetic. `calculate`
+ * evaluates model-supplied `expression` strings, so any escape from the
+ * arithmetic grammar back into a host object (`constructor`, `process`,
+ * `globalThis`, ...) would be a remote-code-execution vector reachable via
+ * `AgentNode` (see `packages/llm-nodes/src/nodes/agent-tool-hydration.ts`,
+ * `STATIC_TOOL_CLASSES`). These tests pin that the tokenizer/parser rejects
+ * such expressions cleanly instead of resolving them through the prototype
+ * chain.
  */
 import { describe, it, expect } from "vitest";
 import { CalculatorTool } from "../../src/tools/calculator-tool.js";
@@ -22,11 +30,77 @@ describe("CalculatorTool — mutation hardening", () => {
     );
   });
 
-  // A boolean result is finite when coerced (isFinite(true) === true), so only
-  // the `typeof result !== "number"` operand rejects it — this pins that operand.
-  it("rejects an expression that evaluates to a boolean", async () => {
+  // The grammar has no comparison/logical operators, so a boolean result is
+  // unreachable via the parser itself — `>` is simply not a token it knows.
+  // This still pins that an unrecognized operator character fails cleanly
+  // (as an `{ error }`, not a thrown exception that escapes `process()`).
+  it("rejects an expression using an unsupported operator", async () => {
     const result = await tool.process(ctx, { expression: "1 > 0" });
     expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain(
+      "Failed to evaluate"
+    );
+  });
+
+  it("rejects a boolean-looking result via the finite-number guard", async () => {
+    // NaN/Infinity are the only non-finite outcomes the parser can actually
+    // produce (there's no path to a boolean or object) — pin that guard here.
+    const result = await tool.process(ctx, { expression: "0/0" });
+    expect(result).toHaveProperty("error");
     expect((result as { error: string }).error).toContain("finite number");
+  });
+});
+
+describe("CalculatorTool — security: no dynamic-code escape", () => {
+  const expectSafeRejection = async (expression: string) => {
+    const result = await tool.process(ctx, { expression });
+    expect(result).toHaveProperty("error");
+    // Must never resolve to a finite number (i.e. must never have "worked"
+    // as an accidental side channel) and must never throw past `process()`.
+    expect(result).not.toHaveProperty("result");
+    return result as { error: string };
+  };
+
+  it("blocks constructor.constructor(...) Function-constructor escape", async () => {
+    await expectSafeRejection(
+      'constructor.constructor("return process.env")()'
+    );
+  });
+
+  it("blocks this.constructor.constructor(...) escape", async () => {
+    await expectSafeRejection('this.constructor.constructor("return 1")()');
+  });
+
+  it("blocks (1).constructor member access", async () => {
+    await expectSafeRejection("(1).constructor");
+  });
+
+  it("blocks bare 'process' identifier", async () => {
+    const { error } = await expectSafeRejection("process");
+    expect(error).toContain("Unknown identifier: process");
+  });
+
+  it("blocks require('fs') call", async () => {
+    await expectSafeRejection('require("fs")');
+  });
+
+  it("blocks bare 'globalThis' identifier", async () => {
+    const { error } = await expectSafeRejection("globalThis");
+    expect(error).toContain("Unknown identifier: globalThis");
+  });
+
+  it("blocks calling 'constructor' as a whitelisted-looking function", async () => {
+    // Own-property lookup on a null-prototype object never resolves
+    // Object.prototype.constructor, even when called like a function.
+    await expectSafeRejection("constructor(1)");
+  });
+
+  it("blocks '__proto__' used as an identifier", async () => {
+    await expectSafeRejection("__proto__");
+  });
+
+  it("blocks 'toString' and 'hasOwnProperty' used as calls", async () => {
+    await expectSafeRejection("toString()");
+    await expectSafeRejection("hasOwnProperty(1)");
   });
 });

--- a/packages/agents/tests/tools/calculator-tool.test.ts
+++ b/packages/agents/tests/tools/calculator-tool.test.ts
@@ -43,6 +43,59 @@ describe("CalculatorTool", () => {
       });
       expect(result).toEqual({ result: 19 });
     });
+
+    it("respects operator precedence (* before +)", async () => {
+      const result = await tool.process(ctx, { expression: "2 + 3 * 4" });
+      expect(result).toEqual({ result: 14 });
+    });
+
+    it("respects modulo", async () => {
+      const result = await tool.process(ctx, { expression: "10 % 3" });
+      expect(result).toEqual({ result: 1 });
+    });
+
+    it("evaluates exponentiation right-associatively", async () => {
+      // 2 ** (3 ** 2) = 2 ** 9 = 512, not (2 ** 3) ** 2 = 64.
+      const result = await tool.process(ctx, { expression: "2 ** 3 ** 2" });
+      expect(result).toEqual({ result: 512 });
+    });
+
+    it("gives ** higher precedence than unary minus", async () => {
+      // Matches conventional math notation: -2**2 === -(2**2) === -4.
+      const result = await tool.process(ctx, { expression: "-2 ** 2" });
+      expect(result).toEqual({ result: -4 });
+    });
+
+    it("evaluates unary minus and plus, including doubled signs", async () => {
+      expect(await tool.process(ctx, { expression: "-5" })).toEqual({
+        result: -5
+      });
+      expect(await tool.process(ctx, { expression: "--5" })).toEqual({
+        result: 5
+      });
+      expect(await tool.process(ctx, { expression: "3 - -2" })).toEqual({
+        result: 5
+      });
+    });
+
+    it("evaluates numeric literals with scientific notation and leading dot", async () => {
+      expect(await tool.process(ctx, { expression: "1e3" })).toEqual({
+        result: 1000
+      });
+      expect(await tool.process(ctx, { expression: "1.5e2" })).toEqual({
+        result: 150
+      });
+      expect(await tool.process(ctx, { expression: ".5 + .25" })).toEqual({
+        result: 0.75
+      });
+    });
+
+    it("evaluates nested function calls and comma-separated args", async () => {
+      const result = await tool.process(ctx, {
+        expression: "max(1, min(9, 5), pow(2, 3))"
+      });
+      expect(result).toEqual({ result: 8 });
+    });
   });
 
   describe("math functions", () => {


### PR DESCRIPTION
## Summary

Replace unsafe dynamic code evaluation in CalculatorTool with a self-contained tokenizer and recursive-descent parser that only understands arithmetic expressions. This closes a remote-code-execution vector reachable via model-supplied `expression` strings in the agent system.

## Key Changes

**CalculatorTool security fix:**
- Remove `new Function()` + `with(scope)` evaluator that could be exploited via prototype-chain escapes (`constructor.constructor(...)`, `__proto__`, etc.)
- Implement a custom tokenizer that rejects any character outside the arithmetic grammar (no `.` for member access, no quotes, no brackets)
- Implement a recursive-descent parser/evaluator with proper operator precedence and right-associative exponentiation
- Use null-prototype lookup objects for `FUNCTIONS` and `CONSTANTS` so bracket access never resolves inherited properties
- Add comprehensive security tests pinning rejection of `constructor`, `process`, `require`, `globalThis`, and other escape attempts

**Checkpoint store improvements:**
- Extract shared file I/O helpers (`readDiskEntries`, `writeAtomic`) for tolerant reads and atomic writes
- Implement read-merge-write persistence in `FilePlanCache` and `FileCheckpointStore`: re-read the file before writing so concurrent instances don't wipe each other's entries
- Serialize writes through a `persistQueue` to prevent interleaved updates and stale snapshots
- Absorb disk-only entries into the in-memory mirror after a successful write

**Task/graph execution robustness:**
- Add `failedTaskIds` tracking in `ParallelTaskExecutor` to distinguish failed tasks from pending ones
- Implement `detectTaskFailure()` to catch incomplete steps and error results, preventing failed tasks from being checkpointed as success
- Add early cycle detection in `GraphBuilder.addEdge()` so the model gets immediate feedback instead of only at `finish_graph`
- Add dangling-dependency warnings in `PlanBuilder.removeTask()` and validation in `finish_plan()`
- Improve `mergeAsyncGenerators` cleanup: wrap in try/finally to terminate child generators on early consumer exit (e.g., cancellation)

**Step/compiler result handling:**
- Strip injected `_message` protocol field from fallback results so it doesn't leak into the output
- Unwrap array-output schemas from `{ result: { items: [...] } }` wrapper back to the array before validation
- Capture real provider exceptions (401, rate limit, network) separately so failure messages report the actual cause

**Plan builder validation:**
- Return validation errors from `applySchemaOverrides()` instead of silently dropping malformed schemas
- Check for dangling task dependencies at `finish_plan()` time

**Misc:**
- Add `view_image` and `list_images` to tool permissions
- Improve frontmatter parsing in skill loader to handle `---` inside skill content

## Testing

- New security tests in `calculator-tool-hardening.test.ts` verify rejection of prototype-chain escapes
- New arithmetic tests in `calculator-tool.test.ts` cover precedence, exponentiation, scientific notation, nested functions
- Existing graph/plan builder tests updated to reflect early cycle detection and validation improvements

https://claude.ai/code/session_01JiLg9DqC6qjXyvXMQvC46x