### PR TITLE
Route source images to primary fields, skip auxiliary slots

### DIFF
--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -638,9 +638,18 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
     if (field.parentField) continue;
     if (field.name === "num_images") continue;
 
+    // Asset inputs need a proper AssetRef default object. Some manifest entries
+    // carry `default: ""` for asset fields (notably inpaint `mask`s); an empty
+    // string must not shadow the AssetRef default, so ignore non-object
+    // manifest defaults for asset propTypes.
+    const manifestDefault =
+      assetKind(field.propType) !== "none" &&
+      typeof field.default !== "object"
+        ? undefined
+        : field.default;
     const propOptions: PropOptions = {
       type: field.propType,
-      default: field.default ?? defaultForPropType(field.propType)
+      default: manifestDefault ?? defaultForPropType(field.propType)
     };
     if (field.description) propOptions.description = field.description;
     if (field.enumValues?.length) propOptions.values = field.enumValues;

--- a/packages/fal-nodes/tests/fal-factory.test.ts
+++ b/packages/fal-nodes/tests/fal-factory.test.ts
@@ -177,6 +177,43 @@ describe("FAL factory argument building", () => {
     });
   });
 
+  it("defaults an asset field to an AssetRef object even when the manifest default is \"\"", () => {
+    // Some manifest entries ship `default: ""` for asset fields (notably inpaint
+    // masks). The `""` must not shadow the proper AssetRef default object.
+    const NodeClass = createFalNodeClass({
+      endpointId: "fal-ai/inpaint",
+      className: "Inpaint",
+      moduleName: "image_to_image",
+      docstring: "test",
+      tags: [],
+      useCases: [],
+      outputType: "image",
+      outputFields: [],
+      enums: [],
+      inputFields: [
+        {
+          name: "mask",
+          propType: "image",
+          tsType: "image",
+          default: "",
+          description: "",
+          fieldType: "input",
+          required: true,
+          apiParamName: "mask_url"
+        }
+      ]
+    });
+
+    const instance = new NodeClass({}) as unknown as Record<string, unknown>;
+    expect(instance.mask).toEqual({
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+  });
+
   it("sends mask assets under mask_url api param", async () => {
     imageToDataUrl.mockResolvedValueOnce(null);
     imageToDataUrl.mockResolvedValueOnce("data:image/png;base64,abc");

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -34,7 +34,9 @@ import {
   loadMusicModels,
   loadTTSModels,
   loadVideoModels,
-  sizeEnumToAspect
+  selectPrimaryImageInput,
+  sizeEnumToAspect,
+  type ModelImageInput
 } from "./manifest-models.js";
 import { sniffAudioMime } from "./audio-mime.js";
 import { safeFetch } from "./safe-url.js";
@@ -163,6 +165,40 @@ class FalArgsBuilder {
   }
 
   /**
+   * The `kind`-typed asset inputs the endpoint declares, as {@link
+   * ModelImageInput}s (apiName / isList / name), in manifest order.
+   */
+  private assetInputs(kind: "image" | "video" | "audio"): ModelImageInput[] {
+    return this.fields
+      .filter((f) => {
+        const t = f.propType.toLowerCase();
+        return t === kind || t === `list[${kind}]`;
+      })
+      .map((f) => ({
+        apiName: f.apiParamName ?? f.name,
+        isList: f.propType.toLowerCase().startsWith("list["),
+        name: f.name
+      }));
+  }
+
+  /**
+   * Pick the field a source asset should attach to. For images this is the
+   * primary source field, skipping auxiliary slots (mask/control/reference/
+   * style/pose/end-frame, …) that must never receive the source image — the
+   * same {@link selectPrimaryImageInput} the model picker uses. For video/audio
+   * (endpoints with a single such field) it's the first declared field.
+   */
+  private selectAssetField(
+    kind: "image" | "video" | "audio",
+    count: number
+  ): ModelImageInput | undefined {
+    const inputs = this.assetInputs(kind);
+    if (inputs.length === 0) return undefined;
+    if (kind === "image") return selectPrimaryImageInput(inputs, count);
+    return inputs[0];
+  }
+
+  /**
    * Attach an uploaded asset URL to whatever field (image/video/audio) the
    * endpoint declares. Handles list-typed fields (`list[image]` -> array).
    * If the endpoint isn't in the manifest, falls back to `${kind}_url`.
@@ -172,15 +208,9 @@ class FalArgsBuilder {
     url: string,
     fallbackApiName?: string
   ): this {
-    const field = this.fields.find((f) => {
-      const t = f.propType.toLowerCase();
-      return t === kind || t === `list[${kind}]`;
-    });
+    const field = this.selectAssetField(kind, 1);
     if (field) {
-      const apiName = field.apiParamName ?? field.name;
-      this.args[apiName] = field.propType.toLowerCase().startsWith("list[")
-        ? [url]
-        : url;
+      this.args[field.apiName] = field.isList ? [url] : url;
     } else {
       this.args[fallbackApiName ?? `${kind}_url`] = url;
     }
@@ -191,8 +221,9 @@ class FalArgsBuilder {
    * Attach one or more uploaded asset URLs to whatever field (image/video/
    * audio) the endpoint declares. When the endpoint declares a list-typed field
    * (e.g. `image_urls`), every URL is sent; otherwise only the first URL is
-   * attached to the single-valued field. Falls back to `${kind}_url` (first
-   * URL) for endpoints not in the manifest.
+   * attached to the single-valued field. Auxiliary image slots (mask, control,
+   * reference/style/end-frame, …) are skipped so the source never lands there.
+   * Falls back to `${kind}_url` (first URL) for endpoints not in the manifest.
    */
   attachAssets(
     kind: "image" | "video" | "audio",
@@ -200,19 +231,9 @@ class FalArgsBuilder {
     fallbackApiName?: string
   ): this {
     if (urls.length === 0) return this;
-    // Skip mask-named fields: inpaint endpoints declare both the source
-    // (`image_url`) and the mask (`mask_url`/`mask_image_url`) as `image`, and
-    // the primary asset must never land in the mask slot.
-    const field = this.fields.find((f) => {
-      const t = f.propType.toLowerCase();
-      const apiName = (f.apiParamName ?? f.name).toLowerCase();
-      return (t === kind || t === `list[${kind}]`) && !apiName.includes("mask");
-    });
+    const field = this.selectAssetField(kind, urls.length);
     if (field) {
-      const apiName = field.apiParamName ?? field.name;
-      this.args[apiName] = field.propType.toLowerCase().startsWith("list[")
-        ? urls
-        : urls[0];
+      this.args[field.apiName] = field.isList ? urls : urls[0];
     } else {
       this.args[fallbackApiName ?? `${kind}_url`] = urls[0];
     }

--- a/packages/runtime/tests/providers/fal-provider.test.ts
+++ b/packages/runtime/tests/providers/fal-provider.test.ts
@@ -236,6 +236,87 @@ describe("FalProvider", () => {
     vi.unstubAllGlobals();
   });
 
+  it("routes the source image to the primary field, not an auxiliary slot", async () => {
+    // image-apps-v2/style-transfer declares `style_reference_image_url` BEFORE
+    // `image_url`; the source must land in the primary `image_url`, never the
+    // style-reference slot.
+    const uploadMock = vi
+      .fn()
+      .mockResolvedValue("https://fal.media/files/src.png");
+    const subscribeMock = vi.fn().mockResolvedValue({
+      data: { image: { url: "https://fal.ai/result.png" } }
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers(),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(4))
+      })
+    );
+
+    const p = createProvider();
+    (p as any)._client = {
+      subscribe: subscribeMock,
+      storage: { upload: uploadMock }
+    };
+
+    await p.imageToImage([new Uint8Array([1, 2, 3, 4])], {
+      prompt: "restyle",
+      model: {
+        id: "fal-ai/image-apps-v2/style-transfer",
+        name: "Style Transfer",
+        provider: "fal_ai"
+      }
+    });
+
+    const input = subscribeMock.mock.calls[0][1].input;
+    expect(input.image_url).toBe("https://fal.media/files/src.png");
+    expect(input.style_reference_image_url).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("imageToVideo puts the frame in the first-frame field, not end_image_url", async () => {
+    // luma-dream-machine/image-to-video declares `end_image_url` BEFORE
+    // `image_url`; the single input frame must land in `image_url`.
+    const uploadMock = vi
+      .fn()
+      .mockResolvedValue("https://fal.media/files/frame.png");
+    const subscribeMock = vi.fn().mockResolvedValue({
+      data: { video: { url: "https://fal.ai/result.mp4" } }
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers(),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(4))
+      })
+    );
+
+    const p = createProvider();
+    (p as any)._client = {
+      subscribe: subscribeMock,
+      storage: { upload: uploadMock }
+    };
+
+    await p.imageToVideo([new Uint8Array([1, 2, 3, 4])], {
+      prompt: "animate",
+      model: {
+        id: "fal-ai/luma-dream-machine/image-to-video",
+        name: "Luma i2v",
+        provider: "fal_ai"
+      }
+    } as any);
+
+    const input = subscribeMock.mock.calls[0][1].input;
+    expect(input.image_url).toBe("https://fal.media/files/frame.png");
+    expect(input.end_image_url).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
   // --- inpaint ---
 
   it("inpaint attaches the mask to the endpoint's declared mask field", async () => {


### PR DESCRIPTION
## Summary

Fixes a critical bug where source images were being routed to auxiliary image slots (mask, style reference, end frame, etc.) instead of the primary source field. This affected endpoints like `style-transfer` and `image-to-video` that declare auxiliary fields before the primary `image_url` field in their manifests.

## Key Changes

- **`packages/runtime/src/providers/fal-provider.ts`**
  - Extracted `selectPrimaryImageInput()` import from `manifest-models.js` to reuse the model picker's logic for identifying the correct primary image field
  - Added `assetInputs()` method to `FalArgsBuilder` to collect asset fields (image/video/audio) in manifest order
  - Added `selectAssetField()` method to intelligently pick the target field:
    - For images: uses `selectPrimaryImageInput()` to skip auxiliary slots (mask, control, reference, style, pose, end-frame, etc.)
    - For video/audio: uses the first declared field
  - Refactored `attachAsset()` and `attachAssets()` to use `selectAssetField()` instead of naive field matching
  - Removed hardcoded mask-field skipping logic (now handled generically)

- **`packages/fal-nodes/src/fal-factory.ts`**
  - Fixed asset field defaults: manifest entries with `default: ""` for asset fields (e.g., inpaint masks) now properly default to `AssetRef` objects instead of empty strings
  - Added logic to ignore non-object manifest defaults for asset propTypes, allowing the proper `AssetRef` default to apply

- **Test coverage**
  - Added test for `imageToImage` with `style-transfer` to verify source lands in `image_url`, not `style_reference_image_url`
  - Added test for `imageToVideo` with `image-to-video` to verify frame lands in `image_url`, not `end_image_url`
  - Added test for asset field defaults to ensure `AssetRef` objects are created even when manifest specifies `default: ""`

## Implementation Details

The fix leverages the existing `selectPrimaryImageInput()` function from the model picker, which already implements the logic to identify primary image fields while skipping known auxiliary patterns. This ensures consistency between model selection and asset routing.

https://claude.ai/code/session_01RNtGivtLsDwvpLVPvPRj88