### PR TITLE
Reorganize cookbook landing page with pattern quick reference

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -4,36 +4,52 @@ title: "NodeTool Workflow Cookbook"
 description: "Reusable workflow patterns for the NodeTool canvas — core concepts, pipeline patterns, and worked end-to-end examples."
 ---
 
-Workflow patterns for the canvas.
+Reusable patterns for building on the NodeTool canvas. Start with a pattern that
+matches what you want to build, then adapt one of the worked examples.
 
 ## Cookbook Sections
 
-1. [**Core Concepts & Architecture**]({{ '/cookbook/core-concepts' | relative_url }}) — DAG structure, streaming execution, and node types.
-2. [**Workflow Patterns**]({{ '/cookbook/patterns' | relative_url }}) — 13 common workflow patterns with diagrams and use cases.
+1. [**Core Concepts & Architecture**]({{ '/cookbook/core-concepts' | relative_url }}) — how graphs, typed edges, streaming, and node types work.
+2. [**Workflow Patterns**]({{ '/cookbook/patterns' | relative_url }}) — 13 patterns with diagrams and the nodes each one uses.
+3. [**Workflow Gallery**]({{ '/workflows/' | relative_url }}) — step-by-step example workflows you can open and run.
 
-## Detailed Workflow Examples
+New to the canvas? Read [Core Concepts]({{ '/cookbook/core-concepts' | relative_url }})
+first, then follow a beginner example like
+[Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}).
 
-Step-by-step guides with diagrams are on the [Workflow Examples Gallery]({{ '/workflows/' | relative_url }}).
-
-Highlights:
-
-- [Movie Posters]({{ '/workflows/movie-posters' | relative_url }}) — Multi-stage AI generation
-- [Story to Video Generator]({{ '/workflows/story-to-video-generator' | relative_url }}) — Prompt → storyboard → animated scenes
-- [Image to Audio Story]({{ '/workflows/image-to-audio-story' | relative_url }}) — Picture in, narrated story out
-- [Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}) — Beginner tutorial
-- [Image Enhance]({{ '/workflows/image-enhance' | relative_url }}) — Basic image enhancement
-- [Chat with Docs]({{ '/workflows/chat-with-docs' | relative_url }}) — RAG-based document Q&A
-
-## Quick Reference: Choose Your Pattern
+## Choose Your Pattern
 
 | I want to… | Pattern | Key nodes |
 |------------|---------|-----------|
-| Generate creative content | 2 (Agent-Driven Generation) | `Agent`, `ListGenerator`, image/audio generators |
-| Transform images with AI | 8 (Advanced Image Processing) | `StableDiffusion`, `StableDiffusionXL`, `Canny`, `ImageToText` |
-| Generate videos from text | 9 (Text-to-Video) | `KlingVideoV16ProTextToVideo`, `MinimaxHailuo23ProTextToVideo`, `Sora2TextToVideo` |
-| Animate images to video | 10 (Image-to-Video) | `KlingVideoV16StandardImageToVideo`, `MinimaxHailuo02ProImageToVideo`, `SeeDanceV15ProImageToVideo`, `WanV225bImageToVideo` |
-| Create talking avatars | 11 (Talking Avatar) | `KlingVideoAiAvatarV2Pro`, `Infinitalk` |
-| Enhance image quality | 12 (Image Enhancement) | `TopazUpscaleImage` |
-| Process emails automatically | 6 (Email Integration) | `GmailSearch`, `Template`, `Classifier`/`Summarizer` |
-| Store data persistently | 5 (Database Persistence) | `CreateTable`, `Insert`, `Query` |
-| Answer questions about documents | 4 (RAG) | `IndexTextChunk`, `HybridSearch`, `Agent` |
+| Transform one input step by step | [1 · Simple Pipeline]({{ '/cookbook/patterns' | relative_url }}#pattern-1-simple-pipeline) | `ImageInput`, `UnsharpMask`, `AutoContrast` |
+| Generate content with an LLM | [2 · Agent-Driven Generation]({{ '/cookbook/patterns' | relative_url }}#pattern-2-agent-driven-generation) | `Agent`, `ListGenerator`, `TextToSpeech` |
+| Show progress during a long run | [3 · Streaming with Previews]({{ '/cookbook/patterns' | relative_url }}#pattern-3-streaming-with-multiple-previews) | `Agent`, `ListGenerator`, `Preview` |
+| Answer questions about documents | [4 · RAG]({{ '/cookbook/patterns' | relative_url }}#pattern-4-rag-retrieval-augmented-generation) | `HybridSearch`, `FormatText`, `Agent` |
+| Store data persistently | [5 · Database Persistence]({{ '/cookbook/patterns' | relative_url }}#pattern-5-database-persistence) | `CreateTable`, `Insert`, `Query` |
+| Process emails or web content | [6 · Email & Web Integration]({{ '/cookbook/patterns' | relative_url }}#pattern-6-email--web-integration) | `GmailSearch`, `Template`, `Summarizer` |
+| Convert between media types | [7 · Multi-Modal Workflows]({{ '/cookbook/patterns' | relative_url }}#pattern-7-multi-modal-workflows) | `Whisper`, `StableDiffusion`, `TextToSpeech` |
+| Transform images with AI | [8 · Advanced Image Processing]({{ '/cookbook/patterns' | relative_url }}#pattern-8-advanced-image-processing) | `StableDiffusionV3MediumImageToImage`, `ImageToText`, `Canny` |
+| Generate video from text | [9 · Text-to-Video]({{ '/cookbook/patterns' | relative_url }}#pattern-9-text-to-video) | `KlingVideoV16ProTextToVideo`, `Sora2TextToVideo` |
+| Animate an image into video | [10 · Image-to-Video]({{ '/cookbook/patterns' | relative_url }}#pattern-10-image-to-video) | `KlingVideoV16StandardImageToVideo`, `SeeDanceV15ProImageToVideo` |
+| Create a lip-synced avatar | [11 · Talking Avatar]({{ '/cookbook/patterns' | relative_url }}#pattern-11-talking-avatar) | `KlingVideoAiAvatarV2Pro`, `Infinitalk` |
+| Upscale and clean up images | [12 · Image Enhancement]({{ '/cookbook/patterns' | relative_url }}#pattern-12-video-enhancement) | `TopazUpscaleImage` |
+| Turn keyframes into a video | [13 · Storyboard to Video]({{ '/cookbook/patterns' | relative_url }}#pattern-13-storyboard-to-video) | `Sora2ImageToVideoPro` |
+
+## Worked Examples
+
+Full walkthroughs with diagrams live in the
+[Workflow Gallery]({{ '/workflows/' | relative_url }}). A few to start with:
+
+- [Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}) — beginner tutorial for agent generation.
+- [Image Enhance]({{ '/workflows/image-enhance' | relative_url }}) — a simple sharpen-and-contrast pipeline.
+- [Movie Posters]({{ '/workflows/movie-posters' | relative_url }}) — multi-stage generation with strategy and previews.
+- [Story to Video Generator]({{ '/workflows/story-to-video-generator' | relative_url }}) — prompt → storyboard → animated scenes.
+- [Image to Audio Story]({{ '/workflows/image-to-audio-story' | relative_url }}) — picture in, narrated story out.
+- [Chat with Docs]({{ '/workflows/chat-with-docs' | relative_url }}) — RAG document Q&A.
+
+## Build Any Example
+
+- Press **Space** to open the node menu and add a node.
+- Drag from an output handle to an input handle to connect nodes.
+- Press **Ctrl/⌘ + Enter** to run.
+- Add **Preview** nodes to inspect intermediate results.


### PR DESCRIPTION
## Summary

Restructured the cookbook landing page to improve discoverability and navigation. The page now leads with a clear "Choose Your Pattern" table that maps user intent to specific workflow patterns, followed by worked examples and quick-start guidance.

## Key Changes

- **Improved introduction**: Replaced generic "Workflow patterns for the canvas" with actionable guidance directing users to start with Core Concepts, then follow a beginner example
- **Added Workflow Gallery link**: Explicitly listed in the cookbook sections for easier discovery
- **Reorganized pattern reference**: Converted the old "Quick Reference" section into a prominent table that maps user goals (e.g., "Transform one input step by step") directly to pattern numbers, descriptions, and key nodes
- **Enhanced pattern descriptions**: Made pattern names and use cases more concrete and user-focused (e.g., "Simple Pipeline" instead of just pattern number)
- **Restructured examples section**: Renamed to "Worked Examples" with clearer framing that these are full walkthroughs in the gallery, plus a curated list of 6 key examples
- **Added quick-start instructions**: New "Build Any Example" section with basic canvas controls (Space to add nodes, drag to connect, Ctrl/⌘+Enter to run, Preview nodes for inspection)

## Implementation Details

- All pattern links now point to anchored sections within the patterns page (e.g., `#pattern-1-simple-pipeline`)
- Reordered content to follow a logical user journey: learn concepts → pick a pattern → see worked examples → start building
- Simplified language throughout to reduce cognitive load and focus on actionable next steps

https://claude.ai/code/session_013RSFNbFQ3cZBXBeZN4eAmn