### PR TITLE
feat(agents): script mode — code-shaped orchestration for agents

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -260,6 +260,53 @@ const agent = new Agent({
 | `DEFAULT_MAX_STEPS` | 50 | `task-executor.ts` |
 | `MAX_RETRIES` (planning) | 3 | `task-planner.ts` |
 
+## Script Mode (code-shaped orchestration)
+
+The third planning mode next to `TaskPlan` and the graph planner: the LLM
+authors a JavaScript *orchestration script* (`ScriptPlanner`), and
+`ScriptRunner` executes it in the QuickJS sandbox. Every `agent()` call in the
+script runs a real `StepExecutor` sub-agent on the host. A script expresses
+what a static DAG cannot — loops until a condition holds, budget-scaled
+fan-out, dedup between rounds, early exit.
+
+```typescript
+const agent = new Agent({
+  name: "researcher",
+  objective: "Find and verify 5 claims about X",
+  provider, model,
+  useScriptPlanner: true,          // LLM writes the script
+  // script: "...",                // or supply one directly (skips planning)
+  maxConcurrentAgents: 8,          // semaphore over concurrent agent() calls
+  maxAgentCalls: 100               // lifetime cap per run
+});
+```
+
+Guest API (see `SCRIPT_PRELUDE` in `script-runner.ts`):
+
+| Primitive | Behavior |
+|---|---|
+| `await agent(prompt, opts?)` | Run a sub-agent. `opts.schema` → structured result via `finish_step`; `opts.tools` restricts the toolset; `opts.label` names progress events. Throws on failure. |
+| `await parallel(thunks)` | Concurrent thunks; a failure resolves to `null` instead of rejecting the batch. |
+| `await pipeline(items, ...stages)` | Each item flows through all stages independently (no barrier). Stages receive `(prev, originalItem, index)`. |
+| `log(message)` | Emits a `log_update` to the host event stream. |
+| `budget` | `maxAgentCalls`, `agentCalls()`, `remainingCalls()`, `await spentUsd()`. |
+| `inputs` | Caller-supplied inputs object. |
+
+The script's `return` value becomes `agent.getResults()`. Sub-agents share
+`context.memory` as usual, and concurrency is bounded host-side by a semaphore
+(`maxConcurrentAgents`, default 8) plus a lifetime call cap (`maxAgentCalls`,
+default 100) — calls past the cap fail with a budget error the script can
+handle (`budget.remainingCalls()` guards loops). Script failures (syntax
+error, uncaught exception, wall-clock timeout — default 60 min including
+sub-agent time) throw from `Agent.execute`.
+
+Host bridges never reject (the QuickJS handle-leak rule from
+`js-sandbox.ts` applies): `__runAgent` resolves `{ok, result|error}` envelopes
+and the guest `agent()` re-throws.
+
+Tests: `tests/script-runner.test.ts`, `tests/script-planner.test.ts`,
+`tests/agent-script-mode.test.ts`.
+
 ## Observing LLM Steps and Planning
 
 ### Execution Tree (CLI)

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -32,6 +32,8 @@ import { ParallelTaskExecutor } from "./parallel-task-executor.js";
 import { CompilerAgent } from "./compiler-agent.js";
 import { GraphPlanner } from "./graph-planner.js";
 import { AgentWorkflowRunner } from "./agent-workflow-runner.js";
+import { ScriptPlanner } from "./script-planner.js";
+import { ScriptRunner } from "./script-runner.js";
 import type { Tool } from "./tools/base-tool.js";
 import { gateTools } from "./tools/tool-permissions.js";
 import {
@@ -262,6 +264,24 @@ export interface AgentOptions {
    * graph executed by {@link AgentWorkflowRunner}.
    */
   useGraphPlanner?: boolean;
+  /**
+   * Use the script planner: the LLM authors a JavaScript orchestration
+   * script (loops, conditionals, budget-scaled fan-out) instead of a
+   * TaskPlan, and {@link ScriptRunner} executes it deterministically in the
+   * QuickJS sandbox — every `agent()` call in the script runs a real
+   * sub-agent. Takes precedence over {@link useGraphPlanner}.
+   */
+  useScriptPlanner?: boolean;
+  /**
+   * Pre-authored orchestration script. Skips planning entirely and runs the
+   * script directly (implies script mode). See {@link ScriptRunner} for the
+   * script API.
+   */
+  script?: string;
+  /** Script mode: concurrent `agent()` calls beyond this queue. Default 8. */
+  maxConcurrentAgents?: number;
+  /** Script mode: lifetime `agent()` call cap per run. Default 100. */
+  maxAgentCalls?: number;
   /** Node registry required when {@link useGraphPlanner} is true. */
   registry?: NodeRegistry;
   /**
@@ -339,6 +359,10 @@ export class Agent {
   private readonly autoPersistMemory: boolean;
   private readonly synthesizeRecall: boolean;
   private readonly useGraphPlanner: boolean;
+  private readonly useScriptPlanner: boolean;
+  private readonly script?: string;
+  private readonly maxConcurrentAgents?: number;
+  private readonly maxAgentCalls?: number;
   private readonly registry?: NodeRegistry;
   private readonly providers?: Record<string, BaseProvider>;
   private readonly securityMonitorEnabled: boolean;
@@ -374,6 +398,10 @@ export class Agent {
     this.autoPersistMemory = opts.autoPersistMemory === true;
     this.synthesizeRecall = opts.synthesizeRecall ?? true;
     this.useGraphPlanner = opts.useGraphPlanner === true;
+    this.useScriptPlanner = opts.useScriptPlanner === true;
+    this.script = opts.script;
+    this.maxConcurrentAgents = opts.maxConcurrentAgents;
+    this.maxAgentCalls = opts.maxAgentCalls;
     this.registry = opts.registry;
     this.providers = opts.providers;
     this.securityMonitorEnabled = opts.securityMonitor?.enabled === true;
@@ -654,6 +682,17 @@ export class Agent {
       return;
     }
 
+    // Script mode: LLM-authored (or pre-authored) orchestration script,
+    // executed deterministically by ScriptRunner.
+    if (this.script || this.useScriptPlanner) {
+      yield* this.executeScriptPlan(
+        context,
+        mergedSystemPrompt,
+        effectiveObjective
+      );
+      return;
+    }
+
     // Graph-native planner: build DAG of nodes directly.
     if (this.useGraphPlanner && this.registry) {
       yield* this.executeGraphPlan(context, mergedSystemPrompt);
@@ -908,6 +947,66 @@ export class Agent {
       }
       plan = next.value;
     }
+  }
+
+  /**
+   * Script mode: obtain an orchestration script (pre-authored via the
+   * `script` option, otherwise written by ScriptPlanner) and execute it with
+   * ScriptRunner. The script's return value becomes the agent result.
+   */
+  private async *executeScriptPlan(
+    context: ProcessingContext,
+    systemPrompt: string | undefined,
+    objective: string
+  ): AsyncGenerator<ProcessingMessage> {
+    let script = this.script ?? null;
+
+    if (!script) {
+      log.info("Script planning phase started", { name: this.name });
+      const planner = new ScriptPlanner({
+        provider: this.provider,
+        model: this.planningModel,
+        tools: this.tools,
+        systemPrompt,
+        outputSchema: this.outputSchema,
+        inputs: this.inputs
+      });
+      const planGen = planner.plan(objective, context);
+      let planResult = await planGen.next();
+      while (!planResult.done) {
+        yield planResult.value;
+        planResult = await planGen.next();
+      }
+      script = planResult.value;
+      if (!script) {
+        throw new Error(
+          "ScriptPlanner failed to produce an orchestration script."
+        );
+      }
+    }
+
+    const runner = new ScriptRunner({
+      provider: this.provider,
+      model: this.model,
+      context,
+      tools: this.buildExecutorTools(),
+      systemPrompt,
+      inputs: this.inputs,
+      maxStepIterations: this.maxStepIterations,
+      maxConcurrentAgents: this.maxConcurrentAgents,
+      maxAgentCalls: this.maxAgentCalls
+    });
+
+    const runGen = runner.execute(script);
+    let next = await runGen.next();
+    while (!next.done) {
+      yield next.value;
+      next = await runGen.next();
+    }
+    this.results = next.value ?? null;
+
+    log.info("Agent completed", { name: this.name });
+    this.persistAgentRunMemory();
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -344,6 +344,17 @@ export type { ParallelTaskExecutorOptions } from "./parallel-task-executor.js";
 export { CompilerAgent } from "./compiler-agent.js";
 export type { CompilerAgentOptions } from "./compiler-agent.js";
 
+// Script-mode planning & execution (code-shaped orchestration)
+export { ScriptPlanner, validateScript } from "./script-planner.js";
+export type { ScriptPlannerOptions } from "./script-planner.js";
+export {
+  ScriptRunner,
+  SCRIPT_RESERVED_NAMES,
+  DEFAULT_MAX_CONCURRENT_AGENTS,
+  DEFAULT_MAX_AGENT_CALLS
+} from "./script-runner.js";
+export type { ScriptRunnerOptions } from "./script-runner.js";
+
 // Graph-native planning & execution
 export { GraphBuilder, AGENT_STEP_NODE_TYPE } from "./graph-builder.js";
 export { GraphPlanner } from "./graph-planner.js";

--- a/packages/agents/src/script-planner.ts
+++ b/packages/agents/src/script-planner.ts
@@ -1,0 +1,306 @@
+/**
+ * ScriptPlanner — asks the LLM to author an orchestration script instead of a
+ * TaskPlan. The script targets the {@link ScriptRunner} guest API (`agent`,
+ * `parallel`, `pipeline`, `log`, `budget`, `inputs`) and is submitted through
+ * a single `submit_script` tool so validation failures round-trip as tool
+ * results the model can fix.
+ *
+ * Validation is host-side and cheap: the script must be non-empty, must call
+ * `agent(`, and must compile as the body of an async function (syntax check
+ * only — nothing is executed).
+ */
+
+import type {
+  BaseProvider,
+  Message,
+  ProcessingContext,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import { createLogger } from "@nodetool-ai/config";
+import type {
+  PlanningUpdate,
+  ProcessingMessage
+} from "@nodetool-ai/protocol";
+import { Tool } from "./tools/base-tool.js";
+
+const log = createLogger("nodetool.agents.script-planner");
+
+const MAX_PLANNER_CALLS = 8;
+
+const PLANNER_SYSTEM_PROMPT = `# Role
+You are an orchestration planner. Given an objective, you write ONE JavaScript
+script that coordinates sub-agents to accomplish it. You do not do the work
+yourself — sub-agents spawned via \`agent()\` do.
+
+# Script API (already defined — do NOT redefine these names)
+- \`await agent(prompt, opts?)\` → runs a sub-agent and returns its result.
+  - \`prompt\`: self-contained instructions. The sub-agent sees NOTHING else —
+    no chat history, no other agents' results. Inline every value it needs.
+  - \`opts.schema\`: JSON schema object. When set, the result is a validated
+    object matching the schema. Without it, the result is free text.
+  - \`opts.tools\`: string[] restricting which tools the sub-agent may use.
+  - \`opts.label\`: short display name for progress events.
+  - Throws on failure — wrap in try/catch or use \`parallel\`/\`pipeline\`,
+    which convert failures to \`null\`.
+- \`await parallel(thunks)\` → runs an array of zero-arg async functions
+  concurrently, returns their results. A failed thunk yields \`null\`.
+- \`await pipeline(items, ...stages)\` → runs each item through all stages
+  independently with no barrier between stages. Each stage receives
+  \`(prevResult, originalItem, index)\`. A failed item yields \`null\`.
+- \`log(message)\` → progress message shown to the user.
+- \`budget\` → \`budget.maxAgentCalls\`, \`budget.agentCalls()\`,
+  \`budget.remainingCalls()\`, \`await budget.spentUsd()\`.
+- \`inputs\` → caller-supplied inputs object.
+
+# Rules
+- Plain JavaScript only: no TypeScript annotations, no import/require, no
+  top-level function wrapper — write statements directly; top-level \`await\`
+  and a final \`return <deliverable>\` are how the script ends.
+- The \`return\` value IS the final deliverable. Synthesize it explicitly —
+  usually with a final \`agent()\` call that aggregates intermediate results
+  (pass them inline in its prompt), constrained by the required schema when
+  one is given.
+- Default to \`parallel\`/\`pipeline\` for independent work; sequential
+  \`await\`s only when a result feeds the next prompt.
+- Filter out \`null\`s from parallel/pipeline results before using them.
+- Guard loops with \`budget.remainingCalls()\` so the script degrades
+  gracefully instead of dying on the call cap.
+- Keep it short. The script is coordination logic, not the work itself.
+
+# Submission
+Call \`submit_script\` with the complete script. If validation fails, fix the
+reported errors and resubmit.`;
+
+const PLANNER_USER_TEMPLATE = `# Objective
+{{objective}}
+
+# Inputs available to the script (via \`inputs\`)
+{{inputs}}
+
+# Tools sub-agents may use (for \`opts.tools\`)
+{{tools}}
+
+# Required final result schema
+{{outputSchema}}
+
+Write the orchestration script and submit it via \`submit_script\`.`;
+
+/** Syntax-check a script as an async function body. Never executes it. */
+export function validateScript(script: string): string[] {
+  const errors: string[] = [];
+  if (!script.trim()) {
+    errors.push("Script is empty.");
+    return errors;
+  }
+  if (!script.includes("agent(")) {
+    errors.push(
+      "Script never calls agent() — sub-agents do the work; a script without them accomplishes nothing."
+    );
+  }
+  if (!/\breturn\b/.test(script)) {
+    errors.push(
+      "Script has no return statement — the return value is the final deliverable."
+    );
+  }
+  try {
+    // Compile only: the returned async function is never invoked.
+    new Function(`"use strict"; return async () => {\n${script}\n};`);
+  } catch (e) {
+    errors.push(
+      `Syntax error: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+  return errors;
+}
+
+class SubmitScriptTool extends Tool {
+  readonly name = "submit_script";
+  readonly description =
+    "Submit the complete orchestration script. Returns validation errors to fix, or accepts the script.";
+  protected override readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      script: {
+        type: "string",
+        description:
+          "The full JavaScript orchestration script (statements only, ending in a return)."
+      }
+    },
+    required: ["script"],
+    additionalProperties: false
+  };
+
+  accepted: string | null = null;
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const script = typeof params.script === "string" ? params.script : "";
+    const errors = validateScript(script);
+    if (errors.length > 0) {
+      return { status: "validation_failed", errors };
+    }
+    this.accepted = script;
+    return { status: "script_accepted" };
+  }
+}
+
+export interface ScriptPlannerOptions {
+  provider: BaseProvider;
+  model: string;
+  /** Tools the executor will offer sub-agents — listed in the prompt. */
+  tools?: Tool[];
+  systemPrompt?: string;
+  outputSchema?: Record<string, unknown>;
+  inputs?: Record<string, unknown>;
+  threadId?: string;
+}
+
+export class ScriptPlanner {
+  private readonly provider: BaseProvider;
+  private readonly model: string;
+  private readonly tools: Tool[];
+  private readonly callerSystemPrompt?: string;
+  private readonly outputSchema?: Record<string, unknown>;
+  private readonly inputs: Record<string, unknown>;
+  private readonly threadId?: string;
+
+  constructor(opts: ScriptPlannerOptions) {
+    this.provider = opts.provider;
+    this.model = opts.model;
+    this.tools = opts.tools ?? [];
+    this.callerSystemPrompt = opts.systemPrompt;
+    this.outputSchema = opts.outputSchema;
+    this.inputs = opts.inputs ?? {};
+    this.threadId = opts.threadId;
+  }
+
+  /**
+   * Plan the orchestration script for `objective`. Yields planning progress
+   * messages and returns the accepted script, or null when the model never
+   * produced a valid one within the call budget.
+   */
+  async *plan(
+    objective: string,
+    context: ProcessingContext
+  ): AsyncGenerator<ProcessingMessage, string | null> {
+    yield {
+      type: "planning_update",
+      phase: "initialization",
+      status: "started",
+      content: "Writing orchestration script..."
+    } satisfies PlanningUpdate;
+
+    const toolsInfo =
+      this.tools.length > 0
+        ? this.tools
+            .map((t) => `- ${t.name}: ${t.description.split("\n")[0]}`)
+            .join("\n")
+        : "None — sub-agents rely on reasoning only.";
+    const userPrompt = PLANNER_USER_TEMPLATE.replace("{{objective}}", objective)
+      .replace(
+        "{{inputs}}",
+        Object.keys(this.inputs).length > 0
+          ? JSON.stringify(this.inputs, null, 2)
+          : "None."
+      )
+      .replace("{{tools}}", toolsInfo)
+      .replace(
+        "{{outputSchema}}",
+        this.outputSchema
+          ? JSON.stringify(this.outputSchema, null, 2)
+          : "None — return whatever shape best answers the objective."
+      );
+
+    const systemPrompt = this.callerSystemPrompt
+      ? `${this.callerSystemPrompt}\n\n${PLANNER_SYSTEM_PROMPT}`
+      : PLANNER_SYSTEM_PROMPT;
+    const messages: Message[] = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt }
+    ];
+
+    const submitTool = new SubmitScriptTool();
+    const abort = new AbortController();
+    const pending: ProcessingMessage[] = [];
+
+    const submitExecute = async (
+      args: Record<string, unknown>
+    ): Promise<string> => {
+      const result = (await Tool.executeTool(
+        submitTool,
+        context,
+        args
+      )) as Record<string, unknown>;
+      if (result["status"] === "script_accepted") {
+        pending.push({
+          type: "planning_update",
+          phase: "complete",
+          status: "success",
+          content: `Orchestration script accepted (${submitTool.accepted?.length ?? 0} chars).`
+        } satisfies PlanningUpdate);
+        abort.abort();
+      } else {
+        const errors = (result["errors"] as string[]) ?? [];
+        pending.push({
+          type: "planning_update",
+          phase: "validation",
+          status: "failed",
+          content: `Script validation failed: ${errors.join("; ")}`
+        } satisfies PlanningUpdate);
+      }
+      return JSON.stringify(result);
+    };
+
+    const stream = this.provider.generateLoop({
+      messages,
+      model: this.model,
+      tools: [{ ...submitTool.toProviderTool(), execute: submitExecute }],
+      toolChoice: "any",
+      threadId: this.threadId,
+      maxIterations: MAX_PLANNER_CALLS,
+      sequentialTools: true,
+      signal: abort.signal
+    });
+
+    try {
+      for await (const item of stream) {
+        while (pending.length > 0) yield pending.shift() as ProcessingMessage;
+        if ("id" in item && "name" in item && "args" in item) {
+          const tc = item as ToolCall;
+          if (tc.name === submitTool.name) {
+            yield {
+              type: "planning_update",
+              phase: "generation",
+              status: "running",
+              content: "Validating submitted script..."
+            } satisfies PlanningUpdate;
+          }
+        }
+      }
+    } catch (e) {
+      // Providers may surface the abort as an error; a captured script means
+      // planning succeeded regardless.
+      if (!submitTool.accepted) throw e;
+      log.debug("Planner stream ended via abort", {
+        error: e instanceof Error ? e.message : String(e)
+      });
+    }
+    while (pending.length > 0) yield pending.shift() as ProcessingMessage;
+
+    if (!submitTool.accepted) {
+      yield {
+        type: "planning_update",
+        phase: "complete",
+        status: "failed",
+        content: "No valid orchestration script was produced."
+      } satisfies PlanningUpdate;
+      return null;
+    }
+    log.info("Orchestration script planned", {
+      chars: submitTool.accepted.length
+    });
+    return submitTool.accepted;
+  }
+}

--- a/packages/agents/src/script-runner.ts
+++ b/packages/agents/src/script-runner.ts
@@ -1,0 +1,449 @@
+/**
+ * ScriptRunner — code-shaped agent orchestration.
+ *
+ * Executes an orchestration *script* (plain JavaScript) inside the QuickJS
+ * sandbox. The script coordinates sub-agents through a small primitive set —
+ * `agent()`, `parallel()`, `pipeline()`, `log()`, `budget` — while every
+ * `agent()` call runs a real {@link StepExecutor} on the host. This is the
+ * counterpart to the data-shaped `TaskPlan`: a script can express loops,
+ * conditionals, budget-scaled fan-out, and dedup-between-rounds that a static
+ * task DAG cannot.
+ *
+ * Guest API (injected as a prelude before the script):
+ *
+ * - `await agent(prompt, opts?)` — run a sub-agent, return its result.
+ *   `opts.schema` (JSON schema object) forces a structured result via
+ *   `finish_step`; `opts.tools` (string[]) restricts the toolset;
+ *   `opts.label` names the run in progress events. Throws on failure.
+ * - `await parallel(thunks)` — run thunks concurrently; a failed thunk
+ *   resolves to `null` instead of rejecting the batch.
+ * - `await pipeline(items, ...stages)` — run each item through all stages
+ *   independently (no barrier between stages). Each stage receives
+ *   `(prevResult, originalItem, index)`. A stage that throws drops the item
+ *   to `null`.
+ * - `log(message)` — emit a progress message to the host event stream.
+ * - `budget` — `maxAgentCalls`, `agentCalls()`, `remainingCalls()`,
+ *   `await spentUsd()`.
+ * - `inputs` — the caller-supplied inputs object, verbatim.
+ *
+ * The script's `return` value is the run's result.
+ *
+ * Host-side limits: concurrent `agent()` calls are capped by a semaphore
+ * (`maxConcurrentAgents`), total calls by `maxAgentCalls`. Excess concurrent
+ * calls queue; calls past the lifetime cap fail.
+ */
+
+import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import { createLogger } from "@nodetool-ai/config";
+import type {
+  LogUpdate,
+  ProcessingMessage,
+  StepResult
+} from "@nodetool-ai/protocol";
+import { StepExecutor } from "./step-executor.js";
+import type { Tool } from "./tools/base-tool.js";
+import type { Step, Task } from "./types.js";
+import { runInSandbox } from "./js-sandbox.js";
+
+const log = createLogger("nodetool.agents.script-runner");
+
+export const DEFAULT_MAX_CONCURRENT_AGENTS = 8;
+export const DEFAULT_MAX_AGENT_CALLS = 100;
+/**
+ * Wall-clock limit for the whole script, agent calls included. Deliberately
+ * generous — the QuickJS `executionTimeout` counts time spent awaiting host
+ * bridges, and sub-agents are slow.
+ */
+export const DEFAULT_SCRIPT_TIMEOUT_MS = 60 * 60 * 1000;
+
+/** Options an `agent()` call may pass from the guest (JSON-decoded). */
+interface AgentCallOpts {
+  schema?: Record<string, unknown>;
+  tools?: string[];
+  label?: string;
+}
+
+/** Never-rejecting bridge envelope; the guest prelude re-throws on `ok: false`. */
+type BridgeResult =
+  | { ok: true; result: unknown }
+  | { ok: false; error: string };
+
+export interface ScriptRunnerOptions {
+  provider: BaseProvider;
+  model: string;
+  context: ProcessingContext;
+  tools?: Tool[];
+  systemPrompt?: string;
+  inputs?: Record<string, unknown>;
+  maxStepIterations?: number;
+  /** Concurrent `agent()` calls beyond this queue. Default 8. */
+  maxConcurrentAgents?: number;
+  /** Lifetime `agent()` call cap for one script run. Default 100. */
+  maxAgentCalls?: number;
+  /** Wall-clock limit for the whole script run. Default 60 min. */
+  scriptTimeoutMs?: number;
+}
+
+/** Simple counting semaphore; released slots go to waiters FIFO. */
+class Semaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(slots: number) {
+    this.available = Math.max(1, slots);
+  }
+
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) next();
+    else this.available++;
+  }
+}
+
+/**
+ * Single-consumer async message channel. Bridges push from inside the sandbox
+ * run; the `execute` generator drains and yields.
+ */
+class MessageChannel {
+  private readonly queue: ProcessingMessage[] = [];
+  private wakeup: (() => void) | null = null;
+
+  push(msg: ProcessingMessage): void {
+    this.queue.push(msg);
+    this.signal();
+  }
+
+  signal(): void {
+    const w = this.wakeup;
+    this.wakeup = null;
+    w?.();
+  }
+
+  drain(): ProcessingMessage[] {
+    return this.queue.splice(0);
+  }
+
+  wait(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.wakeup = resolve;
+    });
+  }
+}
+
+/**
+ * Guest-side prelude prepended to every orchestration script. Defines the
+ * public primitives on top of the host bridges (`__runAgent`, `__log`,
+ * `__budgetSpentUsd`, `__maxAgentCalls`). Host bridges never reject — they
+ * resolve `{ok, result|error}` envelopes and `agent()` re-throws, mirroring
+ * the js-sandbox never-reject convention.
+ */
+const SCRIPT_PRELUDE = `
+function log(message) {
+  void __log(typeof message === "string" ? message : JSON.stringify(message));
+}
+const __budgetState = { calls: 0 };
+async function agent(prompt, opts) {
+  __budgetState.calls += 1;
+  const response = await __runAgent(
+    prompt,
+    opts === undefined ? "" : JSON.stringify(opts)
+  );
+  if (!response || response.ok !== true) {
+    throw new Error(
+      response && response.error ? response.error : "agent call failed"
+    );
+  }
+  return response.result;
+}
+async function parallel(thunks) {
+  return Promise.all(
+    thunks.map((thunk, i) =>
+      Promise.resolve()
+        .then(thunk)
+        .catch((e) => {
+          log("parallel: thunk " + i + " failed: " + (e && e.message ? e.message : e));
+          return null;
+        })
+    )
+  );
+}
+async function pipeline(items, ...stages) {
+  return Promise.all(
+    items.map(async (item, index) => {
+      let value = item;
+      for (const stage of stages) {
+        try {
+          value = await stage(value, item, index);
+        } catch (e) {
+          log("pipeline: item " + index + " failed: " + (e && e.message ? e.message : e));
+          return null;
+        }
+      }
+      return value;
+    })
+  );
+}
+const budget = {
+  maxAgentCalls: __maxAgentCalls,
+  agentCalls: () => __budgetState.calls,
+  remainingCalls: () => Math.max(0, __maxAgentCalls - __budgetState.calls),
+  spentUsd: () => __budgetSpentUsd()
+};
+`;
+
+/** Names the prelude/bridges claim inside the guest. */
+export const SCRIPT_RESERVED_NAMES = [
+  "agent",
+  "parallel",
+  "pipeline",
+  "log",
+  "budget",
+  "inputs"
+] as const;
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** Force a value through JSON so it marshals cleanly across the WASM boundary. */
+function toTransferable(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+export class ScriptRunner {
+  private readonly provider: BaseProvider;
+  private readonly model: string;
+  private readonly context: ProcessingContext;
+  private readonly tools: Tool[];
+  private readonly systemPrompt?: string;
+  private readonly inputs: Record<string, unknown>;
+  private readonly maxStepIterations?: number;
+  private readonly maxAgentCalls: number;
+  private readonly scriptTimeoutMs: number;
+  private readonly semaphore: Semaphore;
+  private readonly channel = new MessageChannel();
+  private agentCalls = 0;
+
+  constructor(opts: ScriptRunnerOptions) {
+    this.provider = opts.provider;
+    this.model = opts.model;
+    this.context = opts.context;
+    this.tools = opts.tools ?? [];
+    this.systemPrompt = opts.systemPrompt;
+    this.inputs = opts.inputs ?? {};
+    this.maxStepIterations = opts.maxStepIterations;
+    this.maxAgentCalls = opts.maxAgentCalls ?? DEFAULT_MAX_AGENT_CALLS;
+    this.scriptTimeoutMs = opts.scriptTimeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS;
+    this.semaphore = new Semaphore(
+      opts.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS
+    );
+  }
+
+  /**
+   * Run the orchestration script. Yields every ProcessingMessage produced by
+   * sub-agents (plus script `log()` lines) and returns the script's return
+   * value. Throws when the script itself fails (syntax error, uncaught guest
+   * exception, timeout).
+   */
+  async *execute(
+    script: string
+  ): AsyncGenerator<ProcessingMessage, unknown> {
+    log.info("Script run started", {
+      bytes: script.length,
+      maxAgentCalls: this.maxAgentCalls
+    });
+    yield this.logUpdate("Executing orchestration script...");
+
+    let settled = false;
+    const sandboxPromise = runInSandbox({
+      code: `${SCRIPT_PRELUDE}\n${script}`,
+      context: this.context,
+      timeoutMs: this.scriptTimeoutMs,
+      globals: {
+        __runAgent: (prompt: string, optsJson: string) =>
+          this.runAgentBridge(prompt, optsJson),
+        __log: async (message: string) => this.logBridge(message),
+        __budgetSpentUsd: async () => {
+          try {
+            return this.provider.getTotalCost();
+          } catch {
+            return 0;
+          }
+        },
+        __maxAgentCalls: this.maxAgentCalls,
+        inputs: toTransferable(this.inputs)
+      }
+    }).finally(() => {
+      settled = true;
+      this.channel.signal();
+    });
+
+    while (true) {
+      for (const msg of this.channel.drain()) yield msg;
+      if (settled) break;
+      await this.channel.wait();
+    }
+    // A push can land between the last drain and the sandbox settling.
+    for (const msg of this.channel.drain()) yield msg;
+
+    const outcome = await sandboxPromise;
+    if (!outcome.success) {
+      const detail = outcome.stack
+        ? `${outcome.error}\n${outcome.stack}`
+        : outcome.error;
+      log.error("Script run failed", { error: outcome.error });
+      throw new Error(`Orchestration script failed: ${detail}`);
+    }
+
+    log.info("Script run completed", { agentCalls: this.agentCalls });
+    yield this.logUpdate(
+      `Orchestration script finished (${this.agentCalls} agent call${this.agentCalls === 1 ? "" : "s"}).`
+    );
+    return outcome.result ?? null;
+  }
+
+  /**
+   * Host bridge behind the guest `agent()` primitive: run one sub-agent as a
+   * single {@link StepExecutor} step. Never rejects — failures come back as
+   * `{ok: false, error}` and the guest prelude re-throws them, so the QuickJS
+   * host-promise-rejection leak is never hit.
+   */
+  private async runAgentBridge(
+    prompt: unknown,
+    optsJson: unknown
+  ): Promise<BridgeResult> {
+    try {
+      if (typeof prompt !== "string" || !prompt.trim()) {
+        return { ok: false, error: "agent: prompt must be a non-empty string" };
+      }
+      if (this.agentCalls >= this.maxAgentCalls) {
+        return {
+          ok: false,
+          error: `agent call budget exhausted (max ${this.maxAgentCalls} calls per script)`
+        };
+      }
+      this.agentCalls++;
+      const callIndex = this.agentCalls;
+
+      let opts: AgentCallOpts = {};
+      if (typeof optsJson === "string" && optsJson) {
+        try {
+          opts = JSON.parse(optsJson) as AgentCallOpts;
+        } catch {
+          return { ok: false, error: "agent: opts must be JSON-serializable" };
+        }
+      }
+
+      await this.semaphore.acquire();
+      try {
+        return await this.runSubAgent(prompt, opts, callIndex);
+      } finally {
+        this.semaphore.release();
+      }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e) };
+    }
+  }
+
+  private async runSubAgent(
+    prompt: string,
+    opts: AgentCallOpts,
+    callIndex: number
+  ): Promise<BridgeResult> {
+    const label = opts.label?.trim() || `agent ${callIndex}`;
+    const step: Step = {
+      id: `script_agent_${callIndex}`,
+      instructions: prompt,
+      completed: false,
+      dependsOn: [],
+      logs: [],
+      outputSchema: opts.schema ? JSON.stringify(opts.schema) : undefined
+    };
+    const task: Task = {
+      id: `script_task_${callIndex}`,
+      title: label,
+      steps: [step]
+    };
+
+    const tools = Array.isArray(opts.tools)
+      ? this.tools.filter((t) => opts.tools!.includes(t.name))
+      : [...this.tools];
+
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: this.context,
+      provider: this.provider,
+      model: this.model,
+      tools,
+      systemPrompt: this.systemPrompt,
+      maxIterations: this.maxStepIterations
+    });
+
+    let result: unknown = null;
+    let error: string | null = null;
+    for await (const msg of executor.execute()) {
+      this.channel.push(msg);
+      if (msg.type === "step_result") {
+        const sr = msg as StepResult;
+        if (sr.error) error = sr.error;
+        else if (sr.result !== null && sr.result !== undefined) {
+          result = sr.result;
+        }
+      }
+    }
+
+    if (error) return { ok: false, error };
+    // A step that dies (iteration cap, provider error) reports the failure as
+    // a `{error}` result payload rather than a step_result error field.
+    if (
+      result !== null &&
+      typeof result === "object" &&
+      Object.keys(result).length === 1 &&
+      "error" in result
+    ) {
+      return { ok: false, error: String((result as { error: unknown }).error) };
+    }
+    if (result === null || result === undefined) {
+      return {
+        ok: false,
+        error: `agent "${label}" ended without producing a result`
+      };
+    }
+    return { ok: true, result: toTransferable(result) };
+  }
+
+  private logBridge(message: unknown): void {
+    this.channel.push(this.logUpdate(String(message)));
+  }
+
+  private logUpdate(content: string): LogUpdate {
+    return {
+      type: "log_update",
+      node_id: "script_runner",
+      node_name: "script_runner",
+      content,
+      severity: "info"
+    };
+  }
+}

--- a/packages/agents/tests/agent-script-mode.test.ts
+++ b/packages/agents/tests/agent-script-mode.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Agent script mode — end-to-end through Agent.execute with a pre-authored
+ * script (skips the planner) and with ScriptPlanner in the loop.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "../src/agent.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const ECHO_SCHEMA = {
+  type: "object",
+  properties: { echo: { type: "string" } },
+  required: ["echo"]
+};
+
+/**
+ * Provider serving both roles: `submit_script` calls (planner) are answered
+ * with `plannerScript`; execution loops finish via `finish_step`, echoing the
+ * step objective.
+ */
+function createDualProvider(plannerScript: string | null): BaseProvider {
+  let calls = 0;
+  return {
+    provider: "dual",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      messages: Array<{ role: string; content: unknown }>;
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      calls++;
+      const submit = args.tools?.find((t) => t.name === "submit_script");
+      if (submit) {
+        if (plannerScript !== null && !args.signal?.aborted) {
+          const tc: ToolCall = {
+            id: `plan_${calls}`,
+            name: "submit_script",
+            args: { script: plannerScript }
+          };
+          yield tc;
+          const content = await submit.execute?.(tc.args as never);
+          yield {
+            type: "message",
+            message: {
+              role: "tool",
+              toolCallId: tc.id,
+              content: String(content)
+            }
+          };
+        }
+        yield { type: "chunk", content: "", done: true };
+        return;
+      }
+
+      const system = String(args.messages[0]?.content ?? "");
+      const objective = /# Objective\n(.*)/.exec(system)?.[1] ?? "?";
+      const finish = args.tools?.find((t) => t.name === "finish_step");
+      const tc: ToolCall = {
+        id: `exec_${calls}`,
+        name: "finish_step",
+        args: { result: { echo: objective } }
+      };
+      yield tc;
+      const content = await finish?.execute?.(tc.args as never);
+      yield {
+        type: "message",
+        message: {
+          role: "tool",
+          toolCallId: tc.id,
+          content: typeof content === "string" ? content : JSON.stringify(content)
+        }
+      };
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+async function makeWorkspace(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "agent-script-test-"));
+}
+
+describe("Agent script mode", () => {
+  it("runs a pre-authored script (no planning) and sets results", async () => {
+    const agent = new Agent({
+      name: "scripted",
+      objective: "echo things",
+      provider: createDualProvider(null),
+      model: "test",
+      workspace: await makeWorkspace(),
+      script: `const results = await parallel(
+        ["one", "two"].map((p) => () =>
+          agent(p, { schema: ${JSON.stringify(ECHO_SCHEMA)} })
+        )
+      );
+      return results.map((r) => r.echo).sort();`
+    });
+
+    const types: string[] = [];
+    for await (const msg of agent.execute(createMockContext())) {
+      types.push(msg.type);
+    }
+
+    expect(agent.getResults()).toEqual(["one", "two"]);
+    expect(types).toContain("step_result");
+  });
+
+  it("plans the script via ScriptPlanner when useScriptPlanner is set", async () => {
+    const plannerScript = `const a = await agent("planned prompt", { schema: ${JSON.stringify(ECHO_SCHEMA)} });
+return a.echo;`;
+
+    const agent = new Agent({
+      name: "planned",
+      objective: "echo via planner",
+      provider: createDualProvider(plannerScript),
+      model: "test",
+      workspace: await makeWorkspace(),
+      useScriptPlanner: true
+    });
+
+    const messages: string[] = [];
+    for await (const msg of agent.execute(createMockContext())) {
+      messages.push(msg.type);
+    }
+
+    expect(agent.getResults()).toBe("planned prompt");
+    expect(messages).toContain("planning_update");
+  });
+
+  it("throws when the planner produces no valid script", async () => {
+    const agent = new Agent({
+      name: "planless",
+      objective: "nothing works",
+      provider: createDualProvider("return 1;"), // fails validation, no retry
+      model: "test",
+      workspace: await makeWorkspace(),
+      useScriptPlanner: true
+    });
+
+    const drain = async () => {
+      for await (const _msg of agent.execute(createMockContext())) {
+        // drain
+      }
+    };
+    await expect(drain()).rejects.toThrow(
+      /ScriptPlanner failed to produce an orchestration script/
+    );
+  });
+});

--- a/packages/agents/tests/script-planner.test.ts
+++ b/packages/agents/tests/script-planner.test.ts
@@ -1,0 +1,138 @@
+/**
+ * ScriptPlanner — the LLM authors an orchestration script through the
+ * `submit_script` tool; invalid submissions round-trip as validation errors.
+ */
+import { describe, it, expect } from "vitest";
+import { ScriptPlanner, validateScript } from "../src/script-planner.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const VALID_SCRIPT = `const a = await agent("do the thing");
+return a;`;
+
+/** Provider that replays scripted submit_script calls through the tool loop. */
+function createPlannerProvider(scripts: string[]): BaseProvider {
+  return {
+    provider: "planner",
+    hasToolSupport: async () => true,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const submit = args.tools?.find((t) => t.name === "submit_script");
+      for (const [i, script] of scripts.entries()) {
+        if (args.signal?.aborted) break;
+        const tc: ToolCall = {
+          id: `tc_${i}`,
+          name: "submit_script",
+          args: { script }
+        };
+        yield tc;
+        const content = (await submit?.execute?.(tc.args as never)) ?? "";
+        yield {
+          type: "message",
+          message: { role: "tool", toolCallId: tc.id, content }
+        };
+        if (args.signal?.aborted) break;
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+async function plan(
+  planner: ScriptPlanner
+): Promise<{ script: string | null; messages: ProcessingMessage[] }> {
+  const messages: ProcessingMessage[] = [];
+  const gen = planner.plan("test objective", createMockContext());
+  let next = await gen.next();
+  while (!next.done) {
+    messages.push(next.value);
+    next = await gen.next();
+  }
+  return { script: next.value, messages };
+}
+
+describe("validateScript", () => {
+  it("accepts a well-formed script", () => {
+    expect(validateScript(VALID_SCRIPT)).toEqual([]);
+  });
+
+  it("rejects empty scripts, missing agent() calls, missing return, and syntax errors", () => {
+    expect(validateScript("")).toContain("Script is empty.");
+    expect(validateScript("return 1;").join(" ")).toMatch(/never calls agent/);
+    expect(validateScript(`await agent("x");`).join(" ")).toMatch(
+      /no return statement/
+    );
+    expect(
+      validateScript(`const a = await agent("x"; return a;`).join(" ")
+    ).toMatch(/Syntax error/);
+  });
+});
+
+describe("ScriptPlanner", () => {
+  it("returns the script accepted via submit_script", async () => {
+    const planner = new ScriptPlanner({
+      provider: createPlannerProvider([VALID_SCRIPT]),
+      model: "test"
+    });
+
+    const { script, messages } = await plan(planner);
+
+    expect(script).toBe(VALID_SCRIPT);
+    expect(
+      messages.some(
+        (m) =>
+          m.type === "planning_update" &&
+          m.phase === "complete" &&
+          m.status === "success"
+      )
+    ).toBe(true);
+  });
+
+  it("feeds validation errors back and accepts a later fixed submission", async () => {
+    const planner = new ScriptPlanner({
+      provider: createPlannerProvider(["return 1;", VALID_SCRIPT]),
+      model: "test"
+    });
+
+    const { script, messages } = await plan(planner);
+
+    expect(script).toBe(VALID_SCRIPT);
+    expect(
+      messages.some(
+        (m) =>
+          m.type === "planning_update" &&
+          m.phase === "validation" &&
+          m.status === "failed"
+      )
+    ).toBe(true);
+  });
+
+  it("returns null when no valid script is produced", async () => {
+    const planner = new ScriptPlanner({
+      provider: createPlannerProvider(["return 1;"]),
+      model: "test"
+    });
+
+    const { script, messages } = await plan(planner);
+
+    expect(script).toBeNull();
+    expect(
+      messages.some(
+        (m) =>
+          m.type === "planning_update" &&
+          m.phase === "complete" &&
+          m.status === "failed"
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/agents/tests/script-runner.test.ts
+++ b/packages/agents/tests/script-runner.test.ts
@@ -1,0 +1,282 @@
+/**
+ * ScriptRunner — orchestration scripts in the QuickJS sandbox, with every
+ * `agent()` call backed by a real StepExecutor driven here by a fake provider
+ * whose loop just calls `finish_step`.
+ */
+import { describe, it, expect } from "vitest";
+import { ScriptRunner } from "../src/script-runner.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const ECHO_SCHEMA = {
+  type: "object",
+  properties: { echo: { type: "string" } },
+  required: ["echo"]
+};
+
+interface EchoProviderOptions {
+  /** Per-call delay so concurrency is observable. */
+  delayMs?: number;
+  /** Transform the step prompt into the `echo` value. Default: identity. */
+  echoFor?: (prompt: string) => string;
+}
+
+/**
+ * Fake provider whose generateLoop finishes every step via `finish_step`,
+ * echoing the step's objective (embedded in the system message). Tracks the
+ * number of concurrently running loops.
+ */
+function createEchoProvider(opts: EchoProviderOptions = {}) {
+  let active = 0;
+  let maxActive = 0;
+  let calls = 0;
+
+  const provider = {
+    provider: "echo",
+    hasToolSupport: async () => true,
+    getTotalCost: () => calls * 0.01,
+    async *generateLoop(args: {
+      messages: Array<{ role: string; content: unknown }>;
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+    }): AsyncGenerator<ProviderStreamItem> {
+      active++;
+      calls++;
+      maxActive = Math.max(maxActive, active);
+      try {
+        if (opts.delayMs) {
+          await new Promise((r) => setTimeout(r, opts.delayMs));
+        }
+        const system = String(args.messages[0]?.content ?? "");
+        const objective = /# Objective\n(.*)/.exec(system)?.[1] ?? "?";
+        const echo = (opts.echoFor ?? ((p: string) => p))(objective);
+        const finish = args.tools?.find((t) => t.name === "finish_step");
+        const tc: ToolCall = {
+          id: `tc_${calls}`,
+          name: "finish_step",
+          args: { result: { echo } }
+        };
+        yield tc;
+        const content = await finish?.execute?.(tc.args as never);
+        yield {
+          type: "message",
+          message: {
+            role: "tool",
+            toolCallId: tc.id,
+            content:
+              typeof content === "string" ? content : JSON.stringify(content)
+          }
+        };
+        yield { type: "chunk", content: "", done: true };
+      } finally {
+        active--;
+      }
+    }
+  } as unknown as BaseProvider;
+
+  return {
+    provider,
+    getMaxActive: () => maxActive,
+    getCalls: () => calls
+  };
+}
+
+async function run(
+  runner: ScriptRunner,
+  script: string
+): Promise<{ result: unknown; messages: ProcessingMessage[] }> {
+  const messages: ProcessingMessage[] = [];
+  const gen = runner.execute(script);
+  let next = await gen.next();
+  while (!next.done) {
+    messages.push(next.value);
+    next = await gen.next();
+  }
+  return { result: next.value, messages };
+}
+
+describe("ScriptRunner", () => {
+  it("runs a single agent call and returns the script's return value", async () => {
+    const { provider } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext()
+    });
+
+    const { result, messages } = await run(
+      runner,
+      `const a = await agent("say hi", { schema: ${JSON.stringify(ECHO_SCHEMA)} });
+       return { got: a.echo };`
+    );
+
+    expect(result).toEqual({ got: "say hi" });
+    expect(messages.some((m) => m.type === "step_result")).toBe(true);
+  });
+
+  it("fans out with parallel() and respects the concurrency cap", async () => {
+    const { provider, getMaxActive } = createEchoProvider({ delayMs: 20 });
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext(),
+      maxConcurrentAgents: 2
+    });
+
+    const { result } = await run(
+      runner,
+      `const results = await parallel(
+         ["a", "b", "c", "d", "e"].map((p) => () =>
+           agent(p, { schema: ${JSON.stringify(ECHO_SCHEMA)} })
+         )
+       );
+       return results.map((r) => r.echo).sort();`
+    );
+
+    expect(result).toEqual(["a", "b", "c", "d", "e"]);
+    expect(getMaxActive()).toBeLessThanOrEqual(2);
+  });
+
+  it("pipeline() threads stage results and passes the original item", async () => {
+    const { provider } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext()
+    });
+
+    const { result } = await run(
+      runner,
+      `const out = await pipeline(
+         ["x", "y"],
+         (item) => agent(item, { schema: ${JSON.stringify(ECHO_SCHEMA)} }),
+         (prev, original, index) => original + ":" + prev.echo + ":" + index
+       );
+       return out;`
+    );
+
+    expect(result).toEqual(["x:x:0", "y:y:1"]);
+  });
+
+  it("enforces the lifetime agent-call cap; failed thunks become null", async () => {
+    const { provider, getCalls } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext(),
+      maxAgentCalls: 2,
+      maxConcurrentAgents: 1
+    });
+
+    const { result } = await run(
+      runner,
+      `const results = await parallel(
+         ["a", "b", "c", "d"].map((p) => () =>
+           agent(p, { schema: ${JSON.stringify(ECHO_SCHEMA)} })
+         )
+       );
+       return results.filter((r) => r !== null).length;`
+    );
+
+    expect(result).toBe(2);
+    expect(getCalls()).toBe(2);
+  });
+
+  it("exposes budget counters and inputs to the script", async () => {
+    const { provider } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext(),
+      maxAgentCalls: 7,
+      inputs: { topic: "foxes" }
+    });
+
+    const { result } = await run(
+      runner,
+      `await agent(inputs.topic, { schema: ${JSON.stringify(ECHO_SCHEMA)} });
+       return {
+         max: budget.maxAgentCalls,
+         used: budget.agentCalls(),
+         remaining: budget.remainingCalls(),
+         spent: await budget.spentUsd(),
+         topic: inputs.topic
+       };`
+    );
+
+    expect(result).toEqual({
+      max: 7,
+      used: 1,
+      remaining: 6,
+      spent: 0.01,
+      topic: "foxes"
+    });
+  });
+
+  it("emits log() lines as log_update messages", async () => {
+    const { provider } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext()
+    });
+
+    const { messages } = await run(runner, `log("round 1 done"); return 1;`);
+
+    const logs = messages.filter(
+      (m) => m.type === "log_update" && m.content === "round 1 done"
+    );
+    expect(logs).toHaveLength(1);
+  });
+
+  it("throws when the script itself fails", async () => {
+    const { provider } = createEchoProvider();
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext()
+    });
+
+    await expect(run(runner, `throw new Error("boom");`)).rejects.toThrow(
+      /Orchestration script failed: .*boom/
+    );
+  });
+
+  it("agent() without a schema returns the sub-agent's text result", async () => {
+    // Unstructured steps finalize on a no-tool-call assistant message.
+    const provider = {
+      provider: "text",
+      hasToolSupport: async () => true,
+      getTotalCost: () => 0,
+      async *generateLoop(): AsyncGenerator<ProviderStreamItem> {
+        yield { type: "chunk", content: "plain answer", done: false };
+        yield {
+          type: "message",
+          message: { role: "assistant", content: "plain answer" }
+        };
+        yield { type: "chunk", content: "", done: true };
+      }
+    } as unknown as BaseProvider;
+
+    const runner = new ScriptRunner({
+      provider,
+      model: "test",
+      context: createMockContext()
+    });
+
+    const { result } = await run(
+      runner,
+      `const text = await agent("answer plainly");
+       return text;`
+    );
+
+    expect(result).toBe("plain answer");
+  });
+});


### PR DESCRIPTION
Add a third planning mode next to TaskPlan and the graph planner: the LLM
authors a JavaScript orchestration script (ScriptPlanner) that ScriptRunner
executes in the QuickJS sandbox. Every agent() call in the script runs a
real StepExecutor sub-agent on the host, so scripts can express what a
static DAG cannot — loops until a condition holds, budget-scaled fan-out,
dedup between rounds, early exit.

- ScriptRunner: guest primitives agent()/parallel()/pipeline()/log()/
  budget/inputs on top of never-rejecting host bridges; host-side
  concurrency semaphore (default 8) and lifetime agent-call cap
  (default 100); sub-agent messages stream out through a channel.
- ScriptPlanner: single submit_script tool loop with host-side
  validation (syntax compile, agent() + return present) that
  round-trips errors for the model to fix.
- Agent: useScriptPlanner / script / maxConcurrentAgents /
  maxAgentCalls options; executeScriptPlan dispatch.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017MopZNJUFJvvjPQQt97BUG