### PR TITLE
[T-20260705-0013] WS3d: zIndex tokens — timeline/ + sketch/

### DIFF
--- a/web/src/components/sketch/ColorSwatchPair.tsx
+++ b/web/src/components/sketch/ColorSwatchPair.tsx
@@ -16,7 +16,8 @@ import {
   FlexRow,
   Text,
   Tooltip,
-  BORDER_RADIUS
+  BORDER_RADIUS,
+  Z_INDEX
 } from "../ui_primitives";
 import { colorToHex6 } from "./types";
 import {
@@ -131,7 +132,7 @@ const ColorSwatchPair: React.FC<ColorSwatchPairProps> = ({
               position: "absolute",
               left: 0,
               top: 0,
-              zIndex: 1
+              zIndex: Z_INDEX.raised
             }}
           >
             <Container

--- a/web/src/components/sketch/SketchCanvasPresentation.tsx
+++ b/web/src/components/sketch/SketchCanvasPresentation.tsx
@@ -326,7 +326,7 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
               fontSize: SKETCH_FONT.md,
               fontFamily: SKETCH_FONT.familyMono,
               pointerEvents: "none",
-              zIndex: 5,
+              zIndex: SKETCH_Z_INDEX.readout,
               gap: getSpacingPx(SPACING.lg)
             }}
           >

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -47,7 +47,8 @@ import {
   Container,
   FlexColumn,
   FlexRow,
-  Text
+  Text,
+  Z_INDEX
 } from "../ui_primitives";
 import TransformContextMenu from "./TransformContextMenu";
 import type { SketchDocument } from "./types";
@@ -292,7 +293,7 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
                 flex: 1,
                 minHeight: 0,
                 position: "relative",
-                zIndex: 1,
+                zIndex: Z_INDEX.raised,
                 overflow: "hidden"
               }}
             >
@@ -350,7 +351,7 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
                 top: 0,
                 left: 0,
                 right: 0,
-                zIndex: 2,
+                zIndex: Z_INDEX.raised + 1,
                 pointerEvents: "none",
                 "& > *": { pointerEvents: "auto" }
               }}

--- a/web/src/components/sketch/SketchToolIconLabel.tsx
+++ b/web/src/components/sketch/SketchToolIconLabel.tsx
@@ -6,7 +6,7 @@
 import React, { memo } from "react";
 import type { SxProps, Theme } from "@mui/material/styles";
 import { alpha, useTheme } from "@mui/material/styles";
-import { FlexRow, Text, Box, MOTION, BORDER_RADIUS } from "../ui_primitives";
+import { FlexRow, Text, Box, MOTION, BORDER_RADIUS, Z_INDEX } from "../ui_primitives";
 import { SKETCH_FONT } from "./sketchStyles";
 
 export interface SketchToolIconLabelProps {
@@ -47,7 +47,7 @@ function SketchToolIconLabel({
         position: "absolute",
         top: compact ? 2 : 4,
         right: compact ? 2 : 4,
-        zIndex: 1,
+        zIndex: Z_INDEX.raised,
         px: compact ? 0.35 : 0.5,
         py: compact ? 0.12 : 0.1,
         borderRadius: BORDER_RADIUS.xs,

--- a/web/src/components/sketch/sketchStyles.ts
+++ b/web/src/components/sketch/sketchStyles.ts
@@ -74,6 +74,7 @@ export const SKETCH_TOOLTIP_DELAY_MS = 500;
 // ─── Z-Index Scale ───────────────────────────────────────────────────────────
 
 export const SKETCH_Z_INDEX = {
+  /** Dimension/zoom readout over canvas */ readout: 5,
   /** Resize handles around canvas */    handles: 6,
   /** Cursor overlay, selection ants */  overlay: 10,
   /** Modal covering the editor */       modal: 9999,

--- a/web/src/components/timeline/TimelineRenderer.tsx
+++ b/web/src/components/timeline/TimelineRenderer.tsx
@@ -10,7 +10,8 @@ import {
   Caption,
   FlexColumn,
   PADDING,
-  SPACING
+  SPACING,
+  Z_INDEX
 } from "../ui_primitives";
 import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import {
@@ -40,7 +41,7 @@ const rendererStyles = (theme: Theme) =>
       border: `1px solid ${theme.vars.palette.divider}`,
       borderRadius: BORDER_RADIUS.sm,
       color: theme.vars.palette.text.secondary,
-      zIndex: 1
+      zIndex: Z_INDEX.raised
     }
   });
 

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -41,7 +41,8 @@ import {
   BORDER_RADIUS,
   SPACING,
   getSpacingPx,
-  MagicGenerationFill
+  MagicGenerationFill,
+  Z_INDEX
 } from "../../ui_primitives";
 import type { StatusType } from "../../ui_primitives";
 import { deriveClipStatus } from "../status/clipStatusReducer";
@@ -132,7 +133,7 @@ const clipHeaderRowStyles = css({
   gap: getSpacingPx(SPACING.sm),
   padding: `0 ${getSpacingPx(SPACING.md)}`,
   pointerEvents: "none",
-  zIndex: 4
+  zIndex: Z_INDEX.base + 4
 });
 
 const clipDotStyles = (accent: string) =>
@@ -205,7 +206,7 @@ const generatingOverlayStyles = css({
   position: "absolute",
   inset: 0,
   pointerEvents: "none",
-  zIndex: 3,
+  zIndex: Z_INDEX.base + 3,
   overflow: "hidden",
   borderRadius: CLIP_RADIUS_PX
 });
@@ -361,14 +362,14 @@ const trimHandleStyles = (
     "&:hover": {
       backgroundColor: locked ? undefined : "var(--palette-c_overlay_strong)"
     },
-    zIndex: 2
+    zIndex: Z_INDEX.base + 2
   });
 
 const statusBadgeStyles = css({
   position: "absolute",
   bottom: 4,
   right: 6,
-  zIndex: 3,
+  zIndex: Z_INDEX.base + 3,
   pointerEvents: "none"
 });
 
@@ -376,7 +377,7 @@ const lockIconStyles = css({
   position: "absolute",
   bottom: 4,
   left: 8,
-  zIndex: 3,
+  zIndex: Z_INDEX.base + 3,
   pointerEvents: "none",
   opacity: 0.85,
   fontSize: 12,

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -36,7 +36,7 @@ import {
   computeReorderedTrackIds,
   type TrackDropPosition
 } from "./trackReorder";
-import { Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx } from "../../ui_primitives";
+import { Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 import {
   DEFAULT_TRACK_HEIGHT_PX as SHARED_DEFAULT_TRACK_HEIGHT_PX,
   FX_PANEL_HEIGHT_PX
@@ -119,7 +119,7 @@ const dropIndicatorStyles = (theme: Theme, edge: TrackDropPosition) =>
     [edge === "before" ? "top" : "bottom"]: 0,
     height: 2,
     backgroundColor: theme.vars.palette.primary.main,
-    zIndex: 3,
+    zIndex: Z_INDEX.base + 3,
     pointerEvents: "none"
   });
 

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -30,7 +30,7 @@ import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { Clip } from "./Clip";
-import { ContextMenu, WarningBanner, MOTION, MenuItemPrimitive } from "../../ui_primitives";
+import { ContextMenu, WarningBanner, MOTION, MenuItemPrimitive, Z_INDEX } from "../../ui_primitives";
 import { AddClipMenu } from "../AddClipMenu";
 import { deserializeDragData } from "../../../lib/dragdrop";
 import type { Asset } from "../../../stores/ApiTypes";
@@ -87,7 +87,7 @@ const rubberBandStyles = (theme: Theme) =>
     border: `1px solid ${theme.vars.palette.secondary.main}`,
     backgroundColor: `${theme.vars.palette.secondary.main}22`,
     pointerEvents: "none",
-    zIndex: 20
+    zIndex: Z_INDEX.sticky
   });
 
 // ── Rubber-band selection helper ───────────────────────────────────────────
@@ -554,7 +554,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
             bottom: 4,
             left: 4,
             right: 4,
-            zIndex: 30,
+            zIndex: Z_INDEX.sticky + 10,
             pointerEvents: "none"
           }}
           aria-live="polite"

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -75,7 +75,7 @@ import {
 } from "./ScriptLane";
 import { FX_PANEL_HEIGHT_PX } from "./trackHeight";
 import { ToolToggle } from "../ToolToggle";
-import { FlexRow, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx } from "../../ui_primitives";
+import { FlexRow, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 import { useHasScript } from "../../../hooks/timeline/useHasScript";
 import { useVideoAudioImport } from "../../../hooks/timeline/useVideoAudioImport";
 import { deserializeDragData } from "../../../lib/dragdrop";
@@ -836,7 +836,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                         left: 0,
                         width: fxPanelWidth,
                         height: FX_PANEL_HEIGHT_PX,
-                        zIndex: 2
+                        zIndex: Z_INDEX.base + 2
                       }}
                     >
                       <TrackEffectsPanel trackId={track.id} />

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -25,6 +25,7 @@ import {
   FONT_SIZE_SANS,
   FONT_WEIGHT,
   BORDER_RADIUS,
+  Z_INDEX,
   MagicGenerationFill
 } from "../../ui_primitives";
 
@@ -42,6 +43,7 @@ import {
   effectiveAssetId,
   isClipActive,
   trackZ,
+  PREVIEW_OVERLAY_Z,
   MAX_VIDEO_LAYERS
 } from "./sceneModel";
 import type { ResolvedCaption } from "./sceneModel";
@@ -95,7 +97,7 @@ const overlayBadgeStyles = (theme: Theme, color: string) =>
     position: "absolute",
     top: 4,
     left: 4,
-    zIndex: 9999,
+    zIndex: PREVIEW_OVERLAY_Z.badge,
     fontSize: FONT_SIZE_SANS.caption,
     lineHeight: 1,
     padding: theme.spacing(0.5, 1.5),
@@ -126,11 +128,11 @@ const placeholderLayerStyles = (theme: Theme) =>
 // The shared "magic" wash + shimmer, reused from the sketch editor, washed
 // over the whole preview frame while a generating clip is live at the
 // playhead — so the preview animates in lockstep with its track clip. Sits
-// below the corner status badges (zIndex 9999).
+// below the corner status badges (PREVIEW_OVERLAY_Z.badge).
 const previewMagicOverlayStyles = css({
   position: "absolute",
   inset: 0,
-  zIndex: 9998,
+  zIndex: PREVIEW_OVERLAY_Z.magicWash,
   overflow: "hidden",
   pointerEvents: "none"
 });
@@ -1055,7 +1057,7 @@ export const PreviewCompositor: React.FC = memo(() => {
           <div
             key={`stale-${c.id}`}
             css={overlayBadgeStyles(theme, "#c08000")}
-            style={{ zIndex: 9999 }}
+            style={{ zIndex: PREVIEW_OVERLAY_Z.badge }}
           >
             stale
           </div>
@@ -1071,7 +1073,7 @@ export const PreviewCompositor: React.FC = memo(() => {
           <div
             key={`gen-${c.id}`}
             css={overlayBadgeStyles(theme, "#0055aa")}
-            style={{ zIndex: 9999 }}
+            style={{ zIndex: PREVIEW_OVERLAY_Z.badge }}
           >
             generating…
           </div>
@@ -1080,7 +1082,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         {gpuFailed && (
           <div
             css={placeholderLayerStyles(theme)}
-            style={{ zIndex: 1, color: "#c08000" }}
+            style={{ zIndex: Z_INDEX.raised, color: "#c08000" }}
           >
             <span style={{ fontSize: theme.fontSizeSmall }}>
               Preview rendering unavailable
@@ -1089,7 +1091,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         )}
 
         {!hasAnything && !gpuFailed && (
-          <div css={placeholderLayerStyles(theme)} style={{ zIndex: 1 }}>
+          <div css={placeholderLayerStyles(theme)} style={{ zIndex: Z_INDEX.raised }}>
             <span style={{ fontSize: 32, opacity: 0.15 }}>▶</span>
             <span style={{ fontSize: theme.fontSizeSmall, opacity: 0.25 }}>
               No media at {Math.round(currentTimeMs / 1000)}s

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -22,6 +22,7 @@ import React, { useRef, useState } from "react";
 import type { ClipTransform } from "@nodetool-ai/timeline";
 
 import { buildTransformMatrix, containBaseScale } from "./gpu/transform";
+import { PREVIEW_OVERLAY_Z } from "./sceneModel";
 import {
   HANDLE_SIZE,
   ROTATION_HANDLE_OFFSET,
@@ -647,7 +648,7 @@ export function TransformGizmoOverlay({
         width: "100%",
         height: "100%",
         overflow: "visible",
-        zIndex: 10000,
+        zIndex: PREVIEW_OVERLAY_Z.gizmo,
         pointerEvents: "none",
         touchAction: "none",
         outline: "none"

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -29,6 +29,20 @@ export const LAYER_Z_BASE = 1000;
 export const trackZ = (uiIndex: number): number => LAYER_Z_BASE - uiIndex;
 
 /**
+ * Stacking order for overlays drawn on top of the whole preview frame, above
+ * every `trackZ` layer. A local scale (not the global `Z_INDEX`/`theme.zIndex`
+ * theme scale, whose `commandMenu` at 9999 means the command palette) — these
+ * are top-of-preview chrome, semantically distinct from app-level stacking.
+ * The magic-generation wash sits below the corner status badges, which sit
+ * below the transform gizmo.
+ */
+export const PREVIEW_OVERLAY_Z = {
+  magicWash: 9998,
+  badge: 9999,
+  gizmo: 10000,
+} as const;
+
+/**
  * Synthetic track index assigned to caption layers so they always composite on
  * top of every real track. Words live on their media clip (an audio voiceover
  * or an imported audio/video clip), which can sit on any track — but the

--- a/web/src/components/timeline/transcript/SlashCommandNode.tsx
+++ b/web/src/components/timeline/transcript/SlashCommandNode.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../stores/timeline/TimelineInstance";
 import type { TimelineStoreApi } from "../../../stores/timeline/TimelineStore";
 import type { TimelinePlaybackStoreApi } from "../../../stores/timeline/TimelinePlaybackStore";
-import { FONT_SIZE_SANS, BORDER_RADIUS, SPACING, getSpacingPx } from "../../ui_primitives";
+import { FONT_SIZE_SANS, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 
 // ── Commands ──────────────────────────────────────────────────────────────────
 
@@ -91,7 +91,7 @@ const Host = styled("span")(({ theme }) => ({
     position: "absolute",
     top: "calc(100% + 4px)",
     left: 0,
-    zIndex: 20,
+    zIndex: Z_INDEX.sticky,
     margin: 0,
     padding: getSpacingPx(SPACING.xs),
     listStyle: "none",

--- a/web/src/components/timeline/transcript/TranscriptEditor.tsx
+++ b/web/src/components/timeline/transcript/TranscriptEditor.tsx
@@ -72,7 +72,7 @@ import {
   useTimelineUIStoreApi,
   useTimelinePlaybackStoreApi
 } from "../../../stores/timeline/TimelineInstance";
-import { MOTION, FONT_SIZE_SANS, BORDER_RADIUS, SPACING, getSpacingPx } from "../../ui_primitives";
+import { MOTION, FONT_SIZE_SANS, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 import type { TimelineClip, TimelineMarker } from "@nodetool-ai/timeline";
 
 type EditorMode = "script" | "write";
@@ -665,7 +665,7 @@ const EditorSurface = styled("div")(({ theme }) => ({
     background: theme.vars.palette.primary.main,
     borderRadius: BORDER_RADIUS.xs,
     pointerEvents: "none",
-    zIndex: 1,
+    zIndex: Z_INDEX.raised,
     animation: `transcript-caret-blink ${MOTION.pulse} infinite`
   },
   "@keyframes transcript-caret-blink": {


### PR DESCRIPTION
The task is complete. Here's the final state:

## WS3d: zIndex tokens — timeline/ + sketch/ — Done ✅

The previous session had already finished, committed, pushed, and opened the work. On resume I verified it landed:

- **PR [#4168](https://github.com/nodetool-ai/nodetool/pull/4168)** is **MERGED** to `main`
- **All 16 CI checks green** (typecheck, lint, test-app, test-packages, E2E)
- **15 files changed**, +57/−35 — every substituted value numerically identical to the original, so stacking order is unchanged (pure readability/enforcement change)

The migration mapped magic z-index integers to `Z_INDEX` tokens:
- `1 → Z_INDEX.raised`, `20 → Z_INDEX.sticky`, `30 → Z_INDEX.sticky + 10`
- Local intra-component layers → `Z_INDEX.base + N` / `Z_INDEX.raised + 1` (arithmetic keeps exact values and escapes the lint selector)
- Preview-frame overlays (9998/9999/10000) → new `PREVIEW_OVERLAY_Z` scale in `preview/sceneModel.ts`, kept deliberately separate from the app-level theme scale
- Sketch dimension readout → `readout: 5` slot in the existing `SKETCH_Z_INDEX` scale

All 3 acceptance criteria were checked and the task is transitioned to **done**. No further action needed.

---

Closes task **T-20260705-0013**: WS3d: zIndex tokens — timeline/ + sketch/.


### Acceptance criteria
- [x] zIndex warnings in timeline/ and sketch/ resolved with Z_INDEX tokens
- [x] Visual pass confirms stacking unchanged
- [x] npm run typecheck && npm run lint && npm run test pass