### PR TITLE
Move Moonshot (Kimi) provider to the OpenAI-compatible endpoint and fix provider bugs

### DIFF
--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -837,7 +837,11 @@ export class AnthropicProvider extends BaseProvider {
       // server tool — the search runs server-side and its result blocks stream
       // back within the same turn (our stream parser ignores them), so the
       // model answers from live web data without a client round-trip.
-      if (tool.name === WEB_SEARCH_TOOL_NAME) {
+      // Gated on supportsNativeWebSearch: subclasses that reuse the Anthropic
+      // SDK against a different endpoint (e.g. Moonshot/Kimi) don't implement
+      // this server tool, so for them the tool falls through to the plain
+      // function-tool shape below and runs client-side via SerpAPI.
+      if (tool.name === WEB_SEARCH_TOOL_NAME && this.supportsNativeWebSearch) {
         return {
           type: "web_search_20250305",
           name: WEB_SEARCH_TOOL_NAME,

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -319,9 +319,9 @@ export class AnthropicProvider extends BaseProvider {
   /**
    * Anthropic runs web search server-side via the `web_search_20250305` server
    * tool. Gate on the provider id so subclasses that reuse the Anthropic SDK
-   * against a different endpoint (e.g. Moonshot/Kimi, which does not implement
-   * that server tool) fall back to the SerpAPI WebSearchTool instead of sending
-   * an unsupported tool that silently breaks web search.
+   * against a different endpoint (gateways that don't implement that server
+   * tool) fall back to the SerpAPI WebSearchTool instead of sending an
+   * unsupported tool that silently breaks web search.
    */
   override get supportsNativeWebSearch(): boolean {
     return this.provider === "anthropic";
@@ -838,9 +838,9 @@ export class AnthropicProvider extends BaseProvider {
       // back within the same turn (our stream parser ignores them), so the
       // model answers from live web data without a client round-trip.
       // Gated on supportsNativeWebSearch: subclasses that reuse the Anthropic
-      // SDK against a different endpoint (e.g. Moonshot/Kimi) don't implement
-      // this server tool, so for them the tool falls through to the plain
-      // function-tool shape below and runs client-side via SerpAPI.
+      // SDK against a different endpoint don't implement this server tool, so
+      // for them the tool falls through to the plain function-tool shape below
+      // and runs client-side via SerpAPI.
       if (tool.name === WEB_SEARCH_TOOL_NAME && this.supportsNativeWebSearch) {
         return {
           type: "web_search_20250305",

--- a/packages/runtime/src/providers/cost-calculator.ts
+++ b/packages/runtime/src/providers/cost-calculator.ts
@@ -157,7 +157,9 @@ const GENAI_PROVIDER_MAP: Record<string, string> = {
   groq: "groq",
   deepseek: "deepseek",
   xai: "x-ai",
-  grok: "x-ai"
+  grok: "x-ai",
+  moonshot: "moonshotai",
+  moonshotai: "moonshotai"
 };
 // Stryker restore all
 

--- a/packages/runtime/src/providers/moonshot-provider.ts
+++ b/packages/runtime/src/providers/moonshot-provider.ts
@@ -1,61 +1,78 @@
-import Anthropic from "@anthropic-ai/sdk";
-import { AnthropicProvider } from "./anthropic-provider.js";
+import {
+  OpenAICompatProvider,
+  type OpenAICompatProviderOptions
+} from "./openai-compat-provider.js";
 import { PROVIDER_IDS, type LanguageModel } from "./types.js";
 
-const MOONSHOT_BASE_URL = "https://api.kimi.com/coding";
-
-interface MoonshotProviderOptions {
-  client?: Anthropic;
-  clientFactory?: (apiKey: string) => Anthropic;
-  fetchFn?: typeof fetch;
-}
+const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
 
 /**
- * Moonshot AI (Kimi) provider. Uses the Anthropic SDK against Moonshot's
- * Claude-compatible endpoint exposed to Kimi coding plan subscribers at
- * https://api.kimi.com/coding.
+ * Moonshot AI (Kimi) provider. Speaks the OpenAI Chat Completions dialect
+ * against Moonshot's OpenAI-compatible endpoint at https://api.moonshot.ai/v1.
+ * Covers the Kimi K2 model family.
  */
-export class MoonshotProvider extends AnthropicProvider {
+export class MoonshotProvider extends OpenAICompatProvider {
   static override requiredSecrets(): string[] {
     return ["KIMI_API_KEY"];
   }
 
+  private _moonshotFetch: typeof fetch;
+
   constructor(
     secrets: { KIMI_API_KEY?: string },
-    options: MoonshotProviderOptions = {}
+    options: OpenAICompatProviderOptions = {}
   ) {
     const apiKey = secrets.KIMI_API_KEY;
     if (!apiKey || !apiKey.trim()) {
       throw new Error("KIMI_API_KEY is not configured");
     }
 
+    const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+
     super(
-      { ANTHROPIC_API_KEY: apiKey },
       {
-        client: options.client,
-        clientFactory:
-          options.clientFactory ??
-          ((key) =>
-            new Anthropic({
-              apiKey: key,
-              baseURL: MOONSHOT_BASE_URL
-            })),
-        fetchFn: options.fetchFn,
-        providerId: PROVIDER_IDS.MOONSHOT
-      }
+        providerId: PROVIDER_IDS.MOONSHOT,
+        apiKey: apiKey.trim(),
+        baseURL: MOONSHOT_BASE_URL
+      },
+      { ...options, fetchFn }
     );
+
+    this._moonshotFetch = fetchFn;
   }
 
   override getContainerEnv(): Record<string, string> {
-    return {
-      KIMI_API_KEY: this.apiKey,
-      ANTHROPIC_API_KEY: this.apiKey,
-      ANTHROPIC_BASE_URL: MOONSHOT_BASE_URL
-    };
+    return { KIMI_API_KEY: this.apiKey };
+  }
+
+  override async hasToolSupport(_model: string): Promise<boolean> {
+    return true;
   }
 
   override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
-    const knownModels = ["kimi-k2.5", "kimi-k2.6", "kimi-k2.7"];
-    return knownModels.map((id) => ({ id, name: id, provider: "moonshot" }));
+    const response = await this._moonshotFetch(`${MOONSHOT_BASE_URL}/models`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string }>;
+    };
+    const rows = payload.data ?? [];
+    return rows
+      .filter(
+        (row): row is { id: string } =>
+          typeof row.id === "string" && row.id.length > 0
+      )
+      .map((row) => ({
+        id: row.id,
+        name: row.id,
+        provider: PROVIDER_IDS.MOONSHOT
+      }));
   }
 }

--- a/packages/runtime/src/providers/moonshot-provider.ts
+++ b/packages/runtime/src/providers/moonshot-provider.ts
@@ -1,6 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { AnthropicProvider } from "./anthropic-provider.js";
-import type { LanguageModel } from "./types.js";
+import { PROVIDER_IDS, type LanguageModel } from "./types.js";
 
 const MOONSHOT_BASE_URL = "https://api.kimi.com/coding";
 
@@ -40,22 +40,18 @@ export class MoonshotProvider extends AnthropicProvider {
               apiKey: key,
               baseURL: MOONSHOT_BASE_URL
             })),
-        fetchFn: options.fetchFn
+        fetchFn: options.fetchFn,
+        providerId: PROVIDER_IDS.MOONSHOT
       }
     );
-
-    (this as { provider: string }).provider = "moonshot";
   }
 
   override getContainerEnv(): Record<string, string> {
     return {
       KIMI_API_KEY: this.apiKey,
+      ANTHROPIC_API_KEY: this.apiKey,
       ANTHROPIC_BASE_URL: MOONSHOT_BASE_URL
     };
-  }
-
-  override async hasToolSupport(_model: string): Promise<boolean> {
-    return true;
   }
 
   override async getAvailableLanguageModels(): Promise<LanguageModel[]> {

--- a/packages/runtime/tests/providers/anthropic-provider.test.ts
+++ b/packages/runtime/tests/providers/anthropic-provider.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AnthropicProvider } from "../../src/providers/anthropic-provider.js";
-import { MoonshotProvider } from "../../src/providers/moonshot-provider.js";
 import type Anthropic from "@anthropic-ai/sdk";
 import type { Message, ProviderTool } from "../../src/providers/types.js";
 
@@ -105,10 +104,13 @@ describe("AnthropicProvider", () => {
     expect(formatted[1].input_schema).toBeDefined();
   });
 
-  it("renders web_search as a plain function tool for subclasses without native web search (Moonshot)", () => {
-    const provider = new MoonshotProvider(
-      { KIMI_API_KEY: "k" },
-      { client: {} as unknown as Anthropic }
+  it("renders web_search as a plain function tool for Anthropic-compatible gateways without native web search", () => {
+    // Subclasses pointed at a non-Anthropic endpoint pass their own providerId;
+    // supportsNativeWebSearch is false for them, so formatTools must not emit
+    // the web_search_20250305 server tool.
+    const provider = new AnthropicProvider(
+      { ANTHROPIC_API_KEY: "k" },
+      { client: {} as unknown as Anthropic, providerId: "moonshot" }
     );
     expect(provider.supportsNativeWebSearch).toBe(false);
 

--- a/packages/runtime/tests/providers/anthropic-provider.test.ts
+++ b/packages/runtime/tests/providers/anthropic-provider.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AnthropicProvider } from "../../src/providers/anthropic-provider.js";
+import { MoonshotProvider } from "../../src/providers/moonshot-provider.js";
+import type Anthropic from "@anthropic-ai/sdk";
 import type { Message, ProviderTool } from "../../src/providers/types.js";
 
 function makeAsyncIterable(items: unknown[]) {
@@ -101,6 +103,25 @@ describe("AnthropicProvider", () => {
     // Other tools are still normal function tools.
     expect(formatted[1].name).toBe("extract");
     expect(formatted[1].input_schema).toBeDefined();
+  });
+
+  it("renders web_search as a plain function tool for subclasses without native web search (Moonshot)", () => {
+    const provider = new MoonshotProvider(
+      { KIMI_API_KEY: "k" },
+      { client: {} as unknown as Anthropic }
+    );
+    expect(provider.supportsNativeWebSearch).toBe(false);
+
+    const tools: ProviderTool[] = [
+      { name: "web_search", description: "Search the web", inputSchema: { type: "object", properties: {} } }
+    ];
+    const formatted = provider.formatTools(tools);
+    expect(formatted[0]).toEqual({
+      name: "web_search",
+      description: "Search the web",
+      input_schema: { type: "object", additionalProperties: false, properties: {} }
+    });
+    expect(formatted[0].type).toBeUndefined();
   });
 
   it("converts tool and assistant messages", async () => {

--- a/packages/runtime/tests/providers/cost-calculator.test.ts
+++ b/packages/runtime/tests/providers/cost-calculator.test.ts
@@ -86,6 +86,15 @@ describe("CostCalculator.calculate – token pricing via genai-prices (USD)", ()
     expect(cost).toBeGreaterThan(0);
   });
 
+  it("prices Moonshot/Kimi models (provider id maps to genai-prices 'moonshotai')", () => {
+    const cost = CostCalculator.calculate(
+      "kimi-k2.5",
+      { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      "moonshot"
+    );
+    expect(cost).toBeGreaterThan(0);
+  });
+
   it("prices embeddings", () => {
     const cost = CostCalculator.calculate(
       "text-embedding-3-small",

--- a/packages/runtime/tests/providers/moonshot-provider-hardening.test.ts
+++ b/packages/runtime/tests/providers/moonshot-provider-hardening.test.ts
@@ -1,7 +1,8 @@
 /**
- * Mutation-hardening for the Moonshot (Kimi) provider — an Anthropic-SDK
- * subclass pointed at Moonshot's Claude-compatible endpoint. Pins the
- * whitespace-key rejection and the default client baseURL. See MUTATION_TESTING.md.
+ * Mutation-hardening for the Moonshot (Kimi) provider — an OpenAI-compat
+ * subclass pointed at Moonshot's OpenAI-compatible endpoint. Pins the
+ * whitespace-key rejection, key trimming, and the default client baseURL.
+ * See MUTATION_TESTING.md.
  */
 import { describe, it, expect } from "vitest";
 import { MoonshotProvider } from "../../src/providers/moonshot-provider.js";
@@ -13,8 +14,13 @@ describe("MoonshotProvider hardening", () => {
     );
   });
 
-  it("builds an Anthropic client at the Moonshot base URL by default", () => {
+  it("trims surrounding whitespace off the API key", () => {
+    const p = new MoonshotProvider({ KIMI_API_KEY: "  k  " });
+    expect(p.apiKey).toBe("k");
+  });
+
+  it("builds an OpenAI SDK client at the Moonshot base URL by default", () => {
     const p = new MoonshotProvider({ KIMI_API_KEY: "k" });
-    expect(p.getClient().baseURL).toBe("https://api.kimi.com/coding");
+    expect(p.getClient().baseURL).toBe("https://api.moonshot.ai/v1");
   });
 });

--- a/packages/runtime/tests/providers/moonshot-provider.test.ts
+++ b/packages/runtime/tests/providers/moonshot-provider.test.ts
@@ -1,98 +1,132 @@
 import { describe, it, expect, vi } from "vitest";
 import { MoonshotProvider } from "../../src/providers/moonshot-provider.js";
+import type { Message } from "../../src/providers/types.js";
+import {
+  chatJsonResponse,
+  chatSSEResponse,
+  mockChatFetch
+} from "./helpers/compat-fetch.js";
 
 describe("MoonshotProvider", () => {
   it("reports required secrets and container env", () => {
-    const provider = new MoonshotProvider(
-      { KIMI_API_KEY: "k" },
-      { client: {} as any }
-    );
+    const provider = new MoonshotProvider({ KIMI_API_KEY: "k" });
 
     expect(MoonshotProvider.requiredSecrets()).toEqual(["KIMI_API_KEY"]);
-    expect(provider.getContainerEnv()).toEqual({
-      KIMI_API_KEY: "k",
-      ANTHROPIC_API_KEY: "k",
-      ANTHROPIC_BASE_URL: "https://api.kimi.com/coding"
-    });
-    expect((provider as unknown as { provider: string }).provider).toBe(
-      "moonshot"
-    );
+    expect(provider.getContainerEnv()).toEqual({ KIMI_API_KEY: "k" });
+    expect(provider.provider).toBe("moonshot");
   });
 
   it("does not claim native web search (#21)", () => {
-    // Kimi's Claude-compatible endpoint does not implement Anthropic's
-    // web_search_20250305 server tool, so it must fall back to the SerpAPI
-    // WebSearchTool rather than sending an unsupported server tool.
-    const provider = new MoonshotProvider(
-      { KIMI_API_KEY: "k" },
-      { client: {} as any }
-    );
+    // Moonshot's $web_search builtin exists only as an OpenAI builtin_function
+    // (and is flagged unstable upstream); it is not wired here, so web search
+    // must fall back to the SerpAPI WebSearchTool.
+    const provider = new MoonshotProvider({ KIMI_API_KEY: "k" });
     expect(provider.supportsNativeWebSearch).toBe(false);
   });
 
   it("throws when KIMI_API_KEY is missing", () => {
-    expect(() => new MoonshotProvider({}, { client: {} as any })).toThrow(
+    expect(() => new MoonshotProvider({})).toThrow(
       "KIMI_API_KEY is not configured"
     );
   });
 
-  it("uses custom clientFactory with Kimi baseURL", () => {
-    const clientFactory = vi.fn().mockReturnValue({ messages: { create: vi.fn() } });
-    const provider = new MoonshotProvider(
-      { KIMI_API_KEY: "kimi-key" },
-      { clientFactory }
-    );
-
-    // Force lazy client creation
-    provider.getClient();
-    expect(clientFactory).toHaveBeenCalledWith("kimi-key");
-  });
-
   it("reports tool support for kimi models", async () => {
-    const provider = new MoonshotProvider(
-      { KIMI_API_KEY: "k" },
-      { client: {} as any }
-    );
+    const provider = new MoonshotProvider({ KIMI_API_KEY: "k" });
     expect(await provider.hasToolSupport("kimi-k2.5")).toBe(true);
   });
 
-  it("returns known Kimi models", async () => {
+  it("fetches available language models from the Moonshot endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "kimi-k2.5" }, { id: "kimi-k2-turbo-preview" }]
+      })
+    });
+
     const provider = new MoonshotProvider(
       { KIMI_API_KEY: "k" },
-      { client: {} as any }
+      { fetchFn: mockFetch as unknown as typeof fetch }
     );
+
     const models = await provider.getAvailableLanguageModels();
-    expect(models.length).toBeGreaterThan(0);
-    for (const model of models) {
-      expect(model.provider).toBe("moonshot");
-      expect(model.id).toMatch(/^kimi-/);
-    }
+    expect(models).toEqual([
+      { id: "kimi-k2.5", name: "kimi-k2.5", provider: "moonshot" },
+      {
+        id: "kimi-k2-turbo-preview",
+        name: "kimi-k2-turbo-preview",
+        provider: "moonshot"
+      }
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.moonshot.ai/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer k" }
+      })
+    );
   });
 
-  it("generates messages through the underlying Anthropic client", async () => {
-    const create = vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "hello from kimi" }]
-    });
+  it("returns empty list when model fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    const provider = new MoonshotProvider(
+      { KIMI_API_KEY: "k" },
+      { fetchFn: mockFetch as unknown as typeof fetch }
+    );
+
+    expect(await provider.getAvailableLanguageModels()).toEqual([]);
+  });
+
+  it("generates non-streaming message via the compat chat client", async () => {
+    const fetchMock = mockChatFetch(
+      chatJsonResponse({
+        choices: [
+          {
+            message: {
+              content: "hello from kimi",
+              tool_calls: null
+            }
+          }
+        ]
+      })
+    );
 
     const provider = new MoonshotProvider(
       { KIMI_API_KEY: "k" },
-      {
-        client: {
-          messages: { create }
-        } as any
-      }
+      { fetchFn: fetchMock as unknown as typeof fetch }
     );
 
-    await expect(
-      provider.generateMessage({
-        model: "kimi-k2.5",
-        messages: [{ role: "user", content: "hi" }]
-      })
-    ).resolves.toEqual({
-      role: "assistant",
-      content: "hello from kimi",
-      toolCalls: []
+    const messages: Message[] = [{ role: "user", content: "hi" }];
+    const result = await provider.generateMessage({
+      messages,
+      model: "kimi-k2.5"
     });
-    expect(create).toHaveBeenCalledTimes(1);
+
+    expect(result.role).toBe("assistant");
+    expect(result.content).toBe("hello from kimi");
+  });
+
+  it("streams messages via the compat chat client", async () => {
+    const chunks = [
+      { choices: [{ delta: { content: "hello" }, finish_reason: null }] },
+      { choices: [{ delta: { content: "" }, finish_reason: "stop" }] }
+    ];
+
+    const fetchMock = mockChatFetch(() => chatSSEResponse(chunks));
+
+    const provider = new MoonshotProvider(
+      { KIMI_API_KEY: "k" },
+      { fetchFn: fetchMock as unknown as typeof fetch }
+    );
+
+    const messages: Message[] = [{ role: "user", content: "hi" }];
+    const items: unknown[] = [];
+    for await (const item of provider.generateMessages({
+      messages,
+      model: "kimi-k2.5"
+    })) {
+      items.push(item);
+    }
+
+    expect(items.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/runtime/tests/providers/moonshot-provider.test.ts
+++ b/packages/runtime/tests/providers/moonshot-provider.test.ts
@@ -11,6 +11,7 @@ describe("MoonshotProvider", () => {
     expect(MoonshotProvider.requiredSecrets()).toEqual(["KIMI_API_KEY"]);
     expect(provider.getContainerEnv()).toEqual({
       KIMI_API_KEY: "k",
+      ANTHROPIC_API_KEY: "k",
       ANTHROPIC_BASE_URL: "https://api.kimi.com/coding"
     });
     expect((provider as unknown as { provider: string }).provider).toBe(

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -277,7 +277,7 @@ sec(
 sec(
   "KIMI_API_KEY",
   "Kimi",
-  "Kimi (Moonshot) API key for accessing Kimi models via the Claude-compatible endpoint. Get yours at https://platform.moonshot.cn/console/api-keys"
+  "Kimi (Moonshot) API key for accessing Kimi models via the OpenAI-compatible endpoint. Get yours at https://platform.moonshot.ai/console/api-keys"
 );
 sec(
   "MINIMAX_API_KEY",


### PR DESCRIPTION
## Summary

Two stages of work on the Moonshot (Kimi) provider:

### 1. Bug fixes (while it was still an Anthropic-SDK subclass)

- **Web search was broken on Moonshot**: `AnthropicProvider.formatTools` converted any tool named `web_search` into Anthropic's `web_search_20250305` server tool unconditionally, even for subclasses whose endpoint doesn't implement it. The conversion is now gated on `supportsNativeWebSearch`, so gateways without native search fall through to a plain function tool served by the SerpAPI `WebSearchTool`. Regression test included.
- **Cost tracking**: mapped the `moonshot` provider id to genai-prices' `moonshotai` catalog id, so Kimi cost lookups are provider-scoped instead of relying on the global model-name fallback. Test pins nonzero cost for `kimi-k2.5`.
- Cleanups: pass `providerId` through the base constructor instead of mutating the readonly `provider` field via a cast; drop a dead `hasToolSupport` override.

### 2. Conversion to the OpenAI-compatible endpoint

`MoonshotProvider` now extends `OpenAICompatProvider` (same base as DeepSeek/Groq) and speaks the OpenAI Chat Completions dialect against `https://api.moonshot.ai/v1`, replacing the Anthropic-SDK subclass pointed at the subscription-gated `api.kimi.com/coding` gateway.

- Model discovery queries `/v1/models` live instead of a hardcoded model list.
- Unchanged: provider id `moonshot`, the `KIMI_API_KEY` secret (existing stored keys keep working), and the SerpAPI web-search fallback (`supportsNativeWebSearch` stays false — Moonshot's native `$web_search` builtin is flagged unstable upstream and deliberately not wired).
- `getContainerEnv` exports just `KIMI_API_KEY` (the `ANTHROPIC_*` vars no longer apply).
- The `formatTools` web-search gate from stage 1 keeps its regression coverage via an `AnthropicProvider` constructed with a non-anthropic `providerId`.
- Provider tests rewritten against the compat chat client (streaming, non-streaming, model fetch, failure fallback); hardening pins updated (base URL, whitespace-key rejection, key trimming); `KIMI_API_KEY` settings description now names the OpenAI-compatible endpoint and `platform.moonshot.ai` console.

## Testing

- `packages/runtime` full suite: 2267/2267 passing
- `packages/cli` provider-resolution tests: 38/38 passing
- `tsc --noEmit` clean on `packages/runtime` and `packages/websocket`
- Lint: no new errors (the test rewrite removed 6 pre-existing `no-explicit-any` violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjUfcGtAsFWeRCJRyKieQn