### PR TITLE
[T-20260705-0003] Phase 3 — Regroup the Integrations tab

### DIFF
--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import SaveIcon from "@mui/icons-material/Save";
 
-import { useMemo, useState, useCallback, useEffect, memo } from "react";
+import { useMemo, useState, useCallback, useEffect, memo, Fragment } from "react";
 
 import {
   TextInput,
@@ -24,9 +24,19 @@ import {
 import { useTheme } from "@mui/material/styles";
 import { getSharedSettingsStyles } from "./sharedSettingsStyles";
 import { formatSettingLabel } from "./settingsLabel";
+import ExternalLink from "../common/ExternalLink";
+import SearchProviderSection from "./SearchProviderSection";
 
-/** Groups surfaced elsewhere (General tab, Folders panel) or via SearchProviderSection. */
-const HIDDEN_SETTING_GROUPS = new Set(["Folders", "Search", "Execution"]);
+/**
+ * Groups surfaced elsewhere (General tab, Folders panel) or via
+ * SearchProviderSection, so they are not echoed by the generic list.
+ */
+const HIDDEN_SETTING_GROUPS = new Set([
+  "Folders",
+  "Search",
+  "Execution",
+  "Autosave" // already surfaced on the General tab
+]);
 /** Search-provider settings rendered by SearchProviderSection, not the generic list. */
 const SEARCH_RELATED_SETTINGS = new Set([
   "SERP_PROVIDER",
@@ -37,19 +47,116 @@ const SEARCH_RELATED_SETTINGS = new Set([
   "APIFY_API_KEY"
 ]);
 
+/**
+ * Ordered meta-sections shown on the Integrations tab. Each maps one or more
+ * registry groups to a single, stable heading so the panel doesn't just echo
+ * raw backend group names. `groups` also defines the preferred display order
+ * within the section. The trailing "Other" section catches any future registry
+ * group that isn't mapped, so nothing silently disappears.
+ */
+const META_SECTION_GROUPS: ReadonlyArray<{
+  key: string;
+  label: string;
+  groups: ReadonlyArray<string>;
+}> = [
+  {
+    key: "local-model-servers",
+    label: "Local Model Servers",
+    groups: ["vLLM", "Ollama", "LlamaCpp", "LMStudio", "TransformersJs"]
+  },
+  {
+    key: "provider-options",
+    label: "Provider Options",
+    groups: ["ZAI", "KIE"]
+  },
+  {
+    key: "observability",
+    label: "Observability",
+    groups: ["Observability", "Traceloop"]
+  },
+  {
+    key: "data-and-storage",
+    label: "Data & Storage",
+    groups: ["NodeSupabase", "Supabase"]
+  },
+  { key: "other", label: "Other", groups: [] }
+];
+
+/** Inverted, lowercased lookup: registry group (lowercase) → meta-section key. */
+const GROUP_SECTIONS: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+  for (const section of META_SECTION_GROUPS) {
+    for (const group of section.groups) {
+      map[group.toLowerCase()] = section.key;
+    }
+  }
+  return map;
+})();
+
+export interface MetaSectionEntry {
+  group: string;
+  settings: SettingWithValue[];
+}
+
+export interface MetaSection {
+  key: string;
+  label: string;
+  entries: MetaSectionEntry[];
+}
+
+export interface DisplayedGroup {
+  id: string;
+  label: string;
+}
+
 /** Anchor id for a settings group heading (e.g. "vLLM" → "vllm"). */
 export const settingGroupSlug = (groupName: string): string =>
   groupName.toLowerCase().replace(/\s+/g, "-");
 
 /**
- * Ordered list of group names the generic settings list actually renders —
- * used to build the Integrations sidebar so it mirrors the visible sections.
+ * Partitions visible registry groups into the fixed meta-section order. Shared
+ * by the panel (rendering) and getDisplayedSettingGroups (sidebar) so the two
+ * stay in sync and never drift.
+ */
+const partitionByMetaSection = (
+  visibleGroups: Map<string, SettingWithValue[]>
+): MetaSection[] => {
+  const sections: MetaSection[] = [];
+  for (const section of META_SECTION_GROUPS) {
+    const entries: MetaSectionEntry[] = [];
+    if (section.key === "other") {
+      // Unmapped (future) groups, in backend order.
+      for (const [groupName, settings] of visibleGroups) {
+        if (groupName.toLowerCase() in GROUP_SECTIONS) continue;
+        entries.push({ group: groupName, settings });
+      }
+    } else {
+      // Known groups, in the section's preferred display order.
+      for (const preferred of section.groups) {
+        for (const [groupName, settings] of visibleGroups) {
+          if (groupName.toLowerCase() === preferred.toLowerCase()) {
+            entries.push({ group: groupName, settings });
+          }
+        }
+      }
+    }
+    if (entries.length > 0) {
+      sections.push({ key: section.key, label: section.label, entries });
+    }
+  }
+  return sections;
+};
+
+/**
+ * Meta-sections the Integrations panel actually renders, in order — used to
+ * build the sidebar so it mirrors the visible sections. The Web-search entry
+ * (rendered by SearchProviderSection) is inserted right after Local Model
+ * Servers, matching the panel layout.
  */
 export const getDisplayedSettingGroups = (
   settings: SettingWithValue[]
-): string[] => {
-  const groups: string[] = [];
-  const seen = new Set<string>();
+): DisplayedGroup[] => {
+  const visibleGroups = new Map<string, SettingWithValue[]>();
   for (const setting of settings) {
     if (
       HIDDEN_SETTING_GROUPS.has(setting.group) ||
@@ -58,15 +165,30 @@ export const getDisplayedSettingGroups = (
     ) {
       continue;
     }
-    if (!seen.has(setting.group)) {
-      seen.add(setting.group);
-      groups.push(setting.group);
+    if (!visibleGroups.has(setting.group)) {
+      visibleGroups.set(setting.group, []);
+    }
+    visibleGroups.get(setting.group)!.push(setting);
+  }
+  if (visibleGroups.size === 0) {
+    return [];
+  }
+  const presentKeys = new Set(
+    partitionByMetaSection(visibleGroups).map((s) => s.key)
+  );
+  const result: DisplayedGroup[] = [];
+  for (const section of META_SECTION_GROUPS) {
+    if (presentKeys.has(section.key)) {
+      result.push({ id: section.key, label: section.label });
+    }
+    // SearchProviderSection always renders alongside the registry list, so
+    // the sidebar always lists it at this slot (after Local Model Servers).
+    if (section.key === "local-model-servers") {
+      result.push({ id: "search-provider", label: "Search Provider" });
     }
   }
-  return groups;
+  return result;
 };
-import ExternalLink from "../common/ExternalLink";
-import SearchProviderSection from "./SearchProviderSection";
 
 const SETTING_LINKS: Record<string, string> = {
   OPENAI_API_KEY: "https://platform.openai.com/api-keys",
@@ -268,31 +390,47 @@ const RemoteSettings = () => {
     return groups;
   }, [data, storeSettingsByGroup]);
 
-  const displayedSettingsByGroup = useMemo(() => {
-    if (!settingsByGroup || settingsByGroup.size === 0) {
-      return new Map<string, SettingWithValue[]>();
+  // Bucket visible registry groups into the fixed meta-sections (Local Model
+  // Servers, Provider Options, …) so the panel renders stable headings instead
+  // of echoing raw backend group names. partitionByMetaSection is shared with
+  // getDisplayedSettingGroups so the sidebar mirrors this exactly.
+  const sectionsMap = useMemo<Map<string, MetaSection>>(() => {
+    const visibleGroups = new Map<string, SettingWithValue[]>();
+    if (settingsByGroup && settingsByGroup.size > 0) {
+      settingsByGroup.forEach((groupSettings, groupName) => {
+        if (HIDDEN_SETTING_GROUPS.has(groupName)) {
+          return;
+        }
+        const allowedSettings = groupSettings.filter(
+          (setting) =>
+            !setting.is_secret && !SEARCH_RELATED_SETTINGS.has(setting.env_var)
+        );
+        if (allowedSettings.length > 0) {
+          visibleGroups.set(groupName, allowedSettings);
+        }
+      });
     }
-
-    const filteredEntries: [string, SettingWithValue[]][] = [];
-
-    settingsByGroup.forEach((groupSettings, groupName) => {
-      // Folders/Search/Execution are surfaced elsewhere — skip them here.
-      if (HIDDEN_SETTING_GROUPS.has(groupName)) {
-        return;
-      }
-
-      const allowedSettings = groupSettings.filter(
-        (setting) =>
-          !setting.is_secret && !SEARCH_RELATED_SETTINGS.has(setting.env_var)
-      );
-
-      if (allowedSettings.length > 0) {
-        filteredEntries.push([groupName, allowedSettings]);
-      }
-    });
-
-    return new Map<string, SettingWithValue[]>(filteredEntries);
+    return new Map(
+      partitionByMetaSection(visibleGroups).map((section) => [
+        section.key,
+        section
+      ])
+    );
   }, [settingsByGroup]);
+
+  const hasVisibleSettings = sectionsMap.size > 0;
+
+  // The sticky save bar only appears when the user has unsaved edits.
+  const isDirty = useMemo(() => {
+    if (!data) return false;
+    for (const setting of data) {
+      const current = settingValues[setting.env_var];
+      if (current === undefined) continue;
+      const original = setting.value != null ? String(setting.value) : "";
+      if (current !== original) return true;
+    }
+    return false;
+  }, [data, settingValues]);
 
   const updateSettingsMutation = useMutation({
     mutationFn: (args: { settings: Record<string, string>; secrets: Record<string, string> }) =>
@@ -358,48 +496,51 @@ const RemoteSettings = () => {
           Loading settings…
         </Text>
       )}
-      {isSuccess &&
-        displayedSettingsByGroup &&
-        displayedSettingsByGroup.size > 0 && (
-          <div
-            className="remote-settings-content"
-            css={getSharedSettingsStyles(theme)}
-          >
-            <div className="settings-main-content">
-              {/* Search Provider Section */}
-              {data && (
-                <SearchProviderSection
-                  allSettings={data}
-                  settingValues={settingValues}
-                  onChange={handleChange}
-                />
-              )}
+      {isSuccess && hasVisibleSettings && (
+        <div
+          className="remote-settings-content"
+          css={getSharedSettingsStyles(theme)}
+        >
+          <div className="settings-main-content">
+            {/* Render meta-sections in the fixed order; the Web-search picker
+                (SearchProviderSection) sits right after Local Model Servers. */}
+            {META_SECTION_GROUPS.map((section) => {
+              const sec = sectionsMap.get(section.key);
+              return (
+                <Fragment key={section.key}>
+                  {sec && (
+                    <div className="settings-section">
+                      <Text
+                        size="big"
+                        id={sec.key}
+                        className="settings-heading"
+                      >
+                        {sec.label}
+                      </Text>
+                      {sec.entries.flatMap(({ settings }) =>
+                        settings.map((setting) => (
+                          <SettingItem
+                            key={setting.env_var}
+                            setting={setting}
+                            value={settingValues[setting.env_var] || ""}
+                            onChange={handleChange}
+                          />
+                        ))
+                      )}
+                    </div>
+                  )}
+                  {section.key === "local-model-servers" && data && (
+                    <SearchProviderSection
+                      allSettings={data}
+                      settingValues={settingValues}
+                      onChange={handleChange}
+                    />
+                  )}
+                </Fragment>
+              );
+            })}
 
-              {/* Render settings grouped by their group field */}
-              {Array.from(displayedSettingsByGroup.entries()).map(
-                ([groupName, groupSettings]) => (
-                  <div key={groupName} className="settings-section">
-                    <Text
-                      size="big"
-                      id={settingGroupSlug(groupName)}
-                      className="settings-heading"
-                    >
-                      {groupName}
-                    </Text>
-                    {groupSettings
-                      .filter((setting) => !setting.is_secret)
-                      .map((setting) => (
-                        <SettingItem
-                          key={setting.env_var}
-                          setting={setting}
-                          value={settingValues[setting.env_var] || ""}
-                          onChange={handleChange}
-                        />
-                      ))}
-                  </div>
-                )
-              )}
-
+            {isDirty && (
               <div className="save-button-container">
                 <EditorButton
                   variant="contained"
@@ -411,15 +552,15 @@ const RemoteSettings = () => {
                   SAVE SETTINGS
                 </EditorButton>
               </div>
-            </div>
+            )}
           </div>
-        )}
-      {isSuccess &&
-        (!displayedSettingsByGroup || displayedSettingsByGroup.size === 0) && (
-          <Text sx={{ textAlign: "center", padding: "2em" }}>
-            No settings available
-          </Text>
-        )}
+        </div>
+      )}
+      {isSuccess && !hasVisibleSettings && (
+        <Text sx={{ textAlign: "center", padding: "2em" }}>
+          No settings available
+        </Text>
+      )}
     </>
   );
 };

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -34,8 +34,7 @@ import {
   SecurityNotice
 } from "./APIKeysTab";
 import {
-  getDisplayedSettingGroups,
-  settingGroupSlug
+  getDisplayedSettingGroups
 } from "./RemoteSettingsMenu";
 import ServerNumberSetting from "./ServerNumberSetting";
 import { getAboutSidebarSections } from "./aboutSidebarUtils";
@@ -560,28 +559,16 @@ function SettingsPage() {
   const secrets = useSecretsStore((state) => state.secrets);
   void secrets;
 
-  // Tab 2: Integrations sidebar folders — Configuration lists every group the
-  // generic settings panel renders, so the sidebar shows all items.
+  // Tab 2: Integrations sidebar folders — Configuration mirrors the panel
+  // top-to-bottom: the registry meta-sections (Local Model Servers, Search
+  // Provider, …) then Folders; Servers (localhost) and the Nodetool API token
+  // (hosted) follow.
   const integrationsSidebarSections = useMemo(() => {
     const configItems = [
-      { id: "api-settings", label: "API Settings" },
-      { id: "search-provider", label: "Search Provider" },
-      ...getDisplayedSettingGroups(remoteSettings ?? []).map((group) => ({
-        id: settingGroupSlug(group),
-        label: group
-      }))
+      ...getDisplayedSettingGroups(remoteSettings ?? []),
+      { id: "folders", label: "Folders" }
     ];
     return [
-      ...(session?.access_token && !isLocalhost
-        ? [
-            {
-              category: "Credentials",
-              items: [
-                { id: "nodetool-api-token", label: "Nodetool API Token" }
-              ]
-            }
-          ]
-        : []),
       { category: "Configuration", items: configItems },
       ...(isLocalhost
         ? [
@@ -594,7 +581,16 @@ function SettingsPage() {
             }
           ]
         : []),
-      { category: "Storage", items: [{ id: "folders", label: "Folders" }] }
+      ...(session?.access_token && !isLocalhost
+        ? [
+            {
+              category: "Credentials",
+              items: [
+                { id: "nodetool-api-token", label: "Nodetool API Token" }
+              ]
+            }
+          ]
+        : [])
     ];
   }, [remoteSettings, session?.access_token]);
 
@@ -1150,6 +1146,39 @@ function SettingsPage() {
                 {/* Tab 2: Integrations (endpoints, MCP, storage, Nodetool API) */}
                 <TabPanel value={settingsTab} index={TAB_INTEGRATIONS}>
                   <div className="integrations-settings">
+                  {/* Meta-sections from the registry + the Web-search picker. */}
+                  <RemoteSettingsMenuComponent />
+
+                  {/* Data & storage: Folders browser. */}
+                  <Text size="big" id="folders" className="settings-heading">
+                    Folders
+                  </Text>
+                  <FoldersSettings />
+
+                  {/* Servers (localhost only): MCP + Browser Extension. */}
+                  {isLocalhost && (
+                    <>
+                      <Text
+                        size="big"
+                        id="mcp-integration"
+                        className="settings-heading"
+                      >
+                        MCP Integration
+                      </Text>
+                      <MCPSettingsMenu />
+
+                      <Text
+                        size="big"
+                        id="browser-extension"
+                        className="settings-heading"
+                      >
+                        Browser Extension
+                      </Text>
+                      <BrowserExtensionSettingsMenu />
+                    </>
+                  )}
+
+                  {/* Nodetool API (hosted only): token copy card. */}
                   {session?.access_token && !isLocalhost && (
                     <>
                       <Text
@@ -1224,42 +1253,6 @@ function SettingsPage() {
                       </div>
                     </>
                   )}
-
-                  <Text
-                    size="big"
-                    id="api-settings"
-                    className="settings-heading"
-                  >
-                    API Settings
-                  </Text>
-                  <RemoteSettingsMenuComponent />
-
-                  {isLocalhost && (
-                    <>
-                      <Text
-                        size="big"
-                        id="mcp-integration"
-                        className="settings-heading"
-                      >
-                        MCP Integration
-                      </Text>
-                      <MCPSettingsMenu />
-
-                      <Text
-                        size="big"
-                        id="browser-extension"
-                        className="settings-heading"
-                      >
-                        Browser Extension
-                      </Text>
-                      <BrowserExtensionSettingsMenu />
-                    </>
-                  )}
-
-                  <Text size="big" id="folders" className="settings-heading">
-                    Folders
-                  </Text>
-                  <FoldersSettings />
                   </div>
                 </TabPanel>
 

--- a/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
+++ b/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
@@ -242,10 +242,13 @@ describe("RemoteSettingsMenu", () => {
 
       render(<RemoteSettingsMenuComponent />, { wrapper });
 
-      // Component should render successfully
+      // Non-secret setting renders; the save bar stays hidden without edits.
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: /SAVE SETTINGS/i })).toBeInTheDocument();
+        expect(screen.getByDisplayValue("localhost")).toBeInTheDocument();
       });
+      expect(
+        screen.queryByRole("button", { name: /SAVE SETTINGS/i })
+      ).not.toBeInTheDocument();
     });
 
     it("should remove empty groups after filtering secrets", async () => {
@@ -292,7 +295,7 @@ describe("RemoteSettingsMenu", () => {
 
       // Component should render without throwing
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: /SAVE SETTINGS/i })).toBeInTheDocument();
+        expect(screen.getByDisplayValue("30")).toBeInTheDocument();
       });
     });
   });
@@ -313,11 +316,62 @@ describe("RemoteSettingsMenu", () => {
 
       mockRemoteSettingsStore.fetchSettings.mockResolvedValue(mockSettings);
       mockRemoteSettingsStore.updateSettings.mockResolvedValue(undefined);
+      const user = userEvent.setup();
 
       render(<RemoteSettingsMenuComponent />, { wrapper });
 
+      // The save bar only appears once a field is edited.
+      const input = await screen.findByDisplayValue("30");
+      expect(
+        screen.queryByRole("button", { name: /SAVE SETTINGS/i })
+      ).not.toBeInTheDocument();
+
+      await user.clear(input);
+      await user.type(input, "60");
+
       const saveButton = await screen.findByRole("button", { name: /SAVE SETTINGS/i });
-      expect(saveButton).toBeInTheDocument();
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockRemoteSettingsStore.updateSettings).toHaveBeenCalledWith(
+          { TIMEOUT: "60" },
+          expect.anything()
+        );
+      });
+    });
+
+    it("hides the save bar until there are unsaved edits", async () => {
+      const mockSettings = [
+        {
+          package_name: "nodetool",
+          env_var: "TIMEOUT",
+          group: "Configuration",
+          description: "Timeout",
+          is_secret: false,
+          value: "30",
+          enum: null
+        }
+      ];
+      mockRemoteSettingsStore.fetchSettings.mockResolvedValue(mockSettings);
+      const user = userEvent.setup();
+
+      render(<RemoteSettingsMenuComponent />, { wrapper });
+
+      // No edits yet — sticky save bar is hidden.
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("30")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole("button", { name: /SAVE SETTINGS/i })
+      ).not.toBeInTheDocument();
+
+      // Edit a field — the bar appears.
+      const input = screen.getByDisplayValue("30");
+      await user.clear(input);
+      await user.type(input, "45");
+      expect(
+        await screen.findByRole("button", { name: /SAVE SETTINGS/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -348,9 +402,9 @@ describe("RemoteSettingsMenu", () => {
 
       render(<RemoteSettingsMenuComponent />, { wrapper });
 
-      // Component should render the save button
+      // Non-secret setting renders (secret filtered out)
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: /SAVE SETTINGS/i })).toBeInTheDocument();
+        expect(screen.getByDisplayValue("value1")).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
Done. Here's the summary of what I did.

## Summary

Regrouped the Integrations tab so it renders a fixed set of explicit meta-sections (`Local Model Servers`, `Web Search`, `Provider Options`, `Observability`, `Data & Storage`) instead of echoing raw backend registry-group names, and made the sticky save bar appear only when there are unsaved edits.

**`RemoteSettingsMenu.tsx`**
- Added `META_SECTION_GROUPS` (ordered meta-sections → their registry groups) and a derived `GROUP_SECTIONS` lookup; an unmapped/future group falls into a trailing **Other** section so nothing disappears.
- Extracted `partitionByMetaSection`, shared by the panel and `getDisplayedSettingGroups`, so the sidebar mirrors the panel exactly. `getDisplayedSettingGroups` now returns `{id,label}` meta-section descriptors (with the Search Provider slot inserted after Local Model Servers) instead of raw group-name strings.
- Renders the meta-sections in fixed order, slotting `SearchProviderSection` in right after Local Model Servers.
- Added `Autosave` to `HIDDEN_SETTING_GROUPS` (already surfaced on the General tab).
- Replaced the always-on sticky **SAVE SETTINGS** button with a dirty-aware bar gated on `isDirty` (local `settingValues` vs. loaded data); it hides again after a successful save.

**`SettingsMenu.tsx`**
- Reordered the Integrations tab to match the plan: registry meta-sections + Search Provider → Folders → Servers (MCP/Browser, localhost only) → Nodetool API token (hosted only). Dropped the redundant "API Settings" heading.
- Rebuilt the Integrations sidebar from `getDisplayedSettingGroups` + Folders, with Servers/Credentials categories following, so it mirrors the panel.

**Tests** — updated the existing assertions that relied on the always-visible save button, and added a dedicated test confirming the bar stays hidden until a field is edited.

### Verification
- `npm run typecheck`: no new errors introduced (81 pre-existing `@nodetool-ai/*` package-resolution errors exist on `main` both before and after this change; none touch the files I edited).
- `npm run lint` (oxlint): exit 0, my files clean.
- `npm run lint:design`: exit 0.
- Menus test suite: 41/41 pass (9 in `RemoteSettingsMenu.test.tsx`).

### Caveats / follow-ups
- The web-search picker keeps its existing "Search Provider" heading/id (`search-provider`) rather than renaming to "Web Search" — this keeps the sidebar↔panel ids in sync with no SearchProviderSection API change.
- The backend settings registry isn't in this repo, so the exact registry-group casing is matched case-insensitively; any misspelled group lands in **Other** (visible, not hidden) as intended.
- Per-field save-on-blur was deferred per the task's recommendation; the dirty-aware sticky bar is the implemented minimum.

Commit `0d8cf8e3e` is on `claude/t-20260705-0003-97`, not pushed — the orchestrator handles that.

---

Closes task **T-20260705-0003**: Phase 3 — Regroup the Integrations tab.


### Acceptance criteria
- [ ] GROUP_SECTIONS map assigns each registry group to a meta-section; unknown groups fall into a trailing Other section
- [ ] Integrations tab renders the fixed meta-section order from the table
- [ ] getDisplayedSettingGroups returns meta-sections so the sidebar mirrors the panel
- [ ] Autosave group is hidden via HIDDEN_SETTING_GROUPS
- [ ] Save UX improved: dirty-aware sticky save bar (only shown with unsaved edits) at minimum
- [ ] npm run typecheck, npm run lint, and web tests pass