### PR TITLE
Multi-thread chat: per-thread runtime state and concurrent generation

### DIFF
--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -158,6 +158,12 @@ type ChatViewProps = {
    * so the title would not match. Defaults to off.
    */
   showConversationHeader?: boolean;
+  /**
+   * Bind thread-scoped store reads (todos) to this thread instead of the
+   * store's current one. Pass it when the surface renders a specific thread
+   * (e.g. a workspace chat tab) that may not be `currentThreadId`.
+   */
+  threadId?: string | null;
 };
 
 // Stable empty-array sentinel so the Zustand selector below returns the same
@@ -196,7 +202,8 @@ const ChatView = ({
   composerPlaceholder,
   hideModePicker,
   useExternalComposer = false,
-  showConversationHeader = false
+  showConversationHeader = false,
+  threadId
 }: ChatViewProps) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
@@ -239,7 +246,7 @@ const ChatView = ({
   );
 
   const todos = useGlobalChatStore((state) => {
-    const id = state.currentThreadId;
+    const id = threadId ?? state.currentThreadId;
     return (id && state.todosByThread[id]) || NO_TODOS;
   });
   const showTodoSidebar = todos.length > 0;

--- a/web/src/components/workspace/ChatSurface.tsx
+++ b/web/src/components/workspace/ChatSurface.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { FlexColumn, Text } from "../ui_primitives";
 import ChatView from "../chat/containers/ChatView";
-import useGlobalChatStore from "../../stores/GlobalChatStore";
+import useGlobalChatStore, {
+  useThreadRuntime
+} from "../../stores/GlobalChatStore";
+import type { Message, LanguageModel } from "../../stores/ApiTypes";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 
 interface ChatSurfaceProps {
@@ -11,31 +14,29 @@ interface ChatSurfaceProps {
   active: boolean;
 }
 
-const NO_MESSAGES: never[] = [];
+const NO_MESSAGES: Message[] = [];
 
 /**
  * The document surface for a chat thread tab. `refId` is the thread id.
  *
- * GlobalChatStore is a single-active-thread store: streaming state, the
- * composer, and `sendMessage` all target `currentThreadId`. All workspace tabs
- * stay mounted in the shell, so only the *active* chat tab claims the store's
- * current thread (via `switchThread`); inactive tabs render their cached
- * message history and re-claim the thread when re-activated.
+ * Each tab is a live, independent session: messages, streaming status,
+ * progress, and agent updates all come from the thread's own entry in
+ * `GlobalChatStore.threadRuntime`, and sends/stops target `refId` explicitly.
+ * Several chat tabs can generate concurrently — a tab keeps streaming while
+ * hidden. Activating a tab additionally makes its thread the store's current
+ * one so thread-global UI (sidebar selection, conversation header) follows
+ * the focused tab.
  */
 const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
   const [notFound, setNotFound] = useState(false);
 
-  const {
-    currentThreadId,
-    thread,
-    cachedMessages,
-    getCurrentMessagesSync
-  } = useGlobalChatStore(
+  const runtime = useThreadRuntime(refId);
+
+  const { currentThreadId, thread, messages } = useGlobalChatStore(
     useShallow((state) => ({
       currentThreadId: state.currentThreadId,
       thread: state.threads[refId],
-      cachedMessages: state.messageCache[refId],
-      getCurrentMessagesSync: state.getCurrentMessagesSync
+      messages: state.messageCache[refId] ?? NO_MESSAGES
     }))
   );
 
@@ -43,56 +44,41 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     connect,
     fetchThread,
     switchThread,
+    loadMessages,
     createNewThread,
     sendMessage,
-    stopGeneration
+    stopGeneration,
+    selectedModel,
+    setSelectedModel
   } = useGlobalChatStore(
     useShallow((state) => ({
       connect: state.connect,
       fetchThread: state.fetchThread,
       switchThread: state.switchThread,
+      loadMessages: state.loadMessages,
       createNewThread: state.createNewThread,
       sendMessage: state.sendMessage,
-      stopGeneration: state.stopGeneration
+      stopGeneration: state.stopGeneration,
+      selectedModel: state.selectedModel,
+      setSelectedModel: state.setSelectedModel
     }))
   );
 
-  const {
-    status,
-    progress,
-    statusMessage,
-    currentLogUpdate,
-    currentPlanningUpdate,
-    currentTaskUpdate,
-    currentTaskUpdateThreadId,
-    lastTaskUpdatesByThread,
-    currentRunningToolCallId,
-    currentToolMessage,
-    selectedModel,
-    setSelectedModel,
-    workflowId
-  } = useGlobalChatStore(
-    useShallow((state) => ({
-      status: state.status,
-      progress: state.progress,
-      statusMessage: state.statusMessage,
-      currentLogUpdate: state.currentLogUpdate,
-      currentPlanningUpdate: state.currentPlanningUpdate,
-      currentTaskUpdate: state.currentTaskUpdate,
-      currentTaskUpdateThreadId: state.currentTaskUpdateThreadId,
-      lastTaskUpdatesByThread: state.lastTaskUpdatesByThread,
-      currentRunningToolCallId: state.currentRunningToolCallId,
-      currentToolMessage: state.currentToolMessage,
-      selectedModel: state.selectedModel,
-      setSelectedModel: state.setSelectedModel,
-      workflowId: state.workflowId
-    }))
+  const workflowId = useGlobalChatStore(
+    (state) =>
+      state.threads[refId]?.workflow_id ?? state.threadWorkflowId[refId] ?? null
+  );
+
+  // The pi transport drives the legacy top-level status (single-thread), not
+  // threadRuntime — fall back to it so a pi run still shows as streaming.
+  const piStatus = useGlobalChatStore((state) =>
+    state.mode === "pi" && state.currentThreadId === refId
+      ? state.status
+      : null
   );
 
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const setTitle = useWorkspaceTabsStore((state) => state.setTitle);
-
-  const isCurrent = currentThreadId === refId;
 
   // Connect the shared chat WebSocket. Deliberately no disconnect on unmount:
   // the connection is a singleton shared by every mounted chat tab, so closing
@@ -103,16 +89,15 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     });
   }, [connect]);
 
-  // The active chat tab owns the store's current thread. A restored tab may
-  // reference a thread the store hasn't seen yet — fetch it first, and mark
-  // the tab when the thread no longer exists on the server.
+  // Hydrate the thread on mount: a restored tab may reference a thread the
+  // store hasn't seen yet. Mark the tab when the thread no longer exists.
   const threadKnown = thread !== undefined;
   useEffect(() => {
-    if (!active || isCurrent || notFound) {
+    if (notFound) {
       return;
     }
     let cancelled = false;
-    const claim = async () => {
+    const hydrate = async () => {
       try {
         if (!threadKnown) {
           const fetched = await fetchThread(refId);
@@ -124,18 +109,27 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
             return;
           }
         }
-        switchThread(refId);
+        await loadMessages(refId);
       } catch (error) {
         if (!cancelled) {
-          console.error("Failed to open chat thread:", error);
+          console.error("Failed to load chat thread:", error);
         }
       }
     };
-    void claim();
+    void hydrate();
     return () => {
       cancelled = true;
     };
-  }, [active, isCurrent, notFound, threadKnown, refId, fetchThread, switchThread]);
+  }, [notFound, threadKnown, refId, fetchThread, loadMessages]);
+
+  // The active tab's thread becomes the store's current one (sidebar
+  // selection, header, persistent composer default). Generation itself is
+  // per-thread and does not depend on this.
+  useEffect(() => {
+    if (active && threadKnown && currentThreadId !== refId) {
+      switchThread(refId);
+    }
+  }, [active, threadKnown, currentThreadId, refId, switchThread]);
 
   // Keep the tab title in sync with the thread title (the server names a
   // thread after its first exchange).
@@ -146,6 +140,20 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     }
   }, [threadTitle, refId, setTitle]);
 
+  const handleSendMessage = useCallback(
+    (message: Message) => sendMessage(message, refId),
+    [sendMessage, refId]
+  );
+
+  const handleStop = useCallback(() => {
+    stopGeneration(refId);
+  }, [stopGeneration, refId]);
+
+  const handleModelChange = useCallback(
+    (model: LanguageModel) => setSelectedModel(model),
+    [setSelectedModel]
+  );
+
   const handleNewChat = useCallback(async () => {
     try {
       const threadId = await createNewThread();
@@ -154,17 +162,6 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
       console.error("Failed to create new chat thread:", error);
     }
   }, [createNewThread, openTab]);
-
-  const messages = isCurrent
-    ? getCurrentMessagesSync()
-    : cachedMessages ?? NO_MESSAGES;
-
-  const taskUpdateForDisplay = useMemo(() => {
-    if (currentTaskUpdate && currentTaskUpdateThreadId === refId) {
-      return currentTaskUpdate;
-    }
-    return lastTaskUpdatesByThread[refId] ?? null;
-  }, [currentTaskUpdate, currentTaskUpdateThreadId, lastTaskUpdatesByThread, refId]);
 
   if (notFound) {
     return (
@@ -179,29 +176,29 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
   return (
     <FlexColumn fullWidth fullHeight sx={{ minHeight: 0, overflow: "hidden" }}>
       <ChatView
-        status={
-          isCurrent
-            ? status === "stopping"
-              ? "loading"
-              : status
-            : "connected"
-        }
+        threadId={refId}
+        status={(() => {
+          const status = piStatus ?? runtime.status;
+          if (status === "idle") return "connected";
+          if (status === "stopping") return "loading";
+          return status;
+        })()}
         messages={messages}
-        sendMessage={sendMessage}
-        progress={isCurrent ? progress.current : 0}
-        total={isCurrent ? progress.total : 0}
-        progressMessage={isCurrent ? statusMessage : null}
-        runningToolCallId={isCurrent ? currentRunningToolCallId : null}
-        runningToolMessage={isCurrent ? currentToolMessage : null}
+        sendMessage={handleSendMessage}
+        progress={runtime.progress.current}
+        total={runtime.progress.total}
+        progressMessage={runtime.statusMessage}
+        runningToolCallId={runtime.runningToolCallId}
+        runningToolMessage={runtime.toolMessage}
         model={selectedModel}
-        onModelChange={setSelectedModel}
-        onStop={stopGeneration}
+        onModelChange={handleModelChange}
+        onStop={handleStop}
         onNewChat={() => void handleNewChat()}
-        currentPlanningUpdate={isCurrent ? currentPlanningUpdate : null}
-        currentTaskUpdate={taskUpdateForDisplay}
-        currentLogUpdate={isCurrent ? currentLogUpdate : null}
+        currentPlanningUpdate={runtime.planningUpdate}
+        currentTaskUpdate={runtime.taskUpdate}
+        currentLogUpdate={runtime.logUpdate}
         workflowId={workflowId}
-        showConversationHeader={isCurrent}
+        showConversationHeader={currentThreadId === refId}
       />
     </FlexColumn>
   );

--- a/web/src/components/workspace/ChatSurface.tsx
+++ b/web/src/components/workspace/ChatSurface.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { FlexColumn, Text } from "../ui_primitives";
+import ChatView from "../chat/containers/ChatView";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+
+interface ChatSurfaceProps {
+  refId: string;
+  active: boolean;
+}
+
+const NO_MESSAGES: never[] = [];
+
+/**
+ * The document surface for a chat thread tab. `refId` is the thread id.
+ *
+ * GlobalChatStore is a single-active-thread store: streaming state, the
+ * composer, and `sendMessage` all target `currentThreadId`. All workspace tabs
+ * stay mounted in the shell, so only the *active* chat tab claims the store's
+ * current thread (via `switchThread`); inactive tabs render their cached
+ * message history and re-claim the thread when re-activated.
+ */
+const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
+  const [notFound, setNotFound] = useState(false);
+
+  const {
+    currentThreadId,
+    thread,
+    cachedMessages,
+    getCurrentMessagesSync
+  } = useGlobalChatStore(
+    useShallow((state) => ({
+      currentThreadId: state.currentThreadId,
+      thread: state.threads[refId],
+      cachedMessages: state.messageCache[refId],
+      getCurrentMessagesSync: state.getCurrentMessagesSync
+    }))
+  );
+
+  const {
+    connect,
+    fetchThread,
+    switchThread,
+    createNewThread,
+    sendMessage,
+    stopGeneration
+  } = useGlobalChatStore(
+    useShallow((state) => ({
+      connect: state.connect,
+      fetchThread: state.fetchThread,
+      switchThread: state.switchThread,
+      createNewThread: state.createNewThread,
+      sendMessage: state.sendMessage,
+      stopGeneration: state.stopGeneration
+    }))
+  );
+
+  const {
+    status,
+    progress,
+    statusMessage,
+    currentLogUpdate,
+    currentPlanningUpdate,
+    currentTaskUpdate,
+    currentTaskUpdateThreadId,
+    lastTaskUpdatesByThread,
+    currentRunningToolCallId,
+    currentToolMessage,
+    selectedModel,
+    setSelectedModel,
+    workflowId
+  } = useGlobalChatStore(
+    useShallow((state) => ({
+      status: state.status,
+      progress: state.progress,
+      statusMessage: state.statusMessage,
+      currentLogUpdate: state.currentLogUpdate,
+      currentPlanningUpdate: state.currentPlanningUpdate,
+      currentTaskUpdate: state.currentTaskUpdate,
+      currentTaskUpdateThreadId: state.currentTaskUpdateThreadId,
+      lastTaskUpdatesByThread: state.lastTaskUpdatesByThread,
+      currentRunningToolCallId: state.currentRunningToolCallId,
+      currentToolMessage: state.currentToolMessage,
+      selectedModel: state.selectedModel,
+      setSelectedModel: state.setSelectedModel,
+      workflowId: state.workflowId
+    }))
+  );
+
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const setTitle = useWorkspaceTabsStore((state) => state.setTitle);
+
+  const isCurrent = currentThreadId === refId;
+
+  // Connect the shared chat WebSocket. Deliberately no disconnect on unmount:
+  // the connection is a singleton shared by every mounted chat tab, so closing
+  // one tab must not sever the others.
+  useEffect(() => {
+    connect().catch((err) => {
+      console.error("Failed to connect chat:", err);
+    });
+  }, [connect]);
+
+  // The active chat tab owns the store's current thread. A restored tab may
+  // reference a thread the store hasn't seen yet — fetch it first, and mark
+  // the tab when the thread no longer exists on the server.
+  const threadKnown = thread !== undefined;
+  useEffect(() => {
+    if (!active || isCurrent || notFound) {
+      return;
+    }
+    let cancelled = false;
+    const claim = async () => {
+      try {
+        if (!threadKnown) {
+          const fetched = await fetchThread(refId);
+          if (cancelled) {
+            return;
+          }
+          if (!fetched) {
+            setNotFound(true);
+            return;
+          }
+        }
+        switchThread(refId);
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to open chat thread:", error);
+        }
+      }
+    };
+    void claim();
+    return () => {
+      cancelled = true;
+    };
+  }, [active, isCurrent, notFound, threadKnown, refId, fetchThread, switchThread]);
+
+  // Keep the tab title in sync with the thread title (the server names a
+  // thread after its first exchange).
+  const threadTitle = thread?.title;
+  useEffect(() => {
+    if (threadTitle) {
+      setTitle(refId, "chat", threadTitle);
+    }
+  }, [threadTitle, refId, setTitle]);
+
+  const handleNewChat = useCallback(async () => {
+    try {
+      const threadId = await createNewThread();
+      openTab({ type: "chat", ref: threadId, mode: "view", title: "New chat" });
+    } catch (error) {
+      console.error("Failed to create new chat thread:", error);
+    }
+  }, [createNewThread, openTab]);
+
+  const messages = isCurrent
+    ? getCurrentMessagesSync()
+    : cachedMessages ?? NO_MESSAGES;
+
+  const taskUpdateForDisplay = useMemo(() => {
+    if (currentTaskUpdate && currentTaskUpdateThreadId === refId) {
+      return currentTaskUpdate;
+    }
+    return lastTaskUpdatesByThread[refId] ?? null;
+  }, [currentTaskUpdate, currentTaskUpdateThreadId, lastTaskUpdatesByThread, refId]);
+
+  if (notFound) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <Text size="normal" weight={600}>
+          Conversation not found
+        </Text>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <FlexColumn fullWidth fullHeight sx={{ minHeight: 0, overflow: "hidden" }}>
+      <ChatView
+        status={
+          isCurrent
+            ? status === "stopping"
+              ? "loading"
+              : status
+            : "connected"
+        }
+        messages={messages}
+        sendMessage={sendMessage}
+        progress={isCurrent ? progress.current : 0}
+        total={isCurrent ? progress.total : 0}
+        progressMessage={isCurrent ? statusMessage : null}
+        runningToolCallId={isCurrent ? currentRunningToolCallId : null}
+        runningToolMessage={isCurrent ? currentToolMessage : null}
+        model={selectedModel}
+        onModelChange={setSelectedModel}
+        onStop={stopGeneration}
+        onNewChat={() => void handleNewChat()}
+        currentPlanningUpdate={isCurrent ? currentPlanningUpdate : null}
+        currentTaskUpdate={taskUpdateForDisplay}
+        currentLogUpdate={isCurrent ? currentLogUpdate : null}
+        workflowId={workflowId}
+        showConversationHeader={isCurrent}
+      />
+    </FlexColumn>
+  );
+};
+
+export default ChatSurface;

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -5,6 +5,7 @@ import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
 import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
 import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
 import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 
 import {
@@ -21,12 +22,17 @@ import { useAssetSearch } from "../../serverState/useAssetSearch";
 import { useCreateTimeline } from "../../hooks/useTimelineSequence";
 import { useAssetStore } from "../../stores/AssetStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
 import {
   useWorkspaceTabsStore,
   type WorkspaceTabType
 } from "../../stores/WorkspaceTabsStore";
 import { assetTabType } from "./assetTabType";
-import type { WorkflowList, AssetWithPath } from "../../stores/ApiTypes";
+import type {
+  WorkflowList,
+  AssetWithPath,
+  Thread
+} from "../../stores/ApiTypes";
 
 /** Render a blank white PNG to seed a "New image" canvas asset. */
 const createBlankImageFile = (): Promise<File> =>
@@ -75,7 +81,7 @@ interface OpenMenuProps {
   onClose: () => void;
 }
 
-type MenuView = "root" | "texts" | "workflows" | "assets";
+type MenuView = "root" | "texts" | "workflows" | "assets" | "chats";
 
 interface TextFileTemplate {
   label: string;
@@ -132,9 +138,11 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const [view, setView] = useState<MenuView>("root");
   const [assetQuery, setAssetQuery] = useState("");
   const [wfFilter, setWfFilter] = useState("");
+  const [chatFilter, setChatFilter] = useState("");
 
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const createNew = useWorkflowManager((state) => state.createNew);
+  const createNewThread = useGlobalChatStore((state) => state.createNewThread);
   const createAsset = useAssetStore((state) => state.createAsset);
   const createTimeline = useCreateTimeline();
   const { searchAssets } = useAssetSearch();
@@ -143,6 +151,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
     setView("root");
     setAssetQuery("");
     setWfFilter("");
+    setChatFilter("");
     onClose();
   }, [onClose]);
 
@@ -212,6 +221,21 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
     }
   }, [createTimeline, openTab, close]);
 
+  const handleNewChat = useCallback(async () => {
+    try {
+      const threadId = await createNewThread();
+      openTab({
+        type: "chat",
+        ref: threadId,
+        mode: "view",
+        title: "New chat"
+      });
+      close();
+    } catch (error) {
+      console.error("Failed to create chat", error);
+    }
+  }, [createNewThread, openTab, close]);
+
   const handleNewModel = useCallback(async () => {
     try {
       const asset = await createAsset(await createBlankModelFile());
@@ -245,6 +269,37 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
     if (!needle) return all;
     return all.filter((w) => w.name.toLowerCase().includes(needle));
   }, [workflowList, wfFilter]);
+
+  const { data: threadList, isLoading: threadsLoading } = useQuery({
+    queryKey: ["open-menu", "threads"],
+    queryFn: () => trpcClient.threads.list.query({ limit: 100 }),
+    enabled: open && view === "chats",
+    staleTime: 30_000
+  });
+
+  const chatThreads = useMemo(() => {
+    const all: Thread[] = threadList?.threads ?? [];
+    const needle = chatFilter.trim().toLowerCase();
+    const filtered = needle
+      ? all.filter((t) => (t.title ?? "").toLowerCase().includes(needle))
+      : all;
+    return [...filtered].sort((a, b) =>
+      (b.updated_at ?? "").localeCompare(a.updated_at ?? "")
+    );
+  }, [threadList, chatFilter]);
+
+  const openChat = useCallback(
+    (thread: Thread) => {
+      openTab({
+        type: "chat",
+        ref: thread.id,
+        mode: "view",
+        title: thread.title || "Untitled chat"
+      });
+      close();
+    },
+    [openTab, close]
+  );
 
   const trimmedAssetQuery = assetQuery.trim();
   const { data: assetResult, isFetching: assetsFetching } = useQuery({
@@ -322,6 +377,11 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               label="New 3D model"
               icon={<ViewInArOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewModel()}
+            />
+            <MenuItemPrimitive
+              label="New chat"
+              icon={<ForumOutlinedIcon fontSize="small" />}
+              onClick={() => void handleNewChat()}
               dividerAfter
             />
             <MenuItemPrimitive
@@ -333,6 +393,11 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               label="Open asset…"
               hasSubmenu
               onClick={() => setView("assets")}
+            />
+            <MenuItemPrimitive
+              label="Open chat…"
+              hasSubmenu
+              onClick={() => setView("chats")}
             />
           </>
         )}
@@ -387,6 +452,43 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                 key={w.id}
                 label={w.name || "Untitled"}
                 onClick={() => openWorkflow(w.id, w.name || "Untitled")}
+              />
+            ))}
+          </>
+        )}
+
+        {view === "chats" && (
+          <>
+            <MenuItemPrimitive
+              label="Back"
+              icon={<ArrowBackRoundedIcon fontSize="small" />}
+              onClick={() => setView("root")}
+              dividerAfter
+            />
+            <FlexRow sx={{ px: 1, py: 0.5 }}>
+              <TextInput
+                autoFocus
+                fullWidth
+                placeholder="Filter chats"
+                value={chatFilter}
+                onChange={(e) => setChatFilter(e.target.value)}
+              />
+            </FlexRow>
+            {threadsLoading && (
+              <FlexRow justify="center" sx={{ py: 2 }}>
+                <LoadingSpinner />
+              </FlexRow>
+            )}
+            {!threadsLoading && chatThreads.length === 0 && (
+              <Caption color="secondary" sx={{ px: 2, py: 1.5 }}>
+                No chats found.
+              </Caption>
+            )}
+            {chatThreads.map((thread) => (
+              <MenuItemPrimitive
+                key={thread.id}
+                label={thread.title || "Untitled chat"}
+                onClick={() => openChat(thread)}
               />
             ))}
           </>

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -7,6 +7,7 @@ import TextSurface from "./TextSurface";
 import Model3DSurface from "./Model3DSurface";
 import AudioSurface from "./AudioSurface";
 import TimelineSurface from "./TimelineSurface";
+import ChatSurface from "./ChatSurface";
 import PageSurface from "./PageSurface";
 import { isPageTabKey } from "./pageTabs";
 
@@ -41,6 +42,8 @@ const TabContent = ({ tab, active }: TabContentProps) => {
       return <AudioSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "timeline":
       return <TimelineSurface refId={tab.ref} mode={tab.mode} active={active} />;
+    case "chat":
+      return <ChatSurface refId={tab.ref} active={active} />;
     case "page":
       return isPageTabKey(tab.ref) ? <PageSurface pageKey={tab.ref} /> : null;
     default: {

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../stores/WorkspaceTabsStore";
 import { useWorkflowManager, useWorkflowManagerStore } from "../../contexts/WorkflowManagerContext";
 import { useAssetStore } from "../../stores/AssetStore";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
 import { trpcClient } from "../../trpc/client";
 import { colorForType } from "../../config/data_types";
 import { TOOLBAR_WIDTH } from "../../config/constants";
@@ -36,6 +37,7 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   model3d: true,
   text: true,
   audio: true,
+  chat: false,
   page: false
 };
 
@@ -44,7 +46,8 @@ const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
   "workflow",
   "sketch",
   "timeline",
-  "model3d"
+  "model3d",
+  "chat"
 ]);
 
 const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
@@ -55,6 +58,7 @@ const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
   model3d: "◈",
   audio: "♪",
   text: "¶",
+  chat: "❝",
   page: "☰"
 };
 
@@ -67,6 +71,7 @@ const TYPE_COLOR: Record<WorkspaceTabType, string> = {
   model3d: colorForType("model_3d"),
   audio: colorForType("audio"),
   text: colorForType("text"),
+  chat: colorForType("str"),
   page: colorForType("any")
 };
 
@@ -424,6 +429,11 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
             break;
           case "model3d":
             await useAssetStore.getState().update({ id: tab.ref, name: trimmed });
+            break;
+          case "chat":
+            await useGlobalChatStore
+              .getState()
+              .updateThreadTitle(tab.ref, trimmed);
             break;
           default:
             break;

--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -302,7 +302,20 @@ describe("chatProtocol", () => {
     let capturedState: any = {
       status: "loading",
       currentThreadId: "thread-1",
-      sendMessageTimeoutId: timeoutId,
+      threadRuntime: {
+        "thread-1": {
+          status: "loading",
+          statusMessage: "Thinking...",
+          progress: { current: 1, total: 2 },
+          error: null,
+          planningUpdate: { planning_status: "in_progress" },
+          taskUpdate: { execution_status: "running" },
+          logUpdate: { message: "step started" },
+          runningToolCallId: null,
+          toolMessage: null,
+          sendMessageTimeoutId: timeoutId
+        }
+      },
       progress: { current: 1, total: 2 },
       statusMessage: "Thinking...",
       currentPlanningUpdate: { planning_status: "in_progress" },
@@ -346,7 +359,10 @@ describe("chatProtocol", () => {
 
     expect(capturedState.status).toBe("connected");
     expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutId);
-    expect(capturedState.sendMessageTimeoutId).toBeNull();
+    expect(
+      capturedState.threadRuntime["thread-1"].sendMessageTimeoutId
+    ).toBeNull();
+    expect(capturedState.threadRuntime["thread-1"].status).toBe("idle");
     expect(capturedState.progress).toEqual({ current: 0, total: 0 });
     expect(capturedState.statusMessage).toBeNull();
     expect(capturedState.currentPlanningUpdate).toBeNull();

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -107,6 +107,11 @@ import { globalWebSocketManager, type WebSocketMessage } from "../../lib/websock
 import useResultsStore from "../../stores/ResultsStore";
 import useStatusStore from "../../stores/StatusStore";
 import type { Graph } from "../../stores/ApiTypes";
+import {
+  getThreadRuntime,
+  threadRuntimeUpdate,
+  type ThreadRuntime
+} from "./threadRuntime";
 
 export interface WorkflowCreatedUpdate {
   type: "workflow_created";
@@ -287,25 +292,29 @@ const generateTitleFromFirstUserMessage = (
 
 const applyJobUpdate = (
   state: GlobalChatState,
-  update: JobUpdate
+  update: JobUpdate,
+  threadId: string | null
 ): ReducerResult => {
+  if (!threadId) {
+    return noopUpdate;
+  }
   if (update.status === "completed") {
     return {
-      update: {
-        status: "connected",
+      update: threadRuntimeUpdate(state, threadId, {
+        status: "idle",
         progress: { current: 0, total: 0 },
         statusMessage: null
-      }
+      })
     };
   }
   if (update.status === "failed" || update.status === "error") {
     return {
-      update: {
+      update: threadRuntimeUpdate(state, threadId, {
         status: "error",
-        error: update.error,
+        error: update.error ?? null,
         progress: { current: 0, total: 0 },
         statusMessage: update.error || null
-      }
+      })
     };
   }
   return noopUpdate;
@@ -313,10 +322,12 @@ const applyJobUpdate = (
 
 const applyEdgeUpdate = (
   state: GlobalChatState,
-  update: EdgeUpdate
+  update: EdgeUpdate,
+  threadId: string | null
 ): ReducerResult => {
   const workflowId = update.workflow_id ?? undefined;
-  const effectiveWorkflowId = workflowId ?? state.threadWorkflowId[state.currentThreadId ?? ""];
+  const effectiveWorkflowId =
+    workflowId ?? state.threadWorkflowId[threadId ?? ""];
   // Edges are scoped by the producing run's job_id so concurrent same-workflow
   // runs stay isolated. Skip the write if job_id is absent.
   const jobId = (update as { job_id?: string | null }).job_id ?? undefined;
@@ -336,10 +347,12 @@ const applyEdgeUpdate = (
 
 const applyNodeUpdate = (
   state: GlobalChatState,
-  update: NodeUpdate
+  update: NodeUpdate,
+  threadId: string | null
 ): ReducerResult => {
   const workflowId = update.workflow_id ?? undefined;
-  const effectiveWorkflowId = workflowId ?? state.threadWorkflowId[state.currentThreadId ?? ""];
+  const effectiveWorkflowId =
+    workflowId ?? state.threadWorkflowId[threadId ?? ""];
 
   if (effectiveWorkflowId) {
     // Sync with ResultsStore
@@ -356,20 +369,31 @@ const applyNodeUpdate = (
     }
   }
 
+  if (!threadId) {
+    return noopUpdate;
+  }
   if (update.status === "completed") {
     return {
-      update: {
-        status: "connected",
+      update: threadRuntimeUpdate(state, threadId, {
+        status: "idle",
         progress: { current: 0, total: 0 },
         statusMessage: null
-      }
+      })
     };
   }
-  return { update: { statusMessage: update.node_name } };
+  return {
+    update: threadRuntimeUpdate(state, threadId, {
+      statusMessage: update.node_name ?? null
+    })
+  };
 };
 
-const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
-  const threadId = chunk.thread_id ?? state.currentThreadId;
+const applyChunk = (
+  state: GlobalChatState,
+  chunk: Chunk,
+  routedThreadId: string | null
+): ReducerResult => {
+  const threadId = chunk.thread_id ?? routedThreadId ?? state.currentThreadId;
   if (!threadId) {
     console.warn("applyChunk: No thread_id or currentThreadId, dropping chunk");
     return noopUpdate;
@@ -400,13 +424,12 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
     if (chunk.done) {
       clearChunkCache(threadId);
       return {
-        update: {
-          status: "connected",
-          currentPlanningUpdate: null,
-          currentTaskUpdate: null,
-          currentTaskUpdateThreadId: null,
-          currentLogUpdate: null
-        }
+        update: threadRuntimeUpdate(state, threadId, {
+          status: "idle",
+          planningUpdate: null,
+          taskUpdate: null,
+          logUpdate: null
+        })
       };
     }
     return noopUpdate;
@@ -444,12 +467,22 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
   // content_metadata.media_generation in the chunk handler above).
   // Only clear it when the stream finishes (done=true) or when the
   // chunk carries actual text content (regular LLM streaming).
+  const runtime = getThreadRuntime(state, threadId);
   const keepStatusMessage =
-    !chunk.done && !chunk.content && state.statusMessage;
+    !chunk.done && !chunk.content && runtime.statusMessage;
+
+  const runtimePatch: Partial<ThreadRuntime> = {
+    status: chunk.done ? "idle" : "streaming",
+    statusMessage: keepStatusMessage ? runtime.statusMessage : null
+  };
+  if (chunk.done) {
+    runtimePatch.planningUpdate = null;
+    runtimePatch.taskUpdate = null;
+    runtimePatch.logUpdate = null;
+  }
 
   const baseUpdate: Partial<GlobalChatState> = {
-    status: chunk.done ? "connected" : "streaming",
-    statusMessage: keepStatusMessage ? state.statusMessage : null,
+    ...threadRuntimeUpdate(state, threadId, runtimePatch),
     messageCache: {
       ...state.messageCache,
       [threadId]: updatedMessages
@@ -492,22 +525,17 @@ const applyChunk = (state: GlobalChatState, chunk: Chunk): ReducerResult => {
   };
 
   return {
-    update: {
-      ...baseUpdate,
-      currentPlanningUpdate: null,
-      currentTaskUpdate: null,
-      currentTaskUpdateThreadId: null,
-      currentLogUpdate: null
-    },
+    update: baseUpdate,
     postAction
   };
 };
 
 const applyOutputUpdate = (
   state: GlobalChatState,
-  update: OutputUpdate
+  update: OutputUpdate,
+  routedThreadId: string | null
 ): ReducerResult => {
-  const threadId = state.currentThreadId;
+  const threadId = routedThreadId ?? state.currentThreadId;
   if (!threadId) {
     return noopUpdate;
   }
@@ -548,8 +576,10 @@ const applyOutputUpdate = (
       };
       return {
         update: {
-          status: "streaming",
-          statusMessage: undefined,
+          ...threadRuntimeUpdate(state, threadId, {
+            status: "streaming",
+            statusMessage: null
+          }),
           messageCache: {
             ...state.messageCache,
             [threadId]: [...messages.slice(0, -1), updatedMessage]
@@ -566,7 +596,7 @@ const applyOutputUpdate = (
     };
     return {
       update: {
-        status: "streaming",
+        ...threadRuntimeUpdate(state, threadId, { status: "streaming" }),
         messageCache: {
           ...state.messageCache,
           [threadId]: [...messages, message]
@@ -591,7 +621,7 @@ const applyOutputUpdate = (
     const messages = state.messageCache[threadId] || [];
     return {
       update: {
-        statusMessage: null,
+        ...threadRuntimeUpdate(state, threadId, { statusMessage: null }),
         messageCache: {
           ...state.messageCache,
           [threadId]: [...messages, message]
@@ -606,7 +636,8 @@ const applyOutputUpdate = (
 
 const applyToolCallUpdate = (
   state: GlobalChatState,
-  update: ToolCallUpdate
+  update: ToolCallUpdate,
+  threadId: string | null
 ): ReducerResult => {
   const toolCallId =
     update.tool_call_id != null
@@ -657,9 +688,13 @@ const applyToolCallUpdate = (
 
   return {
     update: {
-      statusMessage: update.message,
-      currentRunningToolCallId: toolCallId || null,
-      currentToolMessage: update.message || null,
+      ...(threadId
+        ? threadRuntimeUpdate(state, threadId, {
+            statusMessage: update.message ?? null,
+            runningToolCallId: toolCallId || null,
+            toolMessage: update.message || null
+          })
+        : {}),
       ...(agentExecutionToolCalls ? { agentExecutionToolCalls } : {})
     }
   };
@@ -731,15 +766,19 @@ const applyAgentExecutionMessage = (
   if (msg.execution_event_type === "planning_update") {
     console.debug("PlanningUpdate content:", content);
     if (isPlanningUpdateContent(content)) {
-      update.currentPlanningUpdate = content;
-      console.info("Set currentPlanningUpdate:", content);
+      Object.assign(
+        update,
+        threadRuntimeUpdate(state, threadId, { planningUpdate: content })
+      );
     } else {
       console.warn("PlanningUpdate content is invalid:", content);
     }
   } else if (msg.execution_event_type === "task_update") {
     if (isTaskUpdateContent(content)) {
-      update.currentTaskUpdate = content;
-      update.currentTaskUpdateThreadId = threadId;
+      Object.assign(
+        update,
+        threadRuntimeUpdate(state, threadId, { taskUpdate: content })
+      );
       update.lastTaskUpdatesByThread = {
         ...state.lastTaskUpdatesByThread,
         [threadId]: content
@@ -747,7 +786,10 @@ const applyAgentExecutionMessage = (
     }
   } else if (msg.execution_event_type === "log_update") {
     if (isLogUpdateContent(content)) {
-      update.currentLogUpdate = content;
+      Object.assign(
+        update,
+        threadRuntimeUpdate(state, threadId, { logUpdate: content })
+      );
     }
   }
 
@@ -913,11 +955,11 @@ const applyToolMessage = (
         ? updateThreadTimestamp(threadId, state.threads)
         : state.threads,
       ...(msg.role === "tool"
-        ? {
-            currentRunningToolCallId: null,
-            currentToolMessage: null,
+        ? threadRuntimeUpdate(state, threadId, {
+            runningToolCallId: null,
+            toolMessage: null,
             statusMessage: null
-          }
+          })
         : {})
     }
   };
@@ -929,12 +971,11 @@ const applyAssistantMessage = (
   messages: Message[],
   msg: Message
 ) => {
-  const isCurrentThreadMessage = threadId === state.currentThreadId;
+  const runtimeStatus = getThreadRuntime(state, threadId).status;
   const shouldResetStatusOnAssistantMessage =
-    isCurrentThreadMessage &&
-    (state.status === "loading" ||
-      state.status === "streaming" ||
-      state.status === "stopping");
+    runtimeStatus === "loading" ||
+    runtimeStatus === "streaming" ||
+    runtimeStatus === "stopping";
 
   const incomingNormalized = normalizeTextForComparison(
     extractTextContent(msg)
@@ -998,23 +1039,26 @@ const applyAssistantMessage = (
         ? updateThreadTimestamp(threadId, state.threads)
         : state.threads,
       ...(shouldResetStatusOnAssistantMessage
-        ? {
-            status: "connected" as const,
+        ? threadRuntimeUpdate(state, threadId, {
+            status: "idle",
             progress: { current: 0, total: 0 },
             statusMessage: null,
-            currentPlanningUpdate: null,
-            currentTaskUpdate: null,
-            currentTaskUpdateThreadId: null,
-            currentLogUpdate: null
-          }
+            planningUpdate: null,
+            taskUpdate: null,
+            logUpdate: null
+          })
         : {})
     },
     postAction
   };
 };
 
-const applyMessage = (state: GlobalChatState, msg: Message): ReducerResult => {
-  const threadId = msg.thread_id ?? state.currentThreadId;
+const applyMessage = (
+  state: GlobalChatState,
+  msg: Message,
+  routedThreadId: string | null
+): ReducerResult => {
+  const threadId = msg.thread_id ?? routedThreadId ?? state.currentThreadId;
   if (!threadId) {
     return noopUpdate;
   }
@@ -1049,10 +1093,12 @@ const applyMessage = (state: GlobalChatState, msg: Message): ReducerResult => {
 
 const applyNodeProgress = (
   state: GlobalChatState,
-  progress: NodeProgress
+  progress: NodeProgress,
+  threadId: string | null
 ): ReducerResult => {
   const workflowId = progress.workflow_id ?? undefined;
-  const effectiveWorkflowId = workflowId ?? state.threadWorkflowId[state.currentThreadId ?? ""];
+  const effectiveWorkflowId =
+    workflowId ?? state.threadWorkflowId[threadId ?? ""];
   // Progress is scoped by the producing run's job_id so concurrent same-workflow
   // runs stay isolated. Skip the write if job_id is absent.
   const jobId = (progress as { job_id?: string | null }).job_id ?? undefined;
@@ -1068,38 +1114,57 @@ const applyNodeProgress = (
       );
   }
 
+  if (!threadId) {
+    return noopUpdate;
+  }
   // Keep the existing statusMessage for heartbeat ticks (empty chunk, total=0)
   // so the "Generating image…" label set from the chunk metadata stays visible.
-  const statusMessage =
-    progress.chunk
-      ? progress.chunk
-      : state.statusMessage;
+  const statusMessage = progress.chunk
+    ? progress.chunk
+    : getThreadRuntime(state, threadId).statusMessage;
   return {
-    update: {
+    update: threadRuntimeUpdate(state, threadId, {
       status: "loading",
       progress: { current: progress.progress, total: progress.total },
       statusMessage
-    }
+    })
   };
 };
 
-const applyGenerationStopped = (): ReducerResult => ({
-  update: {
-    status: "connected",
-    progress: { current: 0, total: 0 },
-    statusMessage: null,
-    currentPlanningUpdate: null,
-    currentTaskUpdate: null,
-    currentTaskUpdateThreadId: null,
-    currentLogUpdate: null
+const applyGenerationStopped = (
+  state: GlobalChatState,
+  threadId: string | null
+): ReducerResult => {
+  if (!threadId) {
+    return noopUpdate;
   }
-});
+  return {
+    update: threadRuntimeUpdate(state, threadId, {
+      status: "idle",
+      progress: { current: 0, total: 0 },
+      statusMessage: null,
+      planningUpdate: null,
+      taskUpdate: null,
+      logUpdate: null
+    })
+  };
+};
 
-const applyError = (message: string): ReducerResult => ({
+const applyError = (
+  state: GlobalChatState,
+  message: string,
+  threadId: string | null
+): ReducerResult => ({
   update: {
+    // The top-level error banner also covers thread-less protocol errors.
     error: message || "An error occurred",
-    status: "error",
-    statusMessage: message
+    ...(threadId
+      ? threadRuntimeUpdate(state, threadId, {
+          error: message || "An error occurred",
+          status: "error",
+          statusMessage: message
+        })
+      : { status: "error" as const, statusMessage: message })
   }
 });
 
@@ -1112,11 +1177,13 @@ async function executeToolCall(
   const { tool_call_id, name, args, thread_id } = toolCallData;
 
   // Update UI immediately
-  set({
-    currentRunningToolCallId: tool_call_id,
-    currentToolMessage: `Executing ${name}`,
-    statusMessage: `Executing ${name}`
-  });
+  set((state) =>
+    threadRuntimeUpdate(state, thread_id, {
+      runningToolCallId: tool_call_id,
+      toolMessage: `Executing ${name}`,
+      statusMessage: `Executing ${name}`
+    })
+  );
 
   if (!FrontendToolRegistry.has(name)) {
     console.warn(`Unknown tool: ${name}`);
@@ -1256,24 +1323,58 @@ export async function sendPlanApprovalResponse(
 export async function handleChatWebSocketMessage(
   msg: WebSocketMessage,
   set: ChatStateSetter,
-  get: ChatStateGetter
+  get: ChatStateGetter,
+  routedThreadId: string | null = null
 ) {
   const data = msg as MsgpackData;
   const currentState = get();
 
-  if (currentState.status === "stopping") {
+  // The thread this message belongs to: an explicit thread_id on the payload
+  // wins, else the subscription key it was routed under (every chat handler
+  // is registered per thread), else the current thread.
+  const tid: string | null =
+    (data as { thread_id?: string | null }).thread_id ??
+    routedThreadId ??
+    currentState.currentThreadId ??
+    null;
+
+  // Swallow stragglers for a thread the user is stopping. The top-level
+  // status check covers the pi transport, which drives the mirror directly.
+  const isStopping =
+    getThreadRuntime(currentState, tid).status === "stopping" ||
+    (currentState.status === "stopping" &&
+      (tid === null || tid === currentState.currentThreadId));
+  if (isStopping) {
     if (!["generation_stopped", "error", "job_update"].includes(data.type ?? "")) {
       return;
     }
   }
 
+  // Clear the owning thread's safety timeout (generation produced a signal).
+  const clearSendTimeout = () => {
+    if (!tid) {
+      return;
+    }
+    const timeoutId = getThreadRuntime(get(), tid).sendMessageTimeoutId;
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      set((state) =>
+        threadRuntimeUpdate(state, tid, { sendMessageTimeoutId: null })
+      );
+    }
+  };
+
   const applyReducer = <T>(
-    fn: (state: GlobalChatState, payload: T) => ReducerResult,
+    fn: (
+      state: GlobalChatState,
+      payload: T,
+      threadId: string | null
+    ) => ReducerResult,
     payload: T
   ) => {
     let postAction: ReducerResult["postAction"];
     set((state) => {
-      const result = fn(state, payload);
+      const result = fn(state, payload, tid);
       postAction = result.postAction;
       return result.update;
     });
@@ -1289,11 +1390,7 @@ export async function handleChatWebSocketMessage(
       data.status === "failed" ||
       data.status === "cancelled"
     ) {
-      const timeoutId = get().sendMessageTimeoutId;
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        set({ sendMessageTimeoutId: null });
-      }
+      clearSendTimeout();
     }
     applyReducer(applyJobUpdate, data);
   } else if (data.type === "node_update") {
@@ -1304,11 +1401,7 @@ export async function handleChatWebSocketMessage(
     if (data.done) {
       console.info("Received final chunk (done=true), clearing timeout");
       // Clear the safety timeout when generation completes
-      const timeoutId = get().sendMessageTimeoutId;
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        set({ sendMessageTimeoutId: null });
-      }
+      clearSendTimeout();
     }
     // Surface a progress message for media generation chunks so the UI shows
     // "Conjuring image…" / "Conjuring video…" instead of "Thinking…". The
@@ -1317,7 +1410,7 @@ export async function handleChatWebSocketMessage(
     const mediaMeta = data.content_metadata?.media_generation as
       | Record<string, unknown>
       | undefined;
-    if (mediaMeta && !data.done) {
+    if (mediaMeta && !data.done && tid) {
       const mode = String(mediaMeta.mode ?? "");
       const model = mediaMeta.model ? String(mediaMeta.model) : "";
       const label =
@@ -1328,7 +1421,11 @@ export async function handleChatWebSocketMessage(
             : mode === "audio"
               ? "Conjuring sound"
               : "Conjuring";
-      set({ statusMessage: model ? `${label} with ${model}…` : `${label}…` });
+      set((state) =>
+        threadRuntimeUpdate(state, tid, {
+          statusMessage: model ? `${label} with ${model}…` : `${label}…`
+        })
+      );
     }
     applyReducer(applyChunk, data);
   } else if (data.type === "output_update") {
@@ -1336,27 +1433,17 @@ export async function handleChatWebSocketMessage(
   } else if (data.type === "tool_call_update") {
     applyReducer(applyToolCallUpdate, data);
   } else if (data.type === "todo_update") {
-    const threadId = data.thread_id ?? get().currentThreadId;
-    if (threadId) {
+    if (tid) {
       set((state) => ({
         todosByThread: {
           ...state.todosByThread,
-          [threadId]: data.todos ?? []
+          [tid]: data.todos ?? []
         }
       }));
     }
   } else if (data.type === "message") {
-    const currentThreadId = get().currentThreadId;
-    const messageThreadId = data.thread_id ?? currentThreadId;
-    if (
-      data.role === "assistant" &&
-      messageThreadId === currentThreadId
-    ) {
-      const timeoutId = get().sendMessageTimeoutId;
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        set({ sendMessageTimeoutId: null });
-      }
+    if (data.role === "assistant") {
+      clearSendTimeout();
     }
     applyReducer(applyMessage, data);
   } else if (data.type === "node_progress") {
@@ -1369,34 +1456,22 @@ export async function handleChatWebSocketMessage(
     get().addPendingPlanApproval(data);
   } else if (data.type === "generation_stopped") {
     // Clear the safety timeout when generation is stopped
-    const timeoutId = get().sendMessageTimeoutId;
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId);
-      set({ sendMessageTimeoutId: null });
-    }
-    applyReducer(
-      (_state) => applyGenerationStopped(),
-      data
-    );
+    clearSendTimeout();
+    applyReducer((state) => applyGenerationStopped(state, tid), data);
     console.info("Generation stopped:", data.message);
   } else if (data.type === "workflow_created" || data.type === "workflow_updated") {
-    const threadId = get().currentThreadId;
-    if (threadId && data.workflow_id) {
+    if (tid && data.workflow_id) {
       set((state) => ({
         threadWorkflowId: {
           ...state.threadWorkflowId,
-          [threadId]: data.workflow_id
+          [tid]: data.workflow_id
         }
       }));
     }
     console.debug(`${data.type}:`, data.workflow_id);
   } else if (data.type === "error") {
     // Clear the safety timeout on error
-    const timeoutId = get().sendMessageTimeoutId;
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId);
-      set({ sendMessageTimeoutId: null });
-    }
-    applyReducer((_state) => applyError(data.message), data);
+    clearSendTimeout();
+    applyReducer((state) => applyError(state, data.message, tid), data);
   }
 }

--- a/web/src/core/chat/threadRuntime.ts
+++ b/web/src/core/chat/threadRuntime.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-thread chat runtime state.
+ *
+ * GlobalChatStore keeps one WebSocket but many concurrently-live threads:
+ * each thread carries its own streaming status, progress, planning/task/log
+ * updates, tool-call state, and safety timeout in `threadRuntime`. The store's
+ * legacy top-level fields (`status`, `statusMessage`, `currentTaskUpdate`, …)
+ * are mirrors of the *current* thread's runtime, kept in sync by
+ * `threadRuntimeUpdate`/`mirrorsForThread` so single-thread consumers
+ * (GlobalChat, editor side panels) keep working unchanged.
+ */
+import type {
+  PlanningUpdate,
+  TaskUpdate,
+  LogUpdate
+} from "../../stores/ApiTypes";
+import type { GlobalChatState } from "../../stores/GlobalChatStore";
+
+/**
+ * A thread's generation lifecycle. "idle" means no generation in flight — the
+ * legacy mirror projects it to the connection-level "connected".
+ */
+export type ThreadRuntimeStatus =
+  | "idle"
+  | "loading"
+  | "streaming"
+  | "error"
+  | "stopping";
+
+export interface ThreadRuntime {
+  status: ThreadRuntimeStatus;
+  statusMessage: string | null;
+  progress: { current: number; total: number };
+  error: string | null;
+  planningUpdate: PlanningUpdate | null;
+  taskUpdate: TaskUpdate | null;
+  logUpdate: LogUpdate | null;
+  runningToolCallId: string | null;
+  toolMessage: string | null;
+  /** Safety timeout that resets a stuck loading/streaming state. */
+  sendMessageTimeoutId: ReturnType<typeof setTimeout> | null;
+}
+
+export const DEFAULT_THREAD_RUNTIME: ThreadRuntime = {
+  status: "idle",
+  statusMessage: null,
+  progress: { current: 0, total: 0 },
+  error: null,
+  planningUpdate: null,
+  taskUpdate: null,
+  logUpdate: null,
+  runningToolCallId: null,
+  toolMessage: null,
+  sendMessageTimeoutId: null
+};
+
+export const getThreadRuntime = (
+  state: Pick<GlobalChatState, "threadRuntime">,
+  threadId: string | null | undefined
+): ThreadRuntime =>
+  (threadId ? state.threadRuntime?.[threadId] : undefined) ??
+  DEFAULT_THREAD_RUNTIME;
+
+/** Runtime statuses that occupy the legacy top-level `status` field. */
+const RUNTIME_STATUSES: ReadonlyArray<GlobalChatState["status"]> = [
+  "loading",
+  "streaming",
+  "error",
+  "stopping"
+];
+
+/** Project a runtime-patch onto the legacy top-level mirror fields. */
+const mirrorFromPatch = (
+  patch: Partial<ThreadRuntime>,
+  threadId: string
+): Partial<GlobalChatState> => {
+  const mirror: Partial<GlobalChatState> = {};
+  if ("status" in patch && patch.status !== undefined) {
+    mirror.status = patch.status === "idle" ? "connected" : patch.status;
+  }
+  if ("statusMessage" in patch) {
+    mirror.statusMessage = patch.statusMessage ?? null;
+  }
+  if ("progress" in patch && patch.progress) {
+    mirror.progress = patch.progress;
+  }
+  if ("error" in patch) {
+    mirror.error = patch.error ?? null;
+  }
+  if ("planningUpdate" in patch) {
+    mirror.currentPlanningUpdate = patch.planningUpdate ?? null;
+  }
+  if ("taskUpdate" in patch) {
+    mirror.currentTaskUpdate = patch.taskUpdate ?? null;
+    mirror.currentTaskUpdateThreadId = patch.taskUpdate ? threadId : null;
+  }
+  if ("logUpdate" in patch) {
+    mirror.currentLogUpdate = patch.logUpdate ?? null;
+  }
+  if ("runningToolCallId" in patch) {
+    mirror.currentRunningToolCallId = patch.runningToolCallId ?? null;
+  }
+  if ("toolMessage" in patch) {
+    mirror.currentToolMessage = patch.toolMessage ?? null;
+  }
+  return mirror;
+};
+
+/**
+ * Build a store update that applies `patch` to one thread's runtime and, when
+ * that thread is the current one, mirrors the patched fields onto the legacy
+ * top-level fields.
+ */
+export const threadRuntimeUpdate = (
+  state: GlobalChatState,
+  threadId: string,
+  patch: Partial<ThreadRuntime>
+): Partial<GlobalChatState> => {
+  const next = { ...getThreadRuntime(state, threadId), ...patch };
+  const update: Partial<GlobalChatState> = {
+    threadRuntime: { ...(state.threadRuntime ?? {}), [threadId]: next }
+  };
+  if (state.currentThreadId === threadId) {
+    Object.assign(update, mirrorFromPatch(patch, threadId));
+  }
+  return update;
+};
+
+/**
+ * Full mirror projection for a thread — used when the current thread changes,
+ * so the top-level fields immediately reflect the newly-focused thread instead
+ * of carrying the previous thread's streaming state.
+ *
+ * `error` is deliberately not projected: the top-level error also carries
+ * connection-level failures that must survive a thread switch.
+ */
+export const mirrorsForThread = (
+  state: GlobalChatState,
+  threadId: string
+): Partial<GlobalChatState> => {
+  const rt = getThreadRuntime(state, threadId);
+  return {
+    status:
+      rt.status !== "idle"
+        ? rt.status
+        : RUNTIME_STATUSES.includes(state.status)
+          ? "connected"
+          : state.status,
+    statusMessage: rt.statusMessage,
+    progress: rt.progress,
+    currentPlanningUpdate: rt.planningUpdate,
+    currentTaskUpdate: rt.taskUpdate,
+    currentTaskUpdateThreadId: rt.taskUpdate ? threadId : null,
+    currentLogUpdate: rt.logUpdate,
+    currentRunningToolCallId: rt.runningToolCallId,
+    currentToolMessage: rt.toolMessage
+  };
+};

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -46,6 +46,14 @@ import {
   WorkflowUpdatedUpdate
 } from "../core/chat/chatProtocol";
 import type { ChatOutgoingMessage } from "./MediaGenerationStore";
+import { useShallow } from "zustand/react/shallow";
+import {
+  DEFAULT_THREAD_RUNTIME,
+  getThreadRuntime,
+  mirrorsForThread,
+  threadRuntimeUpdate,
+  type ThreadRuntime
+} from "../core/chat/threadRuntime";
 
 // Include additional runtime statuses used during message streaming
 type ChatStatus =
@@ -148,11 +156,17 @@ interface PlanApprovalRequest {
 }
 
 export interface GlobalChatState extends ChatPiSlice {
-  // Connection state
+  // Connection state + mirror of the CURRENT thread's runtime (see
+  // core/chat/threadRuntime.ts). Multi-thread consumers read `threadRuntime`.
   status: ChatStatus;
   statusMessage: string | null;
   progress: { current: number; total: number };
   error: string | null;
+  /**
+   * Per-thread generation runtime, keyed by thread id. Every thread streams
+   * independently; the top-level fields above mirror the current thread.
+   */
+  threadRuntime: Record<string, ThreadRuntime>;
   workflowId: string | null;
   threadWorkflowId: Record<string, string | null>;
 
@@ -249,15 +263,21 @@ export interface GlobalChatState extends ChatPiSlice {
   // Workflow graph updates
   lastWorkflowGraphUpdate: WorkflowCreatedUpdate | WorkflowUpdatedUpdate | null;
 
-  // Safety timeout tracking for sendMessage
-  sendMessageTimeoutId: ReturnType<typeof setTimeout> | null;
   // Safety timeout tracking for loadMessages after delete
   loadMessagesTimeoutId: ReturnType<typeof setTimeout> | null;
 
   // Actions
   connect: () => Promise<void>;
   disconnect: () => void;
-  sendMessage: (message: Message | ChatOutgoingMessage) => Promise<void>;
+  /**
+   * Send a message to `threadId`, or to the current thread when omitted
+   * (creating one if none exists). Threads generate independently, so a
+   * send to a background thread does not disturb the current one.
+   */
+  sendMessage: (
+    message: Message | ChatOutgoingMessage,
+    threadId?: string
+  ) => Promise<void>;
   resetMessages: () => void;
 
   // Thread actions
@@ -279,7 +299,8 @@ export interface GlobalChatState extends ChatPiSlice {
     model: string,
     content: string
   ) => Promise<void>;
-  stopGeneration: () => void;
+  /** Stop generation on `threadId`, or the current thread when omitted. */
+  stopGeneration: (threadId?: string) => void;
 
   // Message cache management
   addMessageToCache: (threadId: string, message: Message) => void;
@@ -336,6 +357,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
       statusMessage: null,
       progress: { current: 0, total: 0 },
       error: null,
+      threadRuntime: {},
       workflowId: null,
       threadWorkflowId: {},
       wsEventUnsubscribes: [],
@@ -511,8 +533,6 @@ const useGlobalChatStore = create<GlobalChatState>()(
       // Workflow graph updates
       lastWorkflowGraphUpdate: null,
 
-      // Safety timeout tracking for sendMessage
-      sendMessageTimeoutId: null,
       loadMessagesTimeoutId: null,
 
       connect: async () => {
@@ -608,7 +628,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           threadSubscriptions[threadId] = globalWebSocketManager.subscribe(
             threadId,
             (data) => {
-              handleChatWebSocketMessage(data, set, get);
+              handleChatWebSocketMessage(data, set, get, threadId);
             }
           );
         });
@@ -686,7 +706,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
         const {
           wsEventUnsubscribes,
           wsThreadSubscriptions,
-          sendMessageTimeoutId,
+          threadRuntime,
           loadMessagesTimeoutId
         } = get();
         wsEventUnsubscribes.forEach((unsubscribe) => unsubscribe());
@@ -694,10 +714,12 @@ const useGlobalChatStore = create<GlobalChatState>()(
           unsubscribe()
         );
 
-        // Clear any pending sendMessage timeout
-        if (sendMessageTimeoutId !== null) {
-          clearTimeout(sendMessageTimeoutId);
-        }
+        // Clear every thread's pending safety timeout
+        Object.values(threadRuntime).forEach((rt) => {
+          if (rt.sendMessageTimeoutId !== null) {
+            clearTimeout(rt.sendMessageTimeoutId);
+          }
+        });
         // Clear any pending loadMessages timeout
         if (loadMessagesTimeoutId !== null) {
           clearTimeout(loadMessagesTimeoutId);
@@ -709,23 +731,21 @@ const useGlobalChatStore = create<GlobalChatState>()(
           status: "disconnected",
           error: null,
           statusMessage: null,
-          sendMessageTimeoutId: null,
+          threadRuntime: {},
           loadMessagesTimeoutId: null
         });
       },
 
-      sendMessage: async (message: Message | ChatOutgoingMessage) => {
-        const {
-          currentThreadId,
-          workflowId,
-          memoryEnabled,
-          selectedModel,
-          sendMessageTimeoutId
-        } = get();
+      sendMessage: async (
+        message: Message | ChatOutgoingMessage,
+        targetThreadId?: string
+      ) => {
+        const { currentThreadId, workflowId, memoryEnabled, selectedModel } =
+          get();
 
         // Pi mode routes through the agent socket instead of the /ws chat loop.
         if (get().mode === "pi") {
-          let threadId = currentThreadId;
+          let threadId = targetThreadId ?? currentThreadId;
           if (!threadId) {
             threadId = await get().createNewThread();
           }
@@ -739,12 +759,6 @@ const useGlobalChatStore = create<GlobalChatState>()(
         const outgoing = message as ChatOutgoingMessage;
         const mediaGeneration = outgoing.media_generation ?? null;
 
-        // Clear any existing safety timeout
-        if (sendMessageTimeoutId !== null) {
-          clearTimeout(sendMessageTimeoutId);
-          set({ sendMessageTimeoutId: null });
-        }
-
         set({ error: null });
 
         // Ensure WebSocket connection is established before sending
@@ -753,29 +767,50 @@ const useGlobalChatStore = create<GlobalChatState>()(
         } catch (connError) {
           const detail =
             connError instanceof Error ? connError.message : String(connError);
-          set({ error: `Not connected to chat service: ${detail}` });
+          const knownTid = targetThreadId ?? currentThreadId;
+          set((state) => ({
+            error: `Not connected to chat service: ${detail}`,
+            ...(knownTid
+              ? threadRuntimeUpdate(state, knownTid, {
+                  error: `Not connected to chat service: ${detail}`
+                })
+              : {})
+          }));
           return;
         }
 
         // Ensure we have a thread
-        let threadId = currentThreadId;
+        let threadId = targetThreadId ?? currentThreadId;
         if (!threadId) {
           threadId = await get().createNewThread();
         }
+        const tid = threadId;
+
+        // Clear the target thread's existing safety timeout
+        const existingTimeoutId = getThreadRuntime(
+          get(),
+          tid
+        ).sendMessageTimeoutId;
+        if (existingTimeoutId !== null) {
+          clearTimeout(existingTimeoutId);
+        }
+        set((state) =>
+          threadRuntimeUpdate(state, tid, {
+            error: null,
+            sendMessageTimeoutId: null
+          })
+        );
 
         // Ensure we have a WS subscription for this thread before sending,
         // otherwise streamed chunks/messages will be routed with no handler.
         if (!get().wsThreadSubscriptions[threadId]) {
-          const unsub = globalWebSocketManager.subscribe(
-            threadId as string,
-            (data) => {
-              handleChatWebSocketMessage(data, set, get);
-            }
-          );
+          const unsub = globalWebSocketManager.subscribe(tid, (data) => {
+            handleChatWebSocketMessage(data, set, get, tid);
+          });
           set((state) => {
             // Guard against a race: if another path registered a handler
             // between our check and this set(), clean ours up to avoid a leak.
-            const existing = state.wsThreadSubscriptions[threadId as string];
+            const existing = state.wsThreadSubscriptions[tid];
             if (existing !== undefined) {
               unsub();
               return {};
@@ -783,16 +818,24 @@ const useGlobalChatStore = create<GlobalChatState>()(
             return {
               wsThreadSubscriptions: {
                 ...state.wsThreadSubscriptions,
-                [threadId as string]: unsub
+                [tid]: unsub
               }
             };
           });
         }
 
+        // Targeted sends (chat tabs) keep the thread's own workflow binding;
+        // untargeted sends bind the thread to the currently-open workflow as
+        // before.
+        const boundWorkflowId = targetThreadId
+          ? get().threads[tid]?.workflow_id ??
+            get().threadWorkflowId[tid] ??
+            null
+          : workflowId ?? null;
         set((state) => ({
           threadWorkflowId: {
             ...state.threadWorkflowId,
-            [threadId as string]: workflowId ?? null
+            [tid]: boundWorkflowId
           }
         }));
 
@@ -819,7 +862,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           message as Message;
         const chatMessageData = {
           ...messageWithoutTools,
-          workflow_id: message.workflow_id ?? workflowId ?? null,
+          workflow_id: message.workflow_id ?? boundWorkflowId,
           thread_id: threadId,
           memory_enabled: memoryEnabled,
           permission_mode: get().getPermissionMode(threadId),
@@ -841,43 +884,52 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // Add message to cache optimistically
         get().addMessageToCache(threadId, messageForCache);
 
-        set({ status: "loading" }); // Waiting for response
+        // Waiting for response — only this thread's runtime enters "loading"
+        set((state) => threadRuntimeUpdate(state, tid, { status: "loading" }));
 
         try {
           await globalWebSocketManager.send(commandMessage);
 
-          // Safety timeout - reset status if no response after 5 minutes
+          // Safety timeout - reset the thread if no response after 5 minutes
           const timeoutId = setTimeout(() => {
-            const currentState = get();
-            if (
-              currentState.status === "loading" ||
-              currentState.status === "streaming"
-            ) {
-              console.warn("Generation timeout - resetting status to connected");
-              set({
-                status: "connected",
-                progress: { current: 0, total: 0 },
-                statusMessage: null,
-                currentPlanningUpdate: null,
-                currentTaskUpdate: null,
-                currentTaskUpdateThreadId: null,
-                sendMessageTimeoutId: null
-              });
+            const runtime = getThreadRuntime(get(), tid);
+            if (runtime.status === "loading" || runtime.status === "streaming") {
+              console.warn("Generation timeout - resetting thread to idle");
+              set((state) =>
+                threadRuntimeUpdate(state, tid, {
+                  status: "idle",
+                  progress: { current: 0, total: 0 },
+                  statusMessage: null,
+                  planningUpdate: null,
+                  taskUpdate: null,
+                  sendMessageTimeoutId: null
+                })
+              );
             }
           }, 5 * 60 * 1000);
-          set({ sendMessageTimeoutId: timeoutId });
+          set((state) =>
+            threadRuntimeUpdate(state, tid, { sendMessageTimeoutId: timeoutId })
+          );
         } catch (error) {
-          // Clear timeout on error
-          const currentTimeoutId = get().sendMessageTimeoutId;
+          // Clear this thread's timeout on error
+          const currentTimeoutId = getThreadRuntime(
+            get(),
+            tid
+          ).sendMessageTimeoutId;
           if (currentTimeoutId !== null) {
             clearTimeout(currentTimeoutId);
-            set({ sendMessageTimeoutId: null });
           }
           console.error("Failed to send message:", error);
-          set({
-            error:
-              error instanceof Error ? error.message : "Failed to send message"
-          });
+          const errorMessage =
+            error instanceof Error ? error.message : "Failed to send message";
+          set((state) => ({
+            error: errorMessage,
+            ...threadRuntimeUpdate(state, tid, {
+              error: errorMessage,
+              status: "idle",
+              sendMessageTimeoutId: null
+            })
+          }));
           throw error;
         }
       },
@@ -991,12 +1043,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
         if (existingUnsub) {
           existingUnsub();
         }
-        const newUnsub = globalWebSocketManager.subscribe(
-          id,
-          (data) => {
-            handleChatWebSocketMessage(data, set, get);
-          }
-        );
+        const newUnsub = globalWebSocketManager.subscribe(id, (data) => {
+          handleChatWebSocketMessage(data, set, get, id);
+        });
 
         set((state) => ({
           threads: {
@@ -1019,7 +1068,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
           wsThreadSubscriptions: {
             ...state.wsThreadSubscriptions,
             [id]: newUnsub
-          }
+          },
+          // The new thread becomes current with a fresh (idle) runtime.
+          ...mirrorsForThread({ ...state, currentThreadId: id }, id)
         }));
 
         return id;
@@ -1032,12 +1083,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
         }
 
         if (!get().wsThreadSubscriptions[threadId]) {
-          const unsub = globalWebSocketManager.subscribe(
-            threadId,
-            (data) => {
-              handleChatWebSocketMessage(data, set, get);
-            }
-          );
+          const unsub = globalWebSocketManager.subscribe(threadId, (data) => {
+            handleChatWebSocketMessage(data, set, get, threadId);
+          });
           set((state) => {
             const existing = state.wsThreadSubscriptions[threadId];
             if (existing !== undefined) {
@@ -1059,7 +1107,11 @@ const useGlobalChatStore = create<GlobalChatState>()(
           workflowId:
             state.threads[threadId]?.workflow_id ??
             state.threadWorkflowId[threadId] ??
-            state.workflowId
+            state.workflowId,
+          // Project the newly-focused thread's runtime onto the legacy
+          // top-level mirrors so the UI doesn't carry the previous thread's
+          // streaming state.
+          ...mirrorsForThread(state, threadId)
         }));
         get().loadMessages(threadId);
       },
@@ -1082,13 +1134,19 @@ const useGlobalChatStore = create<GlobalChatState>()(
             threadUnsubscribe?.();
             const { [threadId]: _deletedTodos, ...remainingTodos } =
               state.todosByThread;
+            const { [threadId]: deletedRuntime, ...remainingRuntime } =
+              state.threadRuntime;
+            if (deletedRuntime?.sendMessageTimeoutId != null) {
+              clearTimeout(deletedRuntime.sendMessageTimeoutId);
+            }
 
             const newState: Partial<GlobalChatState> = {
               threads: remainingThreads,
               messageCache: remainingCache,
               messageCursors: remainingCursors,
               wsThreadSubscriptions: remainingSubscriptions,
-              todosByThread: remainingTodos
+              todosByThread: remainingTodos,
+              threadRuntime: remainingRuntime
             };
 
             // If deleting current thread, switch to another or create new
@@ -1324,21 +1382,23 @@ const useGlobalChatStore = create<GlobalChatState>()(
         });
       },
 
-      stopGeneration: () => {
-        const { currentThreadId, sendMessageTimeoutId, loadMessagesTimeoutId } = get();
+      stopGeneration: (threadId?: string) => {
+        const { currentThreadId, loadMessagesTimeoutId } = get();
+        const tid = threadId ?? currentThreadId;
 
         // Pi mode stops via the agent socket, not the /ws stop command.
         if (get().mode === "pi") {
           FrontendToolRegistry.abortAll();
-          if (currentThreadId) {
-            get().stopPi(currentThreadId);
+          if (tid) {
+            get().stopPi(tid);
           }
           return;
         }
 
-        // Clear any pending sendMessage timeout
-        if (sendMessageTimeoutId !== null) {
-          clearTimeout(sendMessageTimeoutId);
+        // Clear the thread's pending sendMessage timeout
+        const pendingTimeoutId = getThreadRuntime(get(), tid).sendMessageTimeoutId;
+        if (pendingTimeoutId !== null) {
+          clearTimeout(pendingTimeoutId);
         }
         // Clear any pending loadMessages timeout
         if (loadMessagesTimeoutId !== null) {
@@ -1356,18 +1416,17 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // socket (including ones from non-thread-bound workflow runs), so
         // keeping their cards would leave orphaned prompts whose responses
         // resolve nothing.
-        if (currentThreadId) {
+        if (tid) {
           set((state) => {
             const remaining = Object.fromEntries(
               Object.entries(state.pendingApprovals).filter(
-                ([, approval]) => approval.thread_id !== currentThreadId
+                ([, approval]) => approval.thread_id !== tid
               )
             );
             const remainingPlans = Object.fromEntries(
               Object.entries(state.pendingPlanApprovals).filter(
                 ([, approval]) =>
-                  approval.thread_id !== null &&
-                  approval.thread_id !== currentThreadId
+                  approval.thread_id !== null && approval.thread_id !== tid
               )
             );
             return {
@@ -1377,18 +1436,16 @@ const useGlobalChatStore = create<GlobalChatState>()(
           });
         }
 
-        if (!globalWebSocketManager) {
-          set({ sendMessageTimeoutId: null });
-          return;
-        }
-
-        if (!globalWebSocketManager.isConnectionOpen()) {
-          set({ sendMessageTimeoutId: null });
-          return;
-        }
-
-        if (!currentThreadId) {
-          set({ sendMessageTimeoutId: null });
+        if (
+          !tid ||
+          !globalWebSocketManager ||
+          !globalWebSocketManager.isConnectionOpen()
+        ) {
+          if (tid) {
+            set((state) =>
+              threadRuntimeUpdate(state, tid, { sendMessageTimeoutId: null })
+            );
+          }
           return;
         }
 
@@ -1399,30 +1456,34 @@ const useGlobalChatStore = create<GlobalChatState>()(
           void globalWebSocketManager
             .send({
               command: "stop",
-              data: { thread_id: currentThreadId }
+              data: { thread_id: tid }
             })
             .catch((error) => {
               console.error("Failed to send stop signal:", error);
             });
 
-          set({
-            status: "connected",
-            progress: { current: 0, total: 0 },
-            statusMessage: null,
-            currentPlanningUpdate: null,
-            currentTaskUpdate: null,
-            currentTaskUpdateThreadId: null,
-            sendMessageTimeoutId: null,
-            loadMessagesTimeoutId: null
-          });
+          set((state) => ({
+            loadMessagesTimeoutId: null,
+            ...threadRuntimeUpdate(state, tid, {
+              status: "idle",
+              progress: { current: 0, total: 0 },
+              statusMessage: null,
+              planningUpdate: null,
+              taskUpdate: null,
+              sendMessageTimeoutId: null
+            })
+          }));
         } catch (error) {
           console.error("Failed to send stop signal:", error);
-          set({
+          set((state) => ({
             error: "Failed to stop generation",
-            status: "error",
-            statusMessage: null,
-            sendMessageTimeoutId: null
-          });
+            ...threadRuntimeUpdate(state, tid, {
+              error: "Failed to stop generation",
+              status: "error",
+              statusMessage: null,
+              sendMessageTimeoutId: null
+            })
+          }));
         }
       },
 
@@ -1673,5 +1734,22 @@ export const useThreadsQuery = () => {
 
   return query;
 };
+
+/**
+ * Subscribe to one thread's generation runtime. Returns the default (idle)
+ * runtime for unknown/null thread ids. Use this instead of the top-level
+ * status/progress mirrors when the component is bound to a specific thread
+ * (e.g. a workspace chat tab) rather than the store's current one.
+ */
+export const useThreadRuntime = (threadId: string | null): ThreadRuntime =>
+  useGlobalChatStore(
+    useShallow((state) =>
+      threadId
+        ? state.threadRuntime[threadId] ?? DEFAULT_THREAD_RUNTIME
+        : DEFAULT_THREAD_RUNTIME
+    )
+  );
+
+export type { ThreadRuntime } from "../core/chat/threadRuntime";
 
 export default useGlobalChatStore;

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -22,6 +22,8 @@ export type WorkspaceTabType =
   | "model3d"
   | "audio"
   | "text"
+  // Chat conversations. `ref` is a chat thread id (GlobalChatStore).
+  | "chat"
   // App pages (Settings, Costs, Model Manager, …) opened from the logo menu.
   // `ref` is a PageTabKey; these have no edit mode.
   | "page";


### PR DESCRIPTION
## Summary

Refactor chat state management to support concurrent message generation across multiple threads. Each thread now maintains independent streaming status, progress, planning/task/log updates, and tool-call state in a new `threadRuntime` store. The legacy top-level fields (`status`, `statusMessage`, etc.) are kept as mirrors of the *current* thread's runtime for backward compatibility with single-thread consumers.

## Key Changes

- **New `threadRuntime.ts` module**: Defines `ThreadRuntime` interface and utilities (`getThreadRuntime`, `threadRuntimeUpdate`, `mirrorsForThread`) to manage per-thread state and project it onto legacy top-level fields when the thread is current.

- **GlobalChatStore refactor**:
  - Added `threadRuntime: Record<string, ThreadRuntime>` to store per-thread state
  - Moved `sendMessageTimeoutId` from top-level to per-thread (each thread has its own safety timeout)
  - Updated `sendMessage()` to accept optional `targetThreadId` parameter; sends to current thread if omitted
  - Updated `stopGeneration()` to accept optional `targetThreadId` parameter
  - Thread switches now project the new thread's runtime onto top-level mirrors via `mirrorsForThread()`

- **Chat protocol handler updates**:
  - All update handlers (`applyChunk`, `applyMessage`, `applyNodeUpdate`, `applyJobUpdate`, `applyOutputUpdate`, `applyToolCallUpdate`, `applyNodeProgress`, `applyGenerationStopped`, `applyError`) now accept a `threadId` parameter
  - Handlers use `threadRuntimeUpdate()` to patch thread-specific state instead of modifying top-level fields directly
  - WebSocket message routing passes the thread ID to handlers so updates target the correct thread

- **New `ChatSurface` component**: Workspace tab surface for chat threads. Each tab:
  - Reads its thread's runtime from `useThreadRuntime(refId)` hook
  - Sends messages and stops generation with explicit `threadId` (no dependency on `currentThreadId`)
  - Activates its thread when the tab becomes active (so sidebar/header follow focus)
  - Streams independently — a background tab continues generating while hidden

- **UI integration**:
  - `OpenMenu` now lists existing chat threads and allows opening them in new tabs
  - `WorkspaceTabsStore` extended with `"chat"` tab type
  - `TabContent` routes chat tabs to `ChatSurface`
  - `WorkspaceTabBar` handles chat tab operations

## Implementation Details

- **Thread-less protocol errors** (connection failures, etc.) still set the top-level `error` field; thread-specific errors are stored in `threadRuntime[threadId].error`
- **Status mapping**: Thread runtime uses `"idle"` internally; the mirror projects it to `"connected"` for legacy consumers
- **Safety timeout per thread**: Each thread's `sendMessage()` call sets its own 5-minute timeout; clearing one thread's timeout does not affect others
- **Backward compatibility**: Single-thread consumers (GlobalChat, editor panels) continue reading top-level fields; multi-thread consumers (ChatSurface) read `threadRuntime` directly via `useThreadRuntime()` hook
- **Test updates**: Updated `chatProtocol.test.ts` to verify timeout state is stored in `threadRuntime` instead of top-level

## Notes

- The WebSocket connection remains a singleton shared by all threads; only the per-thread state is decoupled
- Threads generate concurrently — no blocking between tabs
- Thread title syncing and message cache are already per-thread; this change completes the isolation

https://claude.ai/code/session_014mWFbcVM8mYWyXhtqk5PEM