### PR TITLE
Replace dockerode with in-house Docker Engine API client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "packages/cli",
         "packages/storage",
         "packages/config",
+        "packages/docker",
         "packages/deploy",
         "packages/compute",
         "packages/elevenlabs-nodes",
@@ -115,7 +116,7 @@
     },
     "electron": {
       "name": "nodetool-electron",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@nodetool-ai/protocol": "*",
@@ -4954,12 +4955,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
-      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -13498,6 +13493,10 @@
     },
     "node_modules/@nodetool-ai/deploy": {
       "resolved": "packages/deploy",
+      "link": true
+    },
+    "node_modules/@nodetool-ai/docker": {
+      "resolved": "packages/docker",
       "link": true
     },
     "node_modules/@nodetool-ai/document-nodes": {
@@ -23183,29 +23182,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/docker-modem": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
-      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/ssh2": "*"
-      }
-    },
-    "node_modules/@types/dockerode": {
-      "version": "3.3.47",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
-      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/docker-modem": "*",
-        "@types/node": "*",
-        "@types/ssh2": "*"
-      }
-    },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
@@ -29498,56 +29474,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/docker-modem": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
-      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "readable-stream": "^3.5.0",
-        "split-ca": "^1.0.1",
-        "ssh2": "^1.15.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
-      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@grpc/grpc-js": "^1.11.1",
-        "@grpc/proto-loader": "^0.7.13",
-        "docker-modem": "^5.0.7",
-        "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4"
-      },
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
-    "node_modules/dockerode/node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dockview": {
@@ -43425,6 +43351,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -43646,6 +43573,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -47152,12 +47080,6 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
-    },
-    "node_modules/split-ca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-      "license": "ISC"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -51334,7 +51256,7 @@
     },
     "packages/agents": {
       "name": "@nodetool-ai/agents",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
@@ -51366,7 +51288,7 @@
     },
     "packages/atlascloud-nodes": {
       "name": "@nodetool-ai/atlascloud-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51384,7 +51306,7 @@
     },
     "packages/audio-nodes": {
       "name": "@nodetool-ai/audio-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@k13engineering/rubberband": "^0.0.8",
@@ -51406,7 +51328,7 @@
     },
     "packages/auth": {
       "name": "@nodetool-ai/auth",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.98.0",
@@ -51424,7 +51346,7 @@
     },
     "packages/automation-nodes": {
       "name": "@nodetool-ai/automation-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51465,7 +51387,7 @@
     },
     "packages/base-nodes": {
       "name": "@nodetool-ai/base-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -51495,7 +51417,7 @@
     },
     "packages/chat": {
       "name": "@nodetool-ai/chat",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51512,7 +51434,7 @@
     },
     "packages/cli": {
       "name": "@nodetool-ai/cli",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.0.0",
@@ -51582,7 +51504,7 @@
     },
     "packages/code-nodes": {
       "name": "@nodetool-ai/code-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -51607,14 +51529,13 @@
     },
     "packages/code-runners": {
       "name": "@nodetool-ai/code-runners",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
-        "dockerode": "^5.0.0"
+        "@nodetool-ai/docker": "*"
       },
       "devDependencies": {
-        "@types/dockerode": "^3.3.34",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
@@ -51625,7 +51546,7 @@
     },
     "packages/compute": {
       "name": "@nodetool-ai/compute",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51639,7 +51560,7 @@
     },
     "packages/config": {
       "name": "@nodetool-ai/config",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.0"
@@ -51656,7 +51577,7 @@
     },
     "packages/core-nodes": {
       "name": "@nodetool-ai/core-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -51678,7 +51599,7 @@
     },
     "packages/data-nodes": {
       "name": "@nodetool-ai/data-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^0.1.65",
@@ -51702,7 +51623,7 @@
     },
     "packages/deploy": {
       "name": "@nodetool-ai/deploy",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51727,9 +51648,22 @@
         "node": ">=22.0.0 <23.0.0"
       }
     },
+    "packages/docker": {
+      "name": "@nodetool-ai/docker",
+      "version": "0.7.0-rc.32",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=22.0.0 <23.0.0"
+      }
+    },
     "packages/document-nodes": {
       "name": "@nodetool-ai/document-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@hyzyla/pdfium": "^2.1.12",
@@ -51758,7 +51692,7 @@
     },
     "packages/dsl": {
       "name": "@nodetool-ai/dsl",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/base-nodes": "*",
@@ -51784,7 +51718,7 @@
     },
     "packages/elevenlabs-nodes": {
       "name": "@nodetool-ai/elevenlabs-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.0.0",
@@ -51818,7 +51752,7 @@
     },
     "packages/fal-nodes": {
       "name": "@nodetool-ai/fal-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fal-ai/client": "^1.9.4",
@@ -51837,7 +51771,7 @@
     },
     "packages/gpu": {
       "name": "@nodetool-ai/gpu",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "typegpu": "^0.11.6"
@@ -51856,7 +51790,7 @@
     },
     "packages/huggingface": {
       "name": "@nodetool-ai/huggingface",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@huggingface/hub": "^2.11.0",
@@ -51873,7 +51807,7 @@
     },
     "packages/huggingface-nodes": {
       "name": "@nodetool-ai/huggingface-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -51889,7 +51823,7 @@
     },
     "packages/image-editor": {
       "name": "@nodetool-ai/image-editor",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -51901,7 +51835,7 @@
     },
     "packages/image-nodes": {
       "name": "@nodetool-ai/image-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -51925,7 +51859,7 @@
     },
     "packages/integration-nodes": {
       "name": "@nodetool-ai/integration-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -51986,7 +51920,7 @@
     },
     "packages/kernel": {
       "name": "@nodetool-ai/kernel",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52025,7 +51959,7 @@
     },
     "packages/kie-nodes": {
       "name": "@nodetool-ai/kie-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52043,7 +51977,7 @@
     },
     "packages/llm-nodes": {
       "name": "@nodetool-ai/llm-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -52064,7 +51998,7 @@
     },
     "packages/minimax-nodes": {
       "name": "@nodetool-ai/minimax-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -52081,7 +52015,7 @@
     },
     "packages/models": {
       "name": "@nodetool-ai/models",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52105,7 +52039,7 @@
     },
     "packages/node-sdk": {
       "name": "@nodetool-ai/node-sdk",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52126,7 +52060,7 @@
     },
     "packages/nodes-utils": {
       "name": "@nodetool-ai/nodes-utils",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*",
@@ -52143,7 +52077,7 @@
     },
     "packages/protocol": {
       "name": "@nodetool-ai/protocol",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*",
@@ -52173,7 +52107,7 @@
     },
     "packages/replicate-nodes": {
       "name": "@nodetool-ai/replicate-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52192,7 +52126,7 @@
     },
     "packages/reve-nodes": {
       "name": "@nodetool-ai/reve-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/node-sdk": "*"
@@ -52208,7 +52142,7 @@
     },
     "packages/runtime": {
       "name": "@nodetool-ai/runtime",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aki-io/aki-io": "^1.0.1",
@@ -52251,15 +52185,14 @@
     },
     "packages/sandbox": {
       "name": "@nodetool-ai/sandbox",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
-        "dockerode": "^4.0.4",
+        "@nodetool-ai/docker": "*",
         "zod": "^4.0.0"
       },
       "devDependencies": {
-        "@types/dockerode": "^3.3.34",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
@@ -52270,7 +52203,7 @@
     },
     "packages/sandbox-agent": {
       "name": "@nodetool-ai/sandbox-agent",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^9.0.0",
@@ -52293,7 +52226,7 @@
     },
     "packages/sandbox-tools": {
       "name": "@nodetool-ai/sandbox-tools",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/agents": "*",
@@ -52310,59 +52243,9 @@
         "node": ">=22.0.0 <23.0.0"
       }
     },
-    "packages/sandbox/node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/sandbox/node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@grpc/grpc-js": "^1.11.1",
-        "@grpc/proto-loader": "^0.7.13",
-        "docker-modem": "^5.0.7",
-        "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "packages/sandbox/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "packages/sdk": {
       "name": "@nodetool-ai/sdk",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/protocol": "*",
@@ -52390,7 +52273,7 @@
     },
     "packages/security": {
       "name": "@nodetool-ai/security",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1029.0",
@@ -52409,7 +52292,7 @@
     },
     "packages/storage": {
       "name": "@nodetool-ai/storage",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1029.0",
@@ -52431,7 +52314,7 @@
     },
     "packages/text-nodes": {
       "name": "@nodetool-ai/text-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
@@ -52461,7 +52344,7 @@
     },
     "packages/timeline": {
       "name": "@nodetool-ai/timeline",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/gpu": "*"
@@ -52476,7 +52359,7 @@
     },
     "packages/together-nodes": {
       "name": "@nodetool-ai/together-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52494,7 +52377,7 @@
     },
     "packages/topaz-nodes": {
       "name": "@nodetool-ai/topaz-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52511,7 +52394,7 @@
     },
     "packages/transformers-js-nodes": {
       "name": "@nodetool-ai/transformers-js-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/audio-nodes": "*",
@@ -52533,7 +52416,7 @@
     },
     "packages/transformers-js-provider": {
       "name": "@nodetool-ai/transformers-js-provider",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52552,7 +52435,7 @@
     },
     "packages/vectorstore": {
       "name": "@nodetool-ai/vectorstore",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/config": "*",
@@ -52573,7 +52456,7 @@
     },
     "packages/video-nodes": {
       "name": "@nodetool-ai/video-nodes",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@gltf-transform/core": "^4.3.0",
@@ -52598,7 +52481,7 @@
     },
     "packages/websocket": {
       "name": "@nodetool-ai/websocket",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
@@ -52658,7 +52541,7 @@
     },
     "packages/workflow-runner": {
       "name": "@nodetool-ai/workflow-runner",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
         "@nodetool-ai/kernel": "*",
@@ -53242,7 +53125,7 @@
     },
     "web": {
       "name": "nodetool",
-      "version": "0.7.0-rc.31",
+      "version": "0.7.0-rc.32",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "packages/cli",
     "packages/storage",
     "packages/config",
+    "packages/docker",
     "packages/deploy",
     "packages/compute",
     "packages/elevenlabs-nodes",

--- a/packages/code-runners/src/server-docker-runner.ts
+++ b/packages/code-runners/src/server-docker-runner.ts
@@ -10,7 +10,11 @@
 
 import { createConnection, type Socket as NetSocket } from "node:net";
 import { StringDecoder } from "node:string_decoder";
-import Dockerode from "dockerode";
+import {
+  DockerClient,
+  demuxDockerStream,
+  type DockerHostConfig
+} from "@nodetool-ai/docker";
 import {
   StreamRunnerBase,
   type StreamRunnerOptions,
@@ -192,7 +196,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
     const environment = this.buildContainerEnvironment({});
     const stdinStream = options?.stdinStream ?? null;
 
-    const docker = new Dockerode();
+    const docker = new DockerClient();
 
     // Ensure Docker daemon is reachable
     try {
@@ -206,14 +210,9 @@ export class ServerDockerRunner extends StreamRunnerBase {
     // Ensure image is available locally
     const imageName = this.image;
     try {
-      await docker.getImage(imageName).inspect();
+      await docker.inspectImage(imageName);
     } catch {
-      const pullStream = await docker.pull(imageName);
-      await new Promise<void>((resolve, reject) => {
-        docker.modem.followProgress(pullStream, (err: Error | null) =>
-          err ? reject(err) : resolve()
-        );
-      });
+      await docker.pullImage(imageName);
     }
 
     // Resolve workspace volumes. Use the base helper so the host path is made
@@ -227,7 +226,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
 
     // Port binding: container port -> ephemeral host port
     const portKey = `${this.containerPort}/tcp`;
-    const hostConfig: Dockerode.HostConfig = {
+    const hostConfig: DockerHostConfig = {
       Memory: parseMemLimit(this.memLimit),
       NanoCpus: this.nanoCpus,
       Binds: binds.length > 0 ? binds : undefined,
@@ -241,7 +240,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
       }
     };
 
-    const container = await docker.createContainer({
+    const containerId = await docker.createContainer({
       Image: imageName,
       Cmd: command,
       Env: Object.entries(environment).map(([k, v]) => `${k}=${v}`),
@@ -255,20 +254,19 @@ export class ServerDockerRunner extends StreamRunnerBase {
     });
 
     // Register the container so the inherited stop() can force-remove it.
-    this._activeContainerId = container.id;
+    this._activeContainerId = containerId;
 
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
     try {
       // Attach before start so we don't miss early output
-      const attachStream = await container.attach({
-        stream: true,
+      const attachStream = await docker.attachContainer(containerId, {
         stdout: true,
         stderr: true,
         stdin: stdinStream !== null
       });
 
-      await container.start();
+      await docker.startContainer(containerId);
 
       // Feed stdin if provided (fire-and-forget)
       if (stdinStream !== null) {
@@ -304,10 +302,10 @@ export class ServerDockerRunner extends StreamRunnerBase {
         }
       };
 
-      // Start demuxing in the background
+      // Start demuxing in the background. Frame parsing lives in
+      // `@nodetool-ai/docker`; here the payloads are split into lines.
       void (async () => {
         try {
-          let buffer = Buffer.alloc(0);
           let stdoutBuf = "";
           let stderrBuf = "";
           // Per-slot incremental decoders so multi-byte UTF-8 characters split
@@ -315,76 +313,26 @@ export class ServerDockerRunner extends StreamRunnerBase {
           const stdoutDecoder = new StringDecoder("utf8");
           const stderrDecoder = new StringDecoder("utf8");
 
-          const chunks: Buffer[] = [];
-          let resolveChunk: (() => void) | null = null;
-          let streamEnded = false;
-
-          attachStream.on("data", (chunk: Buffer) => {
-            chunks.push(Buffer.from(chunk));
-            if (resolveChunk) {
-              const r = resolveChunk;
-              resolveChunk = null;
-              r();
-            }
-          });
-
-          attachStream.on("end", () => {
-            streamEnded = true;
-            if (resolveChunk) {
-              const r = resolveChunk;
-              resolveChunk = null;
-              r();
-            }
-          });
-
-          attachStream.on("error", () => {
-            streamEnded = true;
-            if (resolveChunk) {
-              const r = resolveChunk;
-              resolveChunk = null;
-              r();
-            }
-          });
-
-          while (true) {
-            if (chunks.length === 0 && !streamEnded) {
-              await new Promise<void>((resolve) => {
-                resolveChunk = resolve;
-              });
-            }
-
-            if (chunks.length > 0) {
-              buffer = Buffer.concat([buffer, ...chunks.splice(0)]);
-            }
-
-            while (buffer.length >= 8) {
-              const streamType = buffer[0];
-              const payloadLength = buffer.readUInt32BE(4);
-              if (buffer.length < 8 + payloadLength) break;
-
-              const payload = buffer.subarray(8, 8 + payloadLength);
-              buffer = buffer.subarray(8 + payloadLength);
-
-              if (streamType === 1) {
-                stdoutBuf += stdoutDecoder.write(payload);
-                while (stdoutBuf.includes("\n")) {
-                  const nlIdx = stdoutBuf.indexOf("\n");
-                  const line = stdoutBuf.substring(0, nlIdx);
-                  stdoutBuf = stdoutBuf.substring(nlIdx + 1);
-                  pushLog({ type: "line", slot: "stdout", value: line + "\n" });
-                }
-              } else if (streamType === 2) {
-                stderrBuf += stderrDecoder.write(payload);
-                while (stderrBuf.includes("\n")) {
-                  const nlIdx = stderrBuf.indexOf("\n");
-                  const line = stderrBuf.substring(0, nlIdx);
-                  stderrBuf = stderrBuf.substring(nlIdx + 1);
-                  pushLog({ type: "line", slot: "stderr", value: line + "\n" });
-                }
+          for await (const [slot, payload] of demuxDockerStream(
+            attachStream
+          )) {
+            if (slot === "stdout") {
+              stdoutBuf += stdoutDecoder.write(payload);
+              while (stdoutBuf.includes("\n")) {
+                const nlIdx = stdoutBuf.indexOf("\n");
+                const line = stdoutBuf.substring(0, nlIdx);
+                stdoutBuf = stdoutBuf.substring(nlIdx + 1);
+                pushLog({ type: "line", slot: "stdout", value: line + "\n" });
+              }
+            } else {
+              stderrBuf += stderrDecoder.write(payload);
+              while (stderrBuf.includes("\n")) {
+                const nlIdx = stderrBuf.indexOf("\n");
+                const line = stderrBuf.substring(0, nlIdx);
+                stderrBuf = stderrBuf.substring(nlIdx + 1);
+                pushLog({ type: "line", slot: "stderr", value: line + "\n" });
               }
             }
-
-            if (streamEnded && chunks.length === 0) break;
           }
 
           // Flush decoder remainder, then the line buffers.
@@ -413,13 +361,14 @@ export class ServerDockerRunner extends StreamRunnerBase {
       })();
 
       // Resolve the published host port
-      const hostPort = await this._waitForHostPort(container);
+      const hostPort = await this._waitForHostPort(docker, containerId);
 
       // Wait for the server to become TCP-reachable
       const ready = await this._waitForServerReady(
         this.hostIp,
         hostPort,
-        container,
+        docker,
+        containerId,
         this.readyTimeoutSeconds
       );
       if (!ready) {
@@ -435,7 +384,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
       // Start timeout timer
       if (this.timeoutSeconds > 0) {
         timeoutHandle = setTimeout(() => {
-          container.remove({ force: true }).catch(() => {
+          docker.removeContainer(containerId, { force: true }).catch(() => {
             // Intentional: best-effort container cleanup on timeout
           });
         }, this.timeoutSeconds * 1000);
@@ -462,7 +411,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
 
       // Wait for container exit (best-effort)
       try {
-        await container.wait();
+        await docker.waitContainer(containerId);
       } catch {
         // ignore
       }
@@ -471,7 +420,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
         clearTimeout(timeoutHandle);
       }
       try {
-        await container.remove({ force: true });
+        await docker.removeContainer(containerId, { force: true });
       } catch {
         // ignore - may already be removed
       }
@@ -485,7 +434,8 @@ export class ServerDockerRunner extends StreamRunnerBase {
    * Poll Docker for the published host port of the container.
    */
   private async _waitForHostPort(
-    container: Dockerode.Container,
+    docker: DockerClient,
+    containerId: string,
     timeout = 20_000
   ): Promise<number> {
     const deadline = Date.now() + timeout;
@@ -496,7 +446,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
         throw new Error("Server start was stopped before port was published");
       }
       try {
-        const info = await container.inspect();
+        const info = await docker.inspectContainer(containerId);
         const state = info.State;
         if (state && state.Status === "exited") {
           throw new Error("Container exited before port was published");
@@ -533,7 +483,8 @@ export class ServerDockerRunner extends StreamRunnerBase {
   private async _waitForServerReady(
     host: string,
     port: number,
-    container: Dockerode.Container,
+    docker: DockerClient,
+    containerId: string,
     timeoutSeconds: number
   ): Promise<boolean> {
     const deadline = Date.now() + timeoutSeconds * 1000;
@@ -545,7 +496,7 @@ export class ServerDockerRunner extends StreamRunnerBase {
 
       // If the container stopped, abort early
       try {
-        const info = await container.inspect();
+        const info = await docker.inspectContainer(containerId);
         const status = info.State?.Status;
         if (
           status &&

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -243,11 +243,15 @@ export class StreamRunnerBase {
     // Force-remove Docker container if active
     const containerId = this._activeContainerId;
     if (containerId) {
-      new DockerClient()
-        .removeContainer(containerId, { force: true })
-        .catch(() => {
-          // Intentional: best-effort container removal during abort
-        });
+      try {
+        new DockerClient()
+          .removeContainer(containerId, { force: true })
+          .catch(() => {
+            // Intentional: best-effort container removal during abort
+          });
+      } catch {
+        // Intentional: an unresolvable DOCKER_HOST must not break abort/cleanup
+      }
     }
   }
 

--- a/packages/code-runners/src/stream-runner-base.ts
+++ b/packages/code-runners/src/stream-runner-base.ts
@@ -10,7 +10,11 @@ import { createInterface } from "node:readline";
 import { resolve as pathResolve } from "node:path";
 import { mkdirSync, existsSync } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
-import Dockerode from "dockerode";
+import {
+  DockerClient,
+  demuxDockerStream,
+  type DockerHostConfig
+} from "@nodetool-ai/docker";
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -239,15 +243,11 @@ export class StreamRunnerBase {
     // Force-remove Docker container if active
     const containerId = this._activeContainerId;
     if (containerId) {
-      try {
-        const docker = new Dockerode();
-        const container = docker.getContainer(containerId);
-        container.remove({ force: true }).catch(() => {
+      new DockerClient()
+        .removeContainer(containerId, { force: true })
+        .catch(() => {
           // Intentional: best-effort container removal during abort
         });
-      } catch {
-        // Intentional: container may already be removed or inaccessible
-      }
     }
   }
 
@@ -441,7 +441,7 @@ export class StreamRunnerBase {
     const environment = this.buildContainerEnvironment(env);
     const stdinStream = options?.stdinStream ?? null;
 
-    const docker = new Dockerode();
+    const docker = new DockerClient();
 
     // Ensure Docker daemon is reachable
     try {
@@ -455,15 +455,9 @@ export class StreamRunnerBase {
     // Ensure image exists locally; pull if needed
     const imageName = this.image;
     try {
-      await docker.getImage(imageName).inspect();
+      await docker.inspectImage(imageName);
     } catch {
-      const pullStream = await docker.pull(imageName);
-      // Wait for pull to complete
-      await new Promise<void>((resolve, reject) => {
-        docker.modem.followProgress(pullStream, (err: Error | null) =>
-          err ? reject(err) : resolve()
-        );
-      });
+      await docker.pullImage(imageName);
     }
 
     // Resolve workspace volumes
@@ -478,7 +472,7 @@ export class StreamRunnerBase {
     // Create container. Defense-in-depth for untrusted code: drop all Linux
     // capabilities, block privilege escalation, and (optionally) lock down the
     // root and workspace filesystems.
-    const hostConfig: Dockerode.HostConfig = {
+    const hostConfig: DockerHostConfig = {
       Memory: this._parseMemLimit(this.memLimit),
       NanoCpus: this.nanoCpus,
       NetworkMode: this.networkDisabled ? "none" : undefined,
@@ -494,7 +488,7 @@ export class StreamRunnerBase {
       Tmpfs: this.readonlyRootfs ? { "/tmp": "rw,noexec,nosuid,size=64m" } : undefined
     };
 
-    const container = await docker.createContainer({
+    const containerId = await docker.createContainer({
       Image: imageName,
       Cmd: command,
       Env: Object.entries(environment).map(([k, v]) => `${k}=${v}`),
@@ -506,21 +500,20 @@ export class StreamRunnerBase {
       HostConfig: hostConfig
     });
 
-    this._activeContainerId = container.id;
+    this._activeContainerId = containerId;
 
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     let timedOut = false;
 
     try {
       // Attach before start to not miss early output
-      const attachStream = await container.attach({
-        stream: true,
+      const attachStream = await docker.attachContainer(containerId, {
         stdout: true,
         stderr: true,
         stdin: stdinStream !== null
       });
 
-      await container.start();
+      await docker.startContainer(containerId);
 
       // Feed stdin if provided
       if (stdinStream !== null) {
@@ -543,7 +536,7 @@ export class StreamRunnerBase {
       if (this.timeoutSeconds > 0) {
         timeoutHandle = setTimeout(() => {
           timedOut = true;
-          container.remove({ force: true }).catch(() => {
+          docker.removeContainer(containerId, { force: true }).catch(() => {
             // Intentional: best-effort container cleanup on timeout
           });
         }, this.timeoutSeconds * 1000);
@@ -553,13 +546,10 @@ export class StreamRunnerBase {
       yield* this._demuxDockerStream(attachStream);
 
       // Wait for container exit
-      const waitResult = await container.wait().catch(() => ({
+      const waitResult = await docker.waitContainer(containerId).catch(() => ({
         StatusCode: -1
       }));
-      const exitCode =
-        typeof waitResult === "object" && waitResult !== null
-          ? ((waitResult as { StatusCode: number }).StatusCode ?? 0)
-          : 0;
+      const exitCode = waitResult.StatusCode;
 
       if (exitCode !== 0) {
         throw new ContainerFailureError(
@@ -575,7 +565,7 @@ export class StreamRunnerBase {
         clearTimeout(timeoutHandle);
       }
       try {
-        await container.remove({ force: true });
+        await docker.removeContainer(containerId, { force: true });
       } catch {
         // ignore - may already be removed
       }
@@ -584,108 +574,47 @@ export class StreamRunnerBase {
   }
 
   /**
-   * Demultiplex Docker's multiplexed stdout/stderr stream.
+   * Demultiplex Docker's multiplexed stdout/stderr stream into whole lines.
    *
-   * Docker uses an 8-byte header per frame:
-   *   [1 byte stream type][3 bytes padding][4 bytes payload length][payload]
-   * Stream type: 1 = stdout, 2 = stderr
+   * Frame parsing (8-byte header: stream type, padding, payload length) lives
+   * in `@nodetool-ai/docker`; this wrapper splits the payloads into
+   * newline-terminated strings per slot.
    */
   private async *_demuxDockerStream(
-    stream: NodeJS.ReadableStream
+    stream: AsyncIterable<Buffer | string>
   ): AsyncGenerator<[Slot, string], void> {
-    let buffer = Buffer.alloc(0);
     let stdoutBuf = "";
     let stderrBuf = "";
     // Decode each slot with its own incremental decoder so multi-byte UTF-8
     // characters that straddle a frame boundary aren't mangled into U+FFFD.
-    const stdoutDecoder = new StringDecoder("utf8");
-    const stderrDecoder = new StringDecoder("utf8");
+    const decoders: Record<Slot, StringDecoder> = {
+      stdout: new StringDecoder("utf8"),
+      stderr: new StringDecoder("utf8")
+    };
 
-    const chunks: Buffer[] = [];
-    let resolveChunk: (() => void) | null = null;
-    let streamEnded = false;
-
-    stream.on("data", (chunk: Buffer) => {
-      chunks.push(Buffer.from(chunk));
-      if (resolveChunk) {
-        const r = resolveChunk;
-        resolveChunk = null;
-        r();
-      }
-    });
-
-    stream.on("end", () => {
-      streamEnded = true;
-      if (resolveChunk) {
-        const r = resolveChunk;
-        resolveChunk = null;
-        r();
-      }
-    });
-
-    stream.on("error", () => {
-      streamEnded = true;
-      if (resolveChunk) {
-        const r = resolveChunk;
-        resolveChunk = null;
-        r();
-      }
-    });
-
-    while (true) {
-      // Wait for data if none available
-      if (chunks.length === 0 && !streamEnded) {
-        await new Promise<void>((resolve) => {
-          resolveChunk = resolve;
-        });
-      }
-
-      // Drain all pending chunks into buffer
-      if (chunks.length > 0) {
-        buffer = Buffer.concat([buffer, ...chunks.splice(0)]);
-      }
-
-      // Parse frames from buffer
-      while (buffer.length >= 8) {
-        const streamType = buffer[0];
-        const payloadLength = buffer.readUInt32BE(4);
-
-        if (buffer.length < 8 + payloadLength) {
-          break; // need more data
+    for await (const [slot, payload] of demuxDockerStream(stream)) {
+      if (slot === "stdout") {
+        stdoutBuf += decoders.stdout.write(payload);
+        while (stdoutBuf.includes("\n")) {
+          const nlIdx = stdoutBuf.indexOf("\n");
+          const line = stdoutBuf.substring(0, nlIdx);
+          stdoutBuf = stdoutBuf.substring(nlIdx + 1);
+          yield ["stdout", line + "\n"];
         }
-
-        const payload = buffer.subarray(8, 8 + payloadLength);
-        buffer = buffer.subarray(8 + payloadLength);
-
-        if (streamType === 1) {
-          // stdout
-          stdoutBuf += stdoutDecoder.write(payload);
-          while (stdoutBuf.includes("\n")) {
-            const nlIdx = stdoutBuf.indexOf("\n");
-            const line = stdoutBuf.substring(0, nlIdx);
-            stdoutBuf = stdoutBuf.substring(nlIdx + 1);
-            yield ["stdout", line + "\n"];
-          }
-        } else if (streamType === 2) {
-          // stderr
-          stderrBuf += stderrDecoder.write(payload);
-          while (stderrBuf.includes("\n")) {
-            const nlIdx = stderrBuf.indexOf("\n");
-            const line = stderrBuf.substring(0, nlIdx);
-            stderrBuf = stderrBuf.substring(nlIdx + 1);
-            yield ["stderr", line + "\n"];
-          }
+      } else {
+        stderrBuf += decoders.stderr.write(payload);
+        while (stderrBuf.includes("\n")) {
+          const nlIdx = stderrBuf.indexOf("\n");
+          const line = stderrBuf.substring(0, nlIdx);
+          stderrBuf = stderrBuf.substring(nlIdx + 1);
+          yield ["stderr", line + "\n"];
         }
-      }
-
-      if (streamEnded && chunks.length === 0) {
-        break;
       }
     }
 
     // Flush any bytes the decoders are still holding, then the line buffers.
-    stdoutBuf += stdoutDecoder.end();
-    stderrBuf += stderrDecoder.end();
+    stdoutBuf += decoders.stdout.end();
+    stderrBuf += decoders.stderr.end();
     if (stdoutBuf) {
       yield ["stdout", stdoutBuf.endsWith("\n") ? stdoutBuf : stdoutBuf + "\n"];
     }

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -1,22 +1,19 @@
 {
-  "name": "@nodetool-ai/code-runners",
+  "name": "@nodetool-ai/docker",
   "type": "module",
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },
   "version": "0.7.0-rc.32",
-  "description": "Streaming code runners: Docker containers and local subprocesses for executing Python, JS, Bash, Ruby, and Lua code",
+  "description": "Minimal typed Docker Engine API client over the unix socket: container lifecycle, attach hijack, stream demux, image pull",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "node ../../scripts/build-typescript-workspace.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@nodetool-ai/config": "*",
-    "@nodetool-ai/docker": "*"
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -35,7 +32,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/nodetool-ai/nodetool.git",
-    "directory": "packages/code-runners"
+    "directory": "packages/docker"
   },
   "homepage": "https://nodetool.ai",
   "bugs": {
@@ -50,15 +47,9 @@
   ],
   "keywords": [
     "nodetool",
-    "ai",
-    "workflow",
-    "workflow-automation",
-    "typescript",
-    "code-execution",
     "docker",
-    "subprocess",
-    "python",
-    "javascript",
-    "sandbox"
+    "docker-engine-api",
+    "container",
+    "typescript"
   ]
 }

--- a/packages/docker/src/client.ts
+++ b/packages/docker/src/client.ts
@@ -1,0 +1,333 @@
+/**
+ * Minimal Docker Engine API client.
+ *
+ * The Engine API is plain HTTP over a unix socket (or TCP when DOCKER_HOST
+ * says so). This client covers exactly the surface NodeTool's code runners
+ * and sandbox provider need: ping, image inspect/pull, container
+ * create/start/wait/remove/inspect/pause/unpause, and attach with connection
+ * hijacking for stdio streaming.
+ */
+
+import { request as httpRequest } from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { createInterface } from "node:readline";
+import { resolveDockerEndpoint, type DockerEndpoint } from "./endpoint.js";
+import type {
+  AttachOptions,
+  ContainerCreateOptions,
+  ContainerInspectInfo,
+  ContainerWaitResult
+} from "./types.js";
+
+/** Error raised for non-2xx daemon responses, carrying the HTTP status. */
+export class DockerError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "DockerError";
+    this.statusCode = statusCode;
+  }
+}
+
+/** Extract the daemon's error message from a response body. */
+export function parseDaemonErrorMessage(
+  body: string,
+  statusCode: number
+): string {
+  const fallback = `Docker daemon returned HTTP ${statusCode}`;
+  const text = body.trim();
+  if (!text) return fallback;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "message" in parsed &&
+      typeof (parsed as { message: unknown }).message === "string"
+    ) {
+      return (parsed as { message: string }).message;
+    }
+  } catch {
+    // Not JSON — use the raw body.
+  }
+  return text;
+}
+
+/** Build a request path with URL-encoded query parameters. */
+export function buildPath(
+  path: string,
+  query?: Record<string, string | number | boolean | undefined>
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value === undefined) continue;
+    if (typeof value === "boolean") {
+      params.set(key, value ? "1" : "0");
+    } else {
+      params.set(key, String(value));
+    }
+  }
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+/**
+ * Split an image reference into the repository and tag for
+ * `POST /images/create`. Without an explicit tag the daemon would pull
+ * every tag of the repository, so default to `latest`.
+ */
+export function splitImageReference(image: string): {
+  fromImage: string;
+  tag: string;
+} {
+  const lastSlash = image.lastIndexOf("/");
+  const lastColon = image.lastIndexOf(":");
+  if (lastColon > lastSlash) {
+    return { fromImage: image.slice(0, lastColon), tag: image.slice(lastColon + 1) };
+  }
+  return { fromImage: image, tag: "latest" };
+}
+
+interface JsonRequestOptions {
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+  body?: unknown;
+}
+
+export interface DockerClientOptions extends DockerEndpoint {
+  /** Override DOCKER_HOST resolution entirely by passing socketPath/host. */
+  dockerHost?: string;
+}
+
+export class DockerClient {
+  private readonly endpoint: DockerEndpoint;
+
+  constructor(options: DockerClientOptions = {}) {
+    if (options.socketPath !== undefined || options.host !== undefined) {
+      this.endpoint = {
+        socketPath: options.socketPath,
+        host: options.host,
+        port: options.port
+      };
+    } else {
+      this.endpoint = resolveDockerEndpoint(options.dockerHost);
+    }
+  }
+
+  // ---- Daemon --------------------------------------------------------------
+
+  async ping(): Promise<void> {
+    await this.requestJson({ method: "GET", path: "/_ping" });
+  }
+
+  // ---- Images ---------------------------------------------------------------
+
+  async inspectImage(image: string): Promise<unknown> {
+    const body = await this.requestJson({
+      method: "GET",
+      path: `/images/${encodeURIComponent(image)}/json`
+    });
+    return body;
+  }
+
+  /**
+   * Pull an image and consume the JSON-lines progress stream to completion.
+   * Rejects when the daemon reports an error either as the HTTP status or as
+   * an `{"error": ...}` progress record.
+   */
+  async pullImage(image: string): Promise<void> {
+    const { fromImage, tag } = splitImageReference(image);
+    const res = await this.openResponse({
+      method: "POST",
+      path: buildPath("/images/create", { fromImage, tag })
+    });
+    const status = res.statusCode ?? 0;
+    if (status < 200 || status >= 300) {
+      const body = await readBody(res);
+      throw new DockerError(parseDaemonErrorMessage(body, status), status);
+    }
+    const lines = createInterface({ input: res, crlfDelay: Infinity });
+    for await (const line of lines) {
+      const text = line.trim();
+      if (!text) continue;
+      let record: unknown;
+      try {
+        record = JSON.parse(text);
+      } catch {
+        continue; // tolerate partial/garbled progress lines
+      }
+      if (
+        typeof record === "object" &&
+        record !== null &&
+        "error" in record &&
+        typeof (record as { error: unknown }).error === "string"
+      ) {
+        throw new DockerError((record as { error: string }).error, status);
+      }
+    }
+  }
+
+  // ---- Containers ------------------------------------------------------------
+
+  /** Create a container; returns its id. */
+  async createContainer(
+    config: ContainerCreateOptions,
+    name?: string
+  ): Promise<string> {
+    const body = await this.requestJson({
+      method: "POST",
+      path: buildPath("/containers/create", { name }),
+      body: config
+    });
+    const id = (body as { Id?: unknown } | null)?.Id;
+    if (typeof id !== "string") {
+      throw new Error("Docker daemon returned no container id");
+    }
+    return id;
+  }
+
+  async startContainer(id: string): Promise<void> {
+    await this.requestJson({
+      method: "POST",
+      path: `/containers/${encodeURIComponent(id)}/start`
+    });
+  }
+
+  /** Wait for a container to exit; resolves with its exit status. */
+  async waitContainer(id: string): Promise<ContainerWaitResult> {
+    const body = await this.requestJson({
+      method: "POST",
+      path: `/containers/${encodeURIComponent(id)}/wait`
+    });
+    const statusCode = (body as { StatusCode?: unknown } | null)?.StatusCode;
+    return { StatusCode: typeof statusCode === "number" ? statusCode : 0 };
+  }
+
+  async removeContainer(
+    id: string,
+    options?: { force?: boolean }
+  ): Promise<void> {
+    await this.requestJson({
+      method: "DELETE",
+      path: buildPath(`/containers/${encodeURIComponent(id)}`, {
+        force: options?.force
+      })
+    });
+  }
+
+  async inspectContainer(idOrName: string): Promise<ContainerInspectInfo> {
+    const body = await this.requestJson({
+      method: "GET",
+      path: `/containers/${encodeURIComponent(idOrName)}/json`
+    });
+    return body as ContainerInspectInfo;
+  }
+
+  async pauseContainer(id: string): Promise<void> {
+    await this.requestJson({
+      method: "POST",
+      path: `/containers/${encodeURIComponent(id)}/pause`
+    });
+  }
+
+  async unpauseContainer(id: string): Promise<void> {
+    await this.requestJson({
+      method: "POST",
+      path: `/containers/${encodeURIComponent(id)}/unpause`
+    });
+  }
+
+  /**
+   * Attach to a container's stdio with connection hijacking.
+   *
+   * Sends `Upgrade: tcp`; after the daemon's 101 response the raw socket is
+   * returned as a Duplex. Reads carry the container's output — multiplexed
+   * with 8-byte frame headers for non-TTY containers (see demuxDockerStream);
+   * writes go to the container's stdin, and `end()` closes stdin.
+   */
+  attachContainer(id: string, options: AttachOptions): Promise<Duplex> {
+    const path = buildPath(`/containers/${encodeURIComponent(id)}/attach`, {
+      stream: true,
+      stdout: options.stdout ?? false,
+      stderr: options.stderr ?? false,
+      stdin: options.stdin ?? false
+    });
+    return new Promise<Duplex>((resolve, reject) => {
+      const req = httpRequest({
+        ...this.endpoint,
+        method: "POST",
+        path,
+        headers: {
+          "Content-Type": "application/vnd.docker.raw-stream",
+          Connection: "Upgrade",
+          Upgrade: "tcp"
+        }
+      });
+      req.on("upgrade", (_res, socket, head) => {
+        if (head.length > 0) {
+          socket.unshift(head);
+        }
+        resolve(socket);
+      });
+      req.on("response", (res) => {
+        // The daemon refused to hijack — surface its error message.
+        const status = res.statusCode ?? 0;
+        void readBody(res).then((body) => {
+          reject(new DockerError(parseDaemonErrorMessage(body, status), status));
+        });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  // ---- Internals --------------------------------------------------------------
+
+  private openResponse(options: JsonRequestOptions): Promise<IncomingMessage> {
+    return new Promise<IncomingMessage>((resolve, reject) => {
+      const payload =
+        options.body === undefined ? undefined : JSON.stringify(options.body);
+      const req = httpRequest({
+        ...this.endpoint,
+        method: options.method,
+        path: options.path,
+        headers:
+          payload === undefined
+            ? {}
+            : {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(payload)
+              }
+      });
+      req.on("response", resolve);
+      req.on("error", reject);
+      req.end(payload);
+    });
+  }
+
+  private async requestJson(options: JsonRequestOptions): Promise<unknown> {
+    const res = await this.openResponse(options);
+    const status = res.statusCode ?? 0;
+    const body = await readBody(res);
+    if (status < 200 || status >= 300) {
+      throw new DockerError(parseDaemonErrorMessage(body, status), status);
+    }
+    const text = body.trim();
+    if (!text) return null;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return text; // e.g. /_ping returns "OK"
+    }
+  }
+}
+
+async function readBody(res: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of res) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/packages/docker/src/demux.ts
+++ b/packages/docker/src/demux.ts
@@ -1,0 +1,78 @@
+/**
+ * Demultiplexer for Docker's non-TTY attach/logs stream.
+ *
+ * When a container runs without a TTY, the daemon multiplexes stdout and
+ * stderr onto one connection using 8-byte frame headers:
+ *
+ *     [1 byte stream type][3 bytes zero][4 bytes big-endian payload length][payload]
+ *
+ * Stream type: 0 = stdin (never sent to clients), 1 = stdout, 2 = stderr.
+ */
+
+export type DemuxSlot = "stdout" | "stderr";
+
+export type DemuxFrame = [DemuxSlot, Buffer];
+
+const HEADER_LENGTH = 8;
+const STDOUT_TYPE = 1;
+const STDERR_TYPE = 2;
+
+/**
+ * Incremental frame parser. Feed raw chunks in any fragmentation (a frame
+ * split across chunks, several frames in one chunk) and get back the frames
+ * that are complete so far. Frames with an unknown stream type are dropped,
+ * matching dockerode's demuxStream.
+ */
+export class DockerStreamDemuxer {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): DemuxFrame[] {
+    this.buffer =
+      this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+
+    const frames: DemuxFrame[] = [];
+    while (this.buffer.length >= HEADER_LENGTH) {
+      const streamType = this.buffer[0];
+      const payloadLength = this.buffer.readUInt32BE(4);
+      if (this.buffer.length < HEADER_LENGTH + payloadLength) {
+        break;
+      }
+      const payload = Buffer.from(
+        this.buffer.subarray(HEADER_LENGTH, HEADER_LENGTH + payloadLength)
+      );
+      this.buffer = this.buffer.subarray(HEADER_LENGTH + payloadLength);
+      if (streamType === STDOUT_TYPE) {
+        frames.push(["stdout", payload]);
+      } else if (streamType === STDERR_TYPE) {
+        frames.push(["stderr", payload]);
+      }
+    }
+    return frames;
+  }
+
+  /** Bytes held back waiting for the rest of a frame. */
+  get pending(): number {
+    return this.buffer.length;
+  }
+}
+
+/**
+ * Demux a readable attach stream into `[slot, payload]` frames.
+ *
+ * Stream errors end the iteration instead of throwing — attach sockets are
+ * torn down forcibly when containers are removed, and consumers treat that
+ * the same as a clean end.
+ */
+export async function* demuxDockerStream(
+  stream: AsyncIterable<Buffer | string>
+): AsyncGenerator<DemuxFrame, void> {
+  const demuxer = new DockerStreamDemuxer();
+  try {
+    for await (const chunk of stream) {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      yield* demuxer.push(buf);
+    }
+  } catch {
+    // Treat abrupt socket teardown as end-of-stream.
+  }
+}

--- a/packages/docker/src/endpoint.ts
+++ b/packages/docker/src/endpoint.ts
@@ -17,9 +17,12 @@ export function resolveDockerEndpoint(
   platform: NodeJS.Platform = process.platform
 ): DockerEndpoint {
   if (dockerHost) {
-    if (dockerHost.startsWith("unix://")) {
-      // Accept both unix:///var/run/docker.sock and unix:/var/run/docker.sock
-      return { socketPath: dockerHost.slice("unix://".length) || "/var/run/docker.sock" };
+    if (dockerHost.startsWith("unix:/")) {
+      // Accept unix:///var/run/docker.sock, unix://var/run/… and unix:/var/run/docker.sock
+      const path = dockerHost.startsWith("unix://")
+        ? dockerHost.slice("unix://".length)
+        : dockerHost.slice("unix:".length);
+      return { socketPath: path || "/var/run/docker.sock" };
     }
     if (dockerHost.startsWith("npipe://")) {
       return { socketPath: dockerHost.slice("npipe://".length) };

--- a/packages/docker/src/endpoint.ts
+++ b/packages/docker/src/endpoint.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve where the Docker daemon listens, mirroring dockerode's default
+ * constructor: honor DOCKER_HOST (unix://, npipe://, tcp:// / http://),
+ * otherwise fall back to the platform's default socket. TLS (DOCKER_TLS_VERIFY)
+ * is not supported — NodeTool only ever talks to a local daemon.
+ */
+
+export interface DockerEndpoint {
+  /** Unix socket / Windows named pipe path. Mutually exclusive with host. */
+  socketPath?: string;
+  host?: string;
+  port?: number;
+}
+
+export function resolveDockerEndpoint(
+  dockerHost: string | undefined = process.env.DOCKER_HOST,
+  platform: NodeJS.Platform = process.platform
+): DockerEndpoint {
+  if (dockerHost) {
+    if (dockerHost.startsWith("unix://")) {
+      // Accept both unix:///var/run/docker.sock and unix:/var/run/docker.sock
+      return { socketPath: dockerHost.slice("unix://".length) || "/var/run/docker.sock" };
+    }
+    if (dockerHost.startsWith("npipe://")) {
+      return { socketPath: dockerHost.slice("npipe://".length) };
+    }
+    if (dockerHost.startsWith("tcp://") || dockerHost.startsWith("http://")) {
+      const url = new URL(dockerHost.replace(/^tcp:\/\//, "http://"));
+      return {
+        host: url.hostname,
+        port: url.port ? Number(url.port) : 2375
+      };
+    }
+    // Bare host:port (dockerode accepts this too)
+    const match = dockerHost.match(/^([^:/]+):(\d+)$/);
+    if (match) {
+      return { host: match[1], port: Number(match[2]) };
+    }
+    throw new Error(`Unsupported DOCKER_HOST value: ${dockerHost}`);
+  }
+  if (platform === "win32") {
+    return { socketPath: "//./pipe/docker_engine" };
+  }
+  return { socketPath: "/var/run/docker.sock" };
+}

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @nodetool-ai/docker — minimal typed Docker Engine API client.
+ *
+ * Talks to the daemon over the unix socket (or DOCKER_HOST) with Node's
+ * `http` module. Covers the surface NodeTool's code runners and sandbox
+ * provider use; nothing more.
+ */
+
+export {
+  DockerClient,
+  DockerError,
+  buildPath,
+  parseDaemonErrorMessage,
+  splitImageReference,
+  type DockerClientOptions
+} from "./client.js";
+
+export { resolveDockerEndpoint, type DockerEndpoint } from "./endpoint.js";
+
+export {
+  DockerStreamDemuxer,
+  demuxDockerStream,
+  type DemuxFrame,
+  type DemuxSlot
+} from "./demux.js";
+
+export type {
+  AttachOptions,
+  ContainerCreateOptions,
+  ContainerInspectInfo,
+  ContainerWaitResult,
+  DockerHostConfig,
+  DockerPortBinding
+} from "./types.js";

--- a/packages/docker/src/types.ts
+++ b/packages/docker/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Typed subset of the Docker Engine API request/response shapes NodeTool
+ * uses. Field names match the wire format (PascalCase JSON), so objects can
+ * be serialized as-is. Only the fields our runners and the sandbox provider
+ * actually read or write are declared — extend when a new call site needs
+ * more.
+ */
+
+export interface DockerPortBinding {
+  HostIp?: string;
+  HostPort?: string;
+}
+
+export interface DockerHostConfig {
+  Memory?: number;
+  NanoCpus?: number;
+  NetworkMode?: string;
+  Binds?: string[];
+  IpcMode?: string;
+  CapDrop?: string[];
+  SecurityOpt?: string[];
+  ReadonlyRootfs?: boolean;
+  Tmpfs?: Record<string, string>;
+  PortBindings?: Record<string, DockerPortBinding[]>;
+}
+
+export interface ContainerCreateOptions {
+  Image: string;
+  Cmd?: string[];
+  Env?: string[];
+  Labels?: Record<string, string>;
+  WorkingDir?: string;
+  User?: string;
+  OpenStdin?: boolean;
+  Tty?: boolean;
+  ExposedPorts?: Record<string, Record<string, never>>;
+  HostConfig?: DockerHostConfig;
+}
+
+export interface ContainerInspectInfo {
+  Id: string;
+  State?: {
+    Status?: string;
+    Running?: boolean;
+    ExitCode?: number;
+  };
+  NetworkSettings?: {
+    Ports?: Record<string, DockerPortBinding[] | null>;
+  };
+}
+
+export interface ContainerWaitResult {
+  StatusCode: number;
+}
+
+export interface AttachOptions {
+  stdout?: boolean;
+  stderr?: boolean;
+  stdin?: boolean;
+}

--- a/packages/docker/tests/client.test.ts
+++ b/packages/docker/tests/client.test.ts
@@ -1,0 +1,311 @@
+/**
+ * DockerClient tests against a fake daemon served over a real unix socket —
+ * the same transport the production client uses, no Docker required.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DockerClient,
+  DockerError,
+  buildPath,
+  parseDaemonErrorMessage,
+  splitImageReference
+} from "../src/client.js";
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+let server: Server;
+let socketDir: string;
+let socketPath: string;
+let client: DockerClient;
+const requests: RecordedRequest[] = [];
+
+beforeAll(async () => {
+  socketDir = mkdtempSync(join(tmpdir(), "nodetool-docker-test-"));
+  socketPath = join(socketDir, "docker.sock");
+
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      requests.push({ method: req.method ?? "", url: req.url ?? "", body });
+      route(req.method ?? "", req.url ?? "", res);
+    });
+  });
+
+  server.on("upgrade", (req, socket) => {
+    requests.push({ method: req.method ?? "", url: req.url ?? "", body: "" });
+    socket.write(
+      "HTTP/1.1 101 UPGRADED\r\n" +
+        "Content-Type: application/vnd.docker.raw-stream\r\n" +
+        "Connection: Upgrade\r\nUpgrade: tcp\r\n\r\n"
+    );
+    // One stdout frame, then wait for stdin and echo it back on stderr.
+    const header = Buffer.alloc(8);
+    header[0] = 1;
+    header.writeUInt32BE(6, 4);
+    socket.write(Buffer.concat([header, Buffer.from("hello\n")]));
+    socket.on("data", (data: Buffer) => {
+      const echoHeader = Buffer.alloc(8);
+      echoHeader[0] = 2;
+      echoHeader.writeUInt32BE(data.length, 4);
+      socket.write(Buffer.concat([echoHeader, data]));
+      socket.end();
+    });
+  });
+
+  function route(
+    method: string,
+    url: string,
+    res: import("node:http").ServerResponse
+  ): void {
+    if (method === "GET" && url === "/_ping") {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("OK");
+      return;
+    }
+    if (method === "GET" && url.startsWith("/images/present%2Fimage/json")) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ Id: "sha256:abc" }));
+      return;
+    }
+    if (method === "GET" && url.startsWith("/images/")) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "No such image: missing:latest" }));
+      return;
+    }
+    if (method === "POST" && url.startsWith("/images/create")) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (url.includes("fromImage=broken")) {
+        res.write('{"status":"Pulling"}\n');
+        res.end('{"error":"manifest unknown"}\n');
+      } else {
+        res.write('{"status":"Pulling from library/bash"}\n');
+        res.write('{"status":"Downloading","progressDetail":{"current":1}}\n');
+        res.end('{"status":"Pull complete"}\n');
+      }
+      return;
+    }
+    if (method === "POST" && url.startsWith("/containers/create")) {
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ Id: "abc123", Warnings: [] }));
+      return;
+    }
+    if (method === "POST" && url === "/containers/abc123/start") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    if (method === "POST" && url === "/containers/abc123/wait") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ StatusCode: 137 }));
+      return;
+    }
+    if (method === "DELETE" && url.startsWith("/containers/abc123")) {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    if (method === "GET" && url === "/containers/abc123/json") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          Id: "abc123",
+          State: { Status: "running", Running: true },
+          NetworkSettings: {
+            Ports: { "7788/tcp": [{ HostIp: "127.0.0.1", HostPort: "32771" }] }
+          }
+        })
+      );
+      return;
+    }
+    if (method === "POST" && url === "/containers/abc123/pause") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    if (method === "POST" && url === "/containers/abc123/unpause") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ message: `No such container: ${url}` }));
+  }
+
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  client = new DockerClient({ socketPath });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  rmSync(socketDir, { recursive: true, force: true });
+});
+
+describe("DockerClient over a unix socket", () => {
+  it("pings the daemon", async () => {
+    await expect(client.ping()).resolves.toBeUndefined();
+  });
+
+  it("inspects an image (URL-encodes the reference)", async () => {
+    const info = await client.inspectImage("present/image");
+    expect(info).toEqual({ Id: "sha256:abc" });
+    expect(requests.at(-1)?.url).toBe("/images/present%2Fimage/json");
+  });
+
+  it("maps a 404 to a DockerError carrying the daemon message", async () => {
+    const err = await client.inspectImage("missing").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DockerError);
+    expect((err as DockerError).statusCode).toBe(404);
+    expect((err as DockerError).message).toBe(
+      "No such image: missing:latest"
+    );
+  });
+
+  it("consumes a pull progress stream to completion", async () => {
+    await expect(client.pullImage("bash:5.2")).resolves.toBeUndefined();
+    expect(requests.at(-1)?.url).toBe(
+      "/images/create?fromImage=bash&tag=5.2"
+    );
+  });
+
+  it("rejects a pull whose progress stream reports an error", async () => {
+    const err = await client.pullImage("broken").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(DockerError);
+    expect((err as DockerError).message).toBe("manifest unknown");
+  });
+
+  it("creates a container with a name query and JSON body", async () => {
+    const id = await client.createContainer(
+      { Image: "bash:5.2", Cmd: ["true"] },
+      "my sandbox"
+    );
+    expect(id).toBe("abc123");
+    const last = requests.at(-1);
+    expect(last?.url).toBe("/containers/create?name=my+sandbox");
+    expect(JSON.parse(last?.body ?? "{}")).toEqual({
+      Image: "bash:5.2",
+      Cmd: ["true"]
+    });
+  });
+
+  it("starts, waits, inspects, pauses, unpauses, removes", async () => {
+    await client.startContainer("abc123");
+    expect((await client.waitContainer("abc123")).StatusCode).toBe(137);
+
+    const info = await client.inspectContainer("abc123");
+    expect(info.State?.Status).toBe("running");
+    expect(info.NetworkSettings?.Ports?.["7788/tcp"]?.[0]?.HostPort).toBe(
+      "32771"
+    );
+
+    await client.pauseContainer("abc123");
+    await client.unpauseContainer("abc123");
+
+    await client.removeContainer("abc123", { force: true });
+    expect(requests.at(-1)?.url).toBe("/containers/abc123?force=1");
+  });
+
+  it("attaches via connection hijack and round-trips stdio", async () => {
+    const socket = await client.attachContainer("abc123", {
+      stdout: true,
+      stderr: true,
+      stdin: true
+    });
+    expect(requests.at(-1)?.url).toBe(
+      "/containers/abc123/attach?stream=1&stdout=1&stderr=1&stdin=1"
+    );
+
+    const received: Buffer[] = [];
+    const done = new Promise<void>((resolve) => {
+      socket.on("data", (chunk: Buffer) => received.push(chunk));
+      socket.on("end", resolve);
+      socket.on("close", resolve);
+    });
+    socket.write("stdin!");
+    await done;
+
+    const all = Buffer.concat(received);
+    // First frame: stdout "hello\n"; second frame: stderr echo of "stdin!".
+    expect(all[0]).toBe(1);
+    expect(all.subarray(8, 14).toString()).toBe("hello\n");
+    const second = all.subarray(14);
+    expect(second[0]).toBe(2);
+    expect(second.subarray(8).toString()).toBe("stdin!");
+  });
+});
+
+describe("buildPath", () => {
+  it("returns the bare path without query values", () => {
+    expect(buildPath("/containers/create")).toBe("/containers/create");
+    expect(buildPath("/containers/create", { name: undefined })).toBe(
+      "/containers/create"
+    );
+  });
+
+  it("encodes string, number, and boolean values", () => {
+    expect(
+      buildPath("/containers/x/attach", {
+        stream: true,
+        stdin: false,
+        n: 5,
+        name: "a b/c"
+      })
+    ).toBe("/containers/x/attach?stream=1&stdin=0&n=5&name=a+b%2Fc");
+  });
+});
+
+describe("splitImageReference", () => {
+  it("splits repo:tag", () => {
+    expect(splitImageReference("bash:5.2")).toEqual({
+      fromImage: "bash",
+      tag: "5.2"
+    });
+  });
+
+  it("defaults the tag to latest", () => {
+    expect(splitImageReference("nodetool/sandbox-agent")).toEqual({
+      fromImage: "nodetool/sandbox-agent",
+      tag: "latest"
+    });
+  });
+
+  it("does not treat a registry port as a tag", () => {
+    expect(splitImageReference("localhost:5000/repo")).toEqual({
+      fromImage: "localhost:5000/repo",
+      tag: "latest"
+    });
+    expect(splitImageReference("localhost:5000/repo:v1")).toEqual({
+      fromImage: "localhost:5000/repo",
+      tag: "v1"
+    });
+  });
+});
+
+describe("parseDaemonErrorMessage", () => {
+  it("extracts the JSON message field", () => {
+    expect(parseDaemonErrorMessage('{"message":"conflict"}', 409)).toBe(
+      "conflict"
+    );
+  });
+
+  it("falls back to the raw body for non-JSON responses", () => {
+    expect(parseDaemonErrorMessage("plain text error", 500)).toBe(
+      "plain text error"
+    );
+  });
+
+  it("falls back to the status code for empty bodies", () => {
+    expect(parseDaemonErrorMessage("", 502)).toBe(
+      "Docker daemon returned HTTP 502"
+    );
+  });
+});

--- a/packages/docker/tests/demux.test.ts
+++ b/packages/docker/tests/demux.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import {
+  DockerStreamDemuxer,
+  demuxDockerStream,
+  type DemuxFrame
+} from "../src/demux.js";
+
+function frame(streamType: number, payload: string): Buffer {
+  const body = Buffer.from(payload, "utf8");
+  const header = Buffer.alloc(8);
+  header[0] = streamType;
+  header.writeUInt32BE(body.length, 4);
+  return Buffer.concat([header, body]);
+}
+
+describe("DockerStreamDemuxer", () => {
+  it("parses a single stdout frame", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const frames = demuxer.push(frame(1, "hello\n"));
+    expect(frames).toEqual([["stdout", Buffer.from("hello\n")]]);
+    expect(demuxer.pending).toBe(0);
+  });
+
+  it("distinguishes stdout from stderr", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const frames = demuxer.push(
+      Buffer.concat([frame(1, "out"), frame(2, "err")])
+    );
+    expect(frames.map(([slot]) => slot)).toEqual(["stdout", "stderr"]);
+    expect(frames.map(([, buf]) => buf.toString())).toEqual(["out", "err"]);
+  });
+
+  it("parses multiple frames arriving in one chunk", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const frames = demuxer.push(
+      Buffer.concat([frame(1, "a"), frame(1, "b"), frame(2, "c")])
+    );
+    expect(frames).toHaveLength(3);
+    expect(frames[2]).toEqual(["stderr", Buffer.from("c")]);
+  });
+
+  it("reassembles a frame split across chunks (payload split)", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const whole = frame(1, "split-payload");
+    const first = demuxer.push(whole.subarray(0, 12));
+    expect(first).toEqual([]);
+    const second = demuxer.push(whole.subarray(12));
+    expect(second).toEqual([["stdout", Buffer.from("split-payload")]]);
+  });
+
+  it("reassembles a frame whose 8-byte header is split across chunks", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const whole = frame(2, "hdr");
+    expect(demuxer.push(whole.subarray(0, 3))).toEqual([]);
+    expect(demuxer.push(whole.subarray(3, 7))).toEqual([]);
+    expect(demuxer.push(whole.subarray(7))).toEqual([
+      ["stderr", Buffer.from("hdr")]
+    ]);
+  });
+
+  it("handles a chunk ending mid-frame followed by more frames", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const combined = Buffer.concat([frame(1, "one"), frame(2, "two")]);
+    const cut = 8 + 2; // inside the first payload
+    const first = demuxer.push(combined.subarray(0, cut));
+    expect(first).toEqual([]);
+    const second = demuxer.push(combined.subarray(cut));
+    expect(second).toEqual([
+      ["stdout", Buffer.from("one")],
+      ["stderr", Buffer.from("two")]
+    ]);
+  });
+
+  it("drops frames with unknown stream types", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const frames = demuxer.push(
+      Buffer.concat([frame(0, "stdin-echo"), frame(1, "kept")])
+    );
+    expect(frames).toEqual([["stdout", Buffer.from("kept")]]);
+  });
+
+  it("handles zero-length payloads", () => {
+    const demuxer = new DockerStreamDemuxer();
+    const frames = demuxer.push(Buffer.concat([frame(1, ""), frame(2, "x")]));
+    expect(frames).toEqual([
+      ["stdout", Buffer.alloc(0)],
+      ["stderr", Buffer.from("x")]
+    ]);
+  });
+});
+
+describe("demuxDockerStream", () => {
+  async function collect(
+    iterable: AsyncGenerator<DemuxFrame, void>
+  ): Promise<Array<[string, string]>> {
+    const out: Array<[string, string]> = [];
+    for await (const [slot, payload] of iterable) {
+      out.push([slot, payload.toString("utf8")]);
+    }
+    return out;
+  }
+
+  it("demuxes frames from a readable stream across chunk boundaries", async () => {
+    const stream = new PassThrough();
+    const collected = collect(demuxDockerStream(stream));
+
+    const combined = Buffer.concat([
+      frame(1, "line one\n"),
+      frame(2, "warning\n"),
+      frame(1, "line two\n")
+    ]);
+    // Write in awkward chunk sizes to exercise reassembly.
+    stream.write(combined.subarray(0, 5));
+    stream.write(combined.subarray(5, 27));
+    stream.end(combined.subarray(27));
+
+    expect(await collected).toEqual([
+      ["stdout", "line one\n"],
+      ["stderr", "warning\n"],
+      ["stdout", "line two\n"]
+    ]);
+  });
+
+  it("ends the iteration on stream error instead of throwing", async () => {
+    const stream = new PassThrough();
+    const collected = collect(demuxDockerStream(stream));
+    stream.write(frame(1, "before error\n"));
+    // Give the consumer a tick to pull the first chunk, then error.
+    await new Promise((resolve) => setImmediate(resolve));
+    stream.destroy(new Error("socket reset"));
+    expect(await collected).toEqual([["stdout", "before error\n"]]);
+  });
+});

--- a/packages/docker/tests/endpoint.test.ts
+++ b/packages/docker/tests/endpoint.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { resolveDockerEndpoint } from "../src/endpoint.js";
+
+describe("resolveDockerEndpoint", () => {
+  it("defaults to the unix socket on linux", () => {
+    expect(resolveDockerEndpoint(undefined, "linux")).toEqual({
+      socketPath: "/var/run/docker.sock"
+    });
+  });
+
+  it("defaults to the named pipe on windows", () => {
+    expect(resolveDockerEndpoint(undefined, "win32")).toEqual({
+      socketPath: "//./pipe/docker_engine"
+    });
+  });
+
+  it("parses unix:// DOCKER_HOST", () => {
+    expect(resolveDockerEndpoint("unix:///run/user/1000/docker.sock")).toEqual({
+      socketPath: "/run/user/1000/docker.sock"
+    });
+  });
+
+  it("parses npipe:// DOCKER_HOST", () => {
+    expect(resolveDockerEndpoint("npipe:////./pipe/docker_engine")).toEqual({
+      socketPath: "//./pipe/docker_engine"
+    });
+  });
+
+  it("parses tcp:// DOCKER_HOST", () => {
+    expect(resolveDockerEndpoint("tcp://192.168.1.5:2376")).toEqual({
+      host: "192.168.1.5",
+      port: 2376
+    });
+  });
+
+  it("defaults the tcp port to 2375", () => {
+    expect(resolveDockerEndpoint("tcp://dockerhost")).toEqual({
+      host: "dockerhost",
+      port: 2375
+    });
+  });
+
+  it("parses bare host:port", () => {
+    expect(resolveDockerEndpoint("localhost:2375")).toEqual({
+      host: "localhost",
+      port: 2375
+    });
+  });
+
+  it("rejects unsupported schemes", () => {
+    expect(() => resolveDockerEndpoint("ssh://host")).toThrow(
+      /Unsupported DOCKER_HOST/
+    );
+  });
+});

--- a/packages/docker/tests/endpoint.test.ts
+++ b/packages/docker/tests/endpoint.test.ts
@@ -20,6 +20,12 @@ describe("resolveDockerEndpoint", () => {
     });
   });
 
+  it("parses single-slash unix:/ DOCKER_HOST", () => {
+    expect(resolveDockerEndpoint("unix:/var/run/docker.sock")).toEqual({
+      socketPath: "/var/run/docker.sock"
+    });
+  });
+
   it("parses npipe:// DOCKER_HOST", () => {
     expect(resolveDockerEndpoint("npipe:////./pipe/docker_engine")).toEqual({
       socketPath: "//./pipe/docker_engine"

--- a/packages/docker/tsconfig.json
+++ b/packages/docker/tsconfig.json
@@ -16,20 +16,6 @@
     "composite": true,
     "incremental": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts"
-  ],
-  "references": [
-    {
-      "path": "../config"
-    },
-    {
-      "path": "../docker"
-    }
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/docker/vitest.config.ts
+++ b/packages/docker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -17,11 +17,10 @@
   },
   "dependencies": {
     "@nodetool-ai/config": "*",
-    "dockerode": "^4.0.4",
+    "@nodetool-ai/docker": "*",
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@types/dockerode": "^3.3.34",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"

--- a/packages/sandbox/src/DockerSandbox.ts
+++ b/packages/sandbox/src/DockerSandbox.ts
@@ -1,5 +1,5 @@
 /**
- * DockerSandbox — Dockerode-backed SandboxProvider.
+ * DockerSandbox — Docker Engine API-backed SandboxProvider.
  *
  * Each acquire() starts a long-running container from the sandbox image,
  * publishes the in-container tool server port (7788) to an ephemeral host
@@ -14,7 +14,7 @@
  *   - network enabled (agents need internet to research)
  */
 
-import Dockerode from "dockerode";
+import { DockerClient } from "@nodetool-ai/docker";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   Sandbox,
@@ -54,7 +54,8 @@ export class DockerSandbox implements Sandbox {
   public readonly endpoint: SandboxEndpoint;
   public readonly client: ToolClient;
 
-  private readonly container: Dockerode.Container;
+  private readonly docker: DockerClient;
+  private readonly containerId: string;
   private released = false;
   private readonly timeoutHandle: ReturnType<typeof setTimeout> | null;
 
@@ -62,13 +63,15 @@ export class DockerSandbox implements Sandbox {
     sessionId: string;
     endpoint: SandboxEndpoint;
     client: ToolClient;
-    container: Dockerode.Container;
+    docker: DockerClient;
+    containerId: string;
     timeoutHandle: ReturnType<typeof setTimeout> | null;
   }) {
     this.sessionId = args.sessionId;
     this.endpoint = args.endpoint;
     this.client = args.client;
-    this.container = args.container;
+    this.docker = args.docker;
+    this.containerId = args.containerId;
     this.timeoutHandle = args.timeoutHandle;
   }
 
@@ -77,28 +80,28 @@ export class DockerSandbox implements Sandbox {
     this.released = true;
     if (this.timeoutHandle !== null) clearTimeout(this.timeoutHandle);
     try {
-      await this.container.remove({ force: true });
+      await this.docker.removeContainer(this.containerId, { force: true });
     } catch (err) {
       // best-effort; container may already be gone (404) — anything else is
       // worth knowing about even if we can't act on it here.
       log.debug(
-        `Failed to remove container ${this.container.id} on release`,
+        `Failed to remove container ${this.containerId} on release`,
         err
       );
     }
   }
 
   async pause(): Promise<void> {
-    await this.container.pause();
+    await this.docker.pauseContainer(this.containerId);
   }
 
   async resume(): Promise<void> {
-    await this.container.unpause();
+    await this.docker.unpauseContainer(this.containerId);
   }
 }
 
 export class DockerSandboxProvider implements SandboxProvider {
-  private readonly docker: Dockerode;
+  private readonly docker: DockerClient;
   private readonly hostIp: string;
   private readonly defaultImage: string;
   private readonly readyTimeoutSeconds: number;
@@ -106,7 +109,7 @@ export class DockerSandboxProvider implements SandboxProvider {
   private readonly userServicePorts: readonly number[];
 
   constructor(options: DockerSandboxProviderOptions = {}) {
-    this.docker = new Dockerode();
+    this.docker = new DockerClient();
     this.hostIp = options.hostIp ?? "127.0.0.1";
     if (this.hostIp !== "127.0.0.1" && this.hostIp !== "::1") {
       throw new Error(
@@ -168,31 +171,39 @@ export class DockerSandboxProvider implements SandboxProvider {
       portBindings[key] = [{ HostIp: this.hostIp, HostPort: "" }];
     }
 
-    const container = await this.docker.createContainer({
-      name: containerName,
-      Image: image,
-      Env: env,
-      Labels: labels,
-      WorkingDir: "/home/ubuntu",
-      OpenStdin: false,
-      Tty: false,
-      ExposedPorts: exposedPorts,
-      HostConfig: {
-        Binds: binds.length > 0 ? binds : undefined,
-        Memory: parseMemLimit(options.memLimit ?? "2g"),
-        NanoCpus: options.nanoCpus ?? 2_000_000_000,
-        SecurityOpt: ["no-new-privileges"],
-        CapDrop: ["ALL"],
-        PortBindings: portBindings
-      }
-    });
+    const containerId = await this.docker.createContainer(
+      {
+        Image: image,
+        Env: env,
+        Labels: labels,
+        WorkingDir: "/home/ubuntu",
+        OpenStdin: false,
+        Tty: false,
+        ExposedPorts: exposedPorts,
+        HostConfig: {
+          Binds: binds.length > 0 ? binds : undefined,
+          Memory: parseMemLimit(options.memLimit ?? "2g"),
+          NanoCpus: options.nanoCpus ?? 2_000_000_000,
+          SecurityOpt: ["no-new-privileges"],
+          CapDrop: ["ALL"],
+          PortBindings: portBindings
+        }
+      },
+      containerName
+    );
 
     try {
-      await container.start();
-      const toolPort = await waitForHostPort(container, toolPortKey);
-      const vncPort = await waitForHostPort(container, vncPortKey).catch(
-        () => null
+      await this.docker.startContainer(containerId);
+      const toolPort = await waitForHostPort(
+        this.docker,
+        containerId,
+        toolPortKey
       );
+      const vncPort = await waitForHostPort(
+        this.docker,
+        containerId,
+        vncPortKey
+      ).catch(() => null);
 
       const toolUrl = `http://${this.hostIp}:${toolPort}`;
       const vncUrl =
@@ -202,9 +213,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       // tool can map container_port → public URL.
       const userServiceMap: Record<string, string> = {};
       for (const p of this.userServicePorts) {
-        const host = await waitForHostPort(container, `${p}/tcp`).catch(
-          () => null
-        );
+        const host = await waitForHostPort(
+          this.docker,
+          containerId,
+          `${p}/tcp`
+        ).catch(() => null);
         if (host !== null) {
           userServiceMap[String(p)] = `http://${this.hostIp}:${host}`;
         }
@@ -239,12 +252,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       const limit = options.timeoutSeconds ?? 3600;
       if (limit > 0) {
         timeoutHandle = setTimeout(() => {
-          container.remove({ force: true }).catch((err) => {
-            log.warn(
-              `Failed to remove sandbox container ${container.id} after ${limit}s timeout`,
-              err
-            );
-          });
+          this.docker
+            .removeContainer(containerId, { force: true })
+            .catch((err) => {
+              log.warn(
+                `Failed to remove sandbox container ${containerId} after ${limit}s timeout`,
+                err
+              );
+            });
         }, limit * 1000);
       }
 
@@ -252,16 +267,19 @@ export class DockerSandboxProvider implements SandboxProvider {
         sessionId: options.sessionId,
         endpoint: { toolUrl, vncUrl },
         client,
-        container,
+        docker: this.docker,
+        containerId,
         timeoutHandle
       });
     } catch (err) {
-      await container.remove({ force: true }).catch((removeErr) => {
-        log.warn(
-          `Failed to remove container ${container.id} during error cleanup`,
-          removeErr
-        );
-      });
+      await this.docker
+        .removeContainer(containerId, { force: true })
+        .catch((removeErr) => {
+          log.warn(
+            `Failed to remove container ${containerId} during error cleanup`,
+            removeErr
+          );
+        });
       throw err;
     }
   }
@@ -277,15 +295,14 @@ export class DockerSandboxProvider implements SandboxProvider {
   }
 
   private async removeExistingContainer(name: string): Promise<void> {
-    const existing = this.docker.getContainer(name);
     try {
-      await existing.inspect();
+      await this.docker.inspectContainer(name);
     } catch {
       // No such container — nothing to clean up.
       return;
     }
     try {
-      await existing.remove({ force: true });
+      await this.docker.removeContainer(name, { force: true });
       log.info(`Removed orphaned sandbox container ${name}`);
     } catch (err) {
       log.warn(
@@ -297,19 +314,14 @@ export class DockerSandboxProvider implements SandboxProvider {
 
   private async ensureImage(image: string): Promise<void> {
     try {
-      await this.docker.getImage(image).inspect();
+      await this.docker.inspectImage(image);
       return;
     } catch {
       if (!this.autoPull) {
         throw new Error(`sandbox image not found locally: ${image}`);
       }
     }
-    const pullStream = await this.docker.pull(image);
-    await new Promise<void>((resolve, reject) => {
-      this.docker.modem.followProgress(pullStream, (err: Error | null) =>
-        err ? reject(err) : resolve()
-      );
-    });
+    await this.docker.pullImage(image);
   }
 }
 
@@ -335,13 +347,14 @@ export function parseMemLimit(mem: string): number {
 }
 
 async function waitForHostPort(
-  container: Dockerode.Container,
+  docker: DockerClient,
+  containerId: string,
   portKey: string,
   timeoutMs = 20_000
 ): Promise<number> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const info = await container.inspect();
+    const info = await docker.inspectContainer(containerId);
     if (info.State?.Status === "exited") {
       throw new Error("container exited before ports were published");
     }

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -18,5 +18,5 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],
-  "references": [{ "path": "../config" }]
+  "references": [{ "path": "../config" }, { "path": "../docker" }]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     { "path": "packages/timeline" },
     { "path": "packages/image-editor" },
     { "path": "packages/config" },
+    { "path": "packages/docker" },
     { "path": "packages/auth" },
     { "path": "packages/storage" },
     { "path": "packages/security" },


### PR DESCRIPTION
## What

Removes `dockerode` (and `@types/dockerode`) from `packages/code-runners` and `packages/sandbox` and replaces it with a new workspace package, **`@nodetool-ai/docker`** — a small typed client that talks to the Docker Engine API directly over the unix socket (or `DOCKER_HOST`) with `node:http`. No runtime dependencies.

## API surface replaced

dockerode was used in exactly three files (`stream-runner-base.ts`, `server-docker-runner.ts`, `DockerSandbox.ts`) for:

- `docker.ping()` → `GET /_ping`
- `docker.getImage(name).inspect()` → `GET /images/{name}/json`
- `docker.pull()` + `modem.followProgress()` → `POST /images/create?fromImage=&tag=`, JSON-lines progress consumed to completion, rejecting on an `{"error": ...}` record
- `docker.createContainer()` (incl. `name`, `HostConfig`, `ExposedPorts`, `PortBindings`, `Labels`) → `POST /containers/create`
- `container.start()/wait()/remove({force})/inspect()/pause()/unpause()` → the corresponding `/containers/{id}/...` endpoints
- `container.attach({stream, stdout, stderr, stdin})` → `POST /containers/{id}/attach` with connection hijacking

Nothing else — the client deliberately covers only this surface.

## Streams and demux

- **Attach** sends `Connection: Upgrade` / `Upgrade: tcp`; after the daemon's 101 the raw socket is returned as a `Duplex`. Writes feed container stdin, `end()` closes it — same contract the runners already relied on.
- **Non-TTY multiplexing** (8-byte frame header: 1 byte stream type, 3 bytes zero, 4 bytes big-endian length) is parsed by a shared `DockerStreamDemuxer` / `demuxDockerStream` in the new package. `stream-runner-base` and `server-docker-runner` previously carried two duplicated inline frame parsers; both now consume the shared demuxer and keep only their line-splitting (with per-slot `StringDecoder`s, as before).
- **Errors**: non-2xx daemon responses become `DockerError` with the daemon's `message` and the HTTP status; abrupt attach-socket teardown ends the stream instead of throwing, matching the old listener-based handling.
- **`DOCKER_HOST`** resolution mirrors dockerode's default constructor: `unix://`, `npipe://`, `tcp://`, bare `host:port`, else the platform default socket.

## Tests

34 new Vitest tests in `packages/docker`:

- demuxer: frame split across chunks (payload and header splits), multiple frames per chunk, stdout vs stderr, unknown stream types dropped, zero-length payloads, end-on-error
- endpoint resolution for every `DOCKER_HOST` form
- `DockerClient` against a fake daemon served over a real unix socket: ping, path/query building and URL-encoding, error mapping (404/500 → `DockerError` with daemon message), pull progress (success and error record), container lifecycle, and an attach hijack round-trip (stdout frame out, stdin echoed back)

Existing `code-runners` (332) and `sandbox` (63) tests pass unchanged; the public behavior of `DockerSandbox`, `StreamRunnerBase`, and `ServerDockerRunner` is preserved.

## Verification

- `npm run build:packages` — 56/56 tasks pass
- `npx oxlint` on the touched sources — clean (one pre-existing warning in an untouched file)
- `npm run check:deps` / `check:circular` — pass
- Lockfile updated via `npm install --ignore-scripts`; `dockerode` is gone from the root lockfile

**Note:** Docker is not available in the CI sandbox, so live-daemon behavior (attach hijack against a real daemon, image pull, container lifecycle) needs a manual smoke test — e.g. run a Bash code node and a sandbox session on a machine with Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y)_