### PR TITLE
ci(fly): deploy the NodeTool server on Fly.io + auto-deploy workflow

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to Fly
+
+# Auto-deploy the NodeTool server to Fly.io (https://nodetool.fly.dev).
+#
+# The deploy unit is the GHCR image published by the "Docker" workflow
+# (.github/workflows/docker.yml). We therefore trigger on that workflow's
+# COMPLETION rather than on push, so we never release an image before it has
+# been built + pushed. On success we release ghcr.io/nodetool-ai/nodetool:latest
+# (which "Docker" tags for the just-built main commit) onto the Fly app — no
+# build happens here, Fly just pulls + rolls the image.
+#
+# Requires a repo secret FLY_API_TOKEN scoped to the `nodetool` app:
+#   fly tokens create deploy -a nodetool --expiry 8760h
+on:
+  workflow_run:
+    workflows: ["Docker"]
+    types: [completed]
+    branches: [main]
+  # Manual re-deploy of the current :latest image.
+  workflow_dispatch:
+
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy server
+    runs-on: ubuntu-latest
+    # Skip when the image build failed/was cancelled (workflow_dispatch always runs).
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Deploy the fly.toml as it was at the built commit (no-op for dispatch).
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: fly deploy (server)
+        run: flyctl deploy --config fly.toml --image ghcr.io/nodetool-ai/nodetool:latest --ha=false
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,9 +5,12 @@ name: Deploy to Fly
 # The deploy unit is the GHCR image published by the "Docker" workflow
 # (.github/workflows/docker.yml). We therefore trigger on that workflow's
 # COMPLETION rather than on push, so we never release an image before it has
-# been built + pushed. On success we release ghcr.io/nodetool-ai/nodetool:latest
-# (which "Docker" tags for the just-built main commit) onto the Fly app — no
-# build happens here, Fly just pulls + rolls the image.
+# been built + pushed. On success we release the image tag that corresponds to
+# the exact triggering commit — `main-<shortsha>`, which "Docker" publishes via
+# `type=sha,prefix={{branch}}-`. We deliberately do NOT deploy `:latest` on
+# workflow_run: if two main builds finish out of order, `:latest` may point at a
+# newer commit and we'd deploy the wrong image. `:latest` is used only for a
+# manual re-deploy (workflow_dispatch).
 #
 # Requires a repo secret FLY_API_TOKEN scoped to the `nodetool` app:
 #   fly tokens create deploy -a nodetool --expiry 8760h
@@ -18,6 +21,11 @@ on:
     branches: [main]
   # Manual re-deploy of the current :latest image.
   workflow_dispatch:
+
+# Least privilege: this job only reads the repo to check out fly.toml. The Fly
+# release is authorized by FLY_API_TOKEN, not the GITHUB_TOKEN.
+permissions:
+  contents: read
 
 concurrency:
   group: fly-deploy
@@ -32,12 +40,28 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          # Deploy the fly.toml as it was at the built commit (no-op for dispatch).
+          # Deploy the fly.toml as it was at the built commit (falls back to the
+          # dispatch ref for manual runs).
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Resolve image tag
+        id: img
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Pin to the exact commit that was just built (main-<7-char-sha>),
+            # matching docker.yml's `type=sha,prefix={{branch}}-`.
+            sha="${{ github.event.workflow_run.head_sha }}"
+            echo "ref=ghcr.io/nodetool-ai/nodetool:main-${sha:0:7}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=ghcr.io/nodetool-ai/nodetool:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: superfly/flyctl-actions/setup-flyctl@v1.4
+
       - name: fly deploy (server)
-        run: flyctl deploy --config fly.toml --image ghcr.io/nodetool-ai/nodetool:latest --ha=false
+        run: flyctl deploy --config fly.toml --image "${{ steps.img.outputs.ref }}" --ha=false
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,51 @@
+# Fly.io config for the NodeTool server.
+#
+# This mirrors the Docker production deploy (deploy.sh) but on Fly.io:
+#   - Runs the SAME published image: ghcr.io/nodetool-ai/nodetool:latest
+#     (self-contained — web/dist + workflow examples are baked in).
+#   - All state lives in Supabase: Postgres DB (DATABASE_URL), asset storage
+#     (NODETOOL_STORAGE_BACKEND=supabase), and auth (AUTH_PROVIDER=supabase).
+#     So the container is stateless and needs no volume.
+#   - Fly terminates TLS at the edge (like Cloudflare did for the Docker box),
+#     so the origin runs plain HTTP on 7777 (no TLS_CERT/TLS_KEY set).
+#
+# Secrets (DATABASE_URL, SUPABASE_URL/KEY, SECRETS_MASTER_KEY, SERPAPI_API_KEY,
+# provider keys, …) are set with `fly secrets set`, NOT baked here.
+#
+# Deploy:  fly deploy --image ghcr.io/nodetool-ai/nodetool:latest
+
+app = "nodetool"
+primary_region = "fra"   # next to the Supabase DB (aws eu-central-1 / Frankfurt)
+
+[build]
+  image = "ghcr.io/nodetool-ai/nodetool:latest"
+
+[env]
+  HOST = "0.0.0.0"
+  PORT = "7777"
+  NODETOOL_ENV = "production"
+  STATIC_FOLDER = "/app/web/dist"
+
+[http_service]
+  internal_port = 7777
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 200
+    hard_limit = 250
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "10s"
+    grace_period = "40s"
+    method = "GET"
+    path = "/health"
+
+# Sized to match the Docker deploy (--memory=4g --cpus=2).
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "4gb"


### PR DESCRIPTION
Deploys the NodeTool server on **Fly.io** reusing the **same Supabase setup as the Docker deploy** (DB + asset storage + auth), and wires auto-deploy on image publish.

Live now at **https://nodetool.fly.dev** — health `{database:"ok",server:"ok"}`, `authMode:"supabase"`.

## What's here
- **`fly.toml`** — releases the published GHCR image `ghcr.io/nodetool-ai/nodetool:latest` (self-contained: `web/dist` + workflow examples baked in). With DB/storage/auth on Supabase and `SECRETS_MASTER_KEY` supplied, the container is **stateless** — no volume. Fly terminates TLS at the edge (like Cloudflare for the Docker box), so the origin runs plain HTTP on 7777.
- **`.github/workflows/fly-deploy.yml`** — triggers on the **"Docker"** workflow's successful completion on `main` (`workflow_run`), then rolls the fresh `:latest` image onto the `nodetool` app. Triggering on image publish (not on push) guarantees the image exists before deploy.

## Config (not in the image)
Secrets are set on the Fly app via `fly secrets import < nodetool/.env` — same values as the Docker `.env` (`DATABASE_URL` Supabase pooler, `SUPABASE_URL`/`KEY`, `NODETOOL_STORAGE_BACKEND=supabase`, buckets, `SECRETS_MASTER_KEY`, `AUTH_PROVIDER=supabase`). Repo secret `FLY_API_TOKEN` (deploy token scoped to `nodetool`) is set for the workflow.

## Notes
- Shares the **live prod Supabase** with the current Docker deployment (parallel instance, not an isolated copy).
- Browser login: `/api/config` returns `supabaseAnonKey:null` (mirrors the Docker `.env`). If the login screen needs it, add `SUPABASE_ANON_KEY` + `AUTH_REDIRECT_URL=https://nodetool.fly.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)