### PR TITLE
Fix OpenAI Responses API 400 on function_call replay

### DIFF
--- a/packages/runtime/src/providers/responses-api.ts
+++ b/packages/runtime/src/providers/responses-api.ts
@@ -115,9 +115,12 @@ export async function messagesToResponsesInput(
         });
       }
       for (const toolCall of message.toolCalls ?? []) {
+        // Only `call_id` (the `call_...`-prefixed id) is echoed back. The item
+        // `id` is deliberately omitted: we track the call_id, not the `fc_...`
+        // item id, and supplying the call_id in the `id` field makes the
+        // Responses API reject it ("Expected an ID that begins with 'fc'").
         input.push({
           type: "function_call",
-          id: toolCall.id,
           call_id: toolCall.id,
           name: toolCall.name,
           arguments: JSON.stringify(toolCall.args ?? {})

--- a/packages/runtime/tests/providers/responses-api.test.ts
+++ b/packages/runtime/tests/providers/responses-api.test.ts
@@ -94,7 +94,6 @@ describe("Responses API helpers", () => {
       },
       {
         type: "function_call",
-        id: "call_1",
         call_id: "call_1",
         name: "lookup",
         arguments: '{"q":"x"}'
@@ -105,6 +104,31 @@ describe("Responses API helpers", () => {
         output: '{"ok":true}'
       }
     ]);
+  });
+
+  it("omits the item id when replaying a function_call so a call_-prefixed id is never sent as the fc_ item id", async () => {
+    // Regression: the Responses API rejects a function_call input whose `id`
+    // does not begin with "fc_". We only track the call_id, so the `id` field
+    // must be omitted rather than filled with the call_id.
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call_AunLsAYx1gOmtr0LdLBCRwIL", name: "add_item", args: { item: "x" } }]
+      }
+    ];
+
+    const input = await messagesToResponsesInput(messages, async (uri) => uri);
+
+    expect(input).toEqual([
+      {
+        type: "function_call",
+        call_id: "call_AunLsAYx1gOmtr0LdLBCRwIL",
+        name: "add_item",
+        arguments: '{"item":"x"}'
+      }
+    ]);
+    expect(input[0]).not.toHaveProperty("id");
   });
 
   it("formats function tools for Responses", () => {


### PR DESCRIPTION
The Responses API distinguishes a function_call's item id (prefixed
`fc_`) from its call_id (prefixed `call_`). The provider only tracks the
call_id, but on replay it also placed that value in the item `id` field,
which OpenAI validates must begin with `fc_`, producing:

  400 Invalid 'input[N].id': 'call_...'. Expected an ID that begins with 'fc'.

Omit the item `id` entirely; only `call_id` is needed to pair a
function_call with its function_call_output.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RWKe52cYGN4tVVRqcy5uNy