### PR TITLE
Add Plausible analytics to production website

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,7 +26,7 @@
     <link rel="manifest" href="/manifest.json" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss: blob: data:; media-src 'self' blob:; frame-src 'self' http://127.0.0.1:*;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss: blob: data:; media-src 'self' blob:; frame-src 'self' http://127.0.0.1:*;"
     />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="theme-color" content="#000000" />

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -52,6 +52,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import useAuth from "./stores/useAuth";
 import { isLocalhost } from "./lib/env";
 import { loadRuntimeConfig, isAuthRequired } from "./lib/runtimeConfig";
+import { initAnalytics } from "./lib/analytics";
 import { initSupabaseFromConfig } from "./lib/supabaseClient";
 import { initKeyListeners } from "./stores/KeyPressedStore";
 import useRemoteSettingsStore from "./stores/RemoteSettingStore";
@@ -728,6 +729,9 @@ const initialize = async () => {
 
   useAuth.getState().initialize();
   initKeyListeners();
+
+  // Load Plausible on the production website only (never local/dev/Electron).
+  initAnalytics();
 
   // Render after initialization and prefetching
   root.render(<AppWrapper />);

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,39 @@
+import { isElectron } from "./env";
+
+// Domain registered in the Plausible dashboard. The hosted production website
+// runs here; events are only accepted for a registered site, so this doubles as
+// the guard that keeps tracking on production and off everywhere else.
+const PLAUSIBLE_DOMAIN = "app.nodetool.ai";
+const PLAUSIBLE_SCRIPT = "https://plausible.io/js/script.js";
+
+/**
+ * Load Plausible analytics on the production website only.
+ *
+ * Runs solely when served from PLAUSIBLE_DOMAIN — never on localhost/dev,
+ * preview hosts, or the Electron desktop app. We only want to understand how
+ * people use the hosted web app online. Privacy-friendly, cookieless, no PII.
+ */
+export const initAnalytics = (): void => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+  if (isElectron || window.location.hostname !== PLAUSIBLE_DOMAIN) {
+    return;
+  }
+  if (document.querySelector(`script[data-domain="${PLAUSIBLE_DOMAIN}"]`)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src = PLAUSIBLE_SCRIPT;
+  script.dataset.domain = PLAUSIBLE_DOMAIN;
+  document.head.appendChild(script);
+
+  // Queue events fired before the script loads (Plausible's standard shim).
+  window.plausible =
+    window.plausible ||
+    function (...args: unknown[]) {
+      (window.plausible!.q = window.plausible!.q || []).push(args);
+    };
+};

--- a/web/src/window.d.ts
+++ b/web/src/window.d.ts
@@ -560,6 +560,14 @@ declare global {
     isLocalhost?: boolean;
     isElectron?: boolean;
     setForceLocalhost?: (force: boolean | null) => void;
+    // Plausible analytics (loaded only on the production website).
+    plausible?: {
+      (
+        event: string,
+        options?: { props?: Record<string, string | number | boolean> }
+      ): void;
+      q?: unknown[];
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
Integrate Plausible analytics into the production website to track user behavior. Analytics only load on the hosted production domain (`app.nodetool.ai`) and are disabled on localhost, dev environments, and the Electron desktop app.

## Changes
- **New `web/src/lib/analytics.ts`**: Created `initAnalytics()` function that dynamically loads the Plausible script with proper guards:
  - Only runs when served from `PLAUSIBLE_DOMAIN` (`app.nodetool.ai`)
  - Skips loading in Electron app (checked via `isElectron` flag)
  - Prevents duplicate script injection
  - Implements Plausible's standard event queue shim for events fired before script loads
  
- **Updated `web/src/window.d.ts`**: Added TypeScript declarations for the `window.plausible` object to support analytics event tracking with optional properties

- **Updated `web/src/index.tsx`**: Integrated `initAnalytics()` call into the app initialization sequence, ensuring analytics loads after core setup but before rendering

- **Updated `web/index.html`**: Modified Content Security Policy to allow loading scripts from `https://plausible.io`

## Implementation Details
- Plausible is privacy-friendly and cookieless, collecting no PII
- The domain registration in the Plausible dashboard acts as a built-in guard, ensuring events are only accepted from the registered production domain
- Analytics gracefully degrade on non-production environments with early returns
- Event queueing via the shim ensures no events are lost if the script loads asynchronously

https://claude.ai/code/session_01R3e3is1isdFTnR1NuhasZR