### PR TITLE
Replace dotenv with in-house env-file parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@nodetool-ai/protocol": "*",
@@ -29728,6 +29728,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -43425,6 +43426,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -43646,6 +43648,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -51334,7 +51337,7 @@
     },
     "packages/agents": {
       "name": "@nodetool-ai/agents",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
@@ -51366,7 +51369,7 @@
     },
     "packages/atlascloud-nodes": {
       "name": "@nodetool-ai/atlascloud-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51384,7 +51387,7 @@
     },
     "packages/audio-nodes": {
       "name": "@nodetool-ai/audio-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@k13engineering/rubberband": "^0.0.8",
@@ -51406,7 +51409,7 @@
     },
     "packages/auth": {
       "name": "@nodetool-ai/auth",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.98.0",
@@ -51424,7 +51427,7 @@
     },
     "packages/automation-nodes": {
       "name": "@nodetool-ai/automation-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51465,7 +51468,7 @@
     },
     "packages/base-nodes": {
       "name": "@nodetool-ai/base-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -51495,7 +51498,7 @@
     },
     "packages/chat": {
       "name": "@nodetool-ai/chat",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51512,7 +51515,7 @@
     },
     "packages/cli": {
       "name": "@nodetool-ai/cli",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.0.0",
@@ -51582,7 +51585,7 @@
     },
     "packages/code-nodes": {
       "name": "@nodetool-ai/code-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51607,7 +51610,7 @@
     },
     "packages/code-runners": {
       "name": "@nodetool-ai/code-runners",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51625,7 +51628,7 @@
     },
     "packages/compute": {
       "name": "@nodetool-ai/compute",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51639,11 +51642,8 @@
     },
     "packages/config": {
       "name": "@nodetool-ai/config",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.4.0"
-      },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
@@ -51656,7 +51656,7 @@
     },
     "packages/core-nodes": {
       "name": "@nodetool-ai/core-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -51678,7 +51678,7 @@
     },
     "packages/data-nodes": {
       "name": "@nodetool-ai/data-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^0.1.65",
@@ -51702,7 +51702,7 @@
     },
     "packages/deploy": {
       "name": "@nodetool-ai/deploy",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51729,7 +51729,7 @@
     },
     "packages/document-nodes": {
       "name": "@nodetool-ai/document-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@hyzyla/pdfium": "^2.1.12",
@@ -51758,7 +51758,7 @@
     },
     "packages/dsl": {
       "name": "@nodetool-ai/dsl",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/base-nodes": "*",
@@ -51784,7 +51784,7 @@
     },
     "packages/elevenlabs-nodes": {
       "name": "@nodetool-ai/elevenlabs-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.0.0",
@@ -51818,7 +51818,7 @@
     },
     "packages/fal-nodes": {
       "name": "@nodetool-ai/fal-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fal-ai/client": "^1.9.4",
@@ -51837,7 +51837,7 @@
     },
     "packages/gpu": {
       "name": "@nodetool-ai/gpu",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "typegpu": "^0.11.6"
@@ -51856,7 +51856,7 @@
     },
     "packages/huggingface": {
       "name": "@nodetool-ai/huggingface",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@huggingface/hub": "^2.11.0",
@@ -51873,7 +51873,7 @@
     },
     "packages/huggingface-nodes": {
       "name": "@nodetool-ai/huggingface-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -51889,7 +51889,7 @@
     },
     "packages/image-editor": {
       "name": "@nodetool-ai/image-editor",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -51901,7 +51901,7 @@
     },
     "packages/image-nodes": {
       "name": "@nodetool-ai/image-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51925,7 +51925,7 @@
     },
     "packages/integration-nodes": {
       "name": "@nodetool-ai/integration-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -51986,7 +51986,7 @@
     },
     "packages/kernel": {
       "name": "@nodetool-ai/kernel",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52025,7 +52025,7 @@
     },
     "packages/kie-nodes": {
       "name": "@nodetool-ai/kie-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52043,7 +52043,7 @@
     },
     "packages/llm-nodes": {
       "name": "@nodetool-ai/llm-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -52064,7 +52064,7 @@
     },
     "packages/minimax-nodes": {
       "name": "@nodetool-ai/minimax-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -52081,7 +52081,7 @@
     },
     "packages/models": {
       "name": "@nodetool-ai/models",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52105,7 +52105,7 @@
     },
     "packages/node-sdk": {
       "name": "@nodetool-ai/node-sdk",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52126,7 +52126,7 @@
     },
     "packages/nodes-utils": {
       "name": "@nodetool-ai/nodes-utils",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -52143,7 +52143,7 @@
     },
     "packages/protocol": {
       "name": "@nodetool-ai/protocol",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*",
@@ -52173,7 +52173,7 @@
     },
     "packages/replicate-nodes": {
       "name": "@nodetool-ai/replicate-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52192,7 +52192,7 @@
     },
     "packages/reve-nodes": {
       "name": "@nodetool-ai/reve-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -52208,7 +52208,7 @@
     },
     "packages/runtime": {
       "name": "@nodetool-ai/runtime",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aki-io/aki-io": "^1.0.1",
@@ -52251,7 +52251,7 @@
     },
     "packages/sandbox": {
       "name": "@nodetool-ai/sandbox",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52270,7 +52270,7 @@
     },
     "packages/sandbox-agent": {
       "name": "@nodetool-ai/sandbox-agent",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^9.0.0",
@@ -52293,7 +52293,7 @@
     },
     "packages/sandbox-tools": {
       "name": "@nodetool-ai/sandbox-tools",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -52362,7 +52362,7 @@
     },
     "packages/sdk": {
       "name": "@nodetool-ai/sdk",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/protocol": "*",
@@ -52390,7 +52390,7 @@
     },
     "packages/security": {
       "name": "@nodetool-ai/security",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1029.0",
@@ -52409,7 +52409,7 @@
     },
     "packages/storage": {
       "name": "@nodetool-ai/storage",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -52431,7 +52431,7 @@
     },
     "packages/text-nodes": {
       "name": "@nodetool-ai/text-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
@@ -52461,7 +52461,7 @@
     },
     "packages/timeline": {
       "name": "@nodetool-ai/timeline",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*"
@@ -52476,7 +52476,7 @@
     },
     "packages/together-nodes": {
       "name": "@nodetool-ai/together-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52494,7 +52494,7 @@
     },
     "packages/topaz-nodes": {
       "name": "@nodetool-ai/topaz-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52511,7 +52511,7 @@
     },
     "packages/transformers-js-nodes": {
       "name": "@nodetool-ai/transformers-js-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -52533,7 +52533,7 @@
     },
     "packages/transformers-js-provider": {
       "name": "@nodetool-ai/transformers-js-provider",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52552,7 +52552,7 @@
     },
     "packages/vectorstore": {
       "name": "@nodetool-ai/vectorstore",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52573,7 +52573,7 @@
     },
     "packages/video-nodes": {
       "name": "@nodetool-ai/video-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@gltf-transform/core": "^4.3.0",
@@ -52598,7 +52598,7 @@
     },
     "packages/websocket": {
       "name": "@nodetool-ai/websocket",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
@@ -52658,7 +52658,7 @@
     },
     "packages/workflow-runner": {
       "name": "@nodetool-ai/workflow-runner",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -53242,7 +53242,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,9 +13,6 @@
     "test:mutation": "stryker run",
     "lint": "tsc --noEmit"
   },
-  "dependencies": {
-    "dotenv": "^16.4.0"
-  },
   "devDependencies": {
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",

--- a/packages/config/src/__tests__/env-file.test.ts
+++ b/packages/config/src/__tests__/env-file.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadEnvFile, parseEnvFile } from "../env-file.js";
+
+describe("parseEnvFile", () => {
+  it("parses simple KEY=VALUE pairs", () => {
+    expect(parseEnvFile("A=1\nB=two")).toEqual({ A: "1", B: "two" });
+  });
+
+  it("skips blank lines and # comments", () => {
+    const input = "\n# a comment\nA=1\n\n  # indented comment\nB=2\n";
+    expect(parseEnvFile(input)).toEqual({ A: "1", B: "2" });
+  });
+
+  it("strips an optional export prefix", () => {
+    expect(parseEnvFile("export A=1\nexport B=2")).toEqual({ A: "1", B: "2" });
+  });
+
+  it("trims unquoted values", () => {
+    expect(parseEnvFile("A=  spaced  ")).toEqual({ A: "spaced" });
+  });
+
+  it("keeps single-quoted values literal", () => {
+    expect(parseEnvFile("A='line\\n still'")).toEqual({ A: "line\\n still" });
+  });
+
+  it("expands \\n \\r \\t in double-quoted values", () => {
+    expect(parseEnvFile('A="line1\\nline2\\tend"')).toEqual({
+      A: "line1\nline2\tend"
+    });
+  });
+
+  it("preserves surrounding whitespace inside quotes", () => {
+    expect(parseEnvFile('A="  padded  "')).toEqual({ A: "  padded  " });
+  });
+
+  it("handles values containing =", () => {
+    expect(parseEnvFile("URL=postgres://u:p@h/db?a=b&c=d")).toEqual({
+      URL: "postgres://u:p@h/db?a=b&c=d"
+    });
+  });
+
+  it("ignores lines without = and empty keys", () => {
+    expect(parseEnvFile("NOTAKEY\n=value\nA=1")).toEqual({ A: "1" });
+  });
+});
+
+describe("loadEnvFile", () => {
+  let dir: string;
+  const created: string[] = [];
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "envfile-"));
+  });
+
+  afterEach(() => {
+    for (const key of created) delete process.env[key];
+    created.length = 0;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, content: string): string => {
+    const file = join(dir, name);
+    writeFileSync(file, content);
+    return file;
+  };
+
+  it("applies pairs to process.env", () => {
+    created.push("ENVFILE_TEST_A");
+    const file = write(".env", "ENVFILE_TEST_A=hello");
+    const parsed = loadEnvFile(fs, file);
+    expect(parsed).toEqual({ ENVFILE_TEST_A: "hello" });
+    expect(process.env.ENVFILE_TEST_A).toBe("hello");
+  });
+
+  it("overrides existing process.env values", () => {
+    created.push("ENVFILE_TEST_B");
+    process.env.ENVFILE_TEST_B = "first";
+    const first = write(".env", "ENVFILE_TEST_B=first-file");
+    loadEnvFile(fs, first);
+    expect(process.env.ENVFILE_TEST_B).toBe("first-file");
+
+    const second = write(".env.local", "ENVFILE_TEST_B=second-file");
+    loadEnvFile(fs, second);
+    expect(process.env.ENVFILE_TEST_B).toBe("second-file");
+  });
+
+  it("tolerates a missing file silently", () => {
+    const parsed = loadEnvFile(fs, join(dir, "does-not-exist.env"));
+    expect(parsed).toEqual({});
+  });
+});

--- a/packages/config/src/env-file.ts
+++ b/packages/config/src/env-file.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal `.env` file parser — a drop-in for the small subset of `dotenv`
+ * we relied on. Node 22's `process.loadEnvFile()` can't override existing
+ * `process.env` values, so we parse by hand.
+ *
+ * Supported syntax (matching dotenv where it matters in practice):
+ * - `KEY=VALUE` pairs, one per line.
+ * - Blank lines and `#` comment lines are skipped.
+ * - An optional `export ` prefix on the key is stripped.
+ * - Single- or double-quoted values; double-quoted values expand `\n`,
+ *   `\r`, and `\t` escapes. Single-quoted values are taken literally.
+ * - Unquoted values are trimmed and may contain `=`.
+ *
+ * Not supported (and not needed by callers): `dotenv-expand`-style
+ * `${VAR}` interpolation.
+ */
+
+/** Parse the text of a `.env` file into key/value pairs. */
+export function parseEnvFile(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const withoutExport = line.startsWith("export ")
+      ? line.slice("export ".length)
+      : line;
+
+    const eq = withoutExport.indexOf("=");
+    if (eq === -1) continue;
+
+    const key = withoutExport.slice(0, eq).trim();
+    if (key === "") continue;
+
+    const rawValue = withoutExport.slice(eq + 1).trim();
+    result[key] = unquoteValue(rawValue);
+  }
+  return result;
+}
+
+function unquoteValue(raw: string): string {
+  if (raw.length >= 2) {
+    const quote = raw[0];
+    if ((quote === '"' || quote === "'") && raw[raw.length - 1] === quote) {
+      const inner = raw.slice(1, -1);
+      if (quote === '"') {
+        return inner
+          .replace(/\\n/g, "\n")
+          .replace(/\\r/g, "\r")
+          .replace(/\\t/g, "\t");
+      }
+      return inner;
+    }
+  }
+  return raw;
+}
+
+type FsApi = {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf8") => string;
+};
+
+/**
+ * Read a `.env` file and apply its pairs to `process.env`, overriding any
+ * existing values. Missing files are tolerated silently. Returns the parsed
+ * pairs (empty when the file is absent).
+ */
+export function loadEnvFile(
+  fs: FsApi,
+  file: string
+): Record<string, string> {
+  if (!fs.existsSync(file)) return {};
+  const parsed = parseEnvFile(fs.readFileSync(file, "utf8"));
+  for (const [key, value] of Object.entries(parsed)) {
+    process.env[key] = value;
+  }
+  return parsed;
+}

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -8,10 +8,13 @@
  * on non-Node runtimes (browser, Edge). `loadEnvironment()` is a no-op
  * outside Node.
  */
-import { config as dotenvConfig } from "dotenv";
+import { loadEnvFile } from "./env-file.js";
 import { IS_NODE, importNodeBuiltin } from "./node-import.js";
 
-type FsApi = { existsSync: (path: string) => boolean };
+type FsApi = {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf8") => string;
+};
 type PathApi = { resolve: (...parts: string[]) => string };
 const fsSync = await importNodeBuiltin<FsApi>("node:fs");
 const pathSync = await importNodeBuiltin<PathApi>("node:path");
@@ -48,13 +51,9 @@ export function loadEnvironment(rootDir?: string): void {
   const systemEnv = { ...process.env };
 
   for (const file of files) {
-    if (fsSync.existsSync(file)) {
-      const result = dotenvConfig({ path: file, override: true });
-      if (result.parsed) {
-        for (const [key, value] of Object.entries(result.parsed)) {
-          envStore.set(key, value);
-        }
-      }
+    const parsed = loadEnvFile(fsSync, file);
+    for (const [key, value] of Object.entries(parsed)) {
+      envStore.set(key, value);
     }
   }
 

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"]
+    include: ["tests/**/*.test.ts", "src/**/__tests__/**/*.test.ts"]
   }
 });


### PR DESCRIPTION
## What

`packages/config` depended on `dotenv` solely to parse `.env` files in `loadEnvironment()`. This replaces it with a small hand-written parser (`packages/config/src/env-file.ts`) and drops the dependency.

## Semantics preserved

`environment.ts` still loads `.env`, `.env.{NODE_ENV}`, `.env.{NODE_ENV}.local` in order with later files overriding earlier ones, and system env vars still win. The new parser matches the dotenv behaviors we relied on:

- `KEY=VALUE` pairs applied to `process.env` with override
- blank lines and `#` comments skipped
- optional `export ` prefix stripped
- single/double quotes; double quotes expand `\n`, `\r`, `\t`; single quotes literal
- unquoted values trimmed; values may contain `=`
- missing files tolerated silently

No `${VAR}` interpolation — nothing in the codebase used it. Node 22's `process.loadEnvFile()` can't override existing `process.env` values, so a hand parser is the right fit.

## Testing

New Vitest cases in `packages/config/src/__tests__/env-file.test.ts` cover quotes, comments, `export` prefix, `\n` expansion, override-on-second-file, values with `=`, and missing files.

- `npm run build:packages` — pass (55/55)
- `npx oxlint packages/config/src` — pass
- `npm run test --workspace=packages/config` — pass (124 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y)_