### PR TITLE
fix(web): resolve connected image-list preview URIs against BASE_URL

### DIFF
--- a/web/src/components/properties/ImageListProperty.tsx
+++ b/web/src/components/properties/ImageListProperty.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../lib/dragdrop";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
 import { useUpstreamValue } from "../../hooks/nodes/useNodeIO";
+import { resolveUri } from "../../utils/imageUtils";
 
 interface ImageItem {
   uri: string;
@@ -474,7 +475,7 @@ const ImageListProperty = (props: PropertyProps) => {
               <div key={image.uri} className="image-item">
                 <div className="image-content">
                   <img
-                    src={image.uri}
+                    src={resolveUri(image.uri)}
                     alt={`Item ${index + 1}`}
                     draggable={false}
                   />
@@ -531,7 +532,7 @@ const ImageListProperty = (props: PropertyProps) => {
                       imageRefs.current[image.uri] = el;
                     }
                   }}
-                  src={image.uri}
+                  src={resolveUri(image.uri)}
                   alt={`Item ${index + 1}`}
                   draggable={false}
                   onLoad={loadHandlers[image.uri]}

--- a/web/src/components/properties/__tests__/ImageListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/ImageListProperty.test.tsx
@@ -16,6 +16,20 @@ jest.mock("../../../contexts/NodeContext", () => {
   };
 });
 
+// Simulate production, where the web app and the API live on different origins.
+// The connected preview must resolve relative `/api/storage/...` URIs against
+// BASE_URL, otherwise the <img> loads from the web origin and 404s.
+jest.mock("../../../stores/BASE_URL", () => ({
+  BASE_URL: "https://api.example.com"
+}));
+
+// The connected branch reads the wired upstream value from this hook.
+let mockUpstreamValue: unknown = undefined;
+jest.mock("../../../hooks/nodes/useNodeIO", () => ({
+  __esModule: true,
+  useUpstreamValue: () => mockUpstreamValue
+}));
+
 // Mock dependencies
 jest.mock("../../../config/data_types", () => ({}));
 jest.mock("../../../serverState/useAssetUpload", () => ({
@@ -44,6 +58,44 @@ const defaultProps = {
 describe("ImageListProperty", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUpstreamValue = undefined;
+  });
+
+  it("resolves connected upstream image URIs against BASE_URL", () => {
+    mockUpstreamValue = { type: "image", uri: "/api/storage/abc.png" };
+
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <ImageListProperty {...defaultProps} isConnected workflowId="wf1" />
+      </ThemeProvider>
+    );
+
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(1);
+    // A raw `/api/storage/...` src would resolve against the web origin and 404
+    // when the API is on a different origin; it must be prefixed with BASE_URL.
+    expect(images[0]).toHaveAttribute(
+      "src",
+      "https://api.example.com/api/storage/abc.png"
+    );
+  });
+
+  it("leaves absolute connected upstream URIs untouched", () => {
+    mockUpstreamValue = {
+      type: "image",
+      uri: "https://cdn.example.com/x.png"
+    };
+
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <ImageListProperty {...defaultProps} isConnected workflowId="wf1" />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/x.png"
+    );
   });
 
   it("renders property label and empty dropzone", () => {


### PR DESCRIPTION
The inspector's connected-input preview for `image_list` / `list[image]`
properties rendered `<img src={image.uri}>` with the raw upstream URI. When
that URI is a relative `/api/storage/...` path (file storage) or an
`asset://` ref, the browser resolved it against the web origin instead of the
API origin — a 404 / broken-image placeholder whenever the web app and API run
on different origins (e.g. nodetool.fly.dev vs api.nodetool.ai).

The single `ImageProperty` preview already avoided this by rendering through
ImageView → createImageUrl → resolveUri; `ImageListProperty` bypassed it.
Route both image-grid `src` values through the same `resolveUri` helper so
`/api/...` paths are prefixed with BASE_URL and `asset://` refs are rewritten,
while absolute `http(s):`/`data:`/`blob:` URIs pass through unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pr9CgbtX95BnZLg4JFMm3c