### PR TITLE
Revise getting started instructions and section title

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,8 @@ Open a template from the Dashboard.
    - **Title**: Ocean Depths
    - **Genre**: Sci-Fi Thriller
    - **Audience**: Adults who love mystery
-4. Press <kbd>Ctrl/⌘ + Enter</kbd>.
+4. Select a model for the Agent and List Generator. (requires provider setup)
+5. Press <kbd>Ctrl/⌘ + Enter</kbd>.
 
 ### Creative Story Ideas
 
@@ -60,7 +61,8 @@ Open a template from the Dashboard.
    - **Genre**: Cyberpunk
    - **Character**: Rogue AI detective
    - **Setting**: Neon-lit underwater city
-3. Run.
+3. Select a model for the Agent and List Generator (requires provider setup)
+4. Run.
 
 ---
 
@@ -85,7 +87,7 @@ Opening a workflow that uses a node from a disabled pack enables that pack for y
 
 ---
 
-## Step 4 — Ship as a Mini-App
+## Step 4 — Build an app
 
 A Mini-App hides the graph and exposes inputs and outputs only.
 


### PR DESCRIPTION
Updated instructions for using the Agent and List Generator, and changed the section title from 'Ship as a Mini-App' to 'Build an app'.