### PR TITLE
feat(atlascloud): add 28 more models from the current catalog

### DIFF
--- a/packages/atlascloud-nodes/src/atlascloud-manifest.json
+++ b/packages/atlascloud-nodes/src/atlascloud-manifest.json
@@ -3013,5 +3013,1967 @@
         ]
       }
     ]
+  },
+  {
+    "className": "Wan27TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.7/text-to-video",
+    "outputType": "video",
+    "title": "Wan 2.7 \u2014 Text to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 generates video from text with multi-shot narrative, audio generation, and sound-image synchronization.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the video content. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Text describing elements to exclude from the video. Maximum length is 500 characters."
+      },
+      {
+        "name": "audio",
+        "type": "audio",
+        "default": null,
+        "title": "Audio (optional)",
+        "description": "URL of an audio file to use as the video soundtrack. Supported formats: wav, mp3. Duration: 2\u201330 seconds. Maximum file size: 15 MB. The alias `audio_url` is also accepted."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "Output video resolution. 720P and 1080P are native Wan 2.7 outputs. Choose 1080P-SR for sharper HD detail, cleaner edges, and better texture retention. For the same duration, 1080P\u2026",
+        "values": [
+          "720P",
+          "1080P",
+          "1080P-SR",
+          "1440P-SR"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video duration in seconds. Longer duration increases cost.",
+        "min": 2,
+        "max": 15
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Whether to use AI to enhance the prompt for better video quality. Increases generation time."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.7/image-to-video",
+    "outputType": "video",
+    "title": "Wan 2.7 \u2014 Image to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 animates images into video with first-frame, first-and-last-frame, video continuation, and audio-driven modes.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired video content. Maximum length is 5000 characters."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Text describing elements to exclude from the video. Maximum length is 500 characters."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First-frame image URL for image-based generation modes. The video starts from this image. Supported formats: JPEG, JPG, PNG (transparent channel not supported), BMP, WEBP. Width an\u2026"
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "Last-frame image URL for end-frame control. Use it with `image` to generate a start-to-end transition, or with `video` to continue a clip toward a target ending frame. Supported fo\u2026"
+      },
+      {
+        "name": "video",
+        "type": "video",
+        "default": null,
+        "title": "Video (optional)",
+        "description": "Video clip URL for video continuation modes. The model extends the content of this clip. `last_image` can be added for end-frame control. Supported formats: mp4, mov. Duration: 2\u20131\u2026"
+      },
+      {
+        "name": "audio",
+        "type": "audio",
+        "default": null,
+        "title": "Audio (optional)",
+        "description": "Driving audio URL for image-based generation modes. The model uses this audio to drive lip-sync or action-matched video generation. Supported only with `image`, or with `image` and\u2026"
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "Output video resolution. The video aspect ratio follows the input image or video. Higher resolution increases cost.",
+        "values": [
+          "720P",
+          "1080P"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video duration in seconds. Longer duration increases cost.",
+        "min": 2,
+        "max": 15
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Whether to use AI to enhance the prompt for better video quality. Increases generation time."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.7/text-to-image",
+    "outputType": "image",
+    "title": "Wan 2.7 \u2014 Text to Image",
+    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 fast text-to-image with strong prompt fidelity for illustration and photorealistic outputs.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt used to generate the image. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2K",
+        "title": "Size",
+        "description": "Output image resolution.",
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "thinking_mode",
+        "type": "bool",
+        "default": true,
+        "title": "Thinking Mode",
+        "description": "Whether to enable thinking mode for higher-quality image generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for image generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27ImageEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.7/image-edit",
+    "outputType": "image",
+    "title": "Wan 2.7 \u2014 Image Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 edits and recomposes images from text instructions with multi-image references.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text instruction used to edit the image. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Input images, each provided as a URL or Base64 string. The first image is treated as the primary input; subsequent images serve as references.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2K",
+        "title": "Size",
+        "description": "Output image resolution.",
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "thinking_mode",
+        "type": "bool",
+        "default": true,
+        "title": "Thinking Mode",
+        "description": "Whether to enable thinking mode for higher-quality image generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for image generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27ProTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.7-pro/text-to-image",
+    "outputType": "image",
+    "title": "Wan 2.7 Pro \u2014 Text to Image",
+    "description": "AtlasCloud / Alibaba Wan 2.7 Pro \u2014 higher-fidelity text-to-image with 4K-ready output.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt used to generate the image. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2K",
+        "title": "Size",
+        "description": "Output image resolution.",
+        "values": [
+          "1K",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "thinking_mode",
+        "type": "bool",
+        "default": true,
+        "title": "Thinking Mode",
+        "description": "Whether to enable thinking mode for higher-quality image generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for image generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27ProImageEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.7-pro/image-edit",
+    "outputType": "image",
+    "title": "Wan 2.7 Pro \u2014 Image Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.7 Pro \u2014 higher-quality image editing from text instructions with multi-image references.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text instruction used to edit the image. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Input images, each provided as a URL or Base64 string. The first image is treated as the primary input; subsequent images serve as references.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2K",
+        "title": "Size",
+        "description": "Output image resolution.",
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "thinking_mode",
+        "type": "bool",
+        "default": true,
+        "title": "Thinking Mode",
+        "description": "Whether to enable thinking mode for higher-quality image generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for image generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Veo31TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1/text-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 \u2014 Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 \u2014 cinematic text-to-video with dynamic camera motion, lifelike detail, and optional audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for generation; Positive text prompt.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the video.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation."
+      }
+    ]
+  },
+  {
+    "className": "Veo31ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1/image-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 \u2014 Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 \u2014 animates a first (and optional last) frame into cinematic video with realistic continuity and sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "The image to use for the generation.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "The end image for generating the output."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation."
+      }
+    ]
+  },
+  {
+    "className": "Veo31FastTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1-fast/text-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 Fast \u2014 Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Fast \u2014 speed-optimized text-to-video for rapid creative iteration.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for generation; Positive text prompt.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the video.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation."
+      }
+    ]
+  },
+  {
+    "className": "Veo31FastImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1-fast/image-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 Fast \u2014 Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Fast \u2014 speed-optimized image-to-video for fast previews and iteration.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "The image to use for the generation.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "The end image for generating the output."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation."
+      }
+    ]
+  },
+  {
+    "className": "Veo31LiteTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1-lite/text-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 Lite \u2014 Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Lite \u2014 cost-efficient text-to-video with synchronized audio at 720p/1080p.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description for the video. Supports audio cues (dialogue in quotes, SFX, ambience) per Veo prompt guidance.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "Length of the generated video in seconds. Must be 8 when using 1080p resolution.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution. 1080p only supports 8s duration. Veo 3.1 Lite does not support 4K.",
+        "values": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Veo31LiteImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1-lite/image-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 Lite \u2014 Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Lite \u2014 cost-efficient image-to-video with synchronized audio at 720p/1080p.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description for the video. Supports audio cues per Veo prompt guidance.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Initial image to animate (instance image). Accepts a public image URL, a data URL, or raw base64-encoded image bytes (e.g. PNG/JPEG inline data). Input image up to 8MB per Veo 3.1\u2026",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "Length of the generated video in seconds (durationSeconds). Must be 8 when using 1080p resolution.",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution. 1080p only supports 8s duration. Veo 3.1 Lite does not support 4K.",
+        "values": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "QwenImage2TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen/qwen-image-2.0/text-to-image",
+    "outputType": "image",
+    "title": "Qwen Image 2.0 \u2014 Text to Image",
+    "description": "AtlasCloud / Qwen Image 2.0 \u2014 text-to-image with enhanced quality and prompt understanding, up to 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired image, supports Chinese and English (max 800 characters)",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility (-1 for random, 0-2147483647 for specific seed)"
+      }
+    ]
+  },
+  {
+    "className": "QwenImage2Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen/qwen-image-2.0/edit",
+    "outputType": "image",
+    "title": "Qwen Image 2.0 \u2014 Edit",
+    "description": "AtlasCloud / Qwen Image 2.0 \u2014 instruction-driven image editing, up to 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Reference images for editing (1-6 images, 384-3072px each dimension)",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired edit, supports Chinese and English (max 800 characters)",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility (-1 for random, 0-2147483647 for specific seed)"
+      }
+    ]
+  },
+  {
+    "className": "QwenImage2ProTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen/qwen-image-2.0-pro/text-to-image",
+    "outputType": "image",
+    "title": "Qwen Image 2.0 Pro \u2014 Text to Image",
+    "description": "AtlasCloud / Qwen Image 2.0 Pro \u2014 professional-grade text-to-image with superior quality, up to 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired image, supports Chinese and English (max 800 characters)",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility (-1 for random, 0-2147483647 for specific seed)"
+      }
+    ]
+  },
+  {
+    "className": "QwenImage2ProEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen/qwen-image-2.0-pro/edit",
+    "outputType": "image",
+    "title": "Qwen Image 2.0 Pro \u2014 Edit",
+    "description": "AtlasCloud / Qwen Image 2.0 Pro \u2014 professional-grade image editing with advanced instruction understanding, up to 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Reference images for editing (1-6 images, 384-3072px each dimension)",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired edit, supports Chinese and English (max 800 characters)",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility (-1 for random, 0-2147483647 for specific seed)"
+      }
+    ]
+  },
+  {
+    "className": "SeedreamV5LiteTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "bytedance/seedream-v5.0-lite",
+    "outputType": "image",
+    "title": "Seedream v5.0 Lite \u2014 Text to Image",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite \u2014 next-generation text-to-image with enhanced typography and poster design.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation. Recommended length: under 600 English words.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2048*2048",
+        "title": "Size",
+        "description": "Output image size in 'WIDTH*HEIGHT' pixels. 16 preset resolutions at 2K and 3K tiers. Total pixel range: [3,686,400, 10,404,496]. Aspect ratio range: [1/16, 16].",
+        "values": [
+          "2048*2048",
+          "2304*1728",
+          "1728*2304",
+          "2848*1600",
+          "1600*2848",
+          "2496*1664",
+          "1664*2496",
+          "3136*1344",
+          "3072*3072",
+          "3456*2592",
+          "2592*3456",
+          "4096*2304",
+          "2304*4096",
+          "2496*3744",
+          "3744*2496",
+          "4704*2016"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "Output image file format. Seedream v5.0 Lite supports both JPEG and PNG output.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "SeedreamV5LiteEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "bytedance/seedream-v5.0-lite/edit",
+    "outputType": "image",
+    "title": "Seedream v5.0 Lite \u2014 Edit",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite \u2014 image editing that preserves facial features, lighting, and color tones.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation. Recommended length: under 600 English words.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "The images to edit. Accepts URLs or Base64 data URLs. A maximum of 14 reference images can be uploaded. Supported formats: JPEG, PNG, WEBP, BMP, TIFF, GIF.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2048*2048",
+        "title": "Size",
+        "description": "Output image size in 'WIDTH*HEIGHT' pixels. 16 preset resolutions at 2K and 3K tiers. Total pixel range: [3,686,400, 10,404,496]. Aspect ratio range: [1/16, 16].",
+        "values": [
+          "2048*2048",
+          "2304*1728",
+          "1728*2304",
+          "2848*1600",
+          "1600*2848",
+          "2496*1664",
+          "1664*2496",
+          "3136*1344",
+          "3072*3072",
+          "3456*2592",
+          "2592*3456",
+          "4096*2304",
+          "2304*4096",
+          "2496*3744",
+          "3744*2496",
+          "4704*2016"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "Output image file format. Seedream v5.0 Lite supports both JPEG and PNG output.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImageQualityTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image-quality/text-to-image",
+    "outputType": "image",
+    "title": "Grok Imagine Image Quality \u2014 Text to Image",
+    "description": "AtlasCloud / xAI Grok Imagine (Quality) \u2014 polished text-to-image at 1K or 2K with 13 aspect ratios.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "A collage of London landmarks in a stenciled street-art style.",
+        "title": "Prompt",
+        "description": "Natural-language description of the image to generate.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate. Each image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024 ($0.05/image), 2k = 2048x2048 ($0.07/image).",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImageQualityEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image-quality/edit",
+    "outputType": "image",
+    "title": "Grok Imagine Image Quality \u2014 Edit",
+    "description": "AtlasCloud / xAI Grok Imagine (Quality) \u2014 edits one or more reference images from natural-language instructions at 1K or 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "Render this as a pencil sketch with detailed shading.",
+        "title": "Prompt",
+        "description": "Editing instruction. For multi-image references, cite each input as <IMAGE_0>, <IMAGE_1>, ...",
+        "required": true
+      },
+      {
+        "name": "image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Source images. Each entry is either a public URL or a base64-encoded data URI (e.g. `data:image/png;base64,...`). At least one image is required; each input is billed at $0.01.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of edited images to generate. Each output image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the edited image. With a single source image, the output respects the input's aspect ratio regardless of this value. `auto` lets the model pick.",
+        "values": [
+          "auto",
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024 ($0.05/image), 2k = 2048x2048 ($0.07/image).",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineVideo15ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "xai/grok-imagine-video-v1.5/image-to-video",
+    "outputType": "video",
+    "title": "Grok Imagine Video v1.5 \u2014 Image to Video",
+    "description": "AtlasCloud / xAI Grok Imagine Video v1.5 \u2014 animates a starting frame with natural-language motion prompts at 480p/720p/1080p.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language motion prompt. The starting frame is taken from the image.",
+        "required": true
+      },
+      {
+        "name": "image_url",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Public HTTPS URL or base64 data URI of the starting-frame image (JPEG, PNG, or WebP).",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "Length of generated video in seconds. Range: 1\u201315.",
+        "min": 1,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution.",
+        "values": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Output aspect ratio. The default matches the input image; specifying a different value stretches the image.",
+        "values": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingV3ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-pro/text-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 Pro \u2014 Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro \u2014 premium text-to-video with multi-shot support and sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "CFG Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      }
+    ]
+  },
+  {
+    "className": "KlingV3ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-pro/image-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 Pro \u2014 Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro \u2014 premium image-to-video with first/end-frame control and sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation. Maximum 2,500 characters; longer prompts will fail Kling generation, including SR modes."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of\u2026",
+        "required": true
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "End Frame (optional)",
+        "description": "URL of the ending image."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "Native 1080P uses the original Kling v3.0 Pro route. 1440P-SR is a FlashVSR super-resolution mode generated from the native 1080P source.",
+        "values": [
+          "1080P",
+          "1440P-SR"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "CFG Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      }
+    ]
+  },
+  {
+    "className": "KlingV3StdTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-std/text-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 Std \u2014 Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard \u2014 high-quality text-to-video generation.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "CFG Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      }
+    ]
+  },
+  {
+    "className": "KlingV3StdImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-std/image-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 Std \u2014 Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard \u2014 high-quality image-to-video generation.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation. Maximum 2,500 characters; longer prompts will fail Kling generation, including SR modes."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of\u2026",
+        "required": true
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "End Frame (optional)",
+        "description": "URL of the ending image."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720P",
+        "title": "Resolution",
+        "description": "Native 720P uses the original Kling v3.0 Std route. 1080P-SR and 1440P-SR are FlashVSR super-resolution modes generated from the native 720P source.",
+        "values": [
+          "720P",
+          "1080P-SR",
+          "1440P-SR"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "CFG Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      }
+    ]
+  },
+  {
+    "className": "GPTImage15TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1.5/text-to-image",
+    "outputType": "image",
+    "title": "GPT Image 1.5 \u2014 Text to Image",
+    "description": "AtlasCloud / OpenAI GPT Image 1.5 \u2014 fast, cost-efficient text-to-image powered by GPT-5 guidance.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GPTImage15Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1.5/edit",
+    "outputType": "image",
+    "title": "GPT Image 1.5 \u2014 Edit",
+    "description": "AtlasCloud / OpenAI GPT Image 1.5 \u2014 precise natural-language image editing (add/remove objects, retouch, swap backgrounds, etc.).",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "The images to edit.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "input_fidelity",
+        "type": "enum",
+        "default": "high",
+        "title": "Input Fidelity",
+        "description": "input fidelity, which allows you to better preserve details from the input images in the output. This is especially useful when using images that contain elements like faces or log\u2026",
+        "values": [
+          "low",
+          "high"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "ZImageTurboTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "z-image/turbo",
+    "outputType": "image",
+    "title": "Z-Image Turbo \u2014 Text to Image",
+    "description": "AtlasCloud / Tongyi-MAI Z-Image Turbo \u2014 6B-parameter text-to-image generating photorealistic images in sub-second time.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": false,
+        "title": "Expand Prompt",
+        "description": "Supports intelligent prompt rewriting for better results."
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1536",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height)."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
   }
 ]

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -452,12 +452,15 @@ export class AtlasCloudProvider extends BaseProvider {
     }
     const info = this.resolveModel(params.model.id, "image");
     const input = mapImageParams(info, params);
-    // AtlasCloud `*/edit` endpoints accept the input image(s) as `images: [url]`.
-    // Seedance never goes through this method (it's video-only). Other future
-    // image-to-image endpoints that use `image` (singular) get that mapping too.
+    // AtlasCloud `*/edit` endpoints accept the input image(s) as `images: [url]`
+    // (Grok Imagine uses `image_urls`). Seedance never goes through this method
+    // (it's video-only). Other image-to-image endpoints that use `image`
+    // (singular) get that mapping too.
     const dataUris = sources.map((b) => imageDataUri(b));
     if (info.fields.has("images")) {
       input.images = dataUris;
+    } else if (info.fields.has("image_urls")) {
+      input.image_urls = dataUris;
     } else if (info.fields.has("image")) {
       input.image = dataUris[0];
     } else {
@@ -485,11 +488,14 @@ export class AtlasCloudProvider extends BaseProvider {
     }
     const info = this.resolveModel(params.model.id, "video");
     const input = mapVideoParams(info, params);
-    // Seedance image-to-video uses `image` (singular). Reference-to-video has
-    // `reference_images` (list) instead — generic imageToVideo can't target it.
+    // Seedance image-to-video uses `image` (singular); Grok Imagine Video uses
+    // `image_url`. Reference-to-video has `reference_images` (list) instead —
+    // generic imageToVideo can't target it.
     const dataUri = imageDataUri(image);
     if (info.fields.has("image")) {
       input.image = dataUri;
+    } else if (info.fields.has("image_url")) {
+      input.image_url = dataUri;
     } else if (info.fields.has("images")) {
       input.images = [dataUri];
     } else if (info.fields.has("reference_images")) {


### PR DESCRIPTION
Adds manifest entries (generated from AtlasCloud's published per-model
schemas) for: Wan 2.7 / 2.7 Pro (t2v, i2v, t2i, edit), Veo 3.1 /
Fast / Lite (t2v, i2v), Kling v3.0 Pro / Std (t2v, i2v), Qwen Image
2.0 / Pro (t2i, edit), Seedream v5.0 Lite (t2i, edit), GPT Image 1.5
(t2i, edit), Grok Imagine Image Quality (t2i, edit), Grok Imagine
Video v1.5 (i2v), and Z-Image Turbo (t2i).

The generic provider's imageToImage/imageToVideo now also map input
images onto the `image_urls`/`image_url` field names Grok Imagine
declares, so those models work from the model picker too.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pw8CsvUQxiN5fCUKnUV8mp