### PR TITLE
Add media generation settings UI to inspector panels

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -37,8 +37,6 @@ import useMediaGenerationStore, {
   AUDIO_FORMATS,
   AUDIO_SPEEDS,
   DEFAULT_TTS_VOICES,
-  IMAGE_EDIT_STRENGTHS,
-  INFERENCE_STEPS,
   resolveImageSize
 } from "../../../stores/MediaGenerationStore";
 import type {
@@ -57,6 +55,7 @@ import {
   videoModelConstraints
 } from "./videoModelOptions";
 import {
+  buildImageEditOptions,
   buildImageModelOptions,
   imageModelConstraints
 } from "./imageModelOptions";
@@ -785,28 +784,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     []
   );
 
-  const strengthOptions = useMemo<MediaOption<number>[]>(
-    () =>
-      IMAGE_EDIT_STRENGTHS.map((s) => ({
-        id: s,
-        label: s.toFixed(2),
-        description:
-          s <= 0.35 ? "subtle" : s >= 0.85 ? "strong" : "balanced",
-        icon: <TuneIcon fontSize="small" />
-      })),
-    []
-  );
-
-  const stepsOptions = useMemo<MediaOption<number>[]>(
-    () =>
-      INFERENCE_STEPS.map((n) => ({
-        id: n,
-        label: `${n}`,
-        description: n <= 15 ? "fast" : n >= 40 ? "high quality" : "balanced",
-        icon: <LayersIcon fontSize="small" />
-      })),
-    []
-  );
+  const { strengthOptions, stepsOptions } = useMemo(buildImageEditOptions, []);
 
   const chatProviderLabel = useMemo(() => {
     const m = selectedModel ?? languageModel;

--- a/web/src/components/chat/composer/MediaSettingChips.tsx
+++ b/web/src/components/chat/composer/MediaSettingChips.tsx
@@ -1,0 +1,105 @@
+/**
+ * MediaSettingChips — self-contained chip + popover pairs for media
+ * generation settings (resolution, duration, strength, steps, aspect ratio).
+ *
+ * The media composer and the editor prompt bars wire `MediaControlChip` to
+ * `MediaOptionMenu` / `MediaAspectRatioMenu` by hand, each with its own
+ * anchor state. These wrappers bundle chip + anchor + menu so the inspector
+ * prompt panels (sketch `DirectGenLayerPanel`, timeline `DirectGenClipPanel`)
+ * present the same controls as the header generation panel without repeating
+ * the plumbing.
+ */
+import React, { useState } from "react";
+import AspectRatioIcon from "@mui/icons-material/CropOriginal";
+import MediaControlChip from "./MediaControlChip";
+import MediaOptionMenu, { type MediaOption } from "./MediaOptionMenu";
+import MediaAspectRatioMenu from "./MediaAspectRatioMenu";
+import type { AspectRatioOption } from "../../../stores/MediaGenerationStore";
+
+interface MediaOptionChipProps<T extends string | number> {
+  icon?: React.ReactNode;
+  /** Chip label; defaults to the selected option's label. */
+  label?: React.ReactNode;
+  /** Popover header (e.g. "Resolution"). */
+  header: string;
+  value: T;
+  options: MediaOption<T>[];
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  size?: "sm" | "md";
+}
+
+export function MediaOptionChip<T extends string | number>({
+  icon,
+  label,
+  header,
+  value,
+  options,
+  onChange,
+  disabled,
+  size = "sm"
+}: MediaOptionChipProps<T>) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const selected = options.find((o) => o.id === value);
+  return (
+    <>
+      <MediaControlChip
+        icon={icon}
+        label={label ?? selected?.label ?? String(value)}
+        active={!!anchor}
+        onClick={(e) => setAnchor(e.currentTarget)}
+        showChevron={false}
+        disabled={disabled}
+        size={size}
+      />
+      <MediaOptionMenu
+        anchorEl={anchor}
+        open={!!anchor}
+        onClose={() => setAnchor(null)}
+        header={header}
+        value={value}
+        options={options}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
+interface MediaAspectChipProps {
+  value: string;
+  options: AspectRatioOption[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  size?: "sm" | "md";
+}
+
+export function MediaAspectChip({
+  value,
+  options,
+  onChange,
+  disabled,
+  size = "sm"
+}: MediaAspectChipProps) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  return (
+    <>
+      <MediaControlChip
+        icon={<AspectRatioIcon fontSize="small" />}
+        label={value}
+        active={!!anchor}
+        onClick={(e) => setAnchor(e.currentTarget)}
+        showChevron={false}
+        disabled={disabled}
+        size={size}
+      />
+      <MediaAspectRatioMenu
+        anchorEl={anchor}
+        open={!!anchor}
+        onClose={() => setAnchor(null)}
+        value={value}
+        options={options}
+        onChange={onChange}
+      />
+    </>
+  );
+}

--- a/web/src/components/chat/composer/imageModelOptions.tsx
+++ b/web/src/components/chat/composer/imageModelOptions.tsx
@@ -9,10 +9,14 @@
  */
 
 import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";
+import TuneIcon from "@mui/icons-material/Tune";
+import LayersIcon from "@mui/icons-material/Layers";
 import type { ImageModel } from "../../../stores/ApiTypes";
 import {
   IMAGE_ASPECT_RATIOS,
+  IMAGE_EDIT_STRENGTHS,
   IMAGE_RESOLUTIONS,
+  INFERENCE_STEPS,
   type AspectRatioOption,
   type ImageResolution
 } from "../../../stores/MediaGenerationStore";
@@ -69,6 +73,30 @@ export function buildImageModelOptions(
       id: r,
       label: r,
       icon: <DisplaySettingsIcon fontSize="small" />
+    }))
+  };
+}
+
+/**
+ * Menu options for the image-to-image edit controls (strength + inference
+ * steps), shared by the media chat composer and the editor prompt panels.
+ */
+export function buildImageEditOptions(): {
+  strengthOptions: MediaOption<number>[];
+  stepsOptions: MediaOption<number>[];
+} {
+  return {
+    strengthOptions: IMAGE_EDIT_STRENGTHS.map((s) => ({
+      id: s,
+      label: s.toFixed(2),
+      description: s <= 0.35 ? "subtle" : s >= 0.85 ? "strong" : "balanced",
+      icon: <TuneIcon fontSize="small" />
+    })),
+    stepsOptions: INFERENCE_STEPS.map((n) => ({
+      id: n,
+      label: `${n}`,
+      description: n <= 15 ? "fast" : n >= 40 ? "high quality" : "balanced",
+      icon: <LayersIcon fontSize="small" />
     }))
   };
 }

--- a/web/src/components/sketch/Inspector/ConnectedGeneratedLayerSection.tsx
+++ b/web/src/components/sketch/Inspector/ConnectedGeneratedLayerSection.tsx
@@ -27,9 +27,10 @@ const ConnectedGeneratedLayerSectionInner: React.FC = () => {
   }
 
   const isWorkflowBound = !binding.kind || binding.kind === "workflow";
-  // Direct-gen layers (text-to-image / image-to-image) share the "GENERATE"
-  // section of the mockup; workflow-bound layers keep their own label.
-  const titleText = isWorkflowBound ? "Generated Layer" : "GENERATE";
+  // Direct-gen layers (text-to-image / image-to-image) share the "Prompt"
+  // section, matching the timeline inspector; workflow-bound layers keep
+  // their own label.
+  const titleText = isWorkflowBound ? "Generated Layer" : "Prompt";
 
   return (
     <CollapsibleSection

--- a/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
@@ -11,28 +11,45 @@
 
 import React, { memo, useCallback, useMemo } from "react";
 import { useTheme } from "@mui/material/styles";
+import TvIcon from "@mui/icons-material/Tv";
+import TuneIcon from "@mui/icons-material/Tune";
+import LayersIcon from "@mui/icons-material/Layers";
 import type { Layer } from "../types";
 import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
 import {
   Caption,
   FlexColumn,
+  FlexRow,
   Panel,
   SelectField,
   Text,
   TextInput
 } from "../../ui_primitives";
 import { EditorButton } from "../../editor_ui";
-import {
-  SketchModeToggle,
-  SketchModeOption
-} from "../tool-settings-panels/SketchModeToggle";
 import ImageModelSelect from "../../properties/ImageModelSelect";
 import type { ImageModelValue } from "../../../stores/ApiTypes";
+import {
+  MediaAspectChip,
+  MediaOptionChip
+} from "../../chat/composer/MediaSettingChips";
+import {
+  buildImageEditOptions,
+  buildImageModelOptions
+} from "../../chat/composer/imageModelOptions";
+import {
+  deriveImageSizePreset,
+  resolveImageSize,
+  type ImageResolution
+} from "../../../stores/MediaGenerationStore";
+import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useSketchStore } from "../state/useSketchStore";
 import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
 
-const SIZE_PRESETS = [512, 1024, 1536, 2048] as const;
+// Defaults for image-to-image controls when the binding has no explicit
+// value yet — same as the media chat composer's image_edit defaults.
+const DEFAULT_STRENGTH = 0.65;
+const DEFAULT_STEPS = 30;
 
 export interface DirectGenLayerPanelProps {
   layer: Layer;
@@ -59,8 +76,45 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
   const isRunning =
     binding.status === "queued" || binding.status === "generating";
 
-  const currentSize =
-    binding.width && binding.width === binding.height ? binding.width : null;
+  // Older bindings carry only width/height; derive the nearest preset so the
+  // chips reflect the actual output size instead of a fixed default.
+  const sizeSeed = useMemo(
+    () => deriveImageSizePreset(binding.width ?? 1024, binding.height ?? 1024),
+    [binding.width, binding.height]
+  );
+  const resolution =
+    (binding.resolution as ImageResolution | undefined) ?? sizeSeed.resolution;
+  const aspectRatio = binding.aspectRatio ?? sizeSeed.aspectRatio;
+
+  // Option lists constrained by the selected model's manifest — same source
+  // as the media chat composer, so both surfaces offer identical choices.
+  const mediaOptions = useMediaOptions({
+    provider: binding.provider,
+    model: binding.model,
+    task: "image"
+  });
+  const { aspectOptions, resolutionOptions } = useMemo(
+    () =>
+      buildImageModelOptions({
+        aspectRatios: mediaOptions.data?.aspectRatios,
+        resolutions: mediaOptions.data?.resolutions
+      }),
+    [mediaOptions.data]
+  );
+  const { strengthOptions, stepsOptions } = useMemo(buildImageEditOptions, []);
+
+  const applySize = useCallback(
+    (nextResolution: ImageResolution, nextAspect: string) => {
+      const { width, height } = resolveImageSize(nextResolution, nextAspect);
+      patchBinding(layer.id, {
+        resolution: nextResolution,
+        aspectRatio: nextAspect,
+        width,
+        height
+      });
+    },
+    [layer.id, patchBinding]
+  );
 
   const sourceLayerOptions = useMemo(
     () =>
@@ -103,30 +157,42 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
           compact
         />
 
-        <FlexColumn gap={0.5}>
-          <Caption color="secondary">Size</Caption>
-          <SketchModeToggle
-            value={currentSize}
-            exclusive
-            onChange={(_e, v: number | null) => {
-              if (v != null) {
-                patchBinding(layer.id, { width: v, height: v });
-              }
-            }}
-            sx={{ flexWrap: "wrap" }}
-            aria-label="Output size"
-          >
-            {SIZE_PRESETS.map((s) => (
-              <SketchModeOption
-                key={s}
-                value={s}
-                data-testid={`direct-gen-size-${s}`}
-              >
-                {s}²
-              </SketchModeOption>
-            ))}
-          </SketchModeToggle>
-        </FlexColumn>
+        <FlexRow gap={0.5} align="center" sx={{ flexWrap: "wrap" }}>
+          <MediaOptionChip
+            icon={<TvIcon fontSize="small" />}
+            header="Resolution"
+            value={resolution}
+            options={resolutionOptions}
+            onChange={(r) => applySize(r, aspectRatio)}
+          />
+          <MediaAspectChip
+            value={aspectRatio}
+            options={aspectOptions}
+            onChange={(a) => applySize(resolution, a)}
+          />
+          {isImageToImage && (
+            <>
+              <MediaOptionChip
+                icon={<TuneIcon fontSize="small" />}
+                label={`Strength ${(binding.strength ?? DEFAULT_STRENGTH).toFixed(2)}`}
+                header="Edit Strength"
+                value={binding.strength ?? DEFAULT_STRENGTH}
+                options={strengthOptions}
+                onChange={(s) => patchBinding(layer.id, { strength: s })}
+              />
+              <MediaOptionChip
+                icon={<LayersIcon fontSize="small" />}
+                label={`${binding.numInferenceSteps ?? DEFAULT_STEPS} steps`}
+                header="Inference Steps"
+                value={binding.numInferenceSteps ?? DEFAULT_STEPS}
+                options={stepsOptions}
+                onChange={(n) =>
+                  patchBinding(layer.id, { numInferenceSteps: n })
+                }
+              />
+            </>
+          )}
+        </FlexRow>
 
         {isImageToImage &&
           (sourceLayerOptions.length === 0 ? (
@@ -162,7 +228,7 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
             onClick={() => void start(layer.id)}
             data-testid="direct-gen-generate"
           >
-            Generate
+            {binding.currentAssetId ? "Regenerate" : "Generate"}
           </EditorButton>
         )}
         {binding.status === "failed" && (

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -41,7 +41,7 @@ import { clampToAllowed } from "../../chat/composer/videoModelOptions";
 import ImageModelMenuDialog from "../../model_menu/ImageModelMenuDialog";
 import type { ImageModel } from "../../../stores/ApiTypes";
 import {
-  IMAGE_ASPECT_RATIOS,
+  deriveImageSizePreset,
   resolveImageSize,
   type ImageResolution
 } from "../../../stores/MediaGenerationStore";
@@ -50,28 +50,6 @@ import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore
 import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
 import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 import { SKETCH_SPACING } from "../sketchStyles";
-
-/** Nearest aspect-ratio + resolution preset for an existing canvas size, so the
- *  controls reflect the artboard on open instead of a fixed default. */
-function deriveSizePreset(
-  width: number,
-  height: number
-): { aspectRatio: string; resolution: ImageResolution } {
-  const ratio = width / height;
-  let aspectRatio = IMAGE_ASPECT_RATIOS[0].id;
-  let bestDiff = Infinity;
-  for (const a of IMAGE_ASPECT_RATIOS) {
-    const diff = Math.abs(a.width / a.height - ratio);
-    if (diff < bestDiff) {
-      bestDiff = diff;
-      aspectRatio = a.id;
-    }
-  }
-  const shortEdge = Math.min(width, height);
-  const resolution: ImageResolution =
-    shortEdge >= 3072 ? "4K" : shortEdge >= 1536 ? "2K" : "1K";
-  return { aspectRatio, resolution };
-}
 
 /** Most recent direct-gen binding's model, to seed the bar's picker. */
 function seedModelFromBindings(): { model: string; provider: string } {
@@ -135,7 +113,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   // composer. These shape the generation output only; the artboard size is
   // controlled separately in the canvas panel. Seeded from the current canvas
   // so the first generation defaults to the artboard's shape.
-  const [sizeSeed] = useState(() => deriveSizePreset(docW, docH));
+  const [sizeSeed] = useState(() => deriveImageSizePreset(docW, docH));
   const [aspectRatio, setAspectRatio] = useState(sizeSeed.aspectRatio);
   const [resolution, setResolution] = useState<ImageResolution>(
     sizeSeed.resolution

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -32,6 +32,28 @@ import type {
 } from "../../../stores/ApiTypes";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import StopRoundedIcon from "@mui/icons-material/StopRounded";
+import TvIcon from "@mui/icons-material/Tv";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import TuneIcon from "@mui/icons-material/Tune";
+import LayersIcon from "@mui/icons-material/Layers";
+
+import {
+  MediaAspectChip,
+  MediaOptionChip
+} from "../../chat/composer/MediaSettingChips";
+import {
+  buildImageEditOptions,
+  buildImageModelOptions
+} from "../../chat/composer/imageModelOptions";
+import { buildVideoModelOptions } from "../../chat/composer/videoModelOptions";
+import {
+  deriveImageSizePreset,
+  resolveImageSize,
+  type ImageResolution,
+  type VideoModelSelection,
+  type VideoResolution
+} from "../../../stores/MediaGenerationStore";
+import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 
 import {
   Caption,
@@ -83,6 +105,13 @@ const EMPTY_SOURCE_ENTRIES: readonly string[] = [];
 // this separator, so splitting on its first occurrence is unambiguous.
 const SOURCE_ENTRY_SEP = "\u0000";
 
+// Defaults for the setting chips when the clip has no explicit value yet —
+// same as the media chat composer's per-mode defaults.
+const DEFAULT_STRENGTH = 0.65;
+const DEFAULT_STEPS = 30;
+const DEFAULT_VIDEO_RESOLUTION: VideoResolution = "720p";
+const DEFAULT_VIDEO_ASPECT = "16:9";
+
 const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   clipId
 }) => {
@@ -94,6 +123,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     (s) => s.setClipDirectGenModel
   );
   const patchClipBinding = useTimelineStore((s) => s.patchClipBinding);
+  const patchClip = useTimelineStore((s) => s.patchClip);
   const addNotification = useNotificationStore((s) => s.addNotification);
 
   const {
@@ -111,6 +141,82 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
         ? "audio"
         : "image";
   const isImageToImage = clip?.bindingKind === "image-to-image";
+
+  // Per-model option constraints from the provider manifest — the same source
+  // the media chat composer uses, so both surfaces offer identical choices.
+  // Audio clips have no size/duration options, so their query stays disabled.
+  const mediaOptions = useMediaOptions({
+    provider: clip?.provider,
+    model: kind === "audio" ? null : clip?.model,
+    task: kind === "video" ? "video" : "image"
+  });
+
+  const { aspectOptions: imageAspectOptions, resolutionOptions } = useMemo(
+    () =>
+      buildImageModelOptions({
+        aspectRatios: mediaOptions.data?.aspectRatios,
+        resolutions: mediaOptions.data?.resolutions
+      }),
+    [mediaOptions.data]
+  );
+  const { strengthOptions, stepsOptions } = useMemo(buildImageEditOptions, []);
+  const videoSelection = useMemo<VideoModelSelection | null>(
+    () =>
+      kind === "video" && clip?.model
+        ? {
+            type: "video_model",
+            id: clip.model,
+            provider: clip.provider ?? "",
+            name: clip.model,
+            durations: mediaOptions.data?.durations ?? undefined,
+            resolutions: mediaOptions.data?.resolutions ?? undefined,
+            aspectRatios: mediaOptions.data?.aspectRatios ?? undefined
+          }
+        : null,
+    [kind, clip?.model, clip?.provider, mediaOptions.data]
+  );
+  const {
+    durationOptions,
+    resolutionOptions: videoResolutionOptions,
+    aspectOptions: videoAspectOptions
+  } = useMemo(() => buildVideoModelOptions(videoSelection), [videoSelection]);
+
+  // Image size chips: derive the nearest preset from width/height for clips
+  // created before aspect/resolution were stored on the binding.
+  const imageSizeSeed = useMemo(
+    () => deriveImageSizePreset(clip?.width ?? 1024, clip?.height ?? 1024),
+    [clip?.width, clip?.height]
+  );
+  const imageResolution =
+    (clip?.resolution as ImageResolution | undefined) ??
+    imageSizeSeed.resolution;
+  const imageAspect = clip?.aspectRatio ?? imageSizeSeed.aspectRatio;
+
+  const applyImageSize = useCallback(
+    (nextResolution: ImageResolution, nextAspect: string) => {
+      const { width, height } = resolveImageSize(nextResolution, nextAspect);
+      patchClipBinding(clipId, {
+        resolution: nextResolution,
+        aspectRatio: nextAspect,
+        width,
+        height
+      });
+    },
+    [clipId, patchClipBinding]
+  );
+
+  // The direct-gen job derives the requested video duration from the clip's
+  // timeline length, so the duration chip resizes the clip itself.
+  const videoDuration = Math.max(
+    1,
+    Math.round((clip?.durationMs ?? 4000) / 1000)
+  );
+  const handleDurationChange = useCallback(
+    (seconds: number) => {
+      patchClip(clipId, { durationMs: seconds * 1000 });
+    },
+    [clipId, patchClip]
+  );
 
   // Eligible image-to-image source clips: any other image/overlay clip with
   // a rendered asset in the sequence. Gated on `isImageToImage` so clips in
@@ -342,6 +448,80 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
                   size="small"
                 />
               )
+            )}
+
+            {/* Output settings — the same fields as the header generation
+                panel (media chat composer) for the matching mode. */}
+            {kind === "image" && (
+              <FlexRow gap={0.5} align="center" sx={{ flexWrap: "wrap" }}>
+                <MediaOptionChip
+                  icon={<TvIcon fontSize="small" />}
+                  header="Resolution"
+                  value={imageResolution}
+                  options={resolutionOptions}
+                  onChange={(r) => applyImageSize(r, imageAspect)}
+                />
+                <MediaAspectChip
+                  value={imageAspect}
+                  options={imageAspectOptions}
+                  onChange={(a) => applyImageSize(imageResolution, a)}
+                />
+                {isImageToImage && (
+                  <>
+                    <MediaOptionChip
+                      icon={<TuneIcon fontSize="small" />}
+                      label={`Strength ${(clip.strength ?? DEFAULT_STRENGTH).toFixed(2)}`}
+                      header="Edit Strength"
+                      value={clip.strength ?? DEFAULT_STRENGTH}
+                      options={strengthOptions}
+                      onChange={(s) =>
+                        patchClipBinding(clipId, { strength: s })
+                      }
+                    />
+                    <MediaOptionChip
+                      icon={<LayersIcon fontSize="small" />}
+                      label={`${clip.numInferenceSteps ?? DEFAULT_STEPS} steps`}
+                      header="Inference Steps"
+                      value={clip.numInferenceSteps ?? DEFAULT_STEPS}
+                      options={stepsOptions}
+                      onChange={(n) =>
+                        patchClipBinding(clipId, { numInferenceSteps: n })
+                      }
+                    />
+                  </>
+                )}
+              </FlexRow>
+            )}
+            {kind === "video" && (
+              <FlexRow gap={0.5} align="center" sx={{ flexWrap: "wrap" }}>
+                <MediaOptionChip
+                  icon={<AccessTimeIcon fontSize="small" />}
+                  label={`${videoDuration} Sec`}
+                  header="Duration"
+                  value={videoDuration}
+                  options={durationOptions}
+                  onChange={handleDurationChange}
+                />
+                <MediaOptionChip
+                  icon={<TvIcon fontSize="small" />}
+                  header="Video Resolution"
+                  value={
+                    (clip.resolution as VideoResolution | undefined) ??
+                    DEFAULT_VIDEO_RESOLUTION
+                  }
+                  options={videoResolutionOptions}
+                  onChange={(r) =>
+                    patchClipBinding(clipId, { resolution: r })
+                  }
+                />
+                <MediaAspectChip
+                  value={clip.aspectRatio ?? DEFAULT_VIDEO_ASPECT}
+                  options={videoAspectOptions}
+                  onChange={(a) =>
+                    patchClipBinding(clipId, { aspectRatio: a })
+                  }
+                />
+              </FlexRow>
             )}
 
             <EditorButton

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -202,12 +202,18 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
           num_inference_steps: clip.numInferenceSteps,
           variations: 1,
           voice: kind === "text-to-audio" ? clip.voice : undefined,
-          // Video models take aspect ratio / resolution / duration natively
-          // (width & height are ignored for video); pass them through when set.
-          ...(kind === "text-to-video"
+          // Image and video models take aspect ratio / resolution natively;
+          // pass them through when set. Video additionally derives its
+          // requested duration from the clip's timeline length (width &
+          // height are ignored for video).
+          ...(kind !== "text-to-audio"
             ? {
                 aspect_ratio: clip.aspectRatio,
-                resolution: clip.resolution,
+                resolution: clip.resolution
+              }
+            : {}),
+          ...(kind === "text-to-video"
+            ? {
                 duration: clip.durationMs
                   ? Math.round(clip.durationMs / 1000)
                   : undefined

--- a/web/src/stores/MediaGenerationStore.ts
+++ b/web/src/stores/MediaGenerationStore.ts
@@ -331,4 +331,29 @@ export function resolveImageSize(
   return { width, height };
 }
 
+/**
+ * Nearest aspect-ratio + resolution preset for a concrete pixel size — the
+ * inverse of {@link resolveImageSize}. Used to seed the size controls from an
+ * existing canvas or binding instead of a fixed default.
+ */
+export function deriveImageSizePreset(
+  width: number,
+  height: number
+): { aspectRatio: string; resolution: ImageResolution } {
+  const ratio = width / height;
+  let aspectRatio = IMAGE_ASPECT_RATIOS[0].id;
+  let bestDiff = Infinity;
+  for (const a of IMAGE_ASPECT_RATIOS) {
+    const diff = Math.abs(a.width / a.height - ratio);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      aspectRatio = a.id;
+    }
+  }
+  const shortEdge = Math.min(width, height);
+  const resolution: ImageResolution =
+    shortEdge >= 3072 ? "4K" : shortEdge >= 1536 ? "2K" : "1K";
+  return { aspectRatio, resolution };
+}
+
 export default useMediaGenerationStore;

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -363,6 +363,8 @@ export interface TimelineStoreState {
         | "sourceClipId"
         | "width"
         | "height"
+        | "aspectRatio"
+        | "resolution"
         | "strength"
         | "numInferenceSteps"
         | "seed"


### PR DESCRIPTION
## Summary

Unifies media generation settings (resolution, aspect ratio, duration, strength, inference steps) across the timeline and sketch inspector panels by introducing reusable `MediaOptionChip` and `MediaAspectChip` components. These chips provide the same control surface as the media chat composer, ensuring consistent UX and option constraints across all generation surfaces.

## Key Changes

- **New component: `MediaSettingChips.tsx`** — Self-contained chip + popover pairs for media settings. Wraps `MediaControlChip` with `MediaOptionMenu` / `MediaAspectRatioMenu` to eliminate plumbing duplication in inspector panels.

- **Refactored `imageModelOptions.tsx`** — Extracted `buildImageEditOptions()` to share strength and inference-steps option lists between the media composer and inspector panels. Both now use identical constraints from the provider manifest.

- **Enhanced `DirectGenClipPanel.tsx`** — Added output settings UI for image and video clips:
  - Image: resolution, aspect ratio, and (for image-to-image) strength + inference steps
  - Video: duration, resolution, aspect ratio
  - Uses `deriveImageSizePreset()` to seed controls from existing clip dimensions for backward compatibility

- **Enhanced `DirectGenLayerPanel.tsx`** — Replaced fixed size preset buttons with dynamic resolution + aspect ratio chips. Added strength and inference steps controls for image-to-image layers. Derives size presets from binding dimensions to reflect actual output instead of defaults.

- **Extracted `deriveImageSizePreset()` to `MediaGenerationStore.ts`** — Moved from `ConnectedModePromptBar.tsx` to share the inverse of `resolveImageSize()` across all size-control surfaces (sketch prompt bar, timeline/sketch inspectors).

- **Updated `useTimelineDirectGenJob.ts`** — Clarified that both image and video models accept aspect ratio and resolution; video additionally derives duration from clip timeline length.

- **Minor UX improvements** — Sketch layer panel now shows "Regenerate" button when an asset exists, matching timeline behavior.

## Implementation Details

- All option lists (resolutions, aspects, strengths, steps, durations) are built from the same provider manifest constraints via `useMediaOptions()`, ensuring parity across surfaces.
- Backward compatibility: clips/bindings created before aspect/resolution were stored derive the nearest preset from width/height.
- Default values (`DEFAULT_STRENGTH`, `DEFAULT_STEPS`, `DEFAULT_VIDEO_RESOLUTION`, `DEFAULT_VIDEO_ASPECT`) match the media composer's per-mode defaults.
- Chips use consistent icons (`TvIcon`, `AccessTimeIcon`, `TuneIcon`, `LayersIcon`) for visual consistency.

https://claude.ai/code/session_016qZz7dUF4xeKsDCbcHHaGY