### PR TITLE
Refactor browser module loading and fix stale-deploy detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24670,7 +24670,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -31544,7 +31543,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -44247,7 +44245,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -53305,6 +53302,7 @@
         "react-simple-keyboard": "^3.8.219",
         "react-syntax-highlighter": "^16.1.1",
         "read-excel-file": "^6.0.3",
+        "readable-stream": "^4.7.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "tabulator-tables": "^6.4.0",
@@ -54043,6 +54041,46 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "web/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "web/node_modules/readable-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "web/node_modules/undici-types": {

--- a/web/package.json
+++ b/web/package.json
@@ -66,6 +66,7 @@
     "react-simple-keyboard": "^3.8.219",
     "react-syntax-highlighter": "^16.1.1",
     "read-excel-file": "^6.0.3",
+    "readable-stream": "^4.7.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tabulator-tables": "^6.4.0",

--- a/web/src/lib/__tests__/preloadErrorReload.test.ts
+++ b/web/src/lib/__tests__/preloadErrorReload.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * preloadErrorReload must reload only for stale deploys (index.html no longer
+ * references this tab's entry script), never for transient chunk/CSS failures
+ * — those reloads masked errors and turned every affected click into a page
+ * reload in production.
+ *
+ * jsdom's `location.reload` can't be mocked, so the reload itself is observed
+ * via its precondition: the sessionStorage guard timestamp is written
+ * immediately before `reload()` and only then.
+ */
+const GUARD_KEY = "nodetool:preload-error-reload";
+const ENTRY_SRC = "/assets/index-abc123.js";
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+// Import once — the module registers a window listener at import time, and
+// re-importing per test would stack duplicate listeners on the shared window.
+import "../preloadErrorReload";
+
+const htmlResponse = (body: string, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    text: async () => body
+  }) as unknown as Response;
+
+const firePreloadError = (): void => {
+  window.dispatchEvent(new Event("vite:preloadError", { cancelable: true }));
+};
+
+const flushAsync = async (): Promise<void> => {
+  // Enough microtask turns for fetch → res.text() → guard write.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("preloadErrorReload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    document.head.innerHTML = "";
+    const script = document.createElement("script");
+    script.type = "module";
+    script.src = ENTRY_SRC;
+    document.head.appendChild(script);
+  });
+
+  it("does not reload when index.html still references the running entry", async () => {
+    mockFetch.mockResolvedValue(
+      htmlResponse(`<script type="module" src="${ENTRY_SRC}"></script>`)
+    );
+
+    firePreloadError();
+    await flushAsync();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/",
+      expect.objectContaining({ cache: "no-store" })
+    );
+    expect(sessionStorage.getItem(GUARD_KEY)).toBeNull();
+  });
+
+  it("does not reload when index.html cannot be fetched", async () => {
+    mockFetch.mockRejectedValue(new Error("offline"));
+
+    firePreloadError();
+    await flushAsync();
+
+    expect(sessionStorage.getItem(GUARD_KEY)).toBeNull();
+  });
+
+  it("does not re-check within the reload guard window", async () => {
+    sessionStorage.setItem(GUARD_KEY, String(Date.now()));
+
+    firePreloadError();
+    await flushAsync();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("suppresses Vite's default rethrow", async () => {
+    mockFetch.mockResolvedValue(htmlResponse(""));
+    const event = new Event("vite:preloadError", { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    await flushAsync();
+  });
+
+  // Last: jsdom's un-mockable location.reload logs a "Not implemented:
+  // navigation" error once this path actually reloads.
+  it("reloads when index.html no longer references the running entry", async () => {
+    mockFetch.mockResolvedValue(
+      htmlResponse('<script type="module" src="/assets/index-NEW.js"></script>')
+    );
+
+    firePreloadError();
+    await flushAsync();
+
+    expect(sessionStorage.getItem(GUARD_KEY)).not.toBeNull();
+  });
+});

--- a/web/src/lib/preloadErrorReload.ts
+++ b/web/src/lib/preloadErrorReload.ts
@@ -1,31 +1,83 @@
 // Recover from stale-deploy chunk-load failures.
 //
 // Vite fires `vite:preloadError` when a dynamically imported JS/CSS chunk fails
-// to load — almost always because a new deploy replaced the content-hashed
-// assets this already-open tab still references, so the old chunk URL now 404s
-// (NodeTool ships web/dist wholesale per deploy, so every hash changes at once).
-// The failed import throws and wedges whatever lazy route/component triggered
-// it. Reloading picks up the fresh index.html and its new asset hashes.
+// to load. The classic cause is a stale deploy: a new deploy replaced the
+// content-hashed assets this already-open tab still references, so the old
+// chunk URL now 404s (NodeTool ships web/dist wholesale per deploy, so every
+// hash changes at once). Reloading picks up the fresh index.html and its new
+// asset hashes.
 //
-// Guarded so a genuinely broken chunk (not just a stale one) can't loop: if we
-// reloaded within the last window and it fired again, let the error surface.
+// But the event also fires for failures a reload cannot fix — a CSS chunk
+// whose external subresource was blocked, a flaky network, a genuinely broken
+// chunk. Blindly reloading on those turns every affected action into a page
+// reload (and hides the real error). So before reloading, confirm the deploy
+// is actually stale: re-fetch index.html and check whether it still references
+// the entry script this tab is running. Reload only when it doesn't.
 
 const RELOAD_GUARD_KEY = "nodetool:preload-error-reload";
 const RELOAD_WINDOW_MS = 10_000;
 
+/** Pathname of the content-hashed entry script this tab is running. */
+function runningEntryPath(): string | null {
+  const script = document.querySelector<HTMLScriptElement>(
+    'script[type="module"][src]'
+  );
+  if (!script?.src) return null;
+  try {
+    return new URL(script.src, window.location.href).pathname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the server now serves an index.html that no longer references
+ * this tab's entry script — i.e. a new deploy replaced the assets and a
+ * reload will recover.
+ */
+async function deployIsStale(): Promise<boolean> {
+  const entry = runningEntryPath();
+  if (!entry) return false;
+  try {
+    const res = await fetch("/", {
+      cache: "no-store",
+      headers: { Accept: "text/html" }
+    });
+    if (!res.ok) return false;
+    return !(await res.text()).includes(entry);
+  } catch {
+    // Server unreachable — a reload wouldn't help.
+    return false;
+  }
+}
+
+let staleCheckInFlight = false;
+
 window.addEventListener("vite:preloadError", (event) => {
-  // Suppress Vite's default rethrow so the reload is the only outcome.
+  // Suppress Vite's default rethrow. A failed CSS preload then degrades to a
+  // missing stylesheet instead of a wedged route, and a stale deploy is
+  // recovered by the reload below.
   event.preventDefault();
+
+  if (staleCheckInFlight) return;
 
   const now = Date.now();
   const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? "0");
   if (now - last < RELOAD_WINDOW_MS) {
-    // Already reloaded moments ago — another reload won't help. Let it through.
+    // Already reloaded moments ago — another reload won't help.
     return;
   }
 
-  sessionStorage.setItem(RELOAD_GUARD_KEY, String(now));
-  window.location.reload();
+  staleCheckInFlight = true;
+  void deployIsStale()
+    .then((stale) => {
+      if (!stale) return;
+      sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+      window.location.reload();
+    })
+    .finally(() => {
+      staleCheckInFlight = false;
+    });
 });
 
 export {};

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -223,24 +223,36 @@ const NODE_MODULE_GROUPS: ReadonlyArray<
  * Import a lazy chunk, tolerating failure. A failed `import()` normally
  * rejects, but on the main thread the app's `vite:preloadError` listener
  * (`preloadErrorReload.ts`) suppresses Vite's rethrow, in which case the
- * import resolves `undefined` instead — treat both as "not available".
+ * import resolves `undefined` instead — treat both as "not available",
+ * keeping the failure for the caller's diagnostics.
  */
-async function importOptional(load: () => Promise<unknown>): Promise<unknown> {
+async function importOptional(
+  load: () => Promise<unknown>
+): Promise<{ mod: unknown; error: unknown }> {
   try {
-    return (await load()) ?? null;
-  } catch {
-    return null;
+    const mod = (await load()) ?? null;
+    return {
+      mod,
+      error: mod
+        ? null
+        : new Error("import resolved empty (chunk preload failure suppressed)")
+    };
+  } catch (error) {
+    return { mod: null, error };
   }
 }
 
 export async function loadBrowserModules(): Promise<LoadedModules> {
   // The runner module is required — without it there is no browser runner and
   // the caller falls back to the server path.
-  const wf = (await importOptional(
+  const wfImport = await importOptional(
     () => import("@nodetool-ai/workflow-runner/browser")
-  )) as WorkflowRunnerModule | null;
+  );
+  const wf = wfImport.mod as WorkflowRunnerModule | null;
   if (!wf) {
-    throw new Error("workflow-runner browser module failed to load");
+    throw new Error(
+      `workflow-runner browser module failed to load: ${String(wfImport.error)}`
+    );
   }
 
   // Node groups are independent: one group failing to load or evaluate in this
@@ -255,10 +267,15 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
 
   const nodeClasses: unknown[] = [];
   const perGroup: Record<string, number> = {};
-  const failedGroups: string[] = [];
-  for (const [name, mod] of loaded) {
+  let failedGroups = 0;
+  for (const [name, { mod, error }] of loaded) {
     if (!mod) {
-      failedGroups.push(name);
+      failedGroups += 1;
+      console.warn(
+        `[browserRunner] node group "${name}" failed to load — ` +
+          "its nodes will run on the server",
+        error
+      );
       continue;
     }
     const classes = collectNodeClasses(mod as Record<string, unknown>);
@@ -267,28 +284,32 @@ export async function loadBrowserModules(): Promise<LoadedModules> {
   }
   console.info(
     `[browserRunner] loaded ${nodeClasses.length} node class(es) from ` +
-      `${loaded.length - failedGroups.length}/${loaded.length} group(s)`,
+      `${loaded.length - failedGroups}/${loaded.length} group(s)`,
     perGroup
   );
-  if (failedGroups.length > 0) {
-    console.warn(
-      `[browserRunner] ${failedGroups.length} node group(s) failed to load — ` +
-        "their nodes will run on the server",
-      failedGroups
-    );
-  }
 
   // The GPU-texture boundary helpers — read-back at serialize points + run-end
   // texture cleanup. Loaded here so they ride the same lazy chunk as the nodes.
   // Optional: without them, GPU-node runs lose texture read-back/cleanup, but
   // those nodes only register when the image groups above loaded.
-  const [imageIo, gpuDevice] = (await Promise.all([
+  const [imageIoImport, gpuDeviceImport] = await Promise.all([
     importOptional(() => import("@nodetool-ai/image-nodes/nodes/image-io")),
     importOptional(() => import("@nodetool-ai/image-nodes/nodes/gpu-device"))
-  ])) as [
-    typeof import("@nodetool-ai/image-nodes/nodes/image-io") | null,
-    typeof import("@nodetool-ai/image-nodes/nodes/gpu-device") | null
-  ];
+  ]);
+  for (const [name, { mod, error }] of [
+    ["image-io", imageIoImport],
+    ["gpu-device", gpuDeviceImport]
+  ] as const) {
+    if (!mod) {
+      console.warn(`[browserRunner] GPU helper "${name}" failed to load`, error);
+    }
+  }
+  const imageIo = imageIoImport.mod as
+    | typeof import("@nodetool-ai/image-nodes/nodes/image-io")
+    | null;
+  const gpuDevice = gpuDeviceImport.mod as
+    | typeof import("@nodetool-ai/image-nodes/nodes/gpu-device")
+    | null;
 
   return {
     wf,

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -138,12 +138,10 @@ const NODE_MODULE_GROUPS: ReadonlyArray<
   ["subgraph", () => import("@nodetool-ai/core-nodes/nodes/subgraph")],
   ["workflow", () => import("@nodetool-ai/core-nodes/nodes/workflow")],
   // The universal Code node (nodetool.code.Code) runs vanilla JS in a QuickJS
-  // WebAssembly sandbox — no Node `vm`, no subprocess. Imported via its own
-  // subpath (not the code-nodes index, which pulls code-runners → Docker/ssh2).
-  // NOTE: currently fails to evaluate in the bundled browser build — the
-  // QuickJS sandbox pulls memfs, whose ReadStream extends `stream.Readable`
-  // from the stubbed-empty `node:stream` — so the group loader below skips it
-  // and Code nodes route to the server.
+  // WebAssembly sandbox — no Node `vm`, no subprocess — so it runs client-side.
+  // Imported via its own subpath (not the code-nodes index, which pulls
+  // code-runners → Docker/ssh2). The sandbox pulls memfs, which needs the real
+  // stream classes from vite's stream-stub (readable-stream) to evaluate.
   ["code-node", () => import("@nodetool-ai/code-nodes/nodes/code-node")],
   [
     "lib-image-color-grading",

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -112,7 +112,7 @@ export function collectNodeClasses(mod: Record<string, unknown>): unknown[] {
 }
 
 /**
- * Import the genuinely browser-portable node groups via per-file subpaths.
+ * The browser-portable node groups, imported via per-file subpaths.
  * We deliberately avoid the package indexes (core-nodes re-exports `vector` →
  * sqlite-vec / better-sqlite3 native bindings; `code-nodes` → code-runners /
  * Docker / ssh2) — neither bundles for the browser. The image node groups run
@@ -120,149 +120,183 @@ export function collectNodeClasses(mod: Record<string, unknown>): unknown[] {
  * lazily, so they bundle cleanly; `createBrowserRegistry` filters by platform
  * tag (e.g. image.ts's Load/Save/AI nodes are tagged server and dropped).
  */
-export async function loadBrowserModules(): Promise<LoadedModules> {
-  const [
-    wf,
-    constant,
-    control,
-    input,
-    list,
-    compare,
-    fakeMedia,
-    datetime,
-    validate,
-    placeholders,
-    subgraph,
-    workflow,
-    codeNode,
-    imageColorGrading,
-    imageColor,
-    imageEffects,
-    imageGenerators,
-    imageKeyer,
-    imageMask,
-    imageWarp,
-    imageChannel,
-    imageFilterExtras,
-    imageFilter,
-    imageEnhance,
-    imageDraw,
-    imageCore,
-    audioPreview,
-    audioCore,
-    audioDsp,
-    audioEffects,
-    audioRealtime,
-    audioSynthesis
-  ] = await Promise.all([
-    import("@nodetool-ai/workflow-runner/browser"),
-    import("@nodetool-ai/core-nodes/nodes/constant"),
-    import("@nodetool-ai/core-nodes/nodes/control"),
-    import("@nodetool-ai/core-nodes/nodes/input"),
-    import("@nodetool-ai/core-nodes/nodes/list"),
-    import("@nodetool-ai/core-nodes/nodes/compare"),
-    import("@nodetool-ai/core-nodes/nodes/fake-media"),
-    import("@nodetool-ai/core-nodes/nodes/lib-datetime"),
-    import("@nodetool-ai/core-nodes/nodes/lib-validate"),
-    import("@nodetool-ai/core-nodes/nodes/extended-placeholders"),
-    import("@nodetool-ai/core-nodes/nodes/subgraph"),
-    import("@nodetool-ai/core-nodes/nodes/workflow"),
-    // The universal Code node (nodetool.code.Code) runs vanilla JS in a QuickJS
-    // WebAssembly sandbox — no Node `vm`, no subprocess — so it runs client-side.
-    // Imported via its own subpath (not the code-nodes index, which pulls
-    // code-runners → Docker/ssh2); its only heavy dep is the QuickJS wasm chunk.
-    import("@nodetool-ai/code-nodes/nodes/code-node"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-color-grading"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-color"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-effects"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-generators"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-keyer"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-mask"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-warp"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-channel"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-filter-extras"),
-    // filter/enhance/draw mix GPU nodes (browser) with sharp/CPU gap nodes
-    // (Canny, histogram enhances, RenderText/Mask) tagged server.
-    import("@nodetool-ai/image-nodes/nodes/lib-image-filter"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-enhance"),
-    import("@nodetool-ai/image-nodes/nodes/lib-image-draw"),
-    // image.ts mixes GPU transform nodes (browser) with node-only Load/Save/AI
-    // nodes; the latter are tagged server, so createBrowserRegistry keeps only
-    // the transforms. It's sharp-free (lazy) and de-barreled, so it bundles.
-    import("@nodetool-ai/image-nodes/nodes/image"),
-    // Preview is a pure pass-through that renders any value; its own browser-safe
-    // module (no audio-codec deps) lets pass-through graphs ending in a Preview
-    // run client-side instead of forcing a server round-trip.
-    import("@nodetool-ai/audio-nodes/nodes/preview"),
-    // audio.ts mixes pure sample/byte transforms (hybrid) with node-only
-    // Load/Save/TTS nodes tagged server; dsp/effects route WebAudio through
-    // lib/audio-context.ts (global OfflineAudioContext or pure-JS biquad
-    // fallback) and hide node-web-audio-api / rubberband behind importHidden,
-    // so all four modules bundle cleanly.
-    import("@nodetool-ai/audio-nodes/nodes/audio"),
-    import("@nodetool-ai/audio-nodes/nodes/lib-audio-dsp"),
-    import("@nodetool-ai/audio-nodes/nodes/lib-audio-effects"),
-    import("@nodetool-ai/audio-nodes/nodes/realtime-audio"),
-    import("@nodetool-ai/audio-nodes/nodes/synthesis")
-  ]);
+const NODE_MODULE_GROUPS: ReadonlyArray<
+  readonly [name: string, load: () => Promise<unknown>]
+> = [
+  ["constant", () => import("@nodetool-ai/core-nodes/nodes/constant")],
+  ["control", () => import("@nodetool-ai/core-nodes/nodes/control")],
+  ["input", () => import("@nodetool-ai/core-nodes/nodes/input")],
+  ["list", () => import("@nodetool-ai/core-nodes/nodes/list")],
+  ["compare", () => import("@nodetool-ai/core-nodes/nodes/compare")],
+  ["fake-media", () => import("@nodetool-ai/core-nodes/nodes/fake-media")],
+  ["lib-datetime", () => import("@nodetool-ai/core-nodes/nodes/lib-datetime")],
+  ["lib-validate", () => import("@nodetool-ai/core-nodes/nodes/lib-validate")],
+  [
+    "extended-placeholders",
+    () => import("@nodetool-ai/core-nodes/nodes/extended-placeholders")
+  ],
+  ["subgraph", () => import("@nodetool-ai/core-nodes/nodes/subgraph")],
+  ["workflow", () => import("@nodetool-ai/core-nodes/nodes/workflow")],
+  // The universal Code node (nodetool.code.Code) runs vanilla JS in a QuickJS
+  // WebAssembly sandbox — no Node `vm`, no subprocess. Imported via its own
+  // subpath (not the code-nodes index, which pulls code-runners → Docker/ssh2).
+  // NOTE: currently fails to evaluate in the bundled browser build — the
+  // QuickJS sandbox pulls memfs, whose ReadStream extends `stream.Readable`
+  // from the stubbed-empty `node:stream` — so the group loader below skips it
+  // and Code nodes route to the server.
+  ["code-node", () => import("@nodetool-ai/code-nodes/nodes/code-node")],
+  [
+    "lib-image-color-grading",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-color-grading")
+  ],
+  [
+    "lib-image-color",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-color")
+  ],
+  [
+    "lib-image-effects",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-effects")
+  ],
+  [
+    "lib-image-generators",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-generators")
+  ],
+  [
+    "lib-image-keyer",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-keyer")
+  ],
+  [
+    "lib-image-mask",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-mask")
+  ],
+  [
+    "lib-image-warp",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-warp")
+  ],
+  [
+    "lib-image-channel",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-channel")
+  ],
+  [
+    "lib-image-filter-extras",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-filter-extras")
+  ],
+  // filter/enhance/draw mix GPU nodes (browser) with sharp/CPU gap nodes
+  // (Canny, histogram enhances, RenderText/Mask) tagged server.
+  [
+    "lib-image-filter",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-filter")
+  ],
+  [
+    "lib-image-enhance",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-enhance")
+  ],
+  [
+    "lib-image-draw",
+    () => import("@nodetool-ai/image-nodes/nodes/lib-image-draw")
+  ],
+  // image.ts mixes GPU transform nodes (browser) with node-only Load/Save/AI
+  // nodes; the latter are tagged server, so createBrowserRegistry keeps only
+  // the transforms. It's sharp-free (lazy) and de-barreled, so it bundles.
+  ["image", () => import("@nodetool-ai/image-nodes/nodes/image")],
+  // Preview is a pure pass-through that renders any value; its own browser-safe
+  // module (no audio-codec deps) lets pass-through graphs ending in a Preview
+  // run client-side instead of forcing a server round-trip.
+  ["preview", () => import("@nodetool-ai/audio-nodes/nodes/preview")],
+  // audio.ts mixes pure sample/byte transforms (hybrid) with node-only
+  // Load/Save/TTS nodes tagged server; dsp/effects route WebAudio through
+  // lib/audio-context.ts (global OfflineAudioContext or pure-JS biquad
+  // fallback) and hide node-web-audio-api / rubberband behind importHidden,
+  // so all four modules bundle cleanly.
+  ["audio", () => import("@nodetool-ai/audio-nodes/nodes/audio")],
+  ["lib-audio-dsp", () => import("@nodetool-ai/audio-nodes/nodes/lib-audio-dsp")],
+  [
+    "lib-audio-effects",
+    () => import("@nodetool-ai/audio-nodes/nodes/lib-audio-effects")
+  ],
+  [
+    "realtime-audio",
+    () => import("@nodetool-ai/audio-nodes/nodes/realtime-audio")
+  ],
+  ["synthesis", () => import("@nodetool-ai/audio-nodes/nodes/synthesis")]
+];
 
-  const groups: Array<[string, unknown]> = [
-    ["constant", constant],
-    ["control", control],
-    ["input", input],
-    ["list", list],
-    ["compare", compare],
-    ["fake-media", fakeMedia],
-    ["lib-datetime", datetime],
-    ["lib-validate", validate],
-    ["extended-placeholders", placeholders],
-    ["subgraph", subgraph],
-    ["workflow", workflow],
-    ["code-node", codeNode],
-    ["lib-image-color-grading", imageColorGrading],
-    ["lib-image-color", imageColor],
-    ["lib-image-effects", imageEffects],
-    ["lib-image-generators", imageGenerators],
-    ["lib-image-keyer", imageKeyer],
-    ["lib-image-mask", imageMask],
-    ["lib-image-warp", imageWarp],
-    ["lib-image-channel", imageChannel],
-    ["lib-image-filter-extras", imageFilterExtras],
-    ["lib-image-filter", imageFilter],
-    ["lib-image-enhance", imageEnhance],
-    ["lib-image-draw", imageDraw],
-    ["image", imageCore],
-    ["preview", audioPreview],
-    ["audio", audioCore],
-    ["lib-audio-dsp", audioDsp],
-    ["lib-audio-effects", audioEffects],
-    ["realtime-audio", audioRealtime],
-    ["synthesis", audioSynthesis]
-  ];
+/**
+ * Import a lazy chunk, tolerating failure. A failed `import()` normally
+ * rejects, but on the main thread the app's `vite:preloadError` listener
+ * (`preloadErrorReload.ts`) suppresses Vite's rethrow, in which case the
+ * import resolves `undefined` instead — treat both as "not available".
+ */
+async function importOptional(load: () => Promise<unknown>): Promise<unknown> {
+  try {
+    return (await load()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function loadBrowserModules(): Promise<LoadedModules> {
+  // The runner module is required — without it there is no browser runner and
+  // the caller falls back to the server path.
+  const wf = (await importOptional(
+    () => import("@nodetool-ai/workflow-runner/browser")
+  )) as WorkflowRunnerModule | null;
+  if (!wf) {
+    throw new Error("workflow-runner browser module failed to load");
+  }
+
+  // Node groups are independent: one group failing to load or evaluate in this
+  // context (a dep that can't run in the browser, a blocked chunk) must not
+  // take down the whole registry. Skip it — its node types then report as not
+  // browser-capable and route to the server.
+  const loaded = await Promise.all(
+    NODE_MODULE_GROUPS.map(
+      async ([name, load]) => [name, await importOptional(load)] as const
+    )
+  );
+
   const nodeClasses: unknown[] = [];
   const perGroup: Record<string, number> = {};
-  for (const [name, mod] of groups) {
+  const failedGroups: string[] = [];
+  for (const [name, mod] of loaded) {
+    if (!mod) {
+      failedGroups.push(name);
+      continue;
+    }
     const classes = collectNodeClasses(mod as Record<string, unknown>);
     perGroup[name] = classes.length;
     nodeClasses.push(...classes);
   }
   console.info(
-    `[browserRunner] loaded ${nodeClasses.length} node class(es) from ${groups.length} group(s)`,
+    `[browserRunner] loaded ${nodeClasses.length} node class(es) from ` +
+      `${loaded.length - failedGroups.length}/${loaded.length} group(s)`,
     perGroup
   );
+  if (failedGroups.length > 0) {
+    console.warn(
+      `[browserRunner] ${failedGroups.length} node group(s) failed to load — ` +
+        "their nodes will run on the server",
+      failedGroups
+    );
+  }
 
   // The GPU-texture boundary helpers — read-back at serialize points + run-end
   // texture cleanup. Loaded here so they ride the same lazy chunk as the nodes.
-  const [imageIo, gpuDevice] = await Promise.all([
-    import("@nodetool-ai/image-nodes/nodes/image-io"),
-    import("@nodetool-ai/image-nodes/nodes/gpu-device")
-  ]);
+  // Optional: without them, GPU-node runs lose texture read-back/cleanup, but
+  // those nodes only register when the image groups above loaded.
+  const [imageIo, gpuDevice] = (await Promise.all([
+    importOptional(() => import("@nodetool-ai/image-nodes/nodes/image-io")),
+    importOptional(() => import("@nodetool-ai/image-nodes/nodes/gpu-device"))
+  ])) as [
+    typeof import("@nodetool-ai/image-nodes/nodes/image-io") | null,
+    typeof import("@nodetool-ai/image-nodes/nodes/gpu-device") | null
+  ];
 
   return {
     wf,
     nodeClasses,
-    resolveImageRefForTransport: imageIo.resolveImageRefForTransport,
-    releaseRunTextures: gpuDevice.releaseRunTextures
+    resolveImageRefForTransport: imageIo?.resolveImageRefForTransport,
+    releaseRunTextures: gpuDevice?.releaseRunTextures
   };
 }
 

--- a/web/vite-node-stubs/stream-stub.js
+++ b/web/vite-node-stubs/stream-stub.js
@@ -1,0 +1,19 @@
+// Real `node:stream` substitute for the browser bundles, backed by
+// readable-stream (the userland port of Node's streams, browser-ready).
+//
+// An empty stub is not enough here: memfs — pulled in by the QuickJS sandbox
+// behind the universal Code node — subclasses `stream.Readable`/`Writable` at
+// module scope (via @jsonjoy.com/fs-node-builtins), and an undefined super
+// constructor throws while the chunk evaluates, taking the whole browser
+// runner registry down with it.
+export {
+  Readable,
+  Writable,
+  Duplex,
+  Transform,
+  PassThrough,
+  Stream,
+  pipeline,
+  finished
+} from "readable-stream";
+export { default } from "readable-stream";

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -128,6 +128,34 @@ function stubServerTelemetryPlugin(): Plugin {
   };
 }
 
+// Strip remote `@import url(https://…)` statements from emitted CSS chunks.
+// Third-party CSS can smuggle one in (e.g. @measured/puck imports Inter from
+// rsms.me). Chrome treats a failed @import as a failure of the whole
+// stylesheet, so when the CDN is blocked/unreachable the chunk's <link> errors,
+// Vite fires `vite:preloadError`, and preloadErrorReload.ts reloads the page —
+// every affected click becomes a page reload. Fonts are already self-hosted
+// (@fontsource imports in ThemeNodetool), so remote font CSS is redundant;
+// drop it at build time.
+function stripExternalCssImportsPlugin(): Plugin {
+  const EXTERNAL_IMPORT_RE =
+    /@import\s*(?:url\(\s*)?["']?https?:\/\/[^"'()\s;]+["']?\s*\)?[^;]*;/gi;
+  return {
+    name: "strip-external-css-imports",
+    generateBundle(_options, bundle) {
+      for (const asset of Object.values(bundle)) {
+        if (asset.type !== "asset" || !asset.fileName.endsWith(".css")) {
+          continue;
+        }
+        const source = asset.source.toString();
+        const stripped = source.replace(EXTERNAL_IMPORT_RE, "");
+        if (stripped !== source) {
+          asset.source = stripped;
+        }
+      }
+    }
+  };
+}
+
 // Cross-origin isolation for the perf harness page only. crossOriginIsolated
 // unlocks performance.measureUserAgentSpecificMemory(), which attributes JS
 // heap to every realm in the agent cluster — including the browser-runner
@@ -258,6 +286,7 @@ export default defineConfig(async ({ mode }) => {
     plugins: [
       perfPageIsolationPlugin(),
       stubNodeProtocolPlugin(),
+      stripExternalCssImportsPlugin(),
       react({
         jsxImportSource: "@emotion/react",
         babel: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -148,7 +148,10 @@ function stripExternalCssImportsPlugin(): Plugin {
         if (asset.type !== "asset" || !asset.fileName.endsWith(".css")) {
           continue;
         }
-        const source = asset.source.toString();
+        const source =
+          typeof asset.source === "string"
+            ? asset.source
+            : new TextDecoder().decode(asset.source);
         const stripped = source.replace(EXTERNAL_IMPORT_RE, "");
         if (stripped !== source) {
           asset.source = stripped;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -59,7 +59,9 @@ const NODE_BUILTIN_STUBS: Record<string, string> = {
   "node:http2": `${NODE_STUBS}/empty.js`,
   "node:perf_hooks": `${NODE_STUBS}/empty.js`,
   "node:vm": `${NODE_STUBS}/empty.js`,
-  "node:stream": `${NODE_STUBS}/empty.js`,
+  // Not empty: memfs (QuickJS sandbox → universal Code node) subclasses
+  // stream.Readable/Writable at module scope — see stream-stub.js.
+  "node:stream": `${NODE_STUBS}/stream-stub.js`,
   "node:async_hooks": `${NODE_STUBS}/empty.js`,
   "node:util": `${NODE_STUBS}/empty.js`,
   "node:buffer": `${NODE_STUBS}/buffer-stub.js`,


### PR DESCRIPTION
## Summary

Refactors the browser module loader to gracefully handle individual module failures, improves stale-deploy detection to avoid unnecessary reloads on transient failures, and fixes a critical stream stub for the QuickJS sandbox.

## Key Changes

- **Refactor `loadBrowserModules()`**: Extract node module groups into a `NODE_MODULE_GROUPS` constant and introduce `importOptional()` helper. Node groups now fail independently—if one group fails to load, others continue and the failed group's nodes route to the server instead of crashing the entire registry.

- **Improve `preloadErrorReload.ts`**: Replace blind reload-on-error with stale-deploy detection. Before reloading, re-fetch `index.html` and confirm it no longer references the running entry script. Only reload when the deploy is actually stale; transient failures (blocked CSS, flaky network) no longer trigger page reloads.

- **Fix `node:stream` stub**: Replace empty stub with real `readable-stream` export. The QuickJS sandbox (via memfs → @jsonjoy.com/fs-node-builtins) subclasses `stream.Readable`/`Writable` at module scope; an undefined super constructor crashed chunk evaluation. Now properly re-exports from `readable-stream`.

- **Add CSS import stripping plugin**: New `stripExternalCssImportsPlugin()` removes remote `@import url(https://…)` statements from emitted CSS chunks. Third-party CSS (e.g., @measured/puck) can smuggle in CDN imports; when blocked, the whole stylesheet fails and triggers `vite:preloadError`. Fonts are already self-hosted, so remote imports are redundant.

- **Add test coverage**: New `preloadErrorReload.test.ts` validates stale-deploy detection logic, guard window behavior, and Vite error suppression.

- **Add `readable-stream` dependency**: Required for the stream stub to work in browser bundles.

## Implementation Details

- `importOptional()` catches both rejected imports and `undefined` returns (from Vite's `preloadError` listener suppression) and treats both as "not available".
- Stale-deploy check is debounced with `staleCheckInFlight` flag to prevent concurrent checks.
- Failed node groups are logged with `console.warn()` for debugging; the registry continues with available groups.
- GPU texture helpers (`image-io`, `gpu-device`) are now optional—they only matter when image groups loaded successfully.

https://claude.ai/code/session_01UNLqhTBMHLgJzrdW2atCYm