### PR TITLE
fix(websocket): disable unauthenticated /ws/extension CDP bridge in production

### DIFF
--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -252,22 +252,38 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
   // Register the in-process channel factory so the browser action loop running
   // in this server rides the bridge instead of opening its own client WS. The
   // dependency points websocket → automation-nodes (no cycle).
-  setExtensionChannelProvider(() => extensionBridge.getChannel());
+  //
+  // This is an unauthenticated, single-connection side channel: whoever connects
+  // to /ws/extension becomes THE extension socket and can proxy CDP through this
+  // server. It is disabled in production by default; set
+  // NODETOOL_ENABLE_EXTENSION_BRIDGE=1 to opt back in for deployments that
+  // actually use the browser extension.
+  const extensionBridgeEnabled =
+    !isProduction ||
+    process.env["NODETOOL_ENABLE_EXTENSION_BRIDGE"] === "1";
 
-  app.get("/ws/extension", { websocket: true }, (socket, _req) => {
-    // The @fastify/websocket socket satisfies the ExtensionSocket surface
-    // (send(string) / close() / on("message"|"close"|"error")).
-    const extSocket = socket as unknown as ExtensionSocket;
-    socket.on("error", (error: Error) => {
-      log.error("Extension WebSocket error", error);
+  if (extensionBridgeEnabled) {
+    setExtensionChannelProvider(() => extensionBridge.getChannel());
+
+    app.get("/ws/extension", { websocket: true }, (socket, _req) => {
+      // The @fastify/websocket socket satisfies the ExtensionSocket surface
+      // (send(string) / close() / on("message"|"close"|"error")).
+      const extSocket = socket as unknown as ExtensionSocket;
+      socket.on("error", (error: Error) => {
+        log.error("Extension WebSocket error", error);
+      });
+      log.info("Extension WebSocket client connected");
+      extensionBridge.registerSocket(extSocket);
+      socket.on("close", () => {
+        extensionBridge.clear(extSocket);
+        log.info("Extension WebSocket client disconnected");
+      });
     });
-    log.info("Extension WebSocket client connected");
-    extensionBridge.registerSocket(extSocket);
-    socket.on("close", () => {
-      extensionBridge.clear(extSocket);
-      log.info("Extension WebSocket client disconnected");
-    });
-  });
+  } else {
+    log.info(
+      "Extension CDP bridge (/ws/extension) disabled in production; set NODETOOL_ENABLE_EXTENSION_BRIDGE=1 to enable"
+    );
+  }
 
   // Download WebSocket endpoint — local development only
   if (!isProduction) {


### PR DESCRIPTION
## What
Disable the Chrome-extension CDP bridge (`/ws/extension`) in production by default.

## Why
`packages/websocket/src/plugins/websocket.ts` registers `/ws/extension` **unconditionally**. It's an **unauthenticated, single-connection** side channel — whoever connects becomes THE extension socket and can proxy Chrome DevTools Protocol frames through the server (`extensionBridge.registerSocket`). For production deployments that don't use the browser extension, that's unnecessary attack surface.

Context: the other dev/debug surfaces are already handled — MCP-over-HTTP (`/mcp`), the Python bridge, and the `fal`/`kie` pricing routes are gated behind `!isProduction`; `e2e-server.ts` / `screenshot-server.ts` are separate entrypoints not wired into the prod server. This bridge was the one exception still live in prod.

## How
Wrap the route registration + `setExtensionChannelProvider(...)` in:

```ts
const extensionBridgeEnabled =
  !isProduction || process.env["NODETOOL_ENABLE_EXTENSION_BRIDGE"] === "1";
```

mirroring the existing `!isProduction` gate on `/ws/download` directly below it. Logs an info line when disabled. Deployments that use the extension opt back in with `NODETOOL_ENABLE_EXTENSION_BRIDGE=1` — no code change required.

## Testing
- `tsc --noEmit` on the `websocket` package: **no new errors** from this change (pre-existing cross-package errors unchanged, 11 → 11).
- With `NODETOOL_ENV=production` and the flag unset → `/ws/extension` is not registered. With the flag set → registers exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)