### PR TITLE
fix(electron): preserve falsy workflow outputs

### DIFF
--- a/electron/src/WorkflowRunner.ts
+++ b/electron/src/WorkflowRunner.ts
@@ -186,7 +186,7 @@ export const createWorkflowRunner = () =>
               });
             } else if (
               data.result &&
-              data.result.output &&
+              data.result.output !== undefined &&
               data.node_name?.includes("Output")
             ) {
               set({

--- a/electron/src/__tests__/WorkflowRunner.messages.test.ts
+++ b/electron/src/__tests__/WorkflowRunner.messages.test.ts
@@ -143,6 +143,39 @@ describe('WorkflowRunner message handling', () => {
       expect(runner.getState().results).toEqual(['my result']);
     });
 
+    it.each([0, false, '', null])(
+      'preserves falsy output %p when workflow completes',
+      async (output) => {
+        const { runner, socket } = await connectRunner();
+        const onComplete = jest.fn();
+        runner.setState({ onComplete });
+
+        sendMessage(socket, {
+          type: 'node_update',
+          node_name: 'ValueOutput',
+          result: { output },
+        });
+        sendMessage(socket, { type: 'job_update', status: 'completed' });
+
+        expect(onComplete).toHaveBeenCalledWith([output]);
+      },
+    );
+
+    it('ignores an undefined output when workflow completes', async () => {
+      const { runner, socket } = await connectRunner();
+      const onComplete = jest.fn();
+      runner.setState({ onComplete });
+
+      sendMessage(socket, {
+        type: 'node_update',
+        node_name: 'ValueOutput',
+        result: { output: undefined },
+      });
+      sendMessage(socket, { type: 'job_update', status: 'completed' });
+
+      expect(onComplete).toHaveBeenCalledWith([]);
+    });
+
     it('sets statusMessage when node_name is present but no error or output', async () => {
       const { runner, socket } = await connectRunner();
 


### PR DESCRIPTION
## Summary

- preserve valid `0`, `false`, empty-string, and `null` values emitted by Electron workflow Output nodes
- keep missing or explicit `undefined` outputs out of the result list
- cover the packed WebSocket `node_update` through completed `onComplete` path

## Root cause

`WorkflowRunner` used truthiness to decide whether an Output node produced a result. Output values are intentionally untyped, and the generic Output node normalizes an absent value to `null`, so value presence cannot be inferred from boolean coercion.

## Test plan

- `npm run build:packages`
- `npm run typecheck --workspace=electron`
- `npm run lint --workspace=electron`
- `npm run lint`
- `npm test --workspace=electron -- --runInBand src/__tests__/WorkflowRunner.messages.test.ts`
