### PR TITLE
Add "Open in new tab" button to chat panel header

### DIFF
--- a/web/src/components/chat/containers/ChatPanelHeader.tsx
+++ b/web/src/components/chat/containers/ChatPanelHeader.tsx
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import AddIcon from "@mui/icons-material/Add";
 import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import {
   FlexRow,
   Text,
@@ -113,6 +114,11 @@ const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
     navigate(currentThreadId ? `/chat/${currentThreadId}` : "/chat");
   }, [navigate, currentThreadId]);
 
+  const handleOpenInNewTab = useCallback(() => {
+    const path = currentThreadId ? `/chat/${currentThreadId}` : "/chat";
+    window.open(path, "_blank", "noopener,noreferrer");
+  }, [currentThreadId]);
+
   return (
     <FlexRow
       align="center"
@@ -148,6 +154,11 @@ const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
           onClick={handleOpenFullscreen}
           tooltip="Open fullscreen chat"
           icon={<OpenInFullIcon fontSize="small" />}
+        />
+        <ToolbarIconButton
+          onClick={handleOpenInNewTab}
+          tooltip="Open in new tab"
+          icon={<OpenInNewIcon fontSize="small" />}
         />
       </FlexRow>
 


### PR DESCRIPTION
## Summary
Adds a new toolbar button to the chat panel header that allows users to open the current chat thread in a new browser tab.

## Changes
- Import `OpenInNewIcon` from MUI icons
- Add `handleOpenInNewTab` callback that opens the chat URL in a new tab with `window.open()` using `noopener,noreferrer` for security
- Add new `ToolbarIconButton` with the open-in-new-tab icon and tooltip, positioned next to the existing fullscreen button

## Implementation Details
- The new button uses the same pattern as the existing fullscreen button (`handleOpenFullscreen`)
- Correctly handles both thread-specific URLs (`/chat/{threadId}`) and the general chat page (`/chat`)
- Uses security best practices with `noopener,noreferrer` flags to prevent the new tab from accessing `window.opener`
- Maintains consistency with existing toolbar button styling and behavior

https://claude.ai/code/session_011CT21hMhWG8Q8taLngeLDo