### PR TITLE
Bake agent tool dependencies into container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,11 +105,42 @@ ENV NODE_ENV=production \
 
 # Runtime-only OS packages. Key management is provided through
 # SECRETS_MASTER_KEY, not a system keychain inside the container.
+#
+# Beyond ca-certificates/curl (health check, downloads), this bakes in the
+# CLIs that agent skill nodes (execute_bash) and document/video nodes shell
+# out to at runtime, so containers don't fail or install tools on every run:
+#   ffmpeg            — FFmpeg + yt-dlp downloader agents, video nodes
+#   git               — Git agent
+#   poppler-utils     — PDF agents, pdf-to-image nodes (pdftoppm/pdftotext)
+#   qpdf              — PDF agents (split/merge/optimize/check)
+#   pandoc            — document conversion nodes
+#   postgresql-client — psql/pg_dump for DATABASE_URL deployments
+#   jq/zip/unzip      — everyday shell plumbing for agents
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl \
+    ffmpeg git jq zip unzip \
+    poppler-utils qpdf pandoc \
+    postgresql-client \
+    python3 python3-venv \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /workspace \
     && chown node:node /workspace
+
+# Python tool venv on PATH for every execute_bash call: yt-dlp for the
+# downloader agent plus the PDF stack the PDF agent's prompt references.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       yt-dlp pypdf pdfplumber pypdfium2 reportlab \
+    && rm -rf /root/.cache
+ENV PATH="/opt/venv/bin:$PATH"
+
+# JS document libraries the DOCX/PDF agents import from ad-hoc Node scripts.
+# Installed globally with NODE_PATH set so require('pdf-lib') resolves from
+# any workspace directory without a per-run npm install. NODE_PATH only
+# affects CommonJS resolution as a last-resort fallback; the ESM server
+# ignores it, so /app/node_modules resolution is unchanged.
+RUN npm install -g pdf-lib docx && npm cache clean --force
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,5 +115,34 @@ services:
       # them (e.g. an Ollama container on the same Docker network).
       # OLLAMA_API_URL: "http://ollama:11434"
 
+      # ── PostgreSQL instead of SQLite ────────────────────────────────────────
+      # The default above is SQLite on the /workspace volume (DB_PATH). To use
+      # Postgres instead, uncomment the `postgres` service below, remove
+      # DB_PATH, and set:
+      # DATABASE_URL: "postgres://nodetool:${POSTGRES_PASSWORD:-nodetool}@postgres:5432/nodetool"
+    # depends_on:
+    #   postgres:
+    #     condition: service_healthy
+
+  # Uncomment to run Postgres alongside the server. The image ships psql, so
+  # you can inspect the database with:
+  #   docker compose exec nodetool psql "$DATABASE_URL"
+  # postgres:
+  #   image: postgres:17
+  #   container_name: nodetool-postgres
+  #   restart: unless-stopped
+  #   environment:
+  #     POSTGRES_USER: nodetool
+  #     POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-nodetool}"
+  #     POSTGRES_DB: nodetool
+  #   volumes:
+  #     - nodetool-pgdata:/var/lib/postgresql/data
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "pg_isready -U nodetool -d nodetool"]
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 10
+
 volumes:
   nodetool-data:
+  # nodetool-pgdata:

--- a/packages/code-nodes/src/nodes/tool-agents.ts
+++ b/packages/code-nodes/src/nodes/tool-agents.ts
@@ -1879,9 +1879,8 @@ export class PdfLibAgentNode extends ToolAgentNode {
     "- CLI tooling for performance/repair: poppler-utils (pdftotext/pdftoppm/pdfimages), qpdf.\n\n" +
     "Execution policy:\n" +
     "1) Use execute_bash for shell commands and script execution.\n" +
-    "2) Before running any Node script that imports pdf-lib, bootstrap dependency availability with:\n" +
-    "   npm -s ls pdf-lib >/dev/null 2>&1 || npm install --no-save pdf-lib\n" +
-    "   Then verify with: node -e \"require.resolve('pdf-lib')\".\n" +
+    "2) pdf-lib is preinstalled in the official container images (resolved via NODE_PATH). Before running any Node script that imports pdf-lib, verify availability with:\n" +
+    "   node -e \"require.resolve('pdf-lib')\" 2>/dev/null || npm install --no-save pdf-lib\n" +
     "3) Keep all outputs workspace-relative.\n" +
     "4) If you produce a final PDF file, call set_output_document with its path.\n" +
     "5) For extraction-only requests, return concise text and artifact locations.\n" +

--- a/packages/sandbox-agent/docker/Dockerfile
+++ b/packages/sandbox-agent/docker/Dockerfile
@@ -18,17 +18,31 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System packages. One big apt install to minimize layers.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl wget git sudo tmux \
+      ca-certificates curl wget git sudo tmux jq zip unzip \
       python3 python3-pip python3-venv \
       xvfb fluxbox x11vnc websockify novnc xterm \
       xdotool scrot imagemagick tesseract-ocr \
       ffmpeg pandoc weasyprint \
+      poppler-utils qpdf postgresql-client \
       chromium fonts-liberation fonts-noto-color-emoji \
       libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
       libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
       libgbm1 libpango-1.0-0 libcairo2 libasound2 \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
+
+# Python tool venv on PATH: yt-dlp for media downloads plus the PDF stack the
+# PDF agents reference. A venv sidesteps Debian's PEP 668 pip lockout.
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir \
+       yt-dlp pypdf pdfplumber pypdfium2 reportlab \
+    && rm -rf /root/.cache
+ENV PATH="/opt/venv/bin:$PATH"
+
+# JS document libraries agents import from ad-hoc Node scripts, preinstalled
+# globally so require('pdf-lib') works without a per-run npm install.
+RUN npm install -g pdf-lib docx && npm cache clean --force
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 # Non-root user for the agent's workload. Passwordless sudo is NOT granted;
 # sudo-gated tools should fail unless the operator explicitly enables it.


### PR DESCRIPTION
## Summary

Pre-install system packages, Python tools, and Node.js libraries that agent skill nodes and document/video processing nodes depend on at runtime. This eliminates the need for containers to install tools on every workflow run and prevents failures when dependencies are unavailable.

## Key Changes

- **Dockerfile (main)**: Added system packages (`ffmpeg`, `git`, `poppler-utils`, `qpdf`, `pandoc`, `postgresql-client`, `jq`, `zip`, `unzip`, `python3`) and created a Python venv with `yt-dlp`, `pypdf`, `pdfplumber`, `pypdfium2`, and `reportlab`. Globally installed `pdf-lib` and `docx` npm packages with `NODE_PATH` configured for CommonJS resolution.

- **packages/sandbox-agent/docker/Dockerfile**: Applied the same Python venv and npm package installations to the sandbox agent image for consistency.

- **docker-compose.yml**: Added commented-out PostgreSQL service configuration with instructions for switching from SQLite to Postgres via `DATABASE_URL` environment variable.

- **packages/code-nodes/src/nodes/tool-agents.ts**: Updated `PdfLibAgentNode` prompt to reflect that `pdf-lib` is now preinstalled in official containers and resolved via `NODE_PATH`, with a fallback verification command instead of a bootstrap install.

## Implementation Details

- Python tools are installed in `/opt/venv` with the venv's `bin/` directory added to `PATH`, avoiding Debian's PEP 668 pip lockout.
- Node.js packages are installed globally with `NODE_PATH=/usr/local/lib/node_modules` set, allowing CommonJS `require('pdf-lib')` to resolve from any workspace directory without per-run `npm install`.
- The `NODE_PATH` fallback only affects CommonJS; the ESM server's module resolution is unchanged.
- PostgreSQL service is optional and commented out; users can enable it by uncommenting and setting `DATABASE_URL`.

https://claude.ai/code/session_01V4995pS88TtzMQD2CKbvyj