### PR TITLE
[T-20260705-0015] WS5: Structural primitive sweeps (FlexRow/ScrollArea/TruncatedText/composites)

### DIFF
--- a/web/src/components/sketch/Inspector/CreateGeneratedLayerDialog.tsx
+++ b/web/src/components/sketch/Inspector/CreateGeneratedLayerDialog.tsx
@@ -298,14 +298,7 @@ const CreateGeneratedLayerDialogBody: React.FC<{
                     >
                       <FlexColumn gap={0.5}>
                         <FlexRow align="center" gap={1}>
-                          <Label
-                            sx={{
-                              flex: 1,
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap"
-                            }}
-                          >
+                          <Label noWrap sx={{ flex: 1 }}>
                             {w.name}
                           </Label>
                           <Caption color="secondary">
@@ -314,14 +307,7 @@ const CreateGeneratedLayerDialogBody: React.FC<{
                           </Caption>
                         </FlexRow>
                         {w.description && (
-                          <Caption
-                            color="secondary"
-                            sx={{
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap"
-                            }}
-                          >
+                          <Caption color="secondary" noWrap>
                             {w.description}
                           </Caption>
                         )}

--- a/web/src/components/sketch/Inspector/GeneratedLayerHeader.tsx
+++ b/web/src/components/sketch/Inspector/GeneratedLayerHeader.tsx
@@ -44,14 +44,7 @@ export const GeneratedLayerHeader: React.FC<GeneratedLayerHeaderProps> = memo(
     return (
       <FlexColumn gap={1} sx={{ px: 1, pt: 0.5, pb: 0.5 }}>
         <FlexRow align="center" gap={1}>
-          <Label
-            sx={{
-              flex: 1,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap"
-            }}
-          >
+          <Label noWrap sx={{ flex: 1 }}>
             {layer.name}
           </Label>
           <StatusIndicator

--- a/web/src/components/sketch/Inspector/ImportedLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/ImportedLayerPanel.tsx
@@ -32,14 +32,7 @@ export const ImportedLayerPanel: React.FC<ImportedLayerPanelProps> = memo(
         <FlexColumn gap={0}>
           <FlexColumn gap={0.5} sx={{ px: 1, pt: 0.5, pb: 0.5 }}>
             <FlexRow align="center" gap={1}>
-              <Label
-                sx={{
-                  flex: 1,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap"
-                }}
-              >
+              <Label noWrap sx={{ flex: 1 }}>
                 {layer.name}
               </Label>
             </FlexRow>

--- a/web/src/components/sketch/Inspector/PaintedLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/PaintedLayerPanel.tsx
@@ -37,14 +37,7 @@ export const PaintedLayerPanel: React.FC<PaintedLayerPanelProps> = memo(
         <FlexColumn gap={0}>
           <FlexColumn gap={0.5} sx={{ px: 1, pt: 0.5, pb: 0.5 }}>
             <FlexRow align="center" gap={1}>
-              <Label
-                sx={{
-                  flex: 1,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap"
-                }}
-              >
+              <Label noWrap sx={{ flex: 1 }}>
                 {layer.name}
               </Label>
             </FlexRow>

--- a/web/src/components/sketch/Inspector/SketchInspector.tsx
+++ b/web/src/components/sketch/Inspector/SketchInspector.tsx
@@ -18,7 +18,7 @@ import { useTheme } from "@mui/material/styles";
 import { useSketchStore } from "../state/useSketchStore";
 import { useLayerBinding } from "../../../stores/sketch/SketchSessionStore";
 import { SKETCH_SIZE } from "../sketchStyles";
-import { EmptyState, Box } from "../../ui_primitives";
+import { EmptyState, ScrollArea } from "../../ui_primitives";
 import { GeneratedLayerPanel } from "./GeneratedLayerPanel";
 import { ImportedLayerPanel } from "./ImportedLayerPanel";
 import { PaintedLayerPanel } from "./PaintedLayerPanel";
@@ -71,7 +71,7 @@ const SketchInspectorInner: React.FC = () => {
   }
 
   return (
-    <Box
+    <ScrollArea
       className="sketch-inspector"
       sx={{
         width: SKETCH_SIZE.panelWidth,
@@ -79,7 +79,6 @@ const SketchInspectorInner: React.FC = () => {
         maxWidth: SKETCH_SIZE.panelWidth,
         flex: 1,
         minHeight: 0,
-        overflowY: "auto",
         // Recessed, darker well for the generate/inspect content so previews
         // and generated output read against a near-black surface (darker than
         // the surrounding `paper` panel).
@@ -89,7 +88,7 @@ const SketchInspectorInner: React.FC = () => {
       }}
     >
       {body}
-    </Box>
+    </ScrollArea>
   );
 };
 


### PR DESCRIPTION
Committed. Here's the summary for the PR.

## WS5 sweep, PR 2 — `sketch/Inspector/`

Continued the gradual structural-primitive sweep (PR 1 was `costs/`). A balanced-brace scan of JSX `sx={{…}}` blocks across `web/src/components` reconfirmed the prior run's finding: the truly convertible `<Box sx={{display:"flex"}}>` population is tiny and scattered (most `display:flex` lives in emotion `css()` blocks). The best remaining non-primitive cluster was `sketch/Inspector/` for the *other* two categories — `overflow:auto` and hand-rolled `textOverflow`. `display:flex` there was already fully on `FlexRow`/`FlexColumn`.

**Changed files:**
- `ImportedLayerPanel`, `PaintedLayerPanel`, `GeneratedLayerHeader`, `CreateGeneratedLayerDialog` — replaced 5 hand-rolled ellipsis triples (`overflow:hidden` + `textOverflow:ellipsis` + `whiteSpace:nowrap`) with the MUI `noWrap` prop.
- `SketchInspector` — converted the one bare `<Box>` scroll container (`overflowY:auto`) to `<ScrollArea>`.

Net: 44 deletions / 8 insertions.

**Decisions / caveats:**
- The ellipsis sites sit on `Label`/`Caption` primitives (Typography wrappers that forward props), **not** bare `Typography` — so `TruncatedText` was the wrong tool (it would discard the primitive's semantics and sizing). `noWrap` is the built-in idiom that clears the DESIGN.md "by hand" violation without changing rendering.
- Deliberately **kept** the 4 remaining `overflow:auto` sites: 3 are on `<Panel sx>` (`Panel` is already a primitive surface with padding/bg/border — swapping to `ScrollArea` would drop the surface look) and 1 is inside an emotion `css()` block, not `sx`.
- **Checks not run locally:** this sandbox has no repo `node_modules` (install fails in the proxied environment, per the CLAUDE.md pitfall). The changes are mechanical and low-risk; `typecheck`/`lint`/`test` will run in CI. The workstream-spanning acceptance criteria (FlexRow-only-where-it-shrinks, the optional `display:flex` warn rule) remain intentionally open — this is a gradual, multi-PR sweep.

---

Closes task **T-20260705-0015**: WS5: Structural primitive sweeps (FlexRow/ScrollArea/TruncatedText/composites).


### Acceptance criteria
- [x] Targeted sweeps land per-directory with reviewable diffs
- [ ] FlexRow/FlexColumn used only where they shrink code; Box kept where heavy sx remains
- [ ] overflow:auto and textOverflow sites in swept directories migrated
- [ ] Optional low-noise display:flex warn rule considered only after the sweep
- [ ] Each PR: npm run typecheck && npm run lint && npm run test pass