### PR TITLE
Improve e2e harness robustness and error handling

### DIFF
--- a/packages/cli/src/debug/browser-runner.ts
+++ b/packages/cli/src/debug/browser-runner.ts
@@ -10,7 +10,7 @@
  * It degrades gracefully (an `unavailableReason`) when the web deps or browser
  * binaries aren't installed.
  */
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -60,6 +60,41 @@ interface StageEntry {
   file: string;
 }
 
+/** Grace period between SIGTERM and SIGKILL when tearing down the child's process group. */
+const GROUP_KILL_GRACE_MS = 5_000;
+
+/**
+ * Kill the Playwright child on timeout. Playwright's webServer (Vite) and the
+ * tsx e2e backend spawned by globalSetup are children of this process, not of
+ * `child` itself, so a plain `child.kill()` orphans them holding ports
+ * 3000/7777. On POSIX, `child` is spawned detached (its own process group), so
+ * we can kill the whole group via the negative pid; on win32 (no process
+ * groups, and no `shell: true` here) fall back to killing just the child.
+ */
+function killChild(child: ChildProcess): void {
+  if (process.platform !== "win32" && child.pid !== undefined) {
+    const pgid = child.pid;
+    try {
+      process.kill(-pgid, "SIGTERM");
+    } catch {
+      // Process group may already be gone.
+    }
+    setTimeout(() => {
+      try {
+        process.kill(-pgid, "SIGKILL");
+      } catch {
+        // Process group may already be gone.
+      }
+    }, GROUP_KILL_GRACE_MS).unref();
+    return;
+  }
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // Already exited.
+  }
+}
+
 function unavailable(reason: string): BrowserRunReport {
   return {
     surface: "browser",
@@ -93,22 +128,38 @@ export async function runInBrowser(input: BrowserRunInput): Promise<BrowserRunRe
     NODETOOL_DEBUG_GRAPH: graphPath,
     NODETOOL_DEBUG_OUT: input.outDir,
     NODETOOL_DEBUG_PARAMS: JSON.stringify(input.params ?? {}),
-    ...(input.captureStages ? { NODETOOL_DEBUG_STAGES: "1" } : {})
+    ...(input.captureStages ? { NODETOOL_DEBUG_STAGES: "1" } : {}),
+    // Read by debug.spec.ts to arm the in-page run's own timeout, so the
+    // Playwright spec doesn't fall back to its internal RUN_TIMEOUT_MS cap.
+    ...(input.timeoutMs ? { NODETOOL_DEBUG_TIMEOUT: String(input.timeoutMs) } : {})
   };
 
+  // The child-kill timer below is the outer backstop; it must stay comfortably
+  // above the in-page timeout the spec applies, or the child gets killed
+  // before the harness can settle and write record.json.
+  const killTimeoutMs =
+    input.timeoutMs !== undefined
+      ? Math.max(input.timeoutMs + 60_000, DEFAULT_TIMEOUT_MS)
+      : DEFAULT_TIMEOUT_MS;
+
+  const isWindows = process.platform === "win32";
   const exitCode = await new Promise<number>((resolvePromise) => {
     const child = spawn(playwrightBin, ["test", "-c", CONFIG_REL], {
       cwd: webDir,
       env,
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
+      // .bin/playwright is a shell shim on win32 (no .exe), so it needs a
+      // shell to resolve; shell mode has no process groups, so detach only
+      // on POSIX where killChild can use them for whole-tree teardown.
+      ...(isWindows ? { shell: true } : { detached: true })
     });
     const onChunk = (buf: Buffer) => input.onLog?.(buf.toString());
     child.stdout?.on("data", onChunk);
     child.stderr?.on("data", onChunk);
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
+      killChild(child);
       resolvePromise(124);
-    }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    }, killTimeoutMs);
     child.on("error", () => {
       clearTimeout(timer);
       resolvePromise(127);

--- a/web/src/e2e_runner/E2ERunnerApp.tsx
+++ b/web/src/e2e_runner/E2ERunnerApp.tsx
@@ -53,6 +53,7 @@ const STATUS_COLOR: Record<string, string> = {
   failed: "#EF4444",
   error: "#EF4444",
   cancelled: "#F59E0B",
+  suspended: "#F59E0B",
   timeout: "#F59E0B",
   skipped: "#94A3B8"
 };
@@ -294,10 +295,13 @@ export default function E2ERunnerApp() {
 
   useEffect(() => {
     const unsubscribe = harness.subscribe(setState);
+    // Install the controller before init so the ad-hoc runGraph path (which
+    // needs no manifest) is reachable even when manifest.json is missing —
+    // otherwise the driver's waitForFunction(window.__E2E__) times out.
+    window.__E2E__ = harness.controller();
     (async () => {
       try {
         await harness.init();
-        window.__E2E__ = harness.controller();
         if (!manual) {
           await harness.runAll();
         }
@@ -337,7 +341,7 @@ export default function E2ERunnerApp() {
                   onRunNext={() => void harness.runNext()}
                 />
                 <div style={{ flex: 1, position: "relative" }}>
-                  {error ? (
+                  {error && !state.adHocGraph ? (
                     <div style={{ ...centeredStyle, color: "#EF4444" }}>{error}</div>
                   ) : (
                     <Canvas harness={harness} state={state} />

--- a/web/src/e2e_runner/graphRender.ts
+++ b/web/src/e2e_runner/graphRender.ts
@@ -188,24 +188,49 @@ export interface RenderGraph {
  */
 export async function buildRenderGraph(raw: RawGraph): Promise<RenderGraph> {
   const workflow = toWorkflow(raw);
-  const metaStore = useMetadataStore.getState();
-  const existing = metaStore.metadata ?? {};
-  const allMetadata: Record<string, NodeMetadata> = { ...existing };
-  const nodeTypesMap: Record<string, unknown> = { ...metaStore.nodeTypes };
   const { default: BaseNode } = await import("../components/node/BaseNode");
 
-  for (const node of workflow.graph?.nodes ?? []) {
+  // Nothing below this point awaits until after the store writes, so the
+  // getState() reads used to compute `newMetadata`/`newNodeTypes` stay valid
+  // through the setMetadata/setNodeTypes calls — no other call can interleave
+  // a write in between and get clobbered.
+  const graphNodes = workflow.graph?.nodes ?? [];
+
+  const currentMetadata = useMetadataStore.getState().metadata;
+  const newMetadata: Record<string, NodeMetadata> = {};
+  for (const node of graphNodes) {
     const nodeType = node.type;
-    if (!allMetadata[nodeType]) {
-      allMetadata[nodeType] = inferMetadata(
+    if (!currentMetadata[nodeType] && !newMetadata[nodeType]) {
+      newMetadata[nodeType] = inferMetadata(
         nodeType,
         (node.data || {}) as Record<string, unknown>
       );
     }
-    nodeTypesMap[nodeType] = BaseNode;
   }
-  metaStore.setMetadata(allMetadata);
-  metaStore.setNodeTypes(nodeTypesMap as Record<string, typeof BaseNode>);
+  const allMetadata: Record<string, NodeMetadata> = {
+    ...currentMetadata,
+    ...newMetadata
+  };
+  if (Object.keys(newMetadata).length > 0) {
+    useMetadataStore.getState().setMetadata(allMetadata);
+  }
+
+  // Only fill in types with no registered component yet — never override one
+  // that's already there.
+  const currentNodeTypes = useMetadataStore.getState().nodeTypes;
+  const newNodeTypes: Record<string, unknown> = {};
+  for (const node of graphNodes) {
+    const nodeType = node.type;
+    if (!currentNodeTypes[nodeType] && !newNodeTypes[nodeType]) {
+      newNodeTypes[nodeType] = BaseNode;
+    }
+  }
+  if (Object.keys(newNodeTypes).length > 0) {
+    useMetadataStore.getState().setNodeTypes({
+      ...useMetadataStore.getState().nodeTypes,
+      ...newNodeTypes
+    } as Record<string, typeof BaseNode>);
+  }
 
   const rfNodes = (workflow.graph?.nodes ?? []).map((n) =>
     graphNodeToReactFlowNode(workflow, n as GraphNode)

--- a/web/src/e2e_runner/harness.ts
+++ b/web/src/e2e_runner/harness.ts
@@ -21,7 +21,13 @@ import type {
   WsEvent
 } from "./types";
 
-const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled", "error"]);
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "error",
+  "suspended"
+]);
 // Faked nodes complete near-instantly; a tight per-run cap keeps the whole
 // 49-template suite within the Playwright test budget even when a template
 // hangs (e.g. a required input with no default/param).
@@ -89,15 +95,18 @@ function extractArtifact(output: {
     const uri = typeof obj.uri === "string" ? obj.uri : undefined;
     const data = typeof obj.data === "string" ? obj.data : undefined;
     const type = typeof obj.type === "string" ? obj.type : output.output_type;
+    const mimeType = typeof obj.mimeType === "string" ? obj.mimeType : undefined;
     if (uri || data) {
+      // The value's own mimeType is authoritative; the type-based guess is a fallback.
       const contentType =
-        type === "image"
+        mimeType ??
+        (type === "image"
           ? "image/png"
           : type === "audio"
             ? "audio/mpeg"
             : type === "video"
               ? "video/mp4"
-              : "application/octet-stream";
+              : "application/octet-stream");
       const artifact: CapturedArtifact = {
         name: output.output_name ?? type ?? "artifact",
         contentType
@@ -133,6 +142,24 @@ function reduceRecordEvent(
   nodeStatus: Record<string, string>
 ): TerminalSignal | null {
   rec.events.push(msg);
+  // The backend's invalid_command / invalid_message envelope carries no `type`
+  // field, only { error, details?/message? }. Catch it before the type switch;
+  // it's terminal and would otherwise fall through and hang to timeout.
+  if (typeof msg.type !== "string") {
+    const errCode = (msg as { error?: unknown }).error;
+    if (typeof errCode === "string" && errCode) {
+      const details = (msg as { details?: unknown; message?: unknown }).details;
+      const message = (msg as { message?: unknown }).message;
+      const text =
+        typeof details === "string" && details
+          ? `${errCode}: ${details}`
+          : typeof message === "string" && message
+            ? `${errCode}: ${message}`
+            : errCode;
+      if (!rec.error) rec.error = text;
+      return { status: "error", error: text };
+    }
+  }
   switch (msg.type) {
     case "job_update": {
       if (typeof msg.job_id === "string" && msg.job_id) rec.jobId = msg.job_id;
@@ -188,6 +215,12 @@ function reduceRecordEvent(
       });
       break;
     }
+    case "error": {
+      // A backend { type:"error", message } frame is terminal.
+      const text = typeof msg.message === "string" && msg.message ? msg.message : "error";
+      if (!rec.error) rec.error = text;
+      return { status: "error", error: text };
+    }
     default:
       break;
   }
@@ -218,6 +251,9 @@ export class Harness {
   };
   private secretsAvailable: string[] = [];
   private graphCache = new Map<string, { nodes: unknown[]; edges: unknown[] }>();
+  // Serializes runs: a second runNext/runGraph while one is in flight returns
+  // the in-flight promise instead of racing the same pending record.
+  private runInFlight: Promise<RunRecord | null> | null = null;
 
   subscribe(listener: Listener): () => void {
     this.listeners.add(listener);
@@ -235,17 +271,25 @@ export class Harness {
   }
 
   async init(manifestUrl = "/e2e-suite/manifest.json"): Promise<void> {
-    const res = await fetch(manifestUrl);
-    if (!res.ok) {
-      throw new Error(`Failed to load manifest: ${res.status} ${res.statusText}`);
+    try {
+      const res = await fetch(manifestUrl);
+      if (!res.ok) {
+        throw new Error(`Failed to load manifest: ${res.status} ${res.statusText}`);
+      }
+      const manifest = (await res.json()) as Manifest;
+      this.secretsAvailable = manifest.secretsAvailable ?? [];
+      this.setState({
+        manifest: manifest.workflows,
+        records: manifest.workflows.map(emptyRecord),
+        state: "idle"
+      });
+    } catch (err) {
+      // No manifest (e.g. the ad-hoc debug path) must not leave the harness
+      // stuck "loading": settle to idle+empty so runGraph still works. The
+      // caller still sees the rejection and surfaces the banner.
+      this.setState({ manifest: [], records: [], state: "idle" });
+      throw err;
     }
-    const manifest = (await res.json()) as Manifest;
-    this.secretsAvailable = manifest.secretsAvailable ?? [];
-    this.setState({
-      manifest: manifest.workflows,
-      records: manifest.workflows.map(emptyRecord),
-      state: "idle"
-    });
   }
 
   /** Load and cache a workflow graph by file path. */
@@ -296,6 +340,13 @@ export class Harness {
     );
   }
 
+  // A single-step run leaves state at "running"; settle it back so manual mode
+  // isn't stuck. "idle" while pending records remain, "done" once none do.
+  private settleManualState(): void {
+    const hasPending = this.state.records.some((r) => r.status === "pending");
+    this.setState({ state: hasPending ? "idle" : "done" });
+  }
+
   private updateRecord(index: number, mutate: (rec: RunRecord) => void): void {
     const records = this.state.records.slice();
     const rec = { ...records[index] };
@@ -306,6 +357,7 @@ export class Harness {
 
   /** Run the next pending workflow. Resolves with its record once settled. */
   async runNext(): Promise<RunRecord | null> {
+    if (this.runInFlight) return this.runInFlight;
     const nextIndex = this.state.records.findIndex(
       (r) => r.status === "pending"
     );
@@ -313,7 +365,11 @@ export class Harness {
       this.setState({ state: "done" });
       return null;
     }
-    return this.runAt(nextIndex);
+    const promise = this.runAt(nextIndex).finally(() => {
+      this.runInFlight = null;
+    });
+    this.runInFlight = promise;
+    return promise;
   }
 
   async runAll(): Promise<RunRecord[]> {
@@ -334,6 +390,7 @@ export class Harness {
         rec.status = "skipped";
         rec.skipReason = `Missing secrets: ${missing.join(", ")}`;
       });
+      this.settleManualState();
       return this.state.records[index];
     }
 
@@ -345,6 +402,7 @@ export class Harness {
         rec.status = "error";
         rec.error = err instanceof Error ? err.message : String(err);
       });
+      this.settleManualState();
       return this.state.records[index];
     }
 
@@ -368,19 +426,35 @@ export class Harness {
         rec.durationMs = finishedAt - startedAt;
         rec.error = err instanceof Error ? err.message : String(err);
       });
+      this.settleManualState();
       return this.state.records[index];
     }
+
+    const runTimeoutMs = ref.timeoutMs ?? RUN_TIMEOUT_MS;
 
     await new Promise<void>((resolve) => {
       const nodeStatus: Record<string, string> = {};
       let settled = false;
-      const timer = window.setTimeout(() => finish("timeout"), RUN_TIMEOUT_MS);
+      const timer = window.setTimeout(() => finish("timeout"), runTimeoutMs);
 
       const finish = (status: RunStatus, error?: string) => {
         if (settled) return;
         settled = true;
         window.clearTimeout(timer);
         unsubscribe();
+        unsubscribeClose();
+        // A timed-out job keeps running server-side after we drop the socket;
+        // best-effort ask the backend to stop it first.
+        if (status === "timeout") {
+          const jobId = this.state.records[index].jobId;
+          if (jobId) {
+            try {
+              ws.send({ command: "stop", data: { job_id: jobId } });
+            } catch {
+              // best-effort; the socket may already be gone
+            }
+          }
+        }
         ws.close();
         const finishedAt = Date.now();
         this.updateRecord(index, (rec) => {
@@ -397,6 +471,9 @@ export class Harness {
       const unsubscribe = ws.onMessage((msg: WsEvent) => {
         this.handleEvent(index, msg, nodeStatus, finish);
       });
+      const unsubscribeClose = ws.onClose(() =>
+        finish("error", "WebSocket connection closed unexpectedly")
+      );
 
       try {
         ws.send({ command: "run_job", data: { graph, params: ref.params } });
@@ -405,6 +482,7 @@ export class Harness {
       }
     });
 
+    this.settleManualState();
     return this.state.records[index];
   }
 
@@ -437,7 +515,11 @@ export class Harness {
       );
     }
     if (expect.outputContains) {
-      const haystack = asString(rec.outputs.map((o) => o.value));
+      // Concatenate raw values (strings verbatim) so an expected substring with
+      // quotes/backslashes/newlines isn't defeated by JSON escaping.
+      const haystack = rec.outputs
+        .map((o) => (typeof o.value === "string" ? o.value : asString(o.value)))
+        .join("\n");
       if (!haystack.includes(expect.outputContains)) {
         failures.push(`outputs did not contain "${expect.outputContains}"`);
       }
@@ -455,6 +537,20 @@ export class Harness {
     graph: { nodes: unknown[]; edges: unknown[] },
     params: Record<string, unknown> = {},
     options: AdHocRunOptions = {}
+  ): Promise<RunRecord> {
+    // Refuse a concurrent run: hand back the in-flight promise instead.
+    if (this.runInFlight) return this.runInFlight as Promise<RunRecord>;
+    const promise = this.runGraphInternal(graph, params, options).finally(() => {
+      this.runInFlight = null;
+    });
+    this.runInFlight = promise;
+    return promise;
+  }
+
+  private async runGraphInternal(
+    graph: { nodes: unknown[]; edges: unknown[] },
+    params: Record<string, unknown>,
+    options: AdHocRunOptions
   ): Promise<RunRecord> {
     const ref: WorkflowRef = {
       id: options.id ?? `adhoc-${Date.now()}`,
@@ -504,6 +600,16 @@ export class Harness {
         settled = true;
         window.clearTimeout(timer);
         unsubscribe();
+        unsubscribeClose();
+        // A timed-out job keeps running server-side after we drop the socket;
+        // best-effort ask the backend to stop it first.
+        if (status === "timeout" && rec.jobId) {
+          try {
+            ws.send({ command: "stop", data: { job_id: rec.jobId } });
+          } catch {
+            // best-effort; the socket may already be gone
+          }
+        }
         ws.close();
         rec.status = status;
         rec.finishedAt = Date.now();
@@ -526,6 +632,9 @@ export class Harness {
         });
         if (terminal) queueMicrotask(() => finish(terminal.status, terminal.error));
       });
+      const unsubscribeClose = ws.onClose(() =>
+        finish("error", "WebSocket connection closed unexpectedly")
+      );
 
       try {
         ws.send({ command: "run_job", data: { graph, params } });

--- a/web/src/e2e_runner/types.ts
+++ b/web/src/e2e_runner/types.ts
@@ -13,6 +13,7 @@ export type RunStatus =
   | "cancelled"
   | "error"
   | "timeout"
+  | "suspended"
   | "skipped";
 
 /** A single workflow entry in the suite manifest. */
@@ -38,6 +39,8 @@ export interface WorkflowRef {
   tags?: string[];
   /** Where the graph came from (cli-fixtures | shipped-examples | custom). */
   source?: string;
+  /** Per-run timeout override in ms; defaults to the harness cap. */
+  timeoutMs?: number;
 }
 
 export interface Manifest {

--- a/web/src/e2e_runner/wsClient.ts
+++ b/web/src/e2e_runner/wsClient.ts
@@ -13,6 +13,10 @@ export type WsMessageHandler = (msg: WsEvent) => void;
 export class HarnessWsClient {
   private ws: WebSocket | null = null;
   private handlers = new Set<WsMessageHandler>();
+  private closeHandlers = new Set<() => void>();
+  // Set by close() so the ws.onclose handler can tell an intentional teardown
+  // from a mid-run drop and only fire onClose subscribers for the latter.
+  private intentionalClose = false;
 
   /** Resolve the /ws URL from the current page origin (proxied by Vite to the backend). */
   static defaultUrl(): string {
@@ -33,6 +37,9 @@ export class HarnessWsClient {
         reject(new Error(`WebSocket connection to ${url} failed`));
       ws.onclose = () => {
         if (this.ws === ws) this.ws = null;
+        if (!this.intentionalClose) {
+          for (const handler of this.closeHandlers) handler();
+        }
       };
       ws.onmessage = (event) => {
         let msg: WsEvent | null = null;
@@ -53,6 +60,12 @@ export class HarnessWsClient {
     return () => this.handlers.delete(handler);
   }
 
+  /** Subscribe to an unexpected socket close (a drop not initiated by close()). */
+  onClose(handler: () => void): () => void {
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
   send(payload: Record<string, unknown>): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("WebSocket is not open");
@@ -65,8 +78,10 @@ export class HarnessWsClient {
   }
 
   close(): void {
+    this.intentionalClose = true;
     this.ws?.close();
     this.ws = null;
     this.handlers.clear();
+    this.closeHandlers.clear();
   }
 }

--- a/web/tests/debug-harness/debug.spec.ts
+++ b/web/tests/debug-harness/debug.spec.ts
@@ -9,9 +9,12 @@
  * written into NODETOOL_DEBUG_OUT for the CLI to read back.
  *
  * Inputs (env):
- *   NODETOOL_DEBUG_GRAPH   path to a JSON file: either a bare graph or { graph }.
- *   NODETOOL_DEBUG_OUT     directory to write record.json / screenshot.png / stages/.
- *   NODETOOL_DEBUG_PARAMS  optional JSON object of run params.
+ *   NODETOOL_DEBUG_GRAPH    path to a JSON file: either a bare graph or { graph }.
+ *   NODETOOL_DEBUG_OUT      directory to write record.json / screenshot.png / stages/.
+ *   NODETOOL_DEBUG_PARAMS   optional JSON object of run params.
+ *   NODETOOL_DEBUG_TIMEOUT  optional per-run timeout (ms) forwarded to runGraph, so a
+ *                           long `nodetool debug --timeout` run isn't capped by the
+ *                           harness's internal RUN_TIMEOUT_MS.
  */
 import { test, expect, type Page } from "@playwright/test";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -25,12 +28,25 @@ const PARAMS_JSON = process.env.NODETOOL_DEBUG_PARAMS;
 const CAPTURE_STAGES =
   process.env.NODETOOL_DEBUG_STAGES === "1" || process.env.NODETOOL_DEBUG_STAGES === "true";
 
+function parseTimeoutMs(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+const RUN_TIMEOUT_MS = parseTimeoutMs(process.env.NODETOOL_DEBUG_TIMEOUT);
+
 const POLL_MS = 120;
 /** Don't snap more often than this even if stages tick fast. */
 const MIN_INTERVAL_MS = 180;
 /** Cap the number of intermediate stage frames (excludes the final). */
 const MAX_STAGES = 16;
-const MAX_WAIT_MS = 5 * 60_000;
+const DEFAULT_MAX_WAIT_MS = 5 * 60_000;
+/** Margin added on top of an explicit run timeout so polling outlives the in-page run. */
+const WAIT_MARGIN_MS = 30_000;
+const MAX_WAIT_MS =
+  RUN_TIMEOUT_MS !== undefined
+    ? Math.max(RUN_TIMEOUT_MS + WAIT_MARGIN_MS, DEFAULT_MAX_WAIT_MS)
+    : DEFAULT_MAX_WAIT_MS;
 
 interface StageShot {
   index: number;
@@ -114,14 +130,15 @@ test("debug harness runs the target workflow", async ({ page }) => {
     if (CAPTURE_STAGES) {
       // Start the run but DON'T await it here, so we can screenshot mid-flight.
       await page.evaluate(
-        ([g, p]) => {
+        ([g, p, timeoutMs]) => {
           (window as unknown as { __DEBUG_RUN__?: Promise<RunRecord> }).__DEBUG_RUN__ =
             window.__E2E__!.runGraph(
               g as { nodes: unknown[]; edges: unknown[] },
-              p as Record<string, unknown>
+              p as Record<string, unknown>,
+              timeoutMs !== undefined ? { timeoutMs } : undefined
             );
         },
-        [graph, params] as const
+        [graph, params, RUN_TIMEOUT_MS] as const
       );
       stages = await captureStages(page, resolve(OUT_DIR, "stages"));
       record = (await page.evaluate(
@@ -130,12 +147,13 @@ test("debug harness runs the target workflow", async ({ page }) => {
     } else {
       // Cheap default: run to completion, capture only the final frame below.
       record = (await page.evaluate(
-        ([g, p]) =>
+        ([g, p, timeoutMs]) =>
           window.__E2E__!.runGraph(
             g as { nodes: unknown[]; edges: unknown[] },
-            p as Record<string, unknown>
+            p as Record<string, unknown>,
+            timeoutMs !== undefined ? { timeoutMs } : undefined
           ),
-        [graph, params] as const
+        [graph, params, RUN_TIMEOUT_MS] as const
       )) as RunRecord;
     }
   } catch (err) {

--- a/web/tests/e2e-runner/globalSetup.ts
+++ b/web/tests/e2e-runner/globalSetup.ts
@@ -29,26 +29,29 @@ const BACKEND_PORT = 7777;
 const STARTUP_TIMEOUT_MS = 120_000;
 const E2E_TEST_MASTER_KEY_B64 = "RTJFX1RFU1RfS0VZX0RPX05PVF9VU0VfSU5fUFJPRCE=";
 
+function checkPortOnce(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise<boolean>((res) => {
+    const socket = net.createConnection({ host, port });
+    let done = false;
+    const settle = (value: boolean) => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      res(value);
+    };
+    // Per-attempt timeout so a filtered/half-open port can't stall past the
+    // overall deadline.
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => settle(true));
+    socket.once("timeout", () => settle(false));
+    socket.once("error", () => settle(false));
+  });
+}
+
 async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const ready = await new Promise<boolean>((res) => {
-      const socket = net.createConnection({ host, port });
-      let done = false;
-      const settle = (value: boolean) => {
-        if (done) return;
-        done = true;
-        socket.destroy();
-        res(value);
-      };
-      // Per-attempt timeout so a filtered/half-open port can't stall past the
-      // overall deadline.
-      socket.setTimeout(2_000);
-      socket.once("connect", () => settle(true));
-      socket.once("timeout", () => settle(false));
-      socket.once("error", () => settle(false));
-    });
-    if (ready) return;
+    if (await checkPortOnce(host, port, 2_000)) return;
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(`[e2e globalSetup] Timed out waiting for backend on ${host}:${port}`);
@@ -56,6 +59,21 @@ async function waitForPort(host: string, port: number, timeoutMs: number): Promi
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+  // Fail loudly if something already holds the port instead of letting the
+  // suite silently run against whatever backend that is (real providers, real
+  // DB) once the hermetic server we spawn below dies on EADDRINUSE.
+  const portAlreadyOpen = await checkPortOnce(BACKEND_HOST, BACKEND_PORT, 2_000);
+  if (portAlreadyOpen) {
+    throw new Error(
+      `[e2e globalSetup] Port ${BACKEND_PORT} on ${BACKEND_HOST} is already in use. ` +
+        `The e2e suite needs to own this port to run its own hermetic backend ` +
+        `(packages/websocket/src/e2e-server.ts) — if it starts against an already-running ` +
+        `server, that server (likely started with \`npm run dev:server\`) would be exercised ` +
+        `instead, with real providers and the real DB. Stop whatever is listening on ` +
+        `${BACKEND_HOST}:${BACKEND_PORT} and re-run.`
+    );
+  }
 
   const { count } = prepareSuite();
   console.log(`[e2e globalSetup] Prepared suite with ${count} workflows`);
@@ -81,8 +99,28 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     console.error("[e2e globalSetup] Failed to start backend:", err)
   );
 
+  // Reject as soon as the child dies rather than burning the full startup
+  // deadline waiting for a port that will never open (e.g. EADDRINUSE).
+  const earlyExit = new Promise<never>((_, reject) => {
+    serverProcess.once("exit", (code, signal) => {
+      reject(
+        new Error(
+          `[e2e globalSetup] Backend process exited before it started listening ` +
+            `(code=${code}, signal=${signal})`
+        )
+      );
+    });
+  });
+  // Attach a handler now so that if waitForPort wins the race, this promise's
+  // later rejection (backend dying during teardown) doesn't surface as an
+  // unhandled rejection.
+  earlyExit.catch(() => {});
+
   try {
-    await waitForPort(BACKEND_HOST, BACKEND_PORT, STARTUP_TIMEOUT_MS);
+    await Promise.race([
+      waitForPort(BACKEND_HOST, BACKEND_PORT, STARTUP_TIMEOUT_MS),
+      earlyExit
+    ]);
   } catch (err) {
     serverProcess.kill("SIGKILL");
     throw err;


### PR DESCRIPTION
## Summary

This PR hardens the e2e test harness and browser runner with better error handling, timeout management, and process cleanup. It adds support for the "suspended" workflow status, improves WebSocket connection handling, and fixes race conditions in concurrent run management.

## Key Changes

### E2E Harness (`web/src/e2e_runner/harness.ts`)
- **Terminal status handling**: Added "suspended" to `TERMINAL_STATUSES` set
- **Error message extraction**: Added handling for backend `invalid_command`/`invalid_message` envelopes (messages without a `type` field) and new `error` message type, both now properly captured and returned as terminal states
- **Artifact MIME type support**: Added `mimeType` field extraction from artifact objects, with fallback to type-based guessing (image/png, audio/mpeg, video/mp4)
- **Concurrent run serialization**: Added `runInFlight` promise tracking to prevent race conditions — a second `runNext()` or `runGraph()` while one is pending now returns the in-flight promise instead of racing
- **Manual mode state settlement**: Added `settleManualState()` to properly transition from "running" back to "idle" or "done" after single-step runs
- **WebSocket close handling**: Added `onClose()` subscription to detect unexpected socket drops and terminate runs with an error message
- **Timeout job cleanup**: On timeout, now sends a `stop` command to the backend before closing the socket to prevent orphaned server-side jobs
- **Manifest loading resilience**: Wrapped `init()` in try-catch to settle to idle+empty state if manifest.json is missing, allowing ad-hoc `runGraph()` to work without a manifest

### Browser Runner (`packages/cli/src/debug/browser-runner.ts`)
- **Process group cleanup**: Added `killChild()` function to properly terminate the Playwright child process and its entire process group (on POSIX via negative pid, on Windows via direct kill) with a 5-second SIGTERM→SIGKILL grace period
- **Timeout configuration**: Pass `NODETOOL_DEBUG_TIMEOUT` env var to the Playwright spec so explicit CLI timeouts override the harness's internal `RUN_TIMEOUT_MS`
- **Kill timeout margin**: Child kill timeout now adds 60s margin above the run timeout to allow the harness time to settle and write `record.json` before the process is forcibly terminated
- **Shell handling**: Use `shell: true` on Windows (where `.bin/playwright` is a shell shim) and `detached: true` on POSIX (for process group management)

### Global Setup (`web/tests/e2e-runner/globalSetup.ts`)
- **Port conflict detection**: Added early check to fail loudly if the backend port is already in use, preventing silent test runs against an unintended server
- **Early exit detection**: Added `earlyExit` promise race to reject immediately if the backend child process dies before it starts listening, rather than burning the full startup timeout
- **Code refactoring**: Extracted `checkPortOnce()` helper to reduce duplication

### WebSocket Client (`web/src/e2e_runner/wsClient.ts`)
- **Close event subscription**: Added `onClose()` method to subscribe to unexpected socket closures
- **Intentional close tracking**: Added `intentionalClose` flag to distinguish between intentional teardown (via `close()`) and mid-run drops, so only unexpected closes trigger subscribers

### Debug Spec (`web/tests/debug-harness/debug.spec.ts`)
- **Timeout propagation**: Parse `NODETOOL_DEBUG_TIMEOUT` env var and pass it to `runGraph()` options
- **Wait margin**: Increase `MAX_WAIT_MS` by 30s above the run timeout to ensure polling outlives the in-page run

### Graph Rendering (`web/src/e2e_runner/graphRender.ts`)
- **Metadata/node-type caching**: Refactored to only write new metadata/node-types to the store when there are actual changes, avoiding unnecessary store updates and potential race conditions with concurrent graph builds

### UI Updates
- **Status color**: Added "suspended" status color (#F59E0

https://claude.ai/code/session_0168LwJduPXfzuRUkfdcZcPG