### PR TITLE
Add generator tool loop support to autoScript provider

### DIFF
--- a/packages/runtime/src/providers/scripted-provider.ts
+++ b/packages/runtime/src/providers/scripted-provider.ts
@@ -247,6 +247,31 @@ export function autoScript(opts: {
   return (messages, tools) => {
     const toolNames = new Set(tools.map((t) => t.name));
 
+    // Generator tool loops (ListGenerator's `add_item`, DataGenerator's
+    // `add_row`): the node calls the provider repeatedly, feeding tool results
+    // back, and gives up if the first call emits no tool calls. Emit a burst of
+    // generator calls on the first invocation, then stop once our own tool
+    // results appear in history so the node's loop terminates.
+    for (const genTool of ["add_item", "add_row"] as const) {
+      if (!toolNames.has(genTool)) continue;
+      const alreadyEmitted = messages.some(
+        (m) =>
+          m.role === "assistant" &&
+          (m.toolCalls ?? []).some((tc) => tc.name === genTool)
+      );
+      if (alreadyEmitted) {
+        return [{ type: "chunk", content: "Done.", done: true }];
+      }
+      return Array.from({ length: 3 }, (_unused, i) => ({
+        type: "tool_call" as const,
+        name: genTool,
+        args:
+          genTool === "add_item"
+            ? { item: `fake item ${i + 1}` }
+            : { row: { id: i + 1, value: `fake row ${i + 1}` } }
+      }));
+    }
+
     // Incremental planner: add_task + finish_plan
     if (
       toolNames.has("add_task") &&


### PR DESCRIPTION
## Summary
Add automatic handling for generator tool loops (ListGenerator's `add_item` and DataGenerator's `add_row`) in the `autoScript` provider. This enables the provider to emit a burst of generator calls on first invocation and gracefully terminate the loop once tool results appear in message history.

## Changes
- **Generator tool loop detection**: Check if `add_item` or `add_row` tools are available in the current tool set
- **Burst emission**: On first invocation (when no prior generator tool calls exist in history), emit 3 fake generator calls with appropriate arguments:
  - `add_item`: generates items with format `"fake item {i+1}"`
  - `add_row`: generates rows with `id` and `value` fields
- **Loop termination**: Once generator tool results appear in message history (indicating the node's loop has processed our calls), return a completion message (`"Done."`) to signal the loop should stop

## Implementation Details
- Uses a `for...of` loop over the generator tool names to check availability and emit appropriate responses
- Leverages existing message history inspection to detect when generator calls have been processed
- Returns early from the function once a generator tool is handled, preventing fallthrough to other provider logic
- Maintains compatibility with existing provider behavior for non-generator tools

https://claude.ai/code/session_01MpXaurvhtxFBNe2TkLULyK