### PR TITLE
KIE provider: Suno music API, schema-driven inputs, robust error handling

### DIFF
--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -20,6 +20,7 @@ import type {
   MessageImageContent,
   MessageTextContent,
   ProviderEffort,
+  ProviderId,
   ProviderStreamItem,
   ProviderThinkingConfig,
   ProviderTool,
@@ -37,6 +38,13 @@ interface AnthropicProviderOptions {
   >;
   cacheControl?: { type: "ephemeral"; ttl?: "5m" | "1h" };
   betas?: string[];
+  /**
+   * Provider id reported by this instance. Defaults to `"anthropic"`.
+   * Anthropic-compatible subclasses (gateways pointed at a different base URL)
+   * pass their own id so the readonly `provider` field is set via the base
+   * constructor rather than reassigned afterwards.
+   */
+  providerId?: ProviderId;
 }
 
 type AnthropicRawBlock = Record<string, unknown>;
@@ -336,7 +344,7 @@ export class AnthropicProvider extends BaseProvider {
     secrets: { ANTHROPIC_API_KEY?: string; ANTHROPIC_AUTH_TOKEN?: string },
     options: AnthropicProviderOptions = {}
   ) {
-    super("anthropic");
+    super(options.providerId ?? "anthropic");
 
     const apiKey = secrets.ANTHROPIC_API_KEY?.trim() ?? "";
     const authToken =

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -35,8 +35,11 @@ import {
   loadMusicModels,
   loadTTSModels,
   getModelImageInputs,
+  getModelInputFields,
+  getManifestNodeMeta,
   selectPrimaryImageInput,
-  selectMaskImageInput
+  selectMaskImageInput,
+  type ModelInputField
 } from "./manifest-models.js";
 import { sniffAudioMime } from "./audio-mime.js";
 import { OpenAIProvider } from "./openai-provider.js";
@@ -56,6 +59,9 @@ const log = createLogger("nodetool.runtime.providers.kie");
 const KIE_API_BASE = "https://api.kie.ai";
 const KIE_UPLOAD_URL =
   "https://kieai.redpandaai.co/api/file-stream-upload";
+// The Suno API always requires a callBackUrl. We poll for results instead of
+// receiving callbacks, so a placeholder satisfies the requirement.
+const KIE_SUNO_CALLBACK = "https://nodetool.ai/kie-callback";
 
 type KieChatApi = "openai" | "anthropic" | "responses";
 
@@ -116,29 +122,186 @@ function headers(apiKey: string): Record<string, string> {
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
 /**
- * Upload raw image bytes to KIE's file store and return the hosted URL.
- * Mirrors the upload flow used by the KIE factory nodes (multipart POST →
- * `downloadUrl`).
+ * KIE reports API errors inside HTTP-200 bodies as `{code, msg}`. Map the known
+ * error codes to a message and throw; code 200 (and any unmapped code) passes
+ * through. Mirrors kie-base's `checkStatus` — without this a failed job returns
+ * a 200 that the poll loop reads as "not done yet" and runs to full timeout.
+ */
+function checkStatus(data: Record<string, unknown>): void {
+  const code = Number(data.code);
+  const map: Record<number, string> = {
+    401: "Unauthorized",
+    402: "Insufficient Credits",
+    404: "Not Found",
+    422: "Validation Error",
+    429: "Rate Limited",
+    455: "Service Unavailable",
+    500: "Server Error",
+    501: "Generation Failed",
+    505: "Feature Disabled"
+  };
+  if (map[code]) throw new Error(`${map[code]}: ${JSON.stringify(data)}`);
+}
+
+/**
+ * Parse a KIE JSON response defensively: a gateway 502 returns an HTML page, not
+ * JSON, so read the text and surface a "Kie <label> failed: <status> …" error
+ * with a body snippet rather than a bare SyntaxError. Applies the HTTP-200 error
+ * envelope check ({@link checkStatus}) on every parsed body.
+ */
+async function parseKieJson(
+  res: Response,
+  label: string
+): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `Kie ${label} failed: ${res.status} ${text.slice(0, 200)}`
+    );
+  }
+  if (data.code !== undefined) checkStatus(data);
+  return data;
+}
+
+/** Detect an image container from its magic bytes; defaults to PNG. */
+function sniffImageType(bytes: Uint8Array): { mime: string; ext: string } {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return { mime: "image/png", ext: "png" };
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return { mime: "image/jpeg", ext: "jpg" };
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return { mime: "image/webp", ext: "webp" };
+  }
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38 &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39) &&
+    bytes[5] === 0x61
+  ) {
+    return { mime: "image/gif", ext: "gif" };
+  }
+  return { mime: "image/png", ext: "png" };
+}
+
+/** Parse an "a:b" aspect ratio string into its numeric value, or undefined. */
+function aspectToNumber(ratio: string): number | undefined {
+  const m = /^(\d+(?:\.\d+)?)\s*:\s*(\d+(?:\.\d+)?)$/.exec(ratio.trim());
+  if (!m) return undefined;
+  const w = Number(m[1]);
+  const h = Number(m[2]);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || h === 0) return undefined;
+  return w / h;
+}
+
+/** Choose the declared enum aspect ratio closest to a target numeric ratio. */
+function nearestAspect(
+  enumValues: string[],
+  target: number
+): string | undefined {
+  let best: { value: string; diff: number } | undefined;
+  for (const value of enumValues) {
+    const n = aspectToNumber(value);
+    if (n === undefined) continue;
+    const diff = Math.abs(n - target);
+    if (!best || diff < best.diff) best = { value, diff };
+  }
+  return best?.value ?? enumValues[0];
+}
+
+/**
+ * Coerce a requested duration (seconds) to the model's declared `duration`
+ * field type: snap to the nearest allowed enum value (sent as the enum's own
+ * value type — the manifest enums are strings), round to an int, or pass a
+ * float through. Returns undefined when the model declares no duration field.
+ */
+function coerceDuration(
+  field: ModelInputField | undefined,
+  seconds: number
+): unknown {
+  if (!field) return undefined;
+  if (field.type === "enum" && field.enumValues && field.enumValues.length > 0) {
+    let best: { value: string; diff: number } | undefined;
+    for (const value of field.enumValues) {
+      const n = Number(value);
+      if (!Number.isFinite(n)) continue;
+      const diff = Math.abs(n - seconds);
+      if (!best || diff < best.diff) best = { value, diff };
+    }
+    return best?.value ?? field.enumValues[0];
+  }
+  if (field.type === "float") return seconds;
+  // int and any other numeric type: send a rounded integer.
+  return Math.round(seconds);
+}
+
+/**
+ * A field's default usable as an input value: the declared default when it's
+ * meaningful (not an empty string), otherwise the first enum option. KIE's
+ * required `model` field ships with an empty default, so the first declared
+ * version is used.
+ */
+function defaultForField(field: ModelInputField): unknown {
+  const d = field.default;
+  if (d !== undefined && !(typeof d === "string" && d === "")) return d;
+  if (field.enumValues && field.enumValues.length > 0) return field.enumValues[0];
+  return undefined;
+}
+
+/**
+ * Upload raw image bytes to KIE's file store and return the hosted URL. Sniffs
+ * the container from the magic bytes so the upload carries the right mime and
+ * extension (KIE rejects a JPEG announced as PNG).
  */
 async function uploadImageBytes(
   apiKey: string,
   bytes: Uint8Array
 ): Promise<string> {
+  const { mime, ext } = sniffImageType(bytes);
+  const fileName = `upload-${Date.now()}.${ext}`;
   const form = new FormData();
-  form.append(
-    "file",
-    new Blob([new Uint8Array(bytes)], { type: "image/png" }),
-    `upload-${Date.now()}.png`
-  );
+  form.append("file", new Blob([new Uint8Array(bytes)], { type: mime }), fileName);
   form.append("uploadPath", "images/user-uploads");
-  form.append("fileName", `upload-${Date.now()}.png`);
+  form.append("fileName", fileName);
   const res = await fetch(KIE_UPLOAD_URL, {
     method: "POST",
     headers: { Authorization: `Bearer ${apiKey}` },
     body: form
   });
-  const data = (await res.json()) as Record<string, unknown>;
+  const data = await parseKieJson(res, "upload");
   if (!res.ok || !data.success) {
     throw new Error(`Kie upload failed: ${res.status} ${JSON.stringify(data)}`);
   }
@@ -160,7 +323,7 @@ async function submitTask(
     headers: headers(apiKey),
     body: JSON.stringify({ model, input })
   });
-  const data = (await res.json()) as Record<string, unknown>;
+  const data = await parseKieJson(res, "submit");
   if (!res.ok) {
     throw new Error(`Kie submit failed: ${res.status} ${JSON.stringify(data)}`);
   }
@@ -178,10 +341,12 @@ async function pollUntilDone(
   maxAttempts = 300
 ): Promise<void> {
   const url = `${KIE_API_BASE}/api/v1/jobs/recordInfo?taskId=${taskId}`;
-  // A persistent non-OK poll (429/5xx/revoked key) after createTask succeeded
-  // used to be treated as "not done yet", so the loop silently ran the full
-  // maxAttempts (~20 min) and then blamed a slow job. Fail fast after a bounded
-  // run of consecutive errors with the real status.
+  // KIE reports failures two ways that both look like "still running" to a naive
+  // loop: a persistent non-OK poll (429/5xx/revoked key) after createTask
+  // succeeded, and an HTTP-200 body carrying an error `code` (checkStatus). Both
+  // used to run the full maxAttempts (~20 min) before blaming a slow job. Fail
+  // fast: on a bounded run of consecutive HTTP errors, and immediately on a code
+  // envelope (via parseKieJson).
   const MAX_CONSECUTIVE_ERRORS = 5;
   let consecutiveErrors = 0;
   for (let i = 0; i < maxAttempts; i++) {
@@ -194,11 +359,11 @@ async function pollUntilDone(
           `Kie recordInfo failed ${consecutiveErrors}× (HTTP ${res.status}) for taskId ${taskId}: ${body.slice(0, 200)}`
         );
       }
-      await new Promise((r) => setTimeout(r, pollInterval));
+      await sleep(pollInterval);
       continue;
     }
     consecutiveErrors = 0;
-    const data = (await res.json()) as Record<string, unknown>;
+    const data = await parseKieJson(res, "recordInfo");
     const state = (data.data as Record<string, unknown>)?.state as string;
     if (state === "success") return;
     if (state === "failed" || state === "fail") {
@@ -206,7 +371,7 @@ async function pollUntilDone(
         (data.data as Record<string, unknown>)?.failMsg || "Unknown error";
       throw new Error(`Kie task failed: ${msg} (taskId: ${taskId})`);
     }
-    await new Promise((r) => setTimeout(r, pollInterval));
+    await sleep(pollInterval);
   }
   const timeoutSeconds = (maxAttempts * pollInterval) / 1000;
   throw new Error(
@@ -222,7 +387,7 @@ async function downloadResultBytes(
   const url = `${KIE_API_BASE}/api/v1/jobs/recordInfo?taskId=${taskId}`;
   const res = await fetch(url, { headers: headers(apiKey) });
   if (!res.ok) throw new Error(`Failed to get Kie result: ${res.status}`);
-  const data = (await res.json()) as Record<string, unknown>;
+  const data = await parseKieJson(res, "recordInfo");
   const resultJsonStr = (data.data as Record<string, unknown>)
     ?.resultJson as string;
   if (!resultJsonStr) throw new Error("No resultJson in Kie response");
@@ -234,6 +399,63 @@ async function downloadResultBytes(
     throw new Error(`Failed to download from ${resultUrls[0]}`);
   }
   return new Uint8Array(await dlRes.arrayBuffer());
+}
+
+/**
+ * Submit a Suno music task to `<sunoEndpoint>` and return the task id. The Suno
+ * API is separate from the generic jobs API and always requires `callBackUrl`.
+ */
+async function submitSuno(
+  apiKey: string,
+  endpoint: string,
+  input: Record<string, unknown>
+): Promise<string> {
+  const body = { ...input, callBackUrl: KIE_SUNO_CALLBACK };
+  const res = await fetch(`${KIE_API_BASE}${endpoint}`, {
+    method: "POST",
+    headers: headers(apiKey),
+    body: JSON.stringify(body)
+  });
+  const data = await parseKieJson(res, "submit");
+  if (!res.ok) {
+    throw new Error(`Kie submit failed: ${res.status} ${JSON.stringify(data)}`);
+  }
+  const taskId = (data.data as Record<string, unknown>)?.taskId as string;
+  if (!taskId) {
+    throw new Error(`No taskId in Kie response: ${JSON.stringify(data)}`);
+  }
+  return taskId;
+}
+
+/** Poll the Suno record-info endpoint until the task reaches a terminal state. */
+async function pollSuno(
+  apiKey: string,
+  taskId: string,
+  pollInterval: number,
+  maxAttempts: number
+): Promise<Record<string, unknown>> {
+  const url = `${KIE_API_BASE}/api/v1/generate/record-info?taskId=${taskId}`;
+  const failed = new Set([
+    "CREATE_TASK_FAILED",
+    "GENERATE_AUDIO_FAILED",
+    "CALLBACK_EXCEPTION",
+    "SENSITIVE_WORD_ERROR"
+  ]);
+  for (let i = 0; i < maxAttempts; i++) {
+    const res = await fetch(url, { headers: headers(apiKey) });
+    const data = await parseKieJson(res, "record-info");
+    const status = (data.data as Record<string, unknown>)?.status as string;
+    if (status === "SUCCESS") return data;
+    if (failed.has(status)) {
+      throw new Error(`Kie Suno task failed: ${status} (taskId: ${taskId})`);
+    }
+    await sleep(pollInterval);
+  }
+  const timeoutSeconds = (maxAttempts * pollInterval) / 1000;
+  throw new Error(
+    `Kie Suno task timed out after ${timeoutSeconds}s (taskId: ${taskId}). ` +
+      "The job may still complete on KIE — check record-info or the KIE dashboard."
+  );
 }
 
 const KIE_MANIFEST_PKG = "@nodetool-ai/kie-nodes";
@@ -263,9 +485,10 @@ export class KieProvider extends BaseProvider {
   }
 
   private makeOpenAIProvider(basePath: string): OpenAIProvider {
-    const provider = new OpenAIProvider(
+    return new OpenAIProvider(
       { OPENAI_API_KEY: this.requireApiKey() },
       {
+        providerId: "kie",
         clientFactory: (apiKey) =>
           new OpenAI({
             apiKey,
@@ -273,14 +496,13 @@ export class KieProvider extends BaseProvider {
           })
       }
     );
-    (provider as { provider: string }).provider = "kie";
-    return provider;
   }
 
   private makeAnthropicProvider(basePath: string): AnthropicProvider {
-    const provider = new AnthropicProvider(
+    return new AnthropicProvider(
       { ANTHROPIC_API_KEY: this.requireApiKey() },
       {
+        providerId: "kie",
         clientFactory: (apiKey) =>
           new Anthropic({
             authToken: apiKey,
@@ -288,8 +510,6 @@ export class KieProvider extends BaseProvider {
           })
       }
     );
-    (provider as { provider: string }).provider = "kie";
-    return provider;
   }
 
   private makeResponsesClient(basePath: string): OpenAI {
@@ -451,28 +671,138 @@ export class KieProvider extends BaseProvider {
     return loadMusicModels(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, "kie");
   }
 
+  /** Resolve poll interval and attempt count for a model's async task. */
+  private pollConfig(
+    modelId: string,
+    timeoutSeconds?: number | null
+  ): { pollInterval: number; maxAttempts: number } {
+    const meta = getManifestNodeMeta(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
+    const pollInterval = meta?.pollInterval ?? 4000;
+    // A caller-supplied timeout wins: translate it into a bounded poll window.
+    if (timeoutSeconds != null && timeoutSeconds > 0) {
+      const maxAttempts = Math.max(
+        1,
+        Math.ceil((timeoutSeconds * 1000) / pollInterval)
+      );
+      return { pollInterval, maxAttempts };
+    }
+    return { pollInterval, maxAttempts: meta?.maxAttempts ?? 300 };
+  }
+
+  private declaresField(fields: ModelInputField[], name: string): boolean {
+    return fields.some((f) => f.name === name);
+  }
+
   /**
-   * Generate music as an encoded audio file. KIE runs music generation (Suno)
-   * as an async job and returns a result URL, so this mirrors the TTS / video
-   * path: submit the task, poll until done, then download the audio bytes.
+   * Generate music as an encoded audio file. The advertised KIE music models
+   * (generate-music, generate-sounds) run through the Suno API — a separate
+   * submit endpoint and record-info poll, not the generic jobs task API. A
+   * music model without Suno metadata falls back to the generic jobs path.
    */
   override async textToMusic(
     params: TextToMusicParams
   ): Promise<EncodedAudioResult> {
     if (!params.prompt) throw new Error("Prompt is required");
+    const apiKey = this.requireApiKey();
+    const modelId = params.model.id;
+    log.debug("Kie textToMusic", { model: modelId });
+
+    const meta = getManifestNodeMeta(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
+    if (meta?.useSuno && meta.sunoEndpoint) {
+      const input = this.buildSunoInput(modelId, params);
+      const taskId = await submitSuno(apiKey, meta.sunoEndpoint, input);
+      const { pollInterval, maxAttempts } = this.sunoPollConfig(
+        meta.pollInterval,
+        meta.maxAttempts,
+        params.timeoutSeconds
+      );
+      const record = await pollSuno(apiKey, taskId, pollInterval, maxAttempts);
+      const bytes = await this.downloadSunoAudio(record);
+      return { data: bytes, mimeType: sniffAudioMime(bytes) };
+    }
+
+    // Fallback: a music model that doesn't route through Suno.
     const input: Record<string, unknown> = { prompt: params.prompt };
     if (params.lyrics) input.lyrics = params.lyrics;
     if (params.durationSeconds != null) {
       input.duration = Math.round(params.durationSeconds);
     }
-
-    const modelId = params.model.id;
-    log.debug("Kie textToMusic", { model: modelId });
-    const apiKey = this.requireApiKey();
+    const { pollInterval, maxAttempts } = this.pollConfig(
+      modelId,
+      params.timeoutSeconds
+    );
     const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
     const bytes = await downloadResultBytes(apiKey, taskId);
     return { data: bytes, mimeType: sniffAudioMime(bytes) };
+  }
+
+  /** Poll interval/attempts for a Suno task, honoring a per-call timeout. */
+  private sunoPollConfig(
+    metaPollInterval: number | undefined,
+    metaMaxAttempts: number | undefined,
+    timeoutSeconds?: number | null
+  ): { pollInterval: number; maxAttempts: number } {
+    const pollInterval = metaPollInterval ?? 4000;
+    if (timeoutSeconds != null && timeoutSeconds > 0) {
+      return {
+        pollInterval,
+        maxAttempts: Math.max(1, Math.ceil((timeoutSeconds * 1000) / pollInterval))
+      };
+    }
+    return { pollInterval, maxAttempts: metaMaxAttempts ?? 120 };
+  }
+
+  /**
+   * Build the Suno submit body from the model's manifest fields. `generate-music`
+   * distinguishes custom mode (lyrics supplied → prompt = lyrics, style = the
+   * description) from non-custom mode (KIE auto-generates lyrics from the
+   * prompt). Required fields with a usable default (e.g. `model`) are filled.
+   */
+  private buildSunoInput(
+    modelId: string,
+    params: TextToMusicParams
+  ): Record<string, unknown> {
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
+    const has = (name: string) => this.declaresField(fields, name);
+    const input: Record<string, unknown> = {};
+
+    if (params.lyrics && has("customMode") && has("style")) {
+      input.customMode = true;
+      input.prompt = params.lyrics;
+      input.style = params.prompt;
+      if (has("instrumental")) input.instrumental = false;
+    } else {
+      if (has("customMode")) input.customMode = false;
+      input.prompt = params.prompt;
+    }
+
+    for (const f of fields) {
+      if (f.required && input[f.name] === undefined) {
+        const d = defaultForField(f);
+        if (d !== undefined) input[f.name] = d;
+      }
+    }
+    return input;
+  }
+
+  /** Download the first audio track from a Suno record-info response. */
+  private async downloadSunoAudio(
+    record: Record<string, unknown>
+  ): Promise<Uint8Array> {
+    const response = (record.data as Record<string, unknown>)?.response as
+      | Record<string, unknown>
+      | undefined;
+    const sunoData = response?.sunoData as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const audioUrl = sunoData?.[0]?.audioUrl as string | undefined;
+    if (!audioUrl) throw new Error("No audioUrl in Kie Suno response");
+    const dlRes = await safeFetch(audioUrl);
+    if (!dlRes.ok) {
+      throw new Error(`Failed to download from ${audioUrl}`);
+    }
+    return new Uint8Array(await dlRes.arrayBuffer());
   }
 
   /**
@@ -494,8 +824,9 @@ export class KieProvider extends BaseProvider {
 
     log.debug("Kie textToSpeech", { model: args.model });
     const apiKey = this.requireApiKey();
+    const { pollInterval, maxAttempts } = this.pollConfig(args.model);
     const taskId = await submitTask(apiKey, args.model, input);
-    await pollUntilDone(apiKey, taskId);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
     const bytes = await downloadResultBytes(apiKey, taskId);
     return { data: bytes, mimeType: sniffAudioMime(bytes) };
   }
@@ -503,31 +834,134 @@ export class KieProvider extends BaseProvider {
   override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
     if (!params.prompt) throw new Error("Prompt is required");
 
+    const modelId = params.model.id;
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
     const input: Record<string, unknown> = { prompt: params.prompt };
     if (params.aspectRatio) input.aspect_ratio = params.aspectRatio;
-    if (params.numFrames) {
-      input.duration = Math.ceil(params.numFrames / 24);
-    }
+    this.applyVideoDuration(input, fields, params);
 
-    const modelId = params.model.id;
     log.debug("Kie textToVideo", { model: modelId });
+    const apiKey = this.requireApiKey();
+    const { pollInterval, maxAttempts } = this.pollConfig(
+      modelId,
+      params.timeoutSeconds
+    );
+    const taskId = await submitTask(apiKey, modelId, input);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    return downloadResultBytes(apiKey, taskId);
+  }
 
-    const taskId = await submitTask(this.requireApiKey(), modelId, input);
-    await pollUntilDone(this.requireApiKey(), taskId);
-    return downloadResultBytes(this.requireApiKey(), taskId);
+  /**
+   * Set the request `duration` from the caller's requested seconds (preferring
+   * `durationSeconds`, falling back to `numFrames`/24), coerced to the model's
+   * declared field type. A declared schema with no `duration` field sends
+   * nothing; an unknown model keeps the historical numeric behavior.
+   */
+  private applyVideoDuration(
+    input: Record<string, unknown>,
+    fields: ModelInputField[],
+    params: { durationSeconds?: number | null; numFrames?: number | null }
+  ): void {
+    const seconds =
+      params.durationSeconds != null
+        ? params.durationSeconds
+        : params.numFrames != null
+          ? params.numFrames / 24
+          : undefined;
+    if (seconds == null) return;
+
+    if (fields.length === 0) {
+      // Unknown model: derive a plain integer as before (ceil for a frame count,
+      // round for an explicit second count).
+      input.duration =
+        params.durationSeconds != null ? Math.round(seconds) : Math.ceil(seconds);
+      return;
+    }
+    const durationField = fields.find((f) => f.name === "duration");
+    if (!durationField) return;
+    input.duration = coerceDuration(durationField, seconds);
   }
 
   override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
-    const input: Record<string, unknown> = { prompt: params.prompt };
-    if (params.width) input.width = params.width;
-    if (params.height) input.height = params.height;
+    if (!params.prompt) throw new Error("Prompt is required");
 
     const modelId = params.model.id;
-    log.debug("Kie textToImage", { model: modelId });
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
+    const input: Record<string, unknown> = { prompt: params.prompt };
 
-    const taskId = await submitTask(this.requireApiKey(), modelId, input);
-    await pollUntilDone(this.requireApiKey(), taskId);
-    return downloadResultBytes(this.requireApiKey(), taskId);
+    // Schema-driven: only send fields the model declares. No KIE model declares
+    // width/height, so those are never sent — an aspect ratio is derived instead.
+    if (params.negativePrompt && this.declaresField(fields, "negative_prompt")) {
+      input.negative_prompt = params.negativePrompt;
+    }
+    if (params.seed != null && this.declaresField(fields, "seed")) {
+      input.seed = params.seed;
+    }
+    this.applyTextToImageAspect(input, fields, params);
+
+    log.debug("Kie textToImage", { model: modelId });
+    const apiKey = this.requireApiKey();
+    const { pollInterval, maxAttempts } = this.pollConfig(modelId);
+    const taskId = await submitTask(apiKey, modelId, input);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    return downloadResultBytes(apiKey, taskId);
+  }
+
+  /**
+   * Set `aspect_ratio` when the model declares it: pass a caller-supplied ratio
+   * through if it's a declared enum value (else snap to the nearest), or derive
+   * the nearest declared ratio from width/height when no ratio was given.
+   */
+  private applyTextToImageAspect(
+    input: Record<string, unknown>,
+    fields: ModelInputField[],
+    params: TextToImageParams
+  ): void {
+    const field = fields.find((f) => f.name === "aspect_ratio");
+    if (!field) return;
+    const enumValues = field.enumValues;
+
+    if (params.aspectRatio) {
+      if (enumValues && enumValues.length > 0) {
+        input.aspect_ratio = enumValues.includes(params.aspectRatio)
+          ? params.aspectRatio
+          : nearestAspect(enumValues, aspectToNumber(params.aspectRatio) ?? 1);
+      } else {
+        input.aspect_ratio = params.aspectRatio;
+      }
+      return;
+    }
+    if (params.width && params.height && enumValues && enumValues.length > 0) {
+      input.aspect_ratio = nearestAspect(enumValues, params.width / params.height);
+    }
+  }
+
+  /**
+   * Set the request's `negative_prompt` / `aspect_ratio` / `seed` from the
+   * caller only when the model declares them. Unknown models (empty schema)
+   * keep the historical behavior: send whatever the caller supplied under the
+   * conventional names.
+   */
+  private applyEditOptions(
+    input: Record<string, unknown>,
+    fields: ModelInputField[],
+    params: {
+      negativePrompt?: string | null;
+      aspectRatio?: string | null;
+      seed?: number | null;
+    }
+  ): void {
+    const declaredOrUnknown = (name: string) =>
+      fields.length === 0 || this.declaresField(fields, name);
+    if (params.negativePrompt && declaredOrUnknown("negative_prompt")) {
+      input.negative_prompt = params.negativePrompt;
+    }
+    if (params.aspectRatio && declaredOrUnknown("aspect_ratio")) {
+      input.aspect_ratio = params.aspectRatio;
+    }
+    if (params.seed != null && declaredOrUnknown("seed")) {
+      input.seed = params.seed;
+    }
   }
 
   /**
@@ -546,18 +980,19 @@ export class KieProvider extends BaseProvider {
       throw new Error("The input image is empty.");
     }
 
+    const modelId = params.model.id;
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
     const input: Record<string, unknown> = {
       prompt: params.prompt,
-      ...this.imageInput(params.model.id, imageUrls)
+      ...this.imageInput(modelId, imageUrls)
     };
-    if (params.negativePrompt) input.negative_prompt = params.negativePrompt;
-    if (params.aspectRatio) input.aspect_ratio = params.aspectRatio;
+    this.applyEditOptions(input, fields, params);
 
-    const modelId = params.model.id;
     log.debug("Kie imageToImage", { model: modelId, images: imageUrls.length });
 
+    const { pollInterval, maxAttempts } = this.pollConfig(modelId);
     const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 
@@ -577,29 +1012,30 @@ export class KieProvider extends BaseProvider {
       throw new Error("The input image is empty.");
     }
 
+    const modelId = params.model.id;
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
     const input: Record<string, unknown> = {
       prompt: params.prompt,
-      ...this.imageInput(params.model.id, imageUrls)
+      ...this.imageInput(modelId, imageUrls)
     };
-    if (params.negativePrompt) input.negative_prompt = params.negativePrompt;
-    if (params.aspectRatio) input.aspect_ratio = params.aspectRatio;
+    this.applyEditOptions(input, fields, params);
 
     if (params.mask && params.mask.length > 0) {
       const [maskUrl] = await this.uploadImages(apiKey, [params.mask]);
       if (maskUrl) {
         const maskField = selectMaskImageInput(
-          getModelImageInputs(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, params.model.id)
+          getModelImageInputs(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId)
         );
         const fieldName = maskField?.apiName ?? "mask_url";
         input[fieldName] = maskField?.isList ? [maskUrl] : maskUrl;
       }
     }
 
-    const modelId = params.model.id;
     log.debug("Kie inpaint", { model: modelId, images: imageUrls.length });
 
+    const { pollInterval, maxAttempts } = this.pollConfig(modelId);
     const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 
@@ -617,22 +1053,21 @@ export class KieProvider extends BaseProvider {
       throw new Error("The input image is empty.");
     }
 
-    const input: Record<string, unknown> = this.imageInput(
-      params.model.id,
-      imageUrls
-    );
-    if (params.prompt) input.prompt = params.prompt;
-    if (params.negativePrompt) input.negative_prompt = params.negativePrompt;
-    if (params.aspectRatio) input.aspect_ratio = params.aspectRatio;
-    if (params.durationSeconds) {
-      input.duration = Math.ceil(params.durationSeconds);
-    }
-
     const modelId = params.model.id;
+    const fields = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
+    const input: Record<string, unknown> = this.imageInput(modelId, imageUrls);
+    if (params.prompt) input.prompt = params.prompt;
+    this.applyEditOptions(input, fields, params);
+    this.applyVideoDuration(input, fields, params);
+
     log.debug("Kie imageToVideo", { model: modelId, images: imageUrls.length });
 
+    const { pollInterval, maxAttempts } = this.pollConfig(
+      modelId,
+      params.timeoutSeconds
+    );
     const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -29,6 +29,21 @@ interface ManifestInputField {
   enumValues?: string[];
 }
 
+/**
+ * Kie-style input field. The field `name` IS the API param name, `type` is a
+ * lowercase primitive ("str" | "enum" | "int" | "float" | "bool"), and enum
+ * options live in `values` (not `enumValues`).
+ */
+interface ManifestField {
+  name: string;
+  type: string;
+  values?: string[];
+  default?: unknown;
+  required?: boolean;
+  min?: number;
+  max?: number;
+}
+
 /** Kie-style asset upload descriptor (carries the real API param name). */
 interface ManifestUpload {
   field: string;
@@ -55,8 +70,18 @@ interface ManifestNode {
   supportedTasks?: string[];
   /** FAL ships per-endpoint input schemas; used to derive option constraints. */
   inputFields?: ManifestInputField[];
+  /** Kie ships per-endpoint input schemas under `fields` (name is the API param). */
+  fields?: ManifestField[];
   /** Kie ships asset upload descriptors (field → API param mapping). */
   uploads?: ManifestUpload[];
+  /** Kie: routes the model through the Suno music API. */
+  useSuno?: boolean;
+  /** Kie: Suno API endpoint path for this model. */
+  sunoEndpoint?: string;
+  /** Kie: poll interval (ms) while waiting on the async task. */
+  pollInterval?: number;
+  /** Kie: maximum poll attempts before giving up. */
+  maxAttempts?: number;
 }
 
 export function explicitTasks(n: ManifestNode): string[] | undefined {
@@ -65,17 +90,25 @@ export function explicitTasks(n: ManifestNode): string[] | undefined {
     : undefined;
 }
 
-/** Enum values declared for a manifest input field, by canonical API name. */
+/**
+ * Enum values declared for a manifest input field, by canonical API name.
+ * Reads both the FAL/Replicate `inputFields` (`apiParamName ?? name` →
+ * `enumValues`) and the Kie `fields` (`name` → `values`) conventions.
+ */
 export function enumValuesFor(
   n: ManifestNode,
   apiName: string
 ): string[] | undefined {
   // Stryker disable next-line ArrayDeclaration: the fallback's contents are irrelevant — a non-array node yields no matching field either way.
-  const field = (n.inputFields ?? []).find(
+  const inputField = (n.inputFields ?? []).find(
     (f) => (f.apiParamName ?? f.name) === apiName
   );
-  const values = field?.enumValues;
-  return values && values.length > 0 ? values : undefined;
+  const fromInput = inputField?.enumValues;
+  if (fromInput && fromInput.length > 0) return fromInput;
+  // Stryker disable next-line ArrayDeclaration: same rationale — a non-array node yields no matching field either way.
+  const field = (n.fields ?? []).find((f) => f.name === apiName);
+  const fromField = field?.values;
+  return fromField && fromField.length > 0 ? fromField : undefined;
 }
 
 /** Option constraints (duration/resolution/aspect) for a video endpoint. */
@@ -348,6 +381,84 @@ export function manifestEntryImageInputs(
     }));
 }
 
+/** A model's declared input field, normalized across manifest conventions. */
+export interface ModelInputField {
+  /** API parameter name to set on the request body. */
+  name: string;
+  /** Declared type: "str" | "enum" | "int" | "float" | "bool" | ... (lowercased). */
+  type: string;
+  enumValues?: string[];
+  required?: boolean;
+  default?: unknown;
+}
+
+/**
+ * The input fields a model declares, normalized across manifest conventions.
+ * Kie `fields` (where `name` is the API param and options live in `values`) take
+ * precedence; otherwise the FAL/Replicate `inputFields` are normalized
+ * (`apiParamName ?? name`, `propType` lowercased, `enumValues`).
+ */
+export function getModelInputFields(
+  packageName: string,
+  exportPath: string,
+  modelId: string
+): ModelInputField[] {
+  const entry = loadManifest(packageName, exportPath).find(
+    (n) => nodeId(n) === modelId
+  );
+  if (!entry) return [];
+  if (entry.fields?.length) {
+    return entry.fields.map((f) => ({
+      name: f.name,
+      type: f.type.toLowerCase(),
+      ...(f.values && f.values.length > 0 ? { enumValues: f.values } : {}),
+      ...(f.required !== undefined ? { required: f.required } : {}),
+      ...(f.default !== undefined ? { default: f.default } : {})
+    }));
+  }
+  return (entry.inputFields ?? []).map((f) => ({
+    name: f.apiParamName ?? f.name,
+    type: f.propType.toLowerCase(),
+    ...(f.enumValues && f.enumValues.length > 0
+      ? { enumValues: f.enumValues }
+      : {})
+  }));
+}
+
+/** Kie execution metadata carried on a manifest entry. */
+export interface ManifestNodeMeta {
+  useSuno: boolean;
+  sunoEndpoint?: string;
+  pollInterval?: number;
+  maxAttempts?: number;
+}
+
+/**
+ * Kie execution metadata for a model, or undefined when the model id is unknown.
+ */
+export function getManifestNodeMeta(
+  packageName: string,
+  exportPath: string,
+  modelId: string
+): ManifestNodeMeta | undefined {
+  const entry = loadManifest(packageName, exportPath).find(
+    (n) => nodeId(n) === modelId
+  );
+  if (!entry) return undefined;
+  return {
+    useSuno: Boolean(entry.useSuno),
+    ...(entry.sunoEndpoint !== undefined
+      ? { sunoEndpoint: entry.sunoEndpoint }
+      : {}),
+    ...(entry.pollInterval !== undefined
+      ? { pollInterval: entry.pollInterval }
+      : {}),
+    ...(entry.maxAttempts !== undefined
+      ? { maxAttempts: entry.maxAttempts }
+      : {})
+  };
+}
+
 // Auxiliary image inputs (mask / control / reference / style / end-frame, …)
 // must never receive the primary source image in a generic request.
 const AUXILIARY_IMAGE_RE =
@@ -535,16 +646,48 @@ const MUSIC_KEYWORDS = [
   "flux-music"
 ];
 
+// Kie Suno ships many audio endpoints, but only a few generate music from a
+// text prompt — the rest transform existing audio or tasks (referenced by
+// upload / task / audio / music ids) or output text (lyrics). A required field
+// whose name references such an existing asset marks a transform, not a
+// generator.
+const AUDIO_ASSET_REF_RE =
+  // Stryker disable next-line Regex: heuristic alternation over Suno field names; the exact-boundary variants are interchangeable for the real manifest names, and the predicate is pinned by a test against the real manifest.
+  /upload|task_?id|audio_?id|music_?id|verify|voice_?url/i;
+
+/**
+ * Is this Kie-style entry a text-to-music generator? True only when it declares
+ * a free-form `prompt`, selects a generation `model`, and requires no field
+ * that references an existing audio asset or task. On the current Kie manifest
+ * this yields exactly {generate-music, generate-sounds}; every Suno utility
+ * (covers, extends, mashups, vocal splits, lyric/voice tools) is rejected.
+ */
+export function isKieMusicNode(n: ManifestNode): boolean {
+  const fields = n.fields ?? [];
+  const hasPrompt = fields.some((f) => f.name === "prompt");
+  const hasModel = fields.some((f) => f.name === "model");
+  const requiresAsset = fields.some(
+    (f) => f.required === true && AUDIO_ASSET_REF_RE.test(f.name)
+  );
+  return hasPrompt && hasModel && !requiresAsset;
+}
+
 /**
  * Is this manifest entry a music-generation model? Music endpoints emit audio
- * but are neither speech (TTS) nor speech-to-text. FAL groups them under
- * `moduleName: "text_to_audio"`; other manifests have no grouping, so fall back
- * to an explicit `text_to_music` task or a music keyword in the id/name. The
- * `outputType === "audio"` and `!isTTSNode` guards keep speech models out.
+ * but are neither speech (TTS) nor speech-to-text. Kie-style entries (those that
+ * carry a `fields` schema or route through Suno) are judged structurally by
+ * `isKieMusicNode` — keyword matching over-tags Suno's utility endpoints. FAL
+ * groups its music under `moduleName: "text_to_audio"`; other manifests have no
+ * grouping, so fall back to an explicit `text_to_music` task or a music keyword
+ * in the id/name. The `outputType === "audio"` and `!isTTSNode` guards keep
+ * speech models out.
  */
 export function isMusicNode(n: ManifestNode): boolean {
   if (n.outputType !== "audio") return false;
   if (isTTSNode(n)) return false;
+  if (Array.isArray(n.fields) || n.useSuno === true) {
+    return isKieMusicNode(n);
+  }
   if (n.moduleName === "text_to_audio") return true;
   if (explicitTasks(n)?.includes("text_to_music")) return true;
   const hay = `${nodeId(n)} ${nodeName(n)}`.toLowerCase();

--- a/packages/runtime/tests/providers/anthropic-provider.test.ts
+++ b/packages/runtime/tests/providers/anthropic-provider.test.ts
@@ -24,6 +24,20 @@ describe("AnthropicProvider", () => {
     expect(await provider.hasToolSupport("claude-sonnet")).toBe(true);
   });
 
+  it("defaults provider to anthropic and honors the providerId option", () => {
+    const base = new AnthropicProvider(
+      { ANTHROPIC_API_KEY: "k" },
+      { client: {} as any }
+    );
+    expect(base.provider).toBe("anthropic");
+
+    const gateway = new AnthropicProvider(
+      { ANTHROPIC_API_KEY: "k" },
+      { client: {} as any, providerId: "kie" }
+    );
+    expect(gateway.provider).toBe("kie");
+  });
+
   it("formats tools with Anthropic schema preparation", () => {
     const provider = new AnthropicProvider(
       { ANTHROPIC_API_KEY: "k" },

--- a/packages/runtime/tests/providers/kie-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/kie-provider-coverage.test.ts
@@ -61,7 +61,6 @@ vi.mock("../../src/providers/anthropic-provider.js", () => ({
 vi.mock("openai", () => ({
   default: class {
     responses = { create: h.responsesCreate };
-    constructor(_opts?: unknown) {}
   }
 }));
 
@@ -72,7 +71,8 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
     ok,
     status,
-    json: async () => body
+    json: async () => body,
+    text: async () => JSON.stringify(body)
   } as unknown as Response;
 }
 
@@ -386,22 +386,68 @@ describe("KieProvider — requireApiKey", () => {
 });
 
 describe("KieProvider — textToImage", () => {
-  it("submits width and height and returns the downloaded bytes", async () => {
+  it("sends only declared fields and derives aspect ratio from width/height", async () => {
     const { createdInputs } = mockKieFlow();
     const p = new KieProvider({ KIE_API_KEY: "k" });
+    // google/imagen4 declares prompt, negative_prompt, aspect_ratio, seed.
     const params: TextToImageParams = {
       prompt: "a fox",
-      width: 512,
-      height: 768,
-      model: { id: "flux/schnell", name: "Flux", provider: "kie" }
+      width: 1920,
+      height: 1080,
+      negativePrompt: "blurry",
+      seed: 42,
+      model: { id: "google/imagen4", name: "Imagen 4", provider: "kie" }
     };
     const bytes = await p.textToImage(params);
     expect(bytes).toEqual(new Uint8Array([7, 7, 7]));
     expect(createdInputs[0]).toMatchObject({
       prompt: "a fox",
-      width: 512,
-      height: 768
+      negative_prompt: "blurry",
+      seed: 42,
+      // 1920:1080 = 16:9, the nearest declared enum ratio.
+      aspect_ratio: "16:9"
     });
+    expect(createdInputs[0].width).toBeUndefined();
+    expect(createdInputs[0].height).toBeUndefined();
+  });
+
+  it("passes a declared aspect ratio through and never sends width/height", async () => {
+    const { createdInputs } = mockKieFlow();
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await p.textToImage({
+      prompt: "a fox",
+      aspectRatio: "3:4",
+      width: 100,
+      height: 100,
+      model: { id: "google/imagen4", name: "Imagen 4", provider: "kie" }
+    });
+    expect(createdInputs[0].aspect_ratio).toBe("3:4");
+    expect(createdInputs[0].width).toBeUndefined();
+    expect(createdInputs[0].height).toBeUndefined();
+  });
+
+  it("sends only the prompt for an unknown model", async () => {
+    const { createdInputs } = mockKieFlow();
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await p.textToImage({
+      prompt: "x",
+      width: 512,
+      height: 512,
+      negativePrompt: "no",
+      model: { id: "flux/schnell", name: "Flux", provider: "kie" }
+    });
+    expect(createdInputs[0]).toEqual({ prompt: "x" });
+  });
+
+  it("throws when the prompt is missing", async () => {
+    mockKieFlow();
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(
+      p.textToImage({
+        prompt: "",
+        model: { id: "google/imagen4", name: "Imagen 4", provider: "kie" }
+      })
+    ).rejects.toThrow("Prompt is required");
   });
 });
 
@@ -436,36 +482,200 @@ describe("KieProvider — textToVideo", () => {
   });
 });
 
-describe("KieProvider — textToMusic", () => {
-  it("submits lyrics and rounded duration, returns encoded audio", async () => {
+interface SunoFlowOptions {
+  status?: string;
+  audioBytes?: Uint8Array;
+}
+
+/**
+ * Routes the Suno music flow (submit → generate/record-info → audio download).
+ * generate-music/generate-sounds submit to `/api/v1/generate[/sounds]` and poll
+ * `/api/v1/generate/record-info`; the submit path is a prefix of the poll path,
+ * so match record-info first. Captures the submit URL + body.
+ */
+function mockSunoFlow(opts: SunoFlowOptions = {}) {
+  const submitted: Array<Record<string, unknown>> = [];
+  const submitUrls: string[] = [];
+  const audio = opts.audioBytes ?? new Uint8Array([0xff, 0xfb, 0x90, 0x00]);
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("/generate/record-info")) {
+      return jsonResponse({
+        data: {
+          status: opts.status ?? "SUCCESS",
+          response: { sunoData: [{ audioUrl: "https://kie.suno/out.mp3" }] }
+        }
+      });
+    }
+    if (u.includes("/api/v1/generate")) {
+      submitUrls.push(u);
+      submitted.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return jsonResponse({ data: { taskId: "suno-1" } });
+    }
+    return {
+      ok: true,
+      headers: new Headers(),
+      arrayBuffer: async () => audio.buffer
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, submitted, submitUrls };
+}
+
+describe("KieProvider — textToMusic (Suno)", () => {
+  it("submits non-custom mode with the prompt and a filled model default", async () => {
     const mp3 = new Uint8Array([0xff, 0xfb, 0x90, 0x00]);
-    const { createdInputs } = mockKieFlow({ downloadBytes: mp3 });
+    const { submitted, submitUrls } = mockSunoFlow({ audioBytes: mp3 });
     const p = new KieProvider({ KIE_API_KEY: "k" });
     const params: TextToMusicParams = {
-      prompt: "lofi beat",
-      lyrics: "la la la",
-      durationSeconds: 30.6,
-      model: { id: "suno/v5", name: "Suno", provider: "kie" }
+      prompt: "a calm piano tune",
+      model: { id: "generate-music", name: "Generate Music", provider: "kie" }
     };
     const result = await p.textToMusic(params);
     expect(result.mimeType).toBe("audio/mpeg");
     expect(result.data).toEqual(mp3);
-    expect(createdInputs[0]).toMatchObject({
-      prompt: "lofi beat",
-      lyrics: "la la la",
-      duration: 31
+    // Suno submit, not the generic jobs createTask endpoint.
+    expect(submitUrls[0]).toContain("/api/v1/generate");
+    expect(submitUrls[0]).not.toContain("/jobs/createTask");
+    expect(submitted[0]).toMatchObject({
+      prompt: "a calm piano tune",
+      customMode: false,
+      instrumental: false,
+      model: "V4",
+      callBackUrl: "https://nodetool.ai/kie-callback"
     });
   });
 
+  it("uses custom mode when lyrics are supplied", async () => {
+    const { submitted } = mockSunoFlow();
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await p.textToMusic({
+      prompt: "jazzy, upbeat",
+      lyrics: "la la la",
+      model: { id: "generate-music", name: "Generate Music", provider: "kie" }
+    });
+    expect(submitted[0]).toMatchObject({
+      customMode: true,
+      prompt: "la la la",
+      style: "jazzy, upbeat",
+      instrumental: false,
+      model: "V4"
+    });
+  });
+
+  it("routes generate-sounds to its own Suno endpoint", async () => {
+    const { submitted, submitUrls } = mockSunoFlow();
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await p.textToMusic({
+      prompt: "rain on a window",
+      model: { id: "generate-sounds", name: "Generate Sounds", provider: "kie" }
+    });
+    expect(submitUrls[0]).toContain("/api/v1/generate/sounds");
+    expect(submitted[0]).toMatchObject({
+      prompt: "rain on a window",
+      model: "V5"
+    });
+  });
+
+  it("fails fast on a terminal failure status", async () => {
+    mockSunoFlow({ status: "SENSITIVE_WORD_ERROR" });
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(
+      p.textToMusic({
+        prompt: "x",
+        model: { id: "generate-music", name: "Generate Music", provider: "kie" }
+      })
+    ).rejects.toThrow("SENSITIVE_WORD_ERROR");
+  });
+
   it("throws when the prompt is missing", async () => {
-    mockKieFlow();
+    mockSunoFlow();
     const p = new KieProvider({ KIE_API_KEY: "k" });
     await expect(
       p.textToMusic({
         prompt: "",
-        model: { id: "suno/v5", name: "Suno", provider: "kie" }
+        model: { id: "generate-music", name: "Generate Music", provider: "kie" }
       })
     ).rejects.toThrow("Prompt is required");
+  });
+});
+
+describe("KieProvider — HTTP-200 error envelope", () => {
+  const imageModel = {
+    id: "flux/schnell",
+    name: "Flux",
+    provider: "kie" as const
+  };
+
+  it("surfaces a code envelope returned by createTask", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/jobs/createTask")) {
+        return jsonResponse({ code: 402, msg: "no credits" });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(
+      p.textToImage({ prompt: "x", model: imageModel })
+    ).rejects.toThrow("Insufficient Credits");
+  });
+
+  it("fails fast on a code envelope returned while polling", async () => {
+    let recordCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/jobs/createTask")) {
+        return jsonResponse({ data: { taskId: "t" } });
+      }
+      if (u.includes("/jobs/recordInfo")) {
+        recordCalls += 1;
+        return jsonResponse({ code: 500, msg: "boom" });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(
+      p.textToImage({ prompt: "x", model: imageModel })
+    ).rejects.toThrow("Server Error");
+    // One poll, then immediate failure — not a full-timeout hang.
+    expect(recordCalls).toBe(1);
+  });
+});
+
+describe("KieProvider — timeoutSeconds bounds poll attempts", () => {
+  it("derives max attempts from timeoutSeconds and the model poll interval", async () => {
+    vi.useFakeTimers();
+    let recordCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/jobs/createTask")) {
+        return jsonResponse({ data: { taskId: "t" } });
+      }
+      if (u.includes("/jobs/recordInfo")) {
+        recordCalls += 1;
+        return jsonResponse({ data: { state: "processing" } });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = new KieProvider({ KIE_API_KEY: "k" });
+    // kling declares pollInterval 8000ms → ceil(20000 / 8000) = 3 attempts.
+    const promise = p.textToVideo({
+      prompt: "x",
+      timeoutSeconds: 20,
+      model: {
+        id: "kling/v2-1-master-image-to-video",
+        name: "Kling",
+        provider: "kie"
+      }
+    });
+    const assertion = expect(promise).rejects.toThrow("timed out");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(recordCalls).toBe(3);
+    vi.useRealTimers();
   });
 });
 

--- a/packages/runtime/tests/providers/kie-provider.test.ts
+++ b/packages/runtime/tests/providers/kie-provider.test.ts
@@ -49,7 +49,8 @@ function jsonResponse(body: unknown): Response {
   return {
     ok: true,
     status: 200,
-    json: async () => body
+    json: async () => body,
+    text: async () => JSON.stringify(body)
   } as unknown as Response;
 }
 
@@ -162,7 +163,26 @@ describe("KieProvider — imageToVideo", () => {
     expect(result).toEqual(new Uint8Array([7, 7, 7]));
     expect(createdInputs[0].image_url).toBe("https://kie.cdn/frame.png");
     expect(createdInputs[0].prompt).toBe("pan left");
-    expect(createdInputs[0].duration).toBe(5);
+    // kling declares `duration` as an enum of strings — 5s snaps to "5".
+    expect(createdInputs[0].duration).toBe("5");
+  });
+
+  it("snaps a durationSeconds request to the nearest declared enum value", async () => {
+    const { createdInputs } = mockKieFlow(["https://kie.cdn/frame.png"]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+
+    // kling declares duration enum ["5","10"]; 7s is closer to 5.
+    await provider.imageToVideo([new Uint8Array([9])], {
+      model: {
+        id: "kling/v2-1-master-image-to-video",
+        name: "Kling",
+        provider: "kie"
+      },
+      prompt: "pan",
+      durationSeconds: 7
+    });
+
+    expect(createdInputs[0].duration).toBe("5");
   });
 });
 

--- a/packages/runtime/tests/providers/manifest-models.test.ts
+++ b/packages/runtime/tests/providers/manifest-models.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   buildMusicModels,
   buildTTSModels,
+  getManifestNodeMeta,
+  getModelInputFields,
+  isKieMusicNode,
   loadImageModels,
   loadMusicModels,
   loadTTSModels,
@@ -10,6 +13,8 @@ import {
 
 const FAL_PKG = "@nodetool-ai/fal-nodes";
 const FAL_MANIFEST = "fal-manifest.json";
+const KIE_PKG = "@nodetool-ai/kie-nodes";
+const KIE_MANIFEST = "kie-manifest.json";
 
 describe("manifest-models task inference (FAL manifest)", () => {
   const images = loadImageModels(FAL_PKG, FAL_MANIFEST, "fal_ai");
@@ -259,6 +264,153 @@ describe("manifest-models music discovery", () => {
     expect(
       models.every((m) => m.supportedTasks?.includes("text_to_music"))
     ).toBe(true);
+  });
+});
+
+describe("manifest-models Kie `fields` schema support", () => {
+  it("extracts TTS preset voices from a Kie enum `voice` field", () => {
+    const tts = loadTTSModels(KIE_PKG, KIE_MANIFEST, "kie");
+    const multilingual = tts.find(
+      (m) => m.id === "elevenlabs/text-to-speech-multilingual-v2"
+    );
+    expect(multilingual?.voices?.length ?? 0).toBeGreaterThan(10);
+    // A free-form-voice model (voice not required) still lists preset voices.
+    const turbo = tts.find(
+      (m) => m.id === "elevenlabs/text-to-speech-turbo-2-5"
+    );
+    expect(turbo?.voices?.length ?? 0).toBeGreaterThan(10);
+  });
+
+  it("derives video durations from a Kie enum `duration` field", () => {
+    const videos = loadVideoModels(KIE_PKG, KIE_MANIFEST, "kie");
+    const kling = videos.find(
+      (m) => m.id === "kling/v2-1-master-image-to-video"
+    );
+    expect(kling?.durations).toEqual([5, 10]);
+  });
+
+  it("derives image aspect ratios from a Kie enum `aspect_ratio` field", () => {
+    const images = loadImageModels(KIE_PKG, KIE_MANIFEST, "kie");
+    const imagen = images.find((m) => m.id === "google/imagen4");
+    expect(imagen?.aspectRatios).toEqual([
+      "1:1",
+      "16:9",
+      "9:16",
+      "3:4",
+      "4:3"
+    ]);
+  });
+});
+
+describe("getModelInputFields", () => {
+  it("normalizes Kie `fields` (name is the API param, options in `values`)", () => {
+    const fields = getModelInputFields(
+      KIE_PKG,
+      KIE_MANIFEST,
+      "google/imagen4"
+    );
+    const aspect = fields.find((f) => f.name === "aspect_ratio");
+    expect(aspect?.type).toBe("enum");
+    expect(aspect?.enumValues).toContain("16:9");
+    const prompt = fields.find((f) => f.name === "prompt");
+    expect(prompt?.type).toBe("str");
+    expect(prompt?.required).toBe(true);
+  });
+
+  it("normalizes FAL `inputFields` (apiParamName, lowercased propType)", () => {
+    const fields = getModelInputFields(FAL_PKG, FAL_MANIFEST, "fal-ai/dia-tts");
+    expect(fields.length).toBeGreaterThan(0);
+    for (const f of fields) {
+      expect(f.type).toBe(f.type.toLowerCase());
+    }
+  });
+
+  it("returns [] for an unknown model id", () => {
+    expect(getModelInputFields(KIE_PKG, KIE_MANIFEST, "nope/nope")).toEqual([]);
+  });
+});
+
+describe("getManifestNodeMeta", () => {
+  it("reads useSuno / sunoEndpoint / poll settings from the manifest", () => {
+    const meta = getManifestNodeMeta(KIE_PKG, KIE_MANIFEST, "generate-music");
+    expect(meta?.useSuno).toBe(true);
+    expect(meta?.sunoEndpoint).toBe("/api/v1/generate");
+    expect(typeof meta?.pollInterval).toBe("number");
+    expect(typeof meta?.maxAttempts).toBe("number");
+  });
+
+  it("reports useSuno false for a plain (non-Suno) Kie model", () => {
+    const meta = getManifestNodeMeta(KIE_PKG, KIE_MANIFEST, "google/imagen4");
+    expect(meta?.useSuno).toBe(false);
+  });
+
+  it("returns undefined for an unknown model id", () => {
+    expect(
+      getManifestNodeMeta(KIE_PKG, KIE_MANIFEST, "nope/nope")
+    ).toBeUndefined();
+  });
+});
+
+describe("Kie music filter (isKieMusicNode)", () => {
+  it("yields exactly {generate-music, generate-sounds} from the real manifest", () => {
+    const music = loadMusicModels(KIE_PKG, KIE_MANIFEST, "kie");
+    expect(music.map((m) => m.id).sort()).toEqual([
+      "generate-music",
+      "generate-sounds"
+    ]);
+    expect(
+      music.every((m) => m.supportedTasks?.includes("text_to_music"))
+    ).toBe(true);
+  });
+
+  it("accepts a prompt+model generator with no asset-referencing required field", () => {
+    expect(
+      isKieMusicNode({
+        modelId: "generate-music",
+        outputType: "audio",
+        fields: [
+          { name: "prompt", type: "str", required: true },
+          { name: "model", type: "str", required: true }
+        ]
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a generator that requires an existing audio asset", () => {
+    expect(
+      isKieMusicNode({
+        modelId: "extend-music",
+        outputType: "audio",
+        fields: [
+          { name: "prompt", type: "str", required: true },
+          { name: "model", type: "str", required: true },
+          { name: "audioId", type: "str", required: true }
+        ]
+      })
+    ).toBe(false);
+  });
+
+  it("rejects a lyrics endpoint (prompt but no model field)", () => {
+    expect(
+      isKieMusicNode({
+        modelId: "generate-lyrics",
+        outputType: "audio",
+        fields: [{ name: "prompt", type: "str", required: true }]
+      })
+    ).toBe(false);
+  });
+
+  it("rejects a task-only utility (no prompt field)", () => {
+    expect(
+      isKieMusicNode({
+        modelId: "separate-vocals",
+        outputType: "audio",
+        fields: [
+          { name: "taskId", type: "str", required: true },
+          { name: "audioId", type: "str", required: true }
+        ]
+      })
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Overhauls the KIE provider to support the Suno music generation API, implement schema-driven input handling across all endpoints, and add robust error detection for HTTP-200 error envelopes and gateway failures.

## Key Changes

**Suno Music API Support**
- Added `submitSuno()` and `pollSuno()` functions to route music generation through Suno's separate submit/record-info endpoints
- `textToMusic()` now detects Suno-routed models via manifest metadata (`useSuno`, `sunoEndpoint`) and submits with required `callBackUrl` placeholder
- Builds Suno input from manifest fields, supporting custom mode (lyrics → prompt, description → style) and auto-generated lyrics
- Suno polling recognizes terminal failure states (`SENSITIVE_WORD_ERROR`, `GENERATE_AUDIO_FAILED`, etc.) and fails fast

**Schema-Driven Input Handling**
- Added `getModelInputFields()` to normalize Kie `fields` (name is API param, options in `values`) and FAL `inputFields` (apiParamName, propType) into a unified `ModelInputField` interface
- `textToImage()` now only sends fields the model declares; derives aspect ratio from width/height using `nearestAspect()` instead of sending raw dimensions
- `textToVideo()` coerces duration to the model's declared field type (enum string, float, or int) via `coerceDuration()`
- `textToMusic()` fills required fields with defaults via `defaultForField()`

**Robust Error Handling**
- Added `parseKieJson()` to defensively parse responses: surfaces "Kie <label> failed: <status> …" errors on gateway 502s (HTML instead of JSON) and applies `checkStatus()` to every parsed body
- `checkStatus()` maps KIE's HTTP-200 error envelopes (`{code, msg}`) to human-readable messages (e.g., 402 → "Insufficient Credits", 501 → "Generation Failed")
- `pollUntilDone()` now fails fast on a single HTTP-200 error code (via parseKieJson) instead of silently retrying to full timeout
- Bounded consecutive HTTP error tracking: fails after 5 consecutive non-OK polls, not after full maxAttempts

**Image Format Detection & Polling Configuration**
- Added `sniffImageType()` to detect image containers from magic bytes (PNG, JPEG, WebP, GIF); upload now sends correct mime/extension instead of always PNG
- Added `pollConfig()` and `sunoPollConfig()` to resolve poll interval and max attempts from manifest metadata, honoring per-call `timeoutSeconds` override
- Extracted `sleep()` helper for cleaner async delays

**Provider ID Propagation**
- `makeOpenAIProvider()` and `makeAnthropicProvider()` now pass `providerId: "kie"` in options instead of mutating the provider object post-construction
- Updated `AnthropicProvider` to accept optional `providerId` in constructor options

**Manifest Schema Extensions**
- Added `ManifestField` interface for Kie's field schema (name, type, values, default, required, min, max)
- Extended `ManifestNode` with `fields`, `useSuno`, `sunoEndpoint`, `pollInterval`, `maxAttempts`
- Added `getManifestNodeMeta()` to extract Kie execution metadata
- Added `isKieMusicNode()` predicate to filter text-to-music generators (requires prompt + model, no asset-referencing required fields)
- Updated `enumValuesFor()` to read both FAL `inputFields` and Kie `fields` conventions

## Notable Implementation Details

- Aspect ratio matching uses numeric comparison (`Math.abs(n - target)`) to snap requested dimensions to declared enum values
- Duration coercion handles three cases: enum (snap to nearest numeric value), float (pass through), int/other (round)
- Suno polling defaults to 120 attempts (vs. 300 for generic jobs), reflecting faster typical completion
- Image upload now sniffs container type from magic bytes to avoid K

https://claude.ai/code/session_01SS8aUCx4Vyqsdmj92fXnK7