### PR TITLE
image-nodes: fix high/medium review findings

### DIFF
--- a/packages/image-nodes/src/nodes/image-io.ts
+++ b/packages/image-nodes/src/nodes/image-io.ts
@@ -252,6 +252,59 @@ export async function decodeRgba(
   return IS_NODE ? decodeBytesNode(bytes) : decodeBytesBrowser(bytes);
 }
 
+/**
+ * Read just the pixel dimensions of an image input, cheaply. In-flight refs
+ * (raw-RGBA, GPU texture, preview bitmap) all carry their dimensions, so this
+ * returns them without touching pixels — in particular it never triggers a GPU
+ * readback for a texture ref. A ref that already carries positive `width`/
+ * `height` fields is trusted directly. Otherwise it loads the encoded bytes and
+ * reads only the header (sharp metadata on Node, `createImageBitmap` in the
+ * browser), decoding the full image only as a last resort.
+ */
+export async function imageDimensions(
+  image: unknown,
+  context?: ProcessingContext
+): Promise<{ width: number; height: number }> {
+  if (
+    isRawRgbaImage(image) ||
+    isGpuTextureImage(image) ||
+    isBitmapImage(image)
+  ) {
+    return { width: image.width, height: image.height };
+  }
+  if (image && typeof image === "object") {
+    const { width, height } = image as { width?: unknown; height?: unknown };
+    if (
+      typeof width === "number" &&
+      typeof height === "number" &&
+      width > 0 &&
+      height > 0
+    ) {
+      return { width, height };
+    }
+  }
+  const bytes = await loadImageBytes(image, context);
+  if (bytes.length === 0) return { width: 0, height: 0 };
+  if (IS_NODE) {
+    const sharp = await loadSharp();
+    if (sharp) {
+      const meta = await sharp(bytes, { failOn: "none" }).metadata();
+      if (meta.width && meta.height) {
+        return { width: meta.width, height: meta.height };
+      }
+    }
+  } else if (typeof createImageBitmap !== "undefined") {
+    const bitmap = await createImageBitmap(new Blob([toArrayBuffer(bytes)]));
+    const { width, height } = bitmap;
+    bitmap.close();
+    return { width, height };
+  }
+  // Last resort — full decode (also covers Node without sharp).
+  const decoded =
+    IS_NODE ? await decodeBytesNode(bytes) : await decodeBytesBrowser(bytes);
+  return { width: decoded.width, height: decoded.height };
+}
+
 /* --------------------------------- encode --------------------------------- */
 
 /** Encode straight-alpha RGBA to PNG via Canvas (browser). Always 4-channel. */

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -13,7 +13,6 @@ import type {
   OutputCorrelation,
   Platform
 } from "@nodetool-ai/protocol";
-import { RAW_RGBA_MIME, isRawRgbaImage } from "@nodetool-ai/protocol";
 import type { ImageRef } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 // Import from browser-safe subpaths (not the runtime barrel, which drags in the
@@ -447,7 +446,8 @@ export class SaveImageFileImageNode extends BaseNode {
   static readonly description =
     "Write an image to disk.\n    image, output, save, file";
   static readonly metadataOutputTypes = {
-    output: "image"
+    output: "image",
+    path: "str"
   };
   static readonly inlineFields = ["filename"];
   static readonly inputFields = ["image"];
@@ -516,8 +516,18 @@ export class SaveImageFileImageNode extends BaseNode {
       }
     }
 
-    await fs.writeFile(p, await imageBytesAsync(this.image));
-    return { output: p };
+    const bytes = await imageBytesAsync(this.image);
+    await fs.writeFile(p, bytes);
+    const meta = await metadataFor(bytes);
+    return {
+      output: imageRef(bytes, {
+        uri: `file://${p}`,
+        mimeType: inferImageMime(p, bytes),
+        width: meta.width,
+        height: meta.height
+      }),
+      path: p
+    };
   }
 }
 
@@ -1347,26 +1357,60 @@ export class CanvasResizeNode extends TransformImageNode {
       offsetY = top;
     }
 
-    // Pad placing the source at (offsetX, offsetY) in the larger canvas. The pad
-    // shader works in normalized-UV units relative to the source; output dims
-    // are derived from those (we also pass the absolute target as the host size).
+    // When the requested canvas is smaller than the source on an axis, padding
+    // alone can't shrink it — crop the source centrally to the canvas on that
+    // axis first (converting px → the crop shader's normalized-UV params the
+    // same way CropNode does), so fixed/scale modes always yield exactly
+    // canvasW × canvasH instead of silently returning the source size.
+    let source: unknown = image;
+    let baseW = srcW;
+    let baseH = srcH;
+    const cropW = Math.min(srcW, canvasW);
+    const cropH = Math.min(srcH, canvasH);
+    if (cropW < srcW || cropH < srcH) {
+      const cropX = Math.floor((srcW - cropW) / 2);
+      const cropY = Math.floor((srcH - cropH) / 2);
+      source = await runShaderNode(
+        transformCropV1,
+        {
+          originX: cropX / srcW,
+          originY: cropY / srcH,
+          width: cropW / srcW,
+          height: cropH / srcH
+        },
+        image,
+        { outputWidth: cropW, outputHeight: cropH },
+        context
+      );
+      baseW = cropW;
+      baseH = cropH;
+      // Re-centre the placement against the cropped source so the pads below
+      // stay non-negative on every axis.
+      offsetX = Math.floor((canvasW - baseW) / 2);
+      offsetY = Math.floor((canvasH - baseH) / 2);
+    }
+
+    // Pad placing the (possibly cropped) source at (offsetX, offsetY) in the
+    // larger canvas. The pad shader works in normalized-UV units relative to the
+    // source; output dims are derived from those (we also pass the absolute
+    // target as the host size).
     const leftPad = Math.max(0, offsetX);
     const topPad = Math.max(0, offsetY);
-    const rightPad = Math.max(0, canvasW - srcW - offsetX);
-    const bottomPad = Math.max(0, canvasH - srcH - offsetY);
+    const rightPad = Math.max(0, canvasW - baseW - offsetX);
+    const bottomPad = Math.max(0, canvasH - baseH - offsetY);
     const output = await runShaderNode(
       transformPadV1,
       {
-        left: leftPad / srcW,
-        top: topPad / srcH,
-        right: rightPad / srcW,
-        bottom: bottomPad / srcH,
+        left: leftPad / baseW,
+        top: topPad / baseH,
+        right: rightPad / baseW,
+        bottom: bottomPad / baseH,
         color: d.vec4f(0, 0, 0, 0)
       },
-      image,
+      source,
       {
-        outputWidth: srcW + leftPad + rightPad,
-        outputHeight: srcH + topPad + bottomPad
+        outputWidth: baseW + leftPad + rightPad,
+        outputHeight: baseH + topPad + bottomPad
       },
       context
     );
@@ -1782,11 +1826,13 @@ export class ImageToImageNode extends BaseNode {
       }
     })) as Uint8Array;
     const meta = await metadataFor(output);
-    const sourceUri = images[0]?.uri ?? "";
+    // The output is freshly generated content — do not carry the source image's
+    // uri onto it (a stale uri shadows `data` wherever a uri is preferred, so
+    // the preview would render the input, not the result). Infer mime from the
+    // output bytes alone.
     return {
       output: imageRef(output, {
-        uri: sourceUri,
-        mimeType: inferImageMime(sourceUri, output),
+        mimeType: inferImageMime(undefined, output),
         width: meta.width,
         height: meta.height
       })
@@ -1860,7 +1906,7 @@ export class RotateAndFlipNode extends TransformImageNode {
     }
 
     let current: unknown = image;
-    let curW = srcW;
+    const curW = srcW;
     const curH = srcH;
 
     // Mirror first (output is same size as source).
@@ -1911,7 +1957,6 @@ export class RotateAndFlipNode extends TransformImageNode {
           { outputWidth: outW, outputHeight: outH },
           context
         );
-        curW = outW;
       }
     }
 

--- a/packages/image-nodes/src/nodes/lib-grid.ts
+++ b/packages/image-nodes/src/nodes/lib-grid.ts
@@ -12,11 +12,74 @@ async function loadImageBuffer(
   return buf;
 }
 
-function toImageRef(buf: Buffer): Record<string, unknown> {
+/**
+ * Placement of a tile within the original canvas. Emitted by SliceImageGrid on
+ * each tile ref's `metadata.grid` so CombineImageGrid can reassemble the source
+ * image exactly (lossless round trip), even when the dimensions are not evenly
+ * divisible by the column/row count.
+ */
+type TilePlacement = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  row: number;
+  column: number;
+  columns: number;
+  rows: number;
+};
+
+function toImageRef(
+  buf: Buffer,
+  placement?: TilePlacement
+): Record<string, unknown> {
   return {
     type: "image",
     data: new Uint8Array(buf),
-    mimeType: "image/png"
+    mimeType: "image/png",
+    metadata: placement ? { grid: placement } : null
+  };
+}
+
+/**
+ * Read tile placement from a ref's `metadata.grid`, or null when absent/malformed.
+ * Refs are plain objects, so the placement payload survives transport.
+ */
+function readPlacement(ref: unknown): TilePlacement | null {
+  if (!ref || typeof ref !== "object") return null;
+  const md = (ref as Record<string, unknown>).metadata;
+  if (!md || typeof md !== "object") return null;
+  const grid = (md as Record<string, unknown>).grid;
+  if (!grid || typeof grid !== "object") return null;
+  const g = grid as Record<string, unknown>;
+  const keys: (keyof TilePlacement)[] = [
+    "x",
+    "y",
+    "width",
+    "height",
+    "canvasWidth",
+    "canvasHeight",
+    "row",
+    "column",
+    "columns",
+    "rows"
+  ];
+  for (const k of keys) {
+    if (typeof g[k] !== "number" || !Number.isFinite(g[k])) return null;
+  }
+  return {
+    x: g.x as number,
+    y: g.y as number,
+    width: g.width as number,
+    height: g.height as number,
+    canvasWidth: g.canvasWidth as number,
+    canvasHeight: g.canvasHeight as number,
+    row: g.row as number,
+    column: g.column as number,
+    columns: g.columns as number,
+    rows: g.rows as number
   };
 }
 
@@ -49,7 +112,8 @@ export class SliceImageGridLibNode extends BaseNode {
     type: "int",
     default: 0,
     title: "Columns",
-    description: "Number of columns in the grid.",
+    description:
+      "Number of columns in the grid. 0 auto-derives from rows, or falls back to a 3x3 grid when rows is also 0.",
     min: 0
   })
   declare columns: any;
@@ -58,7 +122,8 @@ export class SliceImageGridLibNode extends BaseNode {
     type: "int",
     default: 0,
     title: "Rows",
-    description: "Number of rows in the grid.",
+    description:
+      "Number of rows in the grid. 0 auto-derives from columns, or falls back to a 3x3 grid when columns is also 0.",
     min: 0
   })
   declare rows: any;
@@ -97,16 +162,31 @@ export class SliceImageGridLibNode extends BaseNode {
         const y = Math.round((row * height) / rows);
         const right = Math.round(((col + 1) * width) / columns);
         const bottom = Math.round(((row + 1) * height) / rows);
+        const tileWidth = Math.max(1, right - x);
+        const tileHeight = Math.max(1, bottom - y);
         const out = await sharp(src, { failOn: "none" })
           .extract({
             left: x,
             top: y,
-            width: Math.max(1, right - x),
-            height: Math.max(1, bottom - y)
+            width: tileWidth,
+            height: tileHeight
           })
           .png()
           .toBuffer();
-        tiles.push(toImageRef(out));
+        tiles.push(
+          toImageRef(out, {
+            x,
+            y,
+            width: tileWidth,
+            height: tileHeight,
+            canvasWidth: width,
+            canvasHeight: height,
+            row,
+            column: col,
+            columns,
+            rows
+          })
+        );
       }
     }
 
@@ -137,7 +217,8 @@ export class CombineImageGridLibNode extends BaseNode {
     type: "int",
     default: 0,
     title: "Columns",
-    description: "Number of columns in the grid.",
+    description:
+      "Number of columns in the grid. 0 auto-derives from the tile count. Ignored when tiles carry grid placement metadata from SliceImageGrid.",
     min: 0
   })
   declare columns: any;
@@ -151,6 +232,32 @@ export class CombineImageGridLibNode extends BaseNode {
     const tiles = await Promise.all(
       tileInputs.map((tile) => loadImageBuffer(tile, context))
     );
+
+    // Lossless path: when every tile carries placement metadata from
+    // SliceImageGrid, reassemble onto a canvas of the original dimensions at the
+    // exact recorded offsets. Tolerant of non-divisible slicing (varying tile
+    // sizes) — no uniform grid, no overlaps, no oversized canvas.
+    const placements = tileInputs.map(readPlacement);
+    if (placements.every((p): p is TilePlacement => p !== null)) {
+      const canvasWidth = placements[0].canvasWidth;
+      const canvasHeight = placements[0].canvasHeight;
+      const canvas = sharp({
+        create: {
+          width: Math.max(1, canvasWidth),
+          height: Math.max(1, canvasHeight),
+          channels: 4,
+          background: { r: 0, g: 0, b: 0, alpha: 0 }
+        }
+      });
+      const composite = tiles.map((tile, index) => ({
+        input: tile,
+        left: placements[index].x,
+        top: placements[index].y
+      }));
+      const out = await canvas.composite(composite).png().toBuffer();
+      return { output: toImageRef(out) };
+    }
+
     const metas = await Promise.all(
       tiles.map((tile) => sharp(tile, { failOn: "none" }).metadata())
     );

--- a/packages/image-nodes/src/nodes/lib-image-color-grading.ts
+++ b/packages/image-nodes/src/nodes/lib-image-color-grading.ts
@@ -136,8 +136,11 @@ function createColorGradingNode(desc: Desc): NodeClass {
         );
       }
 
-      // Vibrance is folded into saturation as an additive boost — the published
-      // HSB shader has no separate skin-tone-protected channel.
+      // Vibrance is folded into saturation as a milder secondary boost (half
+      // weight) — the published HSB shader has no separate skin-tone-protected
+      // channel. Clamp the combined multiplier at 0 so extreme negatives (e.g.
+      // saturation=-1, vibrance=-1) bottom out at grayscale instead of
+      // inverting past it.
       if (t.endsWith(".SaturationVibrance")) {
         const saturation = num(props.saturation, 0);
         const vibrance = num(props.vibrance, 0);
@@ -146,7 +149,7 @@ function createColorGradingNode(desc: Desc): NodeClass {
             colorHsbV1,
             {
               hue: 0,
-              saturation: 1 + saturation + vibrance * 0.5,
+              saturation: Math.max(0, 1 + saturation + vibrance * 0.5),
               brightness: 1
             },
             baseObj,
@@ -293,6 +296,9 @@ function createColorGradingNode(desc: Desc): NodeClass {
 
       // Shader `intensity` maps to the legacy `amount`; midpoint/feather map
       // onto the shader's `radius` (where the vignette begins) and `softness`.
+      // The shader darkens where `dist > radius - softness`, so `radius` grows
+      // with `midpoint`: midpoint=0 starts the vignette at the center,
+      // midpoint=1 pushes its onset out to the edges.
       if (t.endsWith(".Vignette")) {
         const midpoint = num(props.midpoint, 0.5);
         const feather = Math.max(0.01, num(props.feather, 0.5));
@@ -301,7 +307,7 @@ function createColorGradingNode(desc: Desc): NodeClass {
             vignetteV1,
             {
               intensity: num(props.amount, 0.5),
-              radius: 1 - midpoint,
+              radius: midpoint,
               softness: feather
             },
             baseObj,
@@ -1032,7 +1038,7 @@ const DESCRIPTORS: readonly Desc[] = [
     nodeType: "lib.image.color_grading.SaturationVibrance",
     title: "Saturation Vibrance",
     description:
-      "Adjust color saturation with vibrance protection for skin tones.\n    saturation, vibrance, color intensity, skin tones\n\n    Use cases:\n    - Boost color intensity without clipping\n    - Protect skin tones while increasing saturation\n    - Create desaturated or oversaturated looks\n    - Fine-tune color intensity independently",
+      "Adjust color saturation with a milder secondary vibrance control.\n    saturation, vibrance, color intensity\n\n    Use cases:\n    - Boost or reduce overall color intensity\n    - Apply a gentler saturation nudge via vibrance\n    - Create desaturated or oversaturated looks\n    - Fine-tune color intensity with two strengths\n\n    Vibrance is a half-weight secondary saturation control; it does not\n    protect skin tones or already-saturated colors.",
     inlineFields: [],
     inputFields:  ["image"],
     outputs: {
@@ -1073,7 +1079,7 @@ const DESCRIPTORS: readonly Desc[] = [
           default: 0,
           title: "Vibrance",
           description:
-            "Smart saturation that protects already-saturated colors and skin tones.",
+            "Secondary saturation control applied at half the strength of Saturation. Milder than Saturation; does not protect skin tones.",
           min: -1,
           max: 1
         }

--- a/packages/image-nodes/src/nodes/lib-image-draw.ts
+++ b/packages/image-nodes/src/nodes/lib-image-draw.ts
@@ -23,6 +23,32 @@ import {
   SHARP_UNAVAILABLE_MESSAGE
 } from "./image-io.js";
 
+// Finite-guarding numeric read (matches the `num` helper used across the
+// package): NaN / non-finite values fall back instead of propagating.
+function num(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// Clamp a requested output dimension to [1, max]. Guards the low end, the NaN
+// case (via num) and the high end so a programmatic graph can't request an
+// arbitrarily large texture. `max` mirrors the prop metadata's documented max.
+function clampDim(value: unknown, fallback: number, max: number): number {
+  return Math.min(max, Math.max(1, Math.round(num(value, fallback))));
+}
+
+// Escape a value for interpolation into an XML/SVG attribute or text node.
+// Escaping the quotes as well as &<> prevents a value from terminating the
+// attribute string and injecting arbitrary markup into the SVG handed to sharp.
+export function escapeXmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
 type Desc = {
   nodeType: string;
   title: string;
@@ -77,8 +103,8 @@ function createDrawNode(desc: Desc): NodeClass {
       const t = desc.nodeType;
 
       if (t === "lib.image.draw.Background") {
-        const width = Math.max(1, Number((this as any).width ?? 512));
-        const height = Math.max(1, Number((this as any).height ?? 512));
+        const width = clampDim((this as any).width, 512, 4096);
+        const height = clampDim((this as any).height, 512, 4096);
         // Source module — no input texture, just the host-specified output dims.
         const [r, g, b, a] = premultiplyVec4(
           colorValueToVec4((this as any).color ?? "#FFFFFF", [1, 1, 1, 1])
@@ -95,10 +121,10 @@ function createDrawNode(desc: Desc): NodeClass {
       }
 
       if (t === "lib.image.draw.GaussianNoise") {
-        const w = Math.max(1, Number((this as any).width ?? 512));
-        const h = Math.max(1, Number((this as any).height ?? 512));
-        const mean = Number((this as any).mean ?? 0);
-        const stddev = Number((this as any).stddev ?? 1);
+        const w = clampDim((this as any).width, 512, 1024);
+        const h = clampDim((this as any).height, 512, 1024);
+        const mean = num((this as any).mean, 0);
+        const stddev = num((this as any).stddev, 1);
         // A fresh seed per run reproduces the old Math.random() variation.
         return {
           output: await runShaderNode(
@@ -125,21 +151,13 @@ function createDrawNode(desc: Desc): NodeClass {
       if (t === "lib.image.Mask") {
         const sharp = await loadSharp();
         if (!sharp) throw new Error(SHARP_UNAVAILABLE_MESSAGE);
+        const self = this as unknown as Record<string, unknown>;
         const fg = await loadImageBytes(
-          (this as any).foreground ??
-            (this as unknown as Record<string, unknown>).foreground ??
-            (this as any).image2 ??
-            (this as unknown as Record<string, unknown>).image2 ??
-            (this as any).image1 ??
-            (this as unknown as Record<string, unknown>).image1,
+          self.foreground ?? self.image2 ?? self.image1,
           context
         );
         if (fg.length) {
-          const mask = await loadImageBytes(
-            (this as any).mask ??
-              (this as unknown as Record<string, unknown>).mask,
-            context
-          );
+          const mask = await loadImageBytes(self.mask, context);
           const baseMeta = await sharp(baseBytes, { failOn: "none" }).metadata();
           const width = Math.max(1, baseMeta.width ?? 1);
           const height = Math.max(1, baseMeta.height ?? 1);
@@ -183,9 +201,9 @@ function createDrawNode(desc: Desc): NodeClass {
         if (!text) {
           return { output: toBase64Ref(baseBytes, baseObj) };
         }
-        const x = Number((this as any).x ?? 0);
-        const y = Number((this as any).y ?? 0);
-        const size = Number((this as any).size ?? 12);
+        const x = num((this as any).x, 0);
+        const y = num((this as any).y, 0);
+        const size = Math.min(512, Math.max(1, num((this as any).size, 12)));
         const colorVal = (this as any).color ?? "#000000";
         const color =
           colorVal &&
@@ -229,14 +247,13 @@ function createDrawNode(desc: Desc): NodeClass {
         if (!sharp) throw new Error(SHARP_UNAVAILABLE_MESSAGE);
         const textAnchor =
           align === "center" ? "middle" : align === "right" ? "end" : "start";
-        const escapedText = text
-          .replaceAll("&", "&amp;")
-          .replaceAll("<", "&lt;")
-          .replaceAll(">", "&gt;");
+        const escapedText = escapeXmlAttr(text);
         const md = await sharp(baseBytes).metadata();
         const svgWidth = md.width ?? 512;
         const svgHeight = md.height ?? 512;
-        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}"><text x="${x}" y="${y + size}" font-size="${size}" fill="${color}" font-family="${fontFamily}" text-anchor="${textAnchor}">${escapedText}</text></svg>`;
+        // Every interpolated attribute is escaped — a quote in color/font would
+        // otherwise break out of the attribute and inject SVG markup into sharp.
+        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}"><text x="${x}" y="${y + size}" font-size="${size}" fill="${escapeXmlAttr(color)}" font-family="${escapeXmlAttr(fontFamily)}" text-anchor="${escapeXmlAttr(textAnchor)}">${escapedText}</text></svg>`;
         const out = await sharp(baseBytes)
           .composite([{ input: Buffer.from(svg) }])
           .png()
@@ -354,7 +371,7 @@ const DESCRIPTORS: readonly Desc[] = [
     nodeType: "lib.image.draw.RenderText",
     title: "Render Text",
     description:
-      'This node allows you to add text to images using system fonts or web fonts.\n    text, font, label, title, watermark, caption, image, overlay, google fonts\n\n    This node takes text, font updates, coordinates (where to place the text), and an image to work with.\n    A user can use the Render Text Node to add a label or title to an image, watermark an image,\n    or place a caption directly on an image.\n\n    The Render Text Node offers customizable options, including the ability to choose the text\'s font,\n    size, color, and alignment (left, center, or right). Text placement can also be defined,\n    providing flexibility to place the text wherever you see fit.\n\n    ### Font Sources\n\n    The node supports three font sources:\n\n    1. **System Fonts** (default): Use fonts installed on the system\n       - `FontRef(name="Arial")` - Uses local Arial font\n\n    2. **Google Fonts**: Automatically download and cache fonts from Google Fonts\n       - `FontRef(name="Roboto", source=FontSource.GOOGLE_FONTS)`\n       - `FontRef(name="Open Sans", source=FontSource.GOOGLE_FONTS, weight="bold")`\n       - Supports 50+ popular fonts including Roboto, Open Sans, Lato, Montserrat, Poppins, etc.\n\n    3. **Custom URL**: Download fonts from any URL\n       - `FontRef(name="CustomFont", source=FontSource.URL, url="https://example.com/font.ttf")`\n\n    #### Applications\n    - Labeling images in an image gallery or database.\n    - Watermarking images for copyright protection.\n    - Adding custom captions to photographs.\n    - Creating instructional images to guide the reader\'s view.\n    - Using premium Google Fonts for professional typography.',
+      "Draw text onto an image using a system-available font family.\n    text, font, label, title, watermark, caption, image, overlay\n\n    This node takes text, a font family name, coordinates (where to place the\n    text), and an image to work with. Use it to add a label or title to an\n    image, watermark an image, or place a caption directly on an image.\n\n    You can set the font family name, size, color, and alignment (left, center,\n    or right), and position the text anywhere on the image.\n\n    ### Fonts\n\n    Only the font's `name` is used, as a font-family name resolved against the\n    fonts available to the renderer (Canvas2D in the browser, sharp/librsvg on\n    the server). If the named family isn't available, the renderer falls back to\n    a default. The node does not download fonts, so the font's `source`, `url`,\n    and `weight` fields are ignored.\n\n    #### Applications\n    - Labeling images in an image gallery or database.\n    - Watermarking images for copyright protection.\n    - Adding custom captions to photographs.\n    - Creating instructional images to guide the reader's view.",
     inlineFields: ["text"],
     inputFields:  ["image"],
     outputs: {
@@ -383,7 +400,7 @@ const DESCRIPTORS: readonly Desc[] = [
           },
           title: "Font",
           description:
-            "The font to use. Supports system fonts, Google Fonts, and custom URLs."
+            "The font family to use, resolved by name against the fonts available to the renderer. Only the font name is used; source, url, and weight are ignored."
         }
       },
       {

--- a/packages/image-nodes/src/nodes/lib-image-enhance.ts
+++ b/packages/image-nodes/src/nodes/lib-image-enhance.ts
@@ -74,11 +74,14 @@ function createEnhanceNode(desc: Desc): NodeClass {
       const totalPixels = w * h;
 
       if (t.endsWith(".AutoContrast")) {
+        // `rgba` may alias the upstream node's buffer (decodeRgba borrows raw
+        // refs by reference), so mutate a copy — never the shared input.
+        const out = new Uint8Array(rgba);
         const cutoff = Number((this as any).cutoff ?? 0);
         const cutCount = Math.floor((totalPixels * cutoff) / 100);
         for (let c = 0; c < 3; c++) {
           const hist = new Uint32Array(256);
-          for (let i = c; i < rgba.length; i += channels) hist[rgba[i]]++;
+          for (let i = c; i < out.length; i += channels) hist[out[i]]++;
           let lo = 0;
           let cumLo = 0;
           while (lo < 255 && cumLo + hist[lo] <= cutCount) {
@@ -93,17 +96,20 @@ function createEnhanceNode(desc: Desc): NodeClass {
           }
           if (lo >= hi) continue;
           const scale = 255.0 / (hi - lo);
-          for (let i = c; i < rgba.length; i += channels) {
-            rgba[i] = Math.max(0, Math.min(255, Math.round((rgba[i] - lo) * scale)));
+          for (let i = c; i < out.length; i += channels) {
+            out[i] = Math.max(0, Math.min(255, Math.round((out[i] - lo) * scale)));
           }
         }
-        return { output: rawRgbaImageRef(rgba, w, h) };
+        return { output: rawRgbaImageRef(out, w, h) };
       }
 
       if (t.endsWith(".Equalize")) {
+        // `rgba` may alias the upstream node's buffer (decodeRgba borrows raw
+        // refs by reference), so mutate a copy — never the shared input.
+        const out = new Uint8Array(rgba);
         for (let c = 0; c < 3; c++) {
           const hist = new Uint32Array(256);
-          for (let i = c; i < rgba.length; i += channels) hist[rgba[i]]++;
+          for (let i = c; i < out.length; i += channels) hist[out[i]]++;
           const cdf = new Uint32Array(256);
           cdf[0] = hist[0];
           for (let j = 1; j < 256; j++) cdf[j] = cdf[j - 1] + hist[j];
@@ -121,9 +127,9 @@ function createEnhanceNode(desc: Desc): NodeClass {
               lut[j] = Math.round(((cdf[j] - cdfMin) / denom) * 255);
             }
           }
-          for (let i = c; i < rgba.length; i += channels) rgba[i] = lut[rgba[i]];
+          for (let i = c; i < out.length; i += channels) out[i] = lut[out[i]];
         }
-        return { output: rawRgbaImageRef(rgba, w, h) };
+        return { output: rawRgbaImageRef(out, w, h) };
       }
 
       if (t.endsWith(".AdaptiveContrast")) {
@@ -204,7 +210,12 @@ function createEnhanceNode(desc: Desc): NodeClass {
       }
 
       if (t.endsWith(".RankFilter")) {
-        const size = Math.max(1, Number((this as any).size ?? 3));
+        // Clamp the window size: each pixel allocates and sorts a
+        // (2*floor(size/2)+1)^2-element array per channel, so an unbounded size
+        // (e.g. 512 → ~262k elements/pixel) would hang the process. 25 matches
+        // typical PIL RankFilter usage. `result` is a copy, so `rgba` (which may
+        // alias the upstream buffer) is only ever read here, never mutated.
+        const size = Math.max(1, Math.min(25, Number((this as any).size ?? 3)));
         const rank = Number((this as any).rank ?? 3);
         const half = Math.floor(size / 2);
         const result = new Uint8Array(rgba); // copy preserves alpha
@@ -447,9 +458,10 @@ const DESCRIPTORS: readonly Desc[] = [
           type: "int",
           default: 3,
           title: "Size",
-          description: "Rank filter size.",
+          description:
+            "Rank filter window size (odd values recommended; the effective window is (2*floor(size/2)+1)^2, so an even size behaves like the next odd size up). Clamped to 25 at runtime to bound per-pixel sort cost.",
           min: 1,
-          max: 512
+          max: 25
         }
       },
       {

--- a/packages/image-nodes/src/nodes/lib-image-filter.ts
+++ b/packages/image-nodes/src/nodes/lib-image-filter.ts
@@ -12,7 +12,7 @@ import {
 } from "@nodetool-ai/gpu/pool";
 import { pickImage } from "./lib-image-utils.js";
 import { runShaderNode } from "./lib-shader-utils.js";
-import { decodeRgba, rawRgbaImageRef } from "./image-io.js";
+import { decodeRgba, imageDimensions, rawRgbaImageRef } from "./image-io.js";
 import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 type Desc = {
@@ -165,7 +165,10 @@ function createFilterNode(desc: Desc): NodeClass {
       if (t.endsWith(".Expand")) {
         const border = Number((this as any).border ?? 0);
         const fill = Number((this as any).fill ?? 0) / 255;
-        const { width: srcW, height: srcH } = await decodeRgba(baseObj, context);
+        const { width: srcW, height: srcH } = await imageDimensions(
+          baseObj,
+          context
+        );
         if (!srcW || !srcH) return { output: baseObj ?? {} };
         return {
           output: await runShaderNode(
@@ -206,14 +209,18 @@ function createFilterNode(desc: Desc): NodeClass {
           0.0586, 0.0965, 0.0586, 0.0131, 0.0029, 0.0131, 0.0215, 0.0131,
           0.0029
         ];
-        for (let y = 2; y < h - 2; y++) {
-          for (let x = 2; x < w - 2; x++) {
+        // Blur every pixel, including the border. Kernel taps that fall outside
+        // the image clamp to the nearest edge pixel (clamp-to-edge sampling);
+        // skipping the border would leave a 2px zero frame that the Sobel pass
+        // reads as a spurious edge just inside the image.
+        for (let y = 0; y < h; y++) {
+          for (let x = 0; x < w; x++) {
             let sum = 0;
             for (let ky = -2; ky <= 2; ky++) {
+              const sy = Math.min(h - 1, Math.max(0, y + ky));
               for (let kx = -2; kx <= 2; kx++) {
-                sum +=
-                  grayData[(y + ky) * w + (x + kx)] *
-                  gaussKernel[(ky + 2) * 5 + (kx + 2)];
+                const sx = Math.min(w - 1, Math.max(0, x + kx));
+                sum += grayData[sy * w + sx] * gaussKernel[(ky + 2) * 5 + (kx + 2)];
               }
             }
             blurred[y * w + x] = sum;

--- a/packages/image-nodes/src/nodes/lib-image-generators.ts
+++ b/packages/image-nodes/src/nodes/lib-image-generators.ts
@@ -31,6 +31,15 @@ function num(value: unknown, fallback: number): number {
 }
 
 /**
+ * Resolve an output dimension, clamped to [1, 8192] whole pixels. Guards the
+ * texture allocation against a non-finite, zero, negative, or runaway wire
+ * value.
+ */
+function dim(value: unknown, fallback: number): number {
+  return Math.min(8192, Math.max(1, Math.round(num(value, fallback))));
+}
+
+/**
  * Generator shader colour params are declared premultiplied (matches the
  * pool's between-modules invariant) and the WGSL returns them via
  * `mix(...)` / direct assignment without re-premultiplying. The colour
@@ -55,8 +64,8 @@ class LinearGradientNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
-    const width = num(props.width, 512);
-    const height = num(props.height, 512);
+    const width = dim(props.width, 512);
+    const height = dim(props.height, 512);
     const output = await runShaderNode(
       sourcesLinearGradientV1,
       {
@@ -89,8 +98,8 @@ class RadialGradientNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
-    const width = num(props.width, 512);
-    const height = num(props.height, 512);
+    const width = dim(props.width, 512);
+    const height = dim(props.height, 512);
     const output = await runShaderNode(
       sourcesRadialGradientV1,
       {
@@ -121,8 +130,8 @@ class AngularGradientNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
-    const width = num(props.width, 512);
-    const height = num(props.height, 512);
+    const width = dim(props.width, 512);
+    const height = dim(props.height, 512);
     const output = await runShaderNode(
       sourcesAngularGradientV1,
       {
@@ -153,8 +162,8 @@ class DiamondGradientNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
-    const width = num(props.width, 512);
-    const height = num(props.height, 512);
+    const width = dim(props.width, 512);
+    const height = dim(props.height, 512);
     const output = await runShaderNode(
       sourcesDiamondGradientV1,
       {
@@ -185,14 +194,15 @@ class CheckerboardNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
-    const width = num(props.width, 512);
-    const height = num(props.height, 512);
+    const width = dim(props.width, 512);
+    const height = dim(props.height, 512);
     const output = await runShaderNode(
       sourcesCheckerboardV1,
       {
         colorA: vec4From(props.color_a, [1, 1, 1, 1]),
         colorB: vec4From(props.color_b, [0, 0, 0, 1]),
-        cellSize: num(props.cell_size, 32)
+        // Clamp to >= 1: a 0/negative cell size divides by zero in the shader.
+        cellSize: Math.max(1, Math.round(num(props.cell_size, 32)))
       },
       null,
       { outputWidth: width, outputHeight: height },

--- a/packages/image-nodes/src/nodes/lib-image-keyer.ts
+++ b/packages/image-nodes/src/nodes/lib-image-keyer.ts
@@ -64,11 +64,17 @@ class LumaKeyNode extends BaseNode {
 
   async process(context?: ProcessingContext): Promise<{ output: ImageRef }> {
     const props = this.serialize() as Record<string, unknown>;
+    // Normalize the band so low <= high: crossed bounds would key out every
+    // pixel and silently produce a blank image.
+    const a = num(props.low, 0);
+    const b = num(props.high, 1);
+    const low = Math.min(a, b);
+    const high = Math.max(a, b);
     const output = await runShaderNode(
       keyerLumaKeyV1,
       {
-        low: num(props.low, 0),
-        high: num(props.high, 1),
+        low,
+        high,
         softness: num(props.softness, 0.05)
       },
       props.image,

--- a/packages/image-nodes/src/nodes/lib-image-warp.ts
+++ b/packages/image-nodes/src/nodes/lib-image-warp.ts
@@ -34,12 +34,16 @@ import {
   runShaderNode,
   type RunShaderOptions
 } from "./lib-shader-utils.js";
-import { decodeRgba } from "./image-io.js";
+import { imageDimensions } from "./image-io.js";
 import { tagAsBrowserGpu, tagAsContentCard } from "@nodetool-ai/nodes-utils";
 
 function num(value: unknown, fallback: number): number {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 /**
@@ -60,7 +64,7 @@ async function imageDims(
   ctx?: ProcessingContext
 ): Promise<{ width: number; height: number } | null> {
   if (!image) return null;
-  const { width, height } = await decodeRgba(image, ctx);
+  const { width, height } = await imageDimensions(image, ctx);
   if (!width || !height) return null;
   return { width, height };
 }
@@ -156,8 +160,10 @@ class TileNode extends BaseNode {
     const output = await runShaderNode(
       transformTileV1,
       {
-        tilesX: num(props.tiles_x, 2),
-        tilesY: num(props.tiles_y, 2),
+        // Prop metadata caps tiles at [1, 32]; clamp so an out-of-range wire
+        // value can't reach the shader as a zero/negative or runaway count.
+        tilesX: clamp(Math.round(num(props.tiles_x, 2)), 1, 32),
+        tilesY: clamp(Math.round(num(props.tiles_y, 2)), 1, 32),
         wrap: num(props.wrap, 1)
       },
       props.image,

--- a/packages/image-nodes/src/nodes/lib-shader-utils.ts
+++ b/packages/image-nodes/src/nodes/lib-shader-utils.ts
@@ -60,7 +60,14 @@ async function importRegistry(): Promise<
 }
 
 async function getRegistry(): Promise<ShaderRegistry> {
-  if (!cachedRegistry) cachedRegistry = importRegistry();
+  // Reset the cache on rejection so a transient dynamic-import failure doesn't
+  // poison every future recipe node in the process (mirrors getGpuContext).
+  if (!cachedRegistry) {
+    cachedRegistry = importRegistry().catch((err) => {
+      cachedRegistry = null;
+      throw err;
+    });
+  }
   return cachedRegistry;
 }
 
@@ -184,55 +191,64 @@ export async function runShaderNode(
   const ctx = await getGpuContext();
   const device = ctx.device;
 
-  const source = sourceImage
-    ? await uploadStraightAlpha(device, sourceImage, context, `${module.id}-source`)
-    : null;
-  if (!source && module.io.inputs.source && !module.io.inputs.source.optional) {
-    // No source bound and module requires one — return an empty ImageRef rather
-    // than fail loud, mirroring lib-image-filter's "no-op when input is empty".
-    return { type: "image", data: "" };
-  }
-
-  const inputs: Record<string, LabeledTexture> = {};
-  if (source) inputs.source = source.texture;
-  // Textures this node OWNS (uploaded here) — freed when it finishes. Borrowed
+  // Textures this node OWNS (uploaded here) — freed in `finally`. Borrowed
   // GPU-texture inputs belong to the run's registry and are never freed here.
+  // Every upload happens inside the try and is pushed onto `owned` the instant
+  // its texture exists, so a later upload that throws (e.g. a second input
+  // fails to decode) can't leak the textures already created.
   const owned: LabeledTexture[] = [];
-  if (source && !source.borrowed) owned.push(source.texture);
-  for (const [name, ref] of Object.entries(opts.extraInputs ?? {})) {
-    const uploaded = await uploadStraightAlpha(
-      device,
-      ref,
-      context,
-      `${module.id}-${name}`
-    );
-    if (uploaded) {
-      inputs[name] = uploaded.texture;
-      if (!uploaded.borrowed) owned.push(uploaded.texture);
-    }
-  }
-  // Bail out before encoding if any *required* declared input is unbound —
-  // executor.encode would throw "missing required input" otherwise. Mirrors
-  // the source-missing no-op above so a stray null upstream produces an
-  // empty image rather than a hard failure.
-  for (const [name, contract] of Object.entries(module.io.inputs)) {
-    if (contract.optional) continue;
-    if (!inputs[name]) {
-      for (const t of owned) t.destroy();
-      return { type: "image", data: "" };
-    }
-  }
-
-  // Keep the output on the GPU when chaining client-side (browser, inside a
-  // run): the next node samples it directly and the run frees it later. On
-  // Node/Dawn (server) or outside a run, read it back to a CPU RGBA buffer.
-  const runId = context?.jobId;
-  const keepOnGpu =
-    GPU_TEXTURES_ENABLED && typeof runId === "string" && runId.length > 0;
-
   let output: LabeledTexture | undefined;
   let handedOff = false;
   try {
+    const source = sourceImage
+      ? await uploadStraightAlpha(device, sourceImage, context, `${module.id}-source`)
+      : null;
+    if (source && !source.borrowed) owned.push(source.texture);
+    if (!source && module.io.inputs.source && !module.io.inputs.source.optional) {
+      // No source bound and module requires one — no-op with an empty ImageRef
+      // rather than fail loud (mirrors lib-image-filter), but warn so the blank
+      // result is visible instead of propagating silently through a chain.
+      console.warn(
+        `${module.id}: required input "source" missing — emitting empty image.`
+      );
+      return { type: "image", data: "" };
+    }
+
+    const inputs: Record<string, LabeledTexture> = {};
+    if (source) inputs.source = source.texture;
+    for (const [name, ref] of Object.entries(opts.extraInputs ?? {})) {
+      const uploaded = await uploadStraightAlpha(
+        device,
+        ref,
+        context,
+        `${module.id}-${name}`
+      );
+      if (uploaded) {
+        inputs[name] = uploaded.texture;
+        if (!uploaded.borrowed) owned.push(uploaded.texture);
+      }
+    }
+    // Bail out before encoding if any *required* declared input is unbound —
+    // executor.encode would throw "missing required input" otherwise. Mirrors
+    // the source-missing no-op above so a stray null upstream produces an
+    // empty image rather than a hard failure.
+    for (const [name, contract] of Object.entries(module.io.inputs)) {
+      if (contract.optional) continue;
+      if (!inputs[name]) {
+        console.warn(
+          `${module.id}: required input "${name}" missing — emitting empty image.`
+        );
+        return { type: "image", data: "" };
+      }
+    }
+
+    // Keep the output on the GPU when chaining client-side (browser, inside a
+    // run): the next node samples it directly and the run frees it later. On
+    // Node/Dawn (server) or outside a run, read it back to a CPU RGBA buffer.
+    const runId = context?.jobId;
+    const keepOnGpu =
+      GPU_TEXTURES_ENABLED && typeof runId === "string" && runId.length > 0;
+
     const dims = resolveOutputDims(module, source, opts);
     output = createLabeledTexture(device, {
       label: `${module.id}-output`,
@@ -299,43 +315,53 @@ export async function runRecipeNode(
   const device = ctx.device;
   const registry = await getRegistry();
 
-  const source = sourceImage
-    ? await uploadStraightAlpha(device, sourceImage, context, `${recipe.id}-source`)
-    : null;
-  if (!source) {
-    return { type: "image", data: "" };
-  }
-
-  const inputs: Record<string, LabeledTexture> = { source: source.texture };
+  // Textures this node OWNS (uploaded here) — freed in `finally`. Every upload
+  // happens inside the try and is pushed onto `owned` the instant its texture
+  // exists, so a later upload that throws can't leak textures already created.
   const owned: LabeledTexture[] = [];
-  if (!source.borrowed) owned.push(source.texture);
-  for (const [name, ref] of Object.entries(opts.extraInputs ?? {})) {
-    const uploaded = await uploadStraightAlpha(
-      device,
-      ref,
-      context,
-      `${recipe.id}-${name}`
-    );
-    if (uploaded) {
-      inputs[name] = uploaded.texture;
-      if (!uploaded.borrowed) owned.push(uploaded.texture);
-    }
-  }
-  for (const [name, contract] of Object.entries(recipe.io.inputs)) {
-    if (contract.optional) continue;
-    if (!inputs[name]) {
-      for (const t of owned) t.destroy();
-      return { type: "image", data: "" };
-    }
-  }
-
-  const runId = context?.jobId;
-  const keepOnGpu =
-    GPU_TEXTURES_ENABLED && typeof runId === "string" && runId.length > 0;
-
   let output: LabeledTexture | undefined;
   let handedOff = false;
   try {
+    const source = sourceImage
+      ? await uploadStraightAlpha(device, sourceImage, context, `${recipe.id}-source`)
+      : null;
+    if (!source) {
+      // No source bound — no-op with an empty ImageRef rather than fail loud,
+      // but warn so the blank result is visible instead of propagating silently.
+      console.warn(
+        `${recipe.id}: required input "source" missing — emitting empty image.`
+      );
+      return { type: "image", data: "" };
+    }
+    if (!source.borrowed) owned.push(source.texture);
+
+    const inputs: Record<string, LabeledTexture> = { source: source.texture };
+    for (const [name, ref] of Object.entries(opts.extraInputs ?? {})) {
+      const uploaded = await uploadStraightAlpha(
+        device,
+        ref,
+        context,
+        `${recipe.id}-${name}`
+      );
+      if (uploaded) {
+        inputs[name] = uploaded.texture;
+        if (!uploaded.borrowed) owned.push(uploaded.texture);
+      }
+    }
+    for (const [name, contract] of Object.entries(recipe.io.inputs)) {
+      if (contract.optional) continue;
+      if (!inputs[name]) {
+        console.warn(
+          `${recipe.id}: required input "${name}" missing — emitting empty image.`
+        );
+        return { type: "image", data: "" };
+      }
+    }
+
+    const runId = context?.jobId;
+    const keepOnGpu =
+      GPU_TEXTURES_ENABLED && typeof runId === "string" && runId.length > 0;
+
     const dims = resolveOutputDims(recipe, source, opts);
     output = createLabeledTexture(device, {
       label: `${recipe.id}-output`,

--- a/packages/image-nodes/tests/canny-border.test.ts
+++ b/packages/image-nodes/tests/canny-border.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test for the Canny border-frame bug.
+ *
+ * The Gaussian pre-blur used to skip the outer 2px of the image, leaving a zero
+ * frame that the Sobel pass read against the real interior as a spurious edge
+ * just inside the border. On a uniform image Canny must produce no edges
+ * anywhere — including within 3px of every border.
+ */
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { LIB_IMAGE_FILTER_NODES } from "@nodetool-ai/image-nodes";
+import { RAW_RGBA_MIME } from "@nodetool-ai/protocol";
+
+/** Build a uniform-gray image as a base64 PNG image ref. */
+async function makeUniformImage(
+  w = 16,
+  h = 16,
+  gray = 128
+): Promise<Record<string, unknown>> {
+  const buf = await sharp({
+    create: { width: w, height: h, channels: 3, background: { r: gray, g: gray, b: gray } }
+  })
+    .png()
+    .toBuffer();
+  return { type: "image", data: buf.toString("base64"), uri: "" };
+}
+
+function findNode(suffix: string) {
+  const cls = (LIB_IMAGE_FILTER_NODES as readonly { nodeType?: string }[]).find(
+    (n) => n.nodeType?.endsWith(suffix)
+  );
+  if (!cls) throw new Error(`Node ending with "${suffix}" not found`);
+  return cls as unknown as {
+    new (): {
+      assign(p: Record<string, unknown>): void;
+      process(): Promise<Record<string, unknown>>;
+    };
+  };
+}
+
+describe("Canny border frame", () => {
+  it("produces no edge pixels on a uniform image, including near the border", async () => {
+    const w = 16;
+    const h = 16;
+    const img = await makeUniformImage(w, h, 128);
+    const Cls = findNode(".Canny");
+    const node = new Cls();
+    node.assign({ image: img, low_threshold: 100, high_threshold: 200 });
+    const output = (await node.process()).output as Record<string, unknown>;
+
+    expect(output.mimeType).toBe(RAW_RGBA_MIME);
+    expect(output.width).toBe(w);
+    expect(output.height).toBe(h);
+    const rgba = output.data as Uint8Array;
+    expect(rgba.length).toBe(w * h * 4);
+
+    // Every pixel must be black (no edge) — the border frame bug lit up pixels
+    // within 3px of the edge.
+    let litPixels = 0;
+    for (let i = 0; i < w * h; i++) {
+      if (rgba[i * 4] !== 0) litPixels++;
+    }
+    expect(litPixels).toBe(0);
+  });
+});

--- a/packages/image-nodes/tests/draw-escaping.test.ts
+++ b/packages/image-nodes/tests/draw-escaping.test.ts
@@ -1,0 +1,44 @@
+/**
+ * SVG attribute escaping for RenderText.
+ *
+ * RenderText (Node path) builds an SVG string and hands it to sharp. Color and
+ * font-family come from node props, so a value containing a quote must not be
+ * able to terminate the attribute and inject arbitrary SVG markup. `escapeXmlAttr`
+ * is the single escaping helper used for every interpolated attribute value.
+ */
+import { describe, it, expect } from "vitest";
+import { escapeXmlAttr } from "../src/nodes/lib-image-draw.js";
+
+describe("escapeXmlAttr", () => {
+  it("escapes the five XML metacharacters", () => {
+    expect(escapeXmlAttr(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&apos;");
+  });
+
+  it("leaves ordinary attribute values untouched", () => {
+    expect(escapeXmlAttr("#FF0000")).toBe("#FF0000");
+    expect(escapeXmlAttr("DejaVu Sans")).toBe("DejaVu Sans");
+  });
+
+  it("neutralizes a double-quote breakout attempt", () => {
+    // A malicious color trying to close fill="" and inject an <image> element.
+    const evil = `red" /><image href="x" onerror="alert(1)`;
+    const escaped = escapeXmlAttr(evil);
+    expect(escaped).not.toContain('"');
+    expect(escaped).toContain("&quot;");
+    // Interpolated into an attribute, the value stays inside the quotes.
+    const svg = `<text fill="${escaped}">hi</text>`;
+    expect(svg).toBe(
+      '<text fill="red&quot; /&gt;&lt;image href=&quot;x&quot; onerror=&quot;alert(1)">hi</text>'
+    );
+    // Only the two literal tag delimiters survive — none from the injected value.
+    expect(svg.match(/</g)?.length).toBe(2);
+  });
+
+  it("neutralizes a single-quote breakout attempt", () => {
+    const evil = `Arial' /><script>x`;
+    const escaped = escapeXmlAttr(evil);
+    expect(escaped).not.toContain("'");
+    expect(escaped).toContain("&apos;");
+    expect(escaped).not.toContain("<script>");
+  });
+});

--- a/packages/image-nodes/tests/enhance-buffer-aliasing.test.ts
+++ b/packages/image-nodes/tests/enhance-buffer-aliasing.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared-buffer aliasing regression for the CPU enhance ops.
+ *
+ * `decodeRgba` returns a raw-RGBA input's pixel array BY REFERENCE (no copy),
+ * which is what upstream GPU nodes emit. AutoContrast and Equalize used to
+ * mutate that array in place, corrupting the upstream node's output for any
+ * other consumer when an edge fans out. These nodes are pure CPU, so no GPU
+ * device is needed here.
+ */
+import { describe, it, expect } from "vitest";
+import { LIB_IMAGE_ENHANCE_NODES, rawRgbaImageRef } from "@nodetool-ai/image-nodes";
+
+function findNode(suffix: string) {
+  const cls = (LIB_IMAGE_ENHANCE_NODES as readonly { nodeType?: string }[]).find(
+    (n) => n.nodeType?.endsWith(suffix)
+  );
+  if (!cls) throw new Error(`node ${suffix} not found`);
+  return cls as unknown as {
+    new (): {
+      assign(p: Record<string, unknown>): void;
+      process(): Promise<Record<string, unknown>>;
+    };
+  };
+}
+
+/** A gradient image so the histogram ops actually transform the pixels. */
+function gradientRgba(w: number, h: number): Uint8Array {
+  const out = new Uint8Array(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    const v = Math.round((i / (w * h - 1)) * 200) + 20; // 20..220, sub-full range
+    out[i * 4] = v;
+    out[i * 4 + 1] = 255 - v;
+    out[i * 4 + 2] = (v * 3) % 256;
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+describe("enhance CPU ops do not mutate the shared input buffer", () => {
+  for (const suffix of [".AutoContrast", ".Equalize"] as const) {
+    it(`${suffix} leaves the raw-RGBA input buffer unchanged`, async () => {
+      const w = 8;
+      const h = 8;
+      const input = gradientRgba(w, h);
+      const before = Uint8Array.from(input); // snapshot of the original bytes
+
+      const node = new (findNode(suffix))();
+      node.assign({ image: rawRgbaImageRef(input, w, h) });
+      const result = await node.process();
+      const output = (result.output ?? result) as Record<string, unknown>;
+
+      // The op transformed something (guards against a no-op passing trivially).
+      expect(output.data).toBeInstanceOf(Uint8Array);
+      expect(output.data).not.toBe(input); // output must not alias the input
+
+      // The input buffer is byte-for-byte identical to before the run.
+      expect(input).toEqual(before);
+    });
+  }
+});

--- a/packages/image-nodes/tests/image-contract-fixes.test.ts
+++ b/packages/image-nodes/tests/image-contract-fixes.test.ts
@@ -1,0 +1,95 @@
+// CanvasResize pads/crops on the GPU shader pool — load the SwiftShader ICD so
+// a CPU WebGPU device is available in CI.
+import "../../gpu/tests/setup/swiftshaderIcd.js";
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { SaveImageFileImageNode, CanvasResizeNode } from "../src/nodes/image.js";
+
+async function makeTestImage(
+  w = 4,
+  h = 4,
+  r = 128,
+  g = 64,
+  b = 32
+): Promise<Record<string, unknown>> {
+  const buf = await sharp({
+    create: { width: w, height: h, channels: 3, background: { r, g, b } }
+  })
+    .png()
+    .toBuffer();
+  return {
+    type: "image",
+    data: buf.toString("base64"),
+    uri: "",
+    width: w,
+    height: h
+  };
+}
+
+describe("SaveImageFileImageNode output contract", () => {
+  it("returns an image-typed output plus the path string", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "save-image-test-"));
+    try {
+      const node = new SaveImageFileImageNode();
+      node.assign({
+        image: await makeTestImage(6, 6, 10, 20, 30),
+        folder: dir,
+        filename: "out.png",
+        overwrite: true
+      });
+      const result = await node.process();
+
+      // path is a plain string pointing at the written file.
+      const path = result.path as string;
+      expect(typeof path).toBe("string");
+      expect(path).toBe(join(dir, "out.png"));
+      const onDisk = await readFile(path);
+      expect(onDisk.length).toBeGreaterThan(0);
+
+      // output is a proper image ref (not the bare path string): carries bytes,
+      // a file:// uri, mime, and dimensions — mirroring LoadImageFile.
+      const output = result.output as Record<string, unknown>;
+      expect(output.type).toBe("image");
+      expect(typeof output.data).toBe("string");
+      expect(output.uri).toBe(`file://${path}`);
+      expect(output.mimeType).toBe("image/png");
+      expect(output.width).toBe(6);
+      expect(output.height).toBe(6);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("CanvasResizeNode fixed mode smaller than source", () => {
+  it("crops centrally so the output is exactly the requested dimensions", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(20, 20, 255, 0, 0),
+      mode: "fixed",
+      width: 8,
+      height: 8
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(8);
+    expect(output.height).toBe(8);
+  });
+
+  it("crops one axis and pads the other when the canvas is mixed", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(20, 4, 0, 255, 0),
+      mode: "fixed",
+      width: 8, // smaller than source width (crop)
+      height: 12 // larger than source height (pad)
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(8);
+    expect(output.height).toBe(12);
+  });
+});

--- a/packages/image-nodes/tests/lib-grid.test.ts
+++ b/packages/image-nodes/tests/lib-grid.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Round-trip tests for the grid nodes: SliceImageGrid must emit placement
+ * metadata that CombineImageGrid uses to reassemble the original image exactly,
+ * even when the dimensions are not evenly divisible by the column/row count.
+ *
+ * These nodes run on the CPU `sharp` codec (no GPU/WebGPU), so no ICD shim is
+ * needed. The helper shape follows tests/lib-image-processing.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { LIB_GRID_NODES } from "@nodetool-ai/image-nodes";
+
+/** Find a node class by its static nodeType suffix. */
+function findNode(suffix: string) {
+  const cls = LIB_GRID_NODES.find((n) =>
+    (n as unknown as { nodeType: string }).nodeType?.endsWith(suffix)
+  );
+  if (!cls) throw new Error(`Node ending with "${suffix}" not found`);
+  return cls;
+}
+
+/** Instantiate a node, assign inputs, call process(), return the raw result. */
+async function runNode(
+  suffix: string,
+  inputs: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const Cls = findNode(suffix);
+  const node = new (Cls as unknown as {
+    new (): {
+      assign(p: Record<string, unknown>): void;
+      process(ctx?: unknown): Promise<Record<string, unknown>>;
+    };
+  })();
+  node.assign(inputs);
+  return node.process();
+}
+
+/** A deterministic per-pixel gradient PNG image ref. */
+async function makeGradientImage(
+  w: number,
+  h: number
+): Promise<Record<string, unknown>> {
+  const pixels = Buffer.alloc(w * h * 3);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 3;
+      pixels[i] = (x * 17 + y * 3) % 256;
+      pixels[i + 1] = (x * 5 + y * 23) % 256;
+      pixels[i + 2] = (x * 11 + y * 7) % 256;
+    }
+  }
+  const buf = await sharp(pixels, { raw: { width: w, height: h, channels: 3 } })
+    .png()
+    .toBuffer();
+  return { type: "image", data: buf.toString("base64"), uri: "" };
+}
+
+/** Decode an image ref (Uint8Array or base64 PNG) to raw RGBA + meta. */
+async function refToRgba(
+  ref: Record<string, unknown>
+): Promise<{ rgba: Buffer; width: number; height: number }> {
+  const buf =
+    ref.data instanceof Uint8Array
+      ? Buffer.from(ref.data)
+      : Buffer.from(ref.data as string, "base64");
+  const { data, info } = await sharp(buf)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return { rgba: data, width: info.width, height: info.height };
+}
+
+type Placement = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  row: number;
+  column: number;
+  columns: number;
+  rows: number;
+};
+
+function placementOf(tile: Record<string, unknown>): Placement {
+  const md = tile.metadata as { grid?: Placement } | null;
+  if (!md?.grid) throw new Error("tile is missing grid placement metadata");
+  return md.grid;
+}
+
+describe("lib-grid round trip", () => {
+  it("SliceImageGrid tile sizes tile exactly, no gaps or overlaps (10x10 into 3x3)", async () => {
+    const img = await makeGradientImage(10, 10);
+    const result = await runNode(".SliceImageGrid", {
+      image: img,
+      columns: 3,
+      rows: 3
+    });
+    const tiles = result.output as Array<Record<string, unknown>>;
+    expect(tiles).toHaveLength(9);
+
+    const placements = tiles.map(placementOf);
+    for (const p of placements) {
+      expect(p.canvasWidth).toBe(10);
+      expect(p.canvasHeight).toBe(10);
+      expect(p.columns).toBe(3);
+      expect(p.rows).toBe(3);
+    }
+
+    // Each row's tile widths sum to the full canvas width, laid edge to edge.
+    for (let row = 0; row < 3; row++) {
+      const rowTiles = placements
+        .filter((p) => p.row === row)
+        .sort((a, b) => a.column - b.column);
+      expect(rowTiles.map((p) => p.width).reduce((a, b) => a + b, 0)).toBe(10);
+      let cursor = 0;
+      for (const p of rowTiles) {
+        expect(p.x).toBe(cursor);
+        cursor += p.width;
+      }
+      expect(cursor).toBe(10);
+    }
+
+    // Each column's tile heights sum to the full canvas height, edge to edge.
+    for (let col = 0; col < 3; col++) {
+      const colTiles = placements
+        .filter((p) => p.column === col)
+        .sort((a, b) => a.row - b.row);
+      expect(colTiles.map((p) => p.height).reduce((a, b) => a + b, 0)).toBe(10);
+      let cursor = 0;
+      for (const p of colTiles) {
+        expect(p.y).toBe(cursor);
+        cursor += p.height;
+      }
+      expect(cursor).toBe(10);
+    }
+  });
+
+  it("Slice -> Combine reproduces original dimensions and pixels exactly", async () => {
+    const img = await makeGradientImage(10, 10);
+    const original = await refToRgba(img);
+
+    const sliced = await runNode(".SliceImageGrid", {
+      image: img,
+      columns: 3,
+      rows: 3
+    });
+    const tiles = sliced.output as Array<Record<string, unknown>>;
+
+    const combined = await runNode(".CombineImageGrid", { tiles });
+    const out = await refToRgba(combined.output as Record<string, unknown>);
+
+    expect(out.width).toBe(original.width);
+    expect(out.height).toBe(original.height);
+    expect(out.width).toBe(10);
+    expect(out.height).toBe(10);
+    expect(Buffer.compare(out.rgba, original.rgba)).toBe(0);
+  });
+
+  it("Combine falls back to uniform grid when tiles lack placement metadata", async () => {
+    // Two equal 4x4 tiles, no metadata → uniform 2-column grid → 8x4 canvas.
+    const tileImg = await makeGradientImage(4, 4);
+    const tileBuf = Buffer.from(tileImg.data as string, "base64");
+    const plainTile = { type: "image", data: new Uint8Array(tileBuf) };
+
+    const combined = await runNode(".CombineImageGrid", {
+      tiles: [plainTile, plainTile],
+      columns: 2
+    });
+    const out = await refToRgba(combined.output as Record<string, unknown>);
+    expect(out.width).toBe(8);
+    expect(out.height).toBe(4);
+  });
+});

--- a/packages/image-nodes/tests/regression-image-nodes.test.ts
+++ b/packages/image-nodes/tests/regression-image-nodes.test.ts
@@ -272,7 +272,7 @@ describe("SaveImageFileImageNode — overwrite=false", () => {
     const node1 = new SaveImageFileImageNode();
     node1.assign({ image: imgRef, folder: dir, filename: "test.png", overwrite: false });
     const result1 = await node1.process();
-    const path1 = result1.output as string;
+    const path1 = result1.path as string;
     expect(path1).toContain("test.png");
     expect(path1).not.toContain("_1");
 
@@ -280,7 +280,7 @@ describe("SaveImageFileImageNode — overwrite=false", () => {
     const node2 = new SaveImageFileImageNode();
     node2.assign({ image: imgRef, folder: dir, filename: "test.png", overwrite: false });
     const result2 = await node2.process();
-    const path2 = result2.output as string;
+    const path2 = result2.path as string;
 
     // The second file must have a different name (e.g. test_1.png)
     expect(path2).not.toBe(path1);
@@ -305,7 +305,7 @@ describe("SaveImageFileImageNode — overwrite=false", () => {
     const result2 = await node2.process();
 
     // Both should return the same path
-    expect(result1.output).toBe(result2.output);
+    expect(result1.path).toBe(result2.path);
   });
 });
 

--- a/packages/image-nodes/tests/vignette-direction.test.ts
+++ b/packages/image-nodes/tests/vignette-direction.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test pinning the Vignette node's midpoint direction.
+ *
+ * The `midpoint` prop is documented "Distance from center where vignette begins
+ * (0=center, 1=edges)". The node maps it onto the shader's `radius`, and the
+ * shader darkens where `dist > radius - softness`. A previous `radius: 1 -
+ * midpoint` mapping inverted this: a low midpoint darkened the center and a
+ * high midpoint darkened the edges — exactly backwards. These tests lock the
+ * documented behaviour in place.
+ *
+ * Requires a WebGPU device (Dawn); the SwiftShader ICD shim supplies a CPU
+ * adapter in CI.
+ */
+import "../../gpu/tests/setup/swiftshaderIcd.js";
+
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { LIB_IMAGE_COLOR_GRADING_NODES } from "@nodetool-ai/image-nodes";
+import { RAW_RGBA_MIME } from "@nodetool-ai/protocol";
+
+/** Resolve a node output ImageRef to straight-alpha RGBA bytes. */
+async function refToRgba(
+  ref: Record<string, unknown>
+): Promise<{ rgba: Buffer; width: number; height: number }> {
+  if (ref.data instanceof Uint8Array && ref.mimeType === RAW_RGBA_MIME) {
+    return {
+      rgba: Buffer.from(ref.data),
+      width: ref.width as number,
+      height: ref.height as number
+    };
+  }
+  const buf = Buffer.from(ref.data as string, "base64");
+  const { data, info } = await sharp(buf)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return { rgba: data, width: info.width, height: info.height };
+}
+
+/** Create a uniform mid-gray image as a base64 image ref. */
+async function makeGrayImage(
+  w = 32,
+  h = 32,
+  gray = 128
+): Promise<Record<string, unknown>> {
+  const buf = await sharp({
+    create: {
+      width: w,
+      height: h,
+      channels: 3,
+      background: { r: gray, g: gray, b: gray }
+    }
+  })
+    .png()
+    .toBuffer();
+  return { type: "image", data: buf.toString("base64"), uri: "" };
+}
+
+/** Instantiate the Vignette node, assign inputs, run it, return the output ref. */
+async function runVignette(
+  inputs: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const Cls = LIB_IMAGE_COLOR_GRADING_NODES.find((n) =>
+    (n as unknown as { nodeType: string }).nodeType?.endsWith(".Vignette")
+  ) as unknown as {
+    new (): {
+      assign(p: Record<string, unknown>): void;
+      process(ctx?: unknown): Promise<Record<string, unknown>>;
+    };
+  };
+  if (!Cls) throw new Error("Vignette node not found");
+  const node = new Cls();
+  node.assign(inputs);
+  const result = await node.process();
+  return (result.output ?? result) as Record<string, unknown>;
+}
+
+/** Read the red channel (grayscale, so any channel works) at pixel (x, y). */
+function pixel(
+  rgba: Buffer,
+  width: number,
+  x: number,
+  y: number
+): number {
+  return rgba[(y * width + x) * 4];
+}
+
+describe("Vignette midpoint direction", () => {
+  const GRAY = 128;
+
+  it("low midpoint + high amount darkens corners relative to center", async () => {
+    const img = await makeGrayImage(32, 32, GRAY);
+    const output = await runVignette({
+      image: img,
+      amount: 1,
+      midpoint: 0.1,
+      feather: 0.5
+    });
+    const { rgba, width, height } = await refToRgba(output);
+
+    const center = pixel(rgba, width, width / 2, height / 2);
+    const corner = pixel(rgba, width, 0, 0);
+
+    // Documented semantics: midpoint near 0 begins the vignette at the center,
+    // so corners must be darker than the center (and darker than the input).
+    expect(corner).toBeLessThan(center);
+    expect(corner).toBeLessThan(GRAY);
+  });
+
+  it("midpoint near 1 leaves the center (nearly) untouched", async () => {
+    const img = await makeGrayImage(32, 32, GRAY);
+    const output = await runVignette({
+      image: img,
+      amount: 1,
+      midpoint: 0.98,
+      feather: 0.5
+    });
+    const { rgba, width, height } = await refToRgba(output);
+
+    const center = pixel(rgba, width, width / 2, height / 2);
+
+    // With the onset pushed to the edges, the center pixel stays at the input
+    // gray value (allow a small tolerance for 8-bit rounding).
+    expect(Math.abs(center - GRAY)).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Correctness:
- Vignette (color grading): midpoint mapping was inverted (radius: 1 - midpoint);
  midpoint=0 now starts the vignette at the center, 1 at the edges, matching docs
- AutoContrast/Equalize: copy the decoded buffer before mutating — decodeRgba
  borrows raw-RGBA input buffers by reference, so in-place edits corrupted the
  upstream node's output on fan-out
- Slice/Combine image grid: slice now emits per-tile placement metadata and
  combine uses it to reassemble losslessly; uniform-grid fallback kept for
  tiles without metadata
- Canny: gaussian pass now clamps kernel taps at the borders instead of leaving
  a 2px zero frame that manufactured spurious edges
- SaveImageFile: output is now an image ref (as declared); the file path moved
  to a new `path` output
- ImageToImage: stop stamping the input image's uri onto the output ref (it
  shadowed the generated bytes in previews)
- CanvasResize: fixed/scale modes smaller than the source now crop centrally to
  the requested canvas instead of silently returning the source size
- LumaKey: normalize low/high so crossed bounds no longer blank the image

Robustness & safety:
- runShaderNode/runRecipeNode: upload textures inside try/finally so decode
  failures mid-upload no longer leak GPU textures; warn on missing inputs
  instead of silently propagating empty images; recipe registry cache no longer
  retains a rejected import forever
- RenderText SVG: escape color/font-family attribute values (injection fix);
  clamp draw/generator dimensions and sizes with finite guards
- RankFilter: clamp window size to 25 (512 allowed a ~262k-element sort per
  pixel per channel)
- SaturationVibrance: clamp combined multiplier at 0; describe vibrance
  honestly (no skin-tone protection); RenderText docs no longer promise font
  downloading
- New imageDimensions() helper reads dims from ref fields or image headers,
  removing full-decode (and GPU readback) round trips in Pad/Affine/Expand

Tests: buffer-aliasing, vignette direction, grid round-trip, canny border,
SVG attribute escaping, SaveImageFile/CanvasResize contracts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PcLhFMwU2Zzu3MJ8877e4K