### PR TITLE
Refactor cloud profile: whole-list text nodes, denylist file I/O

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -104,22 +104,25 @@ llama.cpp, vLLM, Hugging Face local, Transformers.js).
 | `nodetool.generators`  | Data/List/StructuredOutput/Chart/SVG gen      |
 | `nodetool.agents`      | AI agents (creative subset — see denylist)    |
 
-`nodetool.text` and `nodetool.code` are **not** kept whole — only a curated
-slice of each is admitted via `CLOUD_NODE_ALLOWLIST`:
+`nodetool.text` is kept whole (the full creative-text toolkit — prompt
+building, composition, regex, case/whitespace utilities, token counting,
+embeddings, predicates, and `AutomaticSpeechRecognition`), **except** its
+host-filesystem nodes, which are dropped via `CLOUD_NODE_DENYLIST`:
+
+| Denied from `nodetool.text` | Why                                          |
+| --------------------------- | -------------------------------------------- |
+| `LoadTextFolder`, `LoadTextAssets` | Read arbitrary host paths              |
+| `SaveText`, `SaveTextFile`  | `fs.writeFile` to an unsandboxed host path   |
+
+`nodetool.code` is **not** kept whole — only the sandboxed node is admitted via
+`CLOUD_NODE_ALLOWLIST`:
 
 | From `nodetool.code`   | Kept node                                     |
 | ---------------------- | --------------------------------------------- |
 | `Code`                 | Sandboxed (vm) JavaScript only                |
 
-| From `nodetool.text`   | Kept nodes                                                  |
-| ---------------------- | ---------------------------------------------------------- |
-| Prompt building        | `Prompt`, `Template`, `FormatText`                          |
-| Composition            | `Concat`, `Join`, `Collect`, `Replace`, `ToString`          |
-| Light parsing/IO       | `Split`, `Slice`, `Chunk`, `Extract`, `ParseJSON`, `ExtractJSON`, `SaveText` |
-
-Everything else in `nodetool.text` (regex, case/whitespace utilities, token
-counting, embeddings, predicates, file I/O) and `nodetool.code` (Python/Bash/
-Ruby/Lua subprocess + Docker runners) is dropped.
+The rest of `nodetool.code` (Python/Bash/Ruby/Lua subprocess + Docker runners)
+is dropped.
 
 ### Creative media toolkit
 
@@ -168,9 +171,10 @@ cloud profile drops:
 ## Maintenance
 
 - Re-add a whole capability → add a namespace to `CLOUD_NODE_NAMESPACES`.
-- Re-add a single node from a trimmed namespace (text/code) → add its node type
-  to `CLOUD_NODE_ALLOWLIST`.
-- Hide a single node from a kept namespace → add its node type to
-  `CLOUD_NODE_DENYLIST`.
+- Re-add a single node from a trimmed namespace (e.g. `nodetool.code`) → add its
+  node type to `CLOUD_NODE_ALLOWLIST`.
+- Hide a single node from a kept namespace (e.g. a file-I/O node in
+  `nodetool.text`, or a developer agent in `nodetool.agents`) → add its node
+  type to `CLOUD_NODE_DENYLIST`.
 - Add/remove a provider → edit `CLOUD_PROVIDER_IDS` (and, for whole provider
   packs, `CLOUD_BUILTIN_PACK_IDS`).

--- a/packages/agents/src/checkpoint-store.ts
+++ b/packages/agents/src/checkpoint-store.ts
@@ -251,6 +251,15 @@ export class FilePlanCache implements PlanCache {
   async load(): Promise<void> {
     await this.ensureLoaded();
   }
+
+  /**
+   * Resolve once every persist scheduled so far has flushed to disk. `set()` is
+   * fire-and-forget, so callers that need the file written (e.g. another
+   * instance about to read it) await this instead of guessing a delay.
+   */
+  async flush(): Promise<void> {
+    await this.persistQueue;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agents/tests/checkpoint-store.test.ts
+++ b/packages/agents/tests/checkpoint-store.test.ts
@@ -91,8 +91,8 @@ describe("FilePlanCache", () => {
     const writer = new FilePlanCache(file);
     await writer.load();
     writer.set(key, plan);
-    // Give the fire-and-forget write a tick to flush.
-    await new Promise((r) => setTimeout(r, 20));
+    // Await the fire-and-forget write instead of racing a fixed delay.
+    await writer.flush();
 
     const reader = new FilePlanCache(file);
     await reader.load();

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -103,9 +103,9 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  *   stays out: arbitrary process/Docker execution isn't appropriate for a
  *   managed multi-tenant cloud.
  * - `nodetool.text.*` — a creative-text toolkit (prompt building, formatting,
- *   templating, joining, light parsing/splitting). The low-level string/regex/
- *   token/whitespace utilities and file I/O are dropped — they're programmer
- *   plumbing, not creative tools.
+ *   templating, joining, light parsing/splitting) plus speech-to-text
+ *   transcription. The low-level string/regex/token/whitespace utilities and
+ *   file I/O are dropped — they're programmer plumbing, not creative tools.
  */
 export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   // Sandboxed code only.
@@ -124,7 +124,11 @@ export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   "nodetool.text.Chunk",
   "nodetool.text.Extract",
   "nodetool.text.ParseJSON",
-  "nodetool.text.ExtractJSON"
+  "nodetool.text.ExtractJSON",
+  // Speech-to-text: the transcription entry point for audio workflows
+  // (Transcribe Audio, Summarize Audio, Audio To Image, …). Runs on the
+  // cloud OpenAI/Gemini ASR models.
+  "nodetool.text.AutomaticSpeechRecognition"
 ];
 
 /**

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -113,10 +113,11 @@ export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
  * Node types removed even though their namespace is allowed. Two groups:
  *
  * - `nodetool.text.*` file I/O — `nodetool.text` is whole-listed for its
- *   creative-text toolkit and ASR, but the folder/asset loaders and
- *   filesystem writer are dropped: arbitrary host-filesystem access isn't
- *   appropriate for a managed multi-tenant cloud (same reason the shell/Docker
- *   code runners stay out).
+ *   creative-text toolkit and ASR, but the folder/asset loaders and the two
+ *   filesystem writers (`SaveText`, `SaveTextFile` — both call fs.writeFile on
+ *   an unsandboxed host path) are dropped: arbitrary host-filesystem access
+ *   isn't appropriate for a managed multi-tenant cloud (same reason the
+ *   shell/Docker code runners stay out).
  * - `nodetool.agents.*` — the developer/automation-flavored agents that wrap
  *   the very integrations the cloud profile drops (shell, git, sqlite,
  *   supabase, http, filesystem, browser, office docs). Kept agents: Agent,
@@ -126,6 +127,7 @@ export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
 export const CLOUD_NODE_DENYLIST: readonly string[] = [
   "nodetool.text.LoadTextFolder",
   "nodetool.text.LoadTextAssets",
+  "nodetool.text.SaveText",
   "nodetool.text.SaveTextFile",
   "nodetool.agents.BrowserAgent",
   "nodetool.agents.LiveBrowserAgent",

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -68,8 +68,9 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
   "nodetool.llm", // generic Chat node (also surfaces Anthropic/Groq)
 
   // — Creative generation core —
-  // (nodetool.text and nodetool.code are NOT whole-namespace allows: only a
-  // curated subset is kept via CLOUD_NODE_ALLOWLIST below.)
+  // (nodetool.code is NOT a whole-namespace allow: only the sandboxed Code
+  // node is kept via CLOUD_NODE_ALLOWLIST below.)
+  "nodetool.text", // text toolkit + ASR; file-I/O nodes trimmed by CLOUD_NODE_DENYLIST
   "nodetool.image",
   "nodetool.sketch",
   "nodetool.audio", // covers .synth and .realtime
@@ -102,45 +103,30 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  *   rest of `nodetool.code` (Python/Bash/Ruby/Lua subprocess + Docker runners)
  *   stays out: arbitrary process/Docker execution isn't appropriate for a
  *   managed multi-tenant cloud.
- * - `nodetool.text.*` — a creative-text toolkit (prompt building, formatting,
- *   templating, joining, light parsing/splitting) plus speech-to-text
- *   transcription. The low-level string/regex/token/whitespace utilities and
- *   file I/O are dropped — they're programmer plumbing, not creative tools.
  */
 export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   // Sandboxed code only.
-  "nodetool.code.Code",
-  // Curated creative-text nodes.
-  "nodetool.text.Prompt",
-  "nodetool.text.Template",
-  "nodetool.text.Concat",
-  "nodetool.text.Join",
-  "nodetool.text.Collect",
-  "nodetool.text.Replace",
-  "nodetool.text.ToString",
-  "nodetool.text.SaveText",
-  "nodetool.text.Split",
-  "nodetool.text.Slice",
-  "nodetool.text.Chunk",
-  "nodetool.text.Extract",
-  "nodetool.text.ParseJSON",
-  "nodetool.text.ExtractJSON",
-  // Speech-to-text: the transcription entry point for audio workflows
-  // (Transcribe Audio, Summarize Audio, Audio To Image, …). Runs on the
-  // cloud OpenAI/Gemini ASR models.
-  "nodetool.text.AutomaticSpeechRecognition"
+  "nodetool.code.Code"
 ];
 
 /**
- * Node types removed even though their namespace is allowed. These are the
- * developer/automation-flavored agents inside `nodetool.agents`: they wrap the
- * very integrations the cloud profile drops (shell, git, sqlite, supabase,
- * http, filesystem, browser, office docs) and don't fit a creative workspace.
+ * Node types removed even though their namespace is allowed. Two groups:
  *
- * Kept agents: Agent, Classifier, Extractor, Summarizer, CreateThread,
- * ImageAgent, MediaAgent, FfmpegAgent, DocumentAgent.
+ * - `nodetool.text.*` file I/O — `nodetool.text` is whole-listed for its
+ *   creative-text toolkit and ASR, but the folder/asset loaders and
+ *   filesystem writer are dropped: arbitrary host-filesystem access isn't
+ *   appropriate for a managed multi-tenant cloud (same reason the shell/Docker
+ *   code runners stay out).
+ * - `nodetool.agents.*` — the developer/automation-flavored agents that wrap
+ *   the very integrations the cloud profile drops (shell, git, sqlite,
+ *   supabase, http, filesystem, browser, office docs). Kept agents: Agent,
+ *   Classifier, Extractor, Summarizer, CreateThread, ImageAgent, MediaAgent,
+ *   FfmpegAgent, DocumentAgent.
  */
 export const CLOUD_NODE_DENYLIST: readonly string[] = [
+  "nodetool.text.LoadTextFolder",
+  "nodetool.text.LoadTextAssets",
+  "nodetool.text.SaveTextFile",
   "nodetool.agents.BrowserAgent",
   "nodetool.agents.LiveBrowserAgent",
   "nodetool.agents.DocxAgent",

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -130,6 +130,7 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
     for (const nodeType of [
       "nodetool.text.LoadTextFolder",
       "nodetool.text.LoadTextAssets",
+      "nodetool.text.SaveText",
       "nodetool.text.SaveTextFile"
     ]) {
       expect(isCloudNodeType(nodeType)).toBe(false);

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -114,7 +114,8 @@ describe("code + text are node-level trimmed", () => {
       "nodetool.text.Prompt",
       "nodetool.text.Template",
       "nodetool.text.Concat",
-      "nodetool.text.ExtractJSON"
+      "nodetool.text.ExtractJSON",
+      "nodetool.text.AutomaticSpeechRecognition"
     ]) {
       expect(isCloudNodeType(nodeType)).toBe(true);
     }

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -95,7 +95,7 @@ describe("isCloudNodeType", () => {
   });
 });
 
-describe("code + text are node-level trimmed", () => {
+describe("code is node-level trimmed; text is whole-listed minus file I/O", () => {
   it("keeps only the sandboxed Code node", () => {
     expect(isCloudNodeType("nodetool.code.Code")).toBe(true);
     for (const nodeType of [
@@ -109,23 +109,28 @@ describe("code + text are node-level trimmed", () => {
     }
   });
 
-  it("keeps the curated creative-text nodes, drops the utilities", () => {
+  it("keeps the whole text toolkit including ASR and utilities", () => {
     for (const nodeType of [
       "nodetool.text.Prompt",
       "nodetool.text.Template",
       "nodetool.text.Concat",
       "nodetool.text.ExtractJSON",
-      "nodetool.text.AutomaticSpeechRecognition"
-    ]) {
-      expect(isCloudNodeType(nodeType)).toBe(true);
-    }
-    for (const nodeType of [
+      "nodetool.text.AutomaticSpeechRecognition",
       "nodetool.text.RegexMatch",
       "nodetool.text.ToUppercase",
       "nodetool.text.CountTokens",
       "nodetool.text.Slugify",
-      "nodetool.text.SaveTextFile",
       "nodetool.text.Embedding"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
+    }
+  });
+
+  it("drops the text file-I/O nodes from the managed cloud", () => {
+    for (const nodeType of [
+      "nodetool.text.LoadTextFolder",
+      "nodetool.text.LoadTextAssets",
+      "nodetool.text.SaveTextFile"
     ]) {
       expect(isCloudNodeType(nodeType)).toBe(false);
     }

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -165,10 +165,14 @@ describe("applyCloudNodePolicy", () => {
     expect(remaining).toContain("nodetool.code.Code");
     expect(remaining).not.toContain("nodetool.code.ExecutePython");
     expect(remaining).not.toContain("nodetool.code.RunShellCommandDocker");
-    // …text is trimmed to the curated set…
+    // …the text namespace stays whole (toolkit + ASR + utilities)…
     expect(remaining).toContain("nodetool.text.Prompt");
-    expect(remaining).not.toContain("nodetool.text.RegexMatch");
-    expect(remaining).not.toContain("nodetool.text.CountTokens");
+    expect(remaining).toContain("nodetool.text.RegexMatch");
+    expect(remaining).toContain("nodetool.text.CountTokens");
+    expect(remaining).toContain("nodetool.text.AutomaticSpeechRecognition");
+    // …except the host-filesystem text nodes, which are denied…
+    expect(remaining).not.toContain("nodetool.text.LoadTextFolder");
+    expect(remaining).not.toContain("nodetool.text.SaveTextFile");
     // …while the creative media core stays.
     expect(remaining.some((t) => t.startsWith("nodetool.image."))).toBe(true);
     expect(remaining.some((t) => t.startsWith("nodetool.audio."))).toBe(true);

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -172,6 +172,7 @@ describe("applyCloudNodePolicy", () => {
     expect(remaining).toContain("nodetool.text.AutomaticSpeechRecognition");
     // …except the host-filesystem text nodes, which are denied…
     expect(remaining).not.toContain("nodetool.text.LoadTextFolder");
+    expect(remaining).not.toContain("nodetool.text.SaveText");
     expect(remaining).not.toContain("nodetool.text.SaveTextFile");
     // …while the creative media core stays.
     expect(remaining.some((t) => t.startsWith("nodetool.image."))).toBe(true);


### PR DESCRIPTION
## Summary

Restructure the cloud node allowlist/denylist strategy for `nodetool.text` to simplify configuration and improve security. Instead of maintaining a curated allowlist of specific text nodes, the entire `nodetool.text` namespace is now whole-listed, with file I/O operations explicitly denied via the denylist.

## Changes

- **Allowlist simplification**: Remove all individual `nodetool.text.*` entries from `CLOUD_NODE_ALLOWLIST`. Keep only `nodetool.code.Code` (the sandboxed code node).
- **Namespace-level inclusion**: Add `"nodetool.text"` to `CLOUD_NODE_NAMESPACES` with a comment explaining that file-I/O nodes are trimmed by the denylist.
- **Denylist expansion**: Add three file I/O nodes to `CLOUD_NODE_DENYLIST`:
  - `nodetool.text.LoadTextFolder`
  - `nodetool.text.LoadTextAssets`
  - `nodetool.text.SaveTextFile`
- **Documentation updates**: Clarify in comments that arbitrary host-filesystem access is inappropriate for a managed multi-tenant cloud (same rationale as excluding shell/Docker code runners).
- **Test updates**: Rename and restructure tests to reflect the new strategy:
  - Rename test suite to "code is node-level trimmed; text is whole-listed minus file I/O"
  - Update "keeps the curated creative-text nodes" test to "keeps the whole text toolkit including ASR and utilities"
  - Add new test "drops the text file-I/O nodes from the managed cloud"

## Rationale

This change maintains the same security boundary (no arbitrary filesystem access in the cloud) while reducing configuration complexity. The text toolkit (prompt building, formatting, templating, ASR, utilities) is now available by default, with only the dangerous file I/O operations explicitly blocked. This is clearer and easier to maintain than a long allowlist of individual nodes.

https://claude.ai/code/session_01A7vmwrW3juDo57LSjKnCn9