### PR TITLE
[T-20260705-0007] WS2: Migrate borderRadius magic values to tokens

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,16 +21,18 @@ Single reference for every design token and visual rule in NodeTool. All fronten
 (oxlint) can't express the design-token AST checks, so they run through ESLint
 as a dedicated gate: `web/eslint.design.config.mjs` (rules shared from
 `web/eslint.design.mjs`) is invoked by `npm run lint:design` and chained into
-the root `npm run lint`. `lint:design` also runs `web/scripts/lint-spacing-css.mjs`
-and `web/scripts/lint-font-color-css.mjs`, which extend the spacing, font-size,
-and color rules to plain `.css` files (ESLint only parses `.ts`/`.tsx`).
+the root `npm run lint`. `lint:design` also runs `web/scripts/lint-spacing-css.mjs`,
+`web/scripts/lint-font-color-css.mjs`, and `web/scripts/lint-radius-css.mjs`, which
+extend the spacing, font-size, color, and border-radius rules to plain `.css` files
+(ESLint only parses `.ts`/`.tsx`).
 **Spacing** (`padding`/`margin`/`gap`), **`fontWeight`**, **font size**
 (`design-tokens/font-size-tokens`), **color** (`design-tokens/color-tokens`),
-raw-MUI imports (`design-tokens/no-raw-mui`), and **ui_primitives barrel imports**
+**border radius** (`design-tokens/border-radius-tokens`), raw-MUI imports
+(`design-tokens/no-raw-mui`), and **ui_primitives barrel imports**
 (`no-restricted-imports` — deep `.../ui_primitives/Foo` paths must go through the
 barrel) have reached zero violations and are promoted to **`error`** to lock them
-in — a new raw px/rem font size, raw hex/rgb color, or deep primitive import fails
-the gate. The remaining categories (`borderRadius`, `zIndex`,
+in — a new raw px/rem font size, raw hex/rgb color, magic/`var(--rounded-*)` radius,
+or deep primitive import fails the gate. The remaining categories (`zIndex`,
 `transition`/`MOTION`) are still **warnings**; promote each to `error` the same
 way as it reaches zero.
 
@@ -435,6 +437,10 @@ borderRadius: `${BORDER_RADIUS.sm} ${BORDER_RADIUS.sm} 0 0`
 ### Forbidden
 
 Magic numbers: `1`, `3`, `4`, `7`, `10`, `18`, `20`. Raw `"var(--rounded-*)"` string literals in TSX where a `BORDER_RADIUS` constant or `theme.rounded.*` key exists (plain `.css` files use the vars — that's what they're for). For circles, use `BORDER_RADIUS.circle` not `"50%"`.
+
+### Enforcement (border radius is fully linted)
+
+Zero violations — locked in at **`error`**. In TSX, `design-tokens/border-radius-tokens` flags any object-literal `borderRadius` that is a magic number, a raw `Npx` string, or a raw `var(--rounded-*)` string; `0` (flush) is allowed. In plain `.css`, `scripts/lint-radius-css.mjs` flags any `border-radius` with a raw px/em/rem/% value (use `var(--rounded-*)`; `0` allowed). The one sanctioned raw value is `theme.shape.borderRadius` in `ThemeNodetool.tsx` — MUI's base multiplier, carrying a scoped `eslint-disable`.
 
 ---
 

--- a/web/eslint.design.config.mjs
+++ b/web/eslint.design.config.mjs
@@ -64,6 +64,10 @@ export default [
       // errors. See docs/DESIGN.md §1 (font size) and §3 (color).
       "design-tokens/font-size-tokens": "error",
       "design-tokens/color-tokens": "error",
+      // Border radius is fully migrated (zero violations) — locked in as an
+      // error so any new raw/magic/var(--rounded-*) radius fails the gate. See
+      // docs/DESIGN.md §4.
+      "design-tokens/border-radius-tokens": "error",
     },
   },
 ];

--- a/web/eslint.design.mjs
+++ b/web/eslint.design.mjs
@@ -180,28 +180,12 @@ export const noRestrictedSyntax = [
     message:
       "Use a MOTION token (MOTION.fast/normal/slow/all/…) instead of a hardcoded transition string. See ui_primitives/tokens.ts.",
   },
-  {
-    // borderRadius: "8px" → use a BORDER_RADIUS token (var(--rounded-*)).
-    selector:
-      "Property[key.name='borderRadius'] > Literal[value=/[1-9][0-9]*px$/]",
-    message:
-      "Use a BORDER_RADIUS token (xs/sm/md/lg/xl/xxl/pill/circle) instead of a hardcoded px radius. See ui_primitives/tokens.ts.",
-  },
-  {
-    // borderRadius: 8 (magic number) → use a BORDER_RADIUS token. The px-string
-    // rule above misses numeric literals; 0 (flush) is allowed.
-    selector: "Property[key.name='borderRadius'] > Literal[value>0]",
-    message:
-      "Use a BORDER_RADIUS token (xs/sm/md/lg/xl/xxl/pill/circle) instead of a magic-number radius. See ui_primitives/tokens.ts and docs/DESIGN.md §4.",
-  },
-  {
-    // borderRadius: "var(--rounded-lg)" raw string → use the BORDER_RADIUS
-    // constant (or theme.rounded.* for semantic aliases) in TSX.
-    selector:
-      "Property[key.name='borderRadius'] > Literal[value=/var\\(--rounded/]",
-    message:
-      "Use a BORDER_RADIUS constant (or theme.rounded.*) instead of a raw var(--rounded-*) string in TSX. See docs/DESIGN.md §4.",
-  },
+  // NOTE: borderRadius is NOT handled here. It graduated to the dedicated
+  // `design-tokens/border-radius-tokens` custom rule (at `error`, fully
+  // migrated) so it can lock in while the transition/zIndex selectors below
+  // remain `warn`. A single `no-restricted-syntax` rule can only carry one
+  // severity, so a category that reaches zero moves to its own rule. See
+  // eslint.design.mjs → borderRadiusTokensRule and docs/DESIGN.md §4.
   // NOTE: Font size is NOT handled here. The `design-tokens/font-size-tokens`
   // custom rule below covers object props AND px/rem inside `styled`/`css`
   // template literals, and (per DESIGN.md §1) deliberately allows `em` for icon
@@ -562,12 +546,68 @@ export const noRawMuiRule = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Border-radius custom rule (DESIGN.md §4 — BORDER_RADIUS / theme.rounded.*).
+//
+// Graduated out of `no-restricted-syntax` (where it lived as three warn-level
+// selectors) into a dedicated rule so it can run at `error` while the still-
+// migrating transition/zIndex selectors stay `warn` on the shared rule. The
+// matching mirrors the original selectors exactly — object-literal `borderRadius`
+// properties only, not `border-radius` inside `styled`/`css` template literals
+// (those are unmigrated backlog, tracked separately). `0` (flush) is allowed.
+// ---------------------------------------------------------------------------
+
+const BORDER_RADIUS_MESSAGE =
+  "Use a BORDER_RADIUS token (xs/sm/md/lg/xl/xxl/pill/circle) or theme.rounded.* instead of a hardcoded/magic-number/raw var(--rounded-*) radius. See ui_primitives/tokens.ts and docs/DESIGN.md §4.";
+
+// A raw px radius as a string value (e.g. "8px", "1.5px"); matches anywhere in
+// the string, mirroring the original esquery `/[1-9][0-9]*px$/` selector.
+const BORDER_RADIUS_PX = /[1-9][0-9]*px$/;
+
+export const borderRadiusTokensRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce BORDER_RADIUS / theme.rounded.* tokens for borderRadius (DESIGN.md §4).",
+    },
+    schema: [],
+    messages: { raw: BORDER_RADIUS_MESSAGE },
+  },
+  create(context) {
+    const keyName = (key) => {
+      if (!key) return null;
+      if (key.type === "Identifier") return key.name;
+      if (key.type === "Literal") return String(key.value);
+      return null;
+    };
+    return {
+      Property(node) {
+        if (keyName(node.key) !== "borderRadius") return;
+        const value = node.value;
+        if (value.type !== "Literal") return;
+        const v = value.value;
+        if (typeof v === "number") {
+          if (v > 0) context.report({ node: value, messageId: "raw" });
+          return;
+        }
+        if (typeof v === "string") {
+          if (BORDER_RADIUS_PX.test(v) || /var\(--rounded/.test(v)) {
+            context.report({ node: value, messageId: "raw" });
+          }
+        }
+      },
+    };
+  },
+};
+
 // Local plugin exposing the design-token rules for the gate config.
 export const designTokensPlugin = {
   rules: {
     "spacing-tokens": spacingTokensRule,
     "font-size-tokens": fontSizeTokensRule,
     "color-tokens": colorTokensRule,
+    "border-radius-tokens": borderRadiusTokensRule,
     "no-raw-mui": noRawMuiRule,
   },
 };

--- a/web/package.json
+++ b/web/package.json
@@ -89,8 +89,8 @@
     "lint:fix": "oxlint src --fix",
     "lint:eslint": "eslint src",
     "lint:eslint:fix": "eslint src --fix",
-    "lint:design": "eslint --config eslint.design.config.mjs src && node scripts/lint-spacing-css.mjs && node scripts/lint-font-color-css.mjs",
-    "lint:design:fix": "eslint --config eslint.design.config.mjs src --fix && node scripts/lint-spacing-css.mjs && node scripts/lint-font-color-css.mjs",
+    "lint:design": "eslint --config eslint.design.config.mjs src && node scripts/lint-spacing-css.mjs && node scripts/lint-font-color-css.mjs && node scripts/lint-radius-css.mjs",
+    "lint:design:fix": "eslint --config eslint.design.config.mjs src --fix && node scripts/lint-spacing-css.mjs && node scripts/lint-font-color-css.mjs && node scripts/lint-radius-css.mjs",
     "check": "tsc && eslint src && jest",
     "test": "TZ=UTC jest --forceExit",
     "test:summary": "jest --reporters=\"summary\" --forceExit",
@@ -108,7 +108,8 @@
     "screenshots": "playwright test tests/benchmarks/screenshots.spec.ts --project=chromium",
     "screenshots:force": "FORCE_SCREENSHOTS=true playwright test tests/benchmarks/screenshots.spec.ts --project=chromium",
     "lint:spacing-css": "node scripts/lint-spacing-css.mjs",
-    "lint:font-color-css": "node scripts/lint-font-color-css.mjs"
+    "lint:font-color-css": "node scripts/lint-font-color-css.mjs",
+    "lint:radius-css": "node scripts/lint-radius-css.mjs"
   },
   "browserslist": {
     "production": [

--- a/web/scripts/lint-radius-css.mjs
+++ b/web/scripts/lint-radius-css.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Border-radius gate for plain .css files (DESIGN.md §4).
+//
+// ESLint's design gate only parses .ts/.tsx, so raw border-radius in .css files
+// goes unchecked. This script closes that gap, mirroring lint-spacing-css.mjs:
+// every `border-radius` declaration must use a --rounded-* custom property
+// (defined in ThemeNodetool.tsx MuiCssBaseline), never a raw px/em/rem/%
+// literal. `0` (flush) and keywords (`inherit`, `initial`, …) are allowed.
+//
+// Run: node scripts/lint-radius-css.mjs  (wired into `npm run lint:design`).
+// Exits 1 when any violation is found so it acts as a real gate.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const SRC = join(ROOT, "src");
+
+// Third-party stylesheets we vendor verbatim — not ours to tokenize.
+const VENDOR = [
+  /styles\/markdown\/github-markdown.*\.css$/,
+  /styles\/microtip\.css$/,
+];
+
+// `border-radius` and its longhands + vendor prefixes.
+const RADIUS_PROP =
+  /^(-webkit-|-moz-)?border-radius$|^border-(top|bottom)-(left|right)-radius$/;
+
+// A raw length/percentage in the value: e.g. 4px, 0.5em, 1.5px, 50%. `0` with
+// no unit is flush (allowed). A `0px` component inside a shorthand is fine too;
+// only *non-zero* magnitudes must become a token.
+const RAW_LEN = /(\d*\.?\d+)(px|em|rem|%)/g;
+
+// px → suggested --rounded-* token, for a helpful message.
+const PX_TO_TOKEN = {
+  2: "var(--rounded-xs)",
+  4: "var(--rounded-sm)",
+  6: "var(--rounded-md)",
+  8: "var(--rounded-lg)",
+  12: "var(--rounded-xl)",
+  16: "var(--rounded-xxl)",
+  20: "var(--rounded-dialog)",
+  9999: "var(--rounded-pill)",
+};
+const STEPS = [2, 4, 6, 8, 12, 16, 20, 9999];
+
+const nearestToken = (px) => {
+  let best = STEPS[0];
+  for (const s of STEPS) {
+    if (Math.abs(s - px) < Math.abs(best - px)) best = s;
+  }
+  return PX_TO_TOKEN[best];
+};
+
+function walk(dir, out) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (name.endsWith(".css")) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(SRC, []).filter(
+  (f) => !VENDOR.some((re) => re.test(f.replace(/\\/g, "/")))
+);
+
+const violations = [];
+
+for (const file of files) {
+  const text = readFileSync(file, "utf8");
+  const lines = text.split("\n");
+  lines.forEach((line, i) => {
+    // Strip inline `/* … */` comments to avoid false hits.
+    const code = line.replace(/\/\*.*?\*\//g, "");
+    const m = code.match(/(^|[;{])\s*([a-z-]+)\s*:\s*([^;{}]*)/i);
+    if (!m) return;
+    const prop = m[2].toLowerCase();
+    if (prop.startsWith("--")) return; // variable definitions
+    if (!RADIUS_PROP.test(prop)) return;
+    const value = m[3];
+    const matches = [...value.matchAll(RAW_LEN)];
+    const nonZero = matches.filter((x) => parseFloat(x[1]) !== 0);
+    if (nonZero.length === 0) return;
+    violations.push({
+      file: relative(ROOT, file),
+      line: i + 1,
+      prop,
+      value: value.trim(),
+      suggestion: nonZero
+        .map((x) => {
+          const n = parseFloat(x[1]);
+          if (x[2] === "%") return `${x[0]}→var(--rounded-circle)`;
+          const px = x[2] === "px" ? n : n * 16; // rough em/rem→px
+          return `${x[0]}→${nearestToken(px)}`;
+        })
+        .join(", "),
+    });
+  });
+}
+
+if (violations.length === 0) {
+  console.log("✓ radius-css: no raw border-radius in .css files");
+  process.exit(0);
+}
+
+console.error(
+  `✗ radius-css: ${violations.length} raw border-radius value(s) in .css files (use var(--rounded-*) — defined in ThemeNodetool.tsx):\n`
+);
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}  ${v.prop}: ${v.value}`);
+  console.error(`      → ${v.suggestion}`);
+}
+console.error(`\n${violations.length} violation(s).`);
+process.exit(1);

--- a/web/src/components/assets/assetGridStyles.ts
+++ b/web/src/components/assets/assetGridStyles.ts
@@ -75,7 +75,7 @@ export const assetGridStyles = (theme: Theme) => {
       alignItems: "center",
       padding: `${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.sm)}`,
       marginLeft: 0,
-      borderRadius: 5
+      borderRadius: BORDER_RADIUS.sm
     },
     ".folder-icon": {
       marginRight: "0.1em",
@@ -170,7 +170,7 @@ export const assetGridStyles = (theme: Theme) => {
         height: "30%",
         maxHeight: "100px",
         backgroundColor: theme.vars.palette.grey[300],
-        borderRadius: "1px",
+        borderRadius: BORDER_RADIUS.xs,
         opacity: 0.6,
         transition: `${MOTION.background}, ${MOTION.opacity}`
       },
@@ -190,7 +190,7 @@ export const assetGridStyles = (theme: Theme) => {
         maxWidth: "100px",
         height: "2px",
         backgroundColor: theme.vars.palette.grey[300],
-        borderRadius: "1px",
+        borderRadius: BORDER_RADIUS.xs,
         opacity: 0.6,
         transition: `${MOTION.background}, ${MOTION.opacity}`
       },

--- a/web/src/components/chat/thread/ThreadList.styles.ts
+++ b/web/src/components/chat/thread/ThreadList.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
-import { scrollbarStyles, MOTION } from "../../ui_primitives";
+import { scrollbarStyles, MOTION, BORDER_RADIUS } from "../../ui_primitives";
 import { SPACING, getSpacingPx } from "../../ui_primitives";
 
 export const createStyles = (theme: Theme) =>
@@ -50,7 +50,7 @@ export const createStyles = (theme: Theme) =>
       width: "100%",
       cursor: "pointer",
       transition: `${MOTION.background}, opacity ${MOTION.normal}, transform ${MOTION.normal}, max-height ${MOTION.normal}`,
-      borderRadius: 5,
+      borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
       outline: "none",
       backgroundColor: "transparent",

--- a/web/src/components/costs/CostsDashboard.tsx
+++ b/web/src/components/costs/CostsDashboard.tsx
@@ -64,7 +64,7 @@ const segmentedSx = (theme: Theme): SxProps<Theme> => ({
   gap: getSpacingPx(SPACING.micro),
   "& .MuiToggleButton-root": {
     border: "none",
-    borderRadius: "var(--rounded-md) !important",
+    borderRadius: `${BORDER_RADIUS.md} !important`,
     color: theme.vars.palette.text.secondary,
     textTransform: "none",
     fontSize: "var(--fontSizeSmall)",

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -16,7 +16,7 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
     "& .MuiTabs-indicator": {
       backgroundColor: "var(--palette-primary-main)",
       height: "3px",
-      borderRadius: "1.5px"
+      borderRadius: BORDER_RADIUS.xs
     },
     "& .MuiTab-root": {
       color: theme.vars.palette.grey[200],

--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -193,7 +193,7 @@ const getAmbientRingCss = (color: string) =>
   css({
     position: "absolute",
     inset: 0,
-    borderRadius: "var(--rounded-node)",
+    borderRadius: BORDER_RADIUS.lg,
     pointerEvents: "none",
     // Pure box-shadow halo (no fill), so it only paints outside the node body
     // regardless of stacking order — robust to whether the container is a
@@ -252,7 +252,7 @@ const getNodeStyles = (colors: string[]) =>
         ${colors[4]},
         ${colors[0]}
       )`,
-        borderRadius: "var(--rounded-node)",
+        borderRadius: BORDER_RADIUS.lg,
         zIndex: -20,
         pointerEvents: "none",
         // Show only a thin ring (border area), not full fill

--- a/web/src/components/node/GroupNode.tsx
+++ b/web/src/components/node/GroupNode.tsx
@@ -172,7 +172,7 @@ const styles = (theme: Theme, minWidth: number, minHeight: number) =>
       ".bypass-button, .menu-button": {
         border: "none !important",
         backgroundColor: `${theme.vars.palette.c_overlay} !important`,
-        borderRadius: "var(--rounded-circle) !important",
+        borderRadius: `${BORDER_RADIUS.circle} !important`,
         color: `${theme.vars.palette.c_white} !important`,
         width: "28px !important",
         height: "28px !important",

--- a/web/src/components/node/NodeHeader.tsx
+++ b/web/src/components/node/NodeHeader.tsx
@@ -93,8 +93,7 @@ const NodeHeaderImpl: React.FC<NodeHeaderProps> = ({
         color: "var(--palette-text-secondary)",
         margin: 0,
         padding: 0,
-        borderRadius:
-          "calc(var(--rounded-node) - 1px) calc(var(--rounded-node) - 1px) 0 0",
+        borderRadius: `calc(${BORDER_RADIUS.lg} - 1px) calc(${BORDER_RADIUS.lg} - 1px) 0 0`,
         borderBottom: "none",
         transition: `background-color ${MOTION.normal}, opacity ${MOTION.fast}`,
         ".header-left": {

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -16,7 +16,7 @@ import { isConnectableCached } from "../node_menu/typeFilterUtils";
 import HandleTooltip from "../HandleTooltip";
 import { NodeData } from "../../stores/NodeData";
 import usePropertyValidationStore from "../../stores/PropertyValidationStore";
-import { Tooltip } from "../ui_primitives";
+import { Tooltip, BORDER_RADIUS } from "../ui_primitives";
 import useModelCalloutStore from "../../stores/ModelCalloutStore";
 import { isModelEmpty } from "../../utils/findMissingModelNodes";
 import ModelSetupCallout from "./ModelSetupCallout";
@@ -33,7 +33,7 @@ const highlightBlink = keyframes({
 });
 
 const highlightStyle = css({
-  borderRadius: "var(--rounded-buttonSmall)",
+  borderRadius: BORDER_RADIUS.sm,
   outline: "2px solid var(--palette-primary-light)",
   outlineOffset: 2,
   // Blink the outline + glow fully on and off to draw the eye to an unset

--- a/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
+++ b/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
@@ -36,7 +36,11 @@ import SkipNextIcon from "@mui/icons-material/SkipNext";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import VolumeOffIcon from "@mui/icons-material/VolumeOff";
 
-import { CheckerDropzone, ToolbarIconButton } from "../../ui_primitives";
+import {
+  CheckerDropzone,
+  ToolbarIconButton,
+  BORDER_RADIUS
+} from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import NumberInput from "../../inputs/NumberInput";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -109,7 +113,7 @@ const styles = (theme: Theme) =>
       position: "relative",
       flex: "1 1 auto",
       minHeight: 140,
-      borderRadius: "var(--rounded-sm)",
+      borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
       backgroundColor: theme.vars.palette.common.black,
       display: "flex",
@@ -129,7 +133,7 @@ const styles = (theme: Theme) =>
       height: 4,
       appearance: "none",
       background: theme.vars.palette.grey[700],
-      borderRadius: 2,
+      borderRadius: BORDER_RADIUS.xs,
       cursor: "pointer",
       margin: `${theme.spacing(0.25)} 0`,
       "&::-webkit-slider-thumb": {
@@ -197,7 +201,7 @@ const styles = (theme: Theme) =>
       fontVariantNumeric: "tabular-nums",
       color: theme.vars.palette.grey[100],
       padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
-      borderRadius: "var(--rounded-sm)",
+      borderRadius: BORDER_RADIUS.sm,
       backgroundColor: theme.vars.palette.grey[800]
     },
     ".outputs-row": {

--- a/web/src/components/portal/DashboardDownloads.tsx
+++ b/web/src/components/portal/DashboardDownloads.tsx
@@ -7,7 +7,7 @@ import { useShallow } from "zustand/react/shallow";
 import DownloadingIcon from "@mui/icons-material/Downloading";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
 import { wrapStyles } from "./dashboardChrome";
-import { MOTION, SPACING, getSpacingPx } from "../ui_primitives";
+import { MOTION, SPACING, getSpacingPx, BORDER_RADIUS } from "../ui_primitives";
 
 const ACTIVE_STATUSES = new Set(["pending", "running", "start", "progress"]);
 
@@ -32,7 +32,7 @@ const styles = (theme: Theme) =>
     ".downloads-bar": {
       width: 90,
       height: 4,
-      borderRadius: 2,
+      borderRadius: BORDER_RADIUS.xs,
       overflow: "hidden",
       background: theme.vars.palette.action.selected
     },

--- a/web/src/components/properties/shared/ModelSelectButton.tsx
+++ b/web/src/components/properties/shared/ModelSelectButton.tsx
@@ -3,7 +3,7 @@ import type { SxProps, Theme } from "@mui/material";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useEditorScope } from "../../editor_ui";
-import { FlexColumn, FlexRow, Text, Caption, Tooltip, EditorButton, MOTION, SPACING, getSpacingPx } from "../../ui_primitives";
+import { FlexColumn, FlexRow, Text, Caption, Tooltip, EditorButton, MOTION, SPACING, getSpacingPx, BORDER_RADIUS } from "../../ui_primitives";
 
 interface ModelSelectButtonProps {
   label: React.ReactNode;
@@ -67,7 +67,7 @@ const ModelSelectButton = memo(forwardRef<HTMLButtonElement, ModelSelectButtonPr
             backgroundColor: active
               ? "var(--palette-action-selected)"
               : "var(--palette-Paper-overlay)",
-            borderRadius: "var(--rounded-buttonSmall, 4px)",
+            borderRadius: BORDER_RADIUS.sm,
             color: "var(--palette-text-primary)",
             textTransform: "none",
             display: "flex",

--- a/web/src/components/themes/ThemeNodetool.tsx
+++ b/web/src/components/themes/ThemeNodetool.tsx
@@ -92,6 +92,11 @@ const ThemeNodetool = createTheme({
   },
   spacing: 4,
   shape: {
+    // MUI's base shape multiplier (unitless px) — the fallback radius for any
+    // MUI component that reads `theme.shape.borderRadius`. Not a BORDER_RADIUS
+    // token: component code uses BORDER_RADIUS.* / theme.rounded.*, this is the
+    // theme-level default those tokens are defined alongside.
+    // eslint-disable-next-line design-tokens/border-radius-tokens
     borderRadius: 6
   },
   zIndex: {

--- a/web/src/styles/command_menu.css
+++ b/web/src/styles/command_menu.css
@@ -71,7 +71,7 @@
   width: 3px;
   height: 20px;
   background: var(--palette-primary-main);
-  border-radius: 0 3px 3px 0;
+  border-radius: 0 var(--rounded-sm) var(--rounded-sm) 0;
   transition: all 150ms ease;
 }
 
@@ -102,7 +102,7 @@
 
 [cmdk-list]::-webkit-scrollbar-thumb {
   background-color: var(--palette-grey-100);
-  border-radius: 3px;
+  border-radius: var(--rounded-sm);
 }
 
 [cmdk-group-heading] {

--- a/web/src/styles/handle_edge_tooltip.css
+++ b/web/src/styles/handle_edge_tooltip.css
@@ -39,12 +39,12 @@
 }
 
 .MuiTooltip-tooltipPlacementLeft span {
-  border-radius: 4px 0 0 4px;
+  border-radius: var(--rounded-sm) 0 0 var(--rounded-sm);
   padding-right: var(--spacing-md);
 }
 
 .MuiTooltip-tooltipPlacementRight span {
-  border-radius: 0 4px 4px 0;
+  border-radius: 0 var(--rounded-sm) var(--rounded-sm) 0;
   padding-left: var(--spacing-md);
 }
 
@@ -264,12 +264,12 @@
 
 .react-flow__node .react-flow__handle.control-handle-top {
   top: -6px;
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--rounded-sm) var(--rounded-sm) 0 0;
 }
 
 .react-flow__node .react-flow__handle.control-handle-bottom {
   bottom: -6px;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--rounded-sm) var(--rounded-sm);
 }
 
 /* Control handle visibility */
@@ -313,7 +313,7 @@
   border-left: 1px solid var(--palette-grey-700);
   border-top: 1px solid var(--palette-grey-700);
   border-bottom: 1px solid var(--palette-grey-700);
-  border-radius: 2px 0 0 2px;
+  border-radius: var(--rounded-xs) 0 0 var(--rounded-xs);
 }
 .react-flow__node .react-flow__handle-right {
   transform-origin: left center;
@@ -322,7 +322,7 @@
   border-bottom: 1px solid var(--palette-grey-700);
   right: calc(-6px - var(--node-body-padding, 0px));
   top: 5px;
-  border-radius: 0 2px 2px 0;
+  border-radius: 0 var(--rounded-xs) var(--rounded-xs) 0;
 }
 
 /* handle hover */
@@ -364,7 +364,7 @@
 .react-flow__node .react-flow__handle-left.collect-handle {
   /* Wider handle to signify multiple inputs */
   height: calc(var(--handle_height) * 1.6);
-  border-radius: 3px 0 0 3px;
+  border-radius: var(--rounded-sm) 0 0 var(--rounded-sm);
   /* Double border effect for visual distinction */
   border-left-width: 3px;
   border-left-style: double;
@@ -402,7 +402,7 @@
 .react-flow__node .react-flow__handle-right.streaming-handle {
   /* Wider handle to signify streaming */
   height: calc(var(--handle_height) * 1.25);
-  border-radius: 0 4px 4px 0;
+  border-radius: 0 var(--rounded-sm) var(--rounded-sm) 0;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   position: relative;
   overflow: visible;

--- a/web/src/styles/interactions.css
+++ b/web/src/styles/interactions.css
@@ -26,7 +26,7 @@
   outline: none;
   border: 1px solid var(--palette-grey-100) !important;
   background-color: var(--palette-c_selection_rect) !important;
-  border-radius: 0.25em;
+  border-radius: var(--rounded-sm);
 }
 
 .react-flow .react-flow__pane.dragging {

--- a/web/src/styles/keyboard.css
+++ b/web/src/styles/keyboard.css
@@ -6,7 +6,7 @@
   /* background-color: var(--palette-background-default); */
   background-color: transparent;
   padding: .5em;
-  border-radius: 0.5em;
+  border-radius: var(--rounded-lg);
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 }
 .keyboard-view .hg-button {

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -22,7 +22,7 @@
     right: 0 !important;
     height: 96dvh !important;
     max-height: 96dvh !important;
-    border-radius: 12px 12px 0 0 !important;
+    border-radius: var(--rounded-xl) var(--rounded-xl) 0 0 !important;
   }
 
   /* Ensure the inner container scroll area fills available height */
@@ -632,7 +632,7 @@
   .mobile .chat-composer .compose-message {
     padding: var(--spacing-sm) var(--spacing-md) !important;
     margin-top: var(--spacing-md) !important;
-    border-radius: 20px !important;
+    border-radius: var(--rounded-dialog) !important;
     min-height: 88px !important;
   }
 
@@ -649,7 +649,7 @@
 
   .mobile .chat-composer .button-container button {
     padding: var(--spacing-xs) !important;
-    border-radius: 10px !important;
+    border-radius: var(--rounded-lg) !important;
   }
 
   .mobile .chat-composer .file-preview-container {

--- a/web/src/styles/properties.css
+++ b/web/src/styles/properties.css
@@ -40,7 +40,7 @@
    Hover the row to see the exact message via Tooltip. */
 .node-property.has-validation-error {
   position: relative;
-  border-radius: 4px;
+  border-radius: var(--rounded-sm);
   background:
     linear-gradient(
       to right,
@@ -56,7 +56,7 @@
   top: 4px;
   bottom: 4px;
   width: 2px;
-  border-radius: 2px;
+  border-radius: var(--rounded-xs);
   background-color: var(--palette-error-main, #f44336);
   box-shadow: 0 0 6px rgba(244, 67, 54, 0.55);
 }


### PR DESCRIPTION
Committed. Here's the summary of the work.

## Summary

Migrated all `borderRadius` magic values to design tokens (WS2 of the DESIGN.md migration plan) and locked the category in at `error`.

**TSX — 17 warnings across 12 files resolved.** Every flagged `borderRadius` now uses a `BORDER_RADIUS.*` token: magic numbers/px-strings → nearest token (`2`→`xs`, `5`→`sm`, `"1.5px"`→`xs`, …), raw `var(--rounded-*)` strings → the constant, and `!important`/`calc()` cases → template literals (`` `${BORDER_RADIUS.md} !important` ``, `` `calc(${BORDER_RADIUS.lg} - 1px) …` ``). Node-radius surfaces (BaseNode ring/glow, NodeHeader) use `BORDER_RADIUS.lg` since `--rounded-node === --rounded-lg === 8px` and `theme.rounded.node` isn't reachable inside module-level emotion `css()` factories.

**CSS — raw radii migrated in 6 files** (`command_menu`, `handle_edge_tooltip`, `interactions`, `keyboard`, `mobile`, `properties`) to `var(--rounded-*)`; only `0`/`inherit` remain.

**Promotion mechanism.** A single `no-restricted-syntax` rule carries one severity, so borderRadius couldn't go to `error` while zIndex/transition stay `warn`. Following the spacing/font/color precedent, I extracted the three borderRadius selectors into a dedicated `design-tokens/border-radius-tokens` custom rule (object-literal `borderRadius` only, mirroring the old selectors exactly so no new template-literal violations surface) set to `error`.

**Main files changed:**
- `web/eslint.design.mjs` — new `borderRadiusTokensRule`; removed the 3 selectors from `noRestrictedSyntax`
- `web/eslint.design.config.mjs` — `border-radius-tokens: error`
- `web/scripts/lint-radius-css.mjs` (new) + `package.json` wiring (`lint:design`, `lint:radius-css`)
- `web/src/components/themes/ThemeNodetool.tsx` — MUI base `shape.borderRadius` kept with a scoped `eslint-disable`
- `docs/DESIGN.md` — Enforcement intro + §4 updated

**Verification & caveats:**
- Ran a real ESLint design gate over `src` (scratch-installed eslint — this worktree has **no** `node_modules`): **0 errors**, 160 warns (all zIndex/transition backlog, unchanged). The radius CSS script passes clean and correctly flags an injected `7px`.
- I could **not** run `npm run typecheck && npm run lint && npm run test` — dependencies aren't installed in the worktree and a full monorepo install is impractical here. ESLint's TS parser accepted every edited file (no parse errors) and all values mirror existing `BORDER_RADIUS` usage, so the last acceptance criterion is left for CI.
- The plan estimated ~36 raw CSS decls / 7 files; the actual raw non-zero count was 17 decls across 6 files.

---

Closes task **T-20260705-0007**: WS2: Migrate borderRadius magic values to tokens.


### Acceptance criteria
- [x] All 17 TSX borderRadius warnings resolved with BORDER_RADIUS tokens
- [x] ~36 raw border-radius px declarations in web/src/styles/*.css use var(--rounded-*)
- [x] CSS lint script covers border-radius
- [x] Both borderRadius selectors promoted to error
- [x] DESIGN.md Enforcement section updated
- [ ] npm run typecheck && npm run lint && npm run test pass