### PR TITLE
Exclude COMPONENT_STREAMLINE_PLAN from docs build

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -58,7 +58,8 @@ jobs:
           # Internal/engineering pages must be excluded from the build.
           for f in STUDIO_PRD STUDIO_MVP_PROMPT DEVELOPMENT_STANDARDS DESIGN \
                    AGENTS THEME WRITING_STYLE CLOUD_NODE_CURATION image-editor-prd \
-                   timeline-editor-prd correlation-design runtime-package-interface; do
+                   timeline-editor-prd correlation-design runtime-package-interface \
+                   COMPONENT_STREAMLINE_PLAN; do
             if [ -e "$site/$f.html" ]; then
               echo "::error::Internal doc leaked into the site: $f.html"
               fail=1

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -114,6 +114,7 @@ exclude:
   - timeline-editor-prd.md
   - correlation-design.md
   # Internal implementation plans & specs (agentic-worker instructions).
+  - COMPONENT_STREAMLINE_PLAN.md
   - superpowers/
 
 # Custom theme settings


### PR DESCRIPTION
## Summary
Adds `COMPONENT_STREAMLINE_PLAN.md` to the documentation build exclusion list to prevent internal implementation plans from leaking into the published site.

## Changes
- **docs/_config.yml**: Added `COMPONENT_STREAMLINE_PLAN.md` to the Jekyll `exclude` list alongside other internal documentation files
- **.github/workflows/docs-ci.yml**: Updated the CI validation script to check for `COMPONENT_STREAMLINE_PLAN.html` in the build output and fail if it's present, matching the pattern used for other internal docs

This ensures the internal component streamline plan document is properly excluded from both the Jekyll build process and the CI validation checks.

https://claude.ai/code/session_01HVbnBxa2bbsiEcpagzTfD9