### PR TITLE
web: drop fast-deep-equal, zundo, and acorn-walk for in-repo implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50932,24 +50932,6 @@
         "zod": "^3.25.28 || ^4"
       }
     },
-    "node_modules/zundo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.3.0.tgz",
-      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/charkour"
-      },
-      "peerDependencies": {
-        "zustand": "^4.3.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zustand": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/zustand": {
       "version": "5.0.14",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
@@ -52889,13 +52871,11 @@
         "@trpc/react-query": "^11.17.0",
         "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "~12.11.2",
-        "acorn-walk": "^8.3.5",
         "buffer": "^5.7.1",
         "cmdk": "^1.1.1",
         "dockview": "^5.2.0",
         "dompurify": "^3.4.11",
         "elkjs": "^0.9.3",
-        "fast-deep-equal": "^3.1.3",
         "fflate": "^0.8.2",
         "lexical": "^0.46.0",
         "mediabunny": "^1.46.0",
@@ -52917,7 +52897,6 @@
         "three": "^0.185.1",
         "wavesurfer.js": "^7.12.7",
         "zod": "^4.4.3",
-        "zundo": "^2.3.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -37,13 +37,11 @@
     "@trpc/react-query": "^11.17.0",
     "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "~12.11.2",
-    "acorn-walk": "^8.3.5",
     "buffer": "^5.7.1",
     "cmdk": "^1.1.1",
     "dockview": "^5.2.0",
     "dompurify": "^3.4.11",
     "elkjs": "^0.9.3",
-    "fast-deep-equal": "^3.1.3",
     "fflate": "^0.8.2",
     "lexical": "^0.46.0",
     "mediabunny": "^1.46.0",
@@ -65,7 +63,6 @@
     "three": "^0.185.1",
     "wavesurfer.js": "^7.12.7",
     "zod": "^4.4.3",
-    "zundo": "^2.3.0",
     "zustand": "^5.0.14"
   },
   "scripts": {

--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -10,7 +10,7 @@ import type { Theme } from "@mui/material/styles";
 import { NodeMetadata, TypeMetadata, Property } from "../stores/ApiTypes";
 import { findOutputHandle } from "../utils/handleUtils";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
-import isEqual from "fast-deep-equal";
+import isEqual from "../utils/isEqual";
 import { areNodesEqualIgnoringPosition } from "../utils/nodeEquality";
 import { EditorUiProvider } from "./editor_ui";
 import {

--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -37,7 +37,7 @@ import {
   SPACING
 } from "../ui_primitives";
 import { TYPE_FILTERS, TypeFilterKey } from "../../utils/formatUtils";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
+++ b/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
@@ -11,7 +11,7 @@ import {
   oneDarkColors,
   oneLightColors
 } from "./codeBlockColors";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../../utils/isEqual";
 
 interface CodeBlockProps {
   node?: unknown;
@@ -47,7 +47,7 @@ const contentStyles = (colors: CodeThemeColors) =>
     overflow: "auto",
     lineHeight: 1.5,
     tabSize: 2,
-    code: {
+    "& code": {
       fontFamily: "inherit",
       background: "none",
       color: "inherit"
@@ -125,7 +125,9 @@ export const CodeBlock: React.FC<CodeBlockProps> = memo(({
   }
   // If inline === true (Markdown `inline code`), renderAsBlock remains false.
 
-  const language = match ? match[1] : "plaintext";
+  // Prism grammar keys are lowercase; normalize so `language-JS` still
+  // highlights. The header keeps displaying the original casing.
+  const language = (match ? match[1] : "plaintext").toLowerCase();
 
   const highlightedHtml = useMemo(() => {
     if (!renderAsBlock) {

--- a/web/src/components/chat/message/markdown_elements/__tests__/CodeBlock.test.tsx
+++ b/web/src/components/chat/message/markdown_elements/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render as rtlRender, RenderResult } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../../__mocks__/themeMock";
+import { CodeBlock } from "../CodeBlock";
+
+const render = (ui: React.ReactElement): RenderResult =>
+  rtlRender(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("CodeBlock", () => {
+  it("renders Prism token spans for a known language", () => {
+    const { container } = render(
+      <CodeBlock inline={false} className="language-javascript">
+        {"const x = 1;"}
+      </CodeBlock>
+    );
+    const code = container.querySelector("code.language-javascript");
+    expect(code).not.toBeNull();
+    expect(container.querySelectorAll(".token").length).toBeGreaterThan(0);
+    expect(code?.textContent).toBe("const x = 1;");
+  });
+
+  it("falls back to plain text for an unknown language", () => {
+    const { container } = render(
+      <CodeBlock inline={false} className="language-notarealanguage">
+        {"some plain content"}
+      </CodeBlock>
+    );
+    const code = container.querySelector("code.language-notarealanguage");
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe("some plain content");
+    expect(container.querySelectorAll(".token").length).toBe(0);
+  });
+
+  it("never renders malicious code content as live DOM (highlighted path)", () => {
+    const payload = 'const s = "<img src=x onerror=alert(1)>";';
+    const { container } = render(
+      <CodeBlock inline={false} className="language-javascript">
+        {payload}
+      </CodeBlock>
+    );
+    expect(container.querySelector("img")).toBeNull();
+    const code = container.querySelector("code");
+    expect(code?.textContent).toBe(payload);
+  });
+
+  it("never renders malicious code content as live DOM (plain-text path)", () => {
+    const payload = "<img src=x onerror=alert(1)>";
+    const { container } = render(
+      <CodeBlock inline={false} className="language-unknownlang">
+        {payload}
+      </CodeBlock>
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("code")?.textContent).toBe(payload);
+  });
+
+  it("highlights mixed-case languages and keeps the original casing in the header", () => {
+    const { container } = render(
+      <CodeBlock inline={false} className="language-JavaScript">
+        {"const x = 1;"}
+      </CodeBlock>
+    );
+    expect(container.querySelectorAll(".token").length).toBeGreaterThan(0);
+    expect(container.querySelector("code.language-javascript")).not.toBeNull();
+    expect(
+      container.querySelector(".code-block-language")?.textContent
+    ).toBe("JavaScript");
+  });
+});

--- a/web/src/components/collections/WorkflowSelect.tsx
+++ b/web/src/components/collections/WorkflowSelect.tsx
@@ -7,7 +7,7 @@ import {
 import { WorkflowList } from "../../stores/ApiTypes";
 import { useQuery } from "@tanstack/react-query";
 import { memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 
 interface WorkflowSelectProps {

--- a/web/src/components/context_menus/SelectionContextMenu.tsx
+++ b/web/src/components/context_menus/SelectionContextMenu.tsx
@@ -27,7 +27,7 @@ import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CallSplitIcon from "@mui/icons-material/CallSplit";
 import { useNodes } from "../../contexts/NodeContext";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { shallow } from "zustand/shallow";
 
 interface SelectionContextMenuProps {

--- a/web/src/components/hugging_face/DownloadManagerDialog.tsx
+++ b/web/src/components/hugging_face/DownloadManagerDialog.tsx
@@ -23,7 +23,7 @@ import { DownloadProgress } from "./DownloadProgress";
 import { useTheme } from "@mui/material/styles";
 import { type Theme } from "@mui/material/styles";
 
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import FolderOutlined from "@mui/icons-material/FolderOutlined";
 import DownloadingIcon from "@mui/icons-material/Downloading";
 import {

--- a/web/src/components/inputs/Select.tsx
+++ b/web/src/components/inputs/Select.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import React, {
   useCallback,
   useMemo,

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -9,7 +9,7 @@ import useAlignNodes from "../../hooks/useAlignNodes";
 import { useWebsocketRunner } from "../../stores/WorkflowRunner";
 import { useClipboard } from "../../hooks/browser/useClipboard";
 import { useNotificationStore } from "../../stores/NotificationStore";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import React from "react";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useQuery, useQueryClient } from "@tanstack/react-query";

--- a/web/src/components/node/ArrayView.tsx
+++ b/web/src/components/node/ArrayView.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from "react";
 import { NPArray } from "../../stores/ApiTypes";
 import { Text, FlexColumn, Surface, BORDER_RADIUS } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 interface ArrayViewProps {
   array: NPArray;

--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -16,7 +16,7 @@ import {
   Position,
   ResizeParams
 } from "@xyflow/react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import {
   Container,
   BORDER_RADIUS,

--- a/web/src/components/node/Column.tsx
+++ b/web/src/components/node/Column.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from "../../stores/ApiTypes";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { memo } from "react";
 import { NodeTextField, NodeSelect, NodeMenuItem, DeleteButton } from "../ui_primitives";
 

--- a/web/src/components/node/ColumnsManager.tsx
+++ b/web/src/components/node/ColumnsManager.tsx
@@ -5,7 +5,7 @@ import type { Theme } from "@mui/material/styles";
 import React, { useState, useEffect, useRef, memo, useCallback, useMemo } from "react";
 import { Label, BORDER_RADIUS } from "../ui_primitives";
 import { ColumnDef } from "../../stores/ApiTypes";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Column from "./Column";
 
 const styles = (theme: Theme) =>

--- a/web/src/components/node/CommentNode.tsx
+++ b/web/src/components/node/CommentNode.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { memo, useState, useCallback, useRef, useMemo } from "react";
 import { NodeProps, Node } from "@xyflow/react";
 import { debounce } from "../../utils/lodashAlternatives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Container, MOTION, BORDER_RADIUS, Z_INDEX } from "../ui_primitives";
 import { NodeData } from "../../stores/NodeData";
 import { hexToRgba } from "../../utils/ColorUtils";

--- a/web/src/components/node/CompareImagesNode/CompareImagesNode.tsx
+++ b/web/src/components/node/CompareImagesNode/CompareImagesNode.tsx
@@ -6,7 +6,7 @@ import { Handle, NodeProps, Position } from "@xyflow/react";
 import { Text, Box, Z_INDEX } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 import { NodeData } from "../../../stores/NodeData";
 import { useNodeArtifacts } from "../../../hooks/nodes/useNodeExecState";

--- a/web/src/components/node/ConstantStringNode.tsx
+++ b/web/src/components/node/ConstantStringNode.tsx
@@ -17,7 +17,7 @@ import {
   Edge
 } from "@xyflow/react";
 import { debounce } from "../../utils/lodashAlternatives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";

--- a/web/src/components/node/DataTable/DataTable.tsx
+++ b/web/src/components/node/DataTable/DataTable.tsx
@@ -27,7 +27,7 @@ import { integerEditor, floatEditor, datetimeEditor } from "./DataTableEditors";
 import { format, isValid, parseISO } from "../../../utils/dateFormat";
 import { tableStyles } from "../../../styles/TableStyles";
 import { useTheme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 /**
  * Union type for all possible cell values in a DataFrame column

--- a/web/src/components/node/DataTable/DictTable.tsx
+++ b/web/src/components/node/DataTable/DictTable.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { useState, useMemo, useRef, useCallback, useEffect, memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import {
   TabulatorFull as Tabulator,
   CellComponent,

--- a/web/src/components/node/DataTable/ListTable.tsx
+++ b/web/src/components/node/DataTable/ListTable.tsx
@@ -15,7 +15,7 @@ import { integerEditor, floatEditor, datetimeEditor } from "./DataTableEditors";
 import { tableStyles } from "../../../styles/TableStyles";
 import TableActions from "./TableActions";
 import { useTheme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import type { TableData } from "./TableActions";
 
 export type ListDataType = "int" | "string" | "datetime" | "float";

--- a/web/src/components/node/ExposedLabeledInputs.tsx
+++ b/web/src/components/node/ExposedLabeledInputs.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 import NodeInputs from "./NodeInputs";
 import { Property, NodeMetadata } from "../../stores/ApiTypes";

--- a/web/src/components/node/GroupNode.tsx
+++ b/web/src/components/node/GroupNode.tsx
@@ -24,7 +24,7 @@ import {
 // store
 import { NodeData } from "../../stores/NodeData";
 import { debounce } from "../../utils/lodashAlternatives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import {
   parse,
   alpha,

--- a/web/src/components/node/HandleOnlyField.tsx
+++ b/web/src/components/node/HandleOnlyField.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { memo, useMemo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Handle, Position } from "@xyflow/react";
 import { useShallow } from "zustand/react/shallow";
 import { css } from "@emotion/react";

--- a/web/src/components/node/NodeDependencyWarning.tsx
+++ b/web/src/components/node/NodeDependencyWarning.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { getIsElectronDetails } from "../../utils/browser";
 import { useOpenPackageManager } from "../../hooks/useOpenPackageManager";
 import {

--- a/web/src/components/node/NodeErrors.tsx
+++ b/web/src/components/node/NodeErrors.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../stores/ErrorStore";
 import useLogsStore, { nodeLogKey } from "../../stores/LogStore";
 import { useNodeError } from "../../hooks/nodes/useNodeExecState";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { CopyButton, ExternalLink, Tooltip, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import { VERSION } from "../../config/constants";
 import { extractKieTaskId, KIE_LOGS_URL } from "../../utils/kieTaskId";

--- a/web/src/components/node/NodeExecutionTime.tsx
+++ b/web/src/components/node/NodeExecutionTime.tsx
@@ -9,7 +9,7 @@ import {
   getSpacingPx,
   Z_INDEX
 } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodeExecutionDuration } from "../../hooks/nodes/useNodeExecState";
 
 interface NodeExecutionTimeProps {

--- a/web/src/components/node/NodeHeader.tsx
+++ b/web/src/components/node/NodeHeader.tsx
@@ -4,7 +4,7 @@ import useContextMenuStore from "../../stores/ContextMenuStore";
 import useLogsStore, { nodeLogKey } from "../../stores/LogStore";
 import { shallow } from "zustand/shallow";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeData } from "../../stores/NodeData";
 import { getCollapseTogglePatches } from "../../stores/collapseNodeLayout";
 import { useNodes } from "../../contexts/NodeContext";

--- a/web/src/components/node/NodeInputs.tsx
+++ b/web/src/components/node/NodeInputs.tsx
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 import PropertyField from "./PropertyField";
 import { Property, NodeMetadata, TypeMetadata } from "../../stores/ApiTypes";
 import { NodeData } from "../../stores/NodeData";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodes } from "../../contexts/NodeContext";
 import { useConnectedEdgesSelector } from "../../hooks/nodes/useConnectedEdges";
 import useMetadataStore from "../../stores/MetadataStore";

--- a/web/src/components/node/NodeLogs.tsx
+++ b/web/src/components/node/NodeLogs.tsx
@@ -5,7 +5,7 @@ import type { Theme } from "@mui/material/styles";
 import { memo, useRef, useEffect, useCallback, useState, useMemo } from "react";
 
 import useLogsStore, { nodeLogKey } from "../../stores/LogStore";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import {
   CopyButton,
   Text,

--- a/web/src/components/node/NodeOutput.tsx
+++ b/web/src/components/node/NodeOutput.tsx
@@ -5,7 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Slugify } from "../../utils/TypeHandler";
 import { OutputSlot, TypeMetadata } from "../../stores/ApiTypes";
 import useContextMenuStore from "../../stores/ContextMenuStore";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { isConnectableCached } from "../node_menu/typeFilterUtils";
 import HandleTooltip from "../HandleTooltip";
 import { useNodes } from "../../contexts/NodeContext";

--- a/web/src/components/node/NodeOutputs.tsx
+++ b/web/src/components/node/NodeOutputs.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 import NodeOutput from "./NodeOutput";
 import { OutputSlot } from "../../stores/ApiTypes";

--- a/web/src/components/node/NodeProgress.tsx
+++ b/web/src/components/node/NodeProgress.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { memo, useCallback, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodeProgress } from "../../hooks/nodes/useNodeExecState";
 import { ProgressBar } from "../ui_primitives";
 

--- a/web/src/components/node/NodePropertyForm.tsx
+++ b/web/src/components/node/NodePropertyForm.tsx
@@ -14,7 +14,7 @@ import {
 import Add from "@mui/icons-material/Add";
 import { useState, useCallback, memo } from "react";
 import { useTheme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useDynamicOutput } from "../../hooks/nodes/useDynamicOutput";
 import { TypeMetadata } from "../../stores/ApiTypes";
 import { validateIdentifierName } from "../../utils/identifierValidation";

--- a/web/src/components/node/NodeStatus.tsx
+++ b/web/src/components/node/NodeStatus.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import React, { memo } from "react";
 import { Text, SPACING, getSpacingPx } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const statusCss = css({
   maxWidth: "250px",

--- a/web/src/components/node/OutputNode/OutputNode.tsx
+++ b/web/src/components/node/OutputNode/OutputNode.tsx
@@ -7,7 +7,7 @@ import { getCopySource, getOutputFromResult } from "../outputResult";
 import { Text, Container, MOTION, BORDER_RADIUS, Z_INDEX } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 import { NodeData } from "../../../stores/NodeData";
 import { useNodeGenerations } from "../../../hooks/nodes/useNodeGenerations";

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -39,7 +39,7 @@ import ImageView from "./ImageView";
 import AssetViewer from "../assets/AssetViewer";
 import TaskPlanView from "./TaskPlanView";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Chunk } from "../../stores/ApiTypes";
 import TaskView from "./TaskView";
 import { trpc } from "../../trpc/client";

--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 import { NodeData } from "../../../stores/NodeData";
 import { useNodeGenerations } from "../../../hooks/nodes/useNodeGenerations";

--- a/web/src/components/node/PropertyField.tsx
+++ b/web/src/components/node/PropertyField.tsx
@@ -10,7 +10,7 @@ import PropertyInput from "./PropertyInput";
 import PropertyLabel from "./PropertyLabel";
 import { Slugify, isCollectType } from "../../utils/TypeHandler";
 import useContextMenuStore from "../../stores/ContextMenuStore";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { isFieldRelevantDataEqual } from "./propertyFieldEquality";
 import { isConnectableCached } from "../node_menu/typeFilterUtils";
 import HandleTooltip from "../HandleTooltip";

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -7,7 +7,7 @@ import { PropertyHandleTooltipContext } from "../../contexts/PropertyHandleToolt
 import useContextMenu from "../../stores/ContextMenuStore";
 import StringProperty from "../properties/StringProperty";
 import DataframeProperty from "../properties/DataframeProperty";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { isFieldRelevantDataEqual } from "./propertyFieldEquality";
 import Close from "@mui/icons-material/Close";
 import Edit from "@mui/icons-material/Edit";

--- a/web/src/components/node/PropertyLabel.tsx
+++ b/web/src/components/node/PropertyLabel.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import React, { memo, useContext, useMemo } from "react";
 import { titleizeString } from "../../utils/titleizeString";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Tooltip, SPACING, getSpacingPx } from "../ui_primitives";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { TypeMetadata } from "../../stores/ApiTypes";

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -68,7 +68,7 @@ import { useProcessedEdges } from "../../hooks/useProcessedEdges";
 import { useFitNodeEvent } from "../../hooks/useFitNodeEvent";
 import { MAX_ZOOM, MIN_ZOOM, ZOOMED_OUT } from "../../config/constants";
 import GroupNode from "../node/GroupNode";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import AxisMarker from "../node_editor/AxisMarker";
 import ConnectionLine from "../node_editor/ConnectionLine";

--- a/web/src/components/node/RerouteNode.tsx
+++ b/web/src/components/node/RerouteNode.tsx
@@ -5,7 +5,7 @@ import { NodeProps, Handle, Position } from "@xyflow/react";
 import { NodeData } from "../../stores/NodeData";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import {
   Tooltip,
   Container,

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -27,7 +27,7 @@ import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import EditIcon from "@mui/icons-material/Edit";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import { NodeData } from "../../../stores/NodeData";
 import { NodeHeader } from "../NodeHeader";
 import EditableTitle from "../EditableTitle";

--- a/web/src/components/node/SubgraphNode/SubgraphSync.tsx
+++ b/web/src/components/node/SubgraphNode/SubgraphSync.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import { useNodes } from "../../../contexts/NodeContext";
 import { extractDynamicIO } from "../WorkflowNode";
 import type { NodeData } from "../../../stores/NodeData";

--- a/web/src/components/node/ThreadMessageList.tsx
+++ b/web/src/components/node/ThreadMessageList.tsx
@@ -6,7 +6,7 @@ import type { Theme } from "@mui/material/styles";
 import { Message, ToolCall } from "../../stores/ApiTypes";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
 import ImageView from "./ImageView";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { BORDER_RADIUS, Z_INDEX } from "../ui_primitives";
 
 const styles = (theme: Theme) =>

--- a/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
+++ b/web/src/components/node/WorkflowNode/WorkflowLoader.tsx
@@ -8,7 +8,7 @@ import {
   MuiAutocomplete as Autocomplete
 } from "../../ui_primitives";
 import { useQuery } from "@tanstack/react-query";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import { useNodes } from "../../../contexts/NodeContext";
 import { useWorkflowManager } from "../../../contexts/WorkflowManagerContext";
 import { Workflow, WorkflowList } from "../../../stores/ApiTypes";

--- a/web/src/components/node/output/DataframeRenderer.tsx
+++ b/web/src/components/node/output/DataframeRenderer.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { ToolbarIconButton, MOTION, BORDER_RADIUS, Z_INDEX } from "../../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 

--- a/web/src/components/node/output/JSONRenderer.tsx
+++ b/web/src/components/node/output/JSONRenderer.tsx
@@ -6,7 +6,7 @@ import type { Theme } from "@mui/material/styles";
 import Prism from "prismjs";
 import "prismjs/components/prism-json";
 import DOMPurify from "dompurify";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import Actions from "./Actions";
 
 import { BORDER_RADIUS, Z_INDEX } from "../../ui_primitives";

--- a/web/src/components/node/output/ObjectRenderer.tsx
+++ b/web/src/components/node/output/ObjectRenderer.tsx
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Text, Box, BORDER_RADIUS } from "../../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 const objectStyles = (theme: Theme) =>
   css({

--- a/web/src/components/node/propertyFieldEquality.ts
+++ b/web/src/components/node/propertyFieldEquality.ts
@@ -1,4 +1,4 @@
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeData } from "../../stores/NodeData";
 
 /**

--- a/web/src/components/node_editor/ConnectionLine.tsx
+++ b/web/src/components/node_editor/ConnectionLine.tsx
@@ -9,7 +9,7 @@ import {
 import useConnectionStore from "../../stores/ConnectionStore";
 import { colorForType } from "../../config/data_types";
 import { Slugify } from "../../utils/TypeHandler";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const CONTROL_EDGE_COLOR = "#f59e0b";
 const DEFAULT_EDGE_COLOR = "#888";

--- a/web/src/components/node_editor/NodeEditor.tsx
+++ b/web/src/components/node_editor/NodeEditor.tsx
@@ -23,7 +23,7 @@ import "../../styles/handle_edge_tooltip.css";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 // constants
 import DraggableNodeDocumentation from "../content/Help/DraggableNodeDocumentation";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useShallow } from "zustand/react/shallow";
 import ReactFlowWrapper from "../node/ReactFlowWrapper";
 import { generateCSS } from "../themes/GenerateCSS";

--- a/web/src/components/node_editor/QuickAddNodeDialog.tsx
+++ b/web/src/components/node_editor/QuickAddNodeDialog.tsx
@@ -31,7 +31,7 @@ import { useTheme, type Theme } from "@mui/material/styles";
 import useQuickAddNodeStore from "../../stores/QuickAddNodeStore";
 import { useNodes } from "../../contexts/NodeContext";
 import { useReactFlow } from "@xyflow/react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/shallow";
 

--- a/web/src/components/node_menu/NamespaceList.tsx
+++ b/web/src/components/node_menu/NamespaceList.tsx
@@ -13,7 +13,7 @@ import NodeInfo from "./NodeInfo";
 import QuickActionTiles from "./QuickActionTiles";
 import RecentNodesTiles from "./RecentNodesTiles";
 import FavoritesTiles from "./FavoritesTiles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import useMetadataStore from "../../stores/MetadataStore";
 import { AddCircleOutline } from "@mui/icons-material";
 import { NamespaceTree } from "../../hooks/useNamespaceTree";

--- a/web/src/components/node_menu/NodeInfo.tsx
+++ b/web/src/components/node_menu/NodeInfo.tsx
@@ -24,7 +24,7 @@ import {
   formatKieUnitPricingTooltip,
   isKieVagueBillingSummary,
 } from "../../utils/formatKieUnitPricing";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 interface NodeInfoProps {
   nodeMetadata: NodeMetadata;

--- a/web/src/components/node_menu/RenderNodes.tsx
+++ b/web/src/components/node_menu/RenderNodes.tsx
@@ -10,7 +10,7 @@ import useNodeMenuStore from "../../stores/NodeMenuStore";
 import NodeItem from "./NodeItem";
 import SearchResultsPanel from "./SearchResultsPanel";
 import { Text } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import ApiKeyValidation from "../node/ApiKeyValidation";
 import usePendingNodeCreateStore from "../../stores/PendingNodeCreateStore";
 import { serializeDragData } from "../../lib/dragdrop";

--- a/web/src/components/node_types/PlaceholderNode.tsx
+++ b/web/src/components/node_types/PlaceholderNode.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { memo, useMemo, useCallback, useEffect, useState } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeData } from "../../stores/NodeData";
 import { NodeHeader } from "../node/NodeHeader";
 import { NodeMetadata } from "../../stores/ApiTypes";

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../stores/BottomPanelStore";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import TracePanel from "./TracePanel";
 import LogPanel from "./LogPanel";
 import QueuePanel from "./jobs/QueuePanel";

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -8,7 +8,7 @@ import {
 import { ToolbarIconButton, FlexColumn, Box, Z_INDEX, SPACING, getSpacingPx } from "../ui_primitives";
 import { useResizePanel } from "../../hooks/handlers/useResizePanel";
 import { BORDER_RADIUS } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import AssetGrid from "../assets/AssetGrid";

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -7,7 +7,7 @@ import Inspector from "../Inspector";
 import { useResizeRightPanel } from "../../hooks/handlers/useResizeRightPanel";
 import { useRightPanelStore } from "../../stores/RightPanelStore";
 import { memo, useCallback, useEffect } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeContext } from "../../contexts/NodeContext";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useShallow } from "zustand/react/shallow";

--- a/web/src/components/panels/jobs/JobItem.tsx
+++ b/web/src/components/panels/jobs/JobItem.tsx
@@ -24,7 +24,7 @@ import { getWorkflowRunnerStore } from "../../../stores/WorkflowRunner";
 import { useJobAssets } from "../../../serverState/useJobAssets";
 import { trpcClient } from "../../../trpc/client";
 import { useQueryClient } from "@tanstack/react-query";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 
 /**
  * Format a duration in milliseconds to a human-readable string

--- a/web/src/components/properties/ASRModelSelect.tsx
+++ b/web/src/components/properties/ASRModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import ASRModelMenuDialog from "../model_menu/ASRModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type { ASRModel, ModelPack, UnifiedModel } from "../../stores/ApiTypes";

--- a/web/src/components/properties/AssetProperty.tsx
+++ b/web/src/components/properties/AssetProperty.tsx
@@ -1,7 +1,7 @@
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Text } from "../ui_primitives";
 
 const AssetProperty = (props: PropertyProps) => {

--- a/web/src/components/properties/AudioListProperty.tsx
+++ b/web/src/components/properties/AudioListProperty.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Tooltip, Text, CloseButton, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
 import AudioFileIcon from "@mui/icons-material/AudioFile";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { isElectron } from "../../utils/browser";
 import {

--- a/web/src/components/properties/AudioProperty.tsx
+++ b/web/src/components/properties/AudioProperty.tsx
@@ -6,7 +6,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyDropzone from "./PropertyDropzone";
 import { memo, useMemo, useState } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { EditorButton, NodeTextField, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";

--- a/web/src/components/properties/BoolProperty.tsx
+++ b/web/src/components/properties/BoolProperty.tsx
@@ -1,7 +1,7 @@
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo, useCallback } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeSwitch } from "../editor_ui";
 
 const BoolProperty = (props: PropertyProps<boolean>) => {

--- a/web/src/components/properties/CollectionProperty.tsx
+++ b/web/src/components/properties/CollectionProperty.tsx
@@ -4,7 +4,7 @@ import { trpcClient } from "../../trpc/client";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo, useMemo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodes } from "../../contexts/NodeContext";
 import Select from "../inputs/Select";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";

--- a/web/src/components/properties/ColorProperty.tsx
+++ b/web/src/components/properties/ColorProperty.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, memo } from "react";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyLabel from "../node/PropertyLabel";
 import ColorPicker from "../inputs/ColorPicker";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import { FlexRow } from "../ui_primitives";
 

--- a/web/src/components/properties/DataframeEditorModal.tsx
+++ b/web/src/components/properties/DataframeEditorModal.tsx
@@ -19,7 +19,7 @@ import {
   getSpacingPx,
   InputAdornment
 } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Markdown from "react-markdown";
 
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";

--- a/web/src/components/properties/DataframeProperty.tsx
+++ b/web/src/components/properties/DataframeProperty.tsx
@@ -13,7 +13,7 @@ import { ToolbarIconButton, EditorButton, ButtonGroup, MOTION, SPACING, BORDER_R
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import {
   parseDataframeFile,
   isSupportedDataframeFile

--- a/web/src/components/properties/DictProperty.tsx
+++ b/web/src/components/properties/DictProperty.tsx
@@ -4,7 +4,7 @@ import Select from "../inputs/Select";
 import DictTable, { DictDataType } from "../node/DataTable/DictTable";
 import PropertyLabel from "../node/PropertyLabel";
 import { SPACING, getSpacingPx } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const detectTypeFromDict = (dict: unknown) => {
   if (!Array.isArray(dict) || dict.length === 0) {

--- a/web/src/components/properties/DocumentProperty.tsx
+++ b/web/src/components/properties/DocumentProperty.tsx
@@ -1,7 +1,7 @@
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Text } from "../ui_primitives";
 import { useAsset } from "../../serverState/useAsset";
 import PropertyDropzone from "./PropertyDropzone";

--- a/web/src/components/properties/EmbeddingModelSelect.tsx
+++ b/web/src/components/properties/EmbeddingModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import EmbeddingModelMenuDialog from "../model_menu/EmbeddingModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type { EmbeddingModel, ModelPack, UnifiedModel } from "../../stores/ApiTypes";

--- a/web/src/components/properties/EnumProperty.tsx
+++ b/web/src/components/properties/EnumProperty.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from "react";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Select from "../inputs/Select";
 import PropertyLabel from "../node/PropertyLabel";
 

--- a/web/src/components/properties/FilePathProperty.tsx
+++ b/web/src/components/properties/FilePathProperty.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from "react";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import BasePathProperty from "./shared/BasePathProperty";
 
 const FilePathProperty = (props: PropertyProps) => (

--- a/web/src/components/properties/FileProperty.tsx
+++ b/web/src/components/properties/FileProperty.tsx
@@ -1,7 +1,7 @@
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { Text } from "../ui_primitives";
 
 interface FileRef {

--- a/web/src/components/properties/FloatProperty.tsx
+++ b/web/src/components/properties/FloatProperty.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback } from "react";
 import NumberInput from "../inputs/NumberInput";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useInputMinMax } from "../../hooks/useInputMinMax";
 import { useTemporalNodes } from "../../contexts/NodeContext";
 

--- a/web/src/components/properties/FolderPathProperty.tsx
+++ b/web/src/components/properties/FolderPathProperty.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from "react";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import BasePathProperty from "./shared/BasePathProperty";
 
 const FolderPathProperty = (props: PropertyProps) => (

--- a/web/src/components/properties/FolderProperty.tsx
+++ b/web/src/components/properties/FolderProperty.tsx
@@ -17,7 +17,7 @@ import { useQuery } from "@tanstack/react-query";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo, useState, useRef, useEffect, useMemo, useCallback } from "react";
 import dialogStyles from "../../styles/DialogStyles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Select from "../inputs/Select";
 import { FlexRow, DialogActionButtons } from "../ui_primitives";
 

--- a/web/src/components/properties/FontProperty.tsx
+++ b/web/src/components/properties/FontProperty.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, memo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import Select from "../inputs/Select";

--- a/web/src/components/properties/HuggingFaceModelSelect.tsx
+++ b/web/src/components/properties/HuggingFaceModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import HuggingFaceModelMenuDialog from "../model_menu/HuggingFaceModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type { ImageModel, ModelPack, UnifiedModel, HuggingFaceModelValue, HuggingFaceModelValueInput } from "../../stores/ApiTypes";

--- a/web/src/components/properties/ImageListProperty.tsx
+++ b/web/src/components/properties/ImageListProperty.tsx
@@ -7,7 +7,7 @@ import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import ImageDimensions from "../node/ImageDimensions";
 import { isElectron } from "../../utils/browser";

--- a/web/src/components/properties/ImageModelSelect.tsx
+++ b/web/src/components/properties/ImageModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import ImageModelMenuDialog from "../model_menu/ImageModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type {

--- a/web/src/components/properties/ImageProperty.tsx
+++ b/web/src/components/properties/ImageProperty.tsx
@@ -7,7 +7,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyDropzone from "./PropertyDropzone";
 import { memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useUpstreamValue } from "../../hooks/nodes/useNodeIO";
 import ImageRefPreview from "../node/ImageRefPreview";
 

--- a/web/src/components/properties/ImageSizeProperty.tsx
+++ b/web/src/components/properties/ImageSizeProperty.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo, useState, useEffect, useRef } from "react";
 import NumberInput from "../inputs/NumberInput";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyLabel from "../node/PropertyLabel";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { FlexColumn, FlexRow, ToolbarIconButton, Box } from "../ui_primitives";
 import { IMAGE_SIZE_PRESETS as PRESETS } from "../../config/constants";
 import Lock from "@mui/icons-material/Lock";

--- a/web/src/components/properties/InferenceProviderModelSelect.tsx
+++ b/web/src/components/properties/InferenceProviderModelSelect.tsx
@@ -2,7 +2,7 @@ import { Text, FlexColumn } from "../ui_primitives";
 import { InferenceProvider, InferenceProviderModelValue } from "../../stores/ApiTypes";
 import { memo, useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Select from "../inputs/Select";
 import type { PropertyProps } from "../node/PropertyInput";
 

--- a/web/src/components/properties/IntegerProperty.tsx
+++ b/web/src/components/properties/IntegerProperty.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback } from "react";
 import NumberInput from "../inputs/NumberInput";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useInputMinMax } from "../../hooks/useInputMinMax";
 import { useTemporalNodes } from "../../contexts/NodeContext";
 

--- a/web/src/components/properties/JSONProperty.tsx
+++ b/web/src/components/properties/JSONProperty.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type * as monaco from "monaco-editor";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyLabel from "../node/PropertyLabel";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useTheme } from "@mui/material/styles";
 import { CopyButton, LoadingSpinner, ToolbarIconButton, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";

--- a/web/src/components/properties/LanguageModelSelect.tsx
+++ b/web/src/components/properties/LanguageModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import LanguageModelMenuDialog from "../model_menu/LanguageModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type {

--- a/web/src/components/properties/ListProperty.tsx
+++ b/web/src/components/properties/ListProperty.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useState, useMemo } from "react";
 import Select from "../inputs/Select";
 import PropertyLabel from "../node/PropertyLabel";
 import { SPACING, getSpacingPx } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const detectTypeFromList = (list: unknown[]) => {
   if (list.length === 0) {

--- a/web/src/components/properties/LlamaModelSelect.tsx
+++ b/web/src/components/properties/LlamaModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef, memo } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 import {
   Text,

--- a/web/src/components/properties/MediaPickerProperties.tsx
+++ b/web/src/components/properties/MediaPickerProperties.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React, { memo, useMemo, useRef, useState } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import AspectRatioIcon from "@mui/icons-material/AspectRatio";
 import DisplaySettingsIcon from "@mui/icons-material/DisplaySettings";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";

--- a/web/src/components/properties/Model3DModelSelect.tsx
+++ b/web/src/components/properties/Model3DModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import { BASE_URL } from "../../stores/BASE_URL";
 import { Model3DModelValue } from "../../stores/ApiTypes";

--- a/web/src/components/properties/Model3DProperty.tsx
+++ b/web/src/components/properties/Model3DProperty.tsx
@@ -6,7 +6,7 @@ import { useAsset } from "../../serverState/useAsset";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo, useState, useCallback } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodes } from "../../contexts/NodeContext";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import ConnectedBadge from "./ConnectedBadge";

--- a/web/src/components/properties/ModelProperty.tsx
+++ b/web/src/components/properties/ModelProperty.tsx
@@ -5,7 +5,7 @@ import { PropertyProps } from "../node/PropertyInput";
 import LlamaModelSelect from "./LlamaModelSelect";
 import HuggingFaceModelSelect from "./HuggingFaceModelSelect";
 import TransformersJsModelSelect from "./TransformersJsModelSelect";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { memo, useMemo } from "react";
 import LanguageModelSelect from "./LanguageModelSelect";
 import EmbeddingModelSelect from "./EmbeddingModelSelect";

--- a/web/src/components/properties/MusicModelSelect.tsx
+++ b/web/src/components/properties/MusicModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import MusicModelMenuDialog from "../model_menu/MusicModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type {

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -13,7 +13,7 @@ import WaveRecorder from "../audio/WaveRecorder";
 import AudioPlayer from "../audio/AudioPlayer";
 import VideoRecorder from "../video/VideoRecorder";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { isElectron } from "../../utils/browser";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { CopyAssetButton } from "../common/CopyAssetButton";

--- a/web/src/components/properties/RecordTypeProperty.tsx
+++ b/web/src/components/properties/RecordTypeProperty.tsx
@@ -10,7 +10,7 @@ import ColumnsManager from "../node/ColumnsManager";
 import { EditorButton, ButtonGroup, BORDER_RADIUS } from "../ui_primitives";
 // icons
 import TableRowsIcon from "@mui/icons-material/TableRows";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/properties/SelectProperty.tsx
+++ b/web/src/components/properties/SelectProperty.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from "react";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import Select from "../inputs/Select";
 import PropertyLabel from "../node/PropertyLabel";
 import { useNodes } from "../../contexts/NodeContext";

--- a/web/src/components/properties/SketchProperty.tsx
+++ b/web/src/components/properties/SketchProperty.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useLocation, useNavigate } from "react-router-dom";
 import BrushOutlinedIcon from "@mui/icons-material/BrushOutlined";
 import type { SelectChangeEvent } from "../ui_primitives";

--- a/web/src/components/properties/StringListProperty.tsx
+++ b/web/src/components/properties/StringListProperty.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "@mui/material/styles";
 import { Autocomplete, Chip, Box, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { NodeTextField } from "../ui_primitives";
 
 const StringListProperty = (props: PropertyProps) => {

--- a/web/src/components/properties/StringProperty.tsx
+++ b/web/src/components/properties/StringProperty.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, memo, useMemo } from "react";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import TextEditorModal from "./TextEditorModal";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useNodes } from "../../contexts/NodeContext";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";

--- a/web/src/components/properties/TTSModelSelect.tsx
+++ b/web/src/components/properties/TTSModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import TTSModelMenuDialog from "../model_menu/TTSModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type {

--- a/web/src/components/properties/TextAssetDisplay.tsx
+++ b/web/src/components/properties/TextAssetDisplay.tsx
@@ -4,7 +4,7 @@ import { useAssetStore } from "../../stores/AssetStore";
 import TextEditorModal from "./TextEditorModal";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { Tooltip, Text } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const MAX_TEXT_LENGTH = 1000;
 const MAX_TEXT_HEIGHT = 50;

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -33,7 +33,7 @@ import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { EditorState, $getRoot } from "lexical";
 import type { editor as MonacoEditorNS } from "monaco-editor";
 import { debounce } from "../../utils/lodashAlternatives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { useCombo } from "../../stores/KeyPressedStore";

--- a/web/src/components/properties/TextListProperty.tsx
+++ b/web/src/components/properties/TextListProperty.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Tooltip, Text, CloseButton, MOTION, SPACING, BORDER_RADIUS, getSpacingPx } from "../ui_primitives";
 import DescriptionIcon from "@mui/icons-material/Description";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { isElectron } from "../../utils/browser";
 import {

--- a/web/src/components/properties/TextProperty.tsx
+++ b/web/src/components/properties/TextProperty.tsx
@@ -7,7 +7,7 @@ import { memo, useMemo } from "react";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import TextAssetDisplay from "./TextAssetDisplay";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/properties/TimelineProperty.tsx
+++ b/web/src/components/properties/TimelineProperty.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useLocation, useNavigate } from "react-router-dom";
 import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
 import type { SelectChangeEvent } from "../ui_primitives";

--- a/web/src/components/properties/ToolsListProperty.tsx
+++ b/web/src/components/properties/ToolsListProperty.tsx
@@ -14,7 +14,7 @@ import {
 } from "../ui_primitives";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 
 /**
  * Interface for a tool object in the tools list property

--- a/web/src/components/properties/TransformersJsModelSelect.tsx
+++ b/web/src/components/properties/TransformersJsModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import TransformersJsModelMenuDialog from "../model_menu/TransformersJsModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type {

--- a/web/src/components/properties/VideoListProperty.tsx
+++ b/web/src/components/properties/VideoListProperty.tsx
@@ -7,7 +7,7 @@ import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Tooltip, CloseButton, MOTION, SPACING, BORDER_RADIUS, Z_INDEX, getSpacingPx } from "../ui_primitives";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { isElectron } from "../../utils/browser";
 import {

--- a/web/src/components/properties/VideoModelSelect.tsx
+++ b/web/src/components/properties/VideoModelSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import VideoModelMenuDialog from "../model_menu/VideoModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
 import type { ModelPack, UnifiedModel, VideoModel } from "../../stores/ApiTypes";

--- a/web/src/components/properties/VideoProperty.tsx
+++ b/web/src/components/properties/VideoProperty.tsx
@@ -7,7 +7,7 @@ import { useAsset } from "../../serverState/useAsset";
 import PropertyLabel from "../node/PropertyLabel";
 import { PropertyProps } from "../node/PropertyInput";
 import PropertyDropzone from "./PropertyDropzone";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { memo, useMemo } from "react";
 
 const styles = (theme: Theme) =>

--- a/web/src/components/properties/WorkflowListProperty.tsx
+++ b/web/src/components/properties/WorkflowListProperty.tsx
@@ -4,7 +4,7 @@ import { WorkflowList } from "../../stores/ApiTypes";
 import PropertyLabel from "../node/PropertyLabel";
 import { useQuery } from "@tanstack/react-query";
 import { PropertyProps } from "../node/PropertyInput";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { NodeSelect, NodeMenuItem } from "../editor_ui";
 

--- a/web/src/components/properties/WorkflowProperty.tsx
+++ b/web/src/components/properties/WorkflowProperty.tsx
@@ -3,7 +3,7 @@ import PropertyLabel from "../node/PropertyLabel";
 import { useQuery } from "@tanstack/react-query";
 import { PropertyProps } from "../node/PropertyInput";
 import { memo, useCallback } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { NodeSelect, NodeMenuItem } from "../editor_ui";
 import type { SelectChangeEvent } from "../ui_primitives";

--- a/web/src/components/properties/shared/BasePathProperty.tsx
+++ b/web/src/components/properties/shared/BasePathProperty.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { memo, useCallback, useState } from "react";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../../utils/isEqual";
 import PropertyLabel from "../../node/PropertyLabel";
 import { PropertyProps } from "../../node/PropertyInput";
 import { useTheme } from "@mui/material/styles";

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -498,7 +498,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   // whole gesture into a single undo entry we begin a batch on pointerdown,
   // mark() after each mutation (which pauses history once the pre-gesture
   // state has actually been checkpointed), and end() on pointerup. While
-  // paused, zundo records nothing — so one undo step reverts the entire drag.
+  // paused, the temporal middleware records nothing — so one undo step reverts the entire drag.
   const history = useTimelineHistoryBatch();
 
   // ── Drag (move) ─────────────────────────────────────────────────────────

--- a/web/src/components/workflows/WorkflowList.tsx
+++ b/web/src/components/workflows/WorkflowList.tsx
@@ -12,7 +12,7 @@ import {
   WorkflowAttributes,
   WorkflowList as WorkflowListType
 } from "../../stores/ApiTypes";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { trpcClient } from "../../trpc/client";
 import { useNavigate, useLocation } from "react-router-dom";

--- a/web/src/components/workflows/WorkflowListItem.tsx
+++ b/web/src/components/workflows/WorkflowListItem.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React, { memo, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { Workflow } from "../../stores/ApiTypes";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { WorkflowMiniPreview } from "../version/WorkflowMiniPreview";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import { useWorkflowActionsStore } from "../../stores/WorkflowActionsStore";

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import isEqual from "fast-deep-equal";
+import isEqual from "../../utils/isEqual";
 import { useQuery } from "@tanstack/react-query";
 import { FileInfo } from "../../stores/ApiTypes";
 import { trpcClient } from "../../trpc/client";

--- a/web/src/config/IconForType.tsx
+++ b/web/src/config/IconForType.tsx
@@ -2,7 +2,7 @@
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import isEqual from "fast-deep-equal";
+import isEqual from "../utils/isEqual";
 import { Tooltip, BORDER_RADIUS } from "../components/ui_primitives";
 import { TOOLTIP_ENTER_DELAY } from "../config/constants";
 import { datatypeByName, normalizeTypeName } from "./data_types";

--- a/web/src/contexts/NodeContext.tsx
+++ b/web/src/contexts/NodeContext.tsx
@@ -6,8 +6,8 @@ import {
 } from "../stores/NodeStore";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
-import { TemporalState } from "zundo";
-import isEqual from "fast-deep-equal";
+import { TemporalState } from "../stores/temporal";
+import isEqual from "../utils/isEqual";
 
 
 // Extend Window interface for HMR context preservation

--- a/web/src/hooks/timeline/useTimelineAutosave.ts
+++ b/web/src/hooks/timeline/useTimelineAutosave.ts
@@ -21,7 +21,7 @@
  *     save; the one exception is a load that migrated a legacy transcript,
  *     which is persisted once (see `markTimelineLoadMigrated`).
  *   - Pending edits are flushed on unmount.
- *   - Gesture-aware: a drag/trim/slider gesture pauses the zundo temporal
+ *   - Gesture-aware: a drag/trim/slider gesture pauses the temporal
  *     store for its duration (`useTimelineHistoryBatch`). If the debounce
  *     timer fires while a gesture is still open, the flush re-arms itself
  *     instead of PATCHing the intermediate, mid-gesture state — pointerup

--- a/web/src/stores/AGENTS.md
+++ b/web/src/stores/AGENTS.md
@@ -12,7 +12,7 @@ Also see: **[Zustand Best Practices](./ZUSTAND_BEST_PRACTICES.md)**
 - Use `shallow` equality for object selections to prevent unnecessary re-renders.
 - Define actions within the store alongside state.
 - Use `persist` middleware for settings that should survive page refreshes.
-- Use `temporal` (zundo) middleware for stores that need undo/redo.
+- Use the in-repo `temporal` middleware (`stores/temporal.ts`) for stores that need undo/redo.
 - Keep state updates immutable. Use Immer middleware for complex nested updates.
 
 ## Patterns

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -1,7 +1,7 @@
 /** NodeStore manages workflow graph state for a single editor tab. */
 
-import { temporal } from "zundo";
-import type { TemporalState } from "zundo";
+import { temporal } from "./temporal";
+import type { TemporalState } from "./temporal";
 import { create, StoreApi, UseBoundStore } from "zustand";
 import { NodeMetadata, Workflow } from "./ApiTypes";
 import { NodeData } from "./NodeData";
@@ -23,7 +23,7 @@ import {
   Viewport
 } from "@xyflow/react";
 import { customEquality } from "./customEquality";
-import isEqual from "fast-deep-equal";
+import isEqual from "../utils/isEqual";
 
 import { Node as GraphNode, Edge as GraphEdge } from "./ApiTypes";
 import { migrateGraphNodeTypes } from "@nodetool-ai/protocol";

--- a/web/src/stores/__tests__/temporal.test.ts
+++ b/web/src/stores/__tests__/temporal.test.ts
@@ -1,0 +1,242 @@
+import { createStore, StoreApi } from "zustand";
+import { temporal, TemporalState, WithTemporal } from "../temporal";
+
+interface CounterState {
+  count: number;
+  untracked: string;
+  increment: () => void;
+  setCount: (n: number) => void;
+  setUntracked: (s: string) => void;
+}
+
+type Partialized = { count: number };
+
+const makeStore = (options?: {
+  limit?: number;
+  equality?: (a: Partialized, b: Partialized) => boolean;
+  partialize?: boolean;
+}) => {
+  const store = createStore<CounterState>()(
+    temporal<CounterState, Partialized>(
+      (set) => ({
+        count: 0,
+        untracked: "initial",
+        increment: () => set((s) => ({ count: s.count + 1 })),
+        setCount: (n: number) => set({ count: n }),
+        setUntracked: (s: string) => set({ untracked: s })
+      }),
+      {
+        limit: options?.limit,
+        equality: options?.equality,
+        partialize:
+          options?.partialize === false
+            ? undefined
+            : (state): Partialized => ({ count: state.count })
+      }
+    )
+  ) as WithTemporal<StoreApi<CounterState>, Partialized>;
+  return store;
+};
+
+const temporalOf = (
+  store: WithTemporal<StoreApi<CounterState>, Partialized>
+): TemporalState<Partialized> => store.temporal.getState();
+
+describe("temporal middleware", () => {
+  it("attaches a temporal store with the expected API", () => {
+    const store = makeStore();
+    const t = temporalOf(store);
+    expect(t.pastStates).toEqual([]);
+    expect(t.futureStates).toEqual([]);
+    expect(t.isTracking).toBe(true);
+    expect(typeof t.undo).toBe("function");
+    expect(typeof t.redo).toBe("function");
+    expect(typeof t.clear).toBe("function");
+    expect(typeof t.pause).toBe("function");
+    expect(typeof t.resume).toBe("function");
+  });
+
+  it("pushes the pre-set snapshot onto pastStates", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }, { count: 1 }]);
+    expect(temporalOf(store).futureStates).toEqual([]);
+  });
+
+  it("tracks direct store.setState calls too", () => {
+    const store = makeStore();
+    store.setState({ count: 5 });
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }]);
+    expect(store.getState().count).toBe(5);
+  });
+
+  it("undo restores the previous state and moves current to futureStates", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    temporalOf(store).undo();
+    expect(store.getState().count).toBe(1);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }]);
+    expect(temporalOf(store).futureStates).toEqual([{ count: 2 }]);
+  });
+
+  it("redo re-applies the undone state", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    temporalOf(store).undo();
+    temporalOf(store).redo();
+    expect(store.getState().count).toBe(2);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }, { count: 1 }]);
+    expect(temporalOf(store).futureStates).toEqual([]);
+  });
+
+  it("undo/redo with multiple steps", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    store.getState().setCount(3);
+    temporalOf(store).undo(2);
+    expect(store.getState().count).toBe(1);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }]);
+    // zundo order: current first, then skipped snapshots newest-first
+    expect(temporalOf(store).futureStates).toEqual([{ count: 3 }, { count: 2 }]);
+    temporalOf(store).redo(2);
+    expect(store.getState().count).toBe(3);
+    expect(temporalOf(store).pastStates).toEqual([
+      { count: 0 },
+      { count: 1 },
+      { count: 2 }
+    ]);
+    expect(temporalOf(store).futureStates).toEqual([]);
+  });
+
+  it("undo with more steps than history clamps to the oldest state", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    temporalOf(store).undo(10);
+    expect(store.getState().count).toBe(0);
+    expect(temporalOf(store).pastStates).toEqual([]);
+  });
+
+  it("undo/redo are no-ops with empty stacks", () => {
+    const store = makeStore();
+    temporalOf(store).undo();
+    temporalOf(store).redo();
+    expect(store.getState().count).toBe(0);
+    expect(temporalOf(store).pastStates).toEqual([]);
+    expect(temporalOf(store).futureStates).toEqual([]);
+  });
+
+  it("a new set after undo clears futureStates", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    temporalOf(store).undo();
+    store.getState().setCount(9);
+    expect(temporalOf(store).futureStates).toEqual([]);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }, { count: 1 }]);
+  });
+
+  it("undo does not itself push history", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    temporalOf(store).undo();
+    expect(temporalOf(store).pastStates).toEqual([]);
+    expect(temporalOf(store).futureStates).toEqual([{ count: 1 }]);
+  });
+
+  it("clear empties both stacks without touching current state", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    temporalOf(store).undo();
+    temporalOf(store).clear();
+    expect(temporalOf(store).pastStates).toEqual([]);
+    expect(temporalOf(store).futureStates).toEqual([]);
+    expect(store.getState().count).toBe(1);
+  });
+
+  it("pause stops tracking, resume restarts it", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    temporalOf(store).pause();
+    expect(temporalOf(store).isTracking).toBe(false);
+    store.getState().setCount(2);
+    store.getState().setCount(3);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }]);
+    temporalOf(store).resume();
+    expect(temporalOf(store).isTracking).toBe(true);
+    store.getState().setCount(4);
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }, { count: 3 }]);
+  });
+
+  it("partialize keeps untracked fields out of history and undo leaves them alone", () => {
+    const store = makeStore();
+    store.getState().setCount(1);
+    store.getState().setUntracked("changed");
+    // untracked change: equality not provided, so a snapshot IS pushed
+    // (zundo behavior), but the snapshot only contains partialized keys.
+    expect(
+      temporalOf(store).pastStates.every(
+        (s) => !("untracked" in (s as Record<string, unknown>))
+      )
+    ).toBe(true);
+    temporalOf(store).undo();
+    expect(store.getState().untracked).toBe("changed");
+  });
+
+  it("equality dedupes snapshots that compare equal", () => {
+    const store = makeStore({
+      equality: (a, b) => a.count === b.count
+    });
+    store.getState().setCount(1);
+    store.getState().setUntracked("x"); // partialized snapshot unchanged
+    store.getState().setCount(1); // value-identical set
+    expect(temporalOf(store).pastStates).toEqual([{ count: 0 }]);
+  });
+
+  it("limit caps pastStates, dropping oldest entries", () => {
+    const store = makeStore({ limit: 3 });
+    for (let i = 1; i <= 6; i++) {
+      store.getState().setCount(i);
+    }
+    expect(temporalOf(store).pastStates).toEqual([
+      { count: 3 },
+      { count: 4 },
+      { count: 5 }
+    ]);
+    temporalOf(store).undo();
+    expect(store.getState().count).toBe(5);
+  });
+
+  it("temporal store is subscribable (Zustand StoreApi)", () => {
+    const store = makeStore();
+    const seen: number[] = [];
+    const unsub = store.temporal.subscribe((s) => {
+      seen.push(s.pastStates.length);
+    });
+    store.getState().setCount(1);
+    store.getState().setCount(2);
+    unsub();
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it("works without partialize (tracks full state)", () => {
+    const store = createStore<{ n: number; bump: () => void }>()(
+      temporal((set) => ({
+        n: 0,
+        bump: () => set((s) => ({ n: s.n + 1 }))
+      }))
+    ) as WithTemporal<
+      StoreApi<{ n: number; bump: () => void }>,
+      { n: number; bump: () => void }
+    >;
+    store.getState().bump();
+    expect(store.temporal.getState().pastStates).toHaveLength(1);
+    expect(store.temporal.getState().pastStates[0].n).toBe(0);
+    store.temporal.getState().undo();
+    expect(store.getState().n).toBe(0);
+  });
+});

--- a/web/src/stores/temporal.ts
+++ b/web/src/stores/temporal.ts
@@ -1,0 +1,153 @@
+/**
+ * In-repo replacement for the `zundo` temporal (undo/redo) middleware.
+ *
+ * Replicates the zundo v2 API surface this codebase uses:
+ *   temporal(config, { partialize, equality, limit })
+ * attaching a vanilla Zustand store at `store.temporal` whose state is
+ * `TemporalState<PartialState>`: `pastStates`, `futureStates`,
+ * `undo(steps?)`, `redo(steps?)`, `clear()`, `pause()`, `resume()`,
+ * `isTracking`.
+ *
+ * Semantics mirror zundo exactly for these options:
+ * - Every `set` (both the one passed to the state creator and direct
+ *   `store.setState` calls) snapshots the partialized state BEFORE the
+ *   update; if tracking is on and `equality(pastState, currentState)` is
+ *   false, the snapshot is pushed to `pastStates` and `futureStates` is
+ *   cleared.
+ * - `undo`/`redo` restore via the RAW store setter (a merge, not a
+ *   replace), so they never push history themselves.
+ * - `limit` drops the oldest entries so `pastStates` never exceeds it.
+ *
+ * Unsupported zundo options (`diff`, `onSave`, `handleSet`, `wrapTemporal`)
+ * are intentionally omitted — nothing in this codebase uses them.
+ */
+import { createStore, StoreApi, StateCreator } from "zustand";
+
+export interface TemporalState<PartialState> {
+  pastStates: PartialState[];
+  futureStates: PartialState[];
+  undo: (steps?: number) => void;
+  redo: (steps?: number) => void;
+  clear: () => void;
+  isTracking: boolean;
+  pause: () => void;
+  resume: () => void;
+}
+
+export interface TemporalOptions<TState, PartialState> {
+  /** Project the tracked slice of state; defaults to the full state. */
+  partialize?: (state: TState) => PartialState;
+  /**
+   * Return true when two partialized snapshots are equivalent, so no-op
+   * sets don't push duplicate undo entries. Without it every set pushes.
+   */
+  equality?: (pastState: PartialState, currentState: PartialState) => boolean;
+  /** Maximum number of past states retained (oldest dropped first). */
+  limit?: number;
+}
+
+/** A store augmented with the temporal (undo/redo) sub-store. */
+export type WithTemporal<S, PartialState> = S & {
+  temporal: StoreApi<TemporalState<PartialState>>;
+};
+
+export function temporal<TState, PartialState = TState>(
+  config: StateCreator<TState, [], []>,
+  options: TemporalOptions<TState, PartialState> = {}
+): StateCreator<TState, [], []> {
+  return (set, get, store) => {
+    const partialize =
+      options.partialize ?? ((state: TState) => state as unknown as PartialState);
+
+    // undo/redo restore through the RAW setter so they don't re-enter the
+    // history tracking below. PartialState is a subset of TState by
+    // construction (zundo semantics), hence the cast.
+    const restore = (state: PartialState): void => {
+      set(state as unknown as Partial<TState>);
+    };
+
+    const temporalStore = createStore<TemporalState<PartialState>>(
+      (tset, tget) => ({
+        pastStates: [],
+        futureStates: [],
+        isTracking: true,
+        undo: (steps = 1) => {
+          const { pastStates, futureStates } = tget();
+          if (pastStates.length === 0) {
+            return;
+          }
+          const currentState = partialize(get());
+          const n = Math.min(steps, pastStates.length);
+          // The last n snapshots, oldest first; the oldest is applied and
+          // the rest land on futureStates newest-first (zundo behavior).
+          const popped = pastStates.slice(pastStates.length - n);
+          const nextState = popped[0];
+          const skipped = popped.slice(1).reverse();
+          restore(nextState);
+          tset({
+            pastStates: pastStates.slice(0, pastStates.length - n),
+            futureStates: [...futureStates, currentState, ...skipped]
+          });
+        },
+        redo: (steps = 1) => {
+          const { pastStates, futureStates } = tget();
+          if (futureStates.length === 0) {
+            return;
+          }
+          const currentState = partialize(get());
+          const n = Math.min(steps, futureStates.length);
+          const popped = futureStates.slice(futureStates.length - n);
+          const nextState = popped[0];
+          const skipped = popped.slice(1).reverse();
+          restore(nextState);
+          tset({
+            pastStates: [...pastStates, currentState, ...skipped],
+            futureStates: futureStates.slice(0, futureStates.length - n)
+          });
+        },
+        clear: () => tset({ pastStates: [], futureStates: [] }),
+        pause: () => tset({ isTracking: false }),
+        resume: () => tset({ isTracking: true })
+      })
+    );
+
+    (
+      store as WithTemporal<StoreApi<TState>, PartialState>
+    ).temporal = temporalStore;
+
+    const handleSet = (pastState: PartialState): void => {
+      const t = temporalStore.getState();
+      if (!t.isTracking) {
+        return;
+      }
+      const currentState = partialize(get());
+      if (options.equality?.(pastState, currentState)) {
+        return;
+      }
+      let pastStates = t.pastStates;
+      if (options.limit !== undefined && pastStates.length >= options.limit) {
+        // Drop the oldest entries so the new push lands within the limit.
+        pastStates = pastStates.slice(pastStates.length - options.limit + 1);
+      }
+      temporalStore.setState({
+        pastStates: [...pastStates, pastState],
+        futureStates: []
+      });
+    };
+
+    const wrappedSet = ((...args: Parameters<typeof set>) => {
+      const pastState = partialize(get());
+      (set as (...a: Parameters<typeof set>) => void)(...args);
+      handleSet(pastState);
+    }) as typeof set;
+
+    const rawSetState = store.setState;
+    store.setState = ((...args: Parameters<typeof rawSetState>) => {
+      const pastState = partialize(get());
+      (rawSetState as (...a: Parameters<typeof rawSetState>) => void)(...args);
+      handleSet(pastState);
+    }) as typeof rawSetState;
+
+    return config(wrappedSet, get, store);
+  };
+}

--- a/web/src/stores/timeline/TimelineInstance.tsx
+++ b/web/src/stores/timeline/TimelineInstance.tsx
@@ -25,7 +25,7 @@ import React, {
   useEffect,
   useMemo
 } from "react";
-import type { TemporalState } from "zundo";
+import type { TemporalState } from "../temporal";
 
 import { createInstanceHook } from "../instanceStoreHook";
 import {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -1,7 +1,7 @@
 /**
  * TimelineStore
  *
- * Central Zustand + zundo store for the timeline sequence document.
+ * Central Zustand store (with temporal undo/redo middleware) for the timeline sequence document.
  * Mirrors NodeStore's undo/redo wiring (temporal middleware, partialize).
  *
  * Responsibilities:
@@ -11,7 +11,7 @@
  *     addTrack, removeTrack, reorderTracks, setTrackHeight.
  *   - Undo granularity: the temporal `equality` option dedupes no-op sets so
  *     guard-returns never create history entries, and drag handlers (e.g. in
- *     Clip.tsx) call zundo's `pause()` / `resume()` from the outside so each
+ *     Clip.tsx) call the temporal middleware's `pause()` / `resume()` from the outside so each
  *     drag gesture collapses into a single undo entry.
  *
  * Usage:
@@ -25,8 +25,8 @@
  */
 
 import { create } from "zustand";
-import { temporal } from "zundo";
-import type { TemporalState } from "zundo";
+import { temporal } from "../temporal";
+import type { TemporalState } from "../temporal";
 import {
   splitClip,
   trimClip,
@@ -422,7 +422,7 @@ export interface TimelineStoreState {
   removeScene: (markerId: string) => void;
 }
 
-// ── Partialized type for zundo (only document state is undo-able) ──────────
+// ── Partialized type for the temporal middleware (only document state is undo-able)
 
 type PartializedState = Pick<
   TimelineStoreState,
@@ -464,7 +464,7 @@ function shallowArrayEqual<T>(a: readonly T[], b: readonly T[]): boolean {
 }
 
 /**
- * zundo `equality`: returns true when two partialized snapshots are
+ * temporal `equality`: returns true when two partialized snapshots are
  * equivalent, so no-op sets (guard-returns, `{}` patches, value-identical
  * remaps) don't push duplicate undo entries.
  */
@@ -1692,10 +1692,10 @@ export const createTimelineStore = (
 
 // ── Store handle type ───────────────────────────────────────────────────────
 
-/** A single timeline-document store instance (with its zundo `temporal`). */
+/** A single timeline-document store instance (with its `temporal` sub-store). */
 export type TimelineStoreApi = ReturnType<typeof createTimelineStore>;
 
-/** Read the zundo temporal (undo/redo) state of a given store instance. */
+/** Read the temporal (undo/redo) state of a given store instance. */
 export const timelineTemporalOf = (
   store: TimelineStoreApi
 ): TemporalState<PartializedState> =>

--- a/web/src/stores/timeline/useTimelineHistoryBatch.ts
+++ b/web/src/stores/timeline/useTimelineHistoryBatch.ts
@@ -5,7 +5,7 @@
  * resize) into a SINGLE undo entry.
  *
  * The pattern: let the first store mutation that actually changes the document
- * record the pre-gesture state (zundo pushes it onto the undo stack), then
+ * record the pre-gesture state (the temporal middleware pushes it onto the undo stack), then
  * pause history tracking so the rest of the gesture records nothing, and
  * resume on pointerup.
  *

--- a/web/src/utils/__tests__/isEqual.test.ts
+++ b/web/src/utils/__tests__/isEqual.test.ts
@@ -1,0 +1,258 @@
+import isEqual from "../isEqual";
+
+describe("isEqual", () => {
+  describe("primitives", () => {
+    it("equal primitives", () => {
+      expect(isEqual(1, 1)).toBe(true);
+      expect(isEqual("a", "a")).toBe(true);
+      expect(isEqual(true, true)).toBe(true);
+      expect(isEqual(null, null)).toBe(true);
+      expect(isEqual(undefined, undefined)).toBe(true);
+    });
+
+    it("unequal primitives", () => {
+      expect(isEqual(1, 2)).toBe(false);
+      expect(isEqual("a", "b")).toBe(false);
+      expect(isEqual(true, false)).toBe(false);
+      expect(isEqual(1, "1")).toBe(false);
+      expect(isEqual(0, false)).toBe(false);
+      expect(isEqual("", false)).toBe(false);
+    });
+
+    it("NaN equals NaN", () => {
+      expect(isEqual(NaN, NaN)).toBe(true);
+      expect(isEqual(NaN, 1)).toBe(false);
+      expect(isEqual({ a: NaN }, { a: NaN })).toBe(true);
+      expect(isEqual([NaN], [NaN])).toBe(true);
+    });
+
+    it("+0 equals -0 (fast-deep-equal semantics)", () => {
+      expect(isEqual(0, -0)).toBe(true);
+      expect(isEqual(-0, 0)).toBe(true);
+    });
+
+    it("null vs undefined vs {}", () => {
+      expect(isEqual(null, undefined)).toBe(false);
+      expect(isEqual(undefined, null)).toBe(false);
+      expect(isEqual(null, {})).toBe(false);
+      expect(isEqual({}, null)).toBe(false);
+      expect(isEqual(undefined, {})).toBe(false);
+      expect(isEqual({}, {})).toBe(true);
+    });
+  });
+
+  describe("reference fast path", () => {
+    it("same reference is equal", () => {
+      const obj = { a: { b: 1 } };
+      expect(isEqual(obj, obj)).toBe(true);
+      const arr = [1, 2, 3];
+      expect(isEqual(arr, arr)).toBe(true);
+      const fn = () => 1;
+      expect(isEqual(fn, fn)).toBe(true);
+    });
+  });
+
+  describe("functions", () => {
+    it("distinct functions are unequal even with same body", () => {
+      expect(
+        isEqual(
+          () => 1,
+          () => 1
+        )
+      ).toBe(false);
+    });
+
+    it("objects holding the same function reference are equal", () => {
+      const fn = () => 1;
+      expect(isEqual({ cb: fn }, { cb: fn })).toBe(true);
+      expect(isEqual({ cb: fn }, { cb: () => 1 })).toBe(false);
+    });
+  });
+
+  describe("arrays", () => {
+    it("flat arrays", () => {
+      expect(isEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+      expect(isEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+      expect(isEqual([1, 2, 3], [1, 2])).toBe(false);
+      expect(isEqual([], [])).toBe(true);
+    });
+
+    it("nested arrays", () => {
+      expect(isEqual([[1], [2, [3]]], [[1], [2, [3]]])).toBe(true);
+      expect(isEqual([[1], [2, [3]]], [[1], [2, [4]]])).toBe(false);
+    });
+
+    it("array vs object", () => {
+      expect(isEqual([1, 2], { 0: 1, 1: 2 })).toBe(false);
+      expect(isEqual({ 0: 1, 1: 2 }, [1, 2])).toBe(false);
+    });
+
+    it("sparse vs dense", () => {
+      // eslint-disable-next-line no-sparse-arrays
+      expect(isEqual([, 1], [undefined, 1])).toBe(true);
+    });
+  });
+
+  describe("plain objects", () => {
+    it("deep equal objects", () => {
+      expect(isEqual({ a: 1, b: { c: [1, 2] } }, { a: 1, b: { c: [1, 2] } })).toBe(
+        true
+      );
+    });
+
+    it("deep unequal objects", () => {
+      expect(isEqual({ a: 1, b: { c: [1, 2] } }, { a: 1, b: { c: [1, 3] } })).toBe(
+        false
+      );
+    });
+
+    it("key order does not matter", () => {
+      expect(isEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    });
+
+    it("different key counts", () => {
+      expect(isEqual({ a: 1 }, { a: 1, b: undefined })).toBe(false);
+      expect(isEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+    });
+
+    it("same key count, different keys", () => {
+      expect(isEqual({ a: 1 }, { b: 1 })).toBe(false);
+    });
+
+    it("undefined values vs missing keys are unequal", () => {
+      expect(isEqual({ a: undefined }, {})).toBe(false);
+    });
+  });
+
+  describe("Date", () => {
+    it("equal timestamps", () => {
+      expect(
+        isEqual(new Date("2024-01-01T00:00:00Z"), new Date("2024-01-01T00:00:00Z"))
+      ).toBe(true);
+    });
+
+    it("unequal timestamps", () => {
+      expect(
+        isEqual(new Date("2024-01-01T00:00:00Z"), new Date("2024-01-02T00:00:00Z"))
+      ).toBe(false);
+    });
+
+    it("invalid dates equal each other", () => {
+      expect(isEqual(new Date("nope"), new Date("also nope"))).toBe(true);
+      expect(isEqual(new Date("nope"), new Date(0))).toBe(false);
+    });
+
+    it("Date vs equivalent number is unequal", () => {
+      expect(isEqual(new Date(0), 0)).toBe(false);
+    });
+  });
+
+  describe("RegExp", () => {
+    it("same source and flags", () => {
+      expect(isEqual(/abc/gi, /abc/gi)).toBe(true);
+    });
+
+    it("different flags", () => {
+      expect(isEqual(/abc/g, /abc/i)).toBe(false);
+    });
+
+    it("different source", () => {
+      expect(isEqual(/abc/, /abd/)).toBe(false);
+    });
+  });
+
+  describe("Map", () => {
+    it("equal maps", () => {
+      expect(
+        isEqual(
+          new Map<string, unknown>([
+            ["a", 1],
+            ["b", { c: 2 }]
+          ]),
+          new Map<string, unknown>([
+            ["b", { c: 2 }],
+            ["a", 1]
+          ])
+        )
+      ).toBe(true);
+    });
+
+    it("unequal values", () => {
+      expect(isEqual(new Map([["a", 1]]), new Map([["a", 2]]))).toBe(false);
+    });
+
+    it("unequal keys / sizes", () => {
+      expect(isEqual(new Map([["a", 1]]), new Map([["b", 1]]))).toBe(false);
+      expect(
+        isEqual(
+          new Map([["a", 1]]),
+          new Map([
+            ["a", 1],
+            ["b", 2]
+          ])
+        )
+      ).toBe(false);
+    });
+
+    it("Map vs plain object is unequal", () => {
+      expect(isEqual(new Map([["a", 1]]), { a: 1 })).toBe(false);
+    });
+  });
+
+  describe("Set", () => {
+    it("equal sets regardless of order", () => {
+      expect(isEqual(new Set([1, 2, 3]), new Set([3, 2, 1]))).toBe(true);
+    });
+
+    it("unequal sets", () => {
+      expect(isEqual(new Set([1, 2]), new Set([1, 3]))).toBe(false);
+      expect(isEqual(new Set([1]), new Set([1, 2]))).toBe(false);
+    });
+  });
+
+  describe("typed arrays", () => {
+    it("equal typed arrays", () => {
+      expect(isEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(
+        true
+      );
+    });
+
+    it("unequal contents or lengths", () => {
+      expect(isEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(
+        false
+      );
+      expect(isEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(
+        false
+      );
+    });
+
+    it("different typed-array kinds are unequal", () => {
+      expect(isEqual(new Uint8Array([1]), new Int8Array([1]))).toBe(false);
+    });
+  });
+
+  describe("mixed / real-world shapes", () => {
+    it("ReactFlow-like node arrays", () => {
+      const a = [
+        { id: "1", position: { x: 0, y: 0 }, data: { props: { v: 1 } } },
+        { id: "2", position: { x: 10, y: 5 }, data: { props: { v: NaN } } }
+      ];
+      const b = [
+        { id: "1", position: { x: 0, y: 0 }, data: { props: { v: 1 } } },
+        { id: "2", position: { x: 10, y: 5 }, data: { props: { v: NaN } } }
+      ];
+      expect(isEqual(a, b)).toBe(true);
+      b[1].position.x = 11;
+      expect(isEqual(a, b)).toBe(false);
+    });
+
+    it("object vs array of same content is unequal", () => {
+      expect(isEqual({ length: 0 }, [])).toBe(false);
+    });
+
+    it("deeply nested null/undefined distinctions", () => {
+      expect(isEqual({ a: { b: null } }, { a: { b: undefined } })).toBe(false);
+      expect(isEqual({ a: { b: null } }, { a: { b: null } })).toBe(true);
+    });
+  });
+});

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -7,7 +7,46 @@
  *           and are not sandbox-provided globals
  */
 import * as acorn from "acorn";
-import * as walk from "acorn-walk";
+
+// ---------------------------------------------------------------------------
+// Minimal AST walker (replaces acorn-walk for the node types used below)
+// ---------------------------------------------------------------------------
+
+const isAstNode = (value: unknown): value is acorn.AnyNode =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { type?: unknown }).type === "string";
+
+/**
+ * Depth-first walk over every ESTree node in the tree, invoking `visit` with
+ * the node and its ancestor chain (root first, the node itself last —
+ * matching acorn-walk's `ancestor` callback contract).
+ */
+function walkAst(
+  root: acorn.Node,
+  visit: (node: acorn.AnyNode, ancestors: acorn.AnyNode[]) => void
+): void {
+  const ancestors: acorn.AnyNode[] = [];
+
+  const walkNode = (node: acorn.AnyNode): void => {
+    ancestors.push(node);
+    visit(node, ancestors);
+    for (const key of Object.keys(node)) {
+      if (key === "type" || key === "start" || key === "end") continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (isAstNode(item)) walkNode(item);
+        }
+      } else if (isAstNode(value)) {
+        walkNode(value);
+      }
+    }
+    ancestors.pop();
+  };
+
+  walkNode(root as acorn.AnyNode);
+}
 
 // ---------------------------------------------------------------------------
 // Output inference
@@ -25,8 +64,8 @@ export function inferOutputKeysFromCode(code: string): string[] | null {
 
   let lastReturnKeys: string[] | null = null;
 
-  walk.simple(ast, {
-    ReturnStatement(node: acorn.ReturnStatement) {
+  walkAst(ast, (node) => {
+    if (node.type === "ReturnStatement") {
       if (node.argument?.type === "ObjectExpression") {
         const keys = extractObjectKeys(node.argument);
         if (keys.length > 0) {
@@ -94,71 +133,95 @@ export function inferInputKeysFromCode(code: string): string[] | null {
   const referenced = new Set<string>();
 
   // Collect all declarations
-  walk.simple(ast, {
-    VariableDeclarator(node: acorn.VariableDeclarator) {
-      collectBindingNames(node.id, declared);
-    },
-    FunctionDeclaration(node: acorn.FunctionDeclaration | acorn.AnonymousFunctionDeclaration) {
-      if (node.id?.name) declared.add(node.id.name);
-      for (const param of node.params) {
-        collectBindingNames(param, declared);
-      }
-    },
-    FunctionExpression(node: acorn.FunctionExpression) {
-      if (node.id?.name) declared.add(node.id.name);
-      for (const param of node.params) {
-        collectBindingNames(param, declared);
-      }
-    },
-    ArrowFunctionExpression(node: acorn.ArrowFunctionExpression) {
-      for (const param of node.params) {
-        collectBindingNames(param, declared);
-      }
-    },
-    ClassDeclaration(node: acorn.ClassDeclaration | acorn.AnonymousClassDeclaration) {
-      if (node.id?.name) declared.add(node.id.name);
-    },
-    CatchClause(node: acorn.CatchClause) {
-      if (node.param) collectBindingNames(node.param, declared);
-    },
-    ImportDeclaration(node: acorn.ImportDeclaration) {
-      for (const spec of node.specifiers) {
-        if (spec.local.name) declared.add(spec.local.name);
-      }
+  walkAst(ast, (node) => {
+    switch (node.type) {
+      case "VariableDeclarator":
+        collectBindingNames(node.id, declared);
+        break;
+      case "FunctionDeclaration":
+      case "FunctionExpression":
+        if (node.id?.name) declared.add(node.id.name);
+        for (const param of node.params) {
+          collectBindingNames(param, declared);
+        }
+        break;
+      case "ArrowFunctionExpression":
+        for (const param of node.params) {
+          collectBindingNames(param, declared);
+        }
+        break;
+      case "ClassDeclaration":
+        if (node.id?.name) declared.add(node.id.name);
+        break;
+      case "CatchClause":
+        if (node.param) collectBindingNames(node.param, declared);
+        break;
+      case "ImportDeclaration":
+        for (const spec of node.specifiers) {
+          if (spec.local.name) declared.add(spec.local.name);
+        }
+        break;
     }
   });
 
   // Collect all referenced identifiers (excluding property access and object keys)
-  walk.ancestor(ast, {
-    Identifier(node: acorn.Identifier, _state: unknown, ancestors: acorn.AnyNode[]) {
-      const parent = ancestors[ancestors.length - 2];
-      if (!parent) return;
+  walkAst(ast, (node, ancestors) => {
+    if (node.type !== "Identifier") return;
+    const parent = ancestors[ancestors.length - 2];
+    if (!parent) return;
 
-      // Skip if this is a property access (obj.prop — skip prop)
-      if (parent.type === "MemberExpression" && parent.property === node && !parent.computed) {
-        return;
-      }
-      // Skip if this is an object key in an object literal
-      if (parent.type === "Property" && parent.key === node && !parent.computed) {
-        return;
-      }
-      // Skip if this is a label
-      if (parent.type === "LabeledStatement" && parent.label === node) {
-        return;
-      }
-      // Skip declaration sites (already collected)
-      if (parent.type === "VariableDeclarator" && parent.id === node) {
-        return;
-      }
-      if (
-        (parent.type === "FunctionDeclaration" || parent.type === "FunctionExpression" ||
-         parent.type === "ClassDeclaration") && parent.id === node
-      ) {
-        return;
-      }
-
-      referenced.add(node.name);
+    // Skip if this is a property access (obj.prop — skip prop)
+    if (parent.type === "MemberExpression" && parent.property === node && !parent.computed) {
+      return;
     }
+    // Skip if this is an object key in an object literal
+    if (parent.type === "Property" && parent.key === node && !parent.computed) {
+      return;
+    }
+    // Skip if this is a class member key (class A { foo() {} })
+    if (
+      (parent.type === "MethodDefinition" || parent.type === "PropertyDefinition") &&
+      parent.key === node &&
+      !parent.computed
+    ) {
+      return;
+    }
+    // Skip labels (declaration and break/continue references)
+    if (parent.type === "LabeledStatement" && parent.label === node) {
+      return;
+    }
+    if (
+      (parent.type === "BreakStatement" || parent.type === "ContinueStatement") &&
+      parent.label === node
+    ) {
+      return;
+    }
+    // Skip meta properties (import.meta, new.target)
+    if (parent.type === "MetaProperty") {
+      return;
+    }
+    // Skip import/export specifier names (locals are collected as declared)
+    if (
+      parent.type === "ImportSpecifier" ||
+      parent.type === "ImportDefaultSpecifier" ||
+      parent.type === "ImportNamespaceSpecifier" ||
+      parent.type === "ExportSpecifier"
+    ) {
+      return;
+    }
+    // Skip declaration sites (already collected)
+    if (parent.type === "VariableDeclarator" && parent.id === node) {
+      return;
+    }
+    if (
+      (parent.type === "FunctionDeclaration" || parent.type === "FunctionExpression" ||
+       parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
+      parent.id === node
+    ) {
+      return;
+    }
+
+    referenced.add(node.name);
   });
 
   const inputs: string[] = [];

--- a/web/src/utils/isEqual.ts
+++ b/web/src/utils/isEqual.ts
@@ -1,0 +1,121 @@
+/**
+ * Deep structural equality, drop-in replacement for `fast-deep-equal/es6`.
+ *
+ * Handles plain objects, arrays, primitives, Date, RegExp, Map, Set, and
+ * typed arrays. NaN equals NaN (SameValueZero via Object.is fallback), +0
+ * equals -0 (matching fast-deep-equal). Functions and other non-plain
+ * objects compare by reference. Reference equality is the fast path.
+ */
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function isEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    // NaN !== NaN under ===; treat them as equal.
+    return a !== a && b !== b;
+  }
+
+  if (a.constructor !== b.constructor) {
+    return false;
+  }
+
+  if (Array.isArray(a)) {
+    const arrB = b as unknown[];
+    if (a.length !== arrB.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (!isEqual(a[i], arrB[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (a instanceof Map) {
+    const mapB = b as Map<unknown, unknown>;
+    if (a.size !== mapB.size) {
+      return false;
+    }
+    for (const [key, value] of a) {
+      if (!mapB.has(key)) {
+        return false;
+      }
+      if (!isEqual(value, mapB.get(key))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (a instanceof Set) {
+    const setB = b as Set<unknown>;
+    if (a.size !== setB.size) {
+      return false;
+    }
+    for (const value of a) {
+      if (!setB.has(value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+    const viewA = a as unknown as ArrayLike<number>;
+    const viewB = b as unknown as ArrayLike<number>;
+    if (viewA.length !== viewB.length) {
+      return false;
+    }
+    for (let i = 0; i < viewA.length; i++) {
+      if (viewA[i] !== viewB[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (a instanceof RegExp) {
+    const reB = b as RegExp;
+    return a.source === reB.source && a.flags === reB.flags;
+  }
+
+  if (a instanceof Date) {
+    // Invalid dates (NaN) compare equal to each other via Object.is.
+    return Object.is(a.getTime(), (b as Date).getTime());
+  }
+
+  if (a.valueOf !== Object.prototype.valueOf) {
+    return a.valueOf() === b.valueOf();
+  }
+  if (a.toString !== Object.prototype.toString) {
+    return a.toString() === b.toString();
+  }
+
+  const recA = a as Record<string, unknown>;
+  const recB = b as Record<string, unknown>;
+  const keys = Object.keys(recA);
+  if (keys.length !== Object.keys(recB).length) {
+    return false;
+  }
+  for (const key of keys) {
+    if (!hasOwn.call(recB, key)) {
+      return false;
+    }
+    if (!isEqual(recA[key], recB[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export default isEqual;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -385,7 +385,7 @@ export default defineConfig(async ({ mode }) => {
                     return "vendor-supabase";
                   // Search / command palette / small utilities cluster
                   if (
-                    /[\\/]node_modules[\\/](cmdk|chroma-js|zundo|uuid|zod|fast-deep-equal|acorn-walk)[\\/]/.test(
+                    /[\\/]node_modules[\\/](cmdk|chroma-js|uuid|zod)[\\/]/.test(
                       id
                     )
                   )


### PR DESCRIPTION
Last of the dependency-removal series: replaces three web runtime deps with small in-repo implementations. Only `web/` declared any of them; no other workspace is affected.

## fast-deep-equal → `web/src/utils/isEqual.ts`

Default-exported `isEqual(a, b)` covering the shapes this app compares: plain objects, arrays, primitives, Date, RegExp, Map, Set, typed arrays. NaN === NaN is true, +0/-0 equal (matching fast-deep-equal), functions compare by reference, reference-equality fast path first. All 120 import sites (every one was the identical `import isEqual from "fast-deep-equal"`) were rewritten by script to the correct relative path per file and verified with `tsc`. New suite: `web/src/utils/__tests__/isEqual.test.ts` (NaN, ±0, Date incl. invalid dates, RegExp, Map/Set, typed arrays, nested structures, key-count mismatches, null vs undefined vs `{}`, functions).

## zundo → `web/src/stores/temporal.ts`

Custom `temporal(config, { partialize, equality, limit })` middleware attaching a vanilla Zustand store at `store.temporal` with `pastStates`, `futureStates`, `undo(steps?)`, `redo(steps?)`, `clear()`, `pause()`, `resume()`, `isTracking` — exactly the surface NodeStore, TimelineStore, `NodeContext.useTemporalNodes`, `workflowUpdates`, and `useTimelineHistoryBatch` consume.

Semantics replicated from zundo v2.3 source:
- History push on every `set` **and** on direct `store.setState` calls, snapshotting the partialized state *before* the update; skipped while paused or when `equality(pastState, currentState)` is true; any tracked push clears `futureStates`.
- `undo`/`redo` restore through the raw setter (merge, not replace) so they never push history themselves; multi-step `undo(n)` lands on the oldest popped snapshot and stacks the skipped ones newest-first, matching zundo's splice/shift/reverse behavior.
- `limit` drops the oldest entries so `pastStates` never exceeds it.

Deliberately **not** replicated (unused in this codebase): `diff`, `onSave`/`setOnSave`, `handleSet` (grouping/throttling — neither store configures it), `wrapTemporal`. New suite: `web/src/stores/__tests__/temporal.test.ts` (push/undo/redo, multi-step ordering, limit, partialize, equality dedupe, pause/resume, futureStates clearing, subscribability). All existing undo/redo suites (NodeStore, TimelineStore, historyBatching, sceneUndo, useSurroundWithGroup, useNodeEditorShortcuts, NodeContext, useTimelineAutosave, …) pass unchanged.

## acorn-walk → recursive visitor in `codeOutputInference.ts`

`acorn` stays for parsing; the walker is now a ~30-line depth-first ESTree traversal with an ancestor stack (same callback contract as `walk.ancestor`). Because acorn-walk's base walker never visits binding-pattern identifiers, non-computed class member keys, break/continue labels, meta properties, or import/export specifier names as `Identifier`, the input-inference visitor gained explicit guards for those positions so no phantom inputs appear. Existing `codeOutputInference.test.ts` passes unchanged.

## CodeBlock rider (post-merge review follow-ups)

In `web/src/components/chat/message/markdown_elements/CodeBlock.tsx` (already touched for the isEqual swap):
- Fenced-code language is lowercased before the `Prism.languages` lookup and `Prism.highlight` call, so `language-JS` still highlights; the header label keeps the original casing.
- The bare `code: {...}` emotion object-style key is now an explicit `"& code": {...}` nested selector.
- New focused suite `__tests__/CodeBlock.test.tsx`: known language renders token spans, unknown language falls back to plain text, malicious content (``'&lt;img src=x onerror=…&gt;'``) never produces a live element on either the highlighted (DOMPurify) or plain-text path, and mixed-case languages still highlight.

## Cleanup

- Removed `fast-deep-equal`, `zundo`, `acorn-walk` from `web/package.json`; lockfile synced (`npm install --package-lock-only`). Remaining lockfile mentions are transitive deps of unrelated tools; the `zundo` entry is fully gone.
- Removed the three names from the vite `vendor-utils` manual-chunk regex.
- Updated stale prose comments referencing zundo (TimelineStore, Clip, autosave hooks, `stores/AGENTS.md`).

## Validation

- `npx tsc --noEmit` (web): clean
- `npm run lint` (web, includes `lint:design`): exit 0, warnings pre-existing
- `TZ=UTC npx jest src/utils src/stores src/components/chat --silent`: **303/303 suites, 4281 passed**
- All undo/temporal-related suites (stores, timeline, hooks, contexts, sketch): pass except pre-existing failures below
- Full `TZ=UTC npx jest --forceExit --silent`: **895 passed / 16 failed suites (11047 passed / 112 failed tests)**. The 16 failing suites are all sketch/canvas tests failing with `canvas.getContext(...) === null`; re-running exactly those suites on unmodified `origin/main` in the same environment reproduces the **identical 16 suites / 112 test failures** (native `canvas` package unavailable under `--ignore-scripts` install). Zero new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVb6BNaXj1xZwPBiQtWB56

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVb6BNaXj1xZwPBiQtWB56)_