### PR TITLE
Normalize MIME types and sniff audio formats in LLM providers

### DIFF
--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -43,6 +43,19 @@ function bytesToBase64(data: Uint8Array | string | undefined): string {
   return Buffer.from(data).toString("base64");
 }
 
+/**
+ * Anthropic's image block accepts only image/jpeg, image/png, image/gif and
+ * image/webp as `media_type`. Strip any Content-Type parameters, normalize the
+ * common `image/jpg` alias, and fall back to image/png for anything else
+ * (including `application/octet-stream` from an unknown file extension).
+ */
+function normalizeAnthropicImageMime(mime: string): string {
+  const base = mime.split(";")[0].trim().toLowerCase();
+  if (base === "image/jpg") return "image/jpeg";
+  const supported = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+  return supported.includes(base) ? base : "image/png";
+}
+
 function parseDataUri(uri: string): { mime: string; base64: string } {
   const idx = uri.indexOf(",");
   if (idx < 0) {
@@ -320,7 +333,7 @@ export class AnthropicProvider extends BaseProvider {
       type: "image",
       source: {
         type: "base64",
-        media_type: mediaType,
+        media_type: normalizeAnthropicImageMime(mediaType),
         data: base64
       }
     };

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -1,6 +1,7 @@
 import type { Chunk } from "@nodetool-ai/protocol";
 import { createLogger } from "@nodetool-ai/config";
 import { BaseProvider } from "./base-provider.js";
+import { sniffAudioMime } from "./audio-mime.js";
 
 const log = createLogger("nodetool.runtime.providers.gemini");
 import type {
@@ -26,6 +27,24 @@ import type {
 } from "./types.js";
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+/** Drop `; charset=…`/`; codecs=…` parameters from a Content-Type header. */
+function stripMimeParams(value: string | null): string | undefined {
+  const mime = value?.split(";")[0].trim();
+  return mime || undefined;
+}
+
+/**
+ * Normalize an audio mime to one Gemini's `inlineData` accepts. Gemini lists
+ * audio/wav, audio/mp3, audio/aiff, audio/aac, audio/ogg and audio/flac; the
+ * common `audio/mpeg` label is remapped to `audio/mp3`. Falls back to
+ * `audio/mp3` when the type is unknown.
+ */
+function geminiAudioMime(mime: string | undefined): string {
+  if (!mime) return "audio/mp3";
+  if (mime === "audio/mpeg" || mime === "audio/mpga") return "audio/mp3";
+  return mime;
+}
 
 interface GeminiProviderOptions {
   fetchFn?: typeof fetch;
@@ -243,7 +262,7 @@ export class GeminiProvider extends BaseProvider {
           const resp = await this._fetch(img.uri);
           if (!resp.ok)
             throw new Error(`Failed to fetch image: ${resp.status}`);
-          mimeType = resp.headers.get("content-type") ?? mimeType;
+          mimeType = stripMimeParams(resp.headers.get("content-type")) ?? mimeType;
           base64Data = Buffer.from(await resp.arrayBuffer()).toString("base64");
         }
       } else {
@@ -256,32 +275,41 @@ export class GeminiProvider extends BaseProvider {
     if (content.type === "audio") {
       const aud = (content as MessageAudioContent).audio;
       let base64Data: string;
-      let mimeType = aud.mimeType ?? "audio/mp3";
+      let mimeType = aud.mimeType;
 
       if (aud.data) {
         if (typeof aud.data === "string") {
           base64Data = aud.data;
+          mimeType = mimeType ?? sniffAudioMime(Buffer.from(aud.data, "base64"));
         } else {
-          base64Data = Buffer.from(aud.data).toString("base64");
+          const bytes = Buffer.from(aud.data);
+          base64Data = bytes.toString("base64");
+          mimeType = mimeType ?? sniffAudioMime(bytes);
         }
       } else if (aud.uri) {
         if (aud.uri.startsWith("data:")) {
           const idx = aud.uri.indexOf(",");
           const header = aud.uri.slice(5, idx);
-          mimeType = header.split(";")[0] || mimeType;
+          mimeType = mimeType ?? header.split(";")[0];
           base64Data = aud.uri.slice(idx + 1);
         } else {
           const resp = await this._fetch(aud.uri);
           if (!resp.ok)
             throw new Error(`Failed to fetch audio: ${resp.status}`);
-          mimeType = resp.headers.get("content-type") ?? mimeType;
-          base64Data = Buffer.from(await resp.arrayBuffer()).toString("base64");
+          const bytes = Buffer.from(await resp.arrayBuffer());
+          mimeType =
+            stripMimeParams(resp.headers.get("content-type")) ??
+            mimeType ??
+            sniffAudioMime(bytes);
+          base64Data = bytes.toString("base64");
         }
       } else {
         base64Data = "";
       }
 
-      return { inlineData: { mimeType, data: base64Data } };
+      return {
+        inlineData: { mimeType: geminiAudioMime(mimeType), data: base64Data }
+      };
     }
 
     return { text: "[unsupported content type]" };

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -8,6 +8,7 @@ import { PROVIDER_IDS } from "@nodetool-ai/protocol";
 import { createLogger, importHidden } from "@nodetool-ai/config";
 import { BaseProvider, splitToolResultImages } from "./base-provider.js";
 import { hashSystemPrompt } from "./provider-session.js";
+import { sniffAudioMime } from "./audio-mime.js";
 import {
   extractResponsesImages,
   extractResponsesText,
@@ -130,6 +131,21 @@ function parseDataUri(uri: string): { mime: string; data: Uint8Array } {
 function makeDataUri(mime: string, data: Uint8Array): string {
   const b64 = Buffer.from(data).toString("base64");
   return `data:${mime};base64,${b64}`;
+}
+
+/**
+ * OpenAI's Chat Completions `input_audio` block accepts only `"wav"` or `"mp3"`
+ * as its `format` — a bare token, not a mime type. Resolve it from the declared
+ * mime when present, otherwise sniff the leading magic bytes. Anything that
+ * isn't WAV is sent as `"mp3"` (the only other format OpenAI decodes).
+ */
+function openAiAudioFormat(
+  mime: string | undefined,
+  bytes: Uint8Array
+): "wav" | "mp3" {
+  const resolved =
+    mime && mime !== "application/octet-stream" ? mime : sniffAudioMime(bytes);
+  return /wave?$/i.test(resolved) ? "wav" : "mp3";
 }
 
 /**
@@ -664,17 +680,21 @@ export class OpenAIProvider extends BaseProvider {
 
     if (content.type === "audio") {
       const c = content as MessageAudioContent;
-      const base64 = c.audio.uri
-        ? (await this.uriToBase64(c.audio.uri)).split(",", 2)[1]
-        : Buffer.from(asUint8Array(c.audio.data ?? new Uint8Array())).toString(
-            "base64"
-          );
+      let bytes: Uint8Array;
+      let mime = c.audio.mimeType;
+      if (c.audio.uri) {
+        const parsed = parseDataUri(await this.uriToBase64(c.audio.uri));
+        bytes = parsed.data;
+        mime = mime ?? parsed.mime;
+      } else {
+        bytes = asUint8Array(c.audio.data ?? new Uint8Array());
+      }
 
       return {
         type: "input_audio",
         input_audio: {
-          format: "mp3",
-          data: base64
+          format: openAiAudioFormat(mime, bytes),
+          data: Buffer.from(bytes).toString("base64")
         }
       };
     }

--- a/packages/runtime/tests/providers/anthropic-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/anthropic-provider-coverage.test.ts
@@ -129,6 +129,50 @@ describe("AnthropicProvider – convertMessage branches", () => {
     expect((result as any).content[0].source.media_type).toBe("image/jpeg");
   });
 
+  it("normalizes the image/jpg alias to image/jpeg", async () => {
+    const base64 = Buffer.from("test").toString("base64");
+    const result = await provider.convertMessage({
+      role: "user",
+      content: [
+        { type: "image_url", image: { data: base64, mimeType: "image/jpg" } }
+      ]
+    });
+    expect((result as any).content[0].source.media_type).toBe("image/jpeg");
+  });
+
+  it("falls back to image/png for a mime Anthropic does not accept", async () => {
+    const base64 = Buffer.from("test").toString("base64");
+    const result = await provider.convertMessage({
+      role: "user",
+      content: [
+        {
+          type: "image_url",
+          image: { data: base64, mimeType: "application/octet-stream" }
+        }
+      ]
+    });
+    expect((result as any).content[0].source.media_type).toBe("image/png");
+  });
+
+  it("strips Content-Type parameters from a fetched image mime", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => "image/jpeg; charset=binary" },
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer
+    });
+    const p = new AnthropicProvider(
+      { ANTHROPIC_API_KEY: "k" },
+      { fetchFn: fetchFn as any }
+    );
+    const result = await p.convertMessage({
+      role: "user",
+      content: [
+        { type: "image_url", image: { uri: "https://example.com/pic" } }
+      ]
+    });
+    expect((result as any).content[0].source.media_type).toBe("image/jpeg");
+  });
+
   it("throws for image with no uri or data", async () => {
     await expect(
       provider.convertMessage({

--- a/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
@@ -220,7 +220,8 @@ describe("GeminiProvider – convertMessages with images", () => {
     ]);
 
     expect(result.contents[0].parts[0].inlineData).toBeDefined();
-    expect(result.contents[0].parts[0].inlineData!.mimeType).toBe("audio/mpeg");
+    // audio/mpeg is normalized to Gemini's accepted audio/mp3 label.
+    expect(result.contents[0].parts[0].inlineData!.mimeType).toBe("audio/mp3");
     expect(fetchFn).toHaveBeenCalledWith("https://example.com/audio.mp3");
   });
 

--- a/packages/runtime/tests/providers/openai-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/openai-provider-coverage.test.ts
@@ -338,6 +338,43 @@ describe("OpenAIProvider – convertMessage edge cases", () => {
     expect((result as any).content[0].input_audio.format).toBe("mp3");
   });
 
+  it("labels WAV audio bytes with format 'wav' by sniffing magic bytes", async () => {
+    // "RIFF....WAVE" header — sniffAudioMime returns audio/wav.
+    const wav = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45
+    ]);
+    const result = await provider.convertMessage({
+      role: "user",
+      content: [{ type: "audio", audio: { data: wav } }]
+    });
+    expect((result as any).content[0].input_audio.format).toBe("wav");
+  });
+
+  it("honors an explicit audio mimeType hint over sniffing", async () => {
+    const result = await provider.convertMessage({
+      role: "user",
+      content: [
+        {
+          type: "audio",
+          audio: { data: new Uint8Array([1, 2, 3]), mimeType: "audio/wav" }
+        }
+      ]
+    });
+    expect((result as any).content[0].input_audio.format).toBe("wav");
+  });
+
+  it("derives audio format from a data URI mime type", async () => {
+    const b64 = Buffer.from([1, 2, 3]).toString("base64");
+    const result = await provider.convertMessage({
+      role: "user",
+      content: [
+        { type: "audio", audio: { uri: `data:audio/wav;base64,${b64}` } }
+      ]
+    });
+    expect((result as any).content[0].input_audio.format).toBe("wav");
+    expect((result as any).content[0].input_audio.data).toBe(b64);
+  });
+
   it("converts user audio content with URI", async () => {
     const data = Buffer.from("audiodata").toString("base64");
     const fetchFn = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

Adds robust MIME type handling across Anthropic, OpenAI, and Gemini providers to normalize aliases, strip Content-Type parameters, and sniff audio formats from magic bytes when MIME types are unavailable.

## Key Changes

- **Anthropic provider**: Added `normalizeAnthropicImageMime()` to normalize `image/jpg` → `image/jpeg`, strip Content-Type parameters, and fall back to `image/png` for unsupported types
- **OpenAI provider**: Added `openAiAudioFormat()` to sniff WAV vs MP3 from magic bytes and honor explicit MIME type hints; improved data URI parsing to extract MIME from URI headers
- **Gemini provider**: Added `stripMimeParams()` to remove charset/codec parameters from Content-Type headers; added `geminiAudioMime()` to normalize `audio/mpeg` → `audio/mp3` and sniff unknown formats; improved audio handling to sniff MIME from bytes when not provided
- **Audio MIME sniffing**: Leverages existing `sniffAudioMime()` utility from `audio-mime.js` to detect WAV (RIFF header) vs other formats

## Implementation Details

- MIME normalization happens at the point of conversion to provider-specific formats, ensuring consistent handling across all content types
- Audio sniffing follows a priority: explicit `mimeType` > data URI MIME > Content-Type header > magic bytes > fallback
- All MIME parameters (e.g., `; charset=binary`) are stripped before validation to handle real-world HTTP responses
- Tests added for image/jpg alias normalization, unsupported MIME fallback, Content-Type parameter stripping, and audio format detection from magic bytes

https://claude.ai/code/session_014467tFUiDcabyJAsGQWHif