### PR TITLE
fix(web): make the workspace shell usable on mobile

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -211,5 +211,35 @@ export const createMediaComposerStyles = (theme: Theme) =>
         objectFit: "cover",
         borderRadius: BORDER_RADIUS.sm
       }
+    },
+
+    // Mobile: the chip cluster plus the trailing workflow actions never fit on
+    // one phone-width line, so the row wraps (actions become their own line)
+    // and the card sheds padding to keep the textarea full-width.
+    [theme.breakpoints.down("sm")]: {
+      ".media-compose-card": {
+        padding: `${theme.spacing(1.5)} ${theme.spacing(1.5)} ${theme.spacing(1)}`,
+        gap: theme.spacing(1)
+      },
+      ".media-compose-card textarea.media-compose-input": {
+        padding: `${theme.spacing(1)} ${theme.spacing(1)}`
+      },
+      ".media-chip-row": {
+        flexWrap: "wrap",
+        rowGap: theme.spacing(1),
+        padding: 0
+      },
+      // Full line for the chip cluster: without this it shrinks (min-width: 0)
+      // to sit beside the action cluster instead of wrapping above it, leaving
+      // the send button stranded mid-row.
+      ".media-chip-main": {
+        minWidth: "100%"
+      },
+      // The zero-basis spacer can land on the previous wrapped line, leaving
+      // the send button left-aligned; margin-left keeps it pinned right on
+      // whichever line it ends up on.
+      ".media-chip-main .media-generate-btn": {
+        marginLeft: "auto"
+      }
     }
   });

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -49,6 +49,11 @@ import useCanvasChatDockStore, {
 import CanvasMediaComposer from "./CanvasMediaComposer";
 import ConversationOverlay from "./ConversationOverlay";
 
+const MOBILE_DOCK_POSITION: DockPosition = { x: 0, y: 0 };
+const MOBILE_DOCK_LAYER_STYLE: React.CSSProperties = {
+  bottom: "calc(8px + env(safe-area-inset-bottom, 0px))"
+};
+
 /** Live elapsed-time readout shown inside the Run button while a run is active. */
 const RunningTime: React.FC<{ isRunning: boolean; timerKey?: string }> = memo(
   function RunningTime({ isRunning, timerKey }) {
@@ -133,6 +138,16 @@ const actionStyles = (theme: Theme) =>
     marginLeft: getSpacingPx(SPACING.sm),
     paddingLeft: getSpacingPx(SPACING.md),
     borderLeft: `1px solid ${theme.vars.palette.divider}`,
+
+    // Mobile: the chip row wraps, so the cluster becomes its own right-aligned
+    // line instead of a bordered appendix pinned to the first one.
+    [theme.breakpoints.down("sm")]: {
+      marginLeft: 0,
+      paddingLeft: 0,
+      borderLeft: "none",
+      flex: 1,
+      justifyContent: "flex-end"
+    },
 
     "& button": {
       display: "inline-flex",
@@ -405,16 +420,21 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
     []
   );
 
+  // Mobile pins the dock to its default bottom-centre anchor: a drag offset
+  // persisted on desktop would push it off a phone screen.
   const dockRef = useDraggable<HTMLDivElement>({
     handle: ".dock-drag-handle",
     cancel: "button, input, textarea, .dock-no-drag",
-    position: storePosition,
+    position: isMobile ? MOBILE_DOCK_POSITION : storePosition,
+    disabled: isMobile,
     onStop: (pos) => setStorePosition(clampToViewport(dockRef.current, pos))
   });
 
   // Keep the dock on-screen when the viewport shrinks (e.g. window resize).
+  // Skipped on mobile: the dock is pinned there, and re-clamping against the
+  // phone viewport would overwrite the position persisted from desktop.
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || isMobile) {
       return;
     }
     const onResize = () => {
@@ -427,10 +447,13 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
     };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, [clampToViewport, setStorePosition, dockRef]);
+  }, [clampToViewport, setStorePosition, dockRef, isMobile]);
 
-  const dockWidthCss =
-    dockWidth != null
+  // Mobile ignores the persisted (desktop) width and MIN_DOCK_WIDTH — a phone
+  // viewport can be narrower than both.
+  const dockWidthCss = isMobile
+    ? "calc(100vw - 16px)"
+    : dockWidth != null
       ? `clamp(${MIN_DOCK_WIDTH}px, ${dockWidth}px, min(${MAX_DOCK_WIDTH}px, calc(100vw - 32px)))`
       : "min(820px, calc(100vw - 32px))";
 
@@ -568,7 +591,9 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
         </button>
       </Tooltip>
 
-      {editorViewMode === "graph" && (
+      {/* On mobile Auto Layout and Save move into the ⋮ menu to keep the
+          action cluster within a phone-width composer row. */}
+      {editorViewMode === "graph" && !isMobile && (
         <Tooltip title="Auto Layout" placement="top" delay={TOOLTIP_ENTER_DELAY}>
           <button
             type="button"
@@ -581,16 +606,18 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
         </Tooltip>
       )}
 
-      <Tooltip title="Save" placement="top" delay={TOOLTIP_ENTER_DELAY}>
-        <button
-          type="button"
-          className="composer-action"
-          onClick={handleSave}
-          aria-label="Save workflow"
-        >
-          <SaveIcon />
-        </button>
-      </Tooltip>
+      {!isMobile && (
+        <Tooltip title="Save" placement="top" delay={TOOLTIP_ENTER_DELAY}>
+          <button
+            type="button"
+            className="composer-action"
+            onClick={handleSave}
+            aria-label="Save workflow"
+          >
+            <SaveIcon />
+          </button>
+        </Tooltip>
+      )}
 
       <Tooltip
         title="Workflow actions"
@@ -613,7 +640,10 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
 
   return (
     <>
-      <div css={dockLayerStyles(theme)} style={toolbarPosition}>
+      <div
+        css={dockLayerStyles(theme)}
+        style={isMobile ? MOBILE_DOCK_LAYER_STYLE : toolbarPosition}
+      >
         <div
           ref={dockRef}
           css={dockStyles(theme)}
@@ -636,7 +666,7 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
             </AlertBanner>
           )}
           <CanvasMediaComposer
-            leadingActions={dragHandle}
+            leadingActions={isMobile ? undefined : dragHandle}
             trailingActions={workflowActions}
           />
         </div>
@@ -679,6 +709,20 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
             label="Stop"
             icon={<StopIcon fontSize="small" />}
             onClick={runWithClose(handleStop)}
+          />
+        )}
+        {isMobile && editorViewMode === "graph" && (
+          <MenuItemPrimitive
+            label="Auto Layout"
+            icon={<LayoutIcon fontSize="small" />}
+            onClick={runWithClose(handleAutoLayout)}
+          />
+        )}
+        {isMobile && (
+          <MenuItemPrimitive
+            label="Save"
+            icon={<SaveIcon fontSize="small" />}
+            onClick={runWithClose(handleSave)}
           />
         )}
         <MenuItemPrimitive

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -477,7 +477,8 @@ const PanelContent = memo(function PanelContent({
 // Mobile variant
 // ---------------------------------------------------------------------------
 
-const MOBILE_LAUNCHER_TOP = 48;
+// Clears the mobile tab bar (48px) plus an 8px gap.
+const MOBILE_LAUNCHER_TOP = 56;
 const MOBILE_LAUNCHER_TOP_STANDALONE = 8;
 
 const mobileLauncherStyles = (theme: Theme, hasHeader: boolean) =>

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, { Suspense, useEffect, useMemo } from "react";
+import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
@@ -73,7 +74,12 @@ const styles = (theme: Theme) =>
       minHeight: 0,
       minWidth: 0,
       marginLeft: `${TOOLBAR_WIDTH}px`,
-      marginBottom: `${BOTTOM_STRIP_HEIGHT}px`
+      marginBottom: `${BOTTOM_STRIP_HEIGHT}px`,
+      // On mobile the left rail is a floating hamburger and the bottom panel
+      // is hidden, so neither gutter exists.
+      [theme.breakpoints.down("sm")]: {
+        marginBottom: 0
+      }
     },
     "& .tab-layer": {
       position: "absolute",
@@ -113,6 +119,7 @@ const WorkspaceShell = () => {
   const openWorkflows = useWorkflowManager((state) => state.openWorkflows);
   const panelVisible = usePanelStore((state) => state.panel.isVisible);
   const panelSize = usePanelStore((state) => state.panel.panelSize);
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   // Cmd+W ("Close Tab") closes the active tab for every surface, not just the
   // node editor.
@@ -129,8 +136,11 @@ const WorkspaceShell = () => {
   // active we reserve the drawer's width and let the content sit beside it.
   // Other surfaces (node editor, etc.) keep the overlay so the canvas stays
   // full-bleed. The width here mirrors PanelLeft's drawer sizing.
-  const contentMarginLeft =
-    activeTab?.type === "timeline" && panelVisible
+  // On mobile PanelLeft renders as a floating hamburger + bottom sheet, so
+  // there is no rail to clear — the content runs full-bleed.
+  const contentMarginLeft = isMobile
+    ? 0
+    : activeTab?.type === "timeline" && panelVisible
       ? TOOLBAR_WIDTH +
         Math.max(panelSize - TOOLBAR_WIDTH, LEFT_PANEL_MIN_DRAWER_WIDTH)
       : TOOLBAR_WIDTH;

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -274,6 +274,26 @@ const styles = (theme: Theme) =>
         height: "16px",
         fontSize: "var(--fontSizeNormal)"
       }
+    },
+
+    // Mobile: no left rail to clear, and the bar grows to 48px so the global
+    // 44px touch-target minimum fits inside it. Text labels drop to icons.
+    [theme.breakpoints.down("sm")]: {
+      height: "48px",
+      paddingLeft: 0,
+      "& .tab": {
+        minWidth: "96px",
+        maxWidth: "160px",
+        padding: `0 ${getSpacingPx(SPACING.sm)} 0 ${getSpacingPx(SPACING.md)}`
+      },
+      "& .new-tab": {
+        padding: `0 ${getSpacingPx(SPACING.md)}`
+      },
+      "& .new-tab .new-tab-label": { display: "none" },
+      "& .app-builder-button .app-builder-label": { display: "none" },
+      "& .mode-toggle": {
+        padding: `0 ${getSpacingPx(SPACING.sm)}`
+      }
     }
   });
 
@@ -501,7 +521,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
         <span className="new-tab-plus" aria-hidden>
           +
         </span>
-        New
+        <span className="new-tab-label">New</span>
         <span className="new-tab-caret" aria-hidden>
           ▾
         </span>
@@ -566,7 +586,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
             onClick={() => navigate(`/app-builder/${activeTab.ref}`)}
           >
             <DashboardCustomizeIcon />
-            App Builder
+            <span className="app-builder-label">App Builder</span>
           </button>
         )}
 


### PR DESCRIPTION
The unified workspace shell (/workspace) had no mobile handling — the
existing mobile.css rules target legacy class names it doesn't emit:

- WorkspaceShell reserved a 50px left-rail gutter and 32px bottom strip
  even though on mobile the rail is a floating hamburger and the bottom
  panel is hidden. The content now runs full-bleed there.
- WorkspaceTabBar grows to 48px so the global 44px touch targets fit,
  drops the rail padding, compacts tabs, and reduces the + New and
  App Builder buttons to icons.
- The canvas chat dock ignored phone widths: MIN_DOCK_WIDTH (360px) plus
  a drag offset and width persisted from desktop could push the composer
  off-screen. On mobile the dock is now pinned full-width (100vw - 16px)
  at the bottom, dragging is disabled, and the resize re-clamp no longer
  overwrites the desktop position.
- The composer chip row wraps on mobile instead of overflowing, with the
  send button pinned right; Auto Layout and Save move from the composer
  footer into the workflow ⋮ menu.
- The mobile panel launcher moves down 8px to clear the taller tab bar.

Verified in Chromium at 390x844: tab bar, App/Edit toggle, composer, and
hamburger sheet all render within the viewport, including with a stale
desktop dock position seeded in localStorage.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011xEk8FkURdA7q8s5DVUSMh