### PR TITLE
Bolt: ⚡ Optimize getAssetPathInfo to use single IN query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43427,7 +43427,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -43649,7 +43648,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -4,7 +4,7 @@
  * Port of Python's `nodetool.models.asset`.
  */
 
-import { eq, and, like, desc, isNull, lt } from "drizzle-orm";
+import { eq, and, like, desc, isNull, lt, inArray } from "drizzle-orm";
 import { DBModel, createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { assets } from "./schema/assets.js";
@@ -239,9 +239,20 @@ export class Asset extends DBModel {
     const result: Record<string, Record<string, string>> = {};
 
     const assetMap = new Map<string, Asset>();
-    for (const id of assetIds) {
-      const asset = await Asset.find(userId, id);
-      if (asset) assetMap.set(id, asset);
+
+    // Chunk ids to avoid sqlite limitations on max parameters if array is huge
+    const chunkSize = 900;
+    for (let i = 0; i < assetIds.length; i += chunkSize) {
+      const chunk = assetIds.slice(i, i + chunkSize);
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(assets)
+        .where(and(eq(assets.user_id, userId), inArray(assets.id, chunk)));
+
+      for (const r of rows) {
+        assetMap.set(r.id as string, new Asset(r as Record<string, unknown>));
+      }
     }
 
     const parentCache = new Map<string, Asset>();


### PR DESCRIPTION
## What
Replaces the N+1 iteration in `Asset.getAssetPathInfo` with a chunked `inArray` query. 

## Why
The original code looped over `assetIds` and issued an individual `await Asset.find(userId, id)` for each item. This created a massive performance bottleneck when processing large numbers of assets. Chunking is used to protect against SQLite parameter binding limits.

## Impact
This change significantly improves the execution speed of fetching folder hierarchy and asset path info.

## Verification
- Wrote a local test (`measure.mjs`) tracking 500 assets being requested through `getAssetPathInfo`.
- **Baseline time:** ~133ms
- **Optimized time:** ~12ms
- `npx tsc --noEmit` and global `npm run test` passed.

---
*PR created automatically by Jules for task [14831815099912963843](https://jules.google.com/task/14831815099912963843) started by @georgi*