### PR TITLE
Use event-driven timing in demo engine to fix badge wiggle

### DIFF
--- a/web/src/demo/__tests__/demoEngine.test.ts
+++ b/web/src/demo/__tests__/demoEngine.test.ts
@@ -7,6 +7,7 @@ import { sampleCast } from "../sampleCast";
 import useStatusStore from "../../stores/StatusStore";
 import useResultsStore from "../../stores/ResultsStore";
 import useWorkflowRunsStore from "../../stores/WorkflowRunsStore";
+import useExecutionTimeStore from "../../stores/ExecutionTimeStore";
 
 const WF = "wf-demo-sample";
 const resolveAssetUrl = (f: string) => `/demo-assets/${f}`;
@@ -63,6 +64,26 @@ describe("DemoEngine", () => {
     // The sample uses an inline data URI (left untouched), proving non-asset
     // strings pass through the resolver unchanged.
     expect(result?.uri?.startsWith("data:image/svg+xml")).toBe(true);
+  });
+
+  it("stamps a stable, event-driven completed duration (no badge wiggle)", () => {
+    // The gen node runs at t=200 and completes at t=2050, so its duration is
+    // fixed at 1850ms regardless of when — or how many times — a frame replays
+    // the events. Wall-clock stamping would give a tiny, frame-varying value.
+    engine.seekToTime(2200);
+    const first = useExecutionTimeStore
+      .getState()
+      .getDuration(WF, focused(), "gen");
+    expect(first).toBe(1850);
+
+    // Re-seeking (backward then forward, as a scrubbing frame renderer does)
+    // reproduces the exact same duration — the source of the visible wiggle.
+    engine.seekToTime(100);
+    engine.seekToTime(2200);
+    const second = useExecutionTimeStore
+      .getState()
+      .getDuration(WF, focused(), "gen");
+    expect(second).toBe(1850);
   });
 
   it("is a pure function of time across a backward seek", () => {

--- a/web/src/demo/demoEngine.ts
+++ b/web/src/demo/demoEngine.ts
@@ -19,6 +19,10 @@ import useMetadataStore from "../stores/MetadataStore";
 import type { NodeData } from "../stores/NodeData";
 import useResultsStore from "../stores/ResultsStore";
 import useStatusStore from "../stores/StatusStore";
+import {
+  setExecutionClock,
+  resetExecutionClock
+} from "../stores/ExecutionTimeStore";
 import useWorkflowRunsStore from "../stores/WorkflowRunsStore";
 import { useNotificationStore, type Notification } from "../stores/NotificationStore";
 import useAuth from "../stores/useAuth";
@@ -188,6 +192,10 @@ export class DemoEngine {
   }
 
   private applyEvent(event: CastEvent): void {
+    // Stamp execution timing from the recorded event timeline, not wall-clock.
+    // Otherwise a node whose start and end events land in the same synchronous
+    // seek gets a tiny, frame-dependent duration that wiggles the badge.
+    setExecutionClock(() => event.t);
     handleUpdate(
       this.workflow,
       event.message as unknown as MsgpackData,
@@ -209,6 +217,9 @@ export class DemoEngine {
       edges: clone(this.pristineEdges),
     });
     this.appliedIndex = 0;
+    // Restore the wall-clock timing clock; the next applyEvent re-installs the
+    // event-driven one before it stamps anything.
+    resetExecutionClock();
   }
 
   /** Drop all global state this engine wrote. Call when unmounting the player. */

--- a/web/src/stores/ExecutionTimeStore.ts
+++ b/web/src/stores/ExecutionTimeStore.ts
@@ -24,6 +24,27 @@
 import { create } from "zustand";
 import { nodeKey, type NodeKey } from "./nodeKey";
 
+/**
+ * Clock used to stamp start/end timestamps. Defaults to wall-clock time.
+ *
+ * Deterministic replays (the demo engine) override this so timings come from
+ * the recorded event timeline instead of `Date.now()`. Without that, a replay
+ * that applies a node's start and end events in the same synchronous pass
+ * stamps both from wall-clock time microseconds apart, producing a tiny,
+ * frame-dependent duration that visibly wiggles the "Completed in" badge.
+ */
+let nowFn: () => number = () => Date.now();
+
+/** Override the timing clock (e.g. deterministic replay). */
+export function setExecutionClock(fn: () => number): void {
+  nowFn = fn;
+}
+
+/** Restore the default wall-clock timing clock. */
+export function resetExecutionClock(): void {
+  nowFn = () => Date.now();
+}
+
 interface ExecutionTiming {
   startTime: number;
   endTime?: number;
@@ -54,7 +75,7 @@ const useExecutionTimeStore = create<ExecutionTimeStore>((set, get) => ({
     set((state) => ({
       timings: {
         ...state.timings,
-        [key]: { startTime: Date.now() }
+        [key]: { startTime: nowFn() }
       }
     }));
   },
@@ -67,7 +88,7 @@ const useExecutionTimeStore = create<ExecutionTimeStore>((set, get) => ({
         return {
           timings: {
             ...state.timings,
-            [key]: { ...existing, endTime: Date.now() }
+            [key]: { ...existing, endTime: nowFn() }
           }
         };
       }


### PR DESCRIPTION
## Summary

Fixes the "Completed in" duration badge visibly wiggling during deterministic replays by stamping execution timings from the recorded event timeline instead of wall-clock time.

## Problem

When the demo engine replays a workflow, a node's start and end events often land in the same synchronous `seekToTime()` call. Using `Date.now()` to stamp both timestamps produces microsecond-apart values, creating a tiny, frame-dependent duration that visibly wiggles the badge as the replay scrubs backward and forward.

## Solution

- **ExecutionTimeStore**: Added `setExecutionClock()` and `resetExecutionClock()` functions to allow overriding the timing source. Replaced direct `Date.now()` calls with a `nowFn()` function that defaults to wall-clock but can be swapped out.
- **DemoEngine**: Before applying each recorded event, calls `setExecutionClock(() => event.t)` to use the event's timestamp. After clearing state (on reset), calls `resetExecutionClock()` to restore wall-clock timing.
- **Test**: Added `demoEngine.test.ts` test verifying that seeking backward and forward produces the same stable duration (1850ms for the gen node), confirming the wiggle is fixed.

## Key Changes

- Introduced a pluggable clock abstraction in `ExecutionTimeStore` to decouple timing from `Date.now()`
- Demo engine now drives execution timing from recorded event timestamps during replay
- Execution timings are now deterministic across multiple replays of the same event sequence

https://claude.ai/code/session_01S9FkYRVtaUbkXXKUCW9yW1