### PR TITLE
Use plain language on marketing landing pages

### DIFF
--- a/marketing/src/app/agents/layout.tsx
+++ b/marketing/src/app/agents/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 
 const TITLE = "AI Agent Workflow Builder — Visual Canvas | NodeTool";
 const DESCRIPTION =
-  "Build and run AI agents visually — plan-act agents on a node canvas that plan the steps, pick the model, and execute, no code required. Wire image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs — into agents that ship the work. Open source, BYOK, runs on your machine.";
+  "Build and run AI agents visually — agents on a node canvas that plan the steps, pick the model, and do the work, no code required. Wire image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs — into agents that ship the work. Open source, your own keys, runs on your machine.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -58,7 +58,7 @@ export default function AgentsLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Agents",
           description:
-            "Plan-act AI agents built visually on NodeTool's node canvas: give an agent a goal and it plans the steps, picks the model, and executes across image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs. Open source, BYOK, runs on your machine.",
+            "AI agents built visually on NodeTool's node canvas: give an agent a goal and it plans the steps, picks the model, and does the work across image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs. Open source, your own keys, runs on your machine.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux, Web browser",
           url: "https://nodetool.ai/agents",

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -55,7 +55,7 @@ const proPoints = [
   {
     icon: Zap,
     title: "Start in 30 seconds",
-    body: "Sign in, open a workflow, hit run. No installer, no native dependencies, no GPU drivers — just a browser tab.",
+    body: "Sign in, open a workflow, hit run. No installer, no drivers, nothing to set up — just a browser tab.",
   },
   {
     icon: Globe,
@@ -69,7 +69,7 @@ const proPoints = [
   },
   {
     icon: KeyRound,
-    title: "Bring your own keys (BYOK)",
+    title: "Bring your own keys",
     body: "OpenAI, Anthropic, Gemini, Mistral, Groq, Replicate, FAL, ElevenLabs, HuggingFace — every cloud provider, billed to your account, not ours.",
   },
   {
@@ -80,18 +80,18 @@ const proPoints = [
   {
     icon: Cloud,
     title: "No GPU required",
-    body: "We run the runtime, the websocket server, the queues, and the storage. Heavy generative jobs go to your chosen cloud APIs.",
+    body: "We run the servers and the storage. Heavy image and video jobs run at the providers you choose.",
   },
 ];
 
 const consPoints = [
   {
-    title: "Alpha — not yet GA",
-    body: "Cloud is in active alpha. Expect breaking changes, missing polish, and occasional downtime. SLAs and production guarantees come with general availability.",
+    title: "Alpha — still early",
+    body: "Cloud is in active alpha. Expect breaking changes, missing polish, and occasional downtime. Uptime and support guarantees come with the full release.",
   },
   {
-    title: "No local LLMs",
-    body: "Cloud doesn't run Ollama, MLX, or GGUF models — those need access to your hardware. Use Studio if you need open-weight models running locally.",
+    title: "No local models",
+    body: "Cloud doesn't run Ollama or MLX models — those need access to your hardware. Use Studio if you want open models running on your own machine.",
   },
   {
     title: "Needs an internet connection",
@@ -227,8 +227,8 @@ export default function CloudPage() {
                   <strong className="text-amber-200">Heads up:</strong> Cloud is
                   in <strong className="text-amber-200">alpha</strong> and not
                   yet generally available. Expect rough edges, breaking changes,
-                  and occasional downtime while we harden it. For production
-                  workloads today, use{" "}
+                  and occasional downtime while we make it solid. For real
+                  work today, use{" "}
                   <a
                     href="/studio"
                     className="underline underline-offset-2 hover:text-amber-50"
@@ -246,8 +246,8 @@ export default function CloudPage() {
                     <ArrowRight className="h-4 w-4" />
                   </a>
                   <p className="text-xs text-slate-400">
-                    Alpha preview · AGPL-3.0 source · BYOK for every provider ·
-                    Self-host any time
+                    Alpha preview · AGPL-3.0 source · Your own keys for every
+                    provider · Self-host any time
                   </p>
                   <div className="mt-5 max-w-md">
                     <p className="mb-2 text-sm text-slate-300">
@@ -345,13 +345,12 @@ export default function CloudPage() {
                     Bring your own keys
                   </div>
                   <h2 className="text-2xl md:text-3xl font-bold text-white">
-                    You pay providers directly. We never mark up tokens.
+                    You pay providers directly. We never add a markup.
                   </h2>
                   <p className="mt-3 text-slate-300 max-w-2xl">
                     Cloud connects to OpenAI, Anthropic, Gemini, Mistral, Groq,
                     Replicate, FAL, ElevenLabs, HuggingFace, and more — using
-                    keys you provide. No hidden inference fees, no resold
-                    credits.
+                    keys you provide. No hidden fees, no resold credits.
                   </p>
                 </div>
               </div>
@@ -428,11 +427,10 @@ export default function CloudPage() {
                 Cloud is just our hosting of open-source code.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Every node, every provider, every line of the runtime that
-                powers Cloud is on GitHub under AGPL-3.0. If you ever want to
-                self-host, the same Docker images, CLI, and websocket server
-                are yours to run — no vendor lock-in, no &ldquo;cloud-only&rdquo;
-                features, no closed source layer.
+                Every node, every provider, every line of code that powers
+                Cloud is on GitHub under AGPL-3.0. If you ever want to run it
+                yourself, everything we run is yours to run too — no lock-in,
+                no &ldquo;cloud-only&rdquo; features, no closed source layer.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool"

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -28,13 +28,13 @@ const creativeFeatures = [
   {
     title: "Visual Workflow Canvas",
     description:
-      "Snap nodes into full creative pipelines — the whole process on one screen, from brief to render.",
+      "Snap nodes into complete creative workflows — the whole process on one screen, from brief to render.",
     icon: Layers,
     image: "/screen_canvas.png",
     features: [
       "Infinite canvas",
-      "Real-time execution graph",
-      "Custom sub-graphs",
+      "Watch every node run live",
+      "Reusable node groups",
     ],
   },
   {
@@ -46,15 +46,15 @@ const creativeFeatures = [
     features: ["Masks, inpaint, outpaint", "Multi-model support", "Batch processing"],
   },
   {
-    title: "Video pipelines",
+    title: "Video workflows",
     description:
       "Wire Seedance, Kling, Veo, Runway, and Sora alongside your edit nodes. Generate, transform, and stitch — without exporting between tools.",
     icon: Video,
     image: "/sora.mp4",
     features: [
       "Frame-accurate edits",
-      "Temporal smoothing",
-      "Format transcoding",
+      "Motion smoothing",
+      "Convert between formats",
     ],
   },
   {
@@ -139,7 +139,7 @@ export default function CreativesPage() {
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
                   Every model. Your keys. Your canvas. Wire Seedance, Kling, Veo, Runway,
-                  Luma, Suno, and Flux on one open-source surface — no credit markup, no vendor lock-in.
+                  Luma, Suno, and Flux on one open-source canvas — no marked-up credits, no lock-in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -401,7 +401,7 @@ export default function CreativesPage() {
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
                 One canvas for <br />
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400">
-                  every modality
+                  every medium
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -18,7 +18,7 @@ const jetBrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "NodeTool — The open creative AI workspace",
   description:
-    "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas you run on your machine or in the browser. Pay providers directly. No credits, no markup, no vendor lock-in.",
+    "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas you run on your machine or in the browser. Pay providers directly. No credits, no markup, no lock-in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "NodeTool — The open creative AI workspace",
     description:
-      "Every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text on one surface. Open source. BYOK. Provider prices.",
+      "Every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text in one place. Open source. Your own keys. Provider prices.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
@@ -65,7 +65,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool — The open creative AI workspace",
     description:
-      "Every model. Your keys. Your canvas. The open-source creative AI workspace, with BYOK to every major provider and provider-price billing.",
+      "Every model. Your keys. Your canvas. The open-source creative AI workspace — bring your own keys to every major provider and pay provider prices.",
     images: ["/preview.png"],
   },
 };
@@ -112,11 +112,11 @@ export default function RootLayout({
               "screenshot": "https://nodetool.ai/preview.png",
               "featureList": [
                 "Node-based creative canvas for image, video, audio, and text",
-                "BYOK to every major provider: FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, HuggingFace",
+                "Bring your own keys to every major provider: FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, HuggingFace",
                 "Pay providers directly at provider prices, no credits, no markup",
                 "Editing tools built in: masks, inpaint, outpaint, relight, upscale, layers, compositing",
-                "Frontier models named by their real names: Flux, Seedance, Wan, Veo, Kling, Hailuo, Whisper, ElevenLabs, Suno",
-                "Local inference via MLX, Ollama, llama.cpp, vLLM, and LM Studio",
+                "The latest models under their real names: Flux, Seedance, Wan, Veo, Kling, Hailuo, Whisper, ElevenLabs, Suno",
+                "Run models locally via MLX, Ollama, llama.cpp, vLLM, and LM Studio",
                 "Two editions on one open-source codebase: Studio (desktop) and Cloud (browser)",
                 "Streaming execution with live output as nodes finish",
                 "Workflows, files, and keys belong to you — runs on your machine or browser",
@@ -172,7 +172,7 @@ export default function RootLayout({
                   "name": "How is NodeTool different from ComfyUI?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "ComfyUI is a Stable Diffusion power tool with engineer-first UX. NodeTool is the full creative workspace — every modality on one canvas, with the editing tools creatives actually use. NodeTool also supports a much wider model roster across providers and modalities, called with your own keys at provider prices."
+                    "text": "ComfyUI is a Stable Diffusion power tool built for engineers. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with the editing tools creatives actually use. NodeTool also supports far more models across providers and media types, called with your own keys at provider prices."
                   }
                 },
                 {
@@ -180,7 +180,7 @@ export default function RootLayout({
                   "name": "How is NodeTool different from Weavy or other closed SaaS canvases?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK. You bring your own API keys to every provider, pay providers directly at provider prices, and own your workflows and files. Cloud is just our managed hosting of the same open-source code you can run yourself."
+                    "text": "Closed canvases lock you into a credit system and a hand-picked list of models. NodeTool is open source. You bring your own API keys to every provider, pay providers directly at provider prices, and own your workflows and files. Cloud is just our managed hosting of the same open-source code you can run yourself."
                   }
                 },
                 {
@@ -188,7 +188,7 @@ export default function RootLayout({
                   "name": "How does pricing work?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool Studio is free to download and use. NodeTool Cloud is a subscription for managed hosting. In both editions, you bring your own API keys to every provider and pay those providers directly at their list prices. NodeTool does not run model inference for you on its own servers, does not issue proprietary credits, and does not mark up model calls."
+                    "text": "NodeTool Studio is free to download and use. NodeTool Cloud is a subscription for managed hosting. In both editions, you bring your own API keys to every provider and pay those providers directly at their list prices. NodeTool does not run models for you on its own servers, does not issue its own credits, and does not mark up model calls."
                   }
                 },
                 {
@@ -196,7 +196,7 @@ export default function RootLayout({
                   "name": "What models does NodeTool support?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Frontier models including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Local inference is supported via MLX, Ollama, llama.cpp, vLLM, and LM Studio."
+                    "text": "The latest models, including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Models can also run on your own machine via MLX, Ollama, llama.cpp, vLLM, and LM Studio."
                   }
                 },
                 {

--- a/marketing/src/app/marketing/layout.tsx
+++ b/marketing/src/app/marketing/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata, Viewport } from "next";
 export const metadata: Metadata = {
   title: "NodeTool for marketing teams | AI production at campaign scale",
   description:
-    "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No credit markup, no vendor lock-in, output at campaign volume.",
+    "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No marked-up credits, no lock-in, output at campaign volume.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/marketing",
@@ -59,7 +59,7 @@ export default function MarketingLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool for Marketing Teams",
           description:
-            "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No credit markup, no vendor lock-in, output at campaign volume.",
+            "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No marked-up credits, no lock-in, output at campaign volume.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux, Web browser",
           url: "https://nodetool.ai/marketing",

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -39,7 +39,7 @@ const marketingBenefits = [
   {
     title: "Brand consistency, built in",
     description:
-      "Lock a palette, a voice, or a product shot into the workflow once. Every asset the pipeline produces inherits it — no manual re-briefing per output.",
+      "Lock a palette, a voice, or a product shot into the workflow once. Every asset it produces inherits it — no manual re-briefing per output.",
     icon: Palette,
   },
 ];
@@ -139,8 +139,8 @@ export default function MarketingSegmentPage() {
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
                   Product videos, ad creative, social calendars, and brand
                   assets from every major model, called with your own keys,
-                  on one node-based canvas. No credit markup, no vendor
-                  lock-in, built for output volume, not one-off polish.
+                  on one node-based canvas. No marked-up credits, no lock-in
+                  — built for output volume, not one-off polish.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -168,13 +168,13 @@ export default function MarketingSegmentPage() {
                     <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-emerald-500/30 bg-emerald-500/10">
                       <Shield className="w-4 h-4 text-emerald-300" />
                     </span>
-                    BYOK, no markup
+                    Your keys, no markup
                   </li>
                   <li className="flex items-center gap-2.5">
                     <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/30 bg-cyan-500/10">
                       <ImageIcon className="w-4 h-4 text-cyan-300" />
                     </span>
-                    Every modality, one canvas
+                    Every format, one canvas
                   </li>
                 </ul>
               </motion.div>
@@ -198,10 +198,10 @@ export default function MarketingSegmentPage() {
                 </span>
               </h2>
               <p className="text-lg text-slate-400 leading-relaxed">
-                Automation tools sell on connector count and throughput.
-                Creative tools sell on per-asset polish. Campaigns need both:
-                a pipeline that runs at volume and still looks on-brand every
-                time.
+                Automation tools compete on integrations and speed. Creative
+                tools compete on the polish of a single asset. Campaigns need
+                both: a workflow that runs at volume and still looks on-brand
+                every time.
               </p>
             </motion.div>
 
@@ -259,7 +259,7 @@ export default function MarketingSegmentPage() {
                   it, ready to re-run across every SKU in the line.
                 </p>
                 <ul className="space-y-3 mb-8">
-                  {["Brief → Prompt → Agent → Text-to-Video", "Re-runnable per SKU or market", "BYOK across every model in the pipeline"].map(
+                  {["Brief → Prompt → Agent → Text-to-Video", "Re-runnable per SKU or market", "Your own keys for every model in the workflow"].map(
                     (item) => (
                       <li key={item} className="flex items-center gap-3 text-slate-300">
                         <Check className="w-5 h-5 text-emerald-400" />
@@ -311,11 +311,11 @@ export default function MarketingSegmentPage() {
               className="text-center mb-12 max-w-2xl mx-auto"
             >
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
-                More marketing-ops workflows on the way
+                More marketing workflows on the way
               </h2>
               <p className="text-lg text-slate-400 leading-relaxed">
-                The Product Video Generator ships today. These are next on
-                the backlog — same pattern: brief in, campaign out.
+                The Product Video Generator ships today. These are next up —
+                same pattern: brief in, campaign out.
               </p>
             </motion.div>
 
@@ -365,7 +365,7 @@ export default function MarketingSegmentPage() {
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
                 Download NodeTool, plug in the providers you already pay for,
-                and build the pipeline that produces your next campaign.
+                and build the workflow that produces your next campaign.
               </p>
               <SmartDownloadButton
                 icon={<Download className="w-6 h-6" />}

--- a/marketing/src/app/pricing/opengraph-image.tsx
+++ b/marketing/src/app/pricing/opengraph-image.tsx
@@ -1,13 +1,13 @@
 import { ogImage, ogSize, ogContentType } from "../../lib/og";
 
-export const alt = "NodeTool Pricing — free Studio, BYOK to every provider";
+export const alt = "NodeTool Pricing — free Studio, your own keys to every provider";
 export const size = ogSize;
 export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
     "Free to download. Pay providers, not us.",
-    "Studio is free and open source. BYOK to every provider — no markup.",
+    "Studio is free and open source. Your own keys to every provider — no markup.",
     { image: "screen_canvas.png", accent: "amber", eyebrow: "Pricing" }
   );
 }

--- a/marketing/src/app/pricing/page.tsx
+++ b/marketing/src/app/pricing/page.tsx
@@ -6,14 +6,14 @@ import JsonLd from "../../components/JsonLd";
 import { SmartDownloadButton } from "../SmartDownloadButton";
 
 export const metadata: Metadata = {
-  title: "Pricing — free Studio, BYOK, pay providers directly | NodeTool",
+  title: "Pricing — free Studio, your own keys, pay providers directly | NodeTool",
   description:
     "NodeTool Studio is free and open source. NodeTool Cloud is a subscription for managed hosting. In both, you bring your own API keys and pay providers their list prices — no credits, no markup.",
   alternates: { canonical: "/pricing" },
   openGraph: {
-    title: "NodeTool Pricing — free Studio, BYOK to every provider",
+    title: "NodeTool Pricing — free Studio, your own keys to every provider",
     description:
-      "Studio is free and open source. Cloud is managed hosting. Both are BYOK: pay providers directly at their list prices, no credits, no markup.",
+      "Studio is free and open source. Cloud is managed hosting. In both you bring your own keys: pay providers directly at their list prices, no credits, no markup.",
     url: "https://nodetool.ai/pricing",
     type: "website",
   },
@@ -33,7 +33,7 @@ const offers = {
   "@type": "Product",
   name: "NodeTool",
   description:
-    "The open creative AI workspace. Studio (desktop) is free; Cloud is a managed subscription. Both are BYOK.",
+    "The open creative AI workspace. Studio (desktop) is free; Cloud is a managed subscription. In both you bring your own API keys.",
   brand: { "@type": "Brand", name: "NodeTool" },
   offers: [
     {
@@ -41,14 +41,14 @@ const offers = {
       name: "NodeTool Studio",
       price: "0",
       priceCurrency: "USD",
-      description: "Free, open-source desktop app. BYOK to every provider.",
+      description: "Free, open-source desktop app. Bring your own keys to every provider.",
       url: "https://nodetool.ai/studio",
     },
     {
       "@type": "Offer",
       name: "NodeTool Cloud",
       description:
-        "Managed hosting subscription (currently in alpha). BYOK to every provider.",
+        "Managed hosting subscription (currently in alpha). Bring your own keys to every provider.",
       url: "https://nodetool.ai/cloud",
       availability: "https://schema.org/PreOrder",
     },
@@ -104,7 +104,7 @@ export default function PricingPage() {
             NodeTool Studio is free and open source. NodeTool Cloud is a
             subscription for managed hosting. In both editions you bring your own
             API keys and pay each provider their list price — no credits, no
-            markup, no curated roster.
+            markup, no locked-down model list.
           </p>
         </section>
 
@@ -114,7 +114,7 @@ export default function PricingPage() {
             {/* Studio */}
             <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
               <h2 className="text-xl font-semibold text-white">NodeTool Studio</h2>
-              <p className="mt-1 text-sm text-slate-400">Desktop app · local-first</p>
+              <p className="mt-1 text-sm text-slate-400">Desktop app · runs on your machine</p>
               <div className="mt-6 flex items-baseline gap-2">
                 <span className="text-4xl font-bold text-white">Free</span>
                 <span className="text-sm text-slate-400">forever · AGPL-3.0</span>
@@ -123,7 +123,7 @@ export default function PricingPage() {
                 {[
                   "Runs on macOS, Windows, and Linux",
                   "Local models via Ollama, MLX, llama.cpp",
-                  "BYOK to every cloud provider",
+                  "Your own keys to every cloud provider",
                   "Your workflows and files stay on your machine",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
@@ -153,13 +153,13 @@ export default function PricingPage() {
                 <span className="text-4xl font-bold text-white">Subscription</span>
               </div>
               <p className="mt-1 text-sm text-slate-400">
-                Managed hosting of the same open-source app. Pricing finalised at
-                general availability.
+                Managed hosting of the same open-source app. Pricing will be
+                set at full release.
               </p>
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
                   "Runs in your browser — no install, no GPU",
-                  "BYOK to every cloud provider",
+                  "Your own keys to every cloud provider",
                   "Same AGPL-3.0 codebase you can self-host",
                   "Pay providers directly at provider prices",
                 ].map((f) => (
@@ -220,8 +220,8 @@ export default function PricingPage() {
               You add your own API keys for the providers you use — FAL, KIE,
               OpenAI, Anthropic, Gemini, Replicate, and the rest. Model calls go
               to those providers and you pay them their published list prices.
-              NodeTool does not run inference on its own servers, does not issue
-              proprietary credits, and does not mark up model calls. Your
+              NodeTool does not run models on its own servers, does not issue
+              its own credits, and does not mark up model calls. Your
               Cloud subscription pays for hosting the workspace, nothing more.
             </p>
           </div>

--- a/marketing/src/app/studio/opengraph-image.tsx
+++ b/marketing/src/app/studio/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = ogContentType;
 export default function Image() {
   return ogImage(
     "AI that runs on your machine",
-    "Local-first desktop app. Ollama, MLX, and GGUF models offline. BYOK.",
+    "Desktop app. Runs Ollama and MLX models offline. Your own keys.",
     { image: "screen_assets.png", accent: "emerald", eyebrow: "Studio" }
   );
 }

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -68,18 +68,18 @@ const proPoints = [
   },
   {
     icon: Cpu,
-    title: "Run open-weight models locally",
-    body: "Ollama, MLX (Apple Silicon), GGUF/GGML, HuggingFace Transformers — all wired into the same nodes. Pick any open model with zero API cost.",
+    title: "Run open models on your machine",
+    body: "Ollama, MLX (Apple Silicon), llama.cpp, Hugging Face — all wired into the same nodes. Pick any open model and pay no API fees.",
   },
   {
     icon: Zap,
     title: "Use your GPU to the fullest",
-    body: "NVIDIA CUDA on Windows/Linux, Metal on Apple Silicon. Image, video, and audio nodes go straight to the metal.",
+    body: "NVIDIA GPUs on Windows and Linux, Apple Silicon on macOS. Image, video, and audio nodes use your hardware directly.",
   },
   {
     icon: HardDrive,
     title: "Own your model library",
-    body: "Built-in Model Manager downloads, organizes, and shares model files across workflows. Curate the exact stack you want.",
+    body: "Built-in Model Manager downloads, organizes, and shares model files across workflows. Keep exactly the models you want.",
   },
   {
     icon: Code2,
@@ -91,7 +91,7 @@ const proPoints = [
 const consPoints = [
   {
     title: "Hardware matters",
-    body: "Local LLMs need RAM and ideally a GPU. We recommend 16GB+ RAM and 4GB+ VRAM for serious local-model work.",
+    body: "Local models need RAM and ideally a GPU. We recommend 16GB+ RAM and 4GB+ of GPU memory for serious local-model work.",
   },
   {
     title: "You manage updates",
@@ -99,7 +99,7 @@ const consPoints = [
   },
   {
     title: "Disk space",
-    body: "Local models are large — plan ~20GB for a small starter set, much more for video/image weights.",
+    body: "Local models are large — plan ~20GB for a small starter set, much more for video and image models.",
   },
 ];
 
@@ -212,10 +212,10 @@ export default function StudioPage() {
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Studio is the desktop app for builders who want their
-                  models, data, and outputs to stay local. Use Ollama, MLX, and
-                  GGUF models with zero per-token cost — and bring your own keys
-                  for any cloud provider when you need them.
+                  NodeTool Studio is the desktop app for builders who want
+                  their models, data, and outputs to stay on their own machine.
+                  Run free local models with Ollama and MLX — and bring your
+                  own keys for any cloud provider when you need them.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton
@@ -281,7 +281,7 @@ export default function StudioPage() {
                 id="why-studio-title"
                 className="text-3xl md:text-5xl font-bold tracking-tight text-white"
               >
-                Privacy, speed, and zero per-token cost.
+                Privacy, speed, and no usage fees.
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl">
                 Everything Studio does, it can do without a network connection.
@@ -328,8 +328,8 @@ export default function StudioPage() {
                 What Studio asks of you.
               </h2>
               <p className="mt-4 text-base text-slate-400 leading-relaxed max-w-2xl">
-                Local-first means you take on a few things the cloud would
-                otherwise handle. If any of these feel heavy,{" "}
+                Running everything on your own machine means you take on a few
+                things the cloud would otherwise handle. If any of these feel heavy,{" "}
                 <a
                   href="/cloud"
                   className="text-blue-300 hover:text-blue-200 underline underline-offset-2"

--- a/marketing/src/app/vs/comfyui/opengraph-image.tsx
+++ b/marketing/src/app/vs/comfyui/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = ogContentType;
 export default function Image() {
   return ogImage(
     "NodeTool vs ComfyUI",
-    "The studio around the node editor — every modality, every provider.",
+    "The studio around the node editor — every medium, every provider.",
     { image: "screen_canvas.png", accent: "blue", eyebrow: "Comparison" }
   );
 }

--- a/marketing/src/app/vs/comfyui/page.tsx
+++ b/marketing/src/app/vs/comfyui/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "NodeTool vs ComfyUI — the open creative AI workspace",
   description:
-    "ComfyUI is an engineer-first node editor for Stable Diffusion. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a far wider model roster across providers, and built-in editing tools — all BYOK at provider prices. Both are open source.",
+    "ComfyUI is an engineer-first node editor for Stable Diffusion. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, far more models across providers, and built-in editing tools — all called with your own keys at provider prices. Both are open source.",
   alternates: { canonical: "/vs/comfyui" },
   openGraph: {
     title: "NodeTool vs ComfyUI — the open creative AI workspace",
     description:
-      "Beyond diffusion images: NodeTool puts image, video, audio, and text on one node-based canvas with editing tools built in. Open source, BYOK, provider prices.",
+      "Beyond Stable Diffusion images: NodeTool puts image, video, audio, and text on one node-based canvas with editing tools built in. Open source, your own keys, provider prices.",
     url: "https://nodetool.ai/vs/comfyui",
     type: "website",
   },
@@ -42,7 +42,7 @@ const faq = {
       name: "What is the difference between NodeTool and ComfyUI?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an engineer-first UX. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a much wider model roster across providers and modalities, and editing tools creatives actually use — called with your own keys at provider prices. Both are node-based and open source.",
+        text: "ComfyUI is a node editor focused on Stable Diffusion image generation, built for engineers. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, far more models across providers and media types, and editing tools creatives actually use — called with your own keys at provider prices. Both are node-based and open source.",
       },
     },
     {
@@ -58,7 +58,7 @@ const faq = {
       name: "Can NodeTool do more than image generation?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Yes. NodeTool works across image, video, audio, and text on one canvas, with editing tools built in — masks, inpaint, outpaint, relight, upscale, layers, and compositing. ComfyUI is centered on diffusion image generation.",
+        text: "Yes. NodeTool works across image, video, audio, and text on one canvas, with editing tools built in — masks, inpaint, outpaint, relight, upscale, layers, and compositing. ComfyUI is centered on image generation.",
       },
     },
     {
@@ -66,7 +66,7 @@ const faq = {
       name: "How does NodeTool handle model pricing?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "NodeTool is BYOK — you bring your own API keys and pay each provider their list price. There are no credits, no markup, and no curated roster. You can also run local models with Ollama, MLX, or llama.cpp in the desktop app.",
+        text: "With NodeTool, you bring your own API keys and pay each provider their list price. There are no credits, no markup, and no hand-picked model list. You can also run local models with Ollama, MLX, or llama.cpp in the desktop app.",
       },
     },
   ],
@@ -74,16 +74,16 @@ const faq = {
 
 const rows: { label: string; comfyui: string | boolean; nodetool: string | boolean }[] = [
   {
-    label: "Modalities",
-    comfyui: "Diffusion images",
+    label: "Media types",
+    comfyui: "Stable Diffusion images",
     nodetool: "Image, video, audio, text",
   },
   {
-    label: "Model roster",
-    comfyui: "Stable Diffusion / diffusion",
-    nodetool: "Every major provider & modality",
+    label: "Model lineup",
+    comfyui: "Stable Diffusion",
+    nodetool: "Every major provider & media type",
   },
-  { label: "BYOK / provider billing", comfyui: false, nodetool: true },
+  { label: "Your own keys / provider billing", comfyui: false, nodetool: true },
   {
     label: "Editing tools (masks, inpaint, relight, layers)",
     comfyui: false,
@@ -126,12 +126,12 @@ export default function VsComfyUIPage() {
             id="vs-title"
             className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
           >
-            The open creative AI workspace, not just a diffusion editor.
+            The open creative AI workspace, not just a Stable Diffusion editor.
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
             ComfyUI is a node editor for Stable Diffusion, built with an
             engineer-first UX. NodeTool is the studio around it: image, video,
-            music, and words on one canvas, a far wider model roster, and the
+            music, and words on one canvas, far more models, and the
             editing tools creatives reach for — called with your own keys at
             provider prices. Both are node-based and open source.
           </p>
@@ -144,11 +144,11 @@ export default function VsComfyUIPage() {
             <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
               <h2 className="text-xl font-semibold text-white">ComfyUI</h2>
               <p className="mt-1 text-sm text-slate-400">
-                Node editor for diffusion images
+                Node editor for Stable Diffusion images
               </p>
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
-                  "Deep control over Stable Diffusion pipelines",
+                  "Deep control over Stable Diffusion workflows",
                   "Engineer-first, graph-based UX",
                   "Local model focused",
                   "Open source community",
@@ -172,7 +172,7 @@ export default function VsComfyUIPage() {
                   "Image, video, audio, and text on one canvas",
                   "Every major model from every major provider",
                   "Editing tools: masks, inpaint, relight, layers",
-                  "BYOK at provider prices — no credits, no markup",
+                  "Your own keys at provider prices — no credits, no markup",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
@@ -219,8 +219,8 @@ export default function VsComfyUIPage() {
             </h2>
             <p className="mt-4 leading-relaxed text-slate-300">
               If your work starts and ends with Stable Diffusion images, ComfyUI
-              gives you fine-grained control. But most creative projects span
-              modalities — image into video, voice and music into a cut, words
+              gives you fine-grained control. But most creative projects cross
+              media — image into video, voice and music into a cut, words
               into everything. NodeTool keeps all of it on one node-based canvas
               with masks, inpaint, outpaint, relight, upscale, layers, and
               compositing built in. You call every major model with your own
@@ -233,7 +233,7 @@ export default function VsComfyUIPage() {
         {/* Closing CTA */}
         <section className="mx-auto my-24 max-w-2xl px-6 text-center">
           <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
-            Open, multimodal, and yours.
+            Open, built for every medium, and yours.
           </h2>
           <p className="mt-4 text-lg text-slate-300">
             Download Studio and build across image, video, audio, and text in one

--- a/marketing/src/app/vs/dify/page.tsx
+++ b/marketing/src/app/vs/dify/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "NodeTool vs Dify — an LLM app platform vs a media-generation canvas",
   description:
-    "Dify is a strong LLM app platform: prompt orchestration, knowledge bases, and agent debugging for text-first products. NodeTool starts from the same agent and RAG ground, then puts native image, video, and music generation and editing tools on the same canvas — BYOK at provider prices, no vendor-hosted markup.",
+    "Dify is a strong LLM app platform: prompt orchestration, knowledge bases, and agent debugging for text-first products. NodeTool starts from the same agent and RAG ground, then puts native image, video, and music generation and editing tools on the same canvas — your own keys at provider prices, no markup.",
   alternates: { canonical: "/vs/dify" },
   openGraph: {
     title: "NodeTool vs Dify — an LLM app platform vs a media-generation canvas",
     description:
-      "Dify is built for text-first LLM apps. NodeTool adds native image, video, and music generation on the same canvas as agents and RAG — BYOK.",
+      "Dify is built for text-first LLM apps. NodeTool adds native image, video, and music generation on the same canvas as agents and RAG — with your own keys.",
     url: "https://nodetool.ai/vs/dify",
     type: "website",
   },
@@ -50,7 +50,7 @@ const faq = {
       name: "Is Dify open source?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Dify's source is published under a modified Apache 2.0 license that adds commercial-use conditions above certain usage thresholds — check Dify's own license file for the current terms before relying on it for a commercial deployment. NodeTool is open source under AGPL-3.0, an OSI-approved license, and is fully BYOK on both self-hosted and NodeTool Cloud deployments.",
+        text: "Dify's source is published under a modified Apache 2.0 license that adds commercial-use conditions above certain usage thresholds — check Dify's own license file for the current terms before relying on it for a commercial deployment. NodeTool is open source under AGPL-3.0, an OSI-approved license, and lets you bring your own keys on both self-hosted and NodeTool Cloud deployments.",
       },
     },
     {
@@ -66,7 +66,7 @@ const faq = {
       name: "When should I pick Dify instead of NodeTool?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "When the product is a text-first LLM app — a support chatbot, an internal copilot, a knowledge-base assistant — and you want Dify's prompt-orchestration UI, built-in observability, and app-store-style deployment. NodeTool is the better fit when the workflow needs to produce image, video, or audio alongside the agent and RAG work, or when you want a desktop app with local-model support and BYOK pricing throughout.",
+        text: "When the product is a text-first LLM app — a support chatbot, an internal copilot, a knowledge-base assistant — and you want Dify's prompt-orchestration UI, built-in observability, and app-store-style deployment. NodeTool is the better fit when the workflow needs to produce image, video, or audio alongside the agent and RAG work, or when you want a desktop app with local-model support and your own keys throughout.",
       },
     },
   ],
@@ -102,7 +102,7 @@ const rows: { label: string; dify: string | boolean; nodetool: string | boolean 
   {
     label: "Pricing model",
     dify: "Seat/usage plans (cloud)",
-    nodetool: "BYOK / provider prices",
+    nodetool: "Your own keys / provider prices",
   },
   { label: "Desktop app", dify: false, nodetool: true },
 ];
@@ -146,7 +146,7 @@ export default function VsDifyPage() {
             orchestration, knowledge bases, agent debugging. NodeTool starts
             from the same agent and RAG ground, then puts native image,
             video, and music generation and editing tools on the same canvas
-            — open source under AGPL-3.0, BYOK at provider prices, with a
+            — open source under AGPL-3.0, your own keys at provider prices, with a
             desktop app and local models.
           </p>
         </section>
@@ -186,7 +186,7 @@ export default function VsDifyPage() {
                   "Agents, RAG, and native image/video/music generation",
                   "Built-in editing tools — masks, inpaint, relight, layers",
                   "Open source under AGPL-3.0, desktop app included",
-                  "BYOK at provider prices — no credits, no markup",
+                  "Your own keys at provider prices — no credits, no markup",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />

--- a/marketing/src/app/vs/flowise/page.tsx
+++ b/marketing/src/app/vs/flowise/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "NodeTool vs Flowise — RAG chatbots plus native media generation",
   description:
-    "Flowise is the fastest drag-and-drop path to a LangChain-based RAG chatbot. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — BYOK at provider prices, no hosted-credit tiers.",
+    "Flowise is the fastest drag-and-drop path to a LangChain-based RAG chatbot. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — your own keys at provider prices, no hosted credit tiers.",
   alternates: { canonical: "/vs/flowise" },
   openGraph: {
     title: "NodeTool vs Flowise — RAG chatbots plus native media generation",
     description:
-      "Flowise builds RAG chatbots fast. NodeTool builds the chatbot and the image, video, and music pipeline around it — one canvas, BYOK.",
+      "Flowise builds RAG chatbots fast. NodeTool builds the chatbot and the image, video, and music workflow around it — one canvas, your own keys.",
     url: "https://nodetool.ai/vs/flowise",
     type: "website",
   },
@@ -50,7 +50,7 @@ const faq = {
       name: "Is Flowise open source?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Flowise is source-available under the Apache 2.0 license, with a hosted Flowise Cloud sold on usage-based credit tiers. NodeTool is open source under AGPL-3.0 and BYOK: you connect your own provider keys and pay providers directly at their list prices, with no credit markup on either self-hosted or NodeTool Cloud usage.",
+        text: "Flowise is source-available under the Apache 2.0 license, with a hosted Flowise Cloud sold on usage-based credit tiers. NodeTool is open source under AGPL-3.0: you connect your own provider keys and pay providers directly at their list prices, with no marked-up credits on either self-hosted or NodeTool Cloud usage.",
       },
     },
     {
@@ -66,7 +66,7 @@ const faq = {
       name: "When should I pick Flowise instead of NodeTool?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "When the job is strictly a LangChain-flavored chatbot or assistant over a document set, and you want the fastest drag-and-drop path to that specific shape. NodeTool is the better fit once the workflow also needs to produce image, video, or audio, or you want a desktop app with local-model support and BYOK pricing across everything, not just the LLM calls.",
+        text: "When the job is strictly a LangChain-flavored chatbot or assistant over a document set, and you want the fastest drag-and-drop path to that specific shape. NodeTool is the better fit once the workflow also needs to produce image, video, or audio, or you want a desktop app with local-model support and your own keys across everything, not just the LLM calls.",
       },
     },
   ],
@@ -102,7 +102,7 @@ const rows: { label: string; flowise: string | boolean; nodetool: string | boole
   {
     label: "Pricing model",
     flowise: "Usage-based credits (cloud)",
-    nodetool: "BYOK / provider prices",
+    nodetool: "Your own keys / provider prices",
   },
   { label: "Desktop app", flowise: false, nodetool: true },
 ];
@@ -145,7 +145,7 @@ export default function VsFlowisePage() {
             Flowise is the fastest drag-and-drop path to a LangChain RAG
             chatbot. NodeTool covers the same agent and retrieval ground, then
             adds native image, video, and music generation and editing tools
-            on the same canvas — open source under AGPL-3.0, BYOK at provider
+            on the same canvas — open source under AGPL-3.0, your own keys at provider
             prices, with a desktop app and local models.
           </p>
         </section>
@@ -185,7 +185,7 @@ export default function VsFlowisePage() {
                   "Agents, RAG, and native image/video/music generation",
                   "Built-in editing tools — masks, inpaint, relight, layers",
                   "Open source under AGPL-3.0, desktop app included",
-                  "BYOK at provider prices — no credits, no markup",
+                  "Your own keys at provider prices — no credits, no markup",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />

--- a/marketing/src/app/vs/langflow/page.tsx
+++ b/marketing/src/app/vs/langflow/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "NodeTool vs Langflow — agents plus native media generation",
   description:
-    "Langflow is a low-code builder for LLM apps: chatbots, RAG, agents. NodeTool covers the same agent and RAG ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas — open source, BYOK, local models included.",
+    "Langflow is a low-code builder for LLM apps: chatbots, RAG, agents. NodeTool covers the same agent and RAG ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas — open source, your own keys, local models included.",
   alternates: { canonical: "/vs/langflow" },
   openGraph: {
     title: "NodeTool vs Langflow — agents plus native media generation",
     description:
-      "Both build agents and RAG pipelines. Only one renders image, video, and music natively on the same canvas. Open source, BYOK, local models.",
+      "Both build agents and RAG workflows. Only one renders image, video, and music natively on the same canvas. Open source, your own keys, local models.",
     url: "https://nodetool.ai/vs/langflow",
     type: "website",
   },
@@ -66,7 +66,7 @@ const faq = {
       name: "Can I run local models in NodeTool?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Yes. NodeTool runs local models via Ollama, MLX, and llama.cpp in the desktop app, and connects to every major cloud provider BYOK — your keys, provider list prices, no credits or markup.",
+        text: "Yes. NodeTool runs local models via Ollama, MLX, and llama.cpp in the desktop app, and connects to every major cloud provider with your own keys — provider list prices, no credits or markup.",
       },
     },
   ],
@@ -90,7 +90,7 @@ const rows: { label: string; langflow: string | boolean; nodetool: string | bool
   },
   { label: "Agents & RAG", langflow: true, nodetool: true },
   { label: "Local models", langflow: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
-  { label: "BYOK / provider billing", langflow: true, nodetool: true },
+  { label: "Your own keys / provider billing", langflow: true, nodetool: true },
   { label: "Open source", langflow: "MIT", nodetool: "AGPL-3.0" },
   {
     label: "Desktop app",
@@ -138,7 +138,7 @@ export default function VsLangflowPage() {
             rooted in Python and LangChain. NodeTool covers that same ground and
             adds what Langflow leaves to external APIs: native image, video, and
             music generation with editing tools on the same canvas. Open source,
-            BYOK at provider prices, local models included.
+            your own keys at provider prices, local models included.
           </p>
         </section>
 
@@ -177,7 +177,7 @@ export default function VsLangflowPage() {
                   "Agents, RAG, and chat on the same canvas",
                   "Native image, video, and music generation nodes",
                   "Editing tools: masks, inpaint, relight, layers",
-                  "BYOK at provider prices — local models via Ollama, MLX, llama.cpp",
+                  "Your own keys at provider prices — local models via Ollama, MLX, llama.cpp",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />

--- a/marketing/src/app/vs/n8n/page.tsx
+++ b/marketing/src/app/vs/n8n/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "NodeTool vs n8n — when the workflow creates, not just connects",
   description:
-    "n8n moves data between hundreds of business apps. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas — open source under AGPL-3.0 (not fair-code), BYOK at provider prices, with a desktop app and local models.",
+    "n8n moves data between hundreds of business apps. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas — open source under AGPL-3.0 (not fair-code), your own keys at provider prices, with a desktop app and local models.",
   alternates: { canonical: "/vs/n8n" },
   openGraph: {
     title: "NodeTool vs n8n — when the workflow creates, not just connects",
     description:
-      "n8n connects apps. NodeTool generates — image, video, music, and agents on one canvas. Open source (AGPL-3.0), BYOK, desktop app, local models.",
+      "n8n connects apps. NodeTool generates — image, video, music, and agents on one canvas. Open source (AGPL-3.0), your own keys, desktop app, local models.",
     url: "https://nodetool.ai/vs/n8n",
     type: "website",
   },
@@ -66,7 +66,7 @@ const faq = {
       name: "When should I pick n8n instead of NodeTool?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "When the hard part of your workflow is business-app plumbing: hundreds of connectors, schedules, retries, and branching between SaaS tools. That is what n8n is built for. NodeTool is the better fit when the workflow's output is AI-generated media or agent work, and you want local models, BYOK provider pricing, and a desktop app.",
+        text: "When the hard part of your workflow is business-app plumbing: hundreds of connectors, schedules, retries, and branching between SaaS tools. That is what n8n is built for. NodeTool is the better fit when the workflow's output is AI-generated media or agent work, and you want local models, your own keys at provider prices, and a desktop app.",
       },
     },
   ],
@@ -102,7 +102,7 @@ const rows: { label: string; n8n: string | boolean; nodetool: string | boolean }
   {
     label: "Pricing model",
     n8n: "Per-execution plans (cloud)",
-    nodetool: "BYOK / provider prices",
+    nodetool: "Your own keys / provider prices",
   },
   { label: "Desktop app", n8n: false, nodetool: true },
 ];
@@ -146,7 +146,7 @@ export default function VsN8nPage() {
             retries, branching. NodeTool is built for workflows where the AI
             work is the point: native image, video, and music generation,
             agents, and editing tools on one canvas. Open source under
-            AGPL-3.0, BYOK at provider prices, with a desktop app and local
+            AGPL-3.0, your own keys at provider prices, with a desktop app and local
             models.
           </p>
         </section>
@@ -163,7 +163,7 @@ export default function VsN8nPage() {
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
                   "400+ integrations for business apps",
-                  "Orchestration: schedules, retries, branching",
+                  "Schedules, retries, branching",
                   "AI agent nodes built on LangChain",
                   "Fair-code: source-available, commercially restricted",
                 ].map((f) => (
@@ -186,7 +186,7 @@ export default function VsN8nPage() {
                   "Native image, video, and music generation nodes",
                   "Agents and RAG on the same canvas as generation",
                   "Open source under AGPL-3.0, desktop app included",
-                  "BYOK at provider prices — no credits, no markup",
+                  "Your own keys at provider prices — no credits, no markup",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />

--- a/marketing/src/app/vs/weavy/opengraph-image.tsx
+++ b/marketing/src/app/vs/weavy/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = ogContentType;
 export default function Image() {
   return ogImage(
     "NodeTool vs Weavy",
-    "Open source and BYOK — no credits, no curated roster, no lock-in.",
+    "Open source, your own keys — no credits, no hand-picked model list, no lock-in.",
     { image: "screen_canvas.png", accent: "violet", eyebrow: "Comparison" }
   );
 }

--- a/marketing/src/app/vs/weavy/page.tsx
+++ b/marketing/src/app/vs/weavy/page.tsx
@@ -6,14 +6,14 @@ import JsonLd from "../../../components/JsonLd";
 import { SmartDownloadButton } from "../../SmartDownloadButton";
 
 export const metadata: Metadata = {
-  title: "NodeTool vs Weavy — open source, BYOK, no credits",
+  title: "NodeTool vs Weavy — open source, your own keys, no credits",
   description:
-    "Weavy and similar closed SaaS canvases lock you into credits and a curated model roster. NodeTool is open source (AGPL-3.0) and BYOK: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same self-hostable code.",
+    "Weavy and similar closed SaaS canvases lock you into credits and a hand-picked model list. NodeTool is open source (AGPL-3.0): every provider, your own keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same self-hostable code.",
   alternates: { canonical: "/vs/weavy" },
   openGraph: {
-    title: "NodeTool vs Weavy — open source, BYOK, no credits",
+    title: "NodeTool vs Weavy — open source, your own keys, no credits",
     description:
-      "No credits, no curated roster, no lock-in. NodeTool is open source and BYOK: every provider at provider prices, with workflows and files you own.",
+      "No credits, no hand-picked model list, no lock-in. NodeTool is open source, and you bring your own keys: every provider at provider prices, with workflows and files you own.",
     url: "https://nodetool.ai/vs/weavy",
     type: "website",
   },
@@ -42,7 +42,7 @@ const faq = {
       name: "How is NodeTool different from Weavy?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Weavy and similar closed SaaS canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK: every provider, your keys, provider prices, and you own your workflows and files. NodeTool Cloud is just managed hosting of the same open-source code you can self-host.",
+        text: "Weavy and similar closed SaaS canvases lock you into a credit system and a hand-picked model list. NodeTool is open source: every provider, your own keys, provider prices, and you own your workflows and files. NodeTool Cloud is just managed hosting of the same open-source code you can self-host.",
       },
     },
     {
@@ -50,7 +50,7 @@ const faq = {
       name: "Does NodeTool use credits?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "No. NodeTool is BYOK — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no curated roster of models.",
+        text: "No. With NodeTool, you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no hand-picked list of models.",
       },
     },
     {
@@ -76,11 +76,11 @@ const rows: { label: string; weavy: string | boolean; nodetool: string | boolean
   {
     label: "Pricing model",
     weavy: "Credits",
-    nodetool: "BYOK / provider prices",
+    nodetool: "Your own keys / provider prices",
   },
   {
-    label: "Model roster",
-    weavy: "Curated roster",
+    label: "Model lineup",
+    weavy: "Hand-picked list",
     nodetool: "Every provider",
   },
   { label: "Source", weavy: "Closed", nodetool: "AGPL-3.0" },
@@ -121,11 +121,11 @@ export default function VsWeavyPage() {
             id="vs-title"
             className="mt-6 text-4xl font-bold tracking-tight text-white md:text-5xl"
           >
-            Open source and BYOK. No credits, no lock-in.
+            Open source, your own keys. No credits, no lock-in.
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
             Weavy and similar closed SaaS canvases lock you into a credit system
-            and a curated model roster. NodeTool is open source and BYOK: every
+            and a hand-picked model list. NodeTool is open source: every
             provider, your keys, provider prices, and you own your workflows and
             files. Cloud is just managed hosting of the same open-source code you
             can self-host.
@@ -142,7 +142,7 @@ export default function VsWeavyPage() {
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
                   "Credit system you top up and burn",
-                  "Curated roster of supported models",
+                  "Hand-picked list of supported models",
                   "Closed source, hosted only",
                   "Work lives on their platform",
                 ].map((f) => (
@@ -157,10 +157,10 @@ export default function VsWeavyPage() {
             {/* NodeTool */}
             <div className="relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-8 ring-1 ring-white/5 backdrop-blur-md">
               <h2 className="text-xl font-semibold text-white">NodeTool</h2>
-              <p className="mt-1 text-sm text-slate-400">Open source · BYOK</p>
+              <p className="mt-1 text-sm text-slate-400">Open source · your own keys</p>
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
-                  "BYOK — pay providers directly at list prices",
+                  "Your own keys — pay providers directly at list prices",
                   "Every major model from every major provider",
                   "Open source under AGPL-3.0, self-hostable",
                   "You own your workflows and files",
@@ -209,7 +209,7 @@ export default function VsWeavyPage() {
               Pay providers, not credits — and keep your work
             </h2>
             <p className="mt-4 leading-relaxed text-slate-300">
-              Credit systems and curated rosters decide which models you can use
+              Credit systems and hand-picked model lists decide which models you can use
               and what each call costs. NodeTool flips that: you add your own API
               keys and pay each provider their published list price. The whole
               workspace is open source under AGPL-3.0, so you can run it as a

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -30,7 +30,7 @@ export default function ComparisonSection({
             transition={{ duration: 0.5 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            Where NodeTool fits in your stack
+            Where NodeTool fits among your tools
           </motion.h2>
           <motion.p
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
@@ -47,13 +47,13 @@ export default function ComparisonSection({
         <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
             competitor="ComfyUI"
-            sentence="ComfyUI is a node editor for diffusion models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away."
+            sentence="ComfyUI is a node editor for image-generation models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away."
             reducedMotion={reducedMotion}
             delay={0}
           />
           <ComparisonCard
             competitor="Weavy / closed canvases"
-            sentence="Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK — every provider, your keys, provider prices."
+            sentence="Closed canvases lock you into a credit system and a hand-picked list of models. NodeTool is open source — every provider, your own keys, provider prices."
             reducedMotion={reducedMotion}
             delay={0.05}
           />
@@ -109,9 +109,9 @@ export default function ComparisonSection({
                 Kling ships, it&apos;s one node swap away.
               </p>
               <p className="text-slate-400 leading-relaxed text-[1.025rem]">
-                That&apos;s what vendor neutrality buys you: the best model at
-                the best price, every week — and no roadmap risk if your
-                favorite tool gets acquired.
+                That&apos;s what not being tied to one vendor buys you: the
+                best model at the best price, every week — and nothing to lose
+                if your favorite tool gets acquired.
               </p>
             </div>
           </div>

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -102,9 +102,9 @@ export default function CostDashboardSection() {
             See what every run actually costs
           </h3>
           <p className="mt-4 text-lg leading-relaxed text-slate-300">
-            NodeTool prices every node execution and rolls it up by workflow,
-            provider, or model. You bring your own keys and pay providers
-            directly, so the numbers are the real ones.
+            NodeTool tracks the cost of every node run and totals it by
+            workflow, provider, or model. You bring your own keys and pay
+            providers directly, so the numbers are the real ones.
           </p>
         </div>
 
@@ -370,8 +370,8 @@ export default function CostDashboardSection() {
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
           {[
             {
-              title: "Per-node accounting",
-              body: "Every execution priced on its own, grouped by node, workflow, provider, or model.",
+              title: "Cost per node",
+              body: "Every run priced on its own, grouped by node, workflow, provider, or model.",
             },
             {
               title: "No markup",

--- a/marketing/src/components/EditionsCompareSection.tsx
+++ b/marketing/src/components/EditionsCompareSection.tsx
@@ -39,7 +39,7 @@ const rows: Row[] = [
     cloud: { value: "Not available — cloud APIs only", ok: false },
   },
   {
-    label: "Bring your own API keys (BYOK)",
+    label: "Bring your own API keys",
     studio: { value: "All providers — keys stored locally", ok: true },
     cloud: { value: "All providers — keys stored encrypted", ok: true },
   },
@@ -71,7 +71,7 @@ const rows: Row[] = [
   {
     label: "Cost",
     studio: { value: "Free — pay only for the cloud APIs you use", ok: true },
-    cloud: { value: "Free during alpha — you pay only your own API spend (BYOK)", ok: true },
+    cloud: { value: "Free during alpha — you pay only your own API costs", ok: true },
   },
 ];
 

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -114,7 +114,7 @@ export default function FeaturesSection({
             {
               title: "Edit where you generate",
               description:
-                "Masks, inpaint, outpaint, relight, upscale, layers, compositing. The post tools you reach for, wired into the same canvas as the model calls.",
+                "Mask, retouch, extend, relight, upscale, layer, and composite. The editing tools you reach for, wired into the same canvas as the model calls.",
               icon: MousePointer2,
               color: "text-blue-400",
               bg: "bg-blue-500/10",
@@ -141,7 +141,7 @@ export default function FeaturesSection({
             {
               title: "Image, video, audio, text",
               description:
-                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, Suno — every modality on one canvas, under their real names. No white-label mystery models.",
+                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, Suno — all of it on one canvas, under their real names. No renamed mystery models.",
               icon: Layers,
               color: "text-orange-400",
               bg: "bg-orange-500/10",

--- a/marketing/src/components/ModelManagerSection.tsx
+++ b/marketing/src/components/ModelManagerSection.tsx
@@ -47,7 +47,7 @@ export default function ModelManagerSection() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Search, download, and manage model weights directly from the Hub.
+            Search, download, and manage models straight from Hugging Face.
             <br />
             Organize your local library without leaving the app.
           </motion.p>

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -109,9 +109,10 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.5, delay: 0.1 }}
                         className="text-lg text-slate-400 leading-relaxed"
                     >
-                        Frontier models from every major provider, called with
-                        the keys you already pay for. Swap models the day they
-                        launch. Run inference locally when you want to.
+                        The newest models from every major provider, called
+                        with the keys you already pay for. Swap models the day
+                        they launch. Run them on your own machine when you
+                        want to.
                     </motion.p>
                 </div>
 
@@ -119,7 +120,7 @@ export default function ModelSupportSection({
                 <div className="mb-10">
                     <div className="flex items-center justify-center gap-3 mb-4">
                         <Sparkles className="w-5 h-5 text-violet-400" />
-                        <span className="text-sm font-medium text-slate-400">Frontier Models</span>
+                        <span className="text-sm font-medium text-slate-400">Latest Models</span>
                     </div>
 
                     <div className="relative overflow-hidden">
@@ -175,7 +176,7 @@ export default function ModelSupportSection({
                 <div>
                     <div className="flex items-center gap-3 mb-4">
                         <Cpu className="w-5 h-5 text-emerald-400" />
-                        <span className="text-sm font-medium text-slate-400">Local Inference</span>
+                        <span className="text-sm font-medium text-slate-400">Runs on Your Machine</span>
                     </div>
 
                     <div className="relative overflow-hidden">

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -41,7 +41,7 @@ export default function NodeToolHero() {
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
             One canvas. Every major model from every major provider, called
             with your own keys. Pay providers what they charge — no credits, no
-            markup, no curated roster. When the next model ships, swap one node
+            markup, no locked-down model list. When the next model ships, swap one node
             and you&apos;re on it the same day.
           </p>
 

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -6,7 +6,7 @@ import { Shield, Cpu, Globe, Lock } from "lucide-react";
 
 const features = [
   {
-    title: "BYOK, every provider",
+    title: "Your keys, every provider",
     body: "Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Keys stay on your disk in Studio, encrypted in Cloud. We never mark up model calls.",
     icon: Lock,
   },
@@ -21,7 +21,7 @@ const features = [
     icon: Globe,
   },
   {
-    title: "Local inference when you want it",
+    title: "Run models on your own machine",
     body: "MLX, Ollama, llama.cpp, vLLM, LM Studio — fully supported. Runs offline once models are downloaded. Local is a feature, not a religion.",
     icon: Cpu,
   },
@@ -57,8 +57,8 @@ export default function OwnershipSection({
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Every closed AI tool ends the same way: a price hike, a worse
-            roster, or an acquisition that quietly rewrites the roadmap.
+            Every closed AI tool ends the same way: a price hike, fewer
+            models, or an acquisition that quietly rewrites the roadmap.
             NodeTool calls whatever models you choose, charges you what the
             providers charge, and ships under a license that outlives whoever
             built it.

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -66,8 +66,8 @@ export default function UseCasesShowcase() {
             transition={{ duration: 0.5, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed"
           >
-            Real workflows you can open, run, and rewire. Each one is a complete
-            pipeline, not a demo, built from the same nodes you get on day one.
+            Real workflows you can open, run, and rewire. Each one is complete,
+            not a demo, and built from the same nodes you get on day one.
           </motion.p>
         </div>
 

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -52,7 +52,7 @@ export default function VideoGenerationSection({
             className="text-lg text-slate-300 leading-relaxed"
           >
             Generate video from text or images with Google Veo, Kling, Hailuo,
-            and Wan — or run open-weight models on your own hardware.
+            and Wan — or run open models on your own hardware.
           </motion.p>
 
           <motion.div

--- a/marketing/src/components/agents/AgentUseCasesSection.tsx
+++ b/marketing/src/components/agents/AgentUseCasesSection.tsx
@@ -48,7 +48,7 @@ const useCases: UseCase[] = [
     example: "Direct a 9:16 sneaker ad, neon noir, ending on the logo",
   },
   {
-    name: "Music Video Pipeline",
+    name: "Music Video Workflow",
     description:
       "Drop in a track, let the agent pace cuts to the beat, pick scenes that match the lyrics, generate visuals across Flux and Veo, and stitch the final video. You direct, it edits.",
     icon: Music,

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -130,7 +130,7 @@ export default function AgentsGraphHero() {
                         <div className="mt-8 flex items-center justify-center gap-6 text-sm text-slate-400 font-medium">
                             <span className="flex items-center gap-2"><Command className="w-4 h-4" /> Open Source</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
-                            <span>BYOK — pay providers direct</span>
+                            <span>Your own keys — pay providers direct</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
                             <span>Watch every step</span>
                         </div>

--- a/marketing/src/components/client/faqs.tsx
+++ b/marketing/src/components/client/faqs.tsx
@@ -10,9 +10,9 @@ const faqs = [
       "NodeTool is the open creative AI workspace. Every major model from every major provider — FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more — wired into one node-based canvas you run on your machine or in the browser.",
   },
   {
-    question: "What does BYOK mean for me?",
+    question: "What does \"bring your own keys\" mean for me?",
     answer:
-      "Bring your own keys. You connect your own provider accounts and pay providers directly at provider prices. NodeTool never marks up model calls and never issues proprietary credits.",
+      "You connect your own provider accounts and pay providers directly at provider prices. NodeTool never marks up model calls and never issues its own credits.",
   },
   {
     question: "Is NodeTool open source?",
@@ -22,22 +22,22 @@ const faqs = [
   {
     question: "How is this different from ComfyUI?",
     answer:
-      "ComfyUI is a node editor for diffusion models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away.",
+      "ComfyUI is a node editor for image-generation models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away.",
   },
   {
     question: "How is this different from Weavy and other closed canvases?",
     answer:
-      "Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK. Your workflows, files, and keys belong to you. Switch providers the moment a better model ships.",
+      "Closed canvases lock you into a credit system and a hand-picked list of models. NodeTool is open source and you bring your own keys. Your workflows, files, and keys belong to you. Switch providers the moment a better model ships.",
   },
   {
     question: "Studio or Cloud — which should I use?",
     answer:
-      "Studio is the desktop app: free, open source, runs on your machine, supports local models via MLX, Ollama, and GGUF. Cloud is the same workspace in the browser — zero setup, no GPU required, your keys still go to providers directly. Same workflows either way.",
+      "Studio is the desktop app: free, open source, runs on your machine, and supports local models via MLX and Ollama. Cloud is the same workspace in the browser — zero setup, no GPU required, your keys still go to providers directly. Same workflows either way.",
   },
   {
     question: "Which models are supported?",
     answer:
-      "Frontier models including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno — called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Local inference via MLX, Ollama, llama.cpp, vLLM, and LM Studio.",
+      "The latest models, including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno — called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Run models on your own machine via MLX, Ollama, llama.cpp, vLLM, and LM Studio.",
   },
 ];
 

--- a/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
+++ b/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
@@ -94,7 +94,7 @@ export default function DeveloperIntegrationsSection({
             transition={{ duration: 0.5, delay: 0.2 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
-            340+ built-in nodes spanning every major provider and modality. BYOK across the board.
+            340+ built-in nodes covering every major provider and media type. Bring your own keys across the board.
           </motion.p>
         </div>
 
@@ -163,7 +163,7 @@ export default function DeveloperIntegrationsSection({
             100% open source
           </h3>
           <p className="text-slate-400 max-w-xl mx-auto mb-6">
-            NodeTool is AGPL-3.0. Fork it, audit it, self-host it. No vendor lock-in,
+            NodeTool is AGPL-3.0. Fork it, audit it, self-host it. No lock-in,
             no usage limits — bring your own keys to every provider and pay providers directly.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/marketing/src/data/staticEntries.ts
+++ b/marketing/src/data/staticEntries.ts
@@ -14,9 +14,9 @@ import type { PageEntry } from "./types";
  */
 export const staticEntries: PageEntry[] = [
   { route: "/", title: "NodeTool", description: "The open creative AI workspace.", priority: 1.0, changeFrequency: "weekly", indexable: true },
-  { route: "/studio", title: "NodeTool Studio", description: "Run open-weight models locally.", priority: 0.9, changeFrequency: "weekly", indexable: true },
+  { route: "/studio", title: "NodeTool Studio", description: "Run open models on your own machine.", priority: 0.9, changeFrequency: "weekly", indexable: true },
   { route: "/cloud", title: "NodeTool Cloud", description: "Run NodeTool workflows in the cloud.", priority: 0.9, changeFrequency: "weekly", indexable: true },
-  { route: "/pricing", title: "Pricing", description: "Free Studio, BYOK, pay providers directly.", priority: 0.8, changeFrequency: "weekly", indexable: true },
+  { route: "/pricing", title: "Pricing", description: "Free Studio, your own keys, pay providers directly.", priority: 0.8, changeFrequency: "weekly", indexable: true },
   { route: "/agents", title: "AI Agents", description: "Build planning agents on a visual canvas.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   { route: "/creatives", title: "For Creatives", description: "A node-based canvas for creative AI work.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   { route: "/developers", title: "For Developers", description: "Wire every major model into one canvas.", priority: 0.8, changeFrequency: "monthly", indexable: true },

--- a/marketing/src/lib/og.tsx
+++ b/marketing/src/lib/og.tsx
@@ -219,7 +219,7 @@ export function ogImage(title: string, subtitle: string, opts: OgOptions = {}) {
           <div
             style={{ display: "flex", color: "#94a3b8", fontSize: 21, fontWeight: 500 }}
           >
-            Open source · BYOK · nodetool.ai
+            Open source · your own keys · nodetool.ai
           </div>
         </div>
 


### PR DESCRIPTION
Replace insider shorthand with plain words across the marketing site's
user-facing copy: BYOK -> "bring your own keys", "local inference" ->
"run models on your own machine", "frontier models" -> "the latest
models", "modality" -> "medium"/"media type", "curated roster" ->
"hand-picked model list", "pipeline" -> "workflow", plus smaller fixes
(GA, per-token cost, vendor lock-in, model weights/the Hub). SEO keyword
arrays are left as-is since they target search queries, and the in-app
dashboard mock keeps its real UI labels.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CpDuvDcJhJ2APXgi7tjTwx