### PR TITLE
Add "Where this fits" sections to surface documentation

### DIFF
--- a/docs/app-builder.md
+++ b/docs/app-builder.md
@@ -16,6 +16,12 @@ onto the workflow.
 - Streams workflow outputs into bound display widgets.
 - Saves the app document with the workflow and serves it in Mini App mode.
 
+## Where this fits
+
+A Mini App is how a **workflow** reaches people who should not have to read a node graph. App Builder wraps the graph in a form: input widgets bind to Input nodes, buttons run the workflow, and display widgets stream Output nodes back. It is the share end of NodeTool's loop — the same **assets** a workflow produces on the canvas, exposed as a usable app.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop.
+
 ## Open App Builder
 
 1. Open a workflow.

--- a/docs/asset-management.md
+++ b/docs/asset-management.md
@@ -8,6 +8,14 @@ NodeTool lets you store and organize files used in your workflows. Assets can be
 
 ---
 
+## Where this fits
+
+Assets are the shared material between NodeTool's surfaces. **Workflows** read assets and write new ones; **sketches** open an asset and render an edited one back; **timelines** import assets as clips and export a finished video asset. The Asset Explorer is the one store all of them read from and write to, so a file produced in any surface is immediately usable in the others.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop.
+
+---
+
 ## Asset Explorer
 
 The **Asset Explorer** is the central hub for managing your files. Open it from the left sidebar.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,6 +102,14 @@ Custom UI? See [App Builder](app-builder.md).
 
 ---
 
+## The bigger picture
+
+You just ran the loop NodeTool is built around: collect assets, build a workflow, generate outputs, and share them as a Mini-App. Two more editing surfaces plug into the same loop — the [Sketch Editor](sketch-editor.md) for layered still images and the [Video Editor](video-editor.md) for timelines — and everything they produce is an **asset** the others can read. All four surfaces share one asset store and the same model/provider system.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop and diagram.
+
+---
+
 ## Next
 
 | Goal | Page |

--- a/docs/sketch-editor.md
+++ b/docs/sketch-editor.md
@@ -28,6 +28,14 @@ The Sketch Editor is a layered raster editor with a built-in AI generation pipel
 
 ---
 
+## Where this fits
+
+The Sketch Editor is one of NodeTool's editing surfaces, and it sits between manual editing and workflow automation. It opens an image **asset**, lets you paint or generate layers by hand or bind a layer to an image **workflow**, then renders the result back into an asset. That asset is the same material every other surface reads — drop it back on the canvas, drag it onto a **timeline**, or expose the workflow behind it as a **Mini-App**. Every surface shares one asset store and the same model/provider system.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop.
+
+---
+
 ## Opening the Editor
 
 The Sketch Editor runs in three places, all backed by the same document so your work stays in sync.

--- a/docs/video-editor.md
+++ b/docs/video-editor.md
@@ -30,6 +30,14 @@ The Video Editor (timeline editor) is a non-linear, multi-track surface for asse
 
 ---
 
+## Where this fits
+
+The Video Editor is the surface where outputs become finished, time-based media. It pulls **assets** in as clips, binds **workflows** to generated clips so footage regenerates when parameters change, and exports the sequence back to a video asset — the same material a sketch, another workflow, or a **Mini-App** can pick up. Every surface shares one asset store and the same model/provider system.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop.
+
+---
+
 ## Opening the Video Editor
 
 There are a few ways in:

--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -12,6 +12,14 @@ The canvas: place nodes, connect ports, run, debug. Covers basic navigation thro
 
 ---
 
+## Where this fits
+
+The workflow editor is NodeTool's automation layer. A workflow reads **assets**, calls models, and writes new assets — which flow on into the **Sketch Editor** and **Video Editor** for hand editing, come back as fresh assets, or ship to non-technical users as a **Mini-App**. Every surface shares this graph's outputs through one asset store and the same model/provider system.
+
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop.
+
+---
+
 ## Editor Layout
 
 | Area | Where | What It Does |


### PR DESCRIPTION
## Summary

Added contextual "Where this fits" sections to documentation for all major NodeTool surfaces (Workflow Editor, Sketch Editor, Video Editor, Asset Management, App Builder) and the Getting Started guide. These sections explain how each surface integrates into NodeTool's unified loop and cross-reference the Key Concepts documentation.

## Changes

- **asset-management.md**: Added "Where this fits" section explaining how assets flow between surfaces and the Asset Explorer's central role
- **getting-started.md**: Added "The bigger picture" section summarizing the complete loop after the initial tutorial
- **sketch-editor.md**: Added "Where this fits" section describing the Sketch Editor's role in the editing pipeline
- **video-editor.md**: Added "Where this fits" section explaining the Video Editor's role in time-based media production
- **workflow-editor.md**: Added "Where this fits" section describing the workflow editor as the automation layer
- **app-builder.md**: Added "Where this fits" section explaining Mini Apps as the share endpoint of the loop

All new sections follow a consistent pattern:
1. Brief explanation of the surface's role in the system
2. How it connects to other surfaces and the asset store
3. Cross-reference to [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together)

This improves documentation discoverability and helps users understand the relationships between NodeTool's four editing surfaces and how they share a unified asset store and model/provider system.

https://claude.ai/code/session_019ELz8WtLJdB1aB9qKG7Ywu