### PR TITLE
Refactor media composer send button layout for mobile wrapping

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -135,8 +135,12 @@ export const createMediaComposerStyles = (theme: Theme) =>
       }
     },
 
-    ".media-chip-spacer": {
-      flex: 1
+    // The primary send/generate action. A row sibling of the chip cluster so
+    // it can wrap onto the action-button line on mobile.
+    ".media-primary-action": {
+      display: "inline-flex",
+      alignItems: "center",
+      flexShrink: 0
     },
 
     ".media-generate-btn": {
@@ -213,9 +217,9 @@ export const createMediaComposerStyles = (theme: Theme) =>
       }
     },
 
-    // Mobile: the chip cluster plus the trailing workflow actions never fit on
-    // one phone-width line, so the row wraps (actions become their own line)
-    // and the card sheds padding to keep the textarea full-width.
+    // Mobile: the chip cluster plus the buttons never fit on one phone-width
+    // line, so the row wraps and the card sheds padding to keep the textarea
+    // full-width.
     [theme.breakpoints.down("sm")]: {
       ".media-compose-card": {
         padding: `${theme.spacing(1.5)} ${theme.spacing(1.5)} ${theme.spacing(1)}`,
@@ -229,16 +233,24 @@ export const createMediaComposerStyles = (theme: Theme) =>
         rowGap: theme.spacing(1),
         padding: 0
       },
-      // Full line for the chip cluster: without this it shrinks (min-width: 0)
-      // to sit beside the action cluster instead of wrapping above it, leaving
-      // the send button stranded mid-row.
-      ".media-chip-main": {
+      // With host workflow actions (the canvas dock), give the chips their own
+      // full line so every button — send plus the workflow actions — lands
+      // together on the next line instead of the send button stranding on the
+      // chip line. The send button follows the actions and is right-aligned.
+      ".media-chip-row.has-trailing .media-chip-main": {
         minWidth: "100%"
       },
-      // The zero-basis spacer can land on the previous wrapped line, leaving
-      // the send button left-aligned; margin-left keeps it pinned right on
-      // whichever line it ends up on.
-      ".media-chip-main .media-generate-btn": {
+      ".media-chip-row.has-trailing .composer-workflow-actions": {
+        flex: "0 0 auto",
+        order: 1,
+        marginLeft: "auto"
+      },
+      ".media-chip-row.has-trailing .media-primary-action": {
+        order: 2
+      },
+      // No host actions (the chat panel): the lone send button shares the chip
+      // line, pinned to the right.
+      ".media-chip-row:not(.has-trailing) .media-primary-action": {
         marginLeft: "auto"
       }
     }

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -866,10 +866,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           </FlexRow>
         )}
 
-        <div className="media-chip-row">
+        <div
+          className={`media-chip-row${trailingActions ? " has-trailing" : ""}`}
+        >
           {/* Leading actions (e.g. the canvas dock drag handle). */}
           {leadingActions}
-          {/* Chip cluster: mode/model chips + primary action. */}
+          {/* Chip cluster: mode/model chips. */}
           <div className="media-chip-main">
           {/* Mode selector chip */}
           {!hideModePicker && (
@@ -1364,35 +1366,40 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
             </>
           )}
 
-          <div className="media-chip-spacer" />
+          </div>
 
-          {/* Primary Generate/Send button, or timer + stop when busy */}
-          {isBusy ? (
-            <FlexRow gap={1} alignItems="center">
-              <Text
-                size="small"
-                sx={{
-                  color: theme.vars.palette.grey[400],
-                  fontVariantNumeric: "tabular-nums",
-                  minWidth: 48,
-                  textAlign: "right"
-                }}
+          {/* Primary Generate/Send button, or timer + stop when busy. Sits
+              between the chip cluster and the host actions rather than inside
+              the chips: on mobile the row wraps, and this lets the send button
+              join the workflow action buttons on one line instead of being
+              stranded on the chip line. */}
+          <div className="media-primary-action">
+            {isBusy ? (
+              <FlexRow gap={1} alignItems="center">
+                <Text
+                  size="small"
+                  sx={{
+                    color: theme.vars.palette.grey[400],
+                    fontVariantNumeric: "tabular-nums",
+                    minWidth: 48,
+                    textAlign: "right"
+                  }}
+                >
+                  {formatElapsed(elapsed)}
+                </Text>
+                {onStop && <StopGenerationButton onClick={onStop} />}
+              </FlexRow>
+            ) : (
+              <button
+                type="button"
+                className={`media-generate-btn${isMediaMode ? "" : " chat-send"}`}
+                onClick={handleSend}
+                disabled={isDisabled || !canGenerate}
+                aria-label={isMediaMode ? "Generate" : "Send"}
               >
-                {formatElapsed(elapsed)}
-              </Text>
-              {onStop && <StopGenerationButton onClick={onStop} />}
-            </FlexRow>
-          ) : (
-            <button
-              type="button"
-              className={`media-generate-btn${isMediaMode ? "" : " chat-send"}`}
-              onClick={handleSend}
-              disabled={isDisabled || !canGenerate}
-              aria-label={isMediaMode ? "Generate" : "Send"}
-            >
-              {isMediaMode ? "Generate" : <ArrowUpwardIcon fontSize="small" />}
-            </button>
-          )}
+                {isMediaMode ? "Generate" : <ArrowUpwardIcon fontSize="small" />}
+              </button>
+            )}
           </div>
 
           {/* Host-supplied actions at the end of the footer (e.g. the canvas


### PR DESCRIPTION
## Summary

Restructures the media chat composer's footer layout to improve mobile responsiveness. The primary send/generate button is moved out of the chip cluster into its own layout container, allowing it to wrap onto the action buttons line on mobile instead of being stranded on the chip line.

## Key Changes

- **Moved send button outside chip cluster**: The primary Generate/Send button and timer+stop UI are now in a separate `.media-primary-action` container (sibling to `.media-chip-main`) rather than nested inside it. This enables proper flex wrapping behavior on mobile.

- **Updated mobile breakpoint styles**: 
  - When host workflow actions are present (`has-trailing` class), the chip cluster takes a full line, and both the send button and workflow actions wrap to the next line together
  - Workflow actions are right-aligned with `order: 1` and `marginLeft: auto`
  - Send button follows with `order: 2`
  - When no host actions exist, the send button shares the chip line and is right-aligned with `marginLeft: auto`

- **Replaced spacer with flex container**: The `.media-chip-spacer` (which used `flex: 1` to push content right) is replaced with `.media-primary-action` using `display: inline-flex` and `flexShrink: 0` for proper alignment without forcing wrapping.

- **Added conditional class**: The `.media-chip-row` now receives a `has-trailing` class when `trailingActions` are present, enabling targeted mobile styling.

- **Updated comments**: Clarified that the send button sits between the chip cluster and host actions to enable proper mobile workflow.

## Implementation Details

The layout now uses CSS `order` properties on mobile to control button grouping, ensuring the send button joins workflow action buttons on one line rather than being separated by the chip cluster. This maintains a cohesive action workflow on narrow viewports while preserving the original desktop layout.

https://claude.ai/code/session_01AZzJAHzw1fxuQ6ADFfmFyH