### PR TITLE
Fix xAI provider media parameter handling

### DIFF
--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -1,4 +1,3 @@
-import { OpenAIProvider } from "./openai-provider.js";
 import {
   OpenAICompatProvider,
   type OpenAICompatProviderOptions
@@ -32,6 +31,15 @@ function detectImageMime(bytes: Uint8Array): string {
     bytes[11] === 0x50
   ) {
     return "image/webp";
+  }
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
   }
   // PNG and everything else default to PNG — xAI accepts both jpeg and png.
   return "image/png";
@@ -124,8 +132,29 @@ export class XAIProvider extends OpenAICompatProvider {
     return true;
   }
 
-  /** Fetch and validate the rows from xAI's `/v1/models` listing. */
-  private async fetchModelRows(): Promise<XAIModelRow[]> {
+  private _modelRows: Promise<XAIModelRow[]> | null = null;
+
+  /**
+   * Fetch and validate the rows from xAI's `/v1/models` listing. The listing
+   * covers every modality, so the language/image/video getters share one
+   * request per instance. Empty results (bad key, transient failure) are not
+   * cached, so a fixed key recovers without a new provider instance.
+   */
+  private fetchModelRows(): Promise<XAIModelRow[]> {
+    this._modelRows ??= this.requestModelRows().then(
+      (rows) => {
+        if (rows.length === 0) this._modelRows = null;
+        return rows;
+      },
+      (error) => {
+        this._modelRows = null;
+        throw error;
+      }
+    );
+    return this._modelRows;
+  }
+
+  private async requestModelRows(): Promise<XAIModelRow[]> {
     const response = await this._xaiFetch(`${XAI_BASE_URL}/models`, {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
@@ -248,6 +277,11 @@ export class XAIProvider extends OpenAICompatProvider {
     if (sources.length === 0) {
       throw new Error("image must not be empty.");
     }
+    if (sources.length > 3) {
+      throw new Error(
+        `xAI image edits accept at most 3 source images, got ${sources.length}.`
+      );
+    }
     if (!params.prompt) {
       throw new Error("The input prompt cannot be empty.");
     }
@@ -272,6 +306,7 @@ export class XAIProvider extends OpenAICompatProvider {
     };
     // A single input image keeps its own aspect ratio; only override when asked.
     if (params.aspectRatio) request.aspect_ratio = params.aspectRatio;
+    if (params.resolution) request.resolution = params.resolution;
 
     const response = await this._xaiFetch(`${XAI_BASE_URL}/images/edits`, {
       method: "POST",
@@ -310,7 +345,9 @@ export class XAIProvider extends OpenAICompatProvider {
       throw new Error("xAI video create response did not contain a request_id");
     }
 
-    const timeoutMs = (timeoutSeconds ?? 600) * 1000;
+    // Non-positive timeouts mean "unset", not "expire immediately".
+    const timeoutMs =
+      (timeoutSeconds && timeoutSeconds > 0 ? timeoutSeconds : 600) * 1000;
     const intervalMs = 5000;
     const start = Date.now();
 
@@ -351,14 +388,22 @@ export class XAIProvider extends OpenAICompatProvider {
     }
   }
 
-  /** Map our duration/frame params onto xAI's `duration` (1–15 seconds). */
+  /**
+   * Map our duration/frame params onto xAI's `duration` (1–15 seconds).
+   * xAI takes any whole second in that range, so frame counts convert at an
+   * assumed 24fps rather than snapping to another provider's duration grid.
+   */
   private static resolveVideoDuration(params: {
     durationSeconds?: number | null;
     numFrames?: number | null;
   }): number | undefined {
     const seconds =
-      params.durationSeconds ?? OpenAIProvider.secondsFromParams(params);
-    if (!seconds || seconds <= 0) return undefined;
+      params.durationSeconds && params.durationSeconds > 0
+        ? params.durationSeconds
+        : params.numFrames && params.numFrames > 0
+          ? params.numFrames / 24
+          : undefined;
+    if (!seconds || !Number.isFinite(seconds)) return undefined;
     return Math.min(15, Math.max(1, Math.round(seconds)));
   }
 

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -145,6 +145,36 @@ describe("XAIProvider", () => {
     ]);
   });
 
+  it("shares one /v1/models request across the modality getters", async () => {
+    const mockFetch = mixedModelsFetch();
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.getAvailableLanguageModels();
+    await provider.getAvailableImageModels();
+    await provider.getAvailableVideoModels();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the model listing after a failed fetch instead of caching the empty result", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockImplementation(mixedModelsFetch());
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    expect(await provider.getAvailableLanguageModels()).toEqual([]);
+    const retried = await provider.getAvailableLanguageModels();
+    expect(retried.map((m) => m.id)).toEqual(["grok-4", "grok-3-mini"]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("returns empty image and video lists when model fetch fails", async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: false });
     const provider = new XAIProvider(
@@ -314,6 +344,57 @@ describe("XAIProvider", () => {
     expect(body.image).toHaveLength(2);
   });
 
+  it("forwards resolution on image-to-image edits", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(jsonOk({ data: [{ b64_json: "QQ==" }] }));
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.imageToImage([pngBytes], {
+      prompt: "upscale",
+      model: imageModel,
+      resolution: "1080p"
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.resolution).toBe("1080p");
+  });
+
+  it("rejects image-to-image with more than 3 source images", async () => {
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: vi.fn() as any }
+    );
+    await expect(
+      provider.imageToImage([pngBytes, pngBytes, pngBytes, pngBytes], {
+        prompt: "blend",
+        model: imageModel
+      })
+    ).rejects.toThrow("at most 3 source images");
+  });
+
+  it("labels GIF sources with the gif MIME in the data URI", async () => {
+    const gifBytes = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(jsonOk({ data: [{ b64_json: "QQ==" }] }));
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.imageToImage([gifBytes], {
+      prompt: "animate style",
+      model: imageModel
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.image.url).toMatch(/^data:image\/gif;base64,/);
+  });
+
   it("rejects image-to-image with no usable source", async () => {
     const provider = new XAIProvider(
       { XAI_API_KEY: "k" },
@@ -370,6 +451,87 @@ describe("XAIProvider", () => {
       resolution: "720p"
     });
     expect(mockFetch.mock.calls[1][0]).toBe("https://api.x.ai/v1/videos/req-1");
+  });
+
+  function videoDoneFetch() {
+    return vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk({ request_id: "req-d" }))
+      .mockResolvedValueOnce(
+        jsonOk({ status: "done", video: { url: "https://vid.x.ai/v.mp4" } })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode("mp4").buffer
+      });
+  }
+
+  it("derives video duration from numFrames at 24fps without Sora snapping", async () => {
+    const mockFetch = videoDoneFetch();
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    // 48 frames = 2 seconds; the old Sora-grid fallback inflated this to 4.
+    await provider.textToVideo({
+      prompt: "a fox",
+      model: videoModel,
+      numFrames: 48
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.duration).toBe(2);
+  });
+
+  it("clamps frame-derived durations to xAI's 15-second ceiling", async () => {
+    const mockFetch = videoDoneFetch();
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    await provider.textToVideo({
+      prompt: "a fox",
+      model: videoModel,
+      numFrames: 480
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.duration).toBe(15);
+  });
+
+  it("treats timeoutSeconds 0 as unset instead of expiring immediately", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk({ request_id: "req-t" }))
+      .mockResolvedValueOnce(jsonOk({ status: "pending" }))
+      .mockResolvedValueOnce(jsonOk({ status: "pending" }))
+      .mockResolvedValueOnce(
+        jsonOk({ status: "done", video: { url: "https://vid.x.ai/v.mp4" } })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode("mp4").buffer
+      });
+    const provider = new XAIProvider(
+      { XAI_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    vi.useFakeTimers();
+    try {
+      const pending = provider.textToVideo({
+        prompt: "a fox",
+        model: videoModel,
+        timeoutSeconds: 0
+      });
+      await vi.runAllTimersAsync();
+      const bytes = await pending;
+      expect(Buffer.from(bytes).toString()).toBe("mp4");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("attaches the source frame for image-to-video", async () => {


### PR DESCRIPTION
- Derive video duration from numFrames at 24fps instead of routing
  through OpenAI's Sora duration grid, which inflated 2s requests to 4s
  and capped 13-15s requests at 12s.
- Forward the resolution param on image-to-image edits (every other
  media method already sent it).
- Treat timeoutSeconds 0 as unset instead of expiring the video poll
  loop immediately.
- Cache the /v1/models listing per instance so enumerating language,
  image, and video models makes one request instead of three; empty
  results are not cached so a fixed API key recovers.
- Label GIF sources with image/gif in data URIs instead of image/png.
- Reject image edits with more than the 3 source images xAI accepts,
  with a clear client-side error.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016QuCeQaevzezj6qwmBFyux