### PR TITLE
Replace @supabase/supabase-js with purpose-fit REST clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51412,7 +51412,6 @@
       "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
-        "@supabase/supabase-js": "^2.98.0",
         "jose": "^6.2.0"
       },
       "devDependencies": {
@@ -51935,7 +51934,6 @@
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/runtime": "*",
-        "@supabase/supabase-js": "^2.98.0",
         "js-yaml": "^5.2.1",
         "nodemailer": "^9.0.3"
       },
@@ -52415,8 +52413,7 @@
         "@aws-sdk/client-s3": "^3.1029.0",
         "@aws-sdk/s3-request-presigner": "^3.1029.0",
         "@nodetool-ai/config": "*",
-        "@openclaw/fs-safe": "^0.1.2",
-        "@supabase/supabase-js": "^2.98.0"
+        "@openclaw/fs-safe": "^0.1.2"
       },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
@@ -52557,7 +52554,6 @@
       "dependencies": {
         "@nodetool-ai/config": "*",
         "@nodetool-ai/models": "*",
-        "@supabase/supabase-js": "^2.98.0",
         "better-sqlite3": "^12.8.0",
         "sqlite-vec": "^0.1.7-alpha.2"
       },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,7 +14,6 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.98.0",
     "jose": "^6.2.0"
   },
   "devDependencies": {

--- a/packages/auth/src/providers/supabase-provider.ts
+++ b/packages/auth/src/providers/supabase-provider.ts
@@ -52,7 +52,8 @@ function createGoTrueClient(
   supabaseUrl: string,
   supabaseKey: string
 ): SupabaseAuthClient {
-  const base = supabaseUrl.replace(/\/+$/, "");
+  let base = supabaseUrl;
+  while (base.endsWith("/")) base = base.slice(0, -1);
   return {
     auth: {
       async getUser(token: string): Promise<GetUserResult> {

--- a/packages/auth/src/providers/supabase-provider.ts
+++ b/packages/auth/src/providers/supabase-provider.ts
@@ -1,20 +1,94 @@
 /**
  * Supabase JWT authentication provider — T-SEC-4.
  *
- * Validates Supabase JWT tokens by calling supabase.auth.getUser(token).
+ * Validates Supabase JWT tokens against the GoTrue REST endpoint
+ * (`GET /auth/v1/user`) with a plain `fetch` call — no supabase-js.
  * Uses an LRU token cache with TTL to avoid repeated API calls.
  *
  * Ported from Python: src/nodetool/security/providers/supabase.py
  */
 
 import { createHash } from "node:crypto";
-import {
-  createClient,
-  type SupabaseClient as SupabaseClientType
-} from "@supabase/supabase-js";
 import { AuthProvider, AuthResult, TokenType } from "../auth-provider.js";
 
-type SupabaseClient = SupabaseClientType;
+/** The slice of the GoTrue user object we consume. */
+interface GoTrueUser {
+  id: string;
+}
+
+interface GetUserResult {
+  data: { user: GoTrueUser | null };
+  error: { message: string } | null;
+}
+
+/**
+ * Minimal client shape kept structurally compatible with the supabase-js
+ * subset previously used (`client.auth.getUser(token)`), so tests can inject
+ * a stub.
+ */
+interface SupabaseAuthClient {
+  auth: {
+    getUser(token: string): Promise<GetUserResult>;
+  };
+}
+
+/** Extract a human-readable message from a GoTrue error body. */
+function readGoTrueErrorMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const obj = body as Record<string, unknown>;
+    for (const field of ["msg", "message", "error_description", "error"]) {
+      const val = obj[field];
+      if (typeof val === "string" && val) return val;
+    }
+  }
+  return `Supabase auth request failed with status ${status}`;
+}
+
+/**
+ * fetch-backed GoTrue client covering exactly the surface we use:
+ * `GET {supabaseUrl}/auth/v1/user` with the token as Bearer auth.
+ */
+function createGoTrueClient(
+  supabaseUrl: string,
+  supabaseKey: string
+): SupabaseAuthClient {
+  const base = supabaseUrl.replace(/\/+$/, "");
+  return {
+    auth: {
+      async getUser(token: string): Promise<GetUserResult> {
+        const response = await fetch(`${base}/auth/v1/user`, {
+          method: "GET",
+          headers: {
+            apikey: supabaseKey,
+            Authorization: `Bearer ${token}`
+          }
+        });
+
+        let body: unknown = null;
+        try {
+          body = await response.json();
+        } catch {
+          // Non-JSON body (e.g. empty 5xx) — handled below via status.
+        }
+
+        if (!response.ok) {
+          return {
+            data: { user: null },
+            error: {
+              message: readGoTrueErrorMessage(body, response.status)
+            }
+          };
+        }
+
+        const user =
+          body && typeof body === "object" && "id" in body
+            ? { id: String((body as { id: unknown }).id) }
+            : null;
+        return { data: { user }, error: null };
+      }
+    }
+  };
+}
 
 export interface SupabaseAuthProviderOptions {
   supabaseUrl: string;
@@ -33,7 +107,7 @@ export class SupabaseAuthProvider extends AuthProvider {
   private supabaseKey: string;
   private cacheTtl: number;
   private cacheMax: number;
-  private _client: SupabaseClient | null = null;
+  private _client: SupabaseAuthClient | null = null;
 
   /**
    * LRU cache: Map preserves insertion order; we delete-and-reinsert on access
@@ -52,9 +126,9 @@ export class SupabaseAuthProvider extends AuthProvider {
 
   // ── Client initialisation ────────────────────────────────────────────
 
-  private _getClient(): SupabaseClient {
+  private _getClient(): SupabaseAuthClient {
     if (!this._client) {
-      this._client = createClient(this.supabaseUrl, this.supabaseKey);
+      this._client = createGoTrueClient(this.supabaseUrl, this.supabaseKey);
     }
     return this._client;
   }

--- a/packages/auth/tests/supabase-client-init.test.ts
+++ b/packages/auth/tests/supabase-client-init.test.ts
@@ -1,55 +1,144 @@
 /**
- * Tests for SupabaseAuthProvider's lazy client initialisation (`_getClient`).
+ * Tests for SupabaseAuthProvider's lazy client initialisation (`_getClient`)
+ * and the fetch-backed GoTrue call it performs.
  *
- * The main supabase-provider.test.ts injects a fake `_client` to avoid the real
- * SDK. This file instead mocks `@supabase/supabase-js` so the `if (!this._client)`
- * creation path is actually exercised — pinning that the client is created once
- * and reused (kills the condition-removal / block-emptying mutants on L56).
+ * The main supabase-provider.test.ts injects a fake `_client` to avoid any
+ * network I/O. This file instead mocks global `fetch` so the
+ * `if (!this._client)` creation path is actually exercised — pinning the
+ * exact request (URL, headers) and the response decoding / error mapping.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createClient } from "@supabase/supabase-js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SupabaseAuthProvider } from "../src/providers/supabase-provider.js";
 
-vi.mock("@supabase/supabase-js", () => {
-  const getUser = vi.fn(async () => ({
-    data: { user: { id: "lazy-client-user" } },
-    error: null
-  }));
-  return { createClient: vi.fn(() => ({ auth: { getUser } })) };
+const fetchMock = vi.fn<typeof fetch>();
+
+function makeProvider(): SupabaseAuthProvider {
+  return new SupabaseAuthProvider({
+    supabaseUrl: "https://test.supabase.co",
+    supabaseKey: "test-key",
+    cacheTtl: 0
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
 });
 
-const mockedCreateClient = vi.mocked(createClient);
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
-describe("SupabaseAuthProvider lazy client initialisation", () => {
-  beforeEach(() => {
-    mockedCreateClient.mockClear();
+describe("SupabaseAuthProvider GoTrue fetch client", () => {
+  it("issues GET /auth/v1/user with apikey and Bearer headers", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: "lazy-client-user" }));
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("tok");
+
+    expect(result.ok).toBe(true);
+    expect(result.userId).toBe("lazy-client-user");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://test.supabase.co/auth/v1/user");
+    expect(init?.method).toBe("GET");
+    expect(init?.headers).toEqual({
+      apikey: "test-key",
+      Authorization: "Bearer tok"
+    });
   });
 
-  it("creates the Supabase client and authenticates through it", async () => {
-    // cacheTtl: 0 keeps caching out of the way so every call goes through the
-    // client; the result proves _getClient returned a real (mocked) client
-    // rather than null (which a removed `if (!this._client)` assignment causes).
+  it("strips trailing slashes from the Supabase URL", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: "u1" }));
+
     const provider = new SupabaseAuthProvider({
-      supabaseUrl: "https://test.supabase.co",
+      supabaseUrl: "https://test.supabase.co///",
       supabaseKey: "test-key",
       cacheTtl: 0
     });
+    await provider.verifyToken("tok");
 
-    const result = await provider.verifyToken("tok");
-    expect(result.ok).toBe(true);
-    expect(result.userId).toBe("lazy-client-user");
-    expect(mockedCreateClient).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://test.supabase.co/auth/v1/user"
+    );
   });
 
   it("reuses the same client across calls instead of recreating it", async () => {
-    const provider = new SupabaseAuthProvider({
-      supabaseUrl: "https://test.supabase.co",
-      supabaseKey: "test-key",
-      cacheTtl: 0
-    });
+    fetchMock.mockResolvedValue(jsonResponse({ id: "u1" }));
 
+    const provider = makeProvider();
     await provider.verifyToken("tok-1");
+    fetchMock.mockResolvedValue(jsonResponse({ id: "u1" }));
     await provider.verifyToken("tok-2");
-    expect(mockedCreateClient).toHaveBeenCalledTimes(1);
+
+    // Same underlying client object was kept between the two calls.
+    const clientAfter = (provider as unknown as Record<string, unknown>)
+      ._client;
+    expect(clientAfter).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toEqual({
+      apikey: "test-key",
+      Authorization: "Bearer tok-2"
+    });
+  });
+
+  it("maps a GoTrue error body (msg) to the auth error", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ msg: "JWT expired" }, 401));
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("expired");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("JWT expired");
+  });
+
+  it("maps an error_description body to the auth error", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ error_description: "Bad token" }, 401)
+    );
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("bad");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Bad token");
+  });
+
+  it("falls back to a status message for a non-JSON error body", async () => {
+    fetchMock.mockResolvedValue(new Response("gateway timeout", { status: 504 }));
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("tok");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Supabase auth request failed with status 504");
+  });
+
+  it("treats a 200 body without an id as an invalid token", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ role: "anon" }));
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("tok");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Invalid Supabase token");
+  });
+
+  it("surfaces network failures as auth errors", async () => {
+    fetchMock.mockRejectedValue(new Error("Network failure"));
+
+    const provider = makeProvider();
+    const result = await provider.verifyToken("tok");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Network failure");
   });
 });

--- a/packages/base-nodes/tests/lib-100pct-coverage.test.ts
+++ b/packages/base-nodes/tests/lib-100pct-coverage.test.ts
@@ -157,77 +157,30 @@ function makeNode<T>(Cls: new () => T, props: Record<string, unknown>): T {
   return node;
 }
 
-// ── lib-supabase: mock createClient for success paths ──────────
+// ── lib-supabase: stub fetch for success paths ──────────
 
-// We mock at the module level since supabase exports are non-configurable
-const mockFromChain: Record<string, any> = {};
-const mockRpc = vi.fn();
-const mockCreateClient = vi.fn().mockReturnValue({
-  from: vi.fn().mockReturnValue(mockFromChain),
-  rpc: mockRpc
-});
-
-vi.mock("@supabase/supabase-js", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    createClient: (...args: any[]) => mockCreateClient(...args)
-  };
-});
+// The supabase nodes issue PostgREST requests directly over fetch, so these
+// tests stub the global fetch with canned PostgREST-shaped responses.
+function stubPostgrest(status: number, body?: unknown) {
+  const impl = vi.fn(
+    async () =>
+      new Response(body === undefined ? null : JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" }
+      })
+  );
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
 
 describe("lib-supabase success paths (mocked)", () => {
-  // Build a chainable query mock
-  function chainable(resolvedValue: { data: unknown; error: unknown }) {
-    const q: Record<string, unknown> = {};
-    const methods = [
-      "select",
-      "eq",
-      "neq",
-      "gt",
-      "gte",
-      "lt",
-      "lte",
-      "in",
-      "like",
-      "contains",
-      "order",
-      "limit",
-      "insert",
-      "update",
-      "upsert",
-      "delete"
-    ];
-    for (const m of methods) {
-      q[m] = vi.fn().mockReturnValue(q);
-    }
-    // Make the object thenable to resolve when awaited
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve(resolvedValue);
-      return q;
-    };
-    return q;
-  }
-
-  beforeEach(() => {
-    // Reset the chain object
-    const q = chainable({ data: [], error: null });
-    Object.assign(mockFromChain, q);
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockFromChain),
-      rpc: mockRpc
-    });
-  });
-
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it("Select succeeds with all filter operators", async () => {
-    const mockQ = chainable({ data: [{ id: 1 }], error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(200, [{ id: 1 }]);
 
     const result = await makeNode(SelectLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -253,10 +206,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Select with unsupported filter throws", async () => {
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(chainable({ data: [], error: null })),
-      rpc: mockRpc
-    });
+    stubPostgrest(200, []);
 
     await expect(
       makeNode(SelectLibNode, {
@@ -269,19 +219,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Select with error response throws", async () => {
-    const q: Record<string, unknown> = {};
-    const methods = ["select", "eq", "order", "limit"];
-    for (const m of methods) {
-      q[m] = vi.fn().mockReturnValue(q);
-    }
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve({ data: null, error: { message: "test error" } });
-      return q;
-    };
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(q),
-      rpc: mockRpc
-    });
+    stubPostgrest(400, { message: "test error" });
 
     await expect(
       makeNode(SelectLibNode, {
@@ -293,11 +231,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Insert succeeds and returns rows", async () => {
-    const mockQ = chainable({ data: [{ id: 1, a: 1 }], error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(201, [{ id: 1, a: 1 }]);
 
     const result = await makeNode(SupabaseInsertLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -310,11 +244,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Insert succeeds with return_rows=false", async () => {
-    const mockQ = chainable({ data: null, error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(201);
 
     const result = await makeNode(SupabaseInsertLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -327,17 +257,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Insert with error response throws", async () => {
-    const q: Record<string, unknown> = {};
-    q.insert = vi.fn().mockReturnValue(q);
-    q.select = vi.fn().mockReturnValue(q);
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve({ data: null, error: { message: "insert failed" } });
-      return q;
-    };
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(q),
-      rpc: mockRpc
-    });
+    stubPostgrest(400, { message: "insert failed" });
 
     await expect(
       makeNode(SupabaseInsertLibNode, {
@@ -350,11 +270,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Update succeeds with filters and return_rows", async () => {
-    const mockQ = chainable({ data: [{ id: 1, x: 2 }], error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(200, [{ id: 1, x: 2 }]);
 
     const result = await makeNode(SupabaseUpdateLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -368,11 +284,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Update succeeds with return_rows=false", async () => {
-    const mockQ = chainable({ data: null, error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(204);
 
     const result = await makeNode(SupabaseUpdateLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -386,17 +298,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Update with error response throws", async () => {
-    const q: Record<string, unknown> = {};
-    q.update = vi.fn().mockReturnValue(q);
-    q.select = vi.fn().mockReturnValue(q);
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve({ data: null, error: { message: "update failed" } });
-      return q;
-    };
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(q),
-      rpc: mockRpc
-    });
+    stubPostgrest(400, { message: "update failed" });
 
     await expect(
       makeNode(SupabaseUpdateLibNode, {
@@ -409,11 +311,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Delete succeeds", async () => {
-    const mockQ = chainable({ data: null, error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(204);
 
     const result = await makeNode(SupabaseDeleteLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -425,17 +323,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Delete with error response throws", async () => {
-    const q: Record<string, unknown> = {};
-    q.delete = vi.fn().mockReturnValue(q);
-    q.eq = vi.fn().mockReturnValue(q);
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve({ data: null, error: { message: "delete failed" } });
-      return q;
-    };
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(q),
-      rpc: mockRpc
-    });
+    stubPostgrest(400, { message: "delete failed" });
 
     await expect(
       makeNode(SupabaseDeleteLibNode, {
@@ -448,11 +336,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Upsert succeeds with return_rows", async () => {
-    const mockQ = chainable({ data: [{ id: 1 }], error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(200, [{ id: 1 }]);
 
     const result = await makeNode(SupabaseUpsertLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -465,11 +349,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Upsert succeeds with return_rows=false", async () => {
-    const mockQ = chainable({ data: null, error: null });
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(mockQ),
-      rpc: mockRpc
-    });
+    stubPostgrest(201);
 
     const result = await makeNode(SupabaseUpsertLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -482,17 +362,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("Upsert with error response throws", async () => {
-    const q: Record<string, unknown> = {};
-    q.upsert = vi.fn().mockReturnValue(q);
-    q.select = vi.fn().mockReturnValue(q);
-    q.then = (resolve: (v: unknown) => void) => {
-      resolve({ data: null, error: { message: "upsert failed" } });
-      return q;
-    };
-    mockCreateClient.mockReturnValue({
-      from: vi.fn().mockReturnValue(q),
-      rpc: mockRpc
-    });
+    stubPostgrest(400, { message: "upsert failed" });
 
     await expect(
       makeNode(SupabaseUpsertLibNode, {
@@ -505,10 +375,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("RPC succeeds", async () => {
-    mockCreateClient.mockReturnValue({
-      from: vi.fn(),
-      rpc: vi.fn().mockResolvedValue({ data: { result: 42 }, error: null })
-    });
+    stubPostgrest(200, { result: 42 });
 
     const result = await makeNode(SupabaseRPCLibNode, {
       supabase_url: "https://test.supabase.co",
@@ -520,12 +387,7 @@ describe("lib-supabase success paths (mocked)", () => {
   });
 
   it("RPC with error response throws", async () => {
-    mockCreateClient.mockReturnValue({
-      from: vi.fn(),
-      rpc: vi
-        .fn()
-        .mockResolvedValue({ data: null, error: { message: "rpc failed" } })
-    });
+    stubPostgrest(400, { message: "rpc failed" });
 
     await expect(
       makeNode(SupabaseRPCLibNode, {

--- a/packages/integration-nodes/package.json
+++ b/packages/integration-nodes/package.json
@@ -22,7 +22,6 @@
     "@nodetool-ai/nodes-utils": "*",
     "@nodetool-ai/protocol": "*",
     "@nodetool-ai/runtime": "*",
-    "@supabase/supabase-js": "^2.98.0",
     "nodemailer": "^9.0.3",
     "js-yaml": "^5.2.1"
   },

--- a/packages/integration-nodes/src/nodes/lib-supabase.ts
+++ b/packages/integration-nodes/src/nodes/lib-supabase.ts
@@ -89,7 +89,8 @@ async function postgrestFetch(
   apiKey: string,
   req: PostgrestRequest
 ): Promise<unknown> {
-  const base = supabaseUrl.replace(/\/+$/, "");
+  let base = supabaseUrl;
+  while (base.endsWith("/")) base = base.slice(0, -1);
   const qs = req.params.toString();
   const url = `${base}/rest/v1/${req.path}${qs ? `?${qs}` : ""}`;
 

--- a/packages/integration-nodes/src/nodes/lib-supabase.ts
+++ b/packages/integration-nodes/src/nodes/lib-supabase.ts
@@ -1,4 +1,3 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
@@ -29,51 +28,109 @@ function getSupabaseCredentials(secrets: Record<string, string>): {
   return { url, key };
 }
 
-function getSupabaseClient(url: string, key: string): SupabaseClient {
-  if (!url || !key) {
-    throw new Error(
-      "Supabase URL and key are required. Provide supabase_url and supabase_key."
-    );
-  }
-  return createClient(url, key);
+// ---------------------------------------------------------------------------
+// PostgREST request plumbing — Supabase's data API is plain PostgREST
+// (`/rest/v1/`), driven by query-string operators and Prefer headers.
+// ---------------------------------------------------------------------------
+
+interface PostgrestRequest {
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  /** Path under /rest/v1/, e.g. "my_table" or "rpc/my_fn". */
+  path: string;
+  params: URLSearchParams;
+  body?: unknown;
+  prefer?: string[];
 }
 
-function applyFilters(query: any, filters: Filter[]): any {
-  let q = query;
+/** Quote one element of an `in.(...)` list per PostgREST rules. */
+function quoteInElement(value: unknown): string {
+  const s = String(value);
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function applyFilters(params: URLSearchParams, filters: Filter[]): void {
   for (const [field, op, value] of filters) {
     switch (op) {
       case "eq":
-        q = q.eq(field, value);
+      case "gt":
+      case "gte":
+      case "lt":
+      case "lte":
+        params.append(field, `${op}.${String(value)}`);
         break;
       case "ne":
-        q = q.neq(field, value);
-        break;
-      case "gt":
-        q = q.gt(field, value);
-        break;
-      case "gte":
-        q = q.gte(field, value);
-        break;
-      case "lt":
-        q = q.lt(field, value);
-        break;
-      case "lte":
-        q = q.lte(field, value);
+        params.append(field, `neq.${String(value)}`);
         break;
       case "in":
-        q = q.in(field, value as unknown[]);
+        params.append(
+          field,
+          `in.(${(value as unknown[]).map(quoteInElement).join(",")})`
+        );
         break;
       case "like":
-        q = q.like(field, value as string);
+        params.append(field, `like.${String(value)}`);
         break;
       case "contains":
-        q = q.contains(field, value as Record<string, unknown>);
+        params.append(field, `cs.${JSON.stringify(value)}`);
         break;
       default:
-        throw new Error(`Unsupported filter operator: ${op}`);
+        throw new Error(`Unsupported filter operator: ${String(op)}`);
     }
   }
-  return q;
+}
+
+/**
+ * Execute one PostgREST request. Returns the decoded JSON body (or null for
+ * empty responses). Maps PostgREST error bodies
+ * (`{ message, code, details, hint }`) to thrown Errors.
+ */
+async function postgrestFetch(
+  supabaseUrl: string,
+  apiKey: string,
+  req: PostgrestRequest
+): Promise<unknown> {
+  const base = supabaseUrl.replace(/\/+$/, "");
+  const qs = req.params.toString();
+  const url = `${base}/rest/v1/${req.path}${qs ? `?${qs}` : ""}`;
+
+  const headers: Record<string, string> = {
+    apikey: apiKey,
+    Authorization: `Bearer ${apiKey}`
+  };
+  if (req.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (req.prefer && req.prefer.length > 0) {
+    headers.Prefer = req.prefer.join(",");
+  }
+
+  const response = await fetch(url, {
+    method: req.method,
+    headers,
+    ...(req.body !== undefined ? { body: JSON.stringify(req.body) } : {})
+  });
+
+  if (!response.ok) {
+    let message = "";
+    let details = "";
+    try {
+      const body = (await response.json()) as Record<string, unknown>;
+      if (typeof body.message === "string") message = body.message;
+      const parts = [body.code, body.details, body.hint]
+        .filter((p): p is string => typeof p === "string" && p.length > 0)
+        .join("; ");
+      details = parts;
+    } catch {
+      // Non-JSON error body — fall back to the status line below.
+    }
+    const suffix = details ? ` (${details})` : "";
+    throw new Error(
+      `${message || `PostgREST request failed with status ${response.status}`}${suffix}`
+    );
+  }
+
+  const text = await response.text();
+  return text ? (JSON.parse(text) as unknown) : null;
 }
 
 export class SelectLibNode extends BaseNode {
@@ -160,26 +217,31 @@ export class SelectLibNode extends BaseNode {
 
     if (!tableName) throw new Error("table_name cannot be empty");
 
-    const client = getSupabaseClient(url, key);
-    const selectColumns =
-      cols.length === 0 ? "*" : cols.map((c) => c.name).join(", ");
-
-    let query = client.from(tableName).select(selectColumns);
-
-    if (filters.length > 0) {
-      query = applyFilters(query, filters);
-    }
+    const params = new URLSearchParams();
+    params.set(
+      "select",
+      cols.length === 0 ? "*" : cols.map((c) => c.name).join(",")
+    );
+    applyFilters(params, filters);
     if (orderBy) {
-      query = query.order(orderBy, { ascending: !descending });
+      params.set("order", `${orderBy}.${descending ? "desc" : "asc"}`);
     }
     if (limit > 0) {
-      query = query.limit(limit);
+      params.set("limit", String(limit));
     }
 
-    const { data, error } = await query;
-    if (error) throw new Error(`Supabase select error: ${error.message}`);
-
-    return { output: data ?? [] };
+    try {
+      const data = await postgrestFetch(url, key, {
+        method: "GET",
+        path: tableName,
+        params
+      });
+      return { output: data ?? [] };
+    } catch (err) {
+      throw new Error(
+        `Supabase select error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 }
 
@@ -230,19 +292,25 @@ export class InsertLibNode extends BaseNode {
       ? (recordsInput as Record<string, unknown>[])
       : [recordsInput as Record<string, unknown>];
 
-    const client = getSupabaseClient(url, key);
+    const params = new URLSearchParams();
+    if (returnRows) params.set("select", "*");
 
-    let query: any = client.from(tableName).insert(data);
-    if (returnRows) {
-      query = query.select("*");
+    try {
+      const result = await postgrestFetch(url, key, {
+        method: "POST",
+        path: tableName,
+        params,
+        body: data,
+        prefer: [returnRows ? "return=representation" : "return=minimal"]
+      });
+      return returnRows
+        ? { output: result }
+        : { output: { inserted: data.length } };
+    } catch (err) {
+      throw new Error(
+        `Supabase insert error: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
-
-    const { data: result, error } = await query;
-    if (error) throw new Error(`Supabase insert error: ${error.message}`);
-
-    return returnRows
-      ? { output: result }
-      : { output: { inserted: data.length } };
   }
 }
 
@@ -300,21 +368,24 @@ export class UpdateLibNode extends BaseNode {
     if (Object.keys(values).length === 0)
       throw new Error("values cannot be empty");
 
-    const client = getSupabaseClient(url, key);
+    const params = new URLSearchParams();
+    applyFilters(params, filters);
+    if (returnRows) params.set("select", "*");
 
-    let query: any = client.from(tableName).update(values);
-
-    if (filters.length > 0) {
-      query = applyFilters(query, filters);
+    try {
+      const data = await postgrestFetch(url, key, {
+        method: "PATCH",
+        path: tableName,
+        params,
+        body: values,
+        prefer: [returnRows ? "return=representation" : "return=minimal"]
+      });
+      return returnRows ? { output: data } : { output: { updated: true } };
+    } catch (err) {
+      throw new Error(
+        `Supabase update error: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
-    if (returnRows) {
-      query = query.select("*");
-    }
-
-    const { data, error } = await query;
-    if (error) throw new Error(`Supabase update error: ${error.message}`);
-
-    return returnRows ? { output: data } : { output: { updated: true } };
   }
 }
 
@@ -357,15 +428,22 @@ export class DeleteLibNode extends BaseNode {
       );
     }
 
-    const client = getSupabaseClient(url, key);
+    const params = new URLSearchParams();
+    applyFilters(params, filters);
 
-    let query: any = client.from(tableName).delete();
-    query = applyFilters(query, filters);
-
-    const { error } = await query;
-    if (error) throw new Error(`Supabase delete error: ${error.message}`);
-
-    return { output: { deleted: true } };
+    try {
+      await postgrestFetch(url, key, {
+        method: "DELETE",
+        path: tableName,
+        params,
+        prefer: ["return=minimal"]
+      });
+      return { output: { deleted: true } };
+    } catch (err) {
+      throw new Error(
+        `Supabase delete error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 }
 
@@ -416,20 +494,28 @@ export class UpsertLibNode extends BaseNode {
       ? (recordsInput as Record<string, unknown>[])
       : [recordsInput as Record<string, unknown>];
 
-    const client = getSupabaseClient(url, key);
+    const params = new URLSearchParams();
+    if (returnRows) params.set("select", "*");
 
-    let query: any = client.from(tableName).upsert(data);
-
-    if (returnRows) {
-      query = query.select("*");
+    try {
+      const result = await postgrestFetch(url, key, {
+        method: "POST",
+        path: tableName,
+        params,
+        body: data,
+        prefer: [
+          "resolution=merge-duplicates",
+          returnRows ? "return=representation" : "return=minimal"
+        ]
+      });
+      return returnRows
+        ? { output: result }
+        : { output: { upserted: data.length } };
+    } catch (err) {
+      throw new Error(
+        `Supabase upsert error: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
-
-    const { data: result, error } = await query;
-    if (error) throw new Error(`Supabase upsert error: ${error.message}`);
-
-    return returnRows
-      ? { output: result }
-      : { output: { upserted: data.length } };
   }
 }
 
@@ -475,11 +561,19 @@ export class RPCLibNode extends BaseNode {
 
     if (!fnName) throw new Error("function cannot be empty");
 
-    const client = getSupabaseClient(url, key);
-    const { data, error } = await client.rpc(fnName, params);
-    if (error) throw new Error(`Supabase RPC error: ${error.message}`);
-
-    return { output: data };
+    try {
+      const data = await postgrestFetch(url, key, {
+        method: "POST",
+        path: `rpc/${fnName}`,
+        params: new URLSearchParams(),
+        body: params
+      });
+      return { output: data };
+    } catch (err) {
+      throw new Error(
+        `Supabase RPC error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 }
 

--- a/packages/integration-nodes/tests/lib-supabase.test.ts
+++ b/packages/integration-nodes/tests/lib-supabase.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Fetch-layer tests for the Supabase (PostgREST) nodes: exact request URLs,
+ * query-string operators, headers, bodies, response decoding, and error
+ * mapping.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  SelectLibNode,
+  InsertLibNode,
+  UpdateLibNode,
+  DeleteLibNode,
+  UpsertLibNode,
+  RPCLibNode
+} from "@nodetool-ai/integration-nodes";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+const SECRETS = {
+  SUPABASE_URL: "https://xyz.supabase.co",
+  SUPABASE_KEY: "service-key"
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(body === null ? null : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function lastRequest(): { url: string; init: RequestInit } {
+  const [url, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  return { url: String(url), init: init ?? {} };
+}
+
+function makeNode<T extends { assign(p: Record<string, unknown>): void; setDynamic(k: string, v: unknown): void }>(
+  NodeCls: new () => T,
+  props: Record<string, unknown>
+): T {
+  const node = new NodeCls();
+  node.assign(props);
+  node.setDynamic("_secrets", SECRETS);
+  return node;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SelectLibNode", () => {
+  it("GETs the table with select, filters, order and limit", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: 1, name: "a" }]));
+
+    const node = makeNode(SelectLibNode, {
+      table_name: "items",
+      columns: { type: "record_type", columns: [{ name: "id" }, { name: "name" }] },
+      filters: [
+        ["status", "eq", "active"],
+        ["score", "gte", 10],
+        ["kind", "in", ["a", "b"]],
+        ["name", "like", "%foo%"],
+        ["meta", "contains", { k: "v" }],
+        ["age", "ne", 3]
+      ],
+      order_by: "name",
+      descending: true,
+      limit: 25
+    });
+
+    const result = await node.process();
+    expect(result.output).toEqual([{ id: 1, name: "a" }]);
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("GET");
+    expect(init.headers).toEqual({
+      apikey: "service-key",
+      Authorization: "Bearer service-key"
+    });
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://xyz.supabase.co/rest/v1/items"
+    );
+    const params = parsed.searchParams;
+    expect(params.get("select")).toBe("id,name");
+    expect(params.get("status")).toBe("eq.active");
+    expect(params.get("score")).toBe("gte.10");
+    expect(params.get("kind")).toBe('in.("a","b")');
+    expect(params.get("name")).toBe("like.%foo%");
+    expect(params.get("meta")).toBe('cs.{"k":"v"}');
+    expect(params.get("age")).toBe("neq.3");
+    expect(params.get("order")).toBe("name.desc");
+    expect(params.get("limit")).toBe("25");
+  });
+
+  it("defaults to select=* and no order/limit", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    const node = makeNode(SelectLibNode, { table_name: "items" });
+    await node.process();
+
+    const params = new URL(lastRequest().url).searchParams;
+    expect(params.get("select")).toBe("*");
+    expect(params.get("order")).toBeNull();
+    expect(params.get("limit")).toBeNull();
+  });
+
+  it("maps PostgREST error bodies into the thrown message", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          message: "relation does not exist",
+          code: "42P01",
+          hint: "check the table name"
+        },
+        404
+      )
+    );
+
+    const node = makeNode(SelectLibNode, { table_name: "nope" });
+    await expect(node.process()).rejects.toThrow(
+      "Supabase select error: relation does not exist (42P01; check the table name)"
+    );
+  });
+});
+
+describe("InsertLibNode", () => {
+  it("POSTs rows with return=representation and returns them", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: 1 }], 201));
+
+    const node = makeNode(InsertLibNode, {
+      table_name: "items",
+      records: { name: "one" },
+      return_rows: true
+    });
+    const result = await node.process();
+    expect(result.output).toEqual([{ id: 1 }]);
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Prefer).toBe("return=representation");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual([{ name: "one" }]);
+    expect(new URL(url).searchParams.get("select")).toBe("*");
+  });
+
+  it("uses return=minimal and reports counts when return_rows is false", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+
+    const node = makeNode(InsertLibNode, {
+      table_name: "items",
+      records: [{ a: 1 }, { a: 2 }],
+      return_rows: false
+    });
+    const result = await node.process();
+    expect(result.output).toEqual({ inserted: 2 });
+
+    const { init } = lastRequest();
+    expect((init.headers as Record<string, string>).Prefer).toBe(
+      "return=minimal"
+    );
+  });
+});
+
+describe("UpdateLibNode", () => {
+  it("PATCHes values with filters", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: 1, status: "done" }]));
+
+    const node = makeNode(UpdateLibNode, {
+      table_name: "items",
+      values: { status: "done" },
+      filters: [["id", "eq", 1]],
+      return_rows: true
+    });
+    const result = await node.process();
+    expect(result.output).toEqual([{ id: 1, status: "done" }]);
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ status: "done" });
+    expect(new URL(url).searchParams.get("id")).toBe("eq.1");
+  });
+});
+
+describe("DeleteLibNode", () => {
+  it("refuses to run without filters", async () => {
+    const node = makeNode(DeleteLibNode, { table_name: "items", filters: [] });
+    await expect(node.process()).rejects.toThrow(/At least one filter/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs with filters and return=minimal", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const node = makeNode(DeleteLibNode, {
+      table_name: "items",
+      filters: [["id", "eq", 7]]
+    });
+    const result = await node.process();
+    expect(result.output).toEqual({ deleted: true });
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+    expect((init.headers as Record<string, string>).Prefer).toBe(
+      "return=minimal"
+    );
+    expect(new URL(url).searchParams.get("id")).toBe("eq.7");
+  });
+});
+
+describe("UpsertLibNode", () => {
+  it("POSTs with merge-duplicates resolution", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: 1 }], 201));
+
+    const node = makeNode(UpsertLibNode, {
+      table_name: "items",
+      records: [{ id: 1, name: "one" }],
+      return_rows: true
+    });
+    const result = await node.process();
+    expect(result.output).toEqual([{ id: 1 }]);
+
+    const { init } = lastRequest();
+    expect((init.headers as Record<string, string>).Prefer).toBe(
+      "resolution=merge-duplicates,return=representation"
+    );
+  });
+});
+
+describe("RPCLibNode", () => {
+  it("POSTs params to /rest/v1/rpc/<fn>", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    const node = makeNode(RPCLibNode, {
+      function: "my_fn",
+      params: { x: 1 }
+    });
+    const result = await node.process();
+    expect(result.output).toEqual({ ok: true });
+
+    const { url, init } = lastRequest();
+    expect(url).toBe("https://xyz.supabase.co/rest/v1/rpc/my_fn");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ x: 1 });
+  });
+
+  it("wraps PostgREST errors", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ message: "function my_fn does not exist" }, 404)
+    );
+
+    const node = makeNode(RPCLibNode, { function: "my_fn", params: {} });
+    await expect(node.process()).rejects.toThrow(
+      "Supabase RPC error: function my_fn does not exist"
+    );
+  });
+});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -24,8 +24,7 @@
     "@aws-sdk/client-s3": "^3.1029.0",
     "@aws-sdk/s3-request-presigner": "^3.1029.0",
     "@nodetool-ai/config": "*",
-    "@openclaw/fs-safe": "^0.1.2",
-    "@supabase/supabase-js": "^2.98.0"
+    "@openclaw/fs-safe": "^0.1.2"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^9.6.1",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -28,6 +28,12 @@ export {
   SupabaseStorageAdapter,
   type SupabaseStorageAdapterOptions
 } from "./supabase-storage-adapter.js";
+export {
+  createSupabaseStorageClient,
+  type SupabaseStorageApi,
+  type SupabaseBucketApi,
+  type SupabaseObjectEntry
+} from "./supabase-rest.js";
 export { createStorageAdapter, type StorageConfig } from "./factory.js";
 
 // URL builder

--- a/packages/storage/src/supabase-rest.ts
+++ b/packages/storage/src/supabase-rest.ts
@@ -98,7 +98,8 @@ export function createSupabaseStorageClient(
   supabaseUrl: string,
   supabaseKey: string
 ): SupabaseStorageApi {
-  const base = supabaseUrl.replace(/\/+$/, "");
+  let base = supabaseUrl;
+  while (base.endsWith("/")) base = base.slice(0, -1);
   const authHeaders: Record<string, string> = {
     apikey: supabaseKey,
     Authorization: `Bearer ${supabaseKey}`

--- a/packages/storage/src/supabase-rest.ts
+++ b/packages/storage/src/supabase-rest.ts
@@ -1,0 +1,221 @@
+/**
+ * Minimal fetch-backed client for the Supabase Storage REST API
+ * (`/storage/v1/`), covering exactly the surface this package uses:
+ * upload, download, remove, list, createSignedUrl, getPublicUrl.
+ *
+ * The shape mirrors the supabase-js subset previously consumed
+ * (`client.storage.from(bucket).<op>()` returning `{ data, error }`), so
+ * call sites and test fakes stay small and structural.
+ */
+
+export interface SupabaseError {
+  message: string;
+}
+
+/** Blob-compatible download payload — only `arrayBuffer()` is consumed. */
+export interface SupabaseDownloadData {
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+/** One entry from the Storage `list` endpoint. */
+export interface SupabaseObjectEntry {
+  name: string;
+  /** `null`/absent for pseudo-directory entries. */
+  id?: string | null;
+  updated_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SupabaseListOptions {
+  limit?: number;
+  offset?: number;
+  search?: string;
+}
+
+export interface SupabaseUploadOptions {
+  contentType?: string;
+  upsert?: boolean;
+}
+
+export interface SupabaseBucketApi {
+  upload(
+    key: string,
+    data: Buffer | Uint8Array,
+    options?: SupabaseUploadOptions
+  ): Promise<{ error: SupabaseError | null }>;
+  download(
+    key: string
+  ): Promise<{ data: SupabaseDownloadData | null; error: SupabaseError | null }>;
+  remove(keys: string[]): Promise<{ error: SupabaseError | null }>;
+  list(
+    dir: string,
+    options?: SupabaseListOptions
+  ): Promise<{ data: SupabaseObjectEntry[] | null; error: SupabaseError | null }>;
+  createSignedUrl(
+    key: string,
+    expiresIn: number
+  ): Promise<{ data: { signedUrl: string } | null; error: SupabaseError | null }>;
+  getPublicUrl(key: string): { data: { publicUrl: string } };
+}
+
+export interface SupabaseStorageApi {
+  storage: {
+    from(bucket: string): SupabaseBucketApi;
+  };
+}
+
+/** Encode an object key path segment-by-segment (slashes stay literal). */
+function encodeKey(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Map a Storage API error body (`{ statusCode, error, message }`) to a
+ * SupabaseError, falling back to the HTTP status.
+ */
+async function readError(response: Response): Promise<SupabaseError> {
+  let message = "";
+  try {
+    const body = (await response.json()) as Record<string, unknown>;
+    if (typeof body.message === "string" && body.message) {
+      message = body.message;
+    } else if (typeof body.error === "string" && body.error) {
+      message = body.error;
+    }
+  } catch {
+    // Non-JSON error body — use the status fallback below.
+  }
+  return {
+    message:
+      message || `Supabase Storage request failed with status ${response.status}`
+  };
+}
+
+/**
+ * Create a fetch-backed Supabase Storage client.
+ */
+export function createSupabaseStorageClient(
+  supabaseUrl: string,
+  supabaseKey: string
+): SupabaseStorageApi {
+  const base = supabaseUrl.replace(/\/+$/, "");
+  const authHeaders: Record<string, string> = {
+    apikey: supabaseKey,
+    Authorization: `Bearer ${supabaseKey}`
+  };
+
+  return {
+    storage: {
+      from(bucket: string): SupabaseBucketApi {
+        const objectUrl = (key: string): string =>
+          `${base}/storage/v1/object/${bucket}/${encodeKey(key)}`;
+
+        return {
+          async upload(key, data, options = {}) {
+            const headers: Record<string, string> = { ...authHeaders };
+            if (options.contentType) {
+              headers["Content-Type"] = options.contentType;
+            }
+            if (options.upsert) {
+              headers["x-upsert"] = "true";
+            }
+            const response = await fetch(objectUrl(key), {
+              method: "POST",
+              headers,
+              body: data as unknown as BodyInit
+            });
+            if (!response.ok) {
+              return { error: await readError(response) };
+            }
+            return { error: null };
+          },
+
+          async download(key) {
+            const response = await fetch(objectUrl(key), {
+              method: "GET",
+              headers: authHeaders
+            });
+            if (!response.ok) {
+              return { data: null, error: await readError(response) };
+            }
+            const bytes = await response.arrayBuffer();
+            return {
+              data: { arrayBuffer: async () => bytes },
+              error: null
+            };
+          },
+
+          async remove(keys) {
+            const response = await fetch(
+              `${base}/storage/v1/object/${bucket}`,
+              {
+                method: "DELETE",
+                headers: { ...authHeaders, "Content-Type": "application/json" },
+                body: JSON.stringify({ prefixes: keys })
+              }
+            );
+            if (!response.ok) {
+              return { error: await readError(response) };
+            }
+            return { error: null };
+          },
+
+          async list(dir, options = {}) {
+            const response = await fetch(
+              `${base}/storage/v1/object/list/${bucket}`,
+              {
+                method: "POST",
+                headers: { ...authHeaders, "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  prefix: dir,
+                  limit: options.limit ?? 100,
+                  offset: options.offset ?? 0,
+                  sortBy: { column: "name", order: "asc" },
+                  ...(options.search ? { search: options.search } : {})
+                })
+              }
+            );
+            if (!response.ok) {
+              return { data: null, error: await readError(response) };
+            }
+            const data = (await response.json()) as SupabaseObjectEntry[];
+            return { data, error: null };
+          },
+
+          async createSignedUrl(key, expiresIn) {
+            const response = await fetch(
+              `${base}/storage/v1/object/sign/${bucket}/${encodeKey(key)}`,
+              {
+                method: "POST",
+                headers: { ...authHeaders, "Content-Type": "application/json" },
+                body: JSON.stringify({ expiresIn })
+              }
+            );
+            if (!response.ok) {
+              return { data: null, error: await readError(response) };
+            }
+            const body = (await response.json()) as { signedURL?: string };
+            if (!body.signedURL) {
+              return {
+                data: null,
+                error: { message: "Supabase sign response missing signedURL" }
+              };
+            }
+            return {
+              data: { signedUrl: `${base}/storage/v1${body.signedURL}` },
+              error: null
+            };
+          },
+
+          getPublicUrl(key) {
+            return {
+              data: {
+                publicUrl: `${base}/storage/v1/object/public/${bucket}/${key}`
+              }
+            };
+          }
+        };
+      }
+    }
+  };
+}

--- a/packages/storage/src/supabase-storage-adapter.ts
+++ b/packages/storage/src/supabase-storage-adapter.ts
@@ -1,4 +1,7 @@
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import {
+  createSupabaseStorageClient,
+  type SupabaseStorageApi
+} from "./supabase-rest.js";
 import type {
   StorageAdapter,
   StorageEntry,
@@ -13,11 +16,12 @@ export interface SupabaseStorageAdapterOptions {
   apiKey: string;
   bucket: string;
   /** Optional pre-built client (used by tests). */
-  client?: SupabaseClient;
+  client?: SupabaseStorageApi;
 }
 
 /**
- * Supabase Storage adapter using `@supabase/supabase-js`.
+ * Supabase Storage adapter using the in-house fetch-backed REST client
+ * (see supabase-rest.ts).
  *
  * URI scheme: `supabase://<bucket>/<key>`. Use `getPublicUrl(uri)` to obtain a
  * client-facing HTTPS URL (the temp-url resolver in the websocket runner does
@@ -27,7 +31,7 @@ export class SupabaseStorageAdapter implements StorageAdapter {
   readonly bucket: string;
   readonly url: string;
   private readonly apiKey: string;
-  private client: SupabaseClient | null;
+  private client: SupabaseStorageApi | null;
 
   constructor(opts: SupabaseStorageAdapterOptions) {
     if (!opts.url) throw new Error("Supabase URL is required");
@@ -39,9 +43,9 @@ export class SupabaseStorageAdapter implements StorageAdapter {
     this.client = opts.client ?? null;
   }
 
-  private getClient(): SupabaseClient {
+  private getClient(): SupabaseStorageApi {
     if (!this.client) {
-      this.client = createClient(this.url, this.apiKey);
+      this.client = createSupabaseStorageClient(this.url, this.apiKey);
     }
     return this.client;
   }

--- a/packages/storage/src/supabase-storage.ts
+++ b/packages/storage/src/supabase-storage.ts
@@ -1,17 +1,19 @@
 /**
  * SupabaseStorage — T-ST-5.
  *
- * Storage backend for Supabase Storage buckets.
+ * Storage backend for Supabase Storage buckets, on top of the in-house
+ * fetch-backed REST client (see supabase-rest.ts).
  */
 
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { AbstractStorage } from "./abstract-storage.js";
+import {
+  createSupabaseStorageClient,
+  type SupabaseStorageApi
+} from "./supabase-rest.js";
 import { assertUploadWithinLimit } from "./storage-limits.js";
 
-type SupabaseClientLike = SupabaseClient;
-
 export class SupabaseStorage implements AbstractStorage {
-  private client: SupabaseClientLike | null = null;
+  private client: SupabaseStorageApi | null = null;
 
   constructor(
     private readonly supabaseUrl: string,
@@ -19,9 +21,12 @@ export class SupabaseStorage implements AbstractStorage {
     private readonly bucketName: string
   ) {}
 
-  private getClientSync(): SupabaseClientLike {
+  private getClientSync(): SupabaseStorageApi {
     if (!this.client) {
-      this.client = createClient(this.supabaseUrl, this.supabaseKey);
+      this.client = createSupabaseStorageClient(
+        this.supabaseUrl,
+        this.supabaseKey
+      );
     }
     return this.client;
   }
@@ -57,7 +62,6 @@ export class SupabaseStorage implements AbstractStorage {
         `Supabase download failed for key "${key}": ${error?.message ?? "no data returned"}`
       );
     }
-    // Blob → ArrayBuffer → Buffer
     const arrayBuffer = await data.arrayBuffer();
     return Buffer.from(arrayBuffer);
   }
@@ -82,14 +86,12 @@ export class SupabaseStorage implements AbstractStorage {
   }
 
   getUrl(key: string): string {
-    // Construct the public URL without needing the client.
-    // Supabase public URL pattern: {supabaseUrl}/storage/v1/object/public/{bucket}/{key}
-    // But we use the SDK pattern when client is available.
+    // Public URL pattern: {supabaseUrl}/storage/v1/object/public/{bucket}/{key}
     if (this.client) {
       return this.client.storage.from(this.bucketName).getPublicUrl(key).data
         .publicUrl;
     }
-    // Fallback: construct manually
+    // Fallback: construct manually before the client is initialised.
     const base = this.supabaseUrl.replace(/\/+$/, "");
     return `${base}/storage/v1/object/public/${this.bucketName}/${key}`;
   }

--- a/packages/storage/src/url-builder.ts
+++ b/packages/storage/src/url-builder.ts
@@ -9,8 +9,8 @@
 
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { createClient } from "@supabase/supabase-js";
 import { SIGNED_URL_TTL } from "@nodetool-ai/config";
+import { createSupabaseStorageClient } from "./supabase-rest.js";
 import type { StorageConfig } from "./factory.js";
 
 export function createAssetUrlBuilder(
@@ -39,7 +39,7 @@ export function createAssetUrlBuilder(
     }
 
     case "supabase": {
-      const supabase = createClient(config.url, config.apiKey);
+      const supabase = createSupabaseStorageClient(config.url, config.apiKey);
       const bucket = config.bucket;
       return async (key: string) => {
         const { data, error } = await supabase.storage

--- a/packages/storage/tests/supabase-rest.test.ts
+++ b/packages/storage/tests/supabase-rest.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSupabaseStorageClient } from "../src/supabase-rest.js";
+import { createAssetUrlBuilder } from "../src/url-builder.js";
+import { SIGNED_URL_TTL } from "@nodetool-ai/config";
+
+// Fetch-layer tests for the in-house Supabase Storage REST client: exact
+// request URLs/headers/bodies for list, createSignedUrl, upsert uploads, and
+// error mapping. Upload/download/remove basics are covered through
+// SupabaseStorage in supabase-storage.test.ts.
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function lastRequest(): { url: string; init: RequestInit } {
+  const [url, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  return { url: String(url), init: init ?? {} };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const client = () =>
+  createSupabaseStorageClient("https://xyz.supabase.co", "service-key");
+
+describe("createSupabaseStorageClient", () => {
+  it("upload with upsert sets the x-upsert header", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}));
+
+    await client()
+      .storage.from("uploads")
+      .upload("a/b.png", new Uint8Array([1]), {
+        contentType: "image/png",
+        upsert: true
+      });
+
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/storage/v1/object/uploads/a/b.png"
+    );
+    expect(init.headers).toEqual({
+      apikey: "service-key",
+      Authorization: "Bearer service-key",
+      "Content-Type": "image/png",
+      "x-upsert": "true"
+    });
+  });
+
+  it("list POSTs prefix/limit/search with name-asc sorting", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse([
+        {
+          name: "b.png",
+          id: "1",
+          updated_at: "2026-01-01T00:00:00Z",
+          metadata: { size: 5, mimetype: "image/png" }
+        }
+      ])
+    );
+
+    const { data, error } = await client()
+      .storage.from("uploads")
+      .list("dir", { search: "b.png", limit: 1 });
+
+    expect(error).toBeNull();
+    expect(data).toEqual([
+      {
+        name: "b.png",
+        id: "1",
+        updated_at: "2026-01-01T00:00:00Z",
+        metadata: { size: 5, mimetype: "image/png" }
+      }
+    ]);
+
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/storage/v1/object/list/uploads"
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      prefix: "dir",
+      limit: 1,
+      offset: 0,
+      sortBy: { column: "name", order: "asc" },
+      search: "b.png"
+    });
+  });
+
+  it("createSignedUrl POSTs expiresIn and resolves the absolute URL", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ signedURL: "/object/sign/uploads/a.png?token=tkn" })
+    );
+
+    const { data, error } = await client()
+      .storage.from("uploads")
+      .createSignedUrl("a.png", 900);
+
+    expect(error).toBeNull();
+    expect(data?.signedUrl).toBe(
+      "https://xyz.supabase.co/storage/v1/object/sign/uploads/a.png?token=tkn"
+    );
+
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/storage/v1/object/sign/uploads/a.png"
+    );
+    expect(JSON.parse(init.body as string)).toEqual({ expiresIn: 900 });
+  });
+
+  it("maps Storage error bodies on list and sign", async () => {
+    // A fresh Response per call — bodies are single-use.
+    fetchMock.mockImplementation(async () =>
+      jsonResponse(
+        { statusCode: 404, error: "Not found", message: "Bucket not found" },
+        404
+      )
+    );
+
+    const listResult = await client().storage.from("nope").list("");
+    expect(listResult.data).toBeNull();
+    expect(listResult.error?.message).toBe("Bucket not found");
+
+    const signResult = await client()
+      .storage.from("nope")
+      .createSignedUrl("a.png", 60);
+    expect(signResult.data).toBeNull();
+    expect(signResult.error?.message).toBe("Bucket not found");
+  });
+
+  it("getPublicUrl builds the public object URL without fetching", () => {
+    const { data } = client().storage.from("uploads").getPublicUrl("a/b.png");
+    expect(data.publicUrl).toBe(
+      "https://xyz.supabase.co/storage/v1/object/public/uploads/a/b.png"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("createAssetUrlBuilder (supabase)", () => {
+  it("returns the signed URL for a key", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ signedURL: "/object/sign/assets/k.png?token=t" })
+    );
+
+    const build = createAssetUrlBuilder({
+      kind: "supabase",
+      url: "https://xyz.supabase.co",
+      apiKey: "service-key",
+      bucket: "assets"
+    });
+    const signed = await build("k.png");
+    expect(signed).toBe(
+      "https://xyz.supabase.co/storage/v1/object/sign/assets/k.png?token=t"
+    );
+
+    const { init } = lastRequest();
+    expect(JSON.parse(init.body as string)).toEqual({
+      expiresIn: SIGNED_URL_TTL
+    });
+  });
+
+  it("throws a mapped error when signing fails", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ statusCode: 400, message: "Object not found" }, 400)
+    );
+
+    const build = createAssetUrlBuilder({
+      kind: "supabase",
+      url: "https://xyz.supabase.co",
+      apiKey: "service-key",
+      bucket: "assets"
+    });
+    await expect(build("missing.png")).rejects.toThrow(
+      'Failed to create signed URL for "missing.png": Object not found'
+    );
+  });
+});

--- a/packages/storage/tests/supabase-storage.test.ts
+++ b/packages/storage/tests/supabase-storage.test.ts
@@ -1,35 +1,35 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SupabaseStorage } from "../src/supabase-storage.js";
 
-// Mock Supabase SDK
-const mockUpload = vi.fn();
-const mockDownload = vi.fn();
-const mockRemove = vi.fn();
-const mockGetPublicUrl = vi.fn();
+// SupabaseStorage sits on the in-house fetch-backed Storage REST client, so
+// the tests mock global fetch and assert the exact requests it issues.
 
-const mockBucket = {
-  upload: mockUpload,
-  download: mockDownload,
-  remove: mockRemove,
-  getPublicUrl: mockGetPublicUrl
-};
+const fetchMock = vi.fn<typeof fetch>();
 
-vi.mock("@supabase/supabase-js", () => ({
-  createClient: vi.fn().mockImplementation(() => ({
-    storage: {
-      from: vi.fn().mockReturnValue(mockBucket)
-    }
-  }))
-}));
+function okResponse(body: BodyInit | null = "{}", status = 200): Response {
+  return new Response(body, { status });
+}
+
+function errorResponse(message: string, status = 400): Response {
+  return new Response(JSON.stringify({ statusCode: status, message }), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("SupabaseStorage", () => {
   let storage: SupabaseStorage;
 
   beforeEach(() => {
-    mockUpload.mockReset();
-    mockDownload.mockReset();
-    mockRemove.mockReset();
-    mockGetPublicUrl.mockReset();
     storage = new SupabaseStorage(
       "https://project.supabase.co",
       "service-key",
@@ -38,263 +38,152 @@ describe("SupabaseStorage", () => {
   });
 
   describe("upload", () => {
-    it("uploads data with content type", async () => {
-      mockUpload.mockResolvedValue({ data: { path: "file.txt" }, error: null });
+    it("POSTs bytes with auth headers and content type", async () => {
+      fetchMock.mockResolvedValue(okResponse());
       await storage.upload("file.txt", Buffer.from("hello"), "text/plain");
-      expect(mockUpload).toHaveBeenCalledWith("file.txt", expect.any(Buffer), {
-        contentType: "text/plain"
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://project.supabase.co/storage/v1/object/assets/file.txt"
+      );
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toEqual({
+        apikey: "service-key",
+        Authorization: "Bearer service-key",
+        "Content-Type": "text/plain"
       });
+      expect(Buffer.from(init?.body as Uint8Array).toString()).toBe("hello");
     });
 
     it("uploads without content type", async () => {
-      mockUpload.mockResolvedValue({ data: { path: "file.txt" }, error: null });
+      fetchMock.mockResolvedValue(okResponse());
       await storage.upload("file.txt", Buffer.from("hello"));
-      expect(mockUpload).toHaveBeenCalledWith(
-        "file.txt",
-        expect.any(Buffer),
-        {}
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init?.headers).toEqual({
+        apikey: "service-key",
+        Authorization: "Bearer service-key"
+      });
+    });
+
+    it("URL-encodes key segments but keeps slashes", async () => {
+      fetchMock.mockResolvedValue(okResponse());
+      await storage.upload("dir name/file #1.txt", Buffer.from("x"));
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "https://project.supabase.co/storage/v1/object/assets/dir%20name/file%20%231.txt"
       );
     });
 
-    it("throws on upload error", async () => {
-      mockUpload.mockResolvedValue({
-        data: null,
-        error: { message: "Bucket full" }
-      });
+    it("throws with the mapped error message on failure", async () => {
+      fetchMock.mockResolvedValue(errorResponse("Bucket full", 507));
       await expect(
         storage.upload("file.txt", Buffer.from("hello"))
-      ).rejects.toThrow("Supabase upload failed");
+      ).rejects.toThrow('Supabase upload failed for key "file.txt": Bucket full');
+    });
+
+    it("falls back to a status message for non-JSON error bodies", async () => {
+      fetchMock.mockResolvedValue(new Response("boom", { status: 502 }));
+      await expect(
+        storage.upload("file.txt", Buffer.from("hello"))
+      ).rejects.toThrow("Supabase Storage request failed with status 502");
     });
   });
 
   describe("download", () => {
-    it("returns buffer from blob", async () => {
-      const blob = new Blob(["hello world"]);
-      mockDownload.mockResolvedValue({ data: blob, error: null });
+    it("GETs the object and returns a Buffer", async () => {
+      fetchMock.mockResolvedValue(okResponse("hello world"));
       const result = await storage.download("file.txt");
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://project.supabase.co/storage/v1/object/assets/file.txt"
+      );
+      expect(init?.method).toBe("GET");
+      expect(init?.headers).toEqual({
+        apikey: "service-key",
+        Authorization: "Bearer service-key"
+      });
       expect(Buffer.isBuffer(result)).toBe(true);
       expect(result.toString()).toBe("hello world");
     });
 
-    it("throws on download error", async () => {
-      mockDownload.mockResolvedValue({
-        data: null,
-        error: { message: "Not found" }
-      });
-      await expect(storage.download("missing.txt")).rejects.toThrow(
-        "Supabase download failed"
-      );
+    it("round-trips binary data", async () => {
+      const binary = new Uint8Array([0, 1, 127, 128, 255, 0, 42]);
+      fetchMock.mockResolvedValue(okResponse(binary));
+      const result = await storage.download("binary.bin");
+      expect([...result]).toEqual([0, 1, 127, 128, 255, 0, 42]);
     });
 
-    it("throws when data is null without error", async () => {
-      mockDownload.mockResolvedValue({ data: null, error: null });
-      await expect(storage.download("missing.txt")).rejects.toThrow(
-        "no data returned"
+    it("throws on download error with the key in the message", async () => {
+      fetchMock.mockResolvedValue(errorResponse("Object not found", 404));
+      await expect(storage.download("missing/file.txt")).rejects.toThrow(
+        'Supabase download failed for key "missing/file.txt": Object not found'
       );
     });
   });
 
   describe("delete", () => {
-    it("removes the file", async () => {
-      mockRemove.mockResolvedValue({ data: {}, error: null });
+    it("DELETEs the bucket path with a prefixes body", async () => {
+      fetchMock.mockResolvedValue(okResponse());
       await storage.delete("file.txt");
-      expect(mockRemove).toHaveBeenCalledWith(["file.txt"]);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://project.supabase.co/storage/v1/object/assets"
+      );
+      expect(init?.method).toBe("DELETE");
+      expect(JSON.parse(init?.body as string)).toEqual({
+        prefixes: ["file.txt"]
+      });
     });
 
     it("throws on delete error", async () => {
-      mockRemove.mockResolvedValue({
-        data: null,
-        error: { message: "Permission denied" }
-      });
-      await expect(storage.delete("file.txt")).rejects.toThrow(
-        "Supabase delete failed"
+      fetchMock.mockResolvedValue(errorResponse("Permission denied", 403));
+      await expect(storage.delete("secret/key.txt")).rejects.toThrow(
+        'Supabase delete failed for key "secret/key.txt": Permission denied'
       );
     });
   });
 
   describe("exists", () => {
-    it("returns true when download succeeds", async () => {
-      mockDownload.mockResolvedValue({ data: new Blob([""]), error: null });
+    it("returns true when the download succeeds", async () => {
+      fetchMock.mockResolvedValue(okResponse(""));
       expect(await storage.exists("file.txt")).toBe(true);
     });
 
-    it("returns false when download errors", async () => {
-      mockDownload.mockResolvedValue({
-        data: null,
-        error: { message: "Not found" }
-      });
+    it("returns false when the download errors", async () => {
+      fetchMock.mockResolvedValue(errorResponse("Object not found", 404));
       expect(await storage.exists("missing.txt")).toBe(false);
     });
   });
 
   describe("getUrl", () => {
-    it("returns public URL via client when initialized", async () => {
-      // Trigger client initialization by calling any async method first
-      mockDownload.mockResolvedValue({ data: new Blob([""]), error: null });
+    it("returns the public URL after client initialisation", async () => {
+      fetchMock.mockResolvedValue(okResponse(""));
       await storage.exists("init");
 
-      mockGetPublicUrl.mockReturnValue({
-        data: {
-          publicUrl:
-            "https://project.supabase.co/storage/v1/object/public/assets/file.txt"
-        }
-      });
-      const url = storage.getUrl("file.txt");
-      expect(url).toBe(
+      expect(storage.getUrl("file.txt")).toBe(
         "https://project.supabase.co/storage/v1/object/public/assets/file.txt"
       );
     });
 
-    it("constructs URL manually before client is initialized", () => {
-      // getUrl is sync and may be called before any async method
-      const freshStorage = new SupabaseStorage(
-        "https://project.supabase.co",
-        "key",
-        "assets"
-      );
-      const url = freshStorage.getUrl("path/file.txt");
-      expect(url).toBe(
+    it("constructs the URL manually before client initialisation", () => {
+      expect(storage.getUrl("path/file.txt")).toBe(
         "https://project.supabase.co/storage/v1/object/public/assets/path/file.txt"
       );
     });
 
-    it("handles trailing slash in supabase URL", () => {
-      const freshStorage = new SupabaseStorage(
+    it("handles a trailing slash in the Supabase URL", () => {
+      const fresh = new SupabaseStorage(
         "https://project.supabase.co/",
         "key",
         "assets"
       );
-      const url = freshStorage.getUrl("file.txt");
-      expect(url).toBe(
+      expect(fresh.getUrl("file.txt")).toBe(
         "https://project.supabase.co/storage/v1/object/public/assets/file.txt"
       );
-    });
-
-    it("handles nested path keys", () => {
-      const freshStorage = new SupabaseStorage(
-        "https://project.supabase.co",
-        "key",
-        "assets"
-      );
-      const url = freshStorage.getUrl("folder/subfolder/file.txt");
-      expect(url).toBe(
-        "https://project.supabase.co/storage/v1/object/public/assets/folder/subfolder/file.txt"
-      );
-    });
-  });
-
-  describe("upload with Uint8Array", () => {
-    it("accepts plain Uint8Array data", async () => {
-      mockUpload.mockResolvedValue({ data: { path: "file.bin" }, error: null });
-      const data = new Uint8Array([1, 2, 3, 4, 5]);
-      await storage.upload("file.bin", data, "application/octet-stream");
-      expect(mockUpload).toHaveBeenCalledWith("file.bin", data, {
-        contentType: "application/octet-stream"
-      });
-    });
-  });
-
-  describe("exists edge cases", () => {
-    it("returns false when data is null without error", async () => {
-      mockDownload.mockResolvedValue({ data: null, error: null });
-      expect(await storage.exists("ghost.txt")).toBe(false);
-    });
-  });
-
-  describe("client caching", () => {
-    it("reuses the same client across multiple operations", async () => {
-      const { createClient } = await import("@supabase/supabase-js");
-
-      mockUpload.mockResolvedValue({ data: { path: "a.txt" }, error: null });
-      mockRemove.mockResolvedValue({ data: {}, error: null });
-
-      await storage.upload("a.txt", Buffer.from("a"));
-      await storage.upload("b.txt", Buffer.from("b"));
-      await storage.delete("c.txt");
-
-      // createClient should have been called only once (for this storage instance)
-      // The mock is shared, so we check the from() calls instead
-      // All operations go through bucket() which calls getClient()
-      // After first call, getClient() returns cached client
-      expect(mockUpload).toHaveBeenCalledTimes(2);
-      expect(mockRemove).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("download binary round-trip", () => {
-    it("correctly handles non-trivial binary data", async () => {
-      const binaryData = new Uint8Array([0, 1, 127, 128, 255, 0, 42]);
-      const blob = new Blob([binaryData]);
-      mockDownload.mockResolvedValue({ data: blob, error: null });
-
-      const result = await storage.download("binary.bin");
-      expect(Buffer.isBuffer(result)).toBe(true);
-      expect([...result]).toEqual([0, 1, 127, 128, 255, 0, 42]);
-    });
-  });
-
-  describe("upload then download round-trip", () => {
-    it("mocked chain works end to end", async () => {
-      const content = Buffer.from("round-trip content");
-      mockUpload.mockResolvedValue({ data: { path: "rt.txt" }, error: null });
-
-      await storage.upload("rt.txt", content, "text/plain");
-      expect(mockUpload).toHaveBeenCalledWith("rt.txt", content, {
-        contentType: "text/plain"
-      });
-
-      const blob = new Blob(["round-trip content"]);
-      mockDownload.mockResolvedValue({ data: blob, error: null });
-
-      const result = await storage.download("rt.txt");
-      expect(result.toString()).toBe("round-trip content");
-    });
-  });
-
-  describe("error propagation includes key name", () => {
-    it("upload error includes key", async () => {
-      mockUpload.mockResolvedValue({
-        data: null,
-        error: { message: "quota exceeded" }
-      });
-      await expect(
-        storage.upload("my/key.txt", Buffer.from("x"))
-      ).rejects.toThrow('"my/key.txt"');
-    });
-
-    it("download error includes key", async () => {
-      mockDownload.mockResolvedValue({
-        data: null,
-        error: { message: "not found" }
-      });
-      await expect(storage.download("missing/file.txt")).rejects.toThrow(
-        '"missing/file.txt"'
-      );
-    });
-
-    it("delete error includes key", async () => {
-      mockRemove.mockResolvedValue({
-        data: null,
-        error: { message: "forbidden" }
-      });
-      await expect(storage.delete("secret/key.txt")).rejects.toThrow(
-        '"secret/key.txt"'
-      );
-    });
-  });
-
-  describe("delete multiple keys sequentially", () => {
-    it("calls remove with correct key for each delete", async () => {
-      mockRemove.mockResolvedValue({ data: {}, error: null });
-
-      await storage.delete("file1.txt");
-      await storage.delete("file2.txt");
-      await storage.delete("file3.txt");
-
-      expect(mockRemove).toHaveBeenCalledTimes(3);
-      expect(mockRemove).toHaveBeenNthCalledWith(1, ["file1.txt"]);
-      expect(mockRemove).toHaveBeenNthCalledWith(2, ["file2.txt"]);
-      expect(mockRemove).toHaveBeenNthCalledWith(3, ["file3.txt"]);
     });
   });
 });

--- a/packages/vectorstore/package.json
+++ b/packages/vectorstore/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@nodetool-ai/config": "*",
     "@nodetool-ai/models": "*",
-    "@supabase/supabase-js": "^2.98.0",
     "better-sqlite3": "^12.8.0",
     "sqlite-vec": "^0.1.7-alpha.2"
   },

--- a/packages/vectorstore/src/index.ts
+++ b/packages/vectorstore/src/index.ts
@@ -39,6 +39,14 @@ export {
 } from "./supabase-provider.js";
 
 export {
+  PostgrestClient,
+  type PostgrestClientApi,
+  type PostgrestError,
+  type PostgrestRow,
+  type PostgrestRowsResult
+} from "./postgrest.js";
+
+export {
   createSqliteVecProvider,
   createVectorProviderFromEnv,
   getDefaultVectorProvider,

--- a/packages/vectorstore/src/postgrest.ts
+++ b/packages/vectorstore/src/postgrest.ts
@@ -321,7 +321,9 @@ export class PostgrestClient implements PostgrestClientApi {
   private readonly schema: string;
 
   constructor(options: PostgrestClientOptions) {
-    this.base = options.url.replace(/\/+$/, "");
+    let base = options.url;
+    while (base.endsWith("/")) base = base.slice(0, -1);
+    this.base = base;
     this.apiKey = options.apiKey;
     this.schema = options.schema ?? "public";
   }

--- a/packages/vectorstore/src/postgrest.ts
+++ b/packages/vectorstore/src/postgrest.ts
@@ -1,0 +1,385 @@
+/**
+ * Minimal fetch-backed PostgREST client (`/rest/v1/`), covering exactly the
+ * query surface SupabaseProvider uses: select (with count/head), insert,
+ * upsert (on_conflict), update, delete, the filter operators
+ * eq / in / is / ilike / contains, order, limit, range, maybeSingle, and rpc.
+ *
+ * The fluent shape mirrors the supabase-js subset previously consumed, so
+ * call sites and test fakes stay structural. Every builder is a thenable
+ * resolving to `{ data, error, count }` — errors are returned, not thrown,
+ * matching PostgREST's `{ message, code, details, hint }` error bodies.
+ */
+
+export interface PostgrestError {
+  message: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+}
+
+export type PostgrestRow = Record<string, unknown>;
+
+export interface PostgrestRowsResult {
+  data: PostgrestRow[] | null;
+  error: PostgrestError | null;
+  count: number | null;
+}
+
+export interface PostgrestMaybeSingleResult {
+  data: PostgrestRow | null;
+  error: PostgrestError | null;
+}
+
+export interface PostgrestRpcResult {
+  data: unknown;
+  error: PostgrestError | null;
+}
+
+export interface PostgrestSelectOptions {
+  count?: "exact";
+  head?: boolean;
+}
+
+export interface PostgrestUpsertOptions {
+  onConflict?: string;
+}
+
+/** The fluent builder surface used by SupabaseProvider. */
+export interface PostgrestFilterBuilder
+  extends PromiseLike<PostgrestRowsResult> {
+  eq(column: string, value: unknown): this;
+  in(column: string, values: readonly unknown[]): this;
+  is(column: string, value: null | boolean): this;
+  ilike(column: string, pattern: string): this;
+  contains(column: string, value: Record<string, unknown>): this;
+  order(column: string, options?: { ascending?: boolean }): this;
+  limit(n: number): this;
+  range(from: number, to: number): this;
+  maybeSingle(): PromiseLike<PostgrestMaybeSingleResult>;
+}
+
+export interface PostgrestTableApi {
+  select(
+    columns?: string,
+    options?: PostgrestSelectOptions
+  ): PostgrestFilterBuilder;
+  insert(values: PostgrestRow | PostgrestRow[]): PostgrestFilterBuilder;
+  upsert(
+    values: PostgrestRow | PostgrestRow[],
+    options?: PostgrestUpsertOptions
+  ): PostgrestFilterBuilder;
+  update(values: PostgrestRow): PostgrestFilterBuilder;
+  delete(): PostgrestFilterBuilder;
+}
+
+/** The client surface used by SupabaseProvider (injectable in tests). */
+export interface PostgrestClientApi {
+  from(table: string): PostgrestTableApi;
+  rpc(
+    name: string,
+    args: Record<string, unknown>
+  ): PromiseLike<PostgrestRpcResult>;
+}
+
+export interface PostgrestClientOptions {
+  /** Base URL of the Supabase project (e.g. https://xyz.supabase.co). */
+  url: string;
+  /** API key sent as both `apikey` and Bearer authorization. */
+  apiKey: string;
+  /** Postgres schema; sent via Accept-Profile / Content-Profile when not "public". */
+  schema?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Value encoding
+// ---------------------------------------------------------------------------
+
+/** Quote one element of an `in.(...)` list per PostgREST rules. */
+function quoteInElement(value: unknown): string {
+  const s = String(value);
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+async function readErrorBody(response: Response): Promise<PostgrestError> {
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = (await response.json()) as Record<string, unknown>;
+  } catch {
+    // Non-JSON error body — fall through to the status fallback.
+  }
+  const message =
+    parsed && typeof parsed.message === "string" && parsed.message
+      ? parsed.message
+      : `PostgREST request failed with status ${response.status}`;
+  const error: PostgrestError = { message };
+  if (parsed) {
+    if (typeof parsed.code === "string") error.code = parsed.code;
+    if (typeof parsed.details === "string") error.details = parsed.details;
+    if (typeof parsed.hint === "string") error.hint = parsed.hint;
+  }
+  return error;
+}
+
+/** Parse the total from a `Content-Range: 0-9/42` header. */
+function parseContentRangeCount(header: string | null): number | null {
+  if (!header) return null;
+  const total = header.split("/")[1];
+  if (!total || total === "*") return null;
+  const n = Number(total);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// Request state + execution
+// ---------------------------------------------------------------------------
+
+type Method = "GET" | "HEAD" | "POST" | "PATCH" | "DELETE";
+
+interface RequestState {
+  method: Method;
+  body?: string;
+  searchParams: URLSearchParams;
+  prefer: string[];
+  hasWriteBody: boolean;
+}
+
+class FilterBuilder implements PostgrestFilterBuilder {
+  constructor(
+    private readonly client: PostgrestClient,
+    private readonly table: string,
+    private readonly state: RequestState
+  ) {}
+
+  eq(column: string, value: unknown): this {
+    this.state.searchParams.append(column, `eq.${String(value)}`);
+    return this;
+  }
+
+  in(column: string, values: readonly unknown[]): this {
+    this.state.searchParams.append(
+      column,
+      `in.(${values.map(quoteInElement).join(",")})`
+    );
+    return this;
+  }
+
+  is(column: string, value: null | boolean): this {
+    this.state.searchParams.append(
+      column,
+      `is.${value === null ? "null" : String(value)}`
+    );
+    return this;
+  }
+
+  ilike(column: string, pattern: string): this {
+    this.state.searchParams.append(column, `ilike.${pattern}`);
+    return this;
+  }
+
+  contains(column: string, value: Record<string, unknown>): this {
+    this.state.searchParams.append(column, `cs.${JSON.stringify(value)}`);
+    return this;
+  }
+
+  order(column: string, options?: { ascending?: boolean }): this {
+    const dir = options?.ascending === false ? "desc" : "asc";
+    this.state.searchParams.append("order", `${column}.${dir}`);
+    return this;
+  }
+
+  limit(n: number): this {
+    this.state.searchParams.set("limit", String(n));
+    return this;
+  }
+
+  range(from: number, to: number): this {
+    this.state.searchParams.set("offset", String(from));
+    this.state.searchParams.set("limit", String(to - from + 1));
+    return this;
+  }
+
+  maybeSingle(): PromiseLike<PostgrestMaybeSingleResult> {
+    this.limit(1);
+    return this.execute().then((res) => ({
+      data: res.data?.[0] ?? null,
+      error: res.error
+    }));
+  }
+
+  then<TResult1 = PostgrestRowsResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: PostgrestRowsResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected);
+  }
+
+  private async execute(): Promise<PostgrestRowsResult> {
+    const response = await this.client.request(
+      `/rest/v1/${this.table}`,
+      this.state
+    );
+    if (!response.ok) {
+      return { data: null, error: await readErrorBody(response), count: null };
+    }
+    const count = parseContentRangeCount(
+      response.headers.get("content-range")
+    );
+    if (this.state.method === "HEAD") {
+      return { data: null, error: null, count };
+    }
+    const text = await response.text();
+    if (!text) {
+      return { data: null, error: null, count };
+    }
+    const parsed = JSON.parse(text) as PostgrestRow[] | PostgrestRow;
+    return {
+      data: Array.isArray(parsed) ? parsed : [parsed],
+      error: null,
+      count
+    };
+  }
+}
+
+class TableApi implements PostgrestTableApi {
+  constructor(
+    private readonly client: PostgrestClient,
+    private readonly table: string
+  ) {}
+
+  private builder(state: RequestState): FilterBuilder {
+    return new FilterBuilder(this.client, this.table, state);
+  }
+
+  select(
+    columns = "*",
+    options: PostgrestSelectOptions = {}
+  ): PostgrestFilterBuilder {
+    const searchParams = new URLSearchParams();
+    searchParams.set("select", columns.replace(/\s/g, ""));
+    const prefer: string[] = [];
+    if (options.count) prefer.push(`count=${options.count}`);
+    return this.builder({
+      method: options.head ? "HEAD" : "GET",
+      searchParams,
+      prefer,
+      hasWriteBody: false
+    });
+  }
+
+  insert(values: PostgrestRow | PostgrestRow[]): PostgrestFilterBuilder {
+    return this.builder({
+      method: "POST",
+      body: JSON.stringify(values),
+      searchParams: new URLSearchParams(),
+      prefer: ["return=minimal"],
+      hasWriteBody: true
+    });
+  }
+
+  upsert(
+    values: PostgrestRow | PostgrestRow[],
+    options: PostgrestUpsertOptions = {}
+  ): PostgrestFilterBuilder {
+    const searchParams = new URLSearchParams();
+    if (options.onConflict) {
+      searchParams.set("on_conflict", options.onConflict);
+    }
+    return this.builder({
+      method: "POST",
+      body: JSON.stringify(values),
+      searchParams,
+      prefer: ["resolution=merge-duplicates", "return=minimal"],
+      hasWriteBody: true
+    });
+  }
+
+  update(values: PostgrestRow): PostgrestFilterBuilder {
+    return this.builder({
+      method: "PATCH",
+      body: JSON.stringify(values),
+      searchParams: new URLSearchParams(),
+      prefer: ["return=minimal"],
+      hasWriteBody: true
+    });
+  }
+
+  delete(): PostgrestFilterBuilder {
+    return this.builder({
+      method: "DELETE",
+      searchParams: new URLSearchParams(),
+      prefer: ["return=minimal"],
+      hasWriteBody: false
+    });
+  }
+}
+
+export class PostgrestClient implements PostgrestClientApi {
+  private readonly base: string;
+  private readonly apiKey: string;
+  private readonly schema: string;
+
+  constructor(options: PostgrestClientOptions) {
+    this.base = options.url.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.schema = options.schema ?? "public";
+  }
+
+  from(table: string): PostgrestTableApi {
+    return new TableApi(this, table);
+  }
+
+  rpc(
+    name: string,
+    args: Record<string, unknown>
+  ): PromiseLike<PostgrestRpcResult> {
+    return this.executeRpc(name, args);
+  }
+
+  private async executeRpc(
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<PostgrestRpcResult> {
+    const response = await this.request(`/rest/v1/rpc/${name}`, {
+      method: "POST",
+      body: JSON.stringify(args),
+      searchParams: new URLSearchParams(),
+      prefer: [],
+      hasWriteBody: true
+    });
+    if (!response.ok) {
+      return { data: null, error: await readErrorBody(response) };
+    }
+    const text = await response.text();
+    return { data: text ? (JSON.parse(text) as unknown) : null, error: null };
+  }
+
+  /** Perform one HTTP request against the PostgREST endpoint. */
+  async request(path: string, state: RequestState): Promise<Response> {
+    const qs = state.searchParams.toString();
+    const url = `${this.base}${path}${qs ? `?${qs}` : ""}`;
+    const headers: Record<string, string> = {
+      apikey: this.apiKey,
+      Authorization: `Bearer ${this.apiKey}`
+    };
+    if (state.hasWriteBody) {
+      headers["Content-Type"] = "application/json";
+    }
+    if (state.prefer.length > 0) {
+      headers.Prefer = state.prefer.join(",");
+    }
+    if (this.schema !== "public") {
+      if (state.method === "GET" || state.method === "HEAD") {
+        headers["Accept-Profile"] = this.schema;
+      } else {
+        headers["Content-Profile"] = this.schema;
+      }
+    }
+    return fetch(url, {
+      method: state.method,
+      headers,
+      ...(state.body !== undefined ? { body: state.body } : {})
+    });
+  }
+}

--- a/packages/vectorstore/src/supabase-provider.ts
+++ b/packages/vectorstore/src/supabase-provider.ts
@@ -1,6 +1,6 @@
 /**
- * Supabase implementation of the VectorProvider interface, on top of
- * `@supabase/supabase-js`.
+ * Supabase implementation of the VectorProvider interface, on top of the
+ * in-house fetch-backed PostgREST client (see postgrest.ts).
  *
  * Storage layout (must be installed once via `sql/supabase-migration.sql`):
  *
@@ -14,7 +14,7 @@
  * Supabase's own AI guides (https://supabase.com/docs/guides/ai).
  */
 
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { PostgrestClient, type PostgrestClientApi } from "./postgrest.js";
 import {
   CollectionNotFoundError,
   ProviderConfigError,
@@ -44,8 +44,8 @@ export interface SupabaseProviderOptions {
   apiKey?: string;
   /** Postgres schema housing the registry and records tables. Defaults to "public". */
   schema?: string;
-  /** Pre-built Supabase client. Used by tests; if set, url/apiKey are ignored. */
-  client?: SupabaseClient;
+  /** Pre-built PostgREST client. Used by tests; if set, url/apiKey are ignored. */
+  client?: PostgrestClientApi;
   /** Default embedding function applied when records/queries are text-only. */
   defaultEmbeddingFunction?: EmbeddingFunction;
   /** Override registry table name. Defaults to "nodetool_vec_collections". */
@@ -505,7 +505,7 @@ export class SupabaseProvider implements VectorProvider {
   private readonly url: string | undefined;
   private readonly apiKey: string | undefined;
   private readonly defaultEf?: EmbeddingFunction;
-  private client: SupabaseClient | null;
+  private client: PostgrestClientApi | null;
 
   constructor(opts: SupabaseProviderOptions = {}) {
     if (!opts.client && (!opts.url || !opts.apiKey)) {
@@ -524,14 +524,12 @@ export class SupabaseProvider implements VectorProvider {
   }
 
   /** Returns the underlying client, instantiating one on first use. */
-  getClient(): SupabaseClient {
+  getClient(): PostgrestClientApi {
     if (!this.client) {
-      // Use the default-schema client; per-query schema scoping happens at
-      // the call site via `client.schema(this.schema)` if needed. Passing
-      // `db.schema` to createClient narrows the generic to a literal string
-      // type and breaks assignment, which doesn't add value for our use.
-      this.client = createClient(this.url!, this.apiKey!, {
-        auth: { persistSession: false }
+      this.client = new PostgrestClient({
+        url: this.url!,
+        apiKey: this.apiKey!,
+        schema: this.schema
       });
     }
     return this.client;
@@ -616,7 +614,7 @@ export class SupabaseProvider implements VectorProvider {
   }
 
   close(): void {
-    // supabase-js does not hold a persistent connection; nothing to close.
+    // The PostgREST client is stateless HTTP; nothing to close.
   }
 
   // ----- internal helpers -------------------------------------------------

--- a/packages/vectorstore/tests/postgrest.test.ts
+++ b/packages/vectorstore/tests/postgrest.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PostgrestClient } from "../src/index.js";
+
+// Fetch-layer tests for the in-house PostgREST client: exact URLs,
+// query-string operators, headers, bodies, response decoding, and error
+// mapping for every operation SupabaseProvider uses.
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {}
+): Response {
+  return new Response(body === null ? null : JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) }
+  });
+}
+
+function lastRequest(): { url: string; init: RequestInit } {
+  const [url, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  return { url: String(url), init: init ?? {} };
+}
+
+let client: PostgrestClient;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  client = new PostgrestClient({
+    url: "https://xyz.supabase.co",
+    apiKey: "service-key"
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("PostgrestClient — select", () => {
+  it("GETs with select, eq filter, order, and auth headers", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: "1" }]));
+
+    const { data, error } = await client
+      .from("records")
+      .select("id, document")
+      .eq("collection", "docs")
+      .order("id");
+
+    expect(error).toBeNull();
+    expect(data).toEqual([{ id: "1" }]);
+
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/rest/v1/records?select=id%2Cdocument&collection=eq.docs&order=id.asc"
+    );
+    expect(init.method).toBe("GET");
+    expect(init.headers).toEqual({
+      apikey: "service-key",
+      Authorization: "Bearer service-key"
+    });
+  });
+
+  it("encodes in.(...) lists with quoted elements", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await client
+      .from("records")
+      .select("id")
+      .in("id", ["a", 'b"quote', "c,comma"]);
+
+    const { url } = lastRequest();
+    const params = new URL(url).searchParams;
+    expect(params.get("id")).toBe('in.("a","b\\"quote","c,comma")');
+  });
+
+  it("encodes ilike, contains (cs) and limit", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await client
+      .from("records")
+      .select("id")
+      .ilike("document", "%fox%")
+      .contains("metadata", { kind: "x" })
+      .limit(5);
+
+    const params = new URL(lastRequest().url).searchParams;
+    expect(params.get("document")).toBe("ilike.%fox%");
+    expect(params.get("metadata")).toBe('cs.{"kind":"x"}');
+    expect(params.get("limit")).toBe("5");
+  });
+
+  it("maps range() to offset+limit", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await client.from("records").select("id").range(10, 19);
+
+    const params = new URL(lastRequest().url).searchParams;
+    expect(params.get("offset")).toBe("10");
+    expect(params.get("limit")).toBe("10");
+  });
+
+  it("order desc via ascending: false", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await client.from("records").select("id").order("id", { ascending: false });
+
+    expect(new URL(lastRequest().url).searchParams.get("order")).toBe(
+      "id.desc"
+    );
+  });
+
+  it("head+count issues HEAD with Prefer count=exact and parses Content-Range", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(null, { status: 200, headers: { "content-range": "0-24/57" } })
+    );
+
+    const result = await client
+      .from("records")
+      .select("*", { count: "exact", head: true })
+      .eq("collection", "docs");
+
+    expect(result.count).toBe(57);
+    expect(result.data).toBeNull();
+    expect(result.error).toBeNull();
+
+    const { init } = lastRequest();
+    expect(init.method).toBe("HEAD");
+    expect((init.headers as Record<string, string>).Prefer).toBe(
+      "count=exact"
+    );
+  });
+
+  it("maybeSingle returns the first row or null and applies limit=1", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ name: "docs" }]));
+
+    const one = await client
+      .from("collections")
+      .select("name")
+      .eq("name", "docs")
+      .maybeSingle();
+    expect(one.data).toEqual({ name: "docs" });
+    expect(new URL(lastRequest().url).searchParams.get("limit")).toBe("1");
+
+    fetchMock.mockResolvedValue(jsonResponse([]));
+    const none = await client
+      .from("collections")
+      .select("name")
+      .eq("name", "missing")
+      .maybeSingle();
+    expect(none.data).toBeNull();
+    expect(none.error).toBeNull();
+  });
+});
+
+describe("PostgrestClient — mutations", () => {
+  it("insert POSTs JSON with Prefer return=minimal", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+
+    const { error } = await client
+      .from("collections")
+      .insert({ name: "docs", dimension: 3 });
+
+    expect(error).toBeNull();
+    const { url, init } = lastRequest();
+    expect(url).toBe("https://xyz.supabase.co/rest/v1/collections");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Prefer).toBe("return=minimal");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "docs",
+      dimension: 3
+    });
+  });
+
+  it("upsert POSTs with on_conflict and merge-duplicates resolution", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+
+    await client
+      .from("records")
+      .upsert([{ id: "1" }], { onConflict: "collection,id" });
+
+    const { url, init } = lastRequest();
+    expect(new URL(url).searchParams.get("on_conflict")).toBe("collection,id");
+    expect((init.headers as Record<string, string>).Prefer).toBe(
+      "resolution=merge-duplicates,return=minimal"
+    );
+    expect(JSON.parse(init.body as string)).toEqual([{ id: "1" }]);
+  });
+
+  it("update PATCHes with filters including is.null", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await client
+      .from("collections")
+      .update({ dimension: 4 })
+      .eq("name", "docs")
+      .is("dimension", null);
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("PATCH");
+    const params = new URL(url).searchParams;
+    expect(params.get("name")).toBe("eq.docs");
+    expect(params.get("dimension")).toBe("is.null");
+    expect(JSON.parse(init.body as string)).toEqual({ dimension: 4 });
+  });
+
+  it("delete issues DELETE with filters and no body", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await client
+      .from("records")
+      .delete()
+      .eq("collection", "docs")
+      .in("id", ["a", "b"]);
+
+    const { url, init } = lastRequest();
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+    const params = new URL(url).searchParams;
+    expect(params.get("collection")).toBe("eq.docs");
+    expect(params.get("id")).toBe('in.("a","b")');
+  });
+});
+
+describe("PostgrestClient — rpc", () => {
+  it("POSTs args to /rest/v1/rpc/<fn> and decodes the result", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ id: "a", distance: 0.1 }]));
+
+    const { data, error } = await client.rpc("nodetool_vec_match", {
+      p_collection: "docs",
+      p_match_count: 5
+    });
+
+    expect(error).toBeNull();
+    expect(data).toEqual([{ id: "a", distance: 0.1 }]);
+
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/rest/v1/rpc/nodetool_vec_match"
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      p_collection: "docs",
+      p_match_count: 5
+    });
+  });
+});
+
+describe("PostgrestClient — error mapping", () => {
+  it("maps PostgREST error bodies to { message, code, details, hint }", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          message: "duplicate key value",
+          code: "23505",
+          details: "Key (name) already exists.",
+          hint: "rename it"
+        },
+        { status: 409 }
+      )
+    );
+
+    const { data, error } = await client
+      .from("collections")
+      .insert({ name: "docs" });
+
+    expect(data).toBeNull();
+    expect(error).toEqual({
+      message: "duplicate key value",
+      code: "23505",
+      details: "Key (name) already exists.",
+      hint: "rename it"
+    });
+  });
+
+  it("falls back to a status message for non-JSON error bodies", async () => {
+    fetchMock.mockResolvedValue(new Response("bad gateway", { status: 502 }));
+
+    const { error } = await client.from("records").select("id");
+    expect(error?.message).toBe("PostgREST request failed with status 502");
+  });
+
+  it("sends Accept-Profile / Content-Profile for a non-public schema", async () => {
+    const scoped = new PostgrestClient({
+      url: "https://xyz.supabase.co",
+      apiKey: "k",
+      schema: "vectors"
+    });
+    fetchMock.mockResolvedValue(jsonResponse([]));
+    await scoped.from("records").select("id");
+    expect(
+      (lastRequest().init.headers as Record<string, string>)["Accept-Profile"]
+    ).toBe("vectors");
+
+    fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+    await scoped.from("records").insert({ id: "1" });
+    expect(
+      (lastRequest().init.headers as Record<string, string>)["Content-Profile"]
+    ).toBe("vectors");
+  });
+});

--- a/packages/vectorstore/tests/supabase-provider.test.ts
+++ b/packages/vectorstore/tests/supabase-provider.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   CollectionNotFoundError,
   ProviderConfigError,
   SupabaseProvider,
   UnsupportedFilterError,
-  type EmbeddingFunction
+  type EmbeddingFunction,
+  type PostgrestClientApi
 } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
@@ -86,8 +86,8 @@ class FakeSupabase {
     return c;
   }
 
-  asSupabase(): SupabaseClient {
-    return this as unknown as SupabaseClient;
+  asSupabase(): PostgrestClientApi {
+    return this as unknown as PostgrestClientApi;
   }
 }
 


### PR DESCRIPTION
## Why

Four backend packages pulled in `@supabase/supabase-js` (auth-js, functions-js, postgrest-js, realtime-js, storage-js and a phoenix websocket client) to call three plain REST surfaces. Every call the codebase makes is expressible as a single `fetch` with `apikey`/`Authorization` headers, PostgREST query-string operators, and `Prefer` headers.

## Replaced surface

| Package | supabase-js usage | Replacement |
|---|---|---|
| `packages/auth` | `auth.getUser(token)` | `GET /auth/v1/user` in `supabase-provider.ts` (GoTrue error bodies `msg`/`message`/`error_description` mapped to the auth error) |
| `packages/storage` | `storage.from().upload/download/remove/list/createSignedUrl/getPublicUrl` | `src/supabase-rest.ts` — one client shared by `SupabaseStorage`, `SupabaseStorageAdapter`, and `createAssetUrlBuilder` |
| `packages/integration-nodes` | `from().select/insert/update/delete/upsert` + filters `eq/ne/gt/gte/lt/lte/in/like/contains`, `order`, `limit`, `rpc()` | direct PostgREST requests in `lib-supabase.ts` (query-string operators, `Prefer: return=…`, `resolution=merge-duplicates`) |
| `packages/vectorstore` | `select` (incl. `count: "exact", head`), `insert`, `upsert` (`onConflict`), `update`, `delete`, filters `eq/in/is/ilike/contains`, `order`, `limit`, `range`, `maybeSingle`, `rpc` | `src/postgrest.ts` — a typed fluent mini-client with the same `{ data, error, count }` result shape, so `SupabaseProvider` call sites are unchanged |

PostgREST error bodies (`{message, code, details, hint}`) map to structured errors; Storage errors (`{statusCode, error, message}`) and non-JSON bodies fall back to a status message. The vectorstore client also wires the previously ignored `schema` option via `Accept-Profile`/`Content-Profile`.

## Per-package notes

- **auth**: the internal client keeps the `{ auth: { getUser } }` shape, so the existing provider tests (cache TTL, LRU, error stringification) run unmodified. `supabase-client-init.test.ts` now mocks `fetch` and pins the exact request.
- **storage**: `SupabaseStorageAdapterOptions.client` is now the in-house `SupabaseStorageApi` type; the existing structural test fakes keep working. `supabase-storage.test.ts` rewritten at the fetch layer.
- **vectorstore**: `SupabaseProviderOptions.client` is now `PostgrestClientApi`; the record-and-replay fake in `supabase-provider.test.ts` needed only a type change. New `postgrest.test.ts` covers URLs, operators (`in.(…)` quoting, `cs.`, `is.null`), `Content-Range` count parsing, and error mapping.
- **integration-nodes**: node metadata, props, and error message prefixes are unchanged; new `lib-supabase.test.ts` exercises all six nodes against a mocked `fetch`.

## Deliberately kept on supabase-js

`web/` and `mobile/` still depend on it for interactive GoTrue session/OAuth flows (sign-in, session persistence) — a real SDK use case, out of scope here. The backend dependency is gone from all four packages.

## Verification

- `npm run build:packages` — 55/55 pass
- `npx oxlint` on all four packages' `src` — clean
- Tests: auth 195 pass, storage 167 pass, integration-nodes 335 pass, vectorstore supabase/postgrest suites 34 pass
- `npm run check:deps`, `check:circular`, `check:coupled-deps` — pass
- vectorstore `sqlite-vec-*` tests fail in this sandbox (better-sqlite3 native bindings absent under `--ignore-scripts` install); confirmed identical on a clean checkout — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y)_