### PR TITLE
Add internal OpenAI-compat client; migrate pure chat-completions providers off the openai SDK

### DIFF
--- a/packages/runtime/src/providers/aki-provider.ts
+++ b/packages/runtime/src/providers/aki-provider.ts
@@ -1,5 +1,5 @@
 import { loadPackageAssetJson } from "@nodetool-ai/config";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import { AkiClient, decodeBinary } from "@aki-io/aki-io";
 import type {
   AkiClientConfig,
@@ -7,7 +7,10 @@ import type {
   ApiResponse
 } from "@aki-io/aki-io";
 import { createLogger } from "@nodetool-ai/config";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type {
   ImageModel,
   ImageToImageParams,
@@ -230,14 +233,13 @@ export function buildAkiImageRequest(
   return request;
 }
 
-interface AkiProviderOptions {
-  client?: OpenAI;
+interface AkiProviderOptions extends OpenAICompatProviderOptions {
+  /** Alias kept for callers that predate {@link OpenAICompatProviderOptions}. */
   openaiClientFactory?: (apiKey: string) => OpenAI;
   akiClientFactory?: (config: AkiClientConfig) => AkiClient;
-  fetchFn?: typeof fetch;
 }
 
-export class AkiProvider extends OpenAIProvider {
+export class AkiProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["AKI_API_KEY"];
   }
@@ -257,17 +259,14 @@ export class AkiProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
+      { providerId: "aki", apiKey, baseURL: AKI_BASE_URL },
       {
-        client: options.client,
-        clientFactory:
-          options.openaiClientFactory ??
-          ((key) => new OpenAI({ apiKey: key, baseURL: AKI_BASE_URL })),
+        ...options,
+        clientFactory: options.openaiClientFactory ?? options.clientFactory,
         fetchFn
       }
     );
 
-    (this as { provider: string }).provider = "aki";
     this._akiClientFactory =
       // Stryker disable next-line ArrowFunction: the default constructs a real AkiClient (network SDK); exercised only outside unit tests, where akiClientFactory is injected.
       options.akiClientFactory ?? ((config) => new AkiClient(config));

--- a/packages/runtime/src/providers/cerebras-provider.ts
+++ b/packages/runtime/src/providers/cerebras-provider.ts
@@ -1,14 +1,10 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type { LanguageModel } from "./types.js";
 
-interface CerebrasProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
-export class CerebrasProvider extends OpenAIProvider {
+export class CerebrasProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["CEREBRAS_API_KEY"];
   }
@@ -17,7 +13,7 @@ export class CerebrasProvider extends OpenAIProvider {
 
   constructor(
     secrets: { CEREBRAS_API_KEY?: string },
-    options: CerebrasProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.CEREBRAS_API_KEY;
     if (!apiKey) {
@@ -27,21 +23,14 @@ export class CerebrasProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: "https://api.cerebras.ai/v1"
-            })),
-        fetchFn
-      }
+        providerId: "cerebras",
+        apiKey,
+        baseURL: "https://api.cerebras.ai/v1"
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "cerebras";
     this._cerebrasFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/deepseek-provider.ts
+++ b/packages/runtime/src/providers/deepseek-provider.ts
@@ -1,21 +1,17 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type { LanguageModel } from "./types.js";
 
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
 
-interface DeepSeekProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
 /**
- * DeepSeek provider. Uses the OpenAI SDK against DeepSeek's
- * OpenAI-compatible endpoint at https://api.deepseek.com/v1.
+ * DeepSeek provider. Speaks the OpenAI Chat Completions dialect against
+ * DeepSeek's OpenAI-compatible endpoint at https://api.deepseek.com/v1.
  * Covers DeepSeek-V3 chat and DeepSeek-R1 reasoning models.
  */
-export class DeepSeekProvider extends OpenAIProvider {
+export class DeepSeekProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["DEEPSEEK_API_KEY"];
   }
@@ -24,7 +20,7 @@ export class DeepSeekProvider extends OpenAIProvider {
 
   constructor(
     secrets: { DEEPSEEK_API_KEY?: string },
-    options: DeepSeekProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.DEEPSEEK_API_KEY;
     if (!apiKey) {
@@ -34,21 +30,10 @@ export class DeepSeekProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
-      {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: DEEPSEEK_BASE_URL
-            })),
-        fetchFn
-      }
+      { providerId: "deepseek", apiKey, baseURL: DEEPSEEK_BASE_URL },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "deepseek";
     this._deepseekFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/evolink-provider.ts
+++ b/packages/runtime/src/providers/evolink-provider.ts
@@ -1,6 +1,8 @@
-import OpenAI from "openai";
 import { createLogger } from "@nodetool-ai/config";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type {
   ASRModel,
   EmbeddingModel,
@@ -18,18 +20,12 @@ const log = createLogger("nodetool.runtime.providers.evolink");
 
 // Evolink fronts two hosts: a synchronous OpenAI/Anthropic-compatible gateway
 // for text models, and an asynchronous, task-based gateway for media. The
-// chat path keeps using the OpenAI SDK against the gateway; image/video calls
+// chat path speaks Chat Completions against the gateway; image/video calls
 // submit a task and poll for the result on the media host.
 const EVOLINK_CHAT_BASE_URL = "https://direct.evolink.ai/v1";
 const EVOLINK_MEDIA_BASE_URL = "https://api.evolink.ai";
 const EVOLINK_FILE_UPLOAD_URL =
   "https://files-api.evolink.ai/api/v1/files/upload/base64";
-
-interface EvolinkProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
 
 interface EvolinkTaskStatus {
   status?: string;
@@ -114,13 +110,13 @@ const EVOLINK_VIDEO_MODELS: VideoModel[] = [
 ].map((m) => ({ ...m, provider: "evolink" as const }));
 
 /**
- * Evolink provider. Uses the OpenAI SDK against Evolink's
+ * Evolink provider. Speaks the OpenAI Chat Completions dialect against Evolink's
  * OpenAI-compatible gateway at https://direct.evolink.ai/v1 for chat (which
  * fronts GPT, Claude, Gemini, DeepSeek and other models behind a single API
  * key), and Evolink's asynchronous task API at https://api.evolink.ai for
  * image and video generation.
  */
-export class EvolinkProvider extends OpenAIProvider {
+export class EvolinkProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["EVOLINK_API_KEY"];
   }
@@ -129,7 +125,7 @@ export class EvolinkProvider extends OpenAIProvider {
 
   constructor(
     secrets: { EVOLINK_API_KEY?: string },
-    options: EvolinkProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.EVOLINK_API_KEY;
     if (!apiKey) {
@@ -139,19 +135,12 @@ export class EvolinkProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
         providerId: "evolink",
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: EVOLINK_CHAT_BASE_URL
-            })),
-        fetchFn
-      }
+        apiKey,
+        baseURL: EVOLINK_CHAT_BASE_URL
+      },
+      { ...options, fetchFn }
     );
 
     this._evolinkFetch = fetchFn;

--- a/packages/runtime/src/providers/gmi-provider.ts
+++ b/packages/runtime/src/providers/gmi-provider.ts
@@ -1,5 +1,7 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type {
   ASRModel,
   EmbeddingModel,
@@ -14,26 +16,24 @@ import type {
 // no DNS record — the live serving host is api.gmi-serving.com.
 const GMI_BASE_URL = "https://api.gmi-serving.com/v1";
 
-interface GMIProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
 /**
- * GMI Cloud provider. Uses the OpenAI SDK against GMI Cloud's
- * OpenAI-compatible inference gateway at https://api.gmi-serving.com/v1, which
- * serves open-weight chat models (Llama, DeepSeek, Qwen, …) behind a single
- * API key. See https://docs.gmicloud.ai/quickstart.
+ * GMI Cloud provider. Speaks the OpenAI Chat Completions dialect against GMI
+ * Cloud's OpenAI-compatible inference gateway at
+ * https://api.gmi-serving.com/v1, which serves open-weight chat models (Llama,
+ * DeepSeek, Qwen, …) behind a single API key.
+ * See https://docs.gmicloud.ai/quickstart.
  */
-export class GMIProvider extends OpenAIProvider {
+export class GMIProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["GMI_API_KEY"];
   }
 
   private _gmiFetch: typeof fetch;
 
-  constructor(secrets: { GMI_API_KEY?: string }, options: GMIProviderOptions = {}) {
+  constructor(
+    secrets: { GMI_API_KEY?: string },
+    options: OpenAICompatProviderOptions = {}
+  ) {
     const apiKey = secrets.GMI_API_KEY;
     if (!apiKey) {
       throw new Error("GMI_API_KEY is required");
@@ -42,19 +42,8 @@ export class GMIProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
-      {
-        providerId: "gmi",
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: GMI_BASE_URL
-            })),
-        fetchFn
-      }
+      { providerId: "gmi", apiKey, baseURL: GMI_BASE_URL },
+      { ...options, fetchFn }
     );
 
     this._gmiFetch = fetchFn;

--- a/packages/runtime/src/providers/groq-provider.ts
+++ b/packages/runtime/src/providers/groq-provider.ts
@@ -1,14 +1,10 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type { LanguageModel } from "./types.js";
 
-interface GroqProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
-export class GroqProvider extends OpenAIProvider {
+export class GroqProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["GROQ_API_KEY"];
   }
@@ -17,7 +13,7 @@ export class GroqProvider extends OpenAIProvider {
 
   constructor(
     secrets: { GROQ_API_KEY?: string },
-    options: GroqProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.GROQ_API_KEY;
     if (!apiKey) {
@@ -27,21 +23,14 @@ export class GroqProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: "https://api.groq.com/openai/v1"
-            })),
-        fetchFn
-      }
+        providerId: "groq",
+        apiKey,
+        baseURL: "https://api.groq.com/openai/v1"
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "groq";
     this._groqFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/llama-provider.ts
+++ b/packages/runtime/src/providers/llama-provider.ts
@@ -1,6 +1,9 @@
-import OpenAI from "openai";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { BaseProvider } from "./base-provider.js";
+import {
+  OpenAICompatClient,
+  type ChatCompletionsRequest
+} from "./openai-compat/index.js";
 import type {
   LanguageModel,
   Message,
@@ -11,8 +14,8 @@ import type {
 } from "./types.js";
 
 interface LlamaProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (baseUrl: string) => OpenAI;
+  compatClient?: OpenAICompatClient;
+  clientFactory?: (baseUrl: string) => OpenAICompatClient;
   fetchFn?: typeof fetch;
 }
 
@@ -20,12 +23,6 @@ interface MutableToolCall {
   id: string;
   name: string;
   arguments: string;
-}
-
-/** Shape of a native OpenAI tool call entry as returned by the SDK. */
-interface NativeToolCall {
-  id?: string | null;
-  function?: { name?: string | null; arguments?: string };
 }
 
 function parseKeywordArgs(raw: string): Record<string, unknown> {
@@ -179,8 +176,8 @@ export class LlamaProvider extends BaseProvider {
   }
 
   readonly baseUrl: string;
-  private _client: OpenAI | null;
-  private _clientFactory: (baseUrl: string) => OpenAI;
+  private _client: OpenAICompatClient | null;
+  private _clientFactory: (baseUrl: string) => OpenAICompatClient;
   private _fetch: typeof fetch;
 
   constructor(
@@ -193,18 +190,22 @@ export class LlamaProvider extends BaseProvider {
     if (!raw || !raw.trim()) {
       throw new Error("LLAMA_CPP_URL is required");
     }
-    const normalized = raw.replace(/\/+$/, "");
+    let end = raw.length;
+    while (end > 0 && raw[end - 1] === "/") end -= 1;
+    const normalized = raw.slice(0, end);
 
+    const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
     this.baseUrl = normalized;
-    this._client = options.client ?? null;
+    this._client = options.compatClient ?? null;
     this._clientFactory =
       options.clientFactory ??
       ((url) =>
-        new OpenAI({
+        new OpenAICompatClient({
           apiKey: "sk-no-key-required",
-          baseURL: `${url}/v1`
+          baseURL: `${url}/v1`,
+          fetchFn
         }));
-    this._fetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this._fetch = fetchFn;
   }
 
   getContainerEnv(): Record<string, string> {
@@ -212,7 +213,7 @@ export class LlamaProvider extends BaseProvider {
     return {};
   }
 
-  private getClient(): OpenAI {
+  private getClient(): OpenAICompatClient {
     if (!this._client) {
       this._client = this._clientFactory(this.baseUrl);
     }
@@ -353,7 +354,7 @@ export class LlamaProvider extends BaseProvider {
       normalized.map((m) => this.convertMessage(m))
     );
 
-    const request: Record<string, unknown> = {
+    const request: ChatCompletionsRequest = {
       model,
       messages: openaiMessages,
       max_tokens: maxTokens,
@@ -364,70 +365,62 @@ export class LlamaProvider extends BaseProvider {
     }
 
     this.recordRequestPayload(request);
-    const stream = (await this.getClient().chat.completions.create(
-      request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
-    )) as AsyncIterable<any> & { close?: () => Promise<void> };
+    const stream = this.getClient().chatCompletionsStream(request);
 
     const deltaToolCalls = new Map<number, MutableToolCall>();
     let accumulatedText = "";
 
-    try {
-      for await (const chunk of stream) {
-        const choice = chunk?.choices?.[0];
-        if (!choice) continue;
-        const delta = choice.delta;
+    for await (const chunk of stream) {
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+      const delta = choice.delta;
 
-        if (Array.isArray(delta?.tool_calls)) {
-          for (const tc of delta.tool_calls) {
-            const index = Number(tc.index ?? 0);
-            const cur = deltaToolCalls.get(index) ?? {
-              id: String(tc.id ?? ""),
-              name: "",
-              arguments: ""
-            };
-            if (tc.id) cur.id = String(tc.id);
-            if (tc.function?.name) cur.name = String(tc.function.name);
-            if (tc.function?.arguments)
-              cur.arguments += String(tc.function.arguments);
-            deltaToolCalls.set(index, cur);
-          }
-        }
-
-        const content = String(delta?.content ?? "");
-        if (content.length > 0) {
-          accumulatedText += content;
-        }
-
-        if (content.length > 0 || choice.finish_reason === "stop") {
-          const out: Chunk = {
-            type: "chunk",
-            content,
-            done: choice.finish_reason === "stop"
+      if (Array.isArray(delta?.tool_calls)) {
+        for (const tc of delta.tool_calls) {
+          const index = Number(tc.index ?? 0);
+          const cur = deltaToolCalls.get(index) ?? {
+            id: String(tc.id ?? ""),
+            name: "",
+            arguments: ""
           };
-          yield out;
-        }
-
-        if (choice.finish_reason === "tool_calls") {
-          for (const call of deltaToolCalls.values()) {
-            yield this.buildToolCall(call.id, call.name, call.arguments);
-          }
-          deltaToolCalls.clear();
-        }
-
-        if (
-          choice.finish_reason === "stop" &&
-          tools.length > 0 &&
-          !(await this.hasToolSupport(model))
-        ) {
-          const parsed = parseEmulatedToolCalls(accumulatedText, tools);
-          for (const tc of parsed.toolCalls) {
-            yield tc;
-          }
+          if (tc.id) cur.id = String(tc.id);
+          if (tc.function?.name) cur.name = String(tc.function.name);
+          if (tc.function?.arguments)
+            cur.arguments += String(tc.function.arguments);
+          deltaToolCalls.set(index, cur);
         }
       }
-    } finally {
-      if (typeof stream.close === "function") {
-        await stream.close();
+
+      const content = String(delta?.content ?? "");
+      if (content.length > 0) {
+        accumulatedText += content;
+      }
+
+      if (content.length > 0 || choice.finish_reason === "stop") {
+        const out: Chunk = {
+          type: "chunk",
+          content,
+          done: choice.finish_reason === "stop"
+        };
+        yield out;
+      }
+
+      if (choice.finish_reason === "tool_calls") {
+        for (const call of deltaToolCalls.values()) {
+          yield this.buildToolCall(call.id, call.name, call.arguments);
+        }
+        deltaToolCalls.clear();
+      }
+
+      if (
+        choice.finish_reason === "stop" &&
+        tools.length > 0 &&
+        !(await this.hasToolSupport(model))
+      ) {
+        const parsed = parseEmulatedToolCalls(accumulatedText, tools);
+        for (const tc of parsed.toolCalls) {
+          yield tc;
+        }
       }
     }
   }
@@ -453,7 +446,7 @@ export class LlamaProvider extends BaseProvider {
       normalized.map((m) => this.convertMessage(m))
     );
 
-    const request: Record<string, unknown> = {
+    const request: ChatCompletionsRequest = {
       model,
       messages: openaiMessages,
       max_tokens: maxTokens,
@@ -464,20 +457,18 @@ export class LlamaProvider extends BaseProvider {
     }
 
     this.recordRequestPayload(request);
-    const completion = await this.getClient().chat.completions.create(
-      request as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming
-    );
+    const completion = await this.getClient().chatCompletions(request);
     const message = completion.choices?.[0]?.message;
     const content = String(message?.content ?? "");
 
     let toolCalls: ToolCall[] = [];
-    const nativeToolCalls = (message?.tool_calls ?? []) as NativeToolCall[];
+    const nativeToolCalls = message?.tool_calls ?? [];
     if (nativeToolCalls.length > 0) {
       toolCalls = nativeToolCalls.map((tc) =>
         this.buildToolCall(
           String(tc.id ?? ""),
           String(tc.function?.name ?? ""),
-          tc.function?.arguments
+          tc.function?.arguments ?? undefined
         )
       );
     } else if (tools.length > 0 && !(await this.hasToolSupport(model))) {

--- a/packages/runtime/src/providers/lmstudio-provider.ts
+++ b/packages/runtime/src/providers/lmstudio-provider.ts
@@ -1,5 +1,8 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
+import { trimTrailingSlashes } from "./openai-compat/index.js";
 import { LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import type { LanguageModel } from "./types.js";
 
@@ -7,14 +10,11 @@ import type { LanguageModel } from "./types.js";
  * can't stall the model menu's parallel provider load. */
 const MODEL_LIST_TIMEOUT_MS = 2500;
 
-interface LMStudioProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
+interface LMStudioProviderOptions extends OpenAICompatProviderOptions {
   baseURL?: string;
 }
 
-export class LMStudioProvider extends OpenAIProvider {
+export class LMStudioProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return [];
   }
@@ -35,26 +35,15 @@ export class LMStudioProvider extends OpenAIProvider {
       secrets.LMSTUDIO_API_URL ??
       process.env["LMSTUDIO_API_URL"] ??
       LMSTUDIO_DEFAULT_URL;
-    const baseURL = rawBaseURL.replace(/\/+$/, "");
+    const baseURL = trimTrailingSlashes(rawBaseURL);
     const apiKey = secrets.LMSTUDIO_API_KEY ?? "lm-studio";
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
-      {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: `${baseURL}/v1`
-            })),
-        fetchFn
-      }
+      { providerId: "lmstudio", apiKey, baseURL: `${baseURL}/v1` },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "lmstudio";
     this._lmstudioFetch = fetchFn;
     this._lmstudioBaseURL = baseURL;
   }

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -9,8 +9,11 @@
  * Docs: https://platform.minimax.io/docs/api-reference/api-overview
  */
 
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
+import type { OpenAIProvider } from "./openai-provider.js";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ASRModel,
@@ -137,12 +140,6 @@ function toInt16Samples(bytes: Uint8Array): Int16Array {
   );
 }
 
-interface MinimaxProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
 interface MinimaxBaseResp {
   status_code?: number;
   status_msg?: string;
@@ -158,7 +155,7 @@ function assertBaseResp(data: Record<string, unknown>, context: string): void {
   }
 }
 
-export class MinimaxProvider extends OpenAIProvider {
+export class MinimaxProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["MINIMAX_API_KEY"];
   }
@@ -167,7 +164,7 @@ export class MinimaxProvider extends OpenAIProvider {
 
   constructor(
     secrets: { MINIMAX_API_KEY?: string },
-    options: MinimaxProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.MINIMAX_API_KEY;
     if (!apiKey) {
@@ -177,21 +174,14 @@ export class MinimaxProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: MINIMAX_OPENAI_BASE_URL
-            })),
-        fetchFn
-      }
+        providerId: "minimax",
+        apiKey,
+        baseURL: MINIMAX_OPENAI_BASE_URL
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "minimax";
     this._minimaxFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/mistral-provider.ts
+++ b/packages/runtime/src/providers/mistral-provider.ts
@@ -1,14 +1,10 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type { EmbeddingModel, LanguageModel } from "./types.js";
 
-interface MistralProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
-export class MistralProvider extends OpenAIProvider {
+export class MistralProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["MISTRAL_API_KEY"];
   }
@@ -17,7 +13,7 @@ export class MistralProvider extends OpenAIProvider {
 
   constructor(
     secrets: { MISTRAL_API_KEY?: string },
-    options: MistralProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.MISTRAL_API_KEY;
     if (!apiKey) {
@@ -27,21 +23,14 @@ export class MistralProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: "https://api.mistral.ai/v1"
-            })),
-        fetchFn
-      }
+        providerId: "mistral",
+        apiKey,
+        baseURL: "https://api.mistral.ai/v1"
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "mistral";
     this._mistralFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/openai-compat-provider.ts
+++ b/packages/runtime/src/providers/openai-compat-provider.ts
@@ -1,0 +1,300 @@
+/**
+ * Base class for providers that speak the OpenAI Chat Completions dialect
+ * against a non-OpenAI endpoint (Groq, Cerebras, xAI, Mistral, DeepSeek, …).
+ *
+ * Chat — the only surface these providers ever used the `openai` npm package
+ * for — runs on the internal {@link OpenAICompatClient} over `fetch`. The SDK
+ * client inherited from {@link OpenAIProvider} remains as a lazily-created
+ * fallback for the OpenAI-compatible media/embedding endpoints some gateways
+ * also expose (Together ASR, OpenRouter images, Mistral embeddings); it is
+ * never constructed on the chat path.
+ */
+import OpenAI from "openai";
+import type { Chunk } from "@nodetool-ai/protocol";
+import { createLogger } from "@nodetool-ai/config";
+import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatClient,
+  type ChatCompletionsRequest
+} from "./openai-compat/index.js";
+import type {
+  Message,
+  ProviderId,
+  ProviderStreamItem,
+  ProviderTool,
+  ToolCall
+} from "./types.js";
+import type { BaseProvider } from "./base-provider.js";
+
+const log = createLogger("nodetool.runtime.providers.openai-compat");
+
+export interface OpenAICompatConfig {
+  /** Provider id reported by this instance (e.g. `"groq"`). */
+  providerId: ProviderId;
+  apiKey: string;
+  /** Chat endpoint root, e.g. `https://api.groq.com/openai/v1`. */
+  baseURL: string;
+  /** Extra headers on every chat request (gateway attribution etc.). */
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface OpenAICompatProviderOptions {
+  /** SDK client used only by inherited non-chat surfaces (images, ASR, …). */
+  client?: OpenAI;
+  clientFactory?: (apiKey: string) => OpenAI;
+  fetchFn?: typeof fetch;
+  /** Internal chat client override (tests). */
+  compatClient?: OpenAICompatClient;
+}
+
+interface MutableToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+export class OpenAICompatProvider extends OpenAIProvider {
+  private _compatClient: OpenAICompatClient | null;
+  private readonly _compatConfig: OpenAICompatConfig;
+  private readonly _compatFetch: typeof fetch;
+
+  constructor(
+    config: OpenAICompatConfig,
+    options: OpenAICompatProviderOptions = {}
+  ) {
+    super(
+      { OPENAI_API_KEY: config.apiKey },
+      {
+        providerId: config.providerId,
+        client: options.client,
+        clientFactory:
+          options.clientFactory ??
+          ((key) =>
+            new OpenAI({
+              apiKey: key,
+              baseURL: config.baseURL,
+              ...(config.defaultHeaders
+                ? { defaultHeaders: config.defaultHeaders }
+                : {})
+            })),
+        fetchFn: options.fetchFn
+      }
+    );
+    this._compatConfig = config;
+    this._compatClient = options.compatClient ?? null;
+    this._compatFetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+  }
+
+  protected getCompatClient(): OpenAICompatClient {
+    if (!this._compatClient) {
+      this._compatClient = new OpenAICompatClient({
+        baseURL: this._compatConfig.baseURL,
+        apiKey: this._compatConfig.apiKey,
+        defaultHeaders: this._compatConfig.defaultHeaders,
+        fetchFn: this._compatFetch
+      });
+    }
+    return this._compatClient;
+  }
+
+  /** Shared request assembly for both streaming and non-streaming chat. */
+  private async buildChatRequest(
+    args: {
+      messages: Message[];
+      model: string;
+      tools?: ProviderTool[];
+      toolChoice?: string | "any";
+      maxTokens?: number;
+      temperature?: number;
+      topP?: number;
+      presencePenalty?: number;
+      frequencyPenalty?: number;
+      audio?: Record<string, unknown>;
+    },
+    stream: boolean
+  ): Promise<ChatCompletionsRequest> {
+    const {
+      model,
+      tools = [],
+      toolChoice,
+      maxTokens = 16384,
+      temperature,
+      topP,
+      presencePenalty,
+      frequencyPenalty,
+      audio
+    } = args;
+
+    const messages = this.convertSystemToUserForOModels(args.messages, model);
+    const openaiMessages = await Promise.all(
+      messages.map((m) => this.convertMessage(m))
+    );
+
+    const request: ChatCompletionsRequest = {
+      model,
+      messages: openaiMessages,
+      max_completion_tokens: maxTokens,
+      stream
+    };
+    if (stream) request.stream_options = { include_usage: true };
+
+    if (temperature != null) request.temperature = temperature;
+    if (topP != null) request.top_p = topP;
+    if (presencePenalty != null) request.presence_penalty = presencePenalty;
+    if (frequencyPenalty != null) request.frequency_penalty = frequencyPenalty;
+
+    if (audio) {
+      request.audio = audio;
+      request.modalities = ["text", "audio"];
+    }
+
+    if (tools.length > 0 && (await this.hasToolSupport(model))) {
+      request.tools = this.formatTools(tools);
+      if (!stream && toolChoice) {
+        request.tool_choice =
+          toolChoice === "any"
+            ? "required"
+            : { type: "function", function: { name: toolChoice } };
+      }
+    }
+
+    return request;
+  }
+
+  override async *generateMessages(
+    args: Parameters<BaseProvider["generateMessages"]>[0]
+  ): AsyncGenerator<ProviderStreamItem> {
+    const { model } = args;
+    const request = await this.buildChatRequest(args, true);
+
+    log.debug("OpenAI-compatible chat request", {
+      provider: this.provider,
+      model
+    });
+
+    this.recordRequestPayload(request);
+    const stream = this.getCompatClient().chatCompletionsStream(request);
+
+    const deltaToolCalls = new Map<number, MutableToolCall>();
+
+    for await (const chunk of stream) {
+      if (chunk.usage) {
+        this.trackUsage(model, {
+          inputTokens: chunk.usage.prompt_tokens ?? 0,
+          outputTokens: chunk.usage.completion_tokens ?? 0,
+          cachedTokens: chunk.usage.prompt_tokens_details?.cached_tokens ?? 0
+        });
+      }
+
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+
+      const delta = choice.delta;
+
+      if (delta?.audio?.data) {
+        const audioChunk: Chunk = {
+          type: "chunk",
+          content_type: "audio",
+          content: String(delta.audio.data)
+        };
+        yield audioChunk;
+      }
+
+      if (Array.isArray(delta?.tool_calls)) {
+        for (const tc of delta.tool_calls) {
+          const index = Number(tc.index ?? 0);
+          const current = deltaToolCalls.get(index) ?? {
+            id: String(tc.id ?? ""),
+            name: String(tc.function?.name ?? ""),
+            arguments: ""
+          };
+
+          if (tc.id) current.id = String(tc.id);
+          if (tc.function?.name) current.name = String(tc.function.name);
+          if (tc.function?.arguments)
+            current.arguments += String(tc.function.arguments);
+
+          deltaToolCalls.set(index, current);
+        }
+      }
+
+      if (delta?.content !== undefined || choice.finish_reason === "stop") {
+        const item: Chunk = {
+          type: "chunk",
+          content: String(delta?.content ?? ""),
+          done: choice.finish_reason === "stop"
+        };
+        yield item;
+      }
+
+      if (choice.finish_reason === "tool_calls") {
+        for (const call of deltaToolCalls.values()) {
+          const toolCall: ToolCall = this.buildToolCall(
+            call.id,
+            call.name,
+            call.arguments
+          );
+          yield toolCall;
+        }
+        deltaToolCalls.clear();
+      }
+
+      // Always emit a terminal `done: true` chunk when the completion
+      // finishes, regardless of reason. "stop" already emits one above; for
+      // every other terminal reason (tool_calls, length, content_filter)
+      // emit one here so consumers get a consistent end-of-stream marker.
+      if (choice.finish_reason && choice.finish_reason !== "stop") {
+        const doneChunk: Chunk = { type: "chunk", content: "", done: true };
+        yield doneChunk;
+      }
+    }
+  }
+
+  override async generateMessage(
+    args: Parameters<BaseProvider["generateMessage"]>[0]
+  ): Promise<Message> {
+    const { model } = args;
+    const request = await this.buildChatRequest(args, false);
+
+    log.debug("OpenAI-compatible chat request", {
+      provider: this.provider,
+      model
+    });
+
+    this.recordRequestPayload(request);
+    const completion = await this.getCompatClient().chatCompletions(request);
+
+    const choice = completion.choices?.[0];
+    if (!choice) {
+      throw new Error(`${this.provider} returned no choices`);
+    }
+
+    const usage = completion.usage;
+    if (usage) {
+      this.trackUsage(model, {
+        inputTokens: usage.prompt_tokens ?? 0,
+        outputTokens: usage.completion_tokens ?? 0,
+        cachedTokens: usage.prompt_tokens_details?.cached_tokens ?? 0
+      });
+    }
+
+    const responseMessage = choice.message;
+    const toolCalls = Array.isArray(responseMessage?.tool_calls)
+      ? responseMessage.tool_calls
+          .filter((tc) => tc.type === "function")
+          .map((tc) =>
+            this.buildToolCall(
+              String(tc.id ?? ""),
+              String(tc.function?.name ?? ""),
+              tc.function?.arguments ?? undefined
+            )
+          )
+      : undefined;
+
+    return {
+      role: "assistant",
+      content: responseMessage?.content ?? null,
+      toolCalls
+    };
+  }
+}

--- a/packages/runtime/src/providers/openai-compat/client.ts
+++ b/packages/runtime/src/providers/openai-compat/client.ts
@@ -202,9 +202,11 @@ export class OpenAICompatClient {
       if (typeof parsed !== "object" || parsed === null) continue;
       const event = parsed as Record<string, unknown>;
       const error = errorFromStreamEvent(event);
-      // A chunk that also carries choices is data, not a failure; only pure
-      // error events (no choices) abort the stream.
-      if (error && !Array.isArray(event.choices)) throw error;
+      // A chunk that also carries choice data is data, not a failure; error
+      // events without any choices (absent or empty) abort the stream.
+      const hasChoiceData =
+        Array.isArray(event.choices) && event.choices.length > 0;
+      if (error && !hasChoiceData) throw error;
       yield event as ChatCompletionChunk;
     }
   }

--- a/packages/runtime/src/providers/openai-compat/client.ts
+++ b/packages/runtime/src/providers/openai-compat/client.ts
@@ -1,0 +1,211 @@
+import { sseEvents } from "./sse.js";
+import {
+  OpenAICompatError,
+  errorFromResponse,
+  errorFromStreamEvent
+} from "./errors.js";
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+  ChatCompletionsRequest
+} from "./types.js";
+
+export interface OpenAICompatClientOptions {
+  /** Endpoint root, e.g. `https://api.groq.com/openai/v1`. */
+  baseURL: string;
+  apiKey: string;
+  /** Extra headers sent on every request (gateway attribution headers etc.). */
+  defaultHeaders?: Record<string, string>;
+  fetchFn?: typeof fetch;
+  /**
+   * Retries on retryable failures (408/409/429/5xx, network errors) before the
+   * response body is consumed. Defaults to 2, matching the `openai` SDK the
+   * migrated providers previously relied on.
+   */
+  maxRetries?: number;
+  /** Time-to-response-headers cap. Defaults to 600s (the `openai` SDK value). */
+  timeoutMs?: number;
+}
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
+const RETRYABLE_STATUS = new Set([408, 409, 429]);
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_TIMEOUT_MS = 600_000;
+
+export function trimTrailingSlashes(url: string): string {
+  // A loop, not `replace(/\/+$/,"")` — the regex backtracks polynomially on
+  // adversarial input.
+  let end = url.length;
+  while (end > 0 && url[end - 1] === "/") end -= 1;
+  return url.slice(0, end);
+}
+
+function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUS.has(status) || status >= 500;
+}
+
+/** `Retry-After` seconds when present and sane (0–60s), else null. */
+function retryAfterMs(response: Response): number | null {
+  const header = response.headers.get("retry-after");
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0 && seconds <= 60) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) {
+    const delta = dateMs - Date.now();
+    if (delta > 0 && delta <= 60_000) return delta;
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backoffMs(attempt: number): number {
+  const base = Math.min(500 * 2 ** attempt, 8000);
+  return base * (0.75 + Math.random() * 0.5);
+}
+
+/**
+ * Minimal typed client for OpenAI-compatible `/chat/completions` endpoints,
+ * built on `fetch`. Replaces the `openai` npm package for providers that only
+ * ever used it as a generic HTTP client (Groq, Cerebras, xAI, Mistral, …).
+ */
+export class OpenAICompatClient {
+  readonly baseURL: string;
+  private readonly _apiKey: string;
+  private readonly _defaultHeaders: Record<string, string>;
+  private readonly _fetch: typeof fetch;
+  private readonly _maxRetries: number;
+  private readonly _timeoutMs: number;
+
+  constructor(options: OpenAICompatClientOptions) {
+    this.baseURL = trimTrailingSlashes(options.baseURL);
+    this._apiKey = options.apiKey;
+    this._defaultHeaders = options.defaultHeaders ?? {};
+    this._fetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this._maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this._timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  private headers(streaming: boolean): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this._apiKey}`,
+      "Content-Type": "application/json",
+      Accept: streaming ? "text/event-stream" : "application/json",
+      ...this._defaultHeaders
+    };
+  }
+
+  /**
+   * POST with retries. Retries fire only before any body is consumed, so both
+   * the non-streaming call and the streaming connection setup are covered.
+   * Non-2xx responses (after retries) surface as {@link OpenAICompatError}.
+   */
+  private async post(
+    path: string,
+    body: unknown,
+    streaming: boolean,
+    options: RequestOptions
+  ): Promise<Response> {
+    const url = `${this.baseURL}${path}`;
+    const payload = JSON.stringify(body);
+
+    for (let attempt = 0; ; attempt++) {
+      options.signal?.throwIfAborted();
+
+      const timeout = AbortSignal.timeout(this._timeoutMs);
+      const signal = options.signal
+        ? AbortSignal.any([options.signal, timeout])
+        : timeout;
+
+      let response: Response;
+      try {
+        response = await this._fetch(url, {
+          method: "POST",
+          headers: this.headers(streaming),
+          body: payload,
+          signal
+        });
+      } catch (error) {
+        // Abort by the caller is never retried; network errors and timeouts are.
+        if (options.signal?.aborted) throw error;
+        if (attempt >= this._maxRetries) throw error;
+        await sleep(backoffMs(attempt));
+        continue;
+      }
+
+      if (response.ok) return response;
+
+      const detail = await response.text().catch(() => "");
+      if (attempt < this._maxRetries && isRetryableStatus(response.status)) {
+        await sleep(retryAfterMs(response) ?? backoffMs(attempt));
+        continue;
+      }
+      throw errorFromResponse(response.status, detail);
+    }
+  }
+
+  /** Non-streaming chat completion. */
+  async chatCompletions(
+    request: ChatCompletionsRequest,
+    options: RequestOptions = {}
+  ): Promise<ChatCompletionResponse> {
+    const response = await this.post(
+      "/chat/completions",
+      { ...request, stream: false },
+      false,
+      options
+    );
+    return (await response.json()) as ChatCompletionResponse;
+  }
+
+  /**
+   * Streaming chat completion. Yields parsed SSE chunks until the `[DONE]`
+   * sentinel (or end of stream). Mid-stream `{"error": …}` events throw an
+   * {@link OpenAICompatError}.
+   */
+  async *chatCompletionsStream(
+    request: ChatCompletionsRequest,
+    options: RequestOptions = {}
+  ): AsyncGenerator<ChatCompletionChunk, void, undefined> {
+    const response = await this.post(
+      "/chat/completions",
+      { ...request, stream: true },
+      true,
+      options
+    );
+    if (!response.body) {
+      throw new OpenAICompatError(
+        response.status,
+        "streaming response has no body"
+      );
+    }
+
+    for await (const data of sseEvents(response.body)) {
+      if (data === "[DONE]") return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        throw new OpenAICompatError(
+          undefined,
+          `could not parse stream event as JSON: ${data.slice(0, 200)}`
+        );
+      }
+      if (typeof parsed !== "object" || parsed === null) continue;
+      const event = parsed as Record<string, unknown>;
+      const error = errorFromStreamEvent(event);
+      // A chunk that also carries choices is data, not a failure; only pure
+      // error events (no choices) abort the stream.
+      if (error && !Array.isArray(event.choices)) throw error;
+      yield event as ChatCompletionChunk;
+    }
+  }
+}

--- a/packages/runtime/src/providers/openai-compat/errors.ts
+++ b/packages/runtime/src/providers/openai-compat/errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Typed error for OpenAI-compatible HTTP endpoints.
+ *
+ * The message deliberately mirrors the `openai` SDK's `APIError` format —
+ * `"<status> <upstream message>"` — because callers classify failures by
+ * matching on `String(error)` (BaseProvider.isRateLimitError looks for `429` /
+ * "rate limit", isContextLengthError for "context length", …).
+ */
+export class OpenAICompatError extends Error {
+  /** HTTP status; `undefined` for mid-stream error events with no status. */
+  readonly status: number | undefined;
+  readonly code: string | null;
+  readonly type: string | null;
+  readonly param: string | null;
+  /** The parsed error body (or raw text when not JSON). */
+  readonly body: unknown;
+
+  constructor(
+    status: number | undefined,
+    message: string,
+    details: {
+      code?: string | null;
+      type?: string | null;
+      param?: string | null;
+      body?: unknown;
+    } = {}
+  ) {
+    super(status === undefined ? message : `${status} ${message}`);
+    this.name = "OpenAICompatError";
+    this.status = status;
+    this.code = details.code ?? null;
+    this.type = details.type ?? null;
+    this.param = details.param ?? null;
+    this.body = details.body;
+  }
+}
+
+interface ParsedErrorBody {
+  message: string;
+  code: string | null;
+  type: string | null;
+  param: string | null;
+  body: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Extract the human-readable message (and code/type/param) from an
+ * OpenAI-style error payload: `{"error": {"message": …, "code": …}}`, a
+ * top-level `{"message": …}`, or plain text.
+ */
+export function parseErrorBody(text: string): ParsedErrorBody {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { message: text, code: null, type: null, param: null, body: text };
+  }
+
+  const root = isRecord(parsed) ? parsed : {};
+  const err = isRecord(root.error) ? root.error : root;
+  const message =
+    stringOrNull(err.message) ??
+    (typeof root.error === "string" ? root.error : null) ??
+    text;
+
+  return {
+    message,
+    code:
+      stringOrNull(err.code) ??
+      (typeof err.code === "number" ? String(err.code) : null),
+    type: stringOrNull(err.type),
+    param: stringOrNull(err.param),
+    body: parsed
+  };
+}
+
+/** Map a non-2xx HTTP response body to an {@link OpenAICompatError}. */
+export function errorFromResponse(
+  status: number,
+  bodyText: string
+): OpenAICompatError {
+  const parsed = parseErrorBody(bodyText);
+  return new OpenAICompatError(status, parsed.message, parsed);
+}
+
+/**
+ * Map a mid-stream SSE `{"error": {...}}` event to an
+ * {@link OpenAICompatError}. Returns `null` when the event is not an error.
+ */
+export function errorFromStreamEvent(
+  event: Record<string, unknown>
+): OpenAICompatError | null {
+  const err = event.error;
+  if (err === undefined || err === null) return null;
+  if (typeof err === "string") {
+    return new OpenAICompatError(undefined, err, { body: event });
+  }
+  if (!isRecord(err)) return null;
+  const message = stringOrNull(err.message) ?? "stream error";
+  const status =
+    typeof err.status === "number"
+      ? err.status
+      : typeof err.http_status === "number"
+        ? err.http_status
+        : undefined;
+  return new OpenAICompatError(status, message, {
+    code:
+      stringOrNull(err.code) ??
+      (typeof err.code === "number" ? String(err.code) : null),
+    type: stringOrNull(err.type),
+    param: stringOrNull(err.param),
+    body: event
+  });
+}

--- a/packages/runtime/src/providers/openai-compat/index.ts
+++ b/packages/runtime/src/providers/openai-compat/index.ts
@@ -1,0 +1,25 @@
+export { OpenAICompatClient, trimTrailingSlashes } from "./client.js";
+export type {
+  OpenAICompatClientOptions,
+  RequestOptions
+} from "./client.js";
+export {
+  OpenAICompatError,
+  errorFromResponse,
+  errorFromStreamEvent,
+  parseErrorBody
+} from "./errors.js";
+export { sseEvents } from "./sse.js";
+export type {
+  ChatCompletionsRequest,
+  ChatCompletionResponse,
+  ChatCompletionChunk,
+  ChatCompletionChunkChoice,
+  ChatCompletionChunkDelta,
+  ChatCompletionChunkDeltaToolCall,
+  ChatCompletionChoice,
+  ChatCompletionAssistantMessage,
+  ChatCompletionMessageToolCall,
+  ChatCompletionToolCallFunction,
+  ChatCompletionUsage
+} from "./types.js";

--- a/packages/runtime/src/providers/openai-compat/sse.ts
+++ b/packages/runtime/src/providers/openai-compat/sse.ts
@@ -1,0 +1,69 @@
+/**
+ * Minimal Server-Sent Events parser for OpenAI-style streaming responses.
+ *
+ * Yields the joined `data:` payload of each event. Handles the parts of the
+ * SSE spec that OpenAI-compatible gateways actually exercise:
+ *  - events separated by blank lines, with LF or CRLF line endings
+ *  - events and lines split across arbitrary network-chunk boundaries
+ *  - multiple `data:` lines per event (joined with `\n`)
+ *  - comment lines (`:`) and non-data fields (`event:`, `id:`, …) are ignored
+ *  - a final unterminated event is flushed at end-of-stream (some gateways
+ *    close the connection right after `data: [DONE]` without a blank line)
+ */
+export async function* sseEvents(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<string, void, undefined> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  let dataLines: string[] = [];
+
+  const takeEvent = (): string | null => {
+    if (dataLines.length === 0) return null;
+    const event = dataLines.join("\n");
+    dataLines = [];
+    return event;
+  };
+
+  const consumeLine = (rawLine: string): string | null => {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line === "") {
+      return takeEvent();
+    }
+    if (line.startsWith("data:")) {
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+    }
+    // Comments (":…") and other fields ("event:", "id:", "retry:") are ignored.
+    return null;
+  };
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineAt: number;
+      while ((newlineAt = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineAt);
+        buffer = buffer.slice(newlineAt + 1);
+        const event = consumeLine(line);
+        if (event !== null) yield event;
+      }
+    }
+
+    // Flush any decoder-buffered bytes and a trailing line without newline.
+    buffer += decoder.decode();
+    if (buffer !== "") {
+      const event = consumeLine(buffer);
+      if (event !== null) yield event;
+    }
+    const trailing = takeEvent();
+    if (trailing !== null) yield trailing;
+  } finally {
+    // Stop the underlying connection if the consumer bails early.
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}

--- a/packages/runtime/src/providers/openai-compat/types.ts
+++ b/packages/runtime/src/providers/openai-compat/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Wire types for the internal OpenAI-compatible Chat Completions client.
+ *
+ * These model only the fields NodeTool reads or writes — not the full OpenAI
+ * schema. Gateways diverge from OpenAI in the long tail, so every response
+ * field is optional and unknown extra request params ride the index signature.
+ */
+
+/** Request body for `POST /chat/completions`. */
+export interface ChatCompletionsRequest {
+  model: string;
+  messages: Array<Record<string, unknown>>;
+  stream?: boolean;
+  /** Extra params (temperature, tools, stream_options, …) pass through as-is. */
+  [param: string]: unknown;
+}
+
+export interface ChatCompletionUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+}
+
+export interface ChatCompletionToolCallFunction {
+  name?: string | null;
+  arguments?: string | null;
+}
+
+export interface ChatCompletionMessageToolCall {
+  id?: string | null;
+  type?: string;
+  function?: ChatCompletionToolCallFunction;
+}
+
+export interface ChatCompletionAssistantMessage {
+  role?: string;
+  content?: string | null;
+  tool_calls?: ChatCompletionMessageToolCall[] | null;
+}
+
+export interface ChatCompletionChoice {
+  index?: number;
+  message?: ChatCompletionAssistantMessage;
+  finish_reason?: string | null;
+}
+
+/** Non-streaming response from `POST /chat/completions`. */
+export interface ChatCompletionResponse {
+  id?: string;
+  model?: string;
+  choices?: ChatCompletionChoice[];
+  usage?: ChatCompletionUsage | null;
+}
+
+export interface ChatCompletionChunkDeltaToolCall {
+  index?: number;
+  id?: string | null;
+  function?: ChatCompletionToolCallFunction;
+}
+
+export interface ChatCompletionChunkDelta {
+  content?: string | null;
+  tool_calls?: ChatCompletionChunkDeltaToolCall[] | null;
+  /** Audio-output models (`modalities: ["text","audio"]`) stream base64 here. */
+  audio?: { data?: string };
+}
+
+export interface ChatCompletionChunkChoice {
+  index?: number;
+  delta?: ChatCompletionChunkDelta;
+  finish_reason?: string | null;
+}
+
+/** One SSE chunk of a streaming chat completion. */
+export interface ChatCompletionChunk {
+  id?: string;
+  model?: string;
+  choices?: ChatCompletionChunkChoice[];
+  usage?: ChatCompletionUsage | null;
+}

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -794,7 +794,7 @@ export class OpenAIProvider extends BaseProvider {
     });
   }
 
-  private convertSystemToUserForOModels(
+  protected convertSystemToUserForOModels(
     messages: Message[],
     model: string
   ): Message[] {

--- a/packages/runtime/src/providers/openrouter-provider.ts
+++ b/packages/runtime/src/providers/openrouter-provider.ts
@@ -1,6 +1,9 @@
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import { createLogger } from "@nodetool-ai/config";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type {
   ImageModel,
   LanguageModel,
@@ -13,12 +16,6 @@ import type {
 // Stryker disable next-line StringLiteral: logger name is diagnostic, not asserted.
 const log = createLogger("nodetool.runtime.providers.openrouter");
 
-interface OpenRouterProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
 /** Known image-capable models on OpenRouter. */
 const OPENROUTER_IMAGE_MODELS: ImageModel[] = [
   {
@@ -29,7 +26,7 @@ const OPENROUTER_IMAGE_MODELS: ImageModel[] = [
   }
 ];
 
-export class OpenRouterProvider extends OpenAIProvider {
+export class OpenRouterProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["OPENROUTER_API_KEY"];
   }
@@ -38,7 +35,7 @@ export class OpenRouterProvider extends OpenAIProvider {
 
   constructor(
     secrets: { OPENROUTER_API_KEY?: string },
-    options: OpenRouterProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.OPENROUTER_API_KEY;
     if (!apiKey) {
@@ -48,31 +45,23 @@ export class OpenRouterProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: "https://openrouter.ai/api/v1",
-              // Default request headers are passed to the OpenAI SDK and only
-              // observable over the wire; the same header values are asserted on
-              // the /models fetch below.
-              // Stryker disable next-line ObjectLiteral
-              defaultHeaders: {
-                // Stryker disable next-line StringLiteral
-                "HTTP-Referer": "https://github.com/nodetool-ai/nodetool-core",
-                // Stryker disable next-line StringLiteral
-                "X-Title": "NodeTool"
-              }
-            })),
-        fetchFn
-      }
+        providerId: "openrouter",
+        apiKey,
+        baseURL: "https://openrouter.ai/api/v1",
+        // Attribution headers ride every chat request (and the SDK fallback);
+        // the same header values are asserted on the /models fetch below.
+        // Stryker disable next-line ObjectLiteral
+        defaultHeaders: {
+          // Stryker disable next-line StringLiteral
+          "HTTP-Referer": "https://github.com/nodetool-ai/nodetool-core",
+          // Stryker disable next-line StringLiteral
+          "X-Title": "NodeTool"
+        }
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "openrouter";
     this._routerFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/together-provider.ts
+++ b/packages/runtime/src/providers/together-provider.ts
@@ -1,5 +1,7 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import { loadImageModels, loadVideoModels } from "./manifest-models.js";
 import type {
   ASRModel,
@@ -15,12 +17,6 @@ import type {
   TTSModel,
   VideoModel
 } from "./types.js";
-
-interface TogetherProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
 
 // ─── Model catalogs ───────────────────────────────────────────────────────────
 
@@ -169,7 +165,7 @@ function parseWavPCM(bytes: Uint8Array): {
 
 // ─── Provider ─────────────────────────────────────────────────────────────────
 
-export class TogetherProvider extends OpenAIProvider {
+export class TogetherProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["TOGETHER_API_KEY"];
   }
@@ -178,7 +174,7 @@ export class TogetherProvider extends OpenAIProvider {
 
   constructor(
     secrets: { TOGETHER_API_KEY?: string },
-    options: TogetherProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.TOGETHER_API_KEY;
     if (!apiKey) {
@@ -188,21 +184,14 @@ export class TogetherProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: "https://api.together.xyz/v1"
-            })),
-        fetchFn
-      }
+        providerId: "together",
+        apiKey,
+        baseURL: "https://api.together.xyz/v1"
+      },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "together";
     this._togetherFetch = fetchFn;
   }
 

--- a/packages/runtime/src/providers/vllm-provider.ts
+++ b/packages/runtime/src/providers/vllm-provider.ts
@@ -1,15 +1,15 @@
-import OpenAI from "openai";
-import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
+import { trimTrailingSlashes } from "./openai-compat/index.js";
 import type { LanguageModel } from "./types.js";
 
-interface VLLMProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
+interface VLLMProviderOptions extends OpenAICompatProviderOptions {
   baseURL?: string;
 }
 
-export class VLLMProvider extends OpenAIProvider {
+export class VLLMProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return [];
   }
@@ -30,7 +30,7 @@ export class VLLMProvider extends OpenAIProvider {
         "VLLM_BASE_URL is required (options.baseURL, secret, or env)"
       );
     }
-    const baseURL = String(rawBaseURL).replace(/\/+$/, "");
+    const baseURL = trimTrailingSlashes(String(rawBaseURL));
 
     const apiKey =
       secrets.VLLM_API_KEY && secrets.VLLM_API_KEY.trim().length > 0
@@ -39,21 +39,10 @@ export class VLLMProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
-      {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: `${baseURL}/v1`
-            })),
-        fetchFn
-      }
+      { providerId: "vllm", apiKey, baseURL: `${baseURL}/v1` },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "vllm";
     this._vllmFetch = fetchFn;
     this._vllmBaseURL = baseURL;
   }

--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -1,5 +1,8 @@
-import OpenAI from "openai";
 import { OpenAIProvider } from "./openai-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import type {
   ImageModel,
   ImageToImageParams,
@@ -45,12 +48,6 @@ function bytesToDataUri(bytes: Uint8Array): string {
   return `data:${detectImageMime(bytes)};base64,${base64}`;
 }
 
-interface XAIProviderOptions {
-  client?: OpenAI;
-  clientFactory?: (apiKey: string) => OpenAI;
-  fetchFn?: typeof fetch;
-}
-
 /** Raw row from xAI's `/v1/models` listing. */
 interface XAIModelRow {
   id: string;
@@ -90,10 +87,10 @@ function classifyModel(row: XAIModelRow): ModelModality {
 }
 
 /**
- * xAI (Grok) provider. Uses the OpenAI SDK against xAI's
- * OpenAI-compatible endpoint at https://api.x.ai/v1.
+ * xAI (Grok) provider. Speaks the OpenAI Chat Completions dialect against
+ * xAI's OpenAI-compatible endpoint at https://api.x.ai/v1.
  */
-export class XAIProvider extends OpenAIProvider {
+export class XAIProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["XAI_API_KEY"];
   }
@@ -102,7 +99,7 @@ export class XAIProvider extends OpenAIProvider {
 
   constructor(
     secrets: { XAI_API_KEY?: string },
-    options: XAIProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.XAI_API_KEY;
     if (!apiKey) {
@@ -112,21 +109,10 @@ export class XAIProvider extends OpenAIProvider {
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super(
-      { OPENAI_API_KEY: apiKey },
-      {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new OpenAI({
-              apiKey: key,
-              baseURL: XAI_BASE_URL
-            })),
-        fetchFn
-      }
+      { providerId: "xai", apiKey, baseURL: XAI_BASE_URL },
+      { ...options, fetchFn }
     );
 
-    (this as { provider: string }).provider = "xai";
     this._xaiFetch = fetchFn;
   }
 

--- a/packages/runtime/tests/providers/aki-provider.test.ts
+++ b/packages/runtime/tests/providers/aki-provider.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import { encodeBinary } from "@aki-io/aki-io";
 import OpenAI from "openai";
 import { AkiProvider } from "../../src/providers/aki-provider.js";
+import {
+  chatJsonResponse,
+  mockChatFetch,
+  requestBodyOf
+} from "./helpers/compat-fetch.js";
 
 type DoApiRequest = ReturnType<typeof vi.fn>;
 type GetGenerator = (params: unknown) => AsyncGenerator<unknown>;
@@ -65,10 +70,10 @@ describe("AkiProvider", () => {
       ],
       usage: { prompt_tokens: 4, completion_tokens: 7 }
     };
-    const create = vi.fn().mockResolvedValue(mockCompletion);
+    const fetchMock = mockChatFetch(chatJsonResponse(mockCompletion));
     const provider = new AkiProvider(
       { AKI_API_KEY: "k" },
-      { client: makeOpenAIClient({ create }) }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const result = await provider.generateMessage({
@@ -84,9 +89,14 @@ describe("AkiProvider", () => {
 
     expect(result.role).toBe("assistant");
     expect(result.content).toBe("hello from aki");
-    expect(create).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "llama3_chat", stream: false })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aki.io/v1/chat/completions",
+      expect.objectContaining({ method: "POST" })
     );
+    expect(requestBodyOf(fetchMock)).toMatchObject({
+      model: "llama3_chat",
+      stream: false
+    });
   });
 
   it("uses https://aki.io/v1 as the OpenAI base URL", () => {

--- a/packages/runtime/tests/providers/cerebras-provider.test.ts
+++ b/packages/runtime/tests/providers/cerebras-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { CerebrasProvider } from "../../src/providers/cerebras-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("CerebrasProvider", () => {
   it("throws if CEREBRAS_API_KEY is missing", () => {
@@ -101,25 +93,23 @@ describe("CerebrasProvider", () => {
     expect(models).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "cerebras response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "cerebras response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new CerebrasProvider(
       { CEREBRAS_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -132,7 +122,7 @@ describe("CerebrasProvider", () => {
     expect(result.content).toBe("cerebras response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [{ delta: { content: "hello" }, finish_reason: null }]
@@ -142,15 +132,11 @@ describe("CerebrasProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new CerebrasProvider(
       { CEREBRAS_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/deepseek-provider.test.ts
+++ b/packages/runtime/tests/providers/deepseek-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { DeepSeekProvider } from "../../src/providers/deepseek-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("DeepSeekProvider", () => {
   it("throws if DEEPSEEK_API_KEY is missing", () => {
@@ -101,25 +93,23 @@ describe("DeepSeekProvider", () => {
     expect(models).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "deepseek response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "deepseek response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new DeepSeekProvider(
       { DEEPSEEK_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -132,7 +122,7 @@ describe("DeepSeekProvider", () => {
     expect(result.content).toBe("deepseek response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [{ delta: { content: "hello" }, finish_reason: null }]
@@ -142,15 +132,11 @@ describe("DeepSeekProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new DeepSeekProvider(
       { DEEPSEEK_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/evolink-provider.test.ts
+++ b/packages/runtime/tests/providers/evolink-provider.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import { EvolinkProvider } from "../../src/providers/evolink-provider.js";
 import { providerCapabilities } from "../../src/providers/base-provider.js";
 import type { Message } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 /**
  * Route Evolink's media calls (file upload, task submit, task poll, result
@@ -44,19 +49,6 @@ function makeMediaFetch(resultBytes: Uint8Array) {
     }
     throw new Error(`Unexpected fetch: ${url}`);
   });
-}
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
 }
 
 describe("EvolinkProvider", () => {
@@ -147,25 +139,23 @@ describe("EvolinkProvider", () => {
     expect(models).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "evolink response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "evolink response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new EvolinkProvider(
       { EVOLINK_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -178,7 +168,7 @@ describe("EvolinkProvider", () => {
     expect(result.content).toBe("evolink response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [{ delta: { content: "hello" }, finish_reason: null }]
@@ -188,15 +178,11 @@ describe("EvolinkProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new EvolinkProvider(
       { EVOLINK_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/gmi-provider.test.ts
+++ b/packages/runtime/tests/providers/gmi-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { GMIProvider } from "../../src/providers/gmi-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("GMIProvider", () => {
   it("throws if GMI_API_KEY is missing", () => {
@@ -113,25 +105,23 @@ describe("GMIProvider", () => {
     expect(await provider.getAvailableEmbeddingModels()).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "gmi response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "gmi response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new GMIProvider(
       { GMI_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -144,21 +134,17 @@ describe("GMIProvider", () => {
     expect(result.content).toBe("gmi response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       { choices: [{ delta: { content: "hello" }, finish_reason: null }] },
       { choices: [{ delta: { content: "" }, finish_reason: "stop" }] }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new GMIProvider(
       { GMI_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/groq-provider.test.ts
+++ b/packages/runtime/tests/providers/groq-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { GroqProvider } from "../../src/providers/groq-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("GroqProvider", () => {
   it("throws if GROQ_API_KEY is missing", () => {
@@ -90,25 +82,23 @@ describe("GroqProvider", () => {
     expect(models).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "fast response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "fast response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+      })
+    );
 
     const provider = new GroqProvider(
       { GROQ_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -119,10 +109,16 @@ describe("GroqProvider", () => {
 
     expect(result.role).toBe("assistant");
     expect(result.content).toBe("fast response");
-    expect(create).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.groq.com/openai/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer k" })
+      })
+    );
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [
@@ -142,15 +138,11 @@ describe("GroqProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new GroqProvider(
       { GROQ_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/helpers/compat-fetch.ts
+++ b/packages/runtime/tests/providers/helpers/compat-fetch.ts
@@ -1,0 +1,59 @@
+import { vi, type Mock } from "vitest";
+
+/** JSON 200 response for a non-streaming chat completion. */
+export function chatJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+/** Encode chunk objects as an OpenAI-style SSE stream, ending in `[DONE]`. */
+export function sseBody(chunks: unknown[]): string {
+  const events = chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`);
+  return `${events.join("")}data: [DONE]\n\n`;
+}
+
+/** SSE 200 response for a streaming chat completion. */
+export function chatSSEResponse(chunks: unknown[]): Response {
+  return new Response(sseBody(chunks), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" }
+  });
+}
+
+/** OpenAI-style error response (`{"error": {"message": …}}`). */
+export function chatErrorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: { message } }), {
+    status,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+/**
+ * Mock `fetch` returning the given response for every call. Pass a factory to
+ * vary responses per call; each call gets a fresh Response either way.
+ */
+export function mockChatFetch(
+  response: Response | (() => Response)
+): Mock<typeof fetch> {
+  if (typeof response === "function") {
+    return vi.fn(async () => response()) as unknown as Mock<typeof fetch>;
+  }
+  // Rebuild a fresh Response per call — a shared body can only be read once.
+  const status = response.status;
+  const headers = new Headers(response.headers);
+  const bodyText = response.text();
+  return vi.fn(
+    async () => new Response(await bodyText, { status, headers })
+  ) as unknown as Mock<typeof fetch>;
+}
+
+/** The parsed JSON body of the `index`-th call made to a mocked fetch. */
+export function requestBodyOf(
+  fetchMock: Mock<typeof fetch>,
+  index = 0
+): Record<string, unknown> {
+  const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
+  return JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+}

--- a/packages/runtime/tests/providers/llama-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/llama-provider-coverage.test.ts
@@ -6,29 +6,24 @@
 import { describe, it, expect, vi } from "vitest";
 import { LlamaProvider } from "../../src/providers/llama-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch,
+  requestBodyOf
+} from "./helpers/compat-fetch.js";
 
 describe("LlamaProvider – message normalization for strict alternation", () => {
   it("inserts empty messages to maintain user/assistant alternation", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [{ message: { content: "ok" } }]
-    });
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [{ message: { content: "ok" } }]
+        })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     // Two consecutive user messages should get an empty assistant between them
@@ -40,7 +35,7 @@ describe("LlamaProvider – message normalization for strict alternation", () =>
       ]
     });
 
-    const sentMessages = create.mock.calls[0][0].messages;
+    const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content?: string }>;
     // Should have system-injected padding for alternation
     // user -> assistant (empty) -> user
     const roles = sentMessages.map((m: any) => m.role);
@@ -53,13 +48,15 @@ describe("LlamaProvider – message normalization for strict alternation", () =>
   });
 
   it("converts system messages into a merged system message", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [{ message: { content: "ok" } }]
-    });
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [{ message: { content: "ok" } }]
+        })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     await provider.generateMessage({
@@ -71,20 +68,22 @@ describe("LlamaProvider – message normalization for strict alternation", () =>
       ]
     });
 
-    const sentMessages = create.mock.calls[0][0].messages;
+    const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content?: string }>;
     const systemMsg = sentMessages.find((m: any) => m.role === "system");
     expect(systemMsg.content).toContain("Be concise.");
     expect(systemMsg.content).toContain("Be helpful.");
   });
 
   it("converts tool messages to user messages", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [{ message: { content: "ok" } }]
-    });
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [{ message: { content: "ok" } }]
+        })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     await provider.generateMessage({
@@ -100,7 +99,7 @@ describe("LlamaProvider – message normalization for strict alternation", () =>
       ]
     });
 
-    const sentMessages = create.mock.calls[0][0].messages;
+    const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content?: string }>;
     const toolResult = sentMessages.find((m: any) =>
       (m.content || "").includes("Tool result:")
     );
@@ -113,7 +112,7 @@ describe("LlamaProvider – convertMessage system message", () => {
   it("converts system role message", async () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any }
+      {}
     );
 
     const result = await provider.convertMessage({
@@ -126,7 +125,7 @@ describe("LlamaProvider – convertMessage system message", () => {
   it("handles system message with array content", async () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any }
+      {}
     );
 
     const result = await provider.convertMessage({
@@ -141,7 +140,7 @@ describe("LlamaProvider – formatTools", () => {
   it("formats tools in OpenAI function format", () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any }
+      {}
     );
 
     const result = provider.formatTools([
@@ -168,7 +167,8 @@ describe("LlamaProvider – formatTools", () => {
 
 describe("LlamaProvider – generateMessages with native tool_calls in stream", () => {
   it("yields tool calls from stream", async () => {
-    const stream = makeAsyncIterable([
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
       {
         choices: [
           {
@@ -188,12 +188,11 @@ describe("LlamaProvider – generateMessages with native tool_calls in stream", 
       {
         choices: [{ delta: {}, finish_reason: "tool_calls" }]
       }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: unknown[] = [];
@@ -211,25 +210,27 @@ describe("LlamaProvider – generateMessages with native tool_calls in stream", 
 
 describe("LlamaProvider – generateMessage with native tool calls", () => {
   it("uses native tool calls when available", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "",
-            tool_calls: [
-              {
-                id: "tc1",
-                function: { name: "calc", arguments: '{"expr":"1+1"}' }
-              }
-            ]
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id: "tc1",
+                  function: { name: "calc", arguments: '{"expr":"1+1"}' }
+                }
+              ]
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const result = await provider.generateMessage({
@@ -253,7 +254,7 @@ describe("LlamaProvider – getAvailableLanguageModels fallback", () => {
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any, fetchFn: fetchFn as any }
+      { fetchFn: fetchFn as any }
     );
 
     const models = await provider.getAvailableLanguageModels();
@@ -267,7 +268,7 @@ describe("LlamaProvider – getAvailableLanguageModels fallback", () => {
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any, fetchFn: fetchFn as any }
+      { fetchFn: fetchFn as any }
     );
 
     expect(await provider.getAvailableLanguageModels()).toEqual([]);
@@ -276,7 +277,8 @@ describe("LlamaProvider – getAvailableLanguageModels fallback", () => {
 
 describe("LlamaProvider – emulated tool calls in streaming (hasToolSupport=false)", () => {
   it("parses emulated tool calls on stop when tools are provided", async () => {
-    const stream = makeAsyncIterable([
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
       {
         choices: [
           {
@@ -288,12 +290,11 @@ describe("LlamaProvider – emulated tool calls in streaming (hasToolSupport=fal
       {
         choices: [{ delta: { content: "" }, finish_reason: "stop" }]
       }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: unknown[] = [];
@@ -319,17 +320,19 @@ describe("LlamaProvider – emulated tool calls in streaming (hasToolSupport=fal
 
 describe("LlamaProvider – emulated tool calls in generateMessage (non-streaming)", () => {
   it("parses emulated tool calls when no native tool_calls", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: { content: 'search(q="test")' }
-        }
-      ]
-    });
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: { content: 'search(q="test")' }
+          }
+        ]
+        })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const result = await provider.generateMessage({
@@ -346,7 +349,8 @@ describe("LlamaProvider – emulated tool calls in generateMessage (non-streamin
 
 describe("LlamaProvider – parseKeywordArgs edge cases", () => {
   it("parses JSON objects and arrays in arguments", async () => {
-    const stream = makeAsyncIterable([
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
       {
         choices: [
           {
@@ -358,12 +362,11 @@ describe("LlamaProvider – parseKeywordArgs edge cases", () => {
       {
         choices: [{ delta: { content: "" }, finish_reason: "stop" }]
       }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: unknown[] = [];
@@ -382,7 +385,8 @@ describe("LlamaProvider – parseKeywordArgs edge cases", () => {
   });
 
   it("parses quoted strings, booleans, nulls, numbers", async () => {
-    const stream = makeAsyncIterable([
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
       {
         choices: [
           {
@@ -396,12 +400,11 @@ describe("LlamaProvider – parseKeywordArgs edge cases", () => {
       {
         choices: [{ delta: { content: "" }, finish_reason: "stop" }]
       }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: unknown[] = [];
@@ -423,7 +426,8 @@ describe("LlamaProvider – parseKeywordArgs edge cases", () => {
   });
 
   it("handles single-quoted strings", async () => {
-    const stream = makeAsyncIterable([
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
       {
         choices: [
           {
@@ -435,12 +439,11 @@ describe("LlamaProvider – parseKeywordArgs edge cases", () => {
       {
         choices: [{ delta: { content: "" }, finish_reason: "stop" }]
       }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: unknown[] = [];
@@ -462,7 +465,7 @@ describe("LlamaProvider – isContextLengthError", () => {
   it("detects context length errors", () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any }
+      {}
     );
     expect(provider.isContextLengthError("context length exceeded")).toBe(true);
     expect(provider.isContextLengthError("random error")).toBe(false);
@@ -473,7 +476,7 @@ describe("LlamaProvider – convertMessage tool role", () => {
   it("converts tool role with object content", async () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://localhost:8080" },
-      { client: {} as any }
+      {}
     );
 
     const result = await provider.convertMessage({

--- a/packages/runtime/tests/providers/llama-provider.test.ts
+++ b/packages/runtime/tests/providers/llama-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { LlamaProvider } from "../../src/providers/llama-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("LlamaProvider", () => {
   it("requires LLAMA_CPP_URL and reports container env behavior", async () => {
@@ -22,7 +14,7 @@ describe("LlamaProvider", () => {
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080/" },
-      { client: {} as any }
+      {}
     );
     expect(provider.baseUrl).toBe("http://127.0.0.1:8080");
     expect(provider.getContainerEnv()).toEqual({});
@@ -42,7 +34,7 @@ describe("LlamaProvider", () => {
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080" },
-      { client: {} as any, fetchFn: fetchFn as any }
+      { fetchFn: fetchFn as any }
     );
 
     await expect(provider.getAvailableLanguageModels()).resolves.toEqual([
@@ -58,7 +50,7 @@ describe("LlamaProvider", () => {
   it("converts messages to OpenAI-compatible payloads", async () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080" },
-      { client: {} as any }
+      {}
     );
 
     const user: Message = { role: "user", content: "hello" };
@@ -91,24 +83,22 @@ describe("LlamaProvider", () => {
   });
 
   it("generates non-streaming response and parses emulated tool calls", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "calculator(expression='5 + 3')",
-            tool_calls: []
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "calculator(expression='5 + 3')",
+              tool_calls: []
+            }
           }
-        }
-      ]
-    });
+        ]
+      })
+    );
 
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const result = await provider.generateMessage({
@@ -127,28 +117,24 @@ describe("LlamaProvider", () => {
   });
 
   it("streams chunks and parses emulated tool call on stop", async () => {
-    const stream = makeAsyncIterable([
-      {
-        choices: [
-          {
-            delta: { content: "calculator(expression='9+1')" },
-            finish_reason: null
-          }
-        ]
-      },
-      {
-        choices: [{ delta: { content: "" }, finish_reason: "stop" }]
-      }
-    ]);
-
-    const create = vi.fn().mockResolvedValue(stream);
+    const fetchMock = mockChatFetch(
+      chatSSEResponse([
+        {
+          choices: [
+            {
+              delta: { content: "calculator(expression='9+1')" },
+              finish_reason: null
+            }
+          ]
+        },
+        {
+          choices: [{ delta: { content: "" }, finish_reason: "stop" }]
+        }
+      ])
+    );
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const out: Array<unknown> = [];
@@ -170,7 +156,7 @@ describe("LlamaProvider", () => {
   it("detects context-length errors", () => {
     const provider = new LlamaProvider(
       { LLAMA_CPP_URL: "http://127.0.0.1:8080" },
-      { client: {} as any }
+      {}
     );
 
     expect(

--- a/packages/runtime/tests/providers/lmstudio-provider.test.ts
+++ b/packages/runtime/tests/providers/lmstudio-provider.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { LMStudioProvider } from "../../src/providers/lmstudio-provider.js";
 import type { Message } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("LMStudioProvider", () => {
   it("creates without secrets (no API key required)", () => {
@@ -111,24 +116,22 @@ describe("LMStudioProvider", () => {
   });
 
   it("generates non-streaming message", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "lmstudio response",
-            tool_calls: null
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "lmstudio response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+      })
+    );
 
     const provider = new LMStudioProvider(
       {},
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];

--- a/packages/runtime/tests/providers/lmstudio-provider.test.ts
+++ b/packages/runtime/tests/providers/lmstudio-provider.test.ts
@@ -3,7 +3,6 @@ import { LMStudioProvider } from "../../src/providers/lmstudio-provider.js";
 import type { Message } from "../../src/providers/types.js";
 import {
   chatJsonResponse,
-  chatSSEResponse,
   mockChatFetch
 } from "./helpers/compat-fetch.js";
 

--- a/packages/runtime/tests/providers/minimax-provider.test.ts
+++ b/packages/runtime/tests/providers/minimax-provider.test.ts
@@ -7,7 +7,6 @@ import type {
 } from "../../src/providers/types.js";
 import {
   chatJsonResponse,
-  chatSSEResponse,
   mockChatFetch
 } from "./helpers/compat-fetch.js";
 

--- a/packages/runtime/tests/providers/minimax-provider.test.ts
+++ b/packages/runtime/tests/providers/minimax-provider.test.ts
@@ -5,6 +5,11 @@ import type {
   Message,
   VideoModel
 } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("MinimaxProvider", () => {
   it("throws if MINIMAX_API_KEY is missing", () => {
@@ -330,13 +335,15 @@ describe("MinimaxProvider", () => {
     expect(body.lyrics).toBe("[Instrumental]");
   });
 
-  it("generates a chat completion via the inherited OpenAI path", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [{ message: { content: "hi", tool_calls: null } }]
-    });
+  it("generates a chat completion via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [{ message: { content: "hi", tool_calls: null } }]
+      })
+    );
     const provider = new MinimaxProvider(
       { MINIMAX_API_KEY: "k" },
-      { client: { chat: { completions: { create } } } as any }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
     const messages: Message[] = [{ role: "user", content: "hello" }];
     const result = await provider.generateMessage({

--- a/packages/runtime/tests/providers/mistral-provider.test.ts
+++ b/packages/runtime/tests/providers/mistral-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { MistralProvider } from "../../src/providers/mistral-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("MistralProvider", () => {
   it("throws if MISTRAL_API_KEY is missing", () => {
@@ -109,25 +101,23 @@ describe("MistralProvider", () => {
     ]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "bonjour",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "bonjour",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new MistralProvider(
       { MISTRAL_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -140,7 +130,7 @@ describe("MistralProvider", () => {
     expect(result.content).toBe("bonjour");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [
@@ -160,15 +150,11 @@ describe("MistralProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new MistralProvider(
       { MISTRAL_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/openai-compat.test.ts
+++ b/packages/runtime/tests/providers/openai-compat.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi } from "vitest";
+import { sseEvents } from "../../src/providers/openai-compat/sse.js";
+import {
+  OpenAICompatClient,
+  trimTrailingSlashes
+} from "../../src/providers/openai-compat/client.js";
+import { OpenAICompatError } from "../../src/providers/openai-compat/errors.js";
+import type { ChatCompletionChunk } from "../../src/providers/openai-compat/types.js";
+import {
+  chatErrorResponse,
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch,
+  requestBodyOf,
+  sseBody
+} from "./helpers/compat-fetch.js";
+
+/** A ReadableStream that emits the given strings as separate network chunks. */
+function streamOf(...parts: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part));
+      controller.close();
+    }
+  });
+}
+
+async function collect(body: ReadableStream<Uint8Array>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const event of sseEvents(body)) out.push(event);
+  return out;
+}
+
+describe("sseEvents", () => {
+  it("parses one event per data block", async () => {
+    const events = await collect(streamOf('data: {"a":1}\n\ndata: {"b":2}\n\n'));
+    expect(events).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it("handles events split across network chunks", async () => {
+    const events = await collect(
+      streamOf("data: {\"a", '":1}', "\n", "\ndata:", ' {"b":2}\n\n')
+    );
+    expect(events).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it("handles multi-byte UTF-8 split across chunk boundaries", async () => {
+    const encoded = new TextEncoder().encode('data: "héllo"\n\n');
+    const cut = 9; // inside the two-byte é sequence
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, cut));
+        controller.enqueue(encoded.slice(cut));
+        controller.close();
+      }
+    });
+    expect(await collect(body)).toEqual(['"héllo"']);
+  });
+
+  it("handles CRLF line endings", async () => {
+    const events = await collect(
+      streamOf('data: {"a":1}\r\n\r\ndata: [DONE]\r\n\r\n')
+    );
+    expect(events).toEqual(['{"a":1}', "[DONE]"]);
+  });
+
+  it("joins multiple data lines of one event with newlines", async () => {
+    const events = await collect(streamOf("data: line1\ndata: line2\n\n"));
+    expect(events).toEqual(["line1\nline2"]);
+  });
+
+  it("ignores comments and non-data fields", async () => {
+    const events = await collect(
+      streamOf(': ping\nevent: message\nid: 42\ndata: {"a":1}\n\n')
+    );
+    expect(events).toEqual(['{"a":1}']);
+  });
+
+  it("flushes a final event not terminated by a blank line", async () => {
+    const events = await collect(streamOf('data: {"a":1}\n\ndata: [DONE]'));
+    expect(events).toEqual(['{"a":1}', "[DONE]"]);
+  });
+
+  it("does not strip more than one leading space from data payloads", async () => {
+    const events = await collect(streamOf("data:  spaced\n\n"));
+    expect(events).toEqual([" spaced"]);
+  });
+});
+
+describe("trimTrailingSlashes", () => {
+  it("removes any number of trailing slashes", () => {
+    expect(trimTrailingSlashes("http://x/v1///")).toBe("http://x/v1");
+    expect(trimTrailingSlashes("http://x/v1")).toBe("http://x/v1");
+    expect(trimTrailingSlashes("////")).toBe("");
+  });
+});
+
+describe("OpenAICompatClient.chatCompletions", () => {
+  const request = {
+    model: "test-model",
+    messages: [{ role: "user", content: "hi" }]
+  };
+
+  it("POSTs to /chat/completions with auth and body, parses the response", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [{ message: { content: "hello" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 3, completion_tokens: 2 }
+      })
+    );
+    const client = new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1/",
+      apiKey: "secret",
+      defaultHeaders: { "X-Title": "NodeTool" },
+      fetchFn: fetchMock as unknown as typeof fetch
+    });
+
+    const response = await client.chatCompletions(request);
+
+    expect(response.choices?.[0]?.message?.content).toBe("hello");
+    expect(response.usage?.prompt_tokens).toBe(3);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+          "Content-Type": "application/json",
+          "X-Title": "NodeTool"
+        })
+      })
+    );
+    expect(requestBodyOf(fetchMock as never)).toEqual({
+      model: "test-model",
+      messages: [{ role: "user", content: "hi" }],
+      stream: false
+    });
+  });
+
+  it("maps a 400 with an OpenAI-style error body to a typed error", async () => {
+    const fetchMock = mockChatFetch(
+      chatErrorResponse(400, "context length exceeded")
+    );
+    const client = new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "k",
+      fetchFn: fetchMock as unknown as typeof fetch,
+      maxRetries: 0
+    });
+
+    const error = await client.chatCompletions(request).catch((e) => e);
+    expect(error).toBeInstanceOf(OpenAICompatError);
+    expect(error.status).toBe(400);
+    // Message matches the openai SDK "<status> <message>" shape callers grep.
+    expect(String(error)).toContain("400 context length exceeded");
+  });
+
+  it("maps a 429 so BaseProvider rate-limit detection keeps working", async () => {
+    const fetchMock = mockChatFetch(
+      chatErrorResponse(429, "Rate limit reached")
+    );
+    const client = new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "k",
+      fetchFn: fetchMock as unknown as typeof fetch,
+      maxRetries: 0
+    });
+
+    const error = await client.chatCompletions(request).catch((e) => e);
+    expect(error.status).toBe(429);
+    expect(/429|rate.?limit|too many requests/i.test(String(error))).toBe(true);
+  });
+
+  it("surfaces a non-JSON error body as the message", async () => {
+    const fetchMock = mockChatFetch(
+      () => new Response("upstream exploded", { status: 502 })
+    );
+    const client = new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "k",
+      fetchFn: fetchMock as unknown as typeof fetch,
+      maxRetries: 0
+    });
+
+    const error = await client.chatCompletions(request).catch((e) => e);
+    expect(error.status).toBe(502);
+    expect(String(error)).toContain("upstream exploded");
+  });
+
+  it("retries retryable statuses then succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const fetchMock = vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) return chatErrorResponse(500, "flaky");
+        return chatJsonResponse({ choices: [{ message: { content: "ok" } }] });
+      });
+      const client = new OpenAICompatClient({
+        baseURL: "https://api.example.com/v1",
+        apiKey: "k",
+        fetchFn: fetchMock as unknown as typeof fetch,
+        maxRetries: 2
+      });
+
+      const pending = client.chatCompletions(request);
+      await vi.runAllTimersAsync();
+      const response = await pending;
+      expect(response.choices?.[0]?.message?.content).toBe("ok");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry non-retryable statuses", async () => {
+    const fetchMock = mockChatFetch(chatErrorResponse(400, "bad request"));
+    const client = new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "k",
+      fetchFn: fetchMock as unknown as typeof fetch,
+      maxRetries: 2
+    });
+
+    await expect(client.chatCompletions(request)).rejects.toThrow(
+      "400 bad request"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OpenAICompatClient.chatCompletionsStream", () => {
+  const request = {
+    model: "test-model",
+    messages: [{ role: "user", content: "hi" }]
+  };
+
+  function clientFor(fetchMock: unknown): OpenAICompatClient {
+    return new OpenAICompatClient({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "k",
+      fetchFn: fetchMock as typeof fetch,
+      maxRetries: 0
+    });
+  }
+
+  it("yields parsed chunks and stops at [DONE]", async () => {
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
+        { choices: [{ delta: { content: "he" }, finish_reason: null }] },
+        { choices: [{ delta: { content: "llo" }, finish_reason: "stop" }] }
+      ])
+    );
+
+    const chunks: ChatCompletionChunk[] = [];
+    for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+      request
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.map((c) => c.choices?.[0]?.delta?.content)).toEqual([
+      "he",
+      "llo"
+    ]);
+    expect(requestBodyOf(fetchMock as never)).toMatchObject({ stream: true });
+    const headers = (
+      (fetchMock as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+    ).headers as Record<string, string>;
+    expect(headers.Accept).toBe("text/event-stream");
+  });
+
+  it("assembles tool-call deltas across chunks (provider-side contract)", async () => {
+    const fetchMock = mockChatFetch(() =>
+      chatSSEResponse([
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  { index: 0, id: "c1", function: { name: "f", arguments: '{"a"' } }
+                ]
+              },
+              finish_reason: null
+            }
+          ]
+        },
+        {
+          choices: [
+            {
+              delta: { tool_calls: [{ index: 0, function: { arguments: ":1}" } }] },
+              finish_reason: null
+            }
+          ]
+        },
+        { choices: [{ delta: {}, finish_reason: "tool_calls" }] }
+      ])
+    );
+
+    const chunks: ChatCompletionChunk[] = [];
+    for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+      request
+    )) {
+      chunks.push(chunk);
+    }
+
+    // The client passes deltas through untouched; providers assemble them.
+    expect(chunks[0].choices?.[0]?.delta?.tool_calls?.[0]?.id).toBe("c1");
+    expect(chunks[1].choices?.[0]?.delta?.tool_calls?.[0]?.function?.arguments).toBe(
+      ":1}"
+    );
+    expect(chunks[2].choices?.[0]?.finish_reason).toBe("tool_calls");
+  });
+
+  it("throws a typed error on a mid-stream error event", async () => {
+    const body =
+      'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}\n\n' +
+      'data: {"error":{"message":"stream blew up","code":"boom"}}\n\n';
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" }
+        })
+    );
+
+    const seen: string[] = [];
+    const error = await (async () => {
+      try {
+        for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+          request
+        )) {
+          seen.push(String(chunk.choices?.[0]?.delta?.content));
+        }
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+
+    expect(seen).toEqual(["hi"]);
+    expect(error).toBeInstanceOf(OpenAICompatError);
+    expect(String(error)).toContain("stream blew up");
+    expect((error as OpenAICompatError).code).toBe("boom");
+  });
+
+  it("throws on a non-2xx streaming response with the parsed error message", async () => {
+    const fetchMock = mockChatFetch(chatErrorResponse(401, "bad key"));
+    const error = await (async () => {
+      try {
+        for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+          request
+        )) {
+          void chunk;
+        }
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect((error as OpenAICompatError).status).toBe(401);
+    expect(String(error)).toContain("401 bad key");
+  });
+
+  it("throws on unparseable stream data", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("data: not-json\n\n", {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" }
+        })
+    );
+    const iterate = async () => {
+      for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+        request
+      )) {
+        void chunk;
+      }
+    };
+    await expect(iterate()).rejects.toThrow(
+      "could not parse stream event as JSON"
+    );
+  });
+
+  it("sseBody helper round-trips through the parser", async () => {
+    const body = sseBody([{ a: 1 }]);
+    expect(body).toBe('data: {"a":1}\n\ndata: [DONE]\n\n');
+  });
+});

--- a/packages/runtime/tests/providers/openai-compat.test.ts
+++ b/packages/runtime/tests/providers/openai-compat.test.ts
@@ -345,6 +345,34 @@ describe("OpenAICompatClient.chatCompletionsStream", () => {
     expect((error as OpenAICompatError).code).toBe("boom");
   });
 
+  it("throws on a mid-stream error event carrying empty choices", async () => {
+    const body =
+      'data: {"error":{"message":"stream blew up","code":"boom"},"choices":[]}\n\n';
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" }
+        })
+    );
+
+    const error = await (async () => {
+      try {
+        for await (const chunk of clientFor(fetchMock).chatCompletionsStream(
+          request
+        )) {
+          void chunk;
+        }
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(OpenAICompatError);
+    expect((error as OpenAICompatError).code).toBe("boom");
+  });
+
   it("throws on a non-2xx streaming response with the parsed error message", async () => {
     const fetchMock = mockChatFetch(chatErrorResponse(401, "bad key"));
     const error = await (async () => {

--- a/packages/runtime/tests/providers/openrouter-provider-hardening.test.ts
+++ b/packages/runtime/tests/providers/openrouter-provider-hardening.test.ts
@@ -7,6 +7,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { OpenRouterProvider } from "../../src/providers/openrouter-provider.js";
 import type { Message, TextToImageParams } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  mockChatFetch,
+  requestBodyOf
+} from "./helpers/compat-fetch.js";
 
 const make = (opts?: object) =>
   new OpenRouterProvider({ OPENROUTER_API_KEY: "k" }, opts as never);
@@ -40,15 +45,21 @@ describe("OpenRouterProvider hardening", () => {
     // A model that does NOT start with "o" (so OpenAIProvider's own converter is
     // inert) but contains "o1" — only OpenRouter's convertSystem handles it.
     const captureSent = async (model: string, content: unknown) => {
-      const create = vi.fn().mockResolvedValue({
-        choices: [{ message: { content: "ok", tool_calls: null } }]
-      });
-      const p = make({ client: { chat: { completions: { create } } } });
+      const fetchMock = mockChatFetch(
+        chatJsonResponse({
+          choices: [{ message: { content: "ok", tool_calls: null } }]
+        })
+      );
+      const p = make({ fetchFn: fetchMock });
       await p.generateMessage({
         messages: [{ role: "system", content } as Message],
         model
       });
-      return create.mock.calls[0][0].messages[0];
+      const sent = requestBodyOf(fetchMock).messages as Array<{
+        role: string;
+        content: string;
+      }>;
+      return sent[0];
     };
 
     it("converts a system message for a non-'o' model containing o1", async () => {
@@ -73,10 +84,12 @@ describe("OpenRouterProvider hardening", () => {
     });
 
     it("converts ONLY system messages, leaving user messages intact", async () => {
-      const create = vi.fn().mockResolvedValue({
-        choices: [{ message: { content: "ok", tool_calls: null } }]
-      });
-      const p = make({ client: { chat: { completions: { create } } } });
+      const fetchMock = mockChatFetch(
+        chatJsonResponse({
+          choices: [{ message: { content: "ok", tool_calls: null } }]
+        })
+      );
+      const p = make({ fetchFn: fetchMock });
       await p.generateMessage({
         messages: [
           { role: "system", content: "sys" } as Message,
@@ -84,7 +97,10 @@ describe("OpenRouterProvider hardening", () => {
         ],
         model: "grok-o1"
       });
-      const sent = create.mock.calls[0][0].messages;
+      const sent = requestBodyOf(fetchMock).messages as Array<{
+        role: string;
+        content: string;
+      }>;
       expect(sent[0].role).toBe("user");
       expect(sent[0].content).toBe("Instructions: sys");
       expect(sent[1].role).toBe("user");

--- a/packages/runtime/tests/providers/openrouter-provider.test.ts
+++ b/packages/runtime/tests/providers/openrouter-provider.test.ts
@@ -1,19 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { OpenRouterProvider } from "../../src/providers/openrouter-provider.js";
 import type { Message, TextToImageParams } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch,
+  requestBodyOf
+} from "./helpers/compat-fetch.js";
 
 describe("OpenRouterProvider", () => {
   it("throws if OPENROUTER_API_KEY is missing", () => {
@@ -106,25 +99,23 @@ describe("OpenRouterProvider", () => {
     expect(models).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "routed response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "routed response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new OpenRouterProvider(
       { OPENROUTER_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -137,7 +128,7 @@ describe("OpenRouterProvider", () => {
     expect(result.content).toBe("routed response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [
@@ -157,15 +148,11 @@ describe("OpenRouterProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new OpenRouterProvider(
       { OPENROUTER_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];
@@ -182,21 +169,19 @@ describe("OpenRouterProvider", () => {
 
   describe("o1/o3 system message conversion", () => {
     it("converts system messages to user with Instructions prefix for o1 models", async () => {
-      const create = vi.fn().mockResolvedValue({
-        choices: [
-          {
-            message: { content: "ok", tool_calls: null }
-          }
-        ]
-      });
+      const fetchMock = mockChatFetch(
+        chatJsonResponse({
+          choices: [
+            {
+              message: { content: "ok", tool_calls: null }
+            }
+          ]
+          })
+      );
 
       const provider = new OpenRouterProvider(
         { OPENROUTER_API_KEY: "k" },
-        {
-          client: {
-            chat: { completions: { create } }
-          } as any
-        }
+        { fetchFn: fetchMock as unknown as typeof fetch }
       );
 
       const messages: Message[] = [
@@ -210,7 +195,7 @@ describe("OpenRouterProvider", () => {
       });
 
       // The first message should have been converted from system to user
-      const sentMessages = create.mock.calls[0][0].messages;
+      const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content: string }>;
       expect(sentMessages[0].role).toBe("user");
       expect(sentMessages[0].content).toBe("Instructions: You are helpful.");
     });
@@ -227,15 +212,11 @@ describe("OpenRouterProvider", () => {
         }
       ];
 
-      const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+      const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
       const provider = new OpenRouterProvider(
         { OPENROUTER_API_KEY: "k" },
-        {
-          client: {
-            chat: { completions: { create } }
-          } as any
-        }
+        { fetchFn: fetchMock as unknown as typeof fetch }
       );
 
       const messages: Message[] = [
@@ -251,27 +232,25 @@ describe("OpenRouterProvider", () => {
         items.push(item);
       }
 
-      const sentMessages = create.mock.calls[0][0].messages;
+      const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content: string }>;
       expect(sentMessages[0].role).toBe("user");
       expect(sentMessages[0].content).toBe("Instructions: Be concise.");
     });
 
     it("does not convert system messages for non-o1/o3 models", async () => {
-      const create = vi.fn().mockResolvedValue({
-        choices: [
-          {
-            message: { content: "ok", tool_calls: null }
-          }
-        ]
-      });
+      const fetchMock = mockChatFetch(
+        chatJsonResponse({
+          choices: [
+            {
+              message: { content: "ok", tool_calls: null }
+            }
+          ]
+          })
+      );
 
       const provider = new OpenRouterProvider(
         { OPENROUTER_API_KEY: "k" },
-        {
-          client: {
-            chat: { completions: { create } }
-          } as any
-        }
+        { fetchFn: fetchMock as unknown as typeof fetch }
       );
 
       const messages: Message[] = [
@@ -284,7 +263,7 @@ describe("OpenRouterProvider", () => {
         model: "anthropic/claude-3-opus"
       });
 
-      const sentMessages = create.mock.calls[0][0].messages;
+      const sentMessages = requestBodyOf(fetchMock).messages as Array<{ role: string; content: string }>;
       expect(sentMessages[0].role).toBe("system");
     });
   });

--- a/packages/runtime/tests/providers/together-provider.test.ts
+++ b/packages/runtime/tests/providers/together-provider.test.ts
@@ -7,19 +7,11 @@ import type {
   TextToImageParams,
   TextToVideoParams
 } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 /** Build a minimal valid WAV buffer containing one zero-valued 16-bit sample at 24 kHz. */
 function buildMinimalWav(sampleRate = 24000): Uint8Array {
@@ -170,25 +162,23 @@ describe("TogetherProvider", () => {
 
   // ─── Chat completions (inherited) ───────────────────────────────────────────
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "together response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "together response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new TogetherProvider(
       { TOGETHER_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -199,10 +189,10 @@ describe("TogetherProvider", () => {
 
     expect(result.role).toBe("assistant");
     expect(result.content).toBe("together response");
-    expect(create).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [{ delta: { content: "hello" }, finish_reason: null }]
@@ -212,15 +202,11 @@ describe("TogetherProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new TogetherProvider(
       { TOGETHER_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];

--- a/packages/runtime/tests/providers/vllm-provider.test.ts
+++ b/packages/runtime/tests/providers/vllm-provider.test.ts
@@ -3,8 +3,7 @@ import { VLLMProvider } from "../../src/providers/vllm-provider.js";
 import type { Message } from "../../src/providers/types.js";
 import {
   chatJsonResponse,
-  mockChatFetch,
-  requestBodyOf
+  mockChatFetch
 } from "./helpers/compat-fetch.js";
 
 describe("VLLMProvider", () => {

--- a/packages/runtime/tests/providers/vllm-provider.test.ts
+++ b/packages/runtime/tests/providers/vllm-provider.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { VLLMProvider } from "../../src/providers/vllm-provider.js";
 import type { Message } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  mockChatFetch,
+  requestBodyOf
+} from "./helpers/compat-fetch.js";
 
 describe("VLLMProvider", () => {
   it("throws if baseURL is not provided", () => {
@@ -143,24 +148,24 @@ describe("VLLMProvider", () => {
   });
 
   it("generates non-streaming message", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "vllm response",
-            tool_calls: null
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "vllm response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+      })
+    );
 
     const provider = new VLLMProvider(
       {},
       {
         baseURL: "http://localhost:8000",
-        client: {
-          chat: { completions: { create } }
-        } as any
+        fetchFn: fetchMock as unknown as typeof fetch
       }
     );
 

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { XAIProvider } from "../../src/providers/xai-provider.js";
 import type { Message } from "../../src/providers/types.js";
-
-function makeAsyncIterable(items: unknown[]) {
-  return {
-    async *[Symbol.asyncIterator]() {
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async close() {
-      return;
-    }
-  };
-}
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("XAIProvider", () => {
   it("throws if XAI_API_KEY is missing", () => {
@@ -164,25 +156,23 @@ describe("XAIProvider", () => {
     expect(await provider.getAvailableVideoModels()).toEqual([]);
   });
 
-  it("generates non-streaming message via inherited OpenAI logic", async () => {
-    const create = vi.fn().mockResolvedValue({
-      choices: [
-        {
-          message: {
-            content: "grok response",
-            tool_calls: null
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "grok response",
+              tool_calls: null
+            }
           }
-        }
-      ]
-    });
+        ]
+        })
+    );
 
     const provider = new XAIProvider(
       { XAI_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hello" }];
@@ -195,7 +185,7 @@ describe("XAIProvider", () => {
     expect(result.content).toBe("grok response");
   });
 
-  it("streams messages via inherited OpenAI logic", async () => {
+  it("streams messages via the compat chat client", async () => {
     const chunks = [
       {
         choices: [{ delta: { content: "hi" }, finish_reason: null }]
@@ -205,15 +195,11 @@ describe("XAIProvider", () => {
       }
     ];
 
-    const create = vi.fn().mockResolvedValue(makeAsyncIterable(chunks));
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
 
     const provider = new XAIProvider(
       { XAI_API_KEY: "k" },
-      {
-        client: {
-          chat: { completions: { create } }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
     const messages: Message[] = [{ role: "user", content: "hi" }];


### PR DESCRIPTION
## What

Most providers used the `openai` npm package only as a generic HTTP client for OpenAI-compatible `/chat/completions` endpoints. This PR replaces that usage with a small internal client in `packages/runtime/src/providers/openai-compat/` and migrates those providers onto it. The `openai` dependency itself stays — the Responses-API surface still needs it (see below).

## The client

- `OpenAICompatClient` with `chatCompletions(request)` and `chatCompletionsStream(request)` over `fetch`, plus request/response/chunk types covering only the fields NodeTool reads and writes (strict TS, no `any`).
- SSE parser (`sse.ts`): events split across network chunks, multiple events per chunk, CRLF, multi-line `data:`, comments, the `[DONE]` sentinel, and a lenient flush of a final unterminated event.
- Error mapping: non-2xx responses become `OpenAICompatError` carrying `status`, `code`, `type`, and the parsed body. The message keeps the SDK's `"<status> <message>"` shape because `BaseProvider.isRateLimitError` / `isContextLengthError` classify by `String(error)`. Mid-stream `{"error": …}` events throw the same typed error.
- Retries: BaseProvider does not retry, so the providers implicitly relied on the SDK's built-in retries. The client keeps parity: two retries on 408/409/429/5xx and network errors, exponential backoff with jitter, `Retry-After` honored, streaming covered only up to connection setup. No double-retry anywhere.
- Trailing-slash trimming uses a loop, not `replace(/\/+$/,"")` — CodeQL flags that regex as polynomially backtracking. The two providers that had the regex (vllm, lmstudio) now share the helper.

## Migrated (chat now on the internal client)

`OpenAICompatProvider extends OpenAIProvider` reroutes `generateMessages` / `generateMessage` through the client, byte-for-byte preserving message conversion, tool-call delta assembly, usage tracking, `llm_call` events, and terminal-chunk semantics. Migrated onto it: **groq, cerebras, xai, mistral, deepseek, vllm, gmi, lmstudio, openrouter, together, minimax, evolink, aki**. **llama_cpp** (its own `BaseProvider` subclass) uses the client directly.

The SDK client remains as a lazily constructed fallback for inherited non-chat surfaces a few gateways expose over the same base URL (Together ASR, OpenRouter `images.generate`, Mistral/Together embeddings). It is never constructed on the chat path.

## Kept on the SDK, and why

- `openai-provider.ts` — Responses API, images/audio/video endpoints, `toFile` multipart uploads.
- `oauth/openai-oauth-provider.ts` — real OpenAI surface incl. Responses.
- `codex-provider.ts` — Responses API over the ChatGPT backend (already raw fetch for chat; SDK import untouched).
- `kie-provider.ts` — mixes Responses API and the Anthropic SDK; not a clean migration.

The `openai` package.json dependency is unchanged; removal can follow once the Responses-API provider migrates.

## Tests

- New `tests/providers/openai-compat.test.ts`: SSE partial-event/CRLF/multi-line/UTF-8-split cases, `[DONE]`, mid-stream error events, URL/header/body assertions, 400/429/502 error mapping, retry and no-retry paths, tool-call delta passthrough.
- Existing provider tests keep their behavioral assertions but mock at the fetch layer instead of the SDK client (`tests/providers/helpers/compat-fetch.ts`).
- Verified end-to-end against a live local HTTP server serving SSE with an event split across TCP writes.

## Verification

- `npm run build:packages` — pass
- `npx oxlint packages/runtime/src` — pass
- `npm run test --workspace=packages/runtime` — 1935/1935 pass
- `npm run test --workspace=packages/chat` — 30/30 pass
- `npm run test --workspace=packages/base-nodes` — 9 failures, identical on a clean `main` checkout: missing `better-sqlite3` native bindings in the sandbox (environment, not this change)
- `npm run check:deps` / `check:circular` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUSxDLRrCiteMhmCof9S4Y)_