### PR TITLE
fix(models): renumber colliding app_doc migration; migrate once per F…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,12 @@ COPY --from=build --chown=node:node /runtime/ ./
 
 # Startup migration runner (Postgres). Depends only on @nodetool-ai/models +
 # postgres, both already present above — no CLI bundle needed.
+#
+# By default the entrypoint applies migrations on every boot (the migration
+# lock keeps concurrent boots safe). Orchestrators that migrate once per
+# release in a dedicated step — e.g. Fly's release_command — should set
+# NODETOOL_MIGRATE_ON_BOOT=0 so the long-lived app machines don't each re-run
+# the migrator on startup. See fly.toml.
 COPY --chown=node:node scripts/db-migrate.mjs ./scripts/db-migrate.mjs
 
 # If neither a master key nor AWS Secrets Manager is configured, persist a
@@ -141,7 +147,7 @@ RUN printf '%s\n' \
     '  fi' \
     '  export SECRETS_MASTER_KEY="$(cat "$KEY_FILE")"' \
     'fi' \
-    'if [ -n "${DATABASE_URL:-}" ]; then' \
+    'if [ -n "${DATABASE_URL:-}" ] && [ "${NODETOOL_MIGRATE_ON_BOOT:-1}" != "0" ]; then' \
     '  echo "Applying database migrations..."' \
     '  node /app/scripts/db-migrate.mjs' \
     'fi' \

--- a/fly.toml
+++ b/fly.toml
@@ -25,6 +25,20 @@ primary_region = "fra"   # next to the Supabase DB (aws eu-central-1 / Frankfurt
   PORT = "7777"
   NODETOOL_ENV = "production"
   STATIC_FOLDER = "/app/web/dist"
+  # Migrations run once per release in the release_command VM below, not on
+  # every app-machine boot. Without this, each machine started during a rolling
+  # deploy (or a scale-up) would re-enter the migrator and contend on the
+  # migration lock — a slow migration could time the lock out and crash-loop a
+  # second machine. One release-phase run avoids that entirely.
+  NODETOOL_MIGRATE_ON_BOOT = "0"
+
+# Fly runs release_command once, in a temporary machine on the new image,
+# BEFORE any app machine is updated — and aborts the deploy if it exits
+# non-zero. So a bad migration blocks the release instead of shipping code that
+# 500s against an un-migrated schema. Uses the same image + DATABASE_URL secret;
+# db-migrate.mjs takes the migration lock, so it's safe regardless.
+[deploy]
+  release_command = "node /app/scripts/db-migrate.mjs"
 
 [http_service]
   internal_port = 7777

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -1659,28 +1659,6 @@ export const migrations: MigrationDef[] = [
     }
   },
 
-  // ── Add app_doc to workflows ───────────────────────────────────────
-  // First-class storage for the app-builder document (Puck layout + bindings),
-  // replacing the legacy `settings.__appbuilder__` JSON string.
-  // Dialect-agnostic: runs for both SQLite and Postgres via the runner.
-  {
-    version: "20260701_000000",
-    name: "add_app_doc_to_workflows",
-    createsTables: [],
-    modifiesTables: ["nodetool_workflows"],
-    async up(db) {
-      if (!(await db.tableExists("nodetool_workflows"))) return;
-      if (!(await db.columnExists("nodetool_workflows", "app_doc"))) {
-        await db.execute(
-          "ALTER TABLE nodetool_workflows ADD COLUMN app_doc TEXT"
-        );
-      }
-    },
-    async down() {
-      // no-op: dropping columns is unsafe across dialects and versions
-    }
-  },
-
   // ── Scope chat threads to a workflow ───────────────────────────────
   // Threads gain a nullable `workflow_id` so the node editor can list only
   // the conversations for the open workflow and reopen the last one. Null
@@ -1704,6 +1682,36 @@ export const migrations: MigrationDef[] = [
     },
     async down(db) {
       await db.execute("DROP INDEX IF EXISTS idx_threads_user_workflow");
+    }
+  },
+
+  // ── Add app_doc to workflows ───────────────────────────────────────
+  // First-class storage for the app-builder document (Puck layout + bindings),
+  // replacing the legacy `settings.__appbuilder__` JSON string.
+  // Dialect-agnostic: runs for both SQLite and Postgres via the runner.
+  //
+  // Version note: this migration originally shipped as `20260701_000000`,
+  // which collided with `add_workflow_id_to_threads` — that version had
+  // already been recorded as applied on existing databases, so the runner
+  // (which tracks by version string) silently skipped app_doc and the column
+  // was never created. Renumbered to a unique, never-applied version so the
+  // migration runs everywhere; the `columnExists` guard keeps it idempotent
+  // on databases where the column was already added out of band.
+  {
+    version: "20260705_000000",
+    name: "add_app_doc_to_workflows",
+    createsTables: [],
+    modifiesTables: ["nodetool_workflows"],
+    async up(db) {
+      if (!(await db.tableExists("nodetool_workflows"))) return;
+      if (!(await db.columnExists("nodetool_workflows", "app_doc"))) {
+        await db.execute(
+          "ALTER TABLE nodetool_workflows ADD COLUMN app_doc TEXT"
+        );
+      }
+    },
+    async down() {
+      // no-op: dropping columns is unsafe across dialects and versions
     }
   }
 ];


### PR DESCRIPTION
…ly release

add_app_doc_to_workflows shipped as version 20260701_000000 — the same version add_workflow_id_to_threads had already been applied under before it was bumped to 20260701_000001. The runner tracks applied migrations by version string, so it treated app_doc as already-applied and never created the column. Every /api/workflows query then 500'd with `column "app_doc" does not exist` on any database migrated before the rename.

- Renumber add_app_doc_to_workflows to a unique 20260705_000000 (guarded by columnExists, so it's idempotent where the column was already added out of band) and move it to the sorted tail of the list.
- Fly: run migrations once per release via [deploy] release_command instead of on every app-machine boot, gating the entrypoint migrator behind NODETOOL_MIGRATE_ON_BOOT=0. Prevents multiple machines from contending on the migration lock during a rolling deploy. Plain docker / deploy.sh keeps migrating on boot (the gate defaults on).


Claude-Session: https://claude.ai/code/session_01G392yJrveGNabaqUY7GZXn