### PR TITLE
[T-20260702-0013] W-4: Model watcher (manifest diff)

### DIFF
--- a/marketing/package.json
+++ b/marketing/package.json
@@ -12,6 +12,8 @@
     "seo:seed": "tsx seo/seed.ts",
     "seo:ingest": "node scripts/ingest-showcase.mjs",
     "seo:model-coverage": "node scripts/generate-model-coverage.mjs",
+    "seo:model-watch": "node scripts/model-watch.mjs",
+    "test:model-watch": "node --test scripts/__tests__/model-watch.test.mjs",
     "seo:catalog": "node scripts/generate-template-catalog.mjs",
     "seo:llms": "tsx scripts/generate-llms-txt.mjs",
     "seo:generate": "npm run seo:catalog && npm run seo:llms",

--- a/marketing/scripts/__tests__/model-watch.test.mjs
+++ b/marketing/scripts/__tests__/model-watch.test.mjs
@@ -1,0 +1,67 @@
+// Run: node --test marketing/scripts/__tests__/model-watch.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseCoverageSlugs,
+  matchesSlug,
+  loadWatchlist,
+  classifyProvider,
+  deriveSeedSlug,
+} from "../model-watch.mjs";
+
+test("parseCoverageSlugs pulls the object keys, not the provider ids", () => {
+  const src = `export const modelProviderCoverage: Record<string, string[]> = {
+  "flux": ["fal_ai","replicate"],
+  "veo-3": ["fal_ai"],
+};`;
+  assert.deepEqual(parseCoverageSlugs(src), ["flux", "veo-3"]);
+});
+
+test("matchesSlug is token-aware, not naive substring", () => {
+  assert.ok(matchesSlug("fal-ai/flux/schnell", "flux"));
+  assert.ok(!matchesSlug("some/influx-model", "flux"));
+  // de-hyphenated variants
+  assert.ok(matchesSlug("veo3-fast", "veo-3"));
+  assert.ok(matchesSlug("google/veo-3", "veo-3"));
+});
+
+test("classifyProvider: covered, ignored, and new are split correctly", () => {
+  const knownSlugs = ["flux", "imagen"];
+  const watchlist = loadWatchlist({
+    all: ["shared-junk"],
+    providers: { fal_ai: ["fal-ai/recraft-v3"] },
+  });
+  const models = [
+    { id: "fal-ai/flux/schnell", name: "FLUX Schnell" }, // covered
+    { id: "fal-ai/imagen4", name: "Imagen 4" }, // covered
+    { id: "fal-ai/recraft-v3", name: "Recraft V3" }, // ignored (provider)
+    { id: "shared-junk", name: "Junk" }, // ignored (all)
+    { id: "fal-ai/nano-banana", name: "Nano Banana" }, // NEW
+  ];
+
+  const r = classifyProvider("fal_ai", models, knownSlugs, watchlist);
+  assert.equal(r.covered, 2);
+  assert.equal(r.ignored, 2);
+  assert.equal(r.newCount, 1);
+  assert.equal(r.new[0].id, "fal-ai/nano-banana");
+  assert.match(r.new[0].seedCommand, /--models nano-banana/);
+  assert.match(r.new[0].seedCommand, /--provider fal_ai/);
+});
+
+test("watchlist suppression is case-insensitive", () => {
+  const watchlist = loadWatchlist({ all: ["Fal-AI/Foo"], providers: {} });
+  const r = classifyProvider(
+    "fal_ai",
+    [{ id: "fal-ai/foo", name: "Foo" }],
+    [],
+    watchlist
+  );
+  assert.equal(r.newCount, 0);
+  assert.equal(r.ignored, 1);
+});
+
+test("deriveSeedSlug takes the last path segment", () => {
+  assert.equal(deriveSeedSlug("fal-ai/flux/schnell"), "schnell");
+  assert.equal(deriveSeedSlug("black-forest-labs/FLUX.1-dev"), "flux-1-dev");
+});

--- a/marketing/scripts/model-watch.mjs
+++ b/marketing/scripts/model-watch.mjs
@@ -1,0 +1,290 @@
+// @ts-nocheck
+/**
+ * Model watcher — flag provider models that NodeTool has no /models page for.
+ *
+ * For each provider that ships a model manifest, run
+ * `nodetool generate <provider> --list-models --json` and diff the returned
+ * model ids against two things:
+ *   1. `marketing/src/data/modelProviderCoverage.generated.ts` — the launch
+ *      model slugs (seedance, flux, imagen, …). An id that contains a launch
+ *      slug is already covered by a page.
+ *   2. `model-watch.watchlist.json` — ids a maintainer has decided NOT to page.
+ * Anything left over is a **new** model: a signal (not content) that a page
+ * might be worth writing. The report is machine-readable and consumed by OPS-2
+ * (`.github/workflows/model-watch.yml`), which opens one issue per provider
+ * batch with a pre-filled seed command.
+ *
+ * There is no API-key-free path for every provider, so this runs where keys are
+ * configured — CI secrets or a maintainer machine.
+ *
+ * Usage (from repo root or marketing/):
+ *   node marketing/scripts/model-watch.mjs                 # print JSON report
+ *   node marketing/scripts/model-watch.mjs --provider fal_ai
+ *   node marketing/scripts/model-watch.mjs --pretty        # human summary to stderr too
+ *   node marketing/scripts/model-watch.mjs --out report.json
+ *   node marketing/scripts/model-watch.mjs --input fixture.json   # skip the CLI, read model lists
+ *
+ * The CLI invocation defaults to `npm run dev:nodetool -- generate …` run from
+ * the repo root. Override with NODETOOL_MODEL_WATCH_CLI (a shell prefix), e.g.
+ *   NODETOOL_MODEL_WATCH_CLI="node packages/cli/dist/index.js"
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MARKETING_DIR = resolve(__dirname, "..");
+const REPO_ROOT = resolve(MARKETING_DIR, "..");
+const COVERAGE_FILE = resolve(
+  MARKETING_DIR,
+  "src",
+  "data",
+  "modelProviderCoverage.generated.ts"
+);
+const WATCHLIST_FILE = resolve(__dirname, "model-watch.watchlist.json");
+
+/**
+ * Providers whose node package ships a model manifest — the exact set
+ * `generate --list-models` can enumerate. Mirrors the PROVIDERS list in
+ * generate-model-coverage.mjs (both derive from the same manifests).
+ */
+const PROVIDERS = ["fal_ai", "replicate", "kie", "together", "atlascloud", "topaz"];
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for the test — no I/O, no CLI).
+// ---------------------------------------------------------------------------
+
+/** Extract the launch-model slugs (object keys) from the generated coverage TS. */
+export function parseCoverageSlugs(tsSource) {
+  const open = tsSource.indexOf("{");
+  const close = tsSource.lastIndexOf("}");
+  if (open === -1 || close === -1) return [];
+  const body = tsSource.slice(open + 1, close);
+  const slugs = [];
+  // Keys look like `  "flux": [...]` — a quoted string immediately before a colon.
+  const re = /"([^"]+)"\s*:/g;
+  let m;
+  while ((m = re.exec(body))) slugs.push(m[1]);
+  return slugs;
+}
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Does `text` contain the launch slug as a token (not an accidental substring)?
+ * "flux" matches "fal-ai/flux/schnell" but not "influx"; "veo-3" also matches
+ * "veo3" / "veo 3" (the de-hyphenated variants the coverage generator keys on).
+ */
+export function matchesSlug(text, slug) {
+  const hay = String(text).toLowerCase();
+  const needles = new Set([slug, slug.replace(/-/g, ""), slug.replace(/-/g, " ")]);
+  for (const n of needles) {
+    if (!n) continue;
+    const re = new RegExp(`(?:^|[^a-z0-9])${escapeRe(n)}(?:[^a-z0-9]|$)`);
+    if (re.test(hay)) return true;
+  }
+  return false;
+}
+
+/** Normalize the watchlist JSON into { all:Set, byProvider:Map<string,Set> }. */
+export function loadWatchlist(json) {
+  const all = new Set((json?.all ?? []).map((s) => String(s).toLowerCase()));
+  const byProvider = new Map();
+  for (const [prov, ids] of Object.entries(json?.providers ?? {})) {
+    byProvider.set(prov, new Set((ids ?? []).map((s) => String(s).toLowerCase())));
+  }
+  return { all, byProvider };
+}
+
+function isIgnored(providerId, modelId, watchlist) {
+  const id = String(modelId).toLowerCase();
+  if (watchlist.all.has(id)) return true;
+  return watchlist.byProvider.get(providerId)?.has(id) ?? false;
+}
+
+function isCovered(model, knownSlugs) {
+  const id = model.id ?? "";
+  const name = model.name ?? "";
+  return knownSlugs.some((s) => matchesSlug(id, s) || matchesSlug(name, s));
+}
+
+/** A best-effort seed slug for the pre-filled command (last path segment). */
+export function deriveSeedSlug(modelId) {
+  const tail = String(modelId).split("/").pop() ?? String(modelId);
+  return tail
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function seedCommand(providerId, modelId) {
+  const slug = deriveSeedSlug(modelId);
+  return `npx tsx marketing/seo/seed.ts --template <template> --models ${slug} --provider ${providerId} --count 5`;
+}
+
+/**
+ * Split one provider's model list into covered / ignored / new.
+ * `models` is the array from `--list-models --json` ({ id, name }).
+ */
+export function classifyProvider(providerId, models, knownSlugs, watchlist) {
+  const fresh = [];
+  let covered = 0;
+  let ignored = 0;
+  for (const model of models) {
+    if (isIgnored(providerId, model.id, watchlist)) {
+      ignored += 1;
+    } else if (isCovered(model, knownSlugs)) {
+      covered += 1;
+    } else {
+      fresh.push({
+        id: model.id,
+        name: model.name ?? null,
+        seedCommand: seedCommand(providerId, model.id),
+      });
+    }
+  }
+  return {
+    provider: providerId,
+    ok: true,
+    totalModels: models.length,
+    covered,
+    ignored,
+    newCount: fresh.length,
+    new: fresh,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// I/O + CLI orchestration.
+// ---------------------------------------------------------------------------
+
+/** Run the CLI for one provider, returning its parsed `{ provider, models }`. */
+function listModels(providerId) {
+  const override = process.env.NODETOOL_MODEL_WATCH_CLI;
+  const args = ["generate", providerId, "--list-models", "--json"];
+  const run = override
+    ? spawnSync(`${override} ${args.join(" ")}`, {
+        cwd: REPO_ROOT,
+        shell: true,
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      })
+    : spawnSync("npm", ["run", "dev:nodetool", "--", ...args], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      });
+
+  if (run.error) {
+    return { ok: false, error: run.error.message };
+  }
+  const parsed = extractJson(run.stdout ?? "");
+  if (!parsed) {
+    const stderr = (run.stderr ?? "").trim().split("\n").slice(-4).join("\n");
+    return {
+      ok: false,
+      error: `could not parse model list (exit ${run.status})${stderr ? `: ${stderr}` : ""}`,
+    };
+  }
+  return { ok: true, models: Array.isArray(parsed.models) ? parsed.models : [] };
+}
+
+/** Pull the JSON object out of CLI stdout, tolerating leading/trailing noise. */
+function extractJson(stdout) {
+  const text = stdout.trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    const open = text.indexOf("{");
+    const close = text.lastIndexOf("}");
+    if (open === -1 || close <= open) return null;
+    try {
+      return JSON.parse(text.slice(open, close + 1));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const opts = { providers: null, pretty: false, out: null, input: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--pretty") opts.pretty = true;
+    else if (a === "--provider") opts.providers = [argv[++i]];
+    else if (a === "--out") opts.out = argv[++i];
+    else if (a === "--input") opts.input = argv[++i];
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const knownSlugs = existsSync(COVERAGE_FILE)
+    ? parseCoverageSlugs(readFileSync(COVERAGE_FILE, "utf8"))
+    : [];
+  const watchlist = loadWatchlist(
+    existsSync(WATCHLIST_FILE)
+      ? JSON.parse(readFileSync(WATCHLIST_FILE, "utf8"))
+      : {}
+  );
+
+  const providerIds = opts.providers ?? PROVIDERS;
+
+  // `--input`: read `{ "<provider>": [ {id,name}, … ] }` instead of the CLI.
+  const fixture = opts.input
+    ? JSON.parse(readFileSync(resolve(process.cwd(), opts.input), "utf8"))
+    : null;
+
+  const results = [];
+  for (const providerId of providerIds) {
+    if (opts.pretty) process.stderr.write(`Checking ${providerId} …\n`);
+    const listed = fixture
+      ? { ok: true, models: fixture[providerId] ?? [] }
+      : listModels(providerId);
+    if (!listed.ok) {
+      results.push({ provider: providerId, ok: false, error: listed.error });
+      continue;
+    }
+    results.push(classifyProvider(providerId, listed.models, knownSlugs, watchlist));
+  }
+
+  const report = {
+    tool: "model-watch",
+    knownSlugs,
+    providers: results,
+    newCount: results.reduce((n, r) => n + (r.newCount ?? 0), 0),
+    errorCount: results.filter((r) => r.ok === false).length,
+  };
+
+  const json = JSON.stringify(report, null, 2);
+  if (opts.out) {
+    writeFileSync(resolve(process.cwd(), opts.out), json + "\n");
+    if (opts.pretty) process.stderr.write(`Wrote ${opts.out}\n`);
+  } else {
+    process.stdout.write(json + "\n");
+  }
+
+  if (opts.pretty) {
+    for (const r of results) {
+      if (r.ok === false) {
+        process.stderr.write(`  ${r.provider}: ERROR — ${r.error}\n`);
+      } else {
+        process.stderr.write(
+          `  ${r.provider}: ${r.newCount} new / ${r.totalModels} total ` +
+            `(${r.covered} covered, ${r.ignored} ignored)\n`
+        );
+      }
+    }
+    process.stderr.write(`Total new models: ${report.newCount}\n`);
+  }
+}
+
+// Run only when invoked directly, so the test can import the pure helpers.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/marketing/scripts/model-watch.watchlist.json
+++ b/marketing/scripts/model-watch.watchlist.json
@@ -1,0 +1,12 @@
+{
+  "note": "Model ids the watcher should stay quiet about. A provider constantly ships models NodeTool has no /models page for; once a maintainer decides an id does NOT warrant a page, list it here and it stops showing up as 'new'. `all` is applied to every provider; `providers.<id>` scopes an id to one provider. Matching is exact (case-insensitive) against the model id returned by `generate <provider> --list-models --json`.",
+  "all": [],
+  "providers": {
+    "fal_ai": [],
+    "replicate": [],
+    "kie": [],
+    "together": [],
+    "atlascloud": [],
+    "topaz": []
+  }
+}


### PR DESCRIPTION
Done. W-4 (model watcher) is implemented and committed.

## Summary

Added `marketing/scripts/model-watch.mjs`, a plain-Node watcher that surfaces provider models NodeTool has no `/models` page for. For each manifest provider it runs `nodetool generate <provider> --list-models --json`, then splits the returned ids three ways: **covered** (id matches a launch slug from `modelProviderCoverage.generated.ts`), **ignored** (id listed in `model-watch.watchlist.json`), or **new** — emitting a machine-readable report that OPS-2 (`model-watch.yml`) consumes to open one issue per provider batch.

Placed under `marketing/scripts/` next to the sibling `generate-model-coverage.mjs` it diffs against (the plan abbreviates these paths as `scripts/…`).

**Files changed**
- `marketing/scripts/model-watch.mjs` — the watcher. Token-aware slug matching (`flux` matches `fal-ai/flux/schnell` but not `influx`; `veo-3` also matches `veo3`/`veo 3`). Report shape: `{ tool, knownSlugs, providers:[{provider, ok, totalModels, covered, ignored, newCount, new:[{id, name, seedCommand}]}], newCount, errorCount }`. CLI invocation overridable via `NODETOOL_MODEL_WATCH_CLI` (built dist in CI); `--input <fixture>` bypasses the CLI; `--out`, `--provider`, `--pretty` flags.
- `marketing/scripts/model-watch.watchlist.json` — ignore list (`all` + per-provider), case-insensitive exact id match.
- `marketing/scripts/__tests__/model-watch.test.mjs` — `node --test` unit tests for the pure helpers (coverage parsing, token matching, classify split, case-insensitive suppression). All 5 pass.
- `marketing/package.json` — added `seo:model-watch` and `test:model-watch` scripts.

**Caveats / follow-ups**
- The watcher needs provider API keys, so it runs in CI secrets or a maintainer machine — no key-free path exists for every provider (as the task notes).
- `generate --list-models` enumerates image models; that's the CLI surface the task specified.
- `npm run lint` (`next lint`) couldn't run in this worktree — the `next` binary is absent from the shared `node_modules` — but the additions are plain `.mjs` outside next lint's app-source scope. The `node --test` suite runs clean.
- The per-model `seedCommand` uses a `<template>` placeholder (the model→template mapping is a maintainer decision) and a best-effort model slug from the id's last path segment.

---

Closes task **T-20260702-0013**: W-4: Model watcher (manifest diff).


### Acceptance criteria
- [x] `scripts/model-watch.mjs` diffs `nodetool generate <provider> --list-models --json` against `modelProviderCoverage.generated.ts` + `watchlist.json`
- [x] New model ids produce a machine-readable report consumable by OPS-2
- [x] Known/ignored ids in `watchlist.json` are suppressed