### PR TITLE
design: migrate zIndex magic integers to tokens in properties/inputs/widgets (WS3c)

### DIFF
--- a/web/src/__mocks__/themeMock.ts
+++ b/web/src/__mocks__/themeMock.ts
@@ -184,8 +184,9 @@ const mockTheme = createTheme({
 (mockTheme as any).tooltip = {};
 (mockTheme as any).vars.tooltip = {};
 
-// Add zIndex for MUI components
-(mockTheme as any).zIndex = {
+// Add zIndex for MUI components plus Nodetool's custom scale
+const zIndexScale = {
+  // MUI
   mobileStepper: 1000,
   fab: 1050,
   speedDial: 1050,
@@ -193,18 +194,19 @@ const mockTheme = createTheme({
   drawer: 1200,
   modal: 1300,
   snackbar: 1400,
-  tooltip: 1500
+  tooltip: 1500,
+  // Nodetool
+  behind: -1,
+  base: 0,
+  commandMenu: 9999,
+  popover: 10001,
+  popover2: 99990,
+  autocomplete: 10002,
+  floating: 10003,
+  highest: 100000
 };
-(mockTheme as any).vars.zIndex = {
-  mobileStepper: 1000,
-  fab: 1050,
-  speedDial: 1050,
-  appBar: 1100,
-  drawer: 1200,
-  modal: 1300,
-  snackbar: 1400,
-  tooltip: 1500
-};
+(mockTheme as any).zIndex = { ...zIndexScale };
+(mockTheme as any).vars.zIndex = { ...zIndexScale };
 
 // Add avatar properties for MUI Chip component
 (mockTheme as any).vars.avatar = {

--- a/web/src/components/inputs/DatePicker.tsx
+++ b/web/src/components/inputs/DatePicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { useTheme } from "@mui/material/styles";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
@@ -12,6 +13,7 @@ const CustomDatePicker: React.FC<CustomDatePickerProps> = ({
   value,
   onChange
 }) => {
+  const theme = useTheme();
   const [selectedDate, setSelectedDate] = useState<Date | null>(
     new Date(value)
   );
@@ -41,7 +43,7 @@ const CustomDatePicker: React.FC<CustomDatePickerProps> = ({
           onClose={handleDateClose}
           slotProps={{
             popper: {
-              style: { zIndex: 99999 }
+              style: { zIndex: theme.zIndex.popover2 }
             }
           }}
         />

--- a/web/src/components/inputs/SpeedDisplay.tsx
+++ b/web/src/components/inputs/SpeedDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { useTheme } from "@mui/material/styles";
 import { MOTION } from "../ui_primitives";
 
 interface SpeedDisplayProps {
@@ -11,6 +12,7 @@ const SpeedDisplay: React.FC<SpeedDisplayProps> = ({
   speedFactor = 1,
   isDragging
 }) => {
+  const theme = useTheme();
   const elRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number>(0);
 
@@ -53,7 +55,7 @@ const SpeedDisplay: React.FC<SpeedDisplayProps> = ({
         borderRadius: ".5em",
         fontSize: "var(--fontSizeSmall)",
         pointerEvents: "none",
-        zIndex: 999999,
+        zIndex: theme.zIndex.highest,
         fontFamily: "var(--fontFamily)",
         textAlign: "center",
         maxWidth: "200px",

--- a/web/src/components/inputs/__tests__/SpeedDisplay.test.tsx
+++ b/web/src/components/inputs/__tests__/SpeedDisplay.test.tsx
@@ -9,7 +9,9 @@
 import React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { createPortal } from "react-dom";
+import { ThemeProvider } from "@mui/material/styles";
 import { SpeedDisplay } from "../SpeedDisplay";
+import mockTheme from "../../../__mocks__/themeMock";
 
 // Mock createPortal to control its behavior
 jest.mock("react-dom", () => ({
@@ -306,14 +308,16 @@ describe("SpeedDisplay", () => {
 
     it("should have high z-index", () => {
       const { container } = render(
-        <SpeedDisplay
-          speedFactor={0.5}
-          isDragging={true}
-        />
+        <ThemeProvider theme={mockTheme}>
+          <SpeedDisplay
+            speedFactor={0.5}
+            isDragging={true}
+          />
+        </ThemeProvider>
       );
 
       const display = container.querySelector("div");
-      expect(display?.style.zIndex).toBe("999999");
+      expect(display?.style.zIndex).toBe(String(mockTheme.zIndex.highest));
     });
 
     it("should disable pointer events", () => {

--- a/web/src/components/inputs/numberInputStyles.ts
+++ b/web/src/components/inputs/numberInputStyles.ts
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
-import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { MOTION, BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx } from "../ui_primitives";
 
 /**
  * Styles for the NumberInput component.
@@ -151,7 +151,7 @@ export const numberInputStyles = (theme: Theme) =>
       padding: "0 !important",
       textAlign: "left",
       maxWidth: "100px",
-      zIndex: 10,
+      zIndex: Z_INDEX.dropdown,
       letterSpacing: "normal",
       fontWeight: 400,
       appearance: "none",

--- a/web/src/components/inputs/selectStyles.ts
+++ b/web/src/components/inputs/selectStyles.ts
@@ -37,7 +37,7 @@ export const selectStyles = (theme: Theme) =>
       border: `1px solid ${theme.vars.palette.divider}`,
       boxShadow: "0 10px 30px rgba(0, 0, 0, 0.5)",
       borderRadius: BORDER_RADIUS.lg,
-      zIndex: 10000
+      zIndex: theme.zIndex.popover
     },
 
     ".options-list .option:first-of-type": {
@@ -158,7 +158,7 @@ export const portalOptionsStyles = (theme: Theme) =>
       border: `1px solid ${theme.vars.palette.divider}`,
       boxShadow: "0 10px 30px rgba(0, 0, 0, 0.5)",
       borderRadius: BORDER_RADIUS.lg,
-      zIndex: 10000
+      zIndex: theme.zIndex.popover
     },
 
     ".option:first-of-type": {

--- a/web/src/components/properties/DataframeEditorModal.tsx
+++ b/web/src/components/properties/DataframeEditorModal.tsx
@@ -15,6 +15,7 @@ import {
   MOTION,
   BORDER_RADIUS,
   SPACING,
+  Z_INDEX,
   getSpacingPx,
   InputAdornment
 } from "../ui_primitives";
@@ -52,7 +53,7 @@ const styles = (theme: Theme) =>
       padding: ".5em .5em 0 .5em",
       backgroundColor: `rgba(${theme.vars.palette.background.defaultChannel} / 0.6)`,
       backdropFilter: "blur(8px)",
-      zIndex: 10000,
+      zIndex: theme.zIndex.popover,
       display: "flex",
       justifyContent: "center",
       alignItems: "flex-start",
@@ -105,7 +106,7 @@ const styles = (theme: Theme) =>
         rgba(${theme.vars.palette.background.defaultChannel} / 0.4) 0%, 
         transparent 100%)`,
       borderBottom: `1px solid rgba(${theme.vars.palette.common.whiteChannel} / 0.05)`,
-      zIndex: 5,
+      zIndex: Z_INDEX.raised,
       h4: {
         cursor: "default",
         fontWeight: 600,

--- a/web/src/components/properties/DataframeProperty.tsx
+++ b/web/src/components/properties/DataframeProperty.tsx
@@ -8,7 +8,7 @@ import { ColumnDef, DataframeRef } from "../../stores/ApiTypes";
 import DataTable from "../node/DataTable/DataTable";
 import ColumnsManager from "../node/ColumnsManager";
 import DataframeEditorModal from "./DataframeEditorModal";
-import { ToolbarIconButton, EditorButton, ButtonGroup, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
+import { ToolbarIconButton, EditorButton, ButtonGroup, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 // icons
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
@@ -40,7 +40,7 @@ const styles = (theme: Theme) =>
       position: "absolute",
       right: "1.5em",
       top: "-2px",
-      zIndex: 10
+      zIndex: Z_INDEX.dropdown
     },
     ".dataframe-action-buttons .MuiIconButton-root": {
       margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,

--- a/web/src/components/properties/ImageListProperty.tsx
+++ b/web/src/components/properties/ImageListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
+import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import ImageDimensions from "../node/ImageDimensions";
@@ -86,7 +86,7 @@ const styles = (theme: Theme) =>
       padding: getSpacingPx(SPACING.micro),
       width: "20px",
       height: "20px",
-      zIndex: 2,
+      zIndex: Z_INDEX.raised,
       "&:hover": {
         backgroundColor: theme.vars.palette.error.main,
         color: theme.vars.palette.common.white

--- a/web/src/components/properties/ImageSizePresetsMenu.tsx
+++ b/web/src/components/properties/ImageSizePresetsMenu.tsx
@@ -7,7 +7,8 @@ import {
   EditorMenu,
   EditorMenuItem,
   ListSubheader,
-  InputAdornment
+  InputAdornment,
+  Z_INDEX
 } from "../ui_primitives";
 import Search from "@mui/icons-material/Search";
 import { IMAGE_SIZE_PRESETS, PresetOption } from "../../config/constants";
@@ -95,7 +96,7 @@ export const ImageSizePresetsMenu: React.FC<ImageSizePresetsMenuProps> = ({
           color: 'primary.light',
           position: 'sticky',
           top: '48px',
-          zIndex: 10,
+          zIndex: Z_INDEX.dropdown,
         }
       }}
     >
@@ -104,7 +105,7 @@ export const ImageSizePresetsMenu: React.FC<ImageSizePresetsMenuProps> = ({
         position: 'sticky',
         top: 0,
         backgroundColor: 'background.paper',
-        zIndex: 11,
+        zIndex: Z_INDEX.sticky,
         borderBottom: '1px solid var(--palette-c_overlay_strong)',
         height: '48px',
         boxSizing: 'border-box'

--- a/web/src/components/properties/JSONProperty.tsx
+++ b/web/src/components/properties/JSONProperty.tsx
@@ -6,7 +6,7 @@ import { PropertyProps } from "../node/PropertyInput";
 import PropertyLabel from "../node/PropertyLabel";
 import isEqual from "fast-deep-equal";
 import { useTheme } from "@mui/material/styles";
-import { CopyButton, LoadingSpinner, ToolbarIconButton, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
+import { CopyButton, LoadingSpinner, ToolbarIconButton, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import TextEditorModal from "./TextEditorModal";
 import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
@@ -158,7 +158,7 @@ const JSONProperty = (props: PropertyProps) => {
           right: 0,
           top: "-3px",
           opacity: 0.8,
-          zIndex: 10
+          zIndex: Z_INDEX.dropdown
         },
         ".json-action-buttons .MuiIconButton-root": {
           margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,

--- a/web/src/components/properties/Model3DProperty.tsx
+++ b/web/src/components/properties/Model3DProperty.tsx
@@ -12,7 +12,7 @@ import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import ConnectedBadge from "./ConnectedBadge";
 import { useFileDrop } from "../../hooks/handlers/useFileDrop";
 import { Asset } from "../../stores/ApiTypes";
-import { Tooltip, EditorButton, NodeTextField, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { Tooltip, EditorButton, NodeTextField, MOTION, BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import AssetViewer from "../assets/AssetViewer";
 import LazyModel3DViewer from "../asset_viewer/LazyModel3DViewer";
 import { resolveAssetUri } from "../node/output/hooks";
@@ -43,7 +43,7 @@ const styles = (theme: Theme) =>
       position: "absolute",
       top: "-15px",
       right: "0",
-      zIndex: 2,
+      zIndex: Z_INDEX.raised,
       color: theme.vars.palette.grey[500],
       backgroundColor: "transparent",
       fontSize: "var(--fontSizeSmaller)",
@@ -64,7 +64,7 @@ const styles = (theme: Theme) =>
       height: "1em",
       width: "calc(100% - 24px)",
       maxWidth: "120px",
-      zIndex: 1,
+      zIndex: Z_INDEX.raised,
       bottom: "0em",
       borderRadius: "0",
       backgroundColor: theme.vars.palette.grey[600],

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -4,7 +4,7 @@ import type { Theme } from "@mui/material/styles";
 import { memo, useCallback, useMemo, useState, useRef, ChangeEvent } from "react";
 import { Asset } from "../../stores/ApiTypes";
 import { useFileDrop } from "../../hooks/handlers/useFileDrop";
-import { Tooltip, ToolbarIconButton, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
+import { Tooltip, ToolbarIconButton, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import ImageDimensions from "../node/ImageDimensions";
 import { useTheme } from "@mui/material/styles";
@@ -143,7 +143,7 @@ const PropertyDropzone = ({
         gap: getSpacingPx(SPACING.xs),
         opacity: 0,
         transition: `opacity ${MOTION.normal}`,
-        zIndex: 10
+        zIndex: Z_INDEX.dropdown
       },
       ".dropzone:hover .asset-actions": {
         opacity: 1

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -8,7 +8,7 @@ import isEqual from "fast-deep-equal";
 import { useNodes } from "../../contexts/NodeContext";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { CopyButton, ToolbarIconButton, SPACING } from "../ui_primitives";
+import { CopyButton, ToolbarIconButton, SPACING, Z_INDEX } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { NodeTextField, editorClassNames, cn } from "../editor_ui";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
@@ -35,7 +35,7 @@ const propertyStyles = (theme: Theme) =>
       right: 0,
       top: "-3px",
       opacity: 0.8,
-      zIndex: 10
+      zIndex: Z_INDEX.dropdown
     },
     ".string-action-buttons .MuiIconButton-root": {
       margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -24,7 +24,7 @@ import TextDecreaseIcon from "@mui/icons-material/TextDecrease";
 import TextIncreaseIcon from "@mui/icons-material/TextIncrease";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import ChatBubbleIcon from "@mui/icons-material/ChatBubble";
-import { Tooltip, LoadingSpinner, MOTION, BORDER_RADIUS, SPACING, getSpacingPx, reducedMotion } from "../ui_primitives";
+import { Tooltip, LoadingSpinner, MOTION, BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx, reducedMotion } from "../ui_primitives";
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { ListItemNode, ListNode } from "@lexical/list";
@@ -215,7 +215,7 @@ const styles = (theme: Theme) =>
       backgroundColor: `rgba(${theme.vars.palette.background.defaultChannel} / 0.6)`,
       backdropFilter: "blur(12px) saturate(150%)",
       WebkitBackdropFilter: "blur(12px) saturate(150%)",
-      zIndex: 10000,
+      zIndex: theme.zIndex.popover,
       display: "flex",
       justifyContent: "center",
       alignItems: "flex-start",
@@ -274,7 +274,7 @@ const styles = (theme: Theme) =>
       background: `linear-gradient(90deg,
         rgba(${theme.vars.palette.background.defaultChannel} / 0.5) 0%,
         rgba(${theme.vars.palette.background.defaultChannel} / 0.15) 100%)`,
-      zIndex: 5,
+      zIndex: Z_INDEX.raised,
       "&::after": {
         content: "''",
         position: "absolute",

--- a/web/src/components/properties/VideoListProperty.tsx
+++ b/web/src/components/properties/VideoListProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
+import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import isEqual from "fast-deep-equal";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { isElectron } from "../../utils/browser";
@@ -80,7 +80,7 @@ const styles = (theme: Theme) =>
       padding: getSpacingPx(SPACING.micro),
       width: "20px",
       height: "20px",
-      zIndex: 2,
+      zIndex: Z_INDEX.raised,
       "&:hover": {
         backgroundColor: theme.vars.palette.error.main,
         color: theme.vars.palette.common.white

--- a/web/src/components/widgets/ImageComparer.tsx
+++ b/web/src/components/widgets/ImageComparer.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import React, { useState, useCallback, useRef, useMemo } from "react";
-import { ToolbarIconButton, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { ToolbarIconButton, BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { alphaSurfaceBg } from "../../styles/AlphaSurface";
@@ -65,7 +65,7 @@ const styles = (theme: Theme) =>
       position: "absolute",
       backgroundColor: theme.vars.palette.common.white,
       boxShadow: `0 0 4px ${theme.vars.palette.c_scrim}`,
-      zIndex: 10,
+      zIndex: Z_INDEX.dropdown,
       pointerEvents: "none"
     },
     ".divider-line.horizontal": {
@@ -86,7 +86,7 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.common.white,
       backgroundColor: theme.vars.palette.c_scrim,
       borderRadius: BORDER_RADIUS.sm,
-      zIndex: 15,
+      zIndex: Z_INDEX.sticky,
       pointerEvents: "none"
     },
     ".label.label-a.horizontal": {
@@ -112,7 +112,7 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.grey[300],
       backgroundColor: theme.vars.palette.c_scrim,
       borderRadius: BORDER_RADIUS.sm,
-      zIndex: 15,
+      zIndex: Z_INDEX.sticky,
       pointerEvents: "none"
     },
     ".metadata.metadata-a.horizontal": {
@@ -135,7 +135,7 @@ const styles = (theme: Theme) =>
       position: "absolute",
       bottom: "8px",
       right: "24px",
-      zIndex: 50,
+      zIndex: Z_INDEX.overlay,
       backgroundColor: theme.vars.palette.c_scrim,
       color: theme.vars.palette.common.white,
       padding: getSpacingPx(SPACING.xs),


### PR DESCRIPTION
## What & why

Part of the DESIGN.md token migration (WS3c). Replaces ~24 magic z-index
integers with named constants across `properties/`, `inputs/`, and
`widgets/`, so stacking order is explicit and the `design-tokens` lint
selector (`Property[key.name='zIndex'] > Literal[value>0]`) no longer warns
in these directories.

## Mapping (preserves stacking order per context)

Per the WS3a guidance, the app theme defines a high zIndex scale
(`popover`, `popover2`, `highest`, …) that large portal values interoperate
with, while the `Z_INDEX` token scale tops out at 400. Values map by
stacking context:

- **Portal / full-screen overlays that must sit above MUI portals →
  `theme.zIndex.*`:**
  - `TextEditorModal` & `DataframeEditorModal` overlays, `selectStyles`
    lists (`10000`) → `popover`
  - `DatePicker` popper (`99999`) → `popover2` (added `useTheme`)
  - `SpeedDisplay` HUD (`999999`) → `highest` (added `useTheme`)
- **Local in-component stacking → `Z_INDEX.*`:** `1`/`2`/`5` → `raised`,
  `10` → `dropdown`, `11`/`15` → `sticky`, `50` → `overlay` (order
  preserved — e.g. the preset-menu search bar stays above its sticky
  subheader).

Left as-is (not matched by the `value>0` selector): `TextProperty`
`zIndex: 0`.

## Test support

`themeMock.ts` gains Nodetool's custom zIndex keys so components using
`theme.zIndex.*` resolve under Jest; the `SpeedDisplay` z-index test now
renders inside `ThemeProvider(mockTheme)` and asserts against
`theme.zIndex.highest`.

## Verification

- `eslint` on all touched files and the three whole directories: **0
  errors, 0 zIndex warnings**.
- `SpeedDisplay.test.tsx`: **31/31 pass** (incl. the z-index assertion).
- Touched files are type-clean (`tsc` reports no errors in any of them).
  The custom `theme.zIndex` keys (`popover`, `popover2`, `highest`) are
  typed via the `ZIndex` augmentation in `web/src/theme.d.ts`.

The selector stays at `warn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)