### PR TITLE
[T-20260709-0002] Set up Storybook foundation and initial design-system coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __pycache__
 build/
 coverage/
 dist/
+# Storybook build output
+storybook-static/
+web/storybook-static/
 # Stryker mutation testing
 **/reports/mutation/
 **/.stryker-tmp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10285,6 +10285,26 @@
         "@jitl/quickjs-ffi-types": "0.31.0"
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -11985,6 +12005,24 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
     "node_modules/@mediabunny/aac-encoder": {
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.47.0.tgz",
@@ -12903,14 +12941,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -16119,6 +16157,371 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -16128,6 +16531,311 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.23.0.tgz",
+      "integrity": "sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.23.0.tgz",
+      "integrity": "sha512-pprVojnNhHxupwTT2gdeUlkxll6XEvWWBk3oVicOSNVWQC99OBnDhMQDoirqnzrE1bScQSMS2JgPpqdlrhz/Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.23.0.tgz",
+      "integrity": "sha512-mbIrWIMAJeytyee36OyUP5XH92TP7FaKaQ2m5AjokKy7STgjrhRt7SMXqpqLjhGm6Xn721Xmsg6H3Rtd9YQETw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.23.0.tgz",
+      "integrity": "sha512-UnIphmZ1LazUCr9DXWaKYWtKDefPMbgLsywaoYxRqVCNHhq4MM6d2q1Nz1i9Vzxt5i+cE2nRUYpAUHr/lijNYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.23.0.tgz",
+      "integrity": "sha512-aaZ/cSEYFkSxgS2hOrobT6RQcsWNviOX8dW6CEkVx2/UYkAf9MeHbjl3W0usWV53rVV//ndBdn2nb1y7jsu4lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.23.0.tgz",
+      "integrity": "sha512-IoJLvO5SjLSVMaq83BNTrPCb1FppvoJc1IhZ5CoUVl3PykUBku7D+LK1j0GSurhJcIc6zfjghsvaZNpq5ev6Mg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.23.0.tgz",
+      "integrity": "sha512-vskFpwg44T/LFsfjSCnVZ5ygcuqzPC1yUzVEiKa8BgHAQz0+QLQQW3EGWLPVi8EXFghzjR4EtgPBtOhCjU4jdw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.23.0.tgz",
+      "integrity": "sha512-//TcHVhrChyw5RYtgts6WO7KcWq9387c1Z5Zvhqpk/ktAbyaRYgBZrpSY1GDCFq50ASt6B6jhh+JxB1rB45IAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.23.0.tgz",
+      "integrity": "sha512-ZFqlwiTf7CXLLSGyAR9tYiO33LiaeIEXW+xm42d8mnUGpDgPltyrCGYtQezyMMEXvjhOgCz1X+i7sbDTJEx+bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.23.0.tgz",
+      "integrity": "sha512-oZ5LeN5+H1R19dRjTAxKrxQguH+AsemHcnthEfFxf4OjmBSty2doHLeSmMunKy3zpTHJQ3lh3Af+dNS+W6dYeA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.23.0.tgz",
+      "integrity": "sha512-O4ciFDyX5ebQd0qkb1bjAIg8IEfiLT03GbSeylwlwlUMK9KwBWaALwrxSbc0Msaz4U6iPj+T9eRXpD5mxBfmvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.23.0.tgz",
+      "integrity": "sha512-P3o8Y9kISYjcxadmbO+94ThRwLhwGuDAbA7dcdd4+YLpfeF+mmobz8fXf4NmSdfSqjyRSkceJDBRZha9NVYkiQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.23.0.tgz",
+      "integrity": "sha512-oj03m1E3RmTFczKhcKJDzHaEDKJnPIsDcQFVxBJsSdXGSuIPdt5TvcM332FfMQgzI6yDJqyl4InrnFfXrmUTKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.23.0.tgz",
+      "integrity": "sha512-BqJxbSC8FdP7mSuSpRePTGHm0hXWV+dfz//f7SjsteZncLaBgWTBmi/OZNv7sX6CyG/Pt/eJkPorP+DkMOhMwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.23.0.tgz",
+      "integrity": "sha512-utmw+VmUrW4K8LI5/6jhg4aGYKJHOIjQ9syYOOA6pF3w7haKu4r4enTe2U0C04/HbUvkq/Zif43xFsKW1Pnq9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.23.0.tgz",
+      "integrity": "sha512-V6lbRrthHa4TbvsLjPtg+EkXT1tRY+s4I8rYLXUfiHlZzGx3sLv1EH9CEOOevjvUYHLsbe/gqCIc73XnQfPb9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.23.0.tgz",
+      "integrity": "sha512-gRoOxQPdnAmIAjxcuQNBxfihvx+wjTaQM/9/eP12xwnGNawOG/+Zz9RHN4WNSxT45b5CrscK4NB8aPh+oZQXAQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.23.0.tgz",
+      "integrity": "sha512-CgTGMYsJVe1eUiCdJTpGw21svXw79ITsemN1h0hcNkiswasDbN5MoibSLY+gRMWP5syfEz5iffrjZnwEP8xeUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.23.0.tgz",
+      "integrity": "sha512-gUGJpr+Rn6zMxm5juApV0K3U845i8t47o8k+rbO0BHbi4PoJIfSPeQmrE2dgohQm2g5k6iviNFyXCGqvmaYUpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.67.0",
@@ -20619,6 +21327,224 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.6.tgz",
+      "integrity": "sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.6"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@storybook/addon-docs": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.6.tgz",
+      "integrity": "sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "@storybook/csf-plugin": "10.4.6",
+        "@storybook/icons": "^2.0.2",
+        "@storybook/react-dom-shim": "10.4.6",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.6.tgz",
+      "integrity": "sha512-BHBtD81HiXUiDQz/CaFynLtWmm7AFUQn8VnXuHipZ8KlnUANopa4yqdVuy/Gwz8ub254uFI5NMZsW/KlgWNgNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.4.6",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.6.tgz",
+      "integrity": "sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.4.6",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.6.tgz",
+      "integrity": "sha512-9Y7YecrVFe1/01KYjfOLxVqTg2Aq+IO6TEv6sC2U0PfD0AWCSCmQ91QqgBpN/XW4aFFWoiZNinyXMUlU8zxy2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.4.6",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.6.tgz",
+      "integrity": "sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.6.tgz",
+      "integrity": "sha512-0arEQtybqGYXHbXpTot+Wv9YtG+V5Vp43QayXavPKQ20M8mpEzhyCPKd0EhqMGSC1Z1UEt0hm365WUBhI9LfKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.4.6",
+        "@storybook/react": "10.4.6",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.0",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@stryker-mutator/api": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
@@ -22902,9 +23828,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23070,6 +23996,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -23351,6 +24284,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -23512,6 +24452,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
@@ -24380,6 +25327,13 @@
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.70",
@@ -26468,6 +27422,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -26768,6 +27738,16 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -28780,6 +29760,36 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -29354,6 +30364,19 @@
       "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-5.2.0.tgz",
       "integrity": "sha512-Gib8yhK2Ng7w47ASvbUZ7GdhBYbeXEflbIDxf/vobdQBMrN/QXmPaouSsSSkEx5YH0N8ap8GYljfvqjug7h5Fg==",
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/docx": {
       "version": "9.7.1",
@@ -30651,6 +31674,16 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -34861,6 +35894,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -39030,6 +40098,13 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -42343,6 +43418,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.23.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.23.0.tgz",
+      "integrity": "sha512-f0+l598CJMOLnYPXsXxttJALH0ljtivdRMKtvHhxRuWa5FYmw5+qODARl8oYjMC/brpzKcrpdORsOBrTqhBZ9A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.23.0",
+        "@oxc-resolver/binding-android-arm64": "11.23.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.23.0",
+        "@oxc-resolver/binding-darwin-x64": "11.23.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.23.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.23.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.23.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.23.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.23.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.23.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.23.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.23.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.23.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.23.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.23.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.23.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.23.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.23.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.23.0"
+      }
+    },
     "node_modules/oxlint": {
       "version": "1.67.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
@@ -42843,6 +43997,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -44621,6 +45785,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-docgen/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -45973,6 +47182,19 @@
       "integrity": "sha512-N0aABkKa1Cuxh/OiK9wHAuO7K/brSCOlHHNwlYfpAgTRtQPZFFxNr20NbsQyokVkw+1mZMcw+cT+3svHG6tPQQ==",
       "license": "GPLv2"
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -47054,6 +48276,180 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/storybook": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.6.tgz",
+      "integrity": "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/storybook/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/stream-browserify": {
@@ -48291,6 +49687,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tlds": {
       "version": "1.261.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
@@ -48604,6 +50010,16 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-graphviz": {
@@ -49391,6 +50807,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -50173,6 +51605,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -50516,6 +51955,38 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xlsx": {
@@ -52927,6 +54398,9 @@
         "@eslint/js": "^9.39.4",
         "@jest/globals": "^29.7.0",
         "@playwright/test": "^1.60.0",
+        "@storybook/addon-a11y": "^10.4.6",
+        "@storybook/addon-docs": "^10.4.6",
+        "@storybook/react-vite": "^10.4.6",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -52951,6 +54425,7 @@
         "jest-axe": "^10.0.0",
         "jest-environment-jsdom": "^30.4.1",
         "mock-socket": "^9.3.1",
+        "storybook": "^10.4.6",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.3",
         "vite": "^8.0.16",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "dev": "concurrently --raw --kill-others-on-fail \"node scripts/dev-server.mjs\" \"npm run dev --workspace=web\"",
     "dev:fast": "npm run dev",
     "dev:web": "npm run dev --workspace=web",
+    "storybook": "npm run storybook --workspace=web",
+    "build-storybook": "npm run build-storybook --workspace=web",
     "dev:server": "node scripts/dev-server.mjs",
     "dev:server:fast": "npm run dev:server",
     "dev:dist": "turbo run dev --filter=@nodetool-ai/websocket --filter=nodetool",

--- a/web/.storybook/README.md
+++ b/web/.storybook/README.md
@@ -1,0 +1,35 @@
+# Storybook
+
+Component catalog and visual-regression source for the NodeTool design system.
+Chromatic (set up by the CI task) snapshots these stories on every PR.
+
+## Run
+
+```bash
+npm run storybook          # dev server on :6006 (from repo root or web/)
+npm run build-storybook    # static build → web/storybook-static/
+```
+
+## Layout
+
+- `main.ts` — framework (`@storybook/react-vite`), story globs, and the Vite
+  overrides that mirror the app: the `nodetool-dev` resolve condition and the
+  `node:*` builtin stubs from `web/vite-node-stubs`.
+- `preview.tsx` — global decorators: the app MUI theme (`ThemeNodetool`) with
+  `CssBaseline`, plus two toolbar globals.
+- `../src/stories/**` — the stories. Primitives are deep-imported per file so a
+  single story never pulls the whole `ui_primitives` barrel (and its runtime
+  deps) into the bundle. `src/stories/**` is exempt from the design-token lint
+  (`web/eslint.design.mjs`) as a harness, like `src/demo/` and `src/e2e_runner/`.
+
+## Deterministic snapshots
+
+Two toolbar globals keep Chromatic diffs stable:
+
+- **Theme** — `dark` (default, the app baseline) or `light`.
+- **Motion** — `Frozen` (default) zeroes every transition/animation duration and
+  hides the caret so snapshots never catch a mid-animation frame; `Animated`
+  restores real motion for local inspection.
+
+Fonts are self-hosted (Inter + JetBrains Mono via `@fontsource`, imported by
+`ThemeNodetool`), so text renders identically in CI.

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,0 +1,76 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configDir = dirname(fileURLToPath(import.meta.url));
+const nodeStubs = resolve(configDir, "../vite-node-stubs");
+
+// The design-system stories only touch pure UI primitives, but a few of those
+// transitively import `@nodetool-ai/*` packages that statically reference
+// `node:*` built-ins for their server code paths. Map the ones that can be
+// pulled in to the browser-safe stubs the main app already uses, so Storybook
+// builds without a Node polyfill. Mirrors web/vite.config.ts.
+const NODE_BUILTIN_STUBS: Record<string, string> = {
+  "node:fs/promises": `${nodeStubs}/fs-promises-stub.js`,
+  "node:fs": `${nodeStubs}/fs-stub.js`,
+  "node:path": `${nodeStubs}/path-stub.js`,
+  "node:url": `${nodeStubs}/url-stub.js`,
+  "node:crypto": `${nodeStubs}/crypto-stub.js`,
+  "node:os": `${nodeStubs}/os-stub.js`,
+  "node:events": `${nodeStubs}/events-stub.js`,
+  "node:child_process": `${nodeStubs}/child-process-stub.js`,
+  "node:worker_threads": `${nodeStubs}/empty.js`,
+  "node:stream": `${nodeStubs}/stream-stub.js`,
+  "node:async_hooks": `${nodeStubs}/empty.js`,
+  "node:util": `${nodeStubs}/empty.js`,
+  "node:buffer": `${nodeStubs}/buffer-stub.js`,
+  "node:assert": `${nodeStubs}/empty.js`,
+  "node:process": `${nodeStubs}/empty.js`,
+  "node:module": `${nodeStubs}/empty.js`,
+  "node:net": `${nodeStubs}/empty.js`,
+  "node:tls": `${nodeStubs}/empty.js`,
+  "node:http": `${nodeStubs}/empty.js`,
+  "node:https": `${nodeStubs}/empty.js`,
+  "node:http2": `${nodeStubs}/empty.js`,
+  "node:zlib": `${nodeStubs}/empty.js`,
+  "node:dns": `${nodeStubs}/empty.js`,
+  "node:dgram": `${nodeStubs}/empty.js`,
+  "node:perf_hooks": `${nodeStubs}/empty.js`,
+  "node:vm": `${nodeStubs}/empty.js`
+};
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-docs", "@storybook/addon-a11y"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {}
+  },
+  core: {
+    disableTelemetry: true
+  },
+  typescript: {
+    // Prop tables are hand-authored via argTypes; skip the slow docgen pass.
+    reactDocgen: false
+  },
+  async viteFinal(viteConfig) {
+    const { mergeConfig } = await import("vite");
+    return mergeConfig(viteConfig, {
+      resolve: {
+        // Resolve @nodetool-ai/* packages to their TS sources, matching the app.
+        conditions: ["nodetool-dev", "import", "module", "browser", "default"]
+      },
+      plugins: [
+        {
+          name: "storybook-stub-node-protocol",
+          enforce: "pre" as const,
+          resolveId(source: string) {
+            return NODE_BUILTIN_STUBS[source] ?? null;
+          }
+        }
+      ]
+    });
+  }
+};
+
+export default config;

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect } from "react";
+import type { Decorator, Preview } from "@storybook/react-vite";
+import { ThemeProvider, useColorScheme } from "@mui/material/styles";
+import InitColorSchemeScript from "@mui/system/InitColorSchemeScript";
+import { CssBaseline, GlobalStyles } from "@mui/material";
+import ThemeNodetool from "../src/components/themes/ThemeNodetool";
+
+/**
+ * Keeps the active MUI color scheme in sync with the Storybook `theme` global.
+ * The app is dark-first, so `dark` is the default and the visual-test baseline.
+ */
+const ModeSync = ({ mode }: { mode: "light" | "dark" }) => {
+  const { setMode } = useColorScheme();
+  useEffect(() => {
+    setMode(mode);
+  }, [mode, setMode]);
+  return null;
+};
+
+/**
+ * Determinism styles for visual regression. Snapshots must not capture
+ * mid-transition or mid-animation frames, and text must render with the
+ * self-hosted fonts only. Enabled by default; toggle off with the `motion`
+ * toolbar to preview real animations.
+ */
+const freezeMotionStyles = {
+  "*, *::before, *::after": {
+    transitionDuration: "0ms !important",
+    transitionDelay: "0ms !important",
+    animationDuration: "0ms !important",
+    animationDelay: "0ms !important",
+    animationIterationCount: "1 !important",
+    scrollBehavior: "auto !important",
+    caretColor: "transparent !important"
+  }
+} as const;
+
+const withTheme: Decorator = (Story, context) => {
+  const mode = (context.globals.theme as "light" | "dark") ?? "dark";
+  const freezeMotion = context.globals.motion !== "on";
+  return (
+    <ThemeProvider theme={ThemeNodetool} defaultMode="dark">
+      <InitColorSchemeScript attribute="class" defaultMode="dark" />
+      <CssBaseline />
+      {freezeMotion && <GlobalStyles styles={freezeMotionStyles} />}
+      <ModeSync mode={mode} />
+      <div style={{ padding: 16 }}>
+        <Story />
+      </div>
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    layout: "centered",
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i
+      }
+    },
+    a11y: {
+      // Report findings in the a11y panel without failing the run.
+      test: "todo"
+    },
+    options: {
+      storySort: {
+        order: [
+          "Design Tokens",
+          ["Colors", "Typography", "Spacing", "Border Radius", "Motion", "Z-Index"],
+          "Primitives",
+          "Surfaces",
+          "Layout",
+          "Feedback"
+        ]
+      }
+    }
+  },
+  globalTypes: {
+    theme: {
+      description: "App color scheme",
+      defaultValue: "dark",
+      toolbar: {
+        title: "Theme",
+        icon: "paintbrush",
+        items: [
+          { value: "dark", title: "Dark" },
+          { value: "light", title: "Light" }
+        ],
+        dynamicTitle: true
+      }
+    },
+    motion: {
+      description: "Enable animations/transitions (off = deterministic snapshots)",
+      defaultValue: "off",
+      toolbar: {
+        title: "Motion",
+        icon: "lightning",
+        items: [
+          { value: "off", title: "Frozen (visual-test)" },
+          { value: "on", title: "Animated" }
+        ],
+        dynamicTitle: true
+      }
+    }
+  },
+  initialGlobals: {
+    theme: "dark",
+    motion: "off"
+  }
+};
+
+export default preview;

--- a/web/eslint.design.mjs
+++ b/web/eslint.design.mjs
@@ -28,6 +28,12 @@ export const designTokenIgnores = [
   "src/__mocks__/**",
   "src/demo/**",
   "src/demo-entry.tsx",
+  // Storybook stories are a component catalog / visual-test harness, not
+  // shipped UI. They deep-import individual primitives on purpose (the barrel
+  // pulls heavy runtime deps into the Storybook bundle) and render raw literals
+  // to showcase the tokens themselves — same category as demo/ and e2e_runner/.
+  "src/stories/**",
+  "**/*.stories.{ts,tsx}",
   "src/e2e_runner/**",
   // Pure color-as-data modules: chart palettes, syntax-highlight themes, and
   // node/type color maps are intrinsically literal colors, not styling.

--- a/web/package.json
+++ b/web/package.json
@@ -109,7 +109,9 @@
     "lint:font-color-css": "node scripts/lint-font-color-css.mjs",
     "lint:radius-css": "node scripts/lint-radius-css.mjs",
     "lint:motion-css": "node scripts/lint-motion-css.mjs",
-    "lint:motion-rule": "node scripts/test-motion-rule.mjs"
+    "lint:motion-rule": "node scripts/test-motion-rule.mjs",
+    "storybook": "storybook dev -p 6006 --no-open",
+    "build-storybook": "storybook build"
   },
   "browserslist": {
     "production": [
@@ -136,6 +138,9 @@
     "@eslint/js": "^9.39.4",
     "@jest/globals": "^29.7.0",
     "@playwright/test": "^1.60.0",
+    "@storybook/addon-a11y": "^10.4.6",
+    "@storybook/addon-docs": "^10.4.6",
+    "@storybook/react-vite": "^10.4.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -160,6 +165,7 @@
     "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.4.1",
     "mock-socket": "^9.3.1",
+    "storybook": "^10.4.6",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",

--- a/web/src/stories/AlertBanner.stories.tsx
+++ b/web/src/stories/AlertBanner.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AlertBanner } from "../components/ui_primitives/AlertBanner";
+
+const meta = {
+  title: "Feedback/AlertBanner",
+  component: AlertBanner,
+  args: {
+    severity: "info",
+    variant: "standard",
+    title: "Heads up",
+    children: "This is an informational message."
+  },
+  argTypes: {
+    severity: { control: "select", options: ["success", "info", "warning", "error"] },
+    variant: { control: "select", options: ["filled", "outlined", "standard"] },
+    compact: { control: "boolean" }
+  }
+} satisfies Meta<typeof AlertBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {};
+
+export const Severities: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, width: 360 }}>
+      {(["success", "info", "warning", "error"] as const).map((s) => (
+        <AlertBanner {...args} key={s} severity={s} title={s}>
+          {s} message
+        </AlertBanner>
+      ))}
+    </div>
+  )
+};
+
+export const Outlined: Story = {
+  args: { variant: "outlined", severity: "warning" }
+};

--- a/web/src/stories/Button.stories.tsx
+++ b/web/src/stories/Button.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "../components/ui_primitives/muiReexports";
+
+const meta = {
+  title: "Primitives/Button",
+  component: Button,
+  args: {
+    children: "Button",
+    variant: "contained",
+    color: "primary"
+  },
+  argTypes: {
+    variant: { control: "select", options: ["text", "outlined", "contained"] },
+    color: {
+      control: "select",
+      options: ["primary", "secondary", "success", "error", "warning", "info", "inherit"]
+    },
+    size: { control: "select", options: ["small", "medium", "large"] },
+    disabled: { control: "boolean" }
+  }
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Contained: Story = {};
+
+export const Outlined: Story = {
+  args: { variant: "outlined" }
+};
+
+export const Text: Story = {
+  args: { variant: "text" }
+};
+
+export const Secondary: Story = {
+  args: { color: "secondary" }
+};
+
+export const Disabled: Story = {
+  args: { disabled: true }
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <Button {...args} size="small">
+        Small
+      </Button>
+      <Button {...args} size="medium">
+        Medium
+      </Button>
+      <Button {...args} size="large">
+        Large
+      </Button>
+    </div>
+  )
+};

--- a/web/src/stories/Card.stories.tsx
+++ b/web/src/stories/Card.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Card } from "../components/ui_primitives/Card";
+
+const Content = () => (
+  <div style={{ maxWidth: 260 }}>
+    <div style={{ fontFamily: "var(--fontFamily1)", fontWeight: 600, marginBottom: 4 }}>
+      Card title
+    </div>
+    <div
+      style={{
+        fontFamily: "var(--fontFamily1)",
+        fontSize: "var(--fontSizeSmall)",
+        opacity: 0.75
+      }}
+    >
+      A surface primitive with padding, elevation, and border variants.
+    </div>
+  </div>
+);
+
+const meta = {
+  title: "Surfaces/Card",
+  component: Card,
+  args: {
+    variant: "default",
+    padding: "normal",
+    children: <Content />
+  },
+  argTypes: {
+    variant: { control: "select", options: ["default", "outlined", "elevated"] },
+    padding: {
+      control: "select",
+      options: ["none", "compact", "normal", "comfortable", "spacious"]
+    },
+    hoverable: { control: "boolean" },
+    clickable: { control: "boolean" }
+  }
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Outlined: Story = {
+  args: { variant: "outlined" }
+};
+
+export const Elevated: Story = {
+  args: { variant: "elevated" }
+};
+
+export const Hoverable: Story = {
+  args: { hoverable: true, clickable: true }
+};

--- a/web/src/stories/Checkbox.stories.tsx
+++ b/web/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Checkbox } from "../components/ui_primitives/Checkbox";
+
+const meta = {
+  title: "Primitives/Checkbox",
+  component: Checkbox,
+  args: {
+    label: "Enable feature",
+    size: "small"
+  },
+  argTypes: {
+    size: { control: "select", options: ["small", "medium"] },
+    compact: { control: "boolean" },
+    disabled: { control: "boolean" },
+    checked: { control: "boolean" }
+  }
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unchecked: Story = {};
+
+export const Checked: Story = {
+  args: { defaultChecked: true }
+};
+
+export const Indeterminate: Story = {
+  args: { indeterminate: true }
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, defaultChecked: true }
+};
+
+export const WithoutLabel: Story = {
+  args: { label: undefined, "aria-label": "toggle" }
+};

--- a/web/src/stories/Chip.stories.tsx
+++ b/web/src/stories/Chip.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip } from "../components/ui_primitives/Chip";
+
+const meta = {
+  title: "Feedback/Chip",
+  component: Chip,
+  args: {
+    label: "Chip",
+    color: "default"
+  },
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["default", "primary", "secondary", "success", "warning", "error", "info"]
+    },
+    active: { control: "boolean" },
+    compact: { control: "boolean" }
+  }
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      {(["default", "primary", "secondary", "success", "warning", "error", "info"] as const).map(
+        (c) => (
+          <Chip {...args} key={c} color={c} label={c} />
+        )
+      )}
+    </div>
+  )
+};
+
+export const Active: Story = {
+  args: { active: true, color: "primary" }
+};
+
+export const Compact: Story = {
+  args: { compact: true }
+};

--- a/web/src/stories/DesignTokens.BorderRadius.stories.tsx
+++ b/web/src/stories/DesignTokens.BorderRadius.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { BORDER_RADIUS } from "../components/ui_primitives/tokens";
+
+const RadiusScale = () => (
+  <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap", maxWidth: 720 }}>
+    {Object.entries(BORDER_RADIUS).map(([token, value]) => (
+      <Box
+        key={token}
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}
+      >
+        <Box
+          sx={{
+            width: 88,
+            height: 88,
+            borderRadius: value,
+            backgroundColor: "var(--palette-primary-main)",
+            border: "1px solid var(--palette-divider)"
+          }}
+        />
+        <Box sx={{ fontFamily: "var(--fontFamily2)", fontSize: "var(--fontSizeSmall)" }}>
+          {token}
+        </Box>
+        <Box
+          sx={{
+            fontFamily: "var(--fontFamily2)",
+            fontSize: "var(--fontSizeSmaller)",
+            opacity: 0.6
+          }}
+        >
+          {value}
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+const meta = {
+  title: "Design Tokens/Border Radius",
+  component: RadiusScale,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof RadiusScale>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Scale: Story = {};

--- a/web/src/stories/DesignTokens.Colors.stories.tsx
+++ b/web/src/stories/DesignTokens.Colors.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useTheme } from "@mui/material/styles";
+import { Box } from "@mui/material";
+
+/**
+ * Palette swatches read straight off the active theme, so this page doubles as
+ * a visual diff of any palette change (light or dark) in Chromatic.
+ */
+const PALETTE_ROLES = [
+  "primary",
+  "secondary",
+  "error",
+  "warning",
+  "info",
+  "success"
+] as const;
+
+const Swatch = ({ label, color }: { label: string; color: string }) => (
+  <Box
+    sx={{
+      display: "flex",
+      flexDirection: "column",
+      gap: 0.5,
+      width: 140
+    }}
+  >
+    <Box
+      sx={{
+        height: 56,
+        borderRadius: "var(--rounded-md)",
+        backgroundColor: color,
+        border: "1px solid var(--palette-divider)"
+      }}
+    />
+    <Box sx={{ fontSize: "var(--fontSizeSmaller)", fontFamily: "var(--fontFamily2)" }}>
+      {label}
+    </Box>
+    <Box
+      sx={{
+        fontSize: "var(--fontSizeSmaller)",
+        fontFamily: "var(--fontFamily2)",
+        opacity: 0.6
+      }}
+    >
+      {color}
+    </Box>
+  </Box>
+);
+
+const ColorPalette = () => {
+  const theme = useTheme();
+  const palette = theme.vars.palette;
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {PALETTE_ROLES.map((role) => {
+        const group = palette[role] as unknown as
+          | Record<string, string>
+          | undefined;
+        if (!group) return null;
+        return (
+          <Box key={role}>
+            <Box
+              sx={{
+                fontFamily: "var(--fontFamily1)",
+                fontSize: "var(--fontSizeSmall)",
+                fontWeight: 600,
+                textTransform: "capitalize",
+                mb: 1
+              }}
+            >
+              {role}
+            </Box>
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+              {["main", "light", "dark", "contrastText"]
+                .filter((tone) => group[tone])
+                .map((tone) => (
+                  <Swatch key={tone} label={tone} color={group[tone]} />
+                ))}
+            </Box>
+          </Box>
+        );
+      })}
+      <Box>
+        <Box
+          sx={{
+            fontFamily: "var(--fontFamily1)",
+            fontSize: "var(--fontSizeSmall)",
+            fontWeight: 600,
+            mb: 1
+          }}
+        >
+          Surfaces & text
+        </Box>
+        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+          <Swatch label="background.default" color={palette.background.default} />
+          <Swatch label="background.paper" color={palette.background.paper} />
+          <Swatch label="text.primary" color={palette.text.primary} />
+          <Swatch label="text.secondary" color={palette.text.secondary} />
+          <Swatch label="divider" color={palette.divider} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const meta = {
+  title: "Design Tokens/Colors",
+  component: ColorPalette,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof ColorPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Palette: Story = {};

--- a/web/src/stories/DesignTokens.Motion.stories.tsx
+++ b/web/src/stories/DesignTokens.Motion.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { MOTION } from "../components/ui_primitives/tokens";
+
+/**
+ * Motion timing tokens. Snapshots freeze animation by default (see the Motion
+ * toolbar), so this page documents the durations rather than animating them.
+ */
+const MotionTokens = () => (
+  <Box sx={{ display: "flex", flexDirection: "column", gap: 1, maxWidth: 640 }}>
+    {Object.entries(MOTION).map(([token, value]) => (
+      <Box
+        key={token}
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "120px 1fr",
+          gap: 2,
+          py: 1,
+          borderBottom: "1px solid var(--palette-divider)"
+        }}
+      >
+        <Box sx={{ fontFamily: "var(--fontFamily2)", fontSize: "var(--fontSizeSmall)" }}>
+          {token}
+        </Box>
+        <Box
+          sx={{
+            fontFamily: "var(--fontFamily2)",
+            fontSize: "var(--fontSizeSmall)",
+            opacity: 0.7
+          }}
+        >
+          {value}
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+const meta = {
+  title: "Design Tokens/Motion",
+  component: MotionTokens,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof MotionTokens>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Timings: Story = {};

--- a/web/src/stories/DesignTokens.Spacing.stories.tsx
+++ b/web/src/stories/DesignTokens.Spacing.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { SPACING } from "../components/ui_primitives/spacing";
+
+/** The canonical 4px-grid spacing steps (plus the 2px micro step). */
+const CANONICAL = [
+  "none",
+  "micro",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "xxl",
+  "xxxl"
+] as const;
+
+const SpacingScale = () => (
+  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, maxWidth: 640 }}>
+    {CANONICAL.map((token) => {
+      const units = SPACING[token];
+      const px = units * 4;
+      return (
+        <Box key={token} sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box
+            sx={{
+              width: 120,
+              fontFamily: "var(--fontFamily2)",
+              fontSize: "var(--fontSizeSmall)"
+            }}
+          >
+            {token}
+          </Box>
+          <Box
+            sx={{
+              width: 64,
+              fontFamily: "var(--fontFamily2)",
+              fontSize: "var(--fontSizeSmaller)",
+              opacity: 0.6
+            }}
+          >
+            {px}px
+          </Box>
+          <Box
+            sx={{
+              height: 16,
+              width: `${px}px`,
+              minWidth: 2,
+              backgroundColor: "var(--palette-primary-main)",
+              borderRadius: "var(--rounded-xs)"
+            }}
+          />
+        </Box>
+      );
+    })}
+  </Box>
+);
+
+const meta = {
+  title: "Design Tokens/Spacing",
+  component: SpacingScale,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof SpacingScale>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Scale: Story = {};

--- a/web/src/stories/DesignTokens.Typography.stories.tsx
+++ b/web/src/stories/DesignTokens.Typography.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { TYPOGRAPHY } from "../components/ui_primitives/tokens";
+
+/**
+ * The eight — and only eight — sanctioned text styles (four sans, four mono).
+ * Any drift in font size, weight, or family shows up here.
+ */
+const Row = ({ name, style }: { name: string; style: Record<string, unknown> }) => (
+  <Box
+    sx={{
+      display: "grid",
+      gridTemplateColumns: "160px 1fr",
+      alignItems: "baseline",
+      gap: 2,
+      py: 1,
+      borderBottom: "1px solid var(--palette-divider)"
+    }}
+  >
+    <Box
+      sx={{ fontFamily: "var(--fontFamily2)", fontSize: "var(--fontSizeSmaller)", opacity: 0.7 }}
+    >
+      {name}
+    </Box>
+    <Box sx={style}>The quick brown fox jumps over the lazy dog</Box>
+  </Box>
+);
+
+const TypeScale = () => (
+  <Box sx={{ display: "flex", flexDirection: "column", gap: 4, maxWidth: 720 }}>
+    <Box>
+      <Box sx={{ ...TYPOGRAPHY.sans.title, mb: 1 }}>Sans (Inter)</Box>
+      {Object.entries(TYPOGRAPHY.sans).map(([role, style]) => (
+        <Row key={role} name={`sans.${role}`} style={style} />
+      ))}
+    </Box>
+    <Box>
+      <Box sx={{ ...TYPOGRAPHY.sans.title, mb: 1 }}>Mono (JetBrains Mono)</Box>
+      {Object.entries(TYPOGRAPHY.mono).map(([role, style]) => (
+        <Row key={role} name={`mono.${role}`} style={style} />
+      ))}
+    </Box>
+  </Box>
+);
+
+const meta = {
+  title: "Design Tokens/Typography",
+  component: TypeScale,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof TypeScale>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Scale: Story = {};

--- a/web/src/stories/DesignTokens.ZIndex.stories.tsx
+++ b/web/src/stories/DesignTokens.ZIndex.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { Z_INDEX } from "../components/ui_primitives/tokens";
+
+const ZIndexScale = () => (
+  <Box sx={{ display: "flex", flexDirection: "column", gap: 1, maxWidth: 480 }}>
+    {Object.entries(Z_INDEX).map(([token, value]) => (
+      <Box
+        key={token}
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          px: 2,
+          py: 1.5,
+          borderRadius: "var(--rounded-md)",
+          backgroundColor: "var(--palette-background-paper)",
+          border: "1px solid var(--palette-divider)"
+        }}
+      >
+        <Box sx={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+          {token}
+        </Box>
+        <Box
+          sx={{
+            fontFamily: "var(--fontFamily2)",
+            fontSize: "var(--fontSizeSmall)",
+            opacity: 0.7
+          }}
+        >
+          {value}
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+const meta = {
+  title: "Design Tokens/Z-Index",
+  component: ZIndexScale,
+  parameters: { layout: "padded" }
+} satisfies Meta<typeof ZIndexScale>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Layers: Story = {};

--- a/web/src/stories/Dialog.stories.tsx
+++ b/web/src/stories/Dialog.stories.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Dialog } from "../components/ui_primitives/Dialog";
+import { Button } from "../components/ui_primitives/muiReexports";
+
+/**
+ * Dialogs render into a portal. The stories keep them open by default so the
+ * modal surface is captured in snapshots without an interaction step.
+ */
+const meta = {
+  title: "Surfaces/Dialog",
+  component: Dialog,
+  parameters: { layout: "fullscreen" },
+  args: {
+    open: true,
+    title: "Dialog title",
+    children: (
+      <div style={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+        Dialog body content. Confirm or cancel to continue.
+      </div>
+    )
+  }
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const WithActions: Story = {
+  args: {
+    showActions: true,
+    confirmText: "Save",
+    cancelText: "Cancel"
+  }
+};
+
+export const Loading: Story = {
+  args: { showActions: true, isLoading: true }
+};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const InteractiveDialog = () => {
+      const [open, setOpen] = useState(false);
+      return (
+        <div style={{ padding: 24 }}>
+          <Button variant="contained" onClick={() => setOpen(true)}>
+            Open dialog
+          </Button>
+          <Dialog
+            {...args}
+            open={open}
+            showActions
+            onClose={() => setOpen(false)}
+            onConfirm={() => setOpen(false)}
+          />
+        </div>
+      );
+    };
+    return <InteractiveDialog />;
+  }
+};

--- a/web/src/stories/Divider.stories.tsx
+++ b/web/src/stories/Divider.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Divider } from "../components/ui_primitives/Divider";
+
+const meta = {
+  title: "Layout/Divider",
+  component: Divider,
+  args: {
+    spacing: "normal",
+    variant: "full",
+    color: "default"
+  },
+  argTypes: {
+    spacing: {
+      control: "select",
+      options: ["none", "compact", "normal", "comfortable", "spacious"]
+    },
+    variant: { control: "select", options: ["full", "inset", "middle"] },
+    color: { control: "select", options: ["default", "subtle", "strong"] }
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <div style={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+          Above
+        </div>
+        <Story />
+        <div style={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+          Below
+        </div>
+      </div>
+    )
+  ]
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Subtle: Story = {
+  args: { color: "subtle" }
+};
+
+export const Strong: Story = {
+  args: { color: "strong" }
+};

--- a/web/src/stories/EmptyState.stories.tsx
+++ b/web/src/stories/EmptyState.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EmptyState } from "../components/ui_primitives/EmptyState";
+
+const meta = {
+  title: "Feedback/EmptyState",
+  component: EmptyState,
+  args: {
+    variant: "empty",
+    title: "Nothing here yet",
+    description: "Create your first item to get started.",
+    actionText: "Create item",
+    size: "medium"
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["empty", "no-results", "no-data", "offline", "error"]
+    },
+    size: { control: "select", options: ["small", "medium", "large"] }
+  }
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+
+export const NoResults: Story = {
+  args: {
+    variant: "no-results",
+    title: "No results found",
+    description: "Try adjusting your search or filters.",
+    actionText: undefined
+  }
+};
+
+export const ErrorState: Story = {
+  args: {
+    variant: "error",
+    title: "Something went wrong",
+    description: "We couldn't load this content.",
+    actionText: "Retry"
+  }
+};

--- a/web/src/stories/IconButton.stories.tsx
+++ b/web/src/stories/IconButton.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Settings as SettingsIcon } from "@mui/icons-material";
+import { IconButton } from "../components/ui_primitives/muiReexports";
+
+const meta = {
+  title: "Primitives/IconButton",
+  component: IconButton,
+  args: {
+    children: <SettingsIcon fontSize="small" />,
+    color: "default",
+    "aria-label": "Settings"
+  },
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["default", "primary", "secondary", "error", "inherit"]
+    },
+    size: { control: "select", options: ["small", "medium", "large"] },
+    disabled: { control: "boolean" }
+  }
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Primary: Story = {
+  args: { color: "primary" }
+};
+
+export const Disabled: Story = {
+  args: { disabled: true }
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      <IconButton {...args} size="small" />
+      <IconButton {...args} size="medium" />
+      <IconButton {...args} size="large" />
+    </div>
+  )
+};

--- a/web/src/stories/Layout.stories.tsx
+++ b/web/src/stories/Layout.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FlexRow } from "../components/ui_primitives/FlexRow";
+import { FlexColumn } from "../components/ui_primitives/FlexColumn";
+
+const Tile = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      padding: "8px 16px",
+      borderRadius: "var(--rounded-md)",
+      backgroundColor: "var(--palette-primary-main)",
+      color: "var(--palette-primary-contrastText)",
+      fontFamily: "var(--fontFamily2)",
+      fontSize: "var(--fontSizeSmall)"
+    }}
+  >
+    {children}
+  </div>
+);
+
+const meta = {
+  title: "Layout/Flex",
+  component: FlexRow,
+  argTypes: {
+    gap: { control: { type: "range", min: 0, max: 8, step: 1 } },
+    align: {
+      control: "select",
+      options: ["flex-start", "center", "flex-end", "stretch", "baseline"]
+    },
+    justify: {
+      control: "select",
+      options: [
+        "flex-start",
+        "center",
+        "flex-end",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ]
+    }
+  }
+} satisfies Meta<typeof FlexRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Row: Story = {
+  args: { gap: 2, align: "center" },
+  render: (args) => (
+    <FlexRow {...args} sx={{ width: 420, border: "1px dashed var(--palette-divider)", p: 2 }}>
+      <Tile>One</Tile>
+      <Tile>Two</Tile>
+      <Tile>Three</Tile>
+    </FlexRow>
+  )
+};
+
+export const RowSpaceBetween: Story = {
+  args: { gap: 2, justify: "space-between" },
+  render: (args) => (
+    <FlexRow {...args} sx={{ width: 420, border: "1px dashed var(--palette-divider)", p: 2 }}>
+      <Tile>Left</Tile>
+      <Tile>Right</Tile>
+    </FlexRow>
+  )
+};
+
+export const Column: Story = {
+  render: () => (
+    <FlexColumn gap={2} sx={{ width: 200, border: "1px dashed var(--palette-divider)", p: 2 }}>
+      <Tile>First</Tile>
+      <Tile>Second</Tile>
+      <Tile>Third</Tile>
+    </FlexColumn>
+  )
+};

--- a/web/src/stories/LoadingSpinner.stories.tsx
+++ b/web/src/stories/LoadingSpinner.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LoadingSpinner } from "../components/ui_primitives/LoadingSpinner";
+
+const meta = {
+  title: "Feedback/LoadingSpinner",
+  component: LoadingSpinner,
+  args: {
+    variant: "circular",
+    size: "medium",
+    color: "primary"
+  },
+  argTypes: {
+    variant: { control: "select", options: ["circular", "dots"] },
+    size: { control: "select", options: ["small", "medium", "large"] },
+    color: { control: "select", options: ["primary", "secondary", "inherit"] }
+  }
+} satisfies Meta<typeof LoadingSpinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Circular: Story = {};
+
+export const Dots: Story = {
+  args: { variant: "dots" }
+};
+
+export const WithText: Story = {
+  args: { text: "Loading…" }
+};

--- a/web/src/stories/Panel.stories.tsx
+++ b/web/src/stories/Panel.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Panel } from "../components/ui_primitives/Panel";
+
+const meta = {
+  title: "Surfaces/Panel",
+  component: Panel,
+  args: {
+    title: "Panel title",
+    subtitle: "Supporting description text",
+    bordered: true,
+    padding: "normal",
+    background: "paper",
+    children: (
+      <div style={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+        Panel body content goes here.
+      </div>
+    ),
+    sx: { width: 320 }
+  },
+  argTypes: {
+    padding: {
+      control: "select",
+      options: ["none", "compact", "normal", "comfortable", "spacious"]
+    },
+    background: { control: "select", options: ["default", "paper", "transparent"] },
+    bordered: { control: "boolean" },
+    collapsible: { control: "boolean" }
+  }
+} satisfies Meta<typeof Panel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithFooter: Story = {
+  args: {
+    footer: (
+      <div style={{ fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmaller)" }}>
+        Footer content
+      </div>
+    )
+  }
+};
+
+export const Collapsible: Story = {
+  args: { collapsible: true }
+};

--- a/web/src/stories/ProgressBar.stories.tsx
+++ b/web/src/stories/ProgressBar.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ProgressBar } from "../components/ui_primitives/ProgressBar";
+
+const meta = {
+  title: "Feedback/ProgressBar",
+  component: ProgressBar,
+  args: {
+    value: 60,
+    label: "Uploading",
+    showValue: true,
+    progressVariant: "determinate"
+  },
+  argTypes: {
+    value: { control: { type: "range", min: 0, max: 100, step: 1 } },
+    progressVariant: {
+      control: "select",
+      options: ["determinate", "indeterminate", "buffer"]
+    },
+    showValue: { control: "boolean" }
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    )
+  ]
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Determinate: Story = {};
+
+export const Complete: Story = {
+  args: { value: 100, label: "Done" }
+};
+
+export const NoLabel: Story = {
+  args: { label: undefined, showValue: false }
+};

--- a/web/src/stories/ScrollArea.stories.tsx
+++ b/web/src/stories/ScrollArea.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScrollArea } from "../components/ui_primitives/ScrollArea";
+
+const rows = Array.from({ length: 30 }, (_, i) => i + 1);
+
+const meta = {
+  title: "Layout/ScrollArea",
+  component: ScrollArea,
+  args: {
+    direction: "vertical",
+    thin: true,
+    maxHeight: 200,
+    padding: 2
+  },
+  argTypes: {
+    direction: { control: "select", options: ["vertical", "horizontal", "both"] },
+    thin: { control: "boolean" },
+    autoHide: { control: "boolean" }
+  }
+} satisfies Meta<typeof ScrollArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Vertical: Story = {
+  render: (args) => (
+    <ScrollArea {...args} sx={{ width: 240, border: "1px solid var(--palette-divider)" }}>
+      {rows.map((n) => (
+        <div
+          key={n}
+          style={{
+            padding: "6px 4px",
+            fontFamily: "var(--fontFamily1)",
+            fontSize: "var(--fontSizeSmall)",
+            borderBottom: "1px solid var(--palette-divider)"
+          }}
+        >
+          Row {n}
+        </div>
+      ))}
+    </ScrollArea>
+  )
+};

--- a/web/src/stories/SearchInput.stories.tsx
+++ b/web/src/stories/SearchInput.stories.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SearchInput } from "../components/ui_primitives/SearchInput";
+
+const meta = {
+  title: "Primitives/SearchInput",
+  component: SearchInput,
+  args: {
+    value: "",
+    onChange: () => {},
+    placeholder: "Search…",
+    showClear: true,
+    size: "small"
+  },
+  argTypes: {
+    size: { control: "select", options: ["small", "medium"] },
+    showClear: { control: "boolean" },
+    disabled: { control: "boolean" }
+  },
+  render: (args) => {
+    const Controlled = () => {
+      const [value, setValue] = useState(args.value);
+      return (
+        <div style={{ width: 280 }}>
+          <SearchInput {...args} value={value} onChange={setValue} />
+        </div>
+      );
+    };
+    return <Controlled />;
+  }
+} satisfies Meta<typeof SearchInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: { value: "workflow" }
+};

--- a/web/src/stories/SelectField.stories.tsx
+++ b/web/src/stories/SelectField.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelectField } from "../components/ui_primitives/SelectField";
+
+const options = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Medium" },
+  { value: "lg", label: "Large" }
+];
+
+const meta = {
+  title: "Primitives/SelectField",
+  component: SelectField,
+  args: {
+    label: "Size",
+    options,
+    value: "md",
+    onChange: () => {},
+    size: "small"
+  },
+  argTypes: {
+    size: { control: "select", options: ["small", "medium"] },
+    variant: { control: "select", options: ["standard", "outlined", "filled"] },
+    disabled: { control: "boolean" }
+  },
+  render: (args) => {
+    const Controlled = () => {
+      const [value, setValue] = useState(String(args.value));
+      return <SelectField {...args} value={value} onChange={setValue} />;
+    };
+    return <Controlled />;
+  }
+} satisfies Meta<typeof SelectField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithDescription: Story = {
+  args: { description: "Choose the rendering size" }
+};
+
+export const Disabled: Story = {
+  args: { disabled: true }
+};

--- a/web/src/stories/Slider.stories.tsx
+++ b/web/src/stories/Slider.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Slider } from "../components/ui_primitives/Slider";
+
+const meta = {
+  title: "Primitives/Slider",
+  component: Slider,
+  args: {
+    defaultValue: 40,
+    min: 0,
+    max: 100,
+    density: "normal"
+  },
+  argTypes: {
+    density: { control: "select", options: ["normal", "compact"] },
+    disabled: { control: "boolean" }
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 260 }}>
+        <Story />
+      </div>
+    )
+  ]
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+  args: { density: "compact" }
+};
+
+export const Range: Story = {
+  args: { defaultValue: [20, 70] }
+};

--- a/web/src/stories/StatusIndicator.stories.tsx
+++ b/web/src/stories/StatusIndicator.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StatusIndicator } from "../components/ui_primitives/StatusIndicator";
+
+const meta = {
+  title: "Feedback/StatusIndicator",
+  component: StatusIndicator,
+  args: {
+    status: "success",
+    label: "Ready",
+    showIcon: true,
+    size: "small"
+  },
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["success", "error", "warning", "info", "pending", "default"]
+    },
+    size: { control: "select", options: ["small", "medium"] },
+    showIcon: { control: "boolean" },
+    pulse: { control: "boolean" }
+  }
+} satisfies Meta<typeof StatusIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {};
+
+export const AllStatuses: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {(["success", "error", "warning", "info", "pending", "default"] as const).map((s) => (
+        <StatusIndicator {...args} key={s} status={s} label={s} />
+      ))}
+    </div>
+  )
+};

--- a/web/src/stories/Surface.stories.tsx
+++ b/web/src/stories/Surface.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Surface } from "../components/ui_primitives/Surface";
+
+const body = (
+  <div style={{ width: 200, fontFamily: "var(--fontFamily1)", fontSize: "var(--fontSizeSmall)" }}>
+    Surface content
+  </div>
+);
+
+const meta = {
+  title: "Surfaces/Surface",
+  component: Surface,
+  args: {
+    elevation: 1,
+    padding: 2,
+    rounded: "medium",
+    bordered: false,
+    background: "paper",
+    children: body
+  },
+  argTypes: {
+    elevation: { control: { type: "range", min: 0, max: 4, step: 1 } },
+    rounded: { control: "select", options: ["none", "small", "medium", "large"] },
+    background: { control: "select", options: ["default", "paper", "transparent"] },
+    bordered: { control: "boolean" }
+  }
+} satisfies Meta<typeof Surface>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Flat: Story = {
+  args: { elevation: 0, bordered: true }
+};
+
+export const Raised: Story = {
+  args: { elevation: 2 }
+};
+
+export const Elevations: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", gap: 24 }}>
+      {[0, 1, 2, 3, 4].map((e) => (
+        <Surface key={e} {...args} elevation={e as 0 | 1 | 2 | 3 | 4}>
+          <div style={{ fontFamily: "var(--fontFamily2)", fontSize: "var(--fontSizeSmaller)" }}>
+            elevation {e}
+          </div>
+        </Surface>
+      ))}
+    </div>
+  )
+};

--- a/web/src/stories/TabGroup.stories.tsx
+++ b/web/src/stories/TabGroup.stories.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TabGroup } from "../components/ui_primitives/TabGroup";
+
+const tabs = [
+  { value: "overview", label: "Overview" },
+  { value: "params", label: "Parameters" },
+  { value: "logs", label: "Logs" }
+];
+
+const meta = {
+  title: "Primitives/TabGroup",
+  component: TabGroup,
+  args: {
+    tabs,
+    value: "overview",
+    onChange: () => {},
+    size: "small"
+  },
+  argTypes: {
+    size: { control: "select", options: ["small", "medium"] },
+    fullWidth: { control: "boolean" }
+  },
+  render: (args) => {
+    const Controlled = () => {
+      const [value, setValue] = useState(args.value);
+      return (
+        <div style={{ width: 380 }}>
+          <TabGroup {...args} value={value} onChange={setValue} />
+        </div>
+      );
+    };
+    return <Controlled />;
+  }
+} satisfies Meta<typeof TabGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FullWidth: Story = {
+  args: { fullWidth: true }
+};

--- a/web/src/stories/Text.stories.tsx
+++ b/web/src/stories/Text.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Text } from "../components/ui_primitives/Text";
+
+const meta = {
+  title: "Primitives/Text",
+  component: Text,
+  args: {
+    children: "The quick brown fox",
+    size: "normal",
+    color: "primary"
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["giant", "bigger", "big", "normal", "small", "smaller", "tiny", "tinyer"]
+    },
+    color: {
+      control: "select",
+      options: ["primary", "secondary", "error", "warning", "success", "inherit"]
+    },
+    weight: { control: "select", options: [400, 500, 600] },
+    family: { control: "select", options: ["primary", "secondary"] },
+    truncate: { control: "boolean" }
+  }
+} satisfies Meta<typeof Text>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Body: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {(["big", "normal", "small", "smaller"] as const).map((s) => (
+        <Text {...args} key={s} size={s}>
+          {s} — The quick brown fox
+        </Text>
+      ))}
+    </div>
+  )
+};
+
+export const Mono: Story = {
+  args: { family: "secondary", children: "const value = 42;" }
+};

--- a/web/src/stories/TextInput.stories.tsx
+++ b/web/src/stories/TextInput.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TextInput } from "../components/ui_primitives/TextInput";
+
+const meta = {
+  title: "Primitives/TextInput",
+  component: TextInput,
+  args: {
+    label: "Label",
+    placeholder: "Type here…",
+    variant: "outlined",
+    size: "small"
+  },
+  argTypes: {
+    variant: { control: "select", options: ["outlined", "filled", "standard"] },
+    size: { control: "select", options: ["small", "medium"] },
+    compact: { control: "boolean" },
+    disabled: { control: "boolean" },
+    fullWidth: { control: "boolean" }
+  }
+} satisfies Meta<typeof TextInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithValue: Story = {
+  args: { defaultValue: "Hello world" }
+};
+
+export const Compact: Story = {
+  args: { compact: true }
+};
+
+export const Error: Story = {
+  args: { errorMessage: "This field is required" }
+};
+
+export const Disabled: Story = {
+  args: { defaultValue: "Read only", disabled: true }
+};
+
+export const Multiline: Story = {
+  args: { multiline: true, minRows: 3, defaultValue: "Line one\nLine two" }
+};

--- a/web/src/stories/Tooltip.stories.tsx
+++ b/web/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tooltip } from "../components/ui_primitives/Tooltip";
+import { Button } from "../components/ui_primitives/muiReexports";
+
+const meta = {
+  title: "Feedback/Tooltip",
+  component: Tooltip,
+  args: {
+    title: "Helpful hint",
+    arrow: true,
+    children: <Button variant="outlined">Hover me</Button>
+  },
+  argTypes: {
+    arrow: { control: "boolean" },
+    placement: {
+      control: "select",
+      options: ["top", "bottom", "left", "right"]
+    }
+  }
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Open: Story = {
+  args: { open: true, placement: "top" }
+};

--- a/web/src/stories/TruncatedText.stories.tsx
+++ b/web/src/stories/TruncatedText.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TruncatedText } from "../components/ui_primitives/TruncatedText";
+
+const LONG =
+  "This is a long piece of text that should be truncated with an ellipsis when it exceeds the available width of its container.";
+
+const meta = {
+  title: "Layout/TruncatedText",
+  component: TruncatedText,
+  args: {
+    children: LONG,
+    maxLines: 1,
+    showTooltip: true
+  },
+  argTypes: {
+    maxLines: { control: { type: "range", min: 1, max: 4, step: 1 } },
+    showTooltip: { control: "boolean" }
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 240, border: "1px solid var(--palette-divider)", padding: 8 }}>
+        <Story />
+      </div>
+    )
+  ]
+} satisfies Meta<typeof TruncatedText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleLine: Story = {};
+
+export const TwoLines: Story = {
+  args: { maxLines: 2 }
+};


### PR DESCRIPTION
Committed. Here's the summary.

## Summary

Set up the Storybook foundation for NodeTool's web design system and seeded it with high-coverage component and token stories — the component-level base for the Chromatic visual-regression work (T-20260709-0003).

**What changed**

- **Storybook 10.4.6 + `@storybook/react-vite`** (supports Vite 8 + React 19), with `addon-docs` and `addon-a11y`. Added to `web/package.json` and installed with `--ignore-scripts` to avoid keytar/electron native postinstall failures in the sandbox.
- **`web/.storybook/main.ts`** — mirrors the app's Vite config so primitives and `@nodetool-ai/*` resolve: the `nodetool-dev` resolve condition plus the `node:*` builtin stubs from `web/vite-node-stubs`.
- **`web/.storybook/preview.tsx`** — global decorator wrapping every story in `ThemeNodetool` + `CssBaseline` + `InitColorSchemeScript`. Two toolbar globals make snapshots deterministic: **Theme** (dark default = app baseline / light) and **Motion** (Frozen default zeroes all transition/animation durations and hides the caret; Animated for local preview). Fonts are self-hosted via `@fontsource`.
- **30 story files / 83 story exports** under `web/src/stories/`: Priority-1 primitives (Button, IconButton, TextInput, Checkbox, SelectField, SearchInput, Slider, Card, Panel, Surface, Dialog, Flex, ScrollArea, TruncatedText, Text, Divider, Chip, AlertBanner, StatusIndicator, ProgressBar, EmptyState, LoadingSpinner, Tooltip, TabGroup) plus token showcases (Colors, Typography, Spacing, Border Radius, Motion, Z-Index).
- **`web/eslint.design.mjs`** — exempt `src/stories/**` from the design-token lint (a harness like `src/demo/` and `src/e2e_runner/`); stories deep-import primitives on purpose to keep the Storybook bundle light.
- `storybook` / `build-storybook` scripts in both `web/package.json` and root `package.json`; `storybook-static/` gitignored.

**Verification**
- `npm run build-storybook` (root + web) — builds successfully.
- Dev server (`npm run storybook`) boots to HTTP 200.
- `npm run typecheck` — exit 0. `npm run lint` and `npm run lint:design` — exit 0.

**Caveats / follow-ups**
- Priority-2 stories (node UI shell, chat panel, settings/provider card) were deferred — they need store/WebSocket mocks and are higher-effort than the "low-mock" bar in the task scope.
- Chromatic project/token/GitHub Action wiring is intentionally out of scope (T-20260709-0003).

---

Closes task **T-20260709-0002**: Set up Storybook foundation and initial design-system coverage.


### Acceptance criteria
- [x] Storybook runs locally with `npm run storybook`
- [x] At least 20 component stories created
- [x] Design system tokens visualized
- [x] MUI theme integration working
- [x] Builds successfully for CI