### PR TITLE
Move provider OAuth sign-in into the API Keys provider cards

### DIFF
--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -4,6 +4,8 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import DeleteIcon from "@mui/icons-material/Delete";
 import LockIcon from "@mui/icons-material/Lock";
+import LoginIcon from "@mui/icons-material/Login";
+import LinkOffIcon from "@mui/icons-material/LinkOff";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ModelTrainingIcon from "@mui/icons-material/ModelTraining";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
@@ -13,6 +15,7 @@ import ShieldIcon from "@mui/icons-material/Shield";
 
 import useSecretsStore from "../../stores/SecretsStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
+import { useOAuthConnection } from "../../hooks/useOAuthConnection";
 import type { SecretResponse } from "../../stores/ApiTypes";
 import {
   FlexColumn,
@@ -74,6 +77,8 @@ interface ProviderMeta {
   mono?: boolean;
   /** Extra hint rendered under the description (e.g. required key scope). */
   note?: string;
+  /** Provider supports OAuth sign-in in place of (or alongside) an API key. */
+  oauth?: "openai" | "hf";
 }
 
 const PROVIDER_META: ProviderMeta[] = [
@@ -85,7 +90,8 @@ const PROVIDER_META: ProviderMeta[] = [
     tag: "Popular",
     docsUrl: "https://platform.openai.com/docs",
     icon: openaiIcon,
-    mono: true
+    mono: true,
+    oauth: "openai"
   },
   {
     key: "ANTHROPIC_API_KEY",
@@ -185,7 +191,8 @@ const PROVIDER_META: ProviderMeta[] = [
     description: "Inference providers and model hub access.",
     category: "other",
     docsUrl: "https://huggingface.co/docs",
-    icon: huggingfaceColorIcon
+    icon: huggingfaceColorIcon,
+    oauth: "hf"
   },
   {
     key: "REPLICATE_API_TOKEN",
@@ -427,7 +434,7 @@ interface ProviderCardProps {
   onDelete: (secret: SecretResponse) => void;
 }
 
-const ProviderCard = memo(function ProviderCard({
+export const ProviderCard = memo(function ProviderCard({
   secret,
   meta,
   onConnect,
@@ -435,6 +442,7 @@ const ProviderCard = memo(function ProviderCard({
   onDelete
 }: ProviderCardProps) {
   const theme = useTheme();
+  const oauth = useOAuthConnection(meta.oauth ?? null);
   const isConnected = secret.is_configured;
 
   const handleConnect = useCallback(() => {
@@ -576,6 +584,29 @@ const ProviderCard = memo(function ProviderCard({
               {isConnected ? "Connected" : "Not connected"}
             </Caption>
           </FlexRow>
+          {oauth.isConnected && (
+            <FlexRow
+              align="center"
+              gap={1}
+              sx={{
+                padding: theme.spacing(0.5, 2),
+                borderRadius: BORDER_RADIUS.pill,
+                backgroundColor: `rgba(${theme.vars.palette.success.mainChannel} / 0.1)`
+              }}
+            >
+              <Caption
+                size="smaller"
+                color="success"
+                sx={{
+                  fontWeight: 500,
+                  lineHeight: 1.6,
+                  whiteSpace: "nowrap"
+                }}
+              >
+                Connected via OAuth
+              </Caption>
+            </FlexRow>
+          )}
           {isConnected && secret.updated_at && (
             <Caption size="tiny" sx={{ opacity: 0.45, whiteSpace: "nowrap" }}>
               Last used{" "}
@@ -599,6 +630,34 @@ const ProviderCard = memo(function ProviderCard({
           >
             Docs
           </EditorButton>
+
+          {meta.oauth &&
+            (oauth.isConnected
+              ? oauth.canDisconnect && (
+                  <EditorButton
+                    density="compact"
+                    variant="text"
+                    size="small"
+                    startIcon={<LinkOffIcon sx={{ fontSize: 14 }} />}
+                    onClick={oauth.disconnect}
+                  >
+                    Disconnect
+                  </EditorButton>
+                )
+              : (
+                  <EditorButton
+                    density="compact"
+                    variant="outlined"
+                    size="small"
+                    startIcon={<LoginIcon sx={{ fontSize: 14 }} />}
+                    onClick={oauth.connect}
+                    disabled={oauth.isConnecting}
+                  >
+                    {oauth.isConnecting
+                      ? "Connecting…"
+                      : `Sign in with ${meta.name}`}
+                  </EditorButton>
+                ))}
 
           {isConnected ? (
             <>

--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -1,9 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import SaveIcon from "@mui/icons-material/Save";
 
-import LoginIcon from "@mui/icons-material/Login";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import LinkOffIcon from "@mui/icons-material/LinkOff";
 import { useMemo, useState, useCallback, useEffect, memo } from "react";
 
 import {
@@ -69,8 +66,6 @@ export const getDisplayedSettingGroups = (
   return groups;
 };
 import ExternalLink from "../common/ExternalLink";
-import { isElectron } from "../../lib/env";
-import { restFetch } from "../../lib/rest-fetch";
 import SearchProviderSection from "./SearchProviderSection";
 
 const SETTING_LINKS: Record<string, string> = {
@@ -218,112 +213,10 @@ const RemoteSettings = () => {
   const settings = useRemoteSettingsStore((state) => state.settings);
   const addNotification = useNotificationStore((state) => state.addNotification);
 
-  // HuggingFace OAuth state
-  const [hfOAuthLoading, setHfOAuthLoading] = useState(false);
-  // OpenAI OAuth state
-  const [openaiOAuthLoading, setOpenaiOAuthLoading] = useState(false);
-
   const { data, isSuccess, isLoading } = useQuery({
     queryKey: ["settings"],
     queryFn: fetchSettings
   });
-
-  // Poll for HuggingFace OAuth completion
-  interface HfTokenResponse {
-    tokens: string[];
-  }
-
-  const { data: hfTokenData, isError: isHfTokenError } = useQuery({
-    queryKey: ["hf-oauth-token"],
-    queryFn: async () => {
-      const response = await restFetch("/api/oauth/hf/tokens");
-      if (!response.ok) {
-        throw new Error("Failed to fetch HuggingFace token");
-      }
-      return (await response.json()) as HfTokenResponse;
-    },
-    refetchInterval: (query) => {
-      const data = query.state.data as HfTokenResponse | undefined;
-      if (hfOAuthLoading && !(data?.tokens && data.tokens.length > 0)) {
-        return 2000;
-      }
-      return false;
-    },
-    retry: true
-  });
-
-  const isConnected = !!(hfTokenData && hfTokenData.tokens && hfTokenData.tokens.length > 0);
-
-  // Handle OAuth completion side effects
-  useEffect(() => {
-    if (hfOAuthLoading) {
-      if (isConnected) {
-        setHfOAuthLoading(false);
-        addNotification({
-          content: "Successfully connected to HuggingFace",
-          type: "success",
-          alert: true
-        });
-      } else if (isHfTokenError) {
-        setHfOAuthLoading(false);
-        addNotification({
-          content: "Failed to check HuggingFace connection",
-          type: "error",
-          alert: true
-        });
-      }
-    }
-  }, [hfOAuthLoading, isConnected, isHfTokenError, addNotification]);
-
-  // Poll for OpenAI OAuth completion
-  interface OpenAITokenResponse {
-    tokens: unknown[];
-  }
-
-  const { data: openaiTokenData, isError: isOpenAITokenError } = useQuery({
-    queryKey: ["openai-oauth-token"],
-    queryFn: async () => {
-      const response = await restFetch("/api/oauth/openai/tokens");
-      if (!response.ok) {
-        throw new Error("Failed to fetch OpenAI token");
-      }
-      return (await response.json()) as OpenAITokenResponse;
-    },
-    refetchInterval: (query) => {
-      const data = query.state.data as OpenAITokenResponse | undefined;
-      if (openaiOAuthLoading && !(data?.tokens && data.tokens.length > 0)) {
-        return 2000;
-      }
-      return false;
-    },
-    retry: true
-  });
-
-  const isOpenAIConnected = !!(
-    openaiTokenData &&
-    openaiTokenData.tokens &&
-    openaiTokenData.tokens.length > 0
-  );
-
-  useEffect(() => {
-    if (openaiOAuthLoading) {
-      if (isOpenAIConnected) {
-        setOpenaiOAuthLoading(false);
-        addNotification({
-          content: "Successfully connected to OpenAI",
-          type: "success",
-          alert: true
-        });
-      } else if (isOpenAITokenError) {
-        setOpenaiOAuthLoading(false);
-        addNotification({
-          content: "Failed to check OpenAI connection",
-          type: "error",
-          alert: true
-        });
-      }
-    }
-  }, [openaiOAuthLoading, isOpenAIConnected, isOpenAITokenError, addNotification]);
 
   const [settingValues, setSettingValues] = useState<Record<string, string>>(
     {}
@@ -425,103 +318,6 @@ const RemoteSettings = () => {
     setSettingValues((prev) => ({ ...prev, [envVar]: value }));
   }, []);
 
-  const handleHuggingFaceOAuth = useCallback(async () => {
-    setHfOAuthLoading(true);
-
-    try {
-      const response = await restFetch("/api/oauth/hf/start");
-      const data = (await response.json().catch(() => null)) as
-        | { auth_url?: string }
-        | null;
-
-      if (!response.ok || !data?.auth_url) {
-        throw new Error("Failed to start OAuth flow");
-      }
-
-      const authUrl = data.auth_url;
-
-      if (isElectron && window.api?.shell?.openExternal) {
-        // Electron environment via IPC
-        await window.api.shell.openExternal(authUrl);
-      } else {
-        // Web environment - open in new window/tab with security attributes
-        window.open(authUrl, "_blank", "noopener,noreferrer,width=600,height=700");
-      }
-    } catch (error) {
-      console.error("OAuth initiation failed:", error);
-      setHfOAuthLoading(false);
-      addNotification({
-        content: "Failed to initiate HuggingFace login",
-        type: "error",
-        alert: true
-      });
-    }
-  }, [addNotification]);
-
-  const handleOpenAIOAuth = useCallback(async () => {
-    setOpenaiOAuthLoading(true);
-
-    try {
-      const response = await restFetch("/api/oauth/openai/start");
-      const data = (await response.json().catch(() => null)) as
-        | { auth_url?: string; detail?: string }
-        | null;
-
-      if (!response.ok || !data?.auth_url) {
-        throw new Error(data?.detail || "Failed to start OAuth flow");
-      }
-
-      const authUrl = data.auth_url;
-
-      if (isElectron && window.api?.shell?.openExternal) {
-        await window.api.shell.openExternal(authUrl);
-      } else {
-        window.open(
-          authUrl,
-          "_blank",
-          "noopener,noreferrer,width=600,height=700"
-        );
-      }
-    } catch (error) {
-      console.error("OpenAI OAuth initiation failed:", error);
-      setOpenaiOAuthLoading(false);
-      addNotification({
-        content:
-          error instanceof Error
-            ? error.message
-            : "Failed to initiate OpenAI login",
-        type: "error",
-        alert: true
-      });
-    }
-  }, [addNotification]);
-
-  const handleOpenAIDisconnect = useCallback(async () => {
-    try {
-      const response = await restFetch("/api/oauth/openai/disconnect", {
-        method: "POST"
-      });
-      if (!response.ok) {
-        throw new Error("Failed to disconnect");
-      }
-      await queryClient.invalidateQueries({
-        queryKey: ["openai-oauth-token"]
-      });
-      addNotification({
-        content: "Disconnected from OpenAI",
-        type: "success",
-        alert: true
-      });
-    } catch (error) {
-      console.error("OpenAI disconnect failed:", error);
-      addNotification({
-        content: "Failed to disconnect from OpenAI",
-        type: "error",
-        alert: true
-      });
-    }
-  }, [addNotification, queryClient]);
-
   const handleSave = useCallback(() => {
     const settings: Record<string, string> = {};
     const secrets: Record<string, string> = {};
@@ -570,97 +366,6 @@ const RemoteSettings = () => {
             css={getSharedSettingsStyles(theme)}
           >
             <div className="settings-main-content">
-              {/* HuggingFace OAuth Section */}
-              <div className="settings-section">
-                <Text
-                  size="big"
-                  id="huggingface-oauth"
-                  className="settings-heading"
-                >
-                  HuggingFace Authentication
-                </Text>
-                <div className="settings-item large">
-                  <Text className="description">
-                    Connect your HuggingFace account to access premium models and features
-                  </Text>
-                  <EditorButton
-                    variant="contained"
-                    color="primary"
-                    onClick={handleHuggingFaceOAuth}
-                    disabled={hfOAuthLoading}
-                    startIcon={
-                      isConnected ? (
-                        <CheckCircleIcon />
-                      ) : hfOAuthLoading ? null : (
-                        <LoginIcon />
-                      )
-                    }
-                    sx={{ marginTop: "1em", alignSelf: "flex-start" }}
-                  >
-                    {isConnected
-                      ? "Connected to HuggingFace"
-                      : hfOAuthLoading
-                        ? "Connecting..."
-                        : "Connect with HuggingFace"}
-                  </EditorButton>
-                </div>
-              </div>
-
-              {/* OpenAI OAuth Section */}
-              <div className="settings-section">
-                <Text
-                  size="big"
-                  id="openai-oauth"
-                  className="settings-heading"
-                >
-                  OpenAI Authentication
-                </Text>
-                <div className="settings-item large">
-                  <Text className="description">
-                    Connect your OpenAI account with OAuth instead of pasting an
-                    API key. Tokens are stored securely and refreshed
-                    automatically.
-                  </Text>
-                  <div
-                    style={{
-                      display: "flex",
-                      gap: "0.5em",
-                      marginTop: "1em",
-                      alignSelf: "flex-start"
-                    }}
-                  >
-                    <EditorButton
-                      variant="contained"
-                      color="primary"
-                      onClick={handleOpenAIOAuth}
-                      disabled={openaiOAuthLoading}
-                      startIcon={
-                        isOpenAIConnected ? (
-                          <CheckCircleIcon />
-                        ) : openaiOAuthLoading ? null : (
-                          <LoginIcon />
-                        )
-                      }
-                    >
-                      {isOpenAIConnected
-                        ? "Connected to OpenAI"
-                        : openaiOAuthLoading
-                          ? "Connecting..."
-                          : "Connect with OpenAI"}
-                    </EditorButton>
-                    {isOpenAIConnected && (
-                      <EditorButton
-                        variant="text"
-                        onClick={handleOpenAIDisconnect}
-                        startIcon={<LinkOffIcon />}
-                      >
-                        Disconnect
-                      </EditorButton>
-                    )}
-                  </div>
-                </div>
-              </div>
-
               {/* Search Provider Section */}
               {data && (
                 <SearchProviderSection

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -565,7 +565,6 @@ function SettingsPage() {
   const integrationsSidebarSections = useMemo(() => {
     const configItems = [
       { id: "api-settings", label: "API Settings" },
-      { id: "huggingface-oauth", label: "HuggingFace" },
       { id: "search-provider", label: "Search Provider" },
       ...getDisplayedSettingGroups(remoteSettings ?? []).map((group) => ({
         id: settingGroupSlug(group),

--- a/web/src/components/menus/__tests__/ProviderCard.test.tsx
+++ b/web/src/components/menus/__tests__/ProviderCard.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import { ProviderCard } from "../APIKeysTab";
+import type { SecretResponse } from "../../../stores/ApiTypes";
+import {
+  useOAuthConnection,
+  type OAuthConnection
+} from "../../../hooks/useOAuthConnection";
+
+jest.mock("../../../hooks/useOAuthConnection");
+
+const mockUseOAuthConnection = useOAuthConnection as jest.MockedFunction<
+  typeof useOAuthConnection
+>;
+
+const oauthState = (overrides: Partial<OAuthConnection>): OAuthConnection => ({
+  label: "",
+  isConnected: false,
+  isConnecting: false,
+  canDisconnect: false,
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  ...overrides
+});
+
+const secret = (isConfigured: boolean): SecretResponse =>
+  ({
+    key: "OPENAI_API_KEY",
+    is_configured: isConfigured,
+    description: "",
+    user_id: null,
+    created_at: null,
+    updated_at: null
+  }) as unknown as SecretResponse;
+
+const oauthMeta = {
+  key: "OPENAI_API_KEY",
+  name: "OpenAI",
+  description: "GPT models.",
+  category: "recommended" as const,
+  docsUrl: "https://platform.openai.com/docs",
+  oauth: "openai" as const
+};
+
+const plainMeta = {
+  key: "GROQ_API_KEY",
+  name: "Groq",
+  description: "Fast inference.",
+  category: "other" as const,
+  docsUrl: "https://console.groq.com/docs"
+};
+
+const renderCard = (meta: typeof oauthMeta | typeof plainMeta, isConfigured = false) =>
+  render(
+    <ThemeProvider theme={createTheme({ cssVariables: true })}>
+      <ProviderCard
+        secret={secret(isConfigured)}
+        meta={meta}
+        onConnect={jest.fn()}
+        onManage={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    </ThemeProvider>
+  );
+
+describe("ProviderCard OAuth variant", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOAuthConnection.mockReturnValue(oauthState({}));
+  });
+
+  it("shows a sign-in action for an OAuth provider that is not connected", () => {
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({ label: "OpenAI", canDisconnect: true })
+    );
+
+    renderCard(oauthMeta);
+
+    expect(
+      screen.getByRole("button", { name: /sign in with openai/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/connected via oauth/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the OAuth pill and a disconnect action when connected", async () => {
+    const disconnect = jest.fn();
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({
+        label: "OpenAI",
+        isConnected: true,
+        canDisconnect: true,
+        disconnect
+      })
+    );
+
+    renderCard(oauthMeta);
+
+    expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
+    const disconnectButton = screen.getByRole("button", {
+      name: /disconnect/i
+    });
+    await userEvent.click(disconnectButton);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides disconnect for a connected provider that does not support it", () => {
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({ label: "HuggingFace", isConnected: true, canDisconnect: false })
+    );
+
+    renderCard(oauthMeta);
+
+    expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /disconnect/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no OAuth affordances for a non-OAuth provider", () => {
+    renderCard(plainMeta);
+
+    expect(
+      screen.queryByRole("button", { name: /sign in with/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/connected via oauth/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/__tests__/useOAuthConnection.test.tsx
+++ b/web/src/hooks/__tests__/useOAuthConnection.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useOAuthConnection } from "../useOAuthConnection";
+import { restFetch } from "../../lib/rest-fetch";
+import { useNotificationStore } from "../../stores/NotificationStore";
+
+jest.mock("../../lib/rest-fetch");
+jest.mock("../../lib/env", () => ({ isElectron: false }));
+jest.mock("../../stores/NotificationStore");
+
+const mockRestFetch = restFetch as jest.MockedFunction<typeof restFetch>;
+const mockAddNotification = jest.fn();
+
+const jsonResponse = (body: unknown, ok = true): Response =>
+  ({ ok, json: async () => body }) as unknown as Response;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+};
+
+describe("useOAuthConnection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNotificationStore as unknown as jest.Mock).mockImplementation(
+      (selector: (state: unknown) => unknown) =>
+        selector({ addNotification: mockAddNotification })
+    );
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens")) return jsonResponse({ tokens: [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({ auth_url: "https://example.com/auth" });
+      if (url.endsWith("/disconnect")) return jsonResponse({});
+      return jsonResponse({});
+    });
+  });
+
+  it("stays inert and issues no request when provider is null", async () => {
+    const { result } = renderHook(() => useOAuthConnection(null), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.canDisconnect).toBe(false);
+    expect(result.current.label).toBe("");
+    // Give any (unexpected) query a tick to fire.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockRestFetch).not.toHaveBeenCalled();
+  });
+
+  it("reports connected once the backend returns a token", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens"))
+        return jsonResponse({ tokens: ["token-1"] });
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("openai"), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+    expect(result.current.label).toBe("OpenAI");
+    expect(result.current.canDisconnect).toBe(true);
+  });
+
+  it("opens the auth URL when connect() is called", async () => {
+    const openSpy = jest
+      .spyOn(window, "open")
+      .mockReturnValue(null as unknown as Window);
+
+    const { result } = renderHook(() => useOAuthConnection("hf"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(mockRestFetch).toHaveBeenCalledWith("/api/oauth/hf/start");
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/auth",
+      "_blank",
+      expect.stringContaining("noopener")
+    );
+    openSpy.mockRestore();
+  });
+
+  it("calls the disconnect endpoint for a provider that supports it", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens"))
+        return jsonResponse({ tokens: ["token-1"] });
+      if (url.endsWith("/disconnect")) return jsonResponse({});
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("openai"), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockRestFetch).toHaveBeenCalledWith("/api/oauth/openai/disconnect", {
+      method: "POST"
+    });
+  });
+
+  it("does not support disconnect for HuggingFace", async () => {
+    const { result } = renderHook(() => useOAuthConnection("hf"), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current.canDisconnect).toBe(false);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    // Only the token poll may have fired; no disconnect request.
+    expect(
+      mockRestFetch.mock.calls.some(([input]) =>
+        String(input).endsWith("/disconnect")
+      )
+    ).toBe(false);
+  });
+});

--- a/web/src/hooks/useOAuthConnection.ts
+++ b/web/src/hooks/useOAuthConnection.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { restFetch } from "../lib/rest-fetch";
+import { isElectron } from "../lib/env";
+import { useNotificationStore } from "../stores/NotificationStore";
+
+export type OAuthProvider = "openai" | "hf";
+
+interface OAuthProviderConfig {
+  label: string;
+  /** Whether the backend exposes a disconnect endpoint for this provider. */
+  canDisconnect: boolean;
+}
+
+const PROVIDER_CONFIG: Record<OAuthProvider, OAuthProviderConfig> = {
+  openai: { label: "OpenAI", canDisconnect: true },
+  hf: { label: "HuggingFace", canDisconnect: false }
+};
+
+interface TokensResponse {
+  tokens: unknown[];
+}
+
+export interface OAuthConnection {
+  /** Provider label for UI (e.g. "OpenAI"). */
+  label: string;
+  /** True once the backend reports at least one stored token. */
+  isConnected: boolean;
+  /** True while an OAuth flow is in progress and we're polling for the token. */
+  isConnecting: boolean;
+  /** Whether disconnect is supported for this provider. */
+  canDisconnect: boolean;
+  /** Open the provider's OAuth flow and poll for completion. */
+  connect: () => Promise<void>;
+  /** Revoke stored tokens (no-op when unsupported). */
+  disconnect: () => Promise<void>;
+}
+
+/**
+ * OAuth connection state for a provider, extracted from the settings menus so
+ * it can drive the provider cards. Pass `null` to keep the hook inert (no
+ * request, never connected) — lets a card call it unconditionally.
+ */
+export const useOAuthConnection = (
+  provider: OAuthProvider | null
+): OAuthConnection => {
+  const queryClient = useQueryClient();
+  const addNotification = useNotificationStore((state) => state.addNotification);
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const config = provider ? PROVIDER_CONFIG[provider] : null;
+  const tokenQueryKey = useMemo(() => ["oauth-token", provider], [provider]);
+
+  const { data, isError } = useQuery({
+    queryKey: tokenQueryKey,
+    queryFn: async () => {
+      const response = await restFetch(`/api/oauth/${provider}/tokens`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${config?.label} token`);
+      }
+      return (await response.json()) as TokensResponse;
+    },
+    enabled: provider !== null,
+    refetchInterval: (query) => {
+      const current = query.state.data as TokensResponse | undefined;
+      if (isConnecting && !(current?.tokens && current.tokens.length > 0)) {
+        return 2000;
+      }
+      return false;
+    },
+    retry: true
+  });
+
+  const isConnected = !!(data?.tokens && data.tokens.length > 0);
+
+  // Resolve the connecting state once the token lands (or the poll errors).
+  useEffect(() => {
+    if (!isConnecting || !config) {
+      return;
+    }
+    if (isConnected) {
+      setIsConnecting(false);
+      addNotification({
+        content: `Successfully connected to ${config.label}`,
+        type: "success",
+        alert: true
+      });
+    } else if (isError) {
+      setIsConnecting(false);
+      addNotification({
+        content: `Failed to check ${config.label} connection`,
+        type: "error",
+        alert: true
+      });
+    }
+  }, [isConnecting, isConnected, isError, addNotification, config]);
+
+  const connect = useCallback(async () => {
+    if (!provider || !config) {
+      return;
+    }
+    setIsConnecting(true);
+    try {
+      const response = await restFetch(`/api/oauth/${provider}/start`);
+      const body = (await response.json().catch(() => null)) as
+        | { auth_url?: string; detail?: string }
+        | null;
+
+      if (!response.ok || !body?.auth_url) {
+        throw new Error(body?.detail || "Failed to start OAuth flow");
+      }
+
+      const authUrl = body.auth_url;
+      if (isElectron && window.api?.shell?.openExternal) {
+        await window.api.shell.openExternal(authUrl);
+      } else {
+        window.open(
+          authUrl,
+          "_blank",
+          "noopener,noreferrer,width=600,height=700"
+        );
+      }
+    } catch (error) {
+      setIsConnecting(false);
+      addNotification({
+        content:
+          error instanceof Error
+            ? error.message
+            : `Failed to initiate ${config.label} login`,
+        type: "error",
+        alert: true
+      });
+    }
+  }, [provider, config, addNotification]);
+
+  const disconnect = useCallback(async () => {
+    if (!provider || !config?.canDisconnect) {
+      return;
+    }
+    try {
+      const response = await restFetch(`/api/oauth/${provider}/disconnect`, {
+        method: "POST"
+      });
+      if (!response.ok) {
+        throw new Error("Failed to disconnect");
+      }
+      await queryClient.invalidateQueries({ queryKey: tokenQueryKey });
+      addNotification({
+        content: `Disconnected from ${config.label}`,
+        type: "success",
+        alert: true
+      });
+    } catch {
+      addNotification({
+        content: `Failed to disconnect from ${config.label}`,
+        type: "error",
+        alert: true
+      });
+    }
+  }, [provider, config, addNotification, queryClient, tokenQueryKey]);
+
+  return {
+    label: config?.label ?? "",
+    isConnected,
+    isConnecting,
+    canDisconnect: config?.canDisconnect ?? false,
+    connect,
+    disconnect
+  };
+};


### PR DESCRIPTION
## What & why

OAuth sign-in for HuggingFace and OpenAI lived in a separate section of the remote-settings panel, disconnected from where users manage those same providers' API keys. This moves OAuth onto the provider cards in the **API Keys** tab, so a provider's key and its OAuth connection sit together.

## Changes

- **New `useOAuthConnection` hook** (`web/src/hooks/useOAuthConnection.ts`) — extracts the token poll, connect flow (opens the auth URL via Electron IPC or a popup window), and disconnect. Takes `"openai" | "hf" | null`; `null` keeps it inert so a card can call it unconditionally.
- **`APIKeysTab.tsx`** — `ProviderMeta` gains `oauth?: "openai" | "hf"` (set on OpenAI and HuggingFace). `ProviderCard` now renders a **"Sign in with &lt;Provider&gt;"** action, a **"Connected via OAuth"** pill, and **Disconnect** where supported (OpenAI only — HuggingFace has no disconnect endpoint).
- **`RemoteSettingsMenu.tsx`** — removed both OAuth sections and all related state/queries/effects/handlers and now-unused imports.
- **`SettingsMenu.tsx`** — removed the `huggingface-oauth` sidebar item.
- **Tests** — `useOAuthConnection.test.tsx` (inert-when-null, connected state, connect opens auth URL, disconnect gated by provider support) and `ProviderCard.test.tsx` (OAuth variant: sign-in action, pill, disconnect, and no affordances for non-OAuth providers).

## Testing

Local dep install was still finishing when this was pushed; `npm run typecheck`, `npm run lint`, and the web tests run in CI. Will follow up with fixes if anything fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)