### PR TITLE
Fix yt-dlp download node: typed outputs, sub_langs prop, stricter validation

### DIFF
--- a/packages/base-nodes/tests/audio-video-image-props.test.ts
+++ b/packages/base-nodes/tests/audio-video-image-props.test.ts
@@ -206,14 +206,19 @@ describe("FpsNode — uses ffprobe for fps extraction", () => {
     expect(typeof result.output).toBe("number");
   });
 
-  it("returns 0 when ffprobe not available", async () => {
+  it("returns 0 for undecodable data, or throws when ffprobe is missing", async () => {
     const node = new FpsNode();
     node.assign({
       video: videoRef([1, 2, 3])
     });
-    // ffprobe will fail for non-video data, returning 0
-    const result = await node.process();
-    expect(typeof result.output).toBe("number");
+    // A genuine probe failure (garbage bytes) degrades to 0; a missing
+    // ffprobe binary must surface as an actionable error instead.
+    try {
+      const result = await node.process();
+      expect(result.output).toBe(0);
+    } catch (error) {
+      expect((error as Error).message).toContain("ffprobe is not installed");
+    }
   });
 });
 

--- a/packages/base-nodes/tests/example-workflows-execute.test.ts
+++ b/packages/base-nodes/tests/example-workflows-execute.test.ts
@@ -192,6 +192,7 @@ function classifyError(message: string | undefined): string {
   if (!message) return "none";
   const m = message.toLowerCase();
   if (m.includes("graph validation failed")) return "graph-validation";
+  if (m.includes("is not installed or not on path")) return "missing-binary";
   if (m.includes("select a model")) return "missing-model";
   if (m.includes("requires a") && m.includes("model")) return "missing-model";
   if (m.includes("is not configured") || m.includes("must be configured"))

--- a/packages/dsl/src/generated/lib.video.download.ts
+++ b/packages/dsl/src/generated/lib.video.download.ts
@@ -10,6 +10,7 @@ export interface YtDlpDownloadInputs {
   format_selector?: Connectable<string>;
   container?: Connectable<string>;
   subtitles?: Connectable<boolean>;
+  sub_langs?: Connectable<string>;
   thumbnail?: Connectable<boolean>;
   overwrite?: Connectable<boolean>;
   rate_limit_kbps?: Connectable<number>;

--- a/packages/video-nodes/AGENTS.md
+++ b/packages/video-nodes/AGENTS.md
@@ -4,6 +4,35 @@
 
 > Read [packages/AGENTS.md](../AGENTS.md) first (media-ref rules apply). This overlay covers video-specific correctness.
 
+## ffmpeg / ffprobe failures throw — no silent pass-through
+
+- **A terminal ffmpeg/ffprobe failure throws**, it never returns the unchanged
+  input. `ffmpegTransform` rejects with `ffmpeg failed: <stderr>` (the execFile
+  error carries `.stderr`); a no-op effect that quietly returns its input is
+  indistinguishable from a real one and hides the bug. The only legitimate
+  fallbacks are explicit multi-attempt chains — SetSpeed (audio+video → video),
+  Overlay/Transition (with-audio → video-only), Reverse (audio+video → video),
+  AddAudio (mix → replace). Pass `{ allowFallback: true }` to the non-terminal
+  attempt so it returns `null`; the LAST attempt omits it and throws.
+- **A missing binary is `MissingBinaryError`**, carrying the binary name, raised
+  by `execFfmpeg`/`execFfprobe` on spawn `ENOENT` — for ffprobe as well as
+  ffmpeg. Every probe site surfaces it (Fps, GetVideoInfo, ForEachFrame, Concat,
+  Transition, ExtractFrame). Info-style nodes (Fps, GetVideoInfo) may still
+  degrade a *genuine* probe failure on corrupt input to a 0/empty result, but
+  must re-throw `MissingBinaryError`.
+- **Empty input bytes short-circuit** to an empty/passthrough ref before any
+  spawn — that is not a failure and stays.
+
+## Shared helpers: `src/nodes/ffmpeg-helpers.ts`
+
+Internal module (not re-exported from the package index) holding the exec
+helpers + `MissingBinaryError`, `videoRef`/`defaultVideoRef`, `parseFrameRate`,
+`ffprobeDuration`, `withTempFile`, `filePath`/`folderPath`, `dateName`,
+`uniqueTargetPath`, and `coerceProviderBytes`. Helpers take no node-specific
+state so `timeline.ts` can import them too. `defaultVideoRef()` is called per
+`@prop` default so each prop gets its own object — never share one mutable
+default across props.
+
 ## Reading input media
 
 - **Read input audio/video bytes with the async, context-aware resolver**

--- a/packages/video-nodes/HANDOVER.md
+++ b/packages/video-nodes/HANDOVER.md
@@ -1,0 +1,90 @@
+# video-nodes: handover for remaining work
+
+Status of the video-nodes review/fix effort on branch
+`claude/video-nodes-critique-3jab65`, and what still needs doing. Delete this
+file once the items below are ticked off or turned into issues.
+
+## Done on this branch
+
+- `801e036` — yt-dlp node: typed empty output refs, `sub_langs` prop,
+  `new URL()` validation, real prop types, malformed-metadata errors, 15 tests.
+- `5936afc` — video.ts: removed the silent ffmpeg-failure fallback (terminal
+  failures now throw with stderr), `MissingBinaryError` for ffmpeg *and*
+  ffprobe, AddSubtitles `textfile=` escaping fix, Concat probe-then-normalize,
+  input-side Trim seek, real two-pass `crop_black` in Stabilize, shared
+  `ffmpeg-helpers.ts`, typed props (no `any`), save-filename de-dup, provider
+  output validation, streaming raw-frame writes. 16 new tests.
+- `a727bc1` — timeline.ts deduped against `ffmpeg-helpers.ts`; base-nodes
+  tests updated for the throw-on-missing-binary contract.
+
+Verified: video-nodes 144/144; downstream per `nodetool affected` all green
+(base-nodes 1320, cli 357, deploy 851, dsl 138, websocket 1576,
+workflow-runner).
+
+## Remaining work
+
+### 1. Media refs hold full video bytes as base64 in memory (large, cross-cutting)
+
+Every node output goes through `videoRef()` → base64 `data` on the ref: +33%
+size, duplicated across `Uint8Array` + string, shipped over msgpack per node in
+a chain. Worst offenders:
+
+- `combineFramesToVideo` / all effect nodes — output re-encoded to base64 even
+  though the bytes already sit in a temp file.
+- `YtDlpDownload` reads the entire download into one base64 ref; a long 4K
+  video can OOM the process.
+- `LoadVideoAssets` reads every file in the folder into memory; its buffered
+  `process()` additionally accumulates the whole list.
+- `ForEachFrame` extracts all frames to PNGs before yielding the first one.
+
+Fix direction: emit `file://` temp URIs or auto-saved assets (`autoSaveAsset`
+plumbing and `loadMediaRefBytes` already exist) instead of inline `data`.
+Needs coordination with the runtime and web preview, which currently expect
+inline bytes for in-flight refs — hence a dedicated PR, not a drive-by.
+
+### 2. Regenerate the DSL package wholesale (drift, pre-existing)
+
+`npm run codegen --workspace=packages/dsl` produces a large diff against the
+committed `packages/dsl/src/generated/`: 18 missing namespace files
+(`nodetool.timeline`, `xai.*`, `lib.image.*`, `lib.comfy`, …), changed output
+shapes (`lib.sqlite.Insert` now has `row_id`/`rows_affected`/`message`), and
+missing nodes (`VideoToVideo`, `LipSync`). Only the one-line `sub_langs`
+addition caused by this branch was committed; the rest was reverted to keep
+this PR reviewable. Also check one suspicious regen change before committing:
+`ConcatInputs` loses its `[video: string]` index signature for dynamic inputs —
+verify that is intended codegen behavior for `supportsDynamicInputs` nodes and
+not a codegen regression.
+
+### 3. Move model3d out of video-nodes
+
+`src/nodes/model3d/` (plus ~1200 lines of model3d tests) lives in a package
+named video-nodes. Extract to its own package or fold into an existing 3D/media
+package. Mechanical, but touches package registration and the DSL codegen.
+
+### 4. Model-aware provider parameter validation
+
+TextToVideo/ImageToVideo offer fixed aspect-ratio/resolution/duration enums
+regardless of what the selected model supports; mismatches surface only as
+provider errors mid-run. The model manifests in `packages/runtime` providers
+know per-model capabilities — validate (or filter the UI choices) against them.
+
+### 5. Small follow-ups
+
+- `FrameToVideoNode.run` has an `fps` stream-handle branch but `fps` is not in
+  `inputFields`. Verify whether a wired `fps` ever arrives via `inputs.any()`;
+  either declare the input or delete the branch.
+- Save nodes default `folder` to `"."` (the server cwd). Pick a sane default
+  (workspace dir or assets) instead.
+- Trim keeps `-c copy` (fast, keyframe-aligned). Consider an "accurate"
+  toggle that re-encodes for frame-exact cuts.
+
+## Environment notes for the next session
+
+- Sandboxed installs: `npm install --ignore-scripts` skips the better-sqlite3
+  native rebuild; base-nodes/websocket tests then fail on missing bindings.
+  Run `npm run rebuild:native` afterwards (worked in this sandbox).
+- Tests import `@nodetool-ai/video-nodes` from `dist/` — run
+  `npm run build --workspace=packages/video-nodes` before `npx vitest run`.
+- ffmpeg/ffprobe are not installed in the sandbox; all tests mock
+  `node:child_process`. The timeline tests' mock covers the shared helpers via
+  a `promisify.custom` handler — keep that if you touch the exec plumbing.

--- a/packages/video-nodes/src/nodes/ffmpeg-helpers.ts
+++ b/packages/video-nodes/src/nodes/ffmpeg-helpers.ts
@@ -1,0 +1,247 @@
+/**
+ * Shared ffmpeg/ffprobe helpers for the video nodes.
+ *
+ * Internal to the package — deliberately NOT re-exported from `src/index.ts`.
+ * Everything here is free of node-specific state so `timeline.ts` (and any other
+ * ffmpeg-backed module) can import it directly.
+ *
+ * Policy: a spawn failure because the binary is missing (`ENOENT`) surfaces as
+ * {@link MissingBinaryError} carrying the binary name. A genuine tool failure
+ * (non-zero exit) rejects with the underlying error, whose `.stderr` carries
+ * ffmpeg's diagnostics — callers turn that into an actionable message instead of
+ * silently passing the input through.
+ */
+import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import type { VideoRef } from "@nodetool-ai/node-sdk";
+
+export const execFile = promisify(execFileCb);
+
+export const FFMPEG_MAX_BUFFER = 50 * 1024 * 1024;
+
+/** A required binary (ffmpeg/ffprobe) is not installed or not on PATH. */
+export class MissingBinaryError extends Error {
+  readonly binary: string;
+  constructor(binary: string) {
+    super(
+      `${binary} is not installed or not on PATH. Install ${binary} (the ` +
+        `Package Manager UI can do this) to process video — these nodes shell ` +
+        `out to ffmpeg/ffprobe and cannot run without it.`
+    );
+    this.name = "MissingBinaryError";
+    this.binary = binary;
+  }
+}
+
+/**
+ * Whether `err` is a spawn ENOENT (binary not on PATH) rather than the tool
+ * running and reporting a non-zero exit. Scope this to the spawn itself so an
+ * unrelated filesystem ENOENT is never mislabeled as a missing binary.
+ */
+function isSpawnEnoent(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+/** Run ffmpeg, mapping a missing binary to {@link MissingBinaryError}. */
+export async function execFfmpeg(
+  args: string[],
+  options: { maxBuffer?: number } = {}
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFile("ffmpeg", args, options);
+  } catch (error) {
+    if (isSpawnEnoent(error)) throw new MissingBinaryError("ffmpeg");
+    throw error;
+  }
+}
+
+/** Run ffprobe, mapping a missing binary to {@link MissingBinaryError}. */
+export async function execFfprobe(
+  args: string[],
+  options: { maxBuffer?: number } = {}
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFile("ffprobe", args, options);
+  } catch (error) {
+    if (isSpawnEnoent(error)) throw new MissingBinaryError("ffprobe");
+    throw error;
+  }
+}
+
+/** Build a VideoRef from raw bytes (raw base64 `data`, `type: "video"`). */
+export function videoRef(
+  data: Uint8Array,
+  extras: Partial<VideoRef> = {}
+): VideoRef {
+  return {
+    type: "video",
+    data: Buffer.from(data).toString("base64"),
+    ...extras
+  };
+}
+
+/** A fresh empty VideoRef prop default. Each call returns its own object. */
+export function defaultVideoRef(): VideoRef {
+  return {
+    type: "video",
+    uri: "",
+    asset_id: null,
+    data: null,
+    metadata: null,
+    duration: null,
+    format: null
+  };
+}
+
+/** Resolve a `file://` URI (or plain path) to a filesystem path. */
+export function filePath(uriOrPath: string): string {
+  if (uriOrPath.startsWith("file://")) {
+    try {
+      return fileURLToPath(new URL(uriOrPath));
+    } catch {
+      // Fallback for non-standard URIs like file://C:\path
+      return uriOrPath.slice("file://".length);
+    }
+  }
+  return uriOrPath;
+}
+
+/**
+ * Resolve a folder value to a filesystem path. Accepts a plain string path/URI
+ * or a folder ref object (`{ uri }`); returns "" when no usable path is present.
+ */
+export function folderPath(raw: unknown): string {
+  if (typeof raw === "string") {
+    return raw.startsWith("file:") ? filePath(raw) : raw;
+  }
+  if (raw && typeof raw === "object") {
+    const uri = (raw as Record<string, unknown>).uri;
+    if (typeof uri === "string" && uri.length > 0) return filePath(uri);
+  }
+  return "";
+}
+
+/** Expand %Y/%m/%d/%H/%M/%S date tokens in a filename. */
+export function dateName(name: string): string {
+  const now = new Date();
+  const pad = (v: number): string => String(v).padStart(2, "0");
+  return name
+    .replaceAll("%Y", String(now.getFullYear()))
+    .replaceAll("%m", pad(now.getMonth() + 1))
+    .replaceAll("%d", pad(now.getDate()))
+    .replaceAll("%H", pad(now.getHours()))
+    .replaceAll("%M", pad(now.getMinutes()))
+    .replaceAll("%S", pad(now.getSeconds()));
+}
+
+/**
+ * Return a non-colliding path: `target` itself if free, otherwise `name-1.ext`,
+ * `name-2.ext`, … Guards saves in the same second (dateName granularity) from
+ * silently overwriting each other.
+ */
+export async function uniqueTargetPath(target: string): Promise<string> {
+  const exists = async (p: string): Promise<boolean> => {
+    try {
+      await fs.access(p);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (!(await exists(target))) return target;
+  const dir = path.dirname(target);
+  const ext = path.extname(target);
+  const base = path.basename(target, ext);
+  for (let i = 1; ; i++) {
+    const candidate = path.join(dir, `${base}-${i}${ext}`);
+    if (!(await exists(candidate))) return candidate;
+  }
+}
+
+/**
+ * Parse an ffprobe `r_frame_rate` value ("30000/1001" or "25") into a number.
+ * Returns 0 for malformed values or zero denominators instead of NaN/Infinity.
+ */
+export function parseFrameRate(raw: string): number {
+  const parts = raw.trim().split("/");
+  if (parts.length === 2) {
+    const num = Number(parts[0]);
+    const den = Number(parts[1]);
+    return Number.isFinite(num) && den > 0 ? num / den : 0;
+  }
+  const val = Number(parts[0]);
+  return Number.isFinite(val) && val > 0 ? val : 0;
+}
+
+/**
+ * Probe a file's duration in seconds. A missing ffprobe binary surfaces as
+ * {@link MissingBinaryError}; a genuine probe failure (corrupt input) returns 0.
+ */
+export async function ffprobeDuration(file: string): Promise<number> {
+  try {
+    const { stdout } = await execFfprobe([
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      file
+    ]);
+    const val = parseFloat(stdout.trim());
+    return isNaN(val) ? 0 : val;
+  } catch (error) {
+    if (error instanceof MissingBinaryError) throw error;
+    return 0;
+  }
+}
+
+/** Write `bytes` to a temp file with `suffix`, returning its path + cleanup. */
+export async function withTempFile(
+  suffix: string,
+  bytes: Uint8Array
+): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-video-"));
+  const file = path.join(dir, `input${suffix}`);
+  await fs.writeFile(file, bytes);
+  return {
+    path: file,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  };
+}
+
+/**
+ * Normalize provider-prediction output to `Uint8Array`. Accepts `Uint8Array`,
+ * `Buffer`, or `ArrayBuffer`; anything else throws a clear error naming the node
+ * and the received type instead of casting blindly.
+ */
+export function coerceProviderBytes(
+  value: unknown,
+  nodeName: string
+): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  const received =
+    value === null
+      ? "null"
+      : Array.isArray(value)
+        ? "array"
+        : typeof value === "object"
+          ? ((value as { constructor?: { name?: string } }).constructor?.name ??
+            "object")
+          : typeof value;
+  throw new Error(
+    `${nodeName}: provider returned ${received}, expected video bytes ` +
+      `(Uint8Array/Buffer).`
+  );
+}

--- a/packages/video-nodes/src/nodes/lib-video-download.ts
+++ b/packages/video-nodes/src/nodes/lib-video-download.ts
@@ -56,8 +56,31 @@ async function runCommand(
   });
 }
 
+// Trust model: the URL is user-supplied and yt-dlp runs on the user's own
+// machine (this is a local desktop tool). We only require a well-formed
+// http(s) URL — there is deliberately no internal-network/SSRF blocking, since
+// the user is free to point this at any host they can already reach.
 function isValidUrl(url: string): boolean {
-  return /^https?:\/\/[^\s/$.?#].[^\s]*$/i.test(url);
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+const DEFAULT_SUB_LANGS = "en,en-US,en-GB";
+
+function emptyVideoRef(): Record<string, unknown> {
+  return { type: "video", uri: "", asset_id: null, data: null, metadata: null };
+}
+
+function emptyAudioRef(): Record<string, unknown> {
+  return { type: "audio", uri: "", asset_id: null, data: null, metadata: null };
+}
+
+function emptyImageRef(): Record<string, unknown> {
+  return { type: "image", uri: "", asset_id: null, data: null, metadata: null };
 }
 
 function safeMetadata(info: Record<string, unknown>): Record<string, unknown> {
@@ -143,7 +166,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Url",
     description: "URL of the media to download"
   })
-  declare url: any;
+  declare url: string;
 
   @prop({
     type: "enum",
@@ -152,7 +175,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     description: "Download mode: video, audio, or metadata only",
     values: ["video", "audio", "metadata"]
   })
-  declare mode: any;
+  declare mode: string;
 
   @prop({
     type: "str",
@@ -160,7 +183,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Format Selector",
     description: "yt-dlp format selector (e.g., 'best', 'bestvideo+bestaudio')"
   })
-  declare format_selector: any;
+  declare format_selector: string;
 
   @prop({
     type: "str",
@@ -168,7 +191,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Container",
     description: "Output container format (e.g., 'mp4', 'webm', 'auto')"
   })
-  declare container: any;
+  declare container: string;
 
   @prop({
     type: "bool",
@@ -176,7 +199,16 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Subtitles",
     description: "Download subtitles if available"
   })
-  declare subtitles: any;
+  declare subtitles: boolean;
+
+  @prop({
+    type: "str",
+    default: DEFAULT_SUB_LANGS,
+    title: "Subtitle Languages",
+    description:
+      "Comma-separated subtitle language codes in yt-dlp syntax (e.g., 'en,en-US,en-GB', 'de.*', 'all'). Only used when Subtitles is enabled."
+  })
+  declare sub_langs: string;
 
   @prop({
     type: "bool",
@@ -184,7 +216,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Thumbnail",
     description: "Download thumbnail if available"
   })
-  declare thumbnail: any;
+  declare thumbnail: boolean;
 
   @prop({
     type: "bool",
@@ -192,7 +224,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     title: "Overwrite",
     description: "Overwrite existing files"
   })
-  declare overwrite: any;
+  declare overwrite: boolean;
 
   @prop({
     type: "int",
@@ -201,7 +233,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     description: "Rate limit in KB/s (0 = unlimited)",
     min: 0
   })
-  declare rate_limit_kbps: any;
+  declare rate_limit_kbps: number;
 
   @prop({
     type: "int",
@@ -211,7 +243,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     min: 1,
     max: 3600
   })
-  declare timeout: any;
+  declare timeout: number;
 
   async process(): Promise<Record<string, unknown>> {
     const url = String(this.url ?? "").trim();
@@ -227,6 +259,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
     const formatSelector = String(this.format_selector ?? "best");
     const container = String(this.container ?? "auto");
     const subtitles = Boolean(this.subtitles ?? false);
+    const subLangs = String(this.sub_langs ?? "").trim() || DEFAULT_SUB_LANGS;
     const thumbnail = Boolean(this.thumbnail ?? false);
     const overwrite = Boolean(this.overwrite ?? false);
     const rateLimitKbps = Number(this.rate_limit_kbps ?? 0);
@@ -262,16 +295,31 @@ export class YtDlpDownloadLibNode extends BaseNode {
           break;
         }
       }
-      const parsedInfo = jsonLine
-        ? (JSON.parse(jsonLine) as Record<string, unknown>)
-        : {};
+      // yt-dlp exited 0 but produced no JSON info line — abnormal output.
+      // Downstream download-file naming relies on parsedInfo.id, so a silent
+      // {} would break it; fail loudly instead.
+      if (!jsonLine) {
+        throw new Error(
+          "yt-dlp metadata output was malformed: no JSON info line found in stdout"
+        );
+      }
+      let parsedInfo: Record<string, unknown>;
+      try {
+        parsedInfo = JSON.parse(jsonLine) as Record<string, unknown>;
+      } catch (error) {
+        throw new Error(
+          `yt-dlp metadata output was malformed: could not parse JSON info line (${
+            error instanceof Error ? error.message : String(error)
+          })`
+        );
+      }
 
       const output: Record<string, unknown> = {
-        video: {},
-        audio: {},
+        video: emptyVideoRef(),
+        audio: emptyAudioRef(),
         metadata: safeMetadata(parsedInfo),
         subtitles: "",
-        thumbnail: null
+        thumbnail: emptyImageRef()
       };
 
       if (mode !== "metadata") {
@@ -292,7 +340,7 @@ export class YtDlpDownloadLibNode extends BaseNode {
             "--write-subs",
             "--write-auto-subs",
             "--sub-langs",
-            "en,en-US,en-GB",
+            subLangs,
             "--sub-format",
             "srt/vtt/ass/best"
           );

--- a/packages/video-nodes/src/nodes/timeline.ts
+++ b/packages/video-nodes/src/nodes/timeline.ts
@@ -10,7 +10,6 @@
  */
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import type { VideoRef } from "@nodetool-ai/node-sdk";
 import type { TimelineRef } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { loadMediaRefBytes } from "@nodetool-ai/runtime";
@@ -23,28 +22,22 @@ import {
   type TimelineTrack
 } from "@nodetool-ai/timeline";
 import { tagAsNode } from "@nodetool-ai/nodes-utils";
-import { execFile as execFileCb } from "node:child_process";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
-
-const execFile = promisify(execFileCb);
-
-const FFMPEG_MAX_BUFFER = 10 * 1024 * 1024;
+import {
+  execFfmpeg,
+  execFfprobe,
+  ffprobeDuration,
+  FFMPEG_MAX_BUFFER,
+  MissingBinaryError,
+  videoRef
+} from "./ffmpeg-helpers.js";
 
 interface TimelineRefLike {
   type?: string;
   id?: string | null;
   data?: unknown;
-}
-
-function videoRef(data: Uint8Array, extras: Partial<VideoRef> = {}): VideoRef {
-  return {
-    type: "video",
-    data: Buffer.from(data).toString("base64"),
-    ...extras
-  };
 }
 
 async function loadTimelineSequence(
@@ -69,27 +62,9 @@ async function loadTimelineSequence(
   return seq;
 }
 
-async function ffprobeDurationSeconds(filePath: string): Promise<number> {
-  try {
-    const { stdout } = await execFile("ffprobe", [
-      "-v",
-      "error",
-      "-show_entries",
-      "format=duration",
-      "-of",
-      "default=noprint_wrappers=1:nokey=1",
-      filePath
-    ]);
-    const val = parseFloat(stdout.trim());
-    return Number.isFinite(val) ? val : 0;
-  } catch {
-    return 0;
-  }
-}
-
 async function ffprobeHasAudio(filePath: string): Promise<boolean> {
   try {
-    const { stdout } = await execFile("ffprobe", [
+    const { stdout } = await execFfprobe([
       "-v",
       "error",
       "-select_streams",
@@ -101,7 +76,8 @@ async function ffprobeHasAudio(filePath: string): Promise<boolean> {
       filePath
     ]);
     return stdout.trim().length > 0;
-  } catch {
+  } catch (error) {
+    if (error instanceof MissingBinaryError) throw error;
     return false;
   }
 }
@@ -225,8 +201,7 @@ async function encodeSegment(opts: {
   ];
 
   if (clip.mediaType === "image") {
-    await execFile(
-      "ffmpeg",
+    await execFfmpeg(
       [
         "-y",
         "-loop",
@@ -266,8 +241,7 @@ async function encodeSegment(opts: {
   if (typeof clip.outPointMs === "number" && clip.outPointMs > 0) {
     seek.push("-to", String(clip.outPointMs / 1000));
   }
-  await execFile(
-    "ffmpeg",
+  await execFfmpeg(
     [
       "-y",
       ...seek,
@@ -405,16 +379,14 @@ export class RenderTimelineNode extends BaseNode {
           listPath,
           segments.map((p) => `file '${p}'`).join("\n")
         );
-        await execFile(
-          "ffmpeg",
+        await execFfmpeg(
           ["-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", basePath],
           { maxBuffer: FFMPEG_MAX_BUFFER }
         );
       } else {
         const totalS =
           Math.max(...audioClips.map((c) => c.startMs + c.durationMs)) / 1000;
-        await execFile(
-          "ffmpeg",
+        await execFfmpeg(
           [
             "-y",
             "-f",
@@ -467,8 +439,7 @@ export class RenderTimelineNode extends BaseNode {
         if (labels.length > 0) {
           outPath = path.join(workDir, "mixed.mp4");
           const amix = `[0:a]${labels.join("")}amix=inputs=${labels.length + 1}:duration=first:normalize=0[aout]`;
-          await execFile(
-            "ffmpeg",
+          await execFfmpeg(
             [
               "-y",
               ...inputs,
@@ -490,7 +461,7 @@ export class RenderTimelineNode extends BaseNode {
       }
 
       const rendered = new Uint8Array(await fs.readFile(outPath));
-      const duration = await ffprobeDurationSeconds(outPath);
+      const duration = await ffprobeDuration(outPath);
       return {
         output: videoRef(rendered, {
           format: "mp4",
@@ -668,7 +639,7 @@ export class AddClipsToTimelineNode extends BaseNode {
           }
           const probePath = path.join(workDir, `probe_${i}`);
           await fs.writeFile(probePath, bytes);
-          const seconds = await ffprobeDurationSeconds(probePath);
+          const seconds = await ffprobeDuration(probePath);
           if (seconds <= 0) {
             console.warn(
               `AddClipsToTimeline: skipping clip ${i} — could not determine duration`

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -1,70 +1,78 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
+import type {
+  InputMode,
+  OutputCorrelation,
+  FolderRef
+} from "@nodetool-ai/protocol";
 import { isRawRgbaImage } from "@nodetool-ai/protocol";
-import type { VideoRef, StreamingInputs, StreamingOutputs } from "@nodetool-ai/node-sdk";
+import type {
+  VideoRef,
+  ImageRef,
+  AudioRef,
+  StreamingInputs,
+  StreamingOutputs
+} from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { loadMediaRefBytes, mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
-import { execFile as execFileCb } from "node:child_process";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import {
   audioBytesAsync,
   toBytes
 } from "@nodetool-ai/audio-nodes";
+import {
+  MissingBinaryError,
+  execFfmpeg,
+  execFfprobe,
+  videoRef,
+  defaultVideoRef,
+  filePath,
+  folderPath,
+  dateName,
+  uniqueTargetPath,
+  parseFrameRate,
+  ffprobeDuration,
+  withTempFile,
+  coerceProviderBytes,
+  FFMPEG_MAX_BUFFER
+} from "./ffmpeg-helpers.js";
 
 type VideoRefLike = { uri?: string; data?: Uint8Array | string };
 type ImageRefLike = { uri?: string; data?: Uint8Array | string };
-const execFile = promisify(execFileCb);
 
-/**
- * Whether `err` is a "binary not on PATH" failure (ffmpeg/ffprobe missing)
- * rather than the tool running and reporting a filtergraph/codec error. A
- * missing binary is never recoverable by retrying with simpler args, so
- * callers must surface a clear install message instead of silently returning
- * the input unchanged (a no-op effect is indistinguishable from a real one).
- */
-function isMissingBinaryError(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  return (err as { code?: unknown }).code === "ENOENT";
+/** Structural type for the `video_model` prop (provider + model id). */
+interface VideoModelRef {
+  type: "video_model";
+  provider?: string;
+  id?: string;
+  name?: string;
+  path?: string | null;
+  supported_tasks?: unknown[];
 }
 
-/** Actionable error for a missing ffmpeg binary, matching the audio pattern. */
-function ffmpegMissingError(): Error {
-  return new Error(
-    "ffmpeg is not installed or not on PATH. Install ffmpeg (the Package " +
-      "Manager UI can do this) to process video — these nodes shell out to " +
-      "ffmpeg/ffprobe and cannot run without it."
-  );
+/** Structural type for the `color` prop. */
+interface ColorRef {
+  type: "color";
+  value?: string;
 }
 
-/** True for the actionable error produced by {@link ffmpegMissingError}. */
-function isFfmpegMissingError(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    err.message.startsWith("ffmpeg is not installed")
-  );
+/** Structural type for the `font` prop. */
+interface FontLike {
+  type: "font";
+  name?: string;
+  source?: string;
+  url?: string;
+  weight?: string;
 }
 
-/**
- * Run ffmpeg, translating a missing-binary failure (spawn ENOENT) into the
- * actionable {@link ffmpegMissingError}. A genuine ffmpeg failure (non-zero
- * exit) rejects unchanged so callers can fall back. Scoping the ENOENT check to
- * the spawn itself — not the surrounding fs reads/writes — keeps an unrelated
- * filesystem ENOENT from being mislabeled as a missing binary.
- */
-async function execFfmpeg(
-  args: string[],
-  options: { maxBuffer?: number } = {}
-): Promise<void> {
-  try {
-    await execFile("ffmpeg", args, options);
-  } catch (error) {
-    if (isMissingBinaryError(error)) throw ffmpegMissingError();
-    throw error;
-  }
+/** Structural type for a subtitle `audio_chunk`. */
+interface SubtitleChunk {
+  text?: string;
+  content?: string;
+  timestamp?: unknown[];
+  start?: number;
+  end?: number;
 }
 
 async function videoBytesAsync(video: unknown, context?: ProcessingContext): Promise<Uint8Array> {
@@ -118,86 +126,16 @@ function normalizeVideoList(value: unknown): VideoRefLike[] {
   );
 }
 
-function filePath(uriOrPath: string): string {
-  if (uriOrPath.startsWith("file://")) {
-    try {
-      return fileURLToPath(new URL(uriOrPath));
-    } catch {
-      // Fallback for non-standard URIs like file://C:\path
-      return uriOrPath.slice("file://".length);
-    }
-  }
-  return uriOrPath;
-}
-
 /**
- * Resolve a folder value to a filesystem path. Accepts either a plain string
- * path/URI or a folder ref object (`{ uri }`); returns "" when no usable path
- * is present. Coercing the ref object with `String()` would yield
- * "[object Object]", so callers must funnel folder props through here.
+ * Parse cropdetect's suggested crop from ffmpeg stderr. cropdetect logs one
+ * `crop=w:h:x:y` per analyzed frame; the last suggestion reflects the full
+ * analysis, so return that. Null when no suggestion is present.
  */
-function folderPath(raw: unknown): string {
-  if (typeof raw === "string") {
-    return raw.startsWith("file:") ? filePath(raw) : raw;
-  }
-  if (raw && typeof raw === "object") {
-    const uri = (raw as Record<string, unknown>).uri;
-    if (typeof uri === "string" && uri.length > 0) return filePath(uri);
-  }
-  return "";
-}
-
-function dateName(name: string): string {
-  const now = new Date();
-  const pad = (v: number): string => String(v).padStart(2, "0");
-  return name
-    .replaceAll("%Y", String(now.getFullYear()))
-    .replaceAll("%m", pad(now.getMonth() + 1))
-    .replaceAll("%d", pad(now.getDate()))
-    .replaceAll("%H", pad(now.getHours()))
-    .replaceAll("%M", pad(now.getMinutes()))
-    .replaceAll("%S", pad(now.getSeconds()));
-}
-
-/**
- * Parse an ffprobe `r_frame_rate` value ("30000/1001" or "25") into a number.
- * Returns 0 for malformed values or zero denominators instead of NaN/Infinity.
- */
-function parseFrameRate(raw: string): number {
-  const parts = raw.trim().split("/");
-  if (parts.length === 2) {
-    const num = Number(parts[0]);
-    const den = Number(parts[1]);
-    return Number.isFinite(num) && den > 0 ? num / den : 0;
-  }
-  const val = Number(parts[0]);
-  return Number.isFinite(val) && val > 0 ? val : 0;
-}
-
-async function ffprobeDuration(filePath: string): Promise<number> {
-  try {
-    const { stdout } = await execFile("ffprobe", [
-      "-v",
-      "error",
-      "-show_entries",
-      "format=duration",
-      "-of",
-      "default=noprint_wrappers=1:nokey=1",
-      filePath
-    ]);
-    const val = parseFloat(stdout.trim());
-    return isNaN(val) ? 0 : val;
-  } catch {
-    return 0;
-  }
-}
-
-function videoRef(data: Uint8Array, extras: Partial<VideoRef> = {}): VideoRef {
-  return {
-    type: "video",
-    data: Buffer.from(data).toString("base64"),
-    ...extras
-  };
+export function parseCropDetectCrop(stderr: string): string | null {
+  const matches = stderr.match(/crop=(\d+:\d+:\d+:\d+)/g);
+  if (!matches || matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  return last.slice("crop=".length);
 }
 
 /**
@@ -233,19 +171,29 @@ async function combineFramesToVideo(
   try {
     if (isRawRgbaImage(first)) {
       const { width, height } = first;
-      const chunks: Buffer[] = [];
-      for (const f of frames) {
-        if (
-          isRawRgbaImage(f) &&
-          f.data.length > 0 &&
-          f.width === width &&
-          f.height === height
-        ) {
-          chunks.push(Buffer.from(f.data.buffer, f.data.byteOffset, f.data.byteLength));
-        }
-      }
+      // Append each frame to the raw file as it is visited. 300 frames of 1080p
+      // RGBA is ~2.5 GB — Buffer.concat'ing them all would blow up memory.
       const rawPath = path.join(inputDir, "frames.raw");
-      await fs.writeFile(rawPath, Buffer.concat(chunks));
+      const handle = await fs.open(rawPath, "w");
+      let framesWritten = 0;
+      try {
+        for (const f of frames) {
+          if (
+            isRawRgbaImage(f) &&
+            f.data.length > 0 &&
+            f.width === width &&
+            f.height === height
+          ) {
+            await handle.write(
+              Buffer.from(f.data.buffer, f.data.byteOffset, f.data.byteLength)
+            );
+            framesWritten += 1;
+          }
+        }
+      } finally {
+        await handle.close();
+      }
+      if (framesWritten === 0) return new Uint8Array();
       await execFfmpeg(
         [
           "-y",
@@ -334,53 +282,76 @@ const VIDEO_ASPECT_RATIO_VALUES = [
 const VIDEO_RESOLUTION_VALUES = ["720p", "1080p", "1440p", "4K"];
 const VIDEO_DURATION_VALUES = [2, 3, 4, 5, 6, 8, 10, 12, 15];
 
-async function withTempFile(
-  suffix: string,
-  bytes: Uint8Array
-): Promise<{ path: string; cleanup: () => Promise<void> }> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-video-"));
-  const file = path.join(dir, `input${suffix}`);
-  await fs.writeFile(file, bytes);
-  return {
-    path: file,
-    cleanup: async () => {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-  };
+interface FfmpegTransformOptions {
+  /** Extra `-i` inputs appended after the main input, in order. */
+  extraInputs?: Array<{ suffix: string; bytes: Uint8Array }>;
+  /** Args placed BEFORE `-i` (e.g. input-side `-ss`/`-to` seeking). */
+  preInputArgs?: string[];
+  /**
+   * When true, a genuine ffmpeg failure returns null so the caller can try the
+   * next attempt in a chain. A missing binary still throws. When false/omitted
+   * a failure throws with ffmpeg's stderr — never a silent input pass-through.
+   */
+  allowFallback?: boolean;
 }
 
 async function ffmpegTransform(
   video: Uint8Array,
   args: string[],
-  extraInputs: Array<{ suffix: string; bytes: Uint8Array }> = []
+  options?: Omit<FfmpegTransformOptions, "allowFallback"> & {
+    allowFallback?: false;
+  }
+): Promise<Uint8Array>;
+async function ffmpegTransform(
+  video: Uint8Array,
+  args: string[],
+  options: FfmpegTransformOptions & { allowFallback: true }
+): Promise<Uint8Array | null>;
+async function ffmpegTransform(
+  video: Uint8Array,
+  args: string[],
+  options: FfmpegTransformOptions = {}
 ): Promise<Uint8Array | null> {
   if (video.length === 0) return new Uint8Array();
   const mainInput = await withTempFile(".mp4", video);
   const others = await Promise.all(
-    extraInputs.map((item) => withTempFile(item.suffix, item.bytes))
+    (options.extraInputs ?? []).map((item) =>
+      withTempFile(item.suffix, item.bytes)
+    )
   );
   const outputDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "nodetool-video-out-")
   );
   const outputPath = path.join(outputDir, "output.mp4");
   try {
-    const inputArgs = ["-y", "-i", mainInput.path];
+    const inputArgs = ["-y", ...(options.preInputArgs ?? []), "-i", mainInput.path];
     for (const other of others) inputArgs.push("-i", other.path);
     await execFfmpeg([...inputArgs, ...args, outputPath], {
       maxBuffer: 10 * 1024 * 1024
     });
     return new Uint8Array(await fs.readFile(outputPath));
   } catch (error) {
-    // A missing ffmpeg binary is unrecoverable — surface it. Every other
-    // failure (a filtergraph error, or no output produced) returns null so
-    // callers fall back to the unchanged input, exactly as before.
-    if (isFfmpegMissingError(error)) throw error;
-    return null;
+    // A missing binary is unrecoverable — surface it. A genuine ffmpeg failure
+    // returns null only when the caller allows a chained fallback; otherwise it
+    // throws with stderr rather than silently passing the input through.
+    if (error instanceof MissingBinaryError) throw error;
+    if (options.allowFallback) return null;
+    const stderr = (error as { stderr?: string }).stderr;
+    const detail = (typeof stderr === "string" && stderr.trim()) || (error as Error).message;
+    throw new Error(`ffmpeg failed: ${detail}`);
   } finally {
     await mainInput.cleanup();
     for (const other of others) await other.cleanup();
     await fs.rm(outputDir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Base for every ffmpeg-backed node. Carries only the runtime gate; each node
+ * declares its own props and `process()`.
+ */
+abstract class VideoTransformNode extends BaseNode {
+  static readonly requiredRuntimes = ["ffmpeg"];
 }
 
 export class TextToVideoNode extends BaseNode {
@@ -409,7 +380,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Model",
     description: "The video generation model to use"
   })
-  declare model: any;
+  declare model: VideoModelRef;
 
   @prop({
     type: "str",
@@ -417,7 +388,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Prompt",
     description: "Text prompt describing the desired video"
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -425,7 +396,7 @@ export class TextToVideoNode extends BaseNode {
     title: "Negative Prompt",
     description: "Text prompt describing what to avoid in the video"
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "str",
@@ -435,7 +406,7 @@ export class TextToVideoNode extends BaseNode {
     values: VIDEO_ASPECT_RATIO_VALUES,
     json_schema_extra: { type: "media_aspect_ratio_video" }
   })
-  declare aspect_ratio: any;
+  declare aspect_ratio: string;
 
   @prop({
     type: "str",
@@ -445,7 +416,7 @@ export class TextToVideoNode extends BaseNode {
     values: VIDEO_RESOLUTION_VALUES,
     json_schema_extra: { type: "media_resolution_video" }
   })
-  declare resolution: any;
+  declare resolution: string;
 
   @prop({
     type: "int",
@@ -455,7 +426,7 @@ export class TextToVideoNode extends BaseNode {
     values: VIDEO_DURATION_VALUES,
     json_schema_extra: { type: "media_duration" }
   })
-  declare duration: any;
+  declare duration: number;
 
   @prop({
     type: "int",
@@ -465,7 +436,7 @@ export class TextToVideoNode extends BaseNode {
     min: 0,
     max: 7200
   })
-  declare timeout_seconds: any;
+  declare timeout_seconds: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const text = String(this.prompt ?? "");
@@ -473,7 +444,8 @@ export class TextToVideoNode extends BaseNode {
     if (!canUseProvider(context, providerId, modelId)) {
       throw new Error("No provider available for text-to-video generation.");
     }
-    const output = (await context.runProviderPrediction({
+    const output = coerceProviderBytes(
+      await context.runProviderPrediction({
       provider: providerId,
       capability: "text_to_video",
       model: modelId,
@@ -485,7 +457,9 @@ export class TextToVideoNode extends BaseNode {
         resolution: this.resolution,
         timeout_seconds: Number(this.timeout_seconds ?? 0) || undefined
       }
-    })) as Uint8Array;
+    }),
+      "Text To Video"
+    );
     return { output: videoRef(output) };
   }
 }
@@ -510,7 +484,7 @@ export class ImageToVideoNode extends BaseNode {
     description:
       "Input image(s) to animate. The first image is the primary frame; additional images are used as references by providers that support multi-image input."
   })
-  declare image: any;
+  declare image: ImageRef[];
 
   @prop({
     type: "video_model",
@@ -525,7 +499,7 @@ export class ImageToVideoNode extends BaseNode {
     title: "Model",
     description: "The video generation model to use"
   })
-  declare model: any;
+  declare model: VideoModelRef;
 
   @prop({
     type: "str",
@@ -533,7 +507,7 @@ export class ImageToVideoNode extends BaseNode {
     title: "Prompt",
     description: "Optional text prompt to guide the video animation"
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -541,7 +515,7 @@ export class ImageToVideoNode extends BaseNode {
     title: "Negative Prompt",
     description: "Text prompt describing what to avoid in the video"
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "str",
@@ -551,7 +525,7 @@ export class ImageToVideoNode extends BaseNode {
     values: VIDEO_ASPECT_RATIO_VALUES,
     json_schema_extra: { type: "media_aspect_ratio_video" }
   })
-  declare aspect_ratio: any;
+  declare aspect_ratio: string;
 
   @prop({
     type: "str",
@@ -561,7 +535,7 @@ export class ImageToVideoNode extends BaseNode {
     values: VIDEO_RESOLUTION_VALUES,
     json_schema_extra: { type: "media_resolution_video" }
   })
-  declare resolution: any;
+  declare resolution: string;
 
   @prop({
     type: "int",
@@ -571,7 +545,7 @@ export class ImageToVideoNode extends BaseNode {
     values: VIDEO_DURATION_VALUES,
     json_schema_extra: { type: "media_duration" }
   })
-  declare duration: any;
+  declare duration: number;
 
   @prop({
     type: "int",
@@ -581,7 +555,7 @@ export class ImageToVideoNode extends BaseNode {
     min: 0,
     max: 7200
   })
-  declare timeout_seconds: any;
+  declare timeout_seconds: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     let images = normalizeImageList(this.image);
@@ -614,7 +588,8 @@ export class ImageToVideoNode extends BaseNode {
     if (!canUseProvider(context, providerId, modelId)) {
       throw new Error("No provider available for image-to-video generation.");
     }
-    const output = (await context.runProviderPrediction({
+    const output = coerceProviderBytes(
+      await context.runProviderPrediction({
       provider: providerId,
       capability: "image_to_video",
       model: modelId,
@@ -627,7 +602,9 @@ export class ImageToVideoNode extends BaseNode {
         resolution: this.resolution,
         timeout_seconds: Number(this.timeout_seconds ?? 0) || undefined
       }
-    })) as Uint8Array;
+    }),
+      "Image To Video"
+    );
     return { output: videoRef(output) };
   }
 }
@@ -649,7 +626,7 @@ export class LoadVideoFileNode extends BaseNode {
     title: "Path",
     description: "Path to the video file to read"
   })
-  declare path: any;
+  declare path: string;
 
   async process(): Promise<Record<string, unknown>> {
     const p = filePath(String(this.path ?? "").trim());
@@ -672,19 +649,11 @@ export class SaveVideoFileVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The video to save"
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "str",
@@ -692,7 +661,7 @@ export class SaveVideoFileVideoNode extends BaseNode {
     title: "Folder",
     description: "Folder where the file will be saved"
   })
-  declare folder: any;
+  declare folder: string;
 
   @prop({
     type: "str",
@@ -701,13 +670,15 @@ export class SaveVideoFileVideoNode extends BaseNode {
     description:
       "\n        Name of the file to save.\n        You can use time and date variables to create unique names:\n        %Y - Year\n        %m - Month\n        %d - Day\n        %H - Hour\n        %M - Minute\n        %S - Second\n        "
   })
-  declare filename: any;
+  declare filename: string;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const folder = folderPath(this.folder) || ".";
     const fname = dateName(String(this.filename || "video.mp4"));
-    const p = path.resolve(folder, fname);
-    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.mkdir(path.resolve(folder), { recursive: true });
+    // dateName resolves to second granularity, so two saves in the same second
+    // collide — de-duplicate with a -1/-2/… suffix rather than overwrite.
+    const p = await uniqueTargetPath(path.resolve(folder, fname));
     const bytes = await videoBytesAsync(this.video, context);
     await fs.writeFile(p, bytes);
     return { output: videoRef(bytes, { uri: `file://${p}` }) };
@@ -748,7 +719,7 @@ export class LoadVideoAssetsNode extends BaseNode {
     title: "Folder",
     description: "The asset folder to load the video files from."
   })
-  declare folder: any;
+  declare folder: FolderRef;
 
   async process(): Promise<Record<string, unknown>> {
     const allVideos: unknown[] = [];
@@ -816,19 +787,11 @@ export class SaveVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The video to save."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "folder",
@@ -842,7 +805,7 @@ export class SaveVideoNode extends BaseNode {
     title: "Folder",
     description: "The asset folder to save the video in."
   })
-  declare folder: any;
+  declare folder: FolderRef;
 
   @prop({
     type: "str",
@@ -851,24 +814,26 @@ export class SaveVideoNode extends BaseNode {
     description:
       "\n        Name of the output video.\n        You can use time and date variables to create unique names:\n        %Y - Year\n        %m - Month\n        %d - Day\n        %H - Hour\n        %M - Minute\n        %S - Second\n        "
   })
-  declare name: any;
+  declare name: string;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const folder = folderPath(this.folder) || ".";
     const filename = dateName(String(this.name || "video.mp4"));
-    const full = path.resolve(folder, filename);
-    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.mkdir(path.resolve(folder), { recursive: true });
+    // dateName resolves to second granularity, so two saves in the same second
+    // collide — de-duplicate with a -1/-2/… suffix rather than overwrite.
+    const full = await uniqueTargetPath(path.resolve(folder, filename));
     const bytes = await videoBytesAsync(this.video, context);
     await fs.writeFile(full, bytes);
     return { output: videoRef(bytes, { uri: `file://${full}` }) };
   }
 }
 
-export class ForEachFrameNode extends BaseNode {
+export class ForEachFrameNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ForEachFrame";
   static readonly title = "For Each Frame";
   static readonly description =
-    "Extract frames from a video file using OpenCV.\n    video, frames, extract, sequence";
+    "Extract frames from a video file with ffmpeg.\n    video, frames, extract, sequence";
   static readonly metadataOutputTypes = {
     frame: "image",
     index: "int",
@@ -886,19 +851,11 @@ export class ForEachFrameNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to extract frames from."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "int",
@@ -906,7 +863,7 @@ export class ForEachFrameNode extends BaseNode {
     title: "Start",
     description: "The frame to start extracting from."
   })
-  declare start: any;
+  declare start: number;
 
   @prop({
     type: "int",
@@ -914,7 +871,7 @@ export class ForEachFrameNode extends BaseNode {
     title: "End",
     description: "The frame to stop extracting from."
   })
-  declare end: any;
+  declare end: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     // Buffered fallback: surface the first frame instead of nothing.
@@ -935,7 +892,7 @@ export class ForEachFrameNode extends BaseNode {
     try {
       let fps = 24;
       try {
-        const { stdout } = await execFile("ffprobe", [
+        const { stdout } = await execFfprobe([
           "-v", "error",
           "-select_streams", "v:0",
           "-show_entries", "stream=r_frame_rate",
@@ -944,8 +901,10 @@ export class ForEachFrameNode extends BaseNode {
         ]);
         const parsed = parseFrameRate(stdout);
         if (parsed > 0) fps = parsed;
-      } catch {
-        // fall back to 24 fps
+      } catch (error) {
+        // Missing ffprobe is actionable; a genuine probe failure falls back to
+        // 24 fps.
+        if (error instanceof MissingBinaryError) throw error;
       }
 
       const start = Math.max(0, Number(this.start ?? 0));
@@ -956,16 +915,21 @@ export class ForEachFrameNode extends BaseNode {
           ? `select='between(n,${start},${end})'`
           : `select='gte(n,${start})'`;
 
-      await execFile(
-        "ffmpeg",
+      // With a bounded range, cap decoding at the number of selected frames so
+      // ffmpeg stops early instead of scanning to the end of the video.
+      const frameLimit =
+        end >= 0 ? ["-frames:v", String(end - start + 1)] : [];
+
+      await execFfmpeg(
         [
           "-y",
           "-i", inputFile.path,
           "-vf", vfFilter,
           "-vsync", "vfr",
+          ...frameLimit,
           path.join(outputDir, "frame_%d.png")
         ],
-        { maxBuffer: 50 * 1024 * 1024 }
+        { maxBuffer: FFMPEG_MAX_BUFFER }
       );
 
       const entries = await fs.readdir(outputDir);
@@ -997,7 +961,7 @@ export class ForEachFrameNode extends BaseNode {
   }
 }
 
-export class FpsNode extends BaseNode {
+export class FpsNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Fps";
   static readonly title = "Fps";
   static readonly description =
@@ -1010,19 +974,11 @@ export class FpsNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to analyze for FPS."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1030,7 +986,7 @@ export class FpsNode extends BaseNode {
 
     const inputFile = await withTempFile(".mp4", bytes);
     try {
-      const { stdout } = await execFile("ffprobe", [
+      const { stdout } = await execFfprobe([
         "-v", "error",
         "-select_streams", "v:0",
         "-show_entries", "stream=r_frame_rate",
@@ -1038,7 +994,9 @@ export class FpsNode extends BaseNode {
         inputFile.path
       ]);
       return { output: parseFrameRate(stdout) };
-    } catch {
+    } catch (error) {
+      // Missing ffprobe is actionable; a genuine probe failure degrades to 0.
+      if (error instanceof MissingBinaryError) throw error;
       return { output: 0 };
     } finally {
       await inputFile.cleanup();
@@ -1046,7 +1004,7 @@ export class FpsNode extends BaseNode {
   }
 }
 
-export class FrameToVideoNode extends BaseNode {
+export class FrameToVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.FrameToVideo";
   static readonly title = "Frame To Video";
   static readonly description =
@@ -1075,7 +1033,7 @@ export class FrameToVideoNode extends BaseNode {
     title: "Frame",
     description: "Collect input frames"
   })
-  declare frame: any;
+  declare frame: ImageRef | ImageRef[];
 
   @prop({
     type: "float",
@@ -1083,7 +1041,7 @@ export class FrameToVideoNode extends BaseNode {
     title: "Fps",
     description: "The FPS of the output video."
   })
-  declare fps: any;
+  declare fps: number;
 
   async run(
     inputs: StreamingInputs,
@@ -1136,22 +1094,103 @@ export class FrameToVideoNode extends BaseNode {
   }
 }
 
-abstract class VideoTransformNode extends BaseNode {
-  static readonly requiredRuntimes = ["ffmpeg"];
-  declare video: any;
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const bytes = await videoBytesAsync(this.video, context);
-    return { output: videoRef(bytes) };
-  }
+interface ConcatMeta {
+  codec: string;
+  width: number;
+  height: number;
+  fps: number;
+  hasAudio: boolean;
 }
 
-export class ConcatVideoNode extends BaseNode {
+/** Probe a file's video codec/dimensions/fps and audio presence. */
+async function probeConcatMeta(file: string): Promise<ConcatMeta> {
+  const { stdout } = await execFfprobe([
+    "-v",
+    "error",
+    "-show_streams",
+    "-show_format",
+    "-of",
+    "json",
+    file
+  ]);
+  const info = JSON.parse(stdout) as {
+    streams?: Array<{
+      codec_type?: string;
+      codec_name?: string;
+      width?: number;
+      height?: number;
+      r_frame_rate?: string;
+    }>;
+  };
+  const streams = info.streams ?? [];
+  const v = streams.find((s) => s.codec_type === "video");
+  return {
+    codec: v?.codec_name ?? "",
+    width: v?.width ?? 0,
+    height: v?.height ?? 0,
+    fps: v?.r_frame_rate ? parseFrameRate(v.r_frame_rate) : 0,
+    hasAudio: streams.some((s) => s.codec_type === "audio")
+  };
+}
+
+/**
+ * Scale + pad to a uniform frame, normalize fps/pixel format, re-encode to
+ * libx264 + AAC (adding silent audio when the source has none) so mismatched
+ * segments can be concatenated losslessly with `-c copy`.
+ */
+async function normalizeConcatSegment(
+  srcPath: string,
+  segPath: string,
+  width: number,
+  height: number,
+  fps: number,
+  hasAudio: boolean
+): Promise<void> {
+  const filter =
+    `scale=${width}:${height}:force_original_aspect_ratio=decrease,` +
+    `pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2:color=black,` +
+    `fps=${fps},format=yuv420p`;
+  const silent = [
+    "-f",
+    "lavfi",
+    "-i",
+    "anullsrc=channel_layout=stereo:sample_rate=48000"
+  ];
+  await execFfmpeg(
+    [
+      "-y",
+      "-i",
+      srcPath,
+      ...(hasAudio ? [] : silent),
+      "-filter_complex",
+      `[0:v]${filter}[v]`,
+      "-map",
+      "[v]",
+      "-map",
+      hasAudio ? "0:a" : "1:a",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "veryfast",
+      "-c:a",
+      "aac",
+      "-ar",
+      "48000",
+      "-ac",
+      "2",
+      "-shortest",
+      segPath
+    ],
+    { maxBuffer: FFMPEG_MAX_BUFFER }
+  );
+}
+
+export class ConcatVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Concat";
   static readonly body = "content_card";
   static readonly title = "Concatenate Video";
   static readonly description =
     "Concatenate multiple video files into a single video, including audio when available. Add inputs dynamically with the “add video input” button, or wire a list of videos into a single input.\n    video, concat, merge, combine, audio, +";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly metadataOutputTypes = {
     output: "video"
   };
@@ -1181,21 +1220,55 @@ export class ConcatVideoNode extends BaseNode {
     const listPath = path.join(concatDir, "list.txt");
     const outputPath = path.join(concatDir, "output.mp4");
     try {
-      const listEntries = inputs
-        .map((input) => `file '${input.path}'`)
-        .join("\n");
-      await fs.writeFile(
-        listPath,
-        `${listEntries}\n`
+      // Stream-copying heterogeneous inputs (different codec/size/fps) with the
+      // concat demuxer produces corrupt output. Probe every input; only take
+      // the fast `-c copy` path when they all match, else normalize each to a
+      // uniform segment (first input's resolution/fps) before concatenating.
+      const metas = await Promise.all(
+        inputs.map((input) => probeConcatMeta(input.path))
       );
-      await execFile(
-        "ffmpeg",
+      const first = metas[0];
+      const uniform = metas.every(
+        (m) =>
+          m.codec === first.codec &&
+          m.width === first.width &&
+          m.height === first.height &&
+          m.fps === first.fps &&
+          m.hasAudio === first.hasAudio
+      );
+
+      let concatPaths: string[];
+      if (uniform) {
+        concatPaths = inputs.map((input) => input.path);
+      } else {
+        const width = first.width > 0 ? first.width : 1920;
+        const height = first.height > 0 ? first.height : 1080;
+        const fps = first.fps > 0 ? first.fps : 30;
+        concatPaths = [];
+        for (const [i, input] of inputs.entries()) {
+          const segPath = path.join(concatDir, `seg_${i}.mp4`);
+          await normalizeConcatSegment(
+            input.path,
+            segPath,
+            width,
+            height,
+            fps,
+            metas[i].hasAudio
+          );
+          concatPaths.push(segPath);
+        }
+      }
+
+      const listEntries = concatPaths.map((p) => `file '${p}'`).join("\n");
+      await fs.writeFile(listPath, `${listEntries}\n`);
+      await execFfmpeg(
         ["-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", outputPath],
-        { maxBuffer: 50 * 1024 * 1024 }
+        { maxBuffer: FFMPEG_MAX_BUFFER }
       );
       const result = new Uint8Array(await fs.readFile(outputPath));
       return { output: videoRef(result) };
     } catch (error) {
+      if (error instanceof MissingBinaryError) throw error;
       throw new Error(
         `Concatenating videos failed: ${
           error instanceof Error ? error.message : String(error)
@@ -1210,12 +1283,11 @@ export class ConcatVideoNode extends BaseNode {
   }
 }
 
-export class TrimVideoNode extends BaseNode {
+export class TrimVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Trim";
   static readonly title = "Trim";
   static readonly description =
     "Trim a video to a specific start and end time.\n    video, trim, cut, segment";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly metadataOutputTypes = {
     output: "video"
   };
@@ -1224,19 +1296,11 @@ export class TrimVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to trim."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1244,7 +1308,7 @@ export class TrimVideoNode extends BaseNode {
     title: "Start Time",
     description: "The start time in seconds for the trimmed video."
   })
-  declare start_time: any;
+  declare start_time: number;
 
   @prop({
     type: "float",
@@ -1253,7 +1317,7 @@ export class TrimVideoNode extends BaseNode {
     description:
       "The end time in seconds for the trimmed video. Use -1 for the end of the video."
   })
-  declare end_time: any;
+  declare end_time: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1262,13 +1326,16 @@ export class TrimVideoNode extends BaseNode {
     const start = Math.max(0, Number(this.start_time ?? 0));
     const end = Number(this.end_time ?? -1);
 
-    const args: string[] = ["-ss", String(start)];
+    // Input-side seek (before -i): ffmpeg jumps to the nearest keyframe instead
+    // of decoding from the start, so trimming a long clip is near-instant.
+    const preInputArgs: string[] = ["-ss", String(start)];
     if (end >= 0) {
-      args.push("-to", String(end));
+      preInputArgs.push("-to", String(end));
     }
-    args.push("-c", "copy");
 
-    const transformed = (await ffmpegTransform(bytes, args)) ?? bytes;
+    const transformed = await ffmpegTransform(bytes, ["-c", "copy"], {
+      preInputArgs
+    });
     return { output: videoRef(transformed) };
   }
 }
@@ -1283,19 +1350,11 @@ export class ResizeVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to resize."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "int",
@@ -1303,7 +1362,7 @@ export class ResizeVideoNode extends VideoTransformNode {
     title: "Width",
     description: "The target width. Use -1 to maintain aspect ratio."
   })
-  declare width: any;
+  declare width: number;
 
   @prop({
     type: "int",
@@ -1311,7 +1370,7 @@ export class ResizeVideoNode extends VideoTransformNode {
     title: "Height",
     description: "The target height. Use -1 to maintain aspect ratio."
   })
-  declare height: any;
+  declare height: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1323,7 +1382,7 @@ export class ResizeVideoNode extends VideoTransformNode {
         `scale=${width}:${height}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1338,19 +1397,11 @@ export class RotateVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to rotate."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1360,7 +1411,7 @@ export class RotateVideoNode extends VideoTransformNode {
     min: -360,
     max: 360
   })
-  declare angle: any;
+  declare angle: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1372,7 +1423,7 @@ export class RotateVideoNode extends VideoTransformNode {
         `rotate=${radians}:ow=rotw(${radians}):oh=roth(${radians})`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1387,19 +1438,11 @@ export class SetSpeedVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to adjust speed."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1408,7 +1451,7 @@ export class SetSpeedVideoNode extends VideoTransformNode {
     description:
       "The speed adjustment factor. Values > 1 speed up, < 1 slow down."
   })
-  declare speed_factor: any;
+  declare speed_factor: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1436,17 +1479,22 @@ export class SetSpeedVideoNode extends VideoTransformNode {
     };
 
     const atempoChain = buildAtempo(speed);
+    // First attempt retimes audio too (fails on videos with no audio stream);
+    // the video-only fallback is the terminal attempt and throws on failure.
     const transformed =
-      (await ffmpegTransform(bytes, [
-        "-filter_complex",
-        `[0:v]setpts=${1 / speed}*PTS[v];[0:a]${atempoChain}[a]`,
-        "-map",
-        "[v]",
-        "-map",
-        "[a]"
-      ])) ??
-      (await ffmpegTransform(bytes, ["-vf", `setpts=${1 / speed}*PTS`])) ??
-      bytes;
+      (await ffmpegTransform(
+        bytes,
+        [
+          "-filter_complex",
+          `[0:v]setpts=${1 / speed}*PTS[v];[0:a]${atempoChain}[a]`,
+          "-map",
+          "[v]",
+          "-map",
+          "[a]"
+        ],
+        { allowFallback: true }
+      )) ??
+      (await ffmpegTransform(bytes, ["-vf", `setpts=${1 / speed}*PTS`]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1461,35 +1509,19 @@ export class OverlayVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Main Video",
     description: "The main (background) video."
   })
-  declare main_video: any;
+  declare main_video: VideoRef;
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Overlay Video",
     description: "The video to overlay on top."
   })
-  declare overlay_video: any;
+  declare overlay_video: VideoRef;
 
   @prop({
     type: "int",
@@ -1497,7 +1529,7 @@ export class OverlayVideoNode extends VideoTransformNode {
     title: "X",
     description: "X-coordinate for overlay placement."
   })
-  declare x: any;
+  declare x: number;
 
   @prop({
     type: "int",
@@ -1505,7 +1537,7 @@ export class OverlayVideoNode extends VideoTransformNode {
     title: "Y",
     description: "Y-coordinate for overlay placement."
   })
-  declare y: any;
+  declare y: number;
 
   @prop({
     type: "float",
@@ -1513,7 +1545,7 @@ export class OverlayVideoNode extends VideoTransformNode {
     title: "Scale",
     description: "Scale factor for the overlay video."
   })
-  declare scale: any;
+  declare scale: number;
 
   @prop({
     type: "float",
@@ -1523,7 +1555,7 @@ export class OverlayVideoNode extends VideoTransformNode {
     min: 0,
     max: 1
   })
-  declare overlay_audio_volume: any;
+  declare overlay_audio_volume: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const mainVideo = await videoBytesAsync(this.main_video, context);
@@ -1550,18 +1582,21 @@ export class OverlayVideoNode extends VideoTransformNode {
           "-map",
           "[outa]"
         ],
-        [{ suffix: ".mp4", bytes: overlayVideo }]
+        {
+          extraInputs: [{ suffix: ".mp4", bytes: overlayVideo }],
+          allowFallback: true
+        }
       )) ??
-      // Fallback: video-only overlay (one or both inputs may lack audio)
+      // Fallback: video-only overlay (one or both inputs may lack audio).
+      // Terminal attempt — throws with stderr if it also fails.
       (await ffmpegTransform(
         mainVideo,
         [
           "-filter_complex",
           `[1:v]scale=iw*${scale}:ih*${scale}[ov];[0:v][ov]overlay=${x}:${y}`
         ],
-        [{ suffix: ".mp4", bytes: overlayVideo }]
-      )) ??
-      mainVideo;
+        { extraInputs: [{ suffix: ".mp4", bytes: overlayVideo }] }
+      ));
     return { output: videoRef(transformed) };
   }
 }
@@ -1576,19 +1611,11 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to adjust color balance."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1598,7 +1625,7 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
     min: 0,
     max: 2
   })
-  declare red_adjust: any;
+  declare red_adjust: number;
 
   @prop({
     type: "float",
@@ -1608,7 +1635,7 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
     min: 0,
     max: 2
   })
-  declare green_adjust: any;
+  declare green_adjust: number;
 
   @prop({
     type: "float",
@@ -1618,7 +1645,7 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
     min: 0,
     max: 2
   })
-  declare blue_adjust: any;
+  declare blue_adjust: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1632,7 +1659,7 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
         `colorbalance=rs=${rs}:gs=${gs}:bs=${bs}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1648,19 +1675,11 @@ export class DenoiseVideoNode extends VideoTransformNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to denoise."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1671,7 +1690,7 @@ export class DenoiseVideoNode extends VideoTransformNode {
     min: 0,
     max: 20
   })
-  declare strength: any;
+  declare strength: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1682,7 +1701,7 @@ export class DenoiseVideoNode extends VideoTransformNode {
         `nlmeans=s=${strength}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1698,19 +1717,11 @@ export class StabilizeVideoNode extends VideoTransformNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to stabilize."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1721,7 +1732,7 @@ export class StabilizeVideoNode extends VideoTransformNode {
     min: 1,
     max: 100
   })
-  declare smoothing: any;
+  declare smoothing: number;
 
   @prop({
     type: "bool",
@@ -1730,22 +1741,58 @@ export class StabilizeVideoNode extends VideoTransformNode {
     description:
       "Whether to crop black borders that may appear after stabilization."
   })
-  declare crop_black: any;
+  declare crop_black: boolean;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
+    if (bytes.length === 0) return { output: videoRef(bytes) };
     const smoothing = Math.max(1, Number(this.smoothing ?? 10));
     const cropBlack = Boolean(this.crop_black ?? true);
 
-    let vf = `deshake=smooth=${smoothing}`;
+    const deshake = `deshake=smooth=${smoothing}`;
 
-    // If crop_black is enabled, chain cropdetect and crop to remove black borders
-    if (cropBlack) {
-      vf += ",cropdetect=24:16:0,crop";
+    if (!cropBlack) {
+      const transformed = await ffmpegTransform(bytes, [
+        "-vf",
+        deshake,
+        "-c:a",
+        "copy"
+      ]);
+      return { output: videoRef(transformed) };
     }
 
-    const transformed =
-      (await ffmpegTransform(bytes, ["-vf", vf, "-c:a", "copy"])) ?? bytes;
+    // Pass 1: run deshake + cropdetect to the null muxer and read cropdetect's
+    // suggested crop from stderr (a bare `crop` filter defaults to the full
+    // frame and removes nothing — cropdetect only logs, it never crops).
+    const probe = await withTempFile(".mp4", bytes);
+    let crop: string | null = null;
+    try {
+      const { stderr } = await execFfmpeg(
+        [
+          "-y",
+          "-i",
+          probe.path,
+          "-vf",
+          `${deshake},cropdetect=24:16:0`,
+          "-f",
+          "null",
+          "-"
+        ],
+        { maxBuffer: FFMPEG_MAX_BUFFER }
+      );
+      crop = parseCropDetectCrop(stderr);
+    } finally {
+      await probe.cleanup();
+    }
+
+    // Pass 2: apply the detected crop, or deshake alone when none was found.
+    const vf = crop ? `${deshake},crop=${crop}` : deshake;
+    const transformed = await ffmpegTransform(bytes, [
+      "-vf",
+      vf,
+      "-c:a",
+      "copy"
+    ]);
     return { output: videoRef(transformed) };
   }
 }
@@ -1761,19 +1808,11 @@ export class SharpnessVideoNode extends VideoTransformNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to sharpen."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1783,7 +1822,7 @@ export class SharpnessVideoNode extends VideoTransformNode {
     min: 0,
     max: 3
   })
-  declare luma_amount: any;
+  declare luma_amount: number;
 
   @prop({
     type: "float",
@@ -1793,7 +1832,7 @@ export class SharpnessVideoNode extends VideoTransformNode {
     min: 0,
     max: 3
   })
-  declare chroma_amount: any;
+  declare chroma_amount: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1805,7 +1844,7 @@ export class SharpnessVideoNode extends VideoTransformNode {
         `unsharp=5:5:${lumaAmount}:5:5:${chromaAmount}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1820,19 +1859,11 @@ export class BlurVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to apply blur effect."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1843,7 +1874,7 @@ export class BlurVideoNode extends VideoTransformNode {
     min: 0,
     max: 20
   })
-  declare strength: any;
+  declare strength: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1855,7 +1886,7 @@ export class BlurVideoNode extends VideoTransformNode {
         `boxblur=${radius}:${radius}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1870,19 +1901,11 @@ export class SaturationVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to adjust saturation."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -1893,7 +1916,7 @@ export class SaturationVideoNode extends VideoTransformNode {
     min: 0,
     max: 3
   })
-  declare saturation: any;
+  declare saturation: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1904,7 +1927,7 @@ export class SaturationVideoNode extends VideoTransformNode {
         `eq=saturation=${saturation}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
@@ -1919,19 +1942,11 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to add subtitles to."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "list[audio_chunk]",
@@ -1939,7 +1954,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     title: "Chunks",
     description: "Audio chunks to add as subtitles."
   })
-  declare chunks: any;
+  declare chunks: SubtitleChunk[];
 
   @prop({
     type: "font",
@@ -1953,7 +1968,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     title: "Font",
     description: "The font to use."
   })
-  declare font: any;
+  declare font: FontLike;
 
   @prop({
     type: "enum",
@@ -1962,7 +1977,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     description: "Vertical alignment of subtitles.",
     values: ["top", "center", "bottom"]
   })
-  declare align: any;
+  declare align: string;
 
   @prop({
     type: "int",
@@ -1972,7 +1987,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     min: 1,
     max: 72
   })
-  declare font_size: any;
+  declare font_size: number;
 
   @prop({
     type: "color",
@@ -1983,7 +1998,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     title: "Font Color",
     description: "The font color."
   })
-  declare font_color: any;
+  declare font_color: ColorRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -1994,10 +2009,12 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
     const fontColorObj = this.font_color as { value?: string } | undefined;
     const fontColor = String(fontColorObj?.value ?? "#FFFFFF").replace("#", "0x");
     // `||` (not `??`): the default font ref has name "", which must also
-    // fall back rather than producing drawtext's font=''.
+    // fall back rather than producing drawtext's font=''. Strip filtergraph-
+    // significant characters \u2014 a font family name never contains them, and
+    // leaving them in would let a crafted name break the -vf argument.
     const fontName = String(
       (this.font as { name?: string } | undefined)?.name || "Sans"
-    );
+    ).replace(/['\\:,;[\]%]/g, "");
     const align = String(this.align ?? "bottom");
 
     let yExpr: string;
@@ -2010,41 +2027,51 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
       yExpr = "h-(text_h*2)";
     }
 
-    // Build chained drawtext filters, one per chunk with enable=between(t,start,end)
-    const drawFilters = chunks
-      .map((chunk: Record<string, unknown>) => {
+    // Write each chunk's text to a temp file and reference it with drawtext's
+    // `textfile=` option. Inline `text='...'` breaks on ordinary punctuation:
+    // a comma or semicolon ends the filter, `[`/`]` are stream-label syntax,
+    // and the two-level filtergraph escaping is easy to get subtly wrong. A
+    // file sidesteps all of it \u2014 arbitrary subtitle text stays literal.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-subs-"));
+    try {
+      const drawFilters: string[] = [];
+      let idx = 0;
+      for (const chunk of chunks as SubtitleChunk[]) {
         const text = String(chunk.text ?? chunk.content ?? "").trim();
-        if (!text) return null;
+        if (!text) continue;
         const ts = Array.isArray(chunk.timestamp) ? chunk.timestamp : [];
         const start = Number(ts[0] ?? chunk.start ?? 0);
         const end = Number(ts[1] ?? chunk.end ?? start + 5);
-        const escaped = text
-          .replaceAll("\\", "\\\\")
-          .replaceAll(":", "\\:")
-          .replaceAll("'", "\u2019")
-          .replaceAll("%", "%%");
-        return (
-          `drawtext=text='${escaped}'` +
-          `:x=(w-text_w)/2:y=${yExpr}` +
-          `:fontcolor=${fontColor}:fontsize=${fontSize}` +
-          `:font='${fontName}'` +
-          `:enable='between(t,${start},${end})'`
+        const textPath = path.join(dir, `sub_${idx}.txt`);
+        await fs.writeFile(textPath, text, "utf8");
+        idx += 1;
+        drawFilters.push(
+          `drawtext=textfile='${textPath}':expansion=none` +
+            `:x=(w-text_w)/2:y=${yExpr}` +
+            `:fontcolor=${fontColor}:fontsize=${fontSize}` +
+            `:font='${fontName}'` +
+            `:enable='between(t,${start},${end})'`
         );
-      })
-      .filter(Boolean);
+      }
 
-    if (drawFilters.length === 0) return { output: videoRef(bytes) };
+      if (drawFilters.length === 0) return { output: videoRef(bytes) };
 
-    const vf = drawFilters.join(",");
-    const transformed =
-      (await ffmpegTransform(bytes, ["-vf", vf, "-c:a", "copy"])) ?? bytes;
-    return { output: videoRef(transformed) };
+      const vf = drawFilters.join(",");
+      const transformed = await ffmpegTransform(bytes, [
+        "-vf",
+        vf,
+        "-c:a",
+        "copy"
+      ]);
+      return { output: videoRef(transformed) };
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   }
 }
 
-export class ReverseVideoNode extends BaseNode {
+export class ReverseVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Reverse";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly title = "Reverse";
   static readonly description =
     "Reverse the playback of a video.\n    video, reverse, backwards, effect";
@@ -2056,29 +2083,22 @@ export class ReverseVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to reverse."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: videoRef(bytes) };
 
-    // Try with both video and audio reverse, fall back to video-only
+    // Reverse audio+video first (fails without an audio stream); the video-only
+    // fallback is terminal and throws on failure.
     const transformed =
-      (await ffmpegTransform(bytes, ["-vf", "reverse", "-af", "areverse"])) ??
-      (await ffmpegTransform(bytes, ["-vf", "reverse"])) ??
-      bytes;
+      (await ffmpegTransform(bytes, ["-vf", "reverse", "-af", "areverse"], {
+        allowFallback: true
+      })) ?? (await ffmpegTransform(bytes, ["-vf", "reverse"]));
     return { output: videoRef(transformed) };
   }
 }
@@ -2093,35 +2113,19 @@ export class TransitionVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video A",
     description: "The first video in the transition."
   })
-  declare video_a: any;
+  declare video_a: VideoRef;
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video B",
     description: "The second video in the transition."
   })
-  declare video_b: any;
+  declare video_b: VideoRef;
 
   @prop({
     type: "enum",
@@ -2189,7 +2193,7 @@ export class TransitionVideoNode extends VideoTransformNode {
       "revealdown"
     ]
   })
-  declare transition_type: any;
+  declare transition_type: string;
 
   @prop({
     type: "float",
@@ -2199,7 +2203,7 @@ export class TransitionVideoNode extends VideoTransformNode {
     min: 0.1,
     max: 5
   })
-  declare duration: any;
+  declare duration: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const a = await videoBytesAsync(this.video_a, context);
@@ -2234,29 +2238,24 @@ export class TransitionVideoNode extends VideoTransformNode {
           "-map",
           "[outa]"
         ],
-        [{ suffix: ".mp4", bytes: b }]
+        { extraInputs: [{ suffix: ".mp4", bytes: b }], allowFallback: true }
       )) ??
-      // Fallback: video-only xfade (inputs may lack audio)
+      // Fallback: video-only xfade (inputs may lack audio). Terminal attempt —
+      // throws with stderr if it also fails.
       (await ffmpegTransform(
         a,
         [
           "-filter_complex",
           `[0:v][1:v]xfade=transition=${transitionType}:duration=${duration}:offset=${offsetVal}`
         ],
-        [{ suffix: ".mp4", bytes: b }]
+        { extraInputs: [{ suffix: ".mp4", bytes: b }] }
       ));
-    if (transformed == null) {
-      throw new Error(
-        "Creating the transition failed: ffmpeg could not crossfade the two videos."
-      );
-    }
     return { output: videoRef(transformed) };
   }
 }
 
-export class AddAudioVideoNode extends BaseNode {
+export class AddAudioVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.AddAudio";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly title = "Add Audio";
   static readonly description =
     "Add an audio track to a video, replacing or mixing with existing audio.\n    video, audio, soundtrack, merge";
@@ -2268,19 +2267,11 @@ export class AddAudioVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to add audio to."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "audio",
@@ -2294,7 +2285,7 @@ export class AddAudioVideoNode extends BaseNode {
     title: "Audio",
     description: "The audio file to add to the video."
   })
-  declare audio: any;
+  declare audio: AudioRef;
 
   @prop({
     type: "float",
@@ -2305,7 +2296,7 @@ export class AddAudioVideoNode extends BaseNode {
     min: 0,
     max: 2
   })
-  declare volume: any;
+  declare volume: number;
 
   @prop({
     type: "bool",
@@ -2314,7 +2305,7 @@ export class AddAudioVideoNode extends BaseNode {
     description:
       "If True, mix new audio with existing. If False, replace existing audio."
   })
-  declare mix: any;
+  declare mix: boolean;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const v = await videoBytesAsync(this.video, context);
@@ -2367,30 +2358,17 @@ export class AddAudioVideoNode extends BaseNode {
       };
 
       try {
-        await execFile("ffmpeg", buildArgs(mix), {
-          maxBuffer: 50 * 1024 * 1024
-        });
+        await execFfmpeg(buildArgs(mix), { maxBuffer: FFMPEG_MAX_BUFFER });
       } catch (error) {
-        if (isMissingBinaryError(error)) throw ffmpegMissingError();
-        // Mixing requires an existing audio stream ([0:a]); videos without
-        // one make ffmpeg fail. Fall back to plain replacement.
+        if (error instanceof MissingBinaryError) throw error;
+        // Mixing requires an existing audio stream ([0:a]); videos without one
+        // make ffmpeg fail. Fall back to plain replacement — the terminal
+        // attempt, which throws (with stderr) if it also fails.
         if (!mix) throw error;
-        try {
-          await execFile("ffmpeg", buildArgs(false), {
-            maxBuffer: 50 * 1024 * 1024
-          });
-        } catch (retryError) {
-          if (isMissingBinaryError(retryError)) throw ffmpegMissingError();
-          throw retryError;
-        }
+        await execFfmpeg(buildArgs(false), { maxBuffer: FFMPEG_MAX_BUFFER });
       }
       const result = new Uint8Array(await fs.readFile(outputPath));
       return { output: videoRef(result) };
-    } catch (error) {
-      // A missing ffmpeg binary must surface clearly; genuine mux failures
-      // (incompatible streams, etc.) still fall back to the unchanged video.
-      if (isFfmpegMissingError(error)) throw error;
-      return { output: videoRef(v) };
     } finally {
       await videoInput.cleanup();
       await audioInput.cleanup();
@@ -2409,19 +2387,11 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
   };
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to apply chroma key effect."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "color",
@@ -2432,7 +2402,7 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
     title: "Key Color",
     description: "The color to key out (e.g., '#00FF00' for green)."
   })
-  declare key_color: any;
+  declare key_color: ColorRef;
 
   @prop({
     type: "float",
@@ -2442,7 +2412,7 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
     min: 0,
     max: 1
   })
-  declare similarity: any;
+  declare similarity: number;
 
   @prop({
     type: "float",
@@ -2452,7 +2422,7 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
     min: 0,
     max: 1
   })
-  declare blend: any;
+  declare blend: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -2466,14 +2436,13 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
         `colorkey=${color}:${similarity}:${blend}`,
         "-c:a",
         "copy"
-      ])) ?? bytes;
+      ]));
     return { output: videoRef(transformed) };
   }
 }
 
-export class ExtractAudioVideoNode extends BaseNode {
+export class ExtractAudioVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ExtractAudio";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly title = "Extract Audio";
   static readonly description =
     "Separate and extract audio track from a video file.\n    video, audio, extract, separate, split";
@@ -2485,19 +2454,11 @@ export class ExtractAudioVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to separate."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -2519,16 +2480,10 @@ export class ExtractAudioVideoNode extends BaseNode {
     );
     const outputPath = path.join(outputDir, "output.wav");
     try {
-      try {
-        await execFile(
-          "ffmpeg",
-          ["-y", "-i", input.path, "-vn", "-acodec", "pcm_s16le", outputPath],
-          { maxBuffer: 50 * 1024 * 1024 }
-        );
-      } catch (error) {
-        if (isMissingBinaryError(error)) throw ffmpegMissingError();
-        throw error;
-      }
+      await execFfmpeg(
+        ["-y", "-i", input.path, "-vn", "-acodec", "pcm_s16le", outputPath],
+        { maxBuffer: FFMPEG_MAX_BUFFER }
+      );
       const audioBytes = new Uint8Array(await fs.readFile(outputPath));
       const b64 = Buffer.from(audioBytes).toString("base64");
       return {
@@ -2547,9 +2502,8 @@ export class ExtractAudioVideoNode extends BaseNode {
   }
 }
 
-export class ExtractFrameVideoNode extends BaseNode {
+export class ExtractFrameVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ExtractFrame";
-  static readonly requiredRuntimes = ["ffmpeg"];
   static readonly title = "Extract Video Frame";
   static readonly description =
     "Extract a single frame from a video at a specific time position.\n    video, frame, extract, screenshot, thumbnail, capture";
@@ -2561,19 +2515,11 @@ export class ExtractFrameVideoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to extract a frame from."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "float",
@@ -2582,7 +2528,7 @@ export class ExtractFrameVideoNode extends BaseNode {
     description: "Time position in seconds to extract the frame from.",
     min: 0
   })
-  declare time: any;
+  declare time: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -2597,8 +2543,7 @@ export class ExtractFrameVideoNode extends BaseNode {
     const outputPath = path.join(outputDir, "frame.png");
     try {
       const time = Math.max(0, Number(this.time ?? 0));
-      await execFile(
-        "ffmpeg",
+      await execFfmpeg(
         [
           "-y",
           "-ss", String(time),
@@ -2616,7 +2561,10 @@ export class ExtractFrameVideoNode extends BaseNode {
           data: Buffer.from(frameData).toString("base64")
         }
       };
-    } catch {
+    } catch (error) {
+      // A missing binary is unrecoverable — surface it. A genuine decode
+      // failure (e.g. seeking past the end) yields an empty frame.
+      if (error instanceof MissingBinaryError) throw error;
       return { output: { type: "image", data: null } };
     } finally {
       await inputFile.cleanup();
@@ -2625,7 +2573,7 @@ export class ExtractFrameVideoNode extends BaseNode {
   }
 }
 
-export class GetVideoInfoNode extends BaseNode {
+export class GetVideoInfoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.GetVideoInfo";
   static readonly title = "Get Video Info";
   static readonly description =
@@ -2644,19 +2592,11 @@ export class GetVideoInfoNode extends BaseNode {
 
   @prop({
     type: "video",
-    default: {
-      type: "video",
-      uri: "",
-      asset_id: null,
-      data: null,
-      metadata: null,
-      duration: null,
-      format: null
-    },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to analyze."
   })
-  declare video: any;
+  declare video: VideoRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -2674,7 +2614,7 @@ export class GetVideoInfoNode extends BaseNode {
 
     const inputFile = await withTempFile(".mp4", bytes);
     try {
-      const { stdout } = await execFile("ffprobe", [
+      const { stdout } = await execFfprobe([
         "-v", "error",
         "-show_streams",
         "-show_format",
@@ -2720,7 +2660,10 @@ export class GetVideoInfoNode extends BaseNode {
         codec: videoStream?.codec_name ?? "",
         has_audio: hasAudio
       };
-    } catch {
+    } catch (error) {
+      // Missing ffprobe is actionable; a genuine probe failure on corrupt
+      // input degrades to the empty info result.
+      if (error instanceof MissingBinaryError) throw error;
       return {
         duration: 0,
         width: 0,
@@ -2760,15 +2703,15 @@ export class VideoToVideoNode extends BaseNode {
     title: "Model",
     description: "The video-to-video model to use"
   })
-  declare model: any;
+  declare model: VideoModelRef;
 
   @prop({
     type: "video",
-    default: { type: "video", uri: "", asset_id: null, data: null, metadata: null },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video to transform"
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "str",
@@ -2776,7 +2719,7 @@ export class VideoToVideoNode extends BaseNode {
     title: "Prompt",
     description: "Text prompt describing the desired transformation"
   })
-  declare prompt: any;
+  declare prompt: string;
 
   @prop({
     type: "str",
@@ -2784,7 +2727,7 @@ export class VideoToVideoNode extends BaseNode {
     title: "Negative Prompt",
     description: "Text prompt describing what to avoid"
   })
-  declare negative_prompt: any;
+  declare negative_prompt: string;
 
   @prop({
     type: "float",
@@ -2794,7 +2737,7 @@ export class VideoToVideoNode extends BaseNode {
     min: 0,
     max: 1
   })
-  declare strength: any;
+  declare strength: number;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
@@ -2803,7 +2746,8 @@ export class VideoToVideoNode extends BaseNode {
     if (!canUseProvider(context, providerId, modelId)) {
       throw new Error("No provider available for video-to-video generation.");
     }
-    const output = (await context.runProviderPrediction({
+    const output = coerceProviderBytes(
+      await context.runProviderPrediction({
       provider: providerId,
       capability: "video_to_video",
       model: modelId,
@@ -2813,7 +2757,9 @@ export class VideoToVideoNode extends BaseNode {
         negative_prompt: this.negative_prompt,
         strength: Number(this.strength ?? 0.6)
       }
-    })) as Uint8Array;
+    }),
+      "Video To Video"
+    );
     return { output: videoRef(output) };
   }
 }
@@ -2842,15 +2788,15 @@ export class LipSyncNode extends BaseNode {
     title: "Model",
     description: "The lip-sync model to use"
   })
-  declare model: any;
+  declare model: VideoModelRef;
 
   @prop({
     type: "video",
-    default: { type: "video", uri: "", asset_id: null, data: null, metadata: null },
+    default: defaultVideoRef(),
     title: "Video",
     description: "The input video containing the face to drive"
   })
-  declare video: any;
+  declare video: VideoRef;
 
   @prop({
     type: "audio",
@@ -2858,7 +2804,7 @@ export class LipSyncNode extends BaseNode {
     title: "Audio",
     description: "The audio track the mouth motion should follow"
   })
-  declare audio: any;
+  declare audio: AudioRef;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const video = await videoBytesAsync(this.video, context);
@@ -2869,12 +2815,15 @@ export class LipSyncNode extends BaseNode {
     if (!canUseProvider(context, providerId, modelId)) {
       throw new Error("No provider available for lip sync.");
     }
-    const output = (await context.runProviderPrediction({
+    const output = coerceProviderBytes(
+      await context.runProviderPrediction({
       provider: providerId,
       capability: "lip_sync",
       model: modelId,
       params: { video, audio }
-    })) as Uint8Array;
+    }),
+      "Lip Sync"
+    );
     return { output: videoRef(output) };
   }
 }

--- a/packages/video-nodes/tests/add-subtitles.test.ts
+++ b/packages/video-nodes/tests/add-subtitles.test.ts
@@ -1,0 +1,112 @@
+/**
+ * AddSubtitles must not let ordinary punctuation in subtitle text break the
+ * ffmpeg -vf filtergraph. It writes each chunk's text to a temp file and points
+ * drawtext at it with `textfile=`, so commas/semicolons/quotes never reach the
+ * filter string.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+
+let execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+  };
+  (mockExecFile as { [k: symbol]: unknown })[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    // ffmpeg "fails" so no real output file is read; args are captured above.
+    return Promise.reject(new Error("mock ffmpeg: no real execution"));
+  };
+  return { ...original, execFile: mockExecFile };
+});
+
+const { AddSubtitlesVideoNode } = await import("@nodetool-ai/video-nodes");
+
+function videoRef(bytes: number[]) {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+  };
+}
+
+/** The -vf argument passed to the (single) ffmpeg invocation. */
+function vfArg(): string {
+  const call = execFileCalls.find((c) => c.cmd === "ffmpeg");
+  if (!call) return "";
+  const i = call.args.indexOf("-vf");
+  return i >= 0 ? call.args[i + 1] : "";
+}
+
+beforeEach(() => {
+  execFileCalls = [];
+});
+
+describe("AddSubtitlesVideoNode — punctuation-safe drawtext", () => {
+  it("routes text through textfile= and keeps punctuation out of the filter", async () => {
+    const writeSpy = vi.spyOn(fs, "writeFile");
+    try {
+      const node = new AddSubtitlesVideoNode();
+      node.assign({
+        video: videoRef([1, 2, 3, 4]),
+        chunks: [
+          { text: "Hello, world; [take 1] 100% 'quoted'", timestamp: [0, 2] }
+        ]
+      });
+      await node.process().catch(() => undefined);
+
+      const vf = vfArg();
+      // Uses a textfile, not an inline text='...'.
+      expect(vf).toContain("textfile=");
+      expect(vf).toContain("expansion=none");
+      expect(vf).not.toContain("text='Hello");
+      // The punctuation that would break the filtergraph never appears in it.
+      expect(vf).not.toContain("Hello, world");
+      // Exactly one drawtext filter for one chunk.
+      expect((vf.match(/drawtext=/g) || []).length).toBe(1);
+
+      // The literal subtitle text (with its punctuation) was written to a file.
+      const wrote = writeSpy.mock.calls.some(
+        (c) =>
+          String(c[0]).includes("sub_") &&
+          c[1] === "Hello, world; [take 1] 100% 'quoted'"
+      );
+      expect(wrote).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("emits one drawtext per non-empty chunk", async () => {
+    const node = new AddSubtitlesVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      chunks: [
+        { text: "first, line", timestamp: [0, 1] },
+        { text: "second; line", timestamp: [1, 2] },
+        { text: "   ", timestamp: [2, 3] } // blank → skipped
+      ]
+    });
+    await node.process().catch(() => undefined);
+
+    const vf = vfArg();
+    expect((vf.match(/drawtext=/g) || []).length).toBe(2);
+  });
+
+  it("sanitizes the font name so it cannot break the filter", async () => {
+    const node = new AddSubtitlesVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      font: { type: "font", name: "Ev;il,Font]" },
+      chunks: [{ text: "hi", timestamp: [0, 1] }]
+    });
+    await node.process().catch(() => undefined);
+
+    const vf = vfArg();
+    expect(vf).toContain("font='EvilFont'");
+  });
+});

--- a/packages/video-nodes/tests/concat-normalize.test.ts
+++ b/packages/video-nodes/tests/concat-normalize.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Concat must not stream-copy heterogeneous inputs (that corrupts output).
+ * It probes each input and takes the fast `-c copy` path only when codec,
+ * dimensions, fps, and audio presence all match; otherwise it re-encodes each
+ * input to a uniform segment (libx264 + aac) before concatenating.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { promises as fs } from "node:fs";
+
+interface Meta {
+  codec: string;
+  width: number;
+  height: number;
+  fps: string;
+  hasAudio: boolean;
+}
+
+let execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+/** ffprobe show_streams responses, consumed in call order. */
+let probeQueue: Meta[] = [];
+
+function metaJson(m: Meta): string {
+  const streams: unknown[] = [
+    {
+      codec_type: "video",
+      codec_name: m.codec,
+      width: m.width,
+      height: m.height,
+      r_frame_rate: m.fps
+    }
+  ];
+  if (m.hasAudio) streams.push({ codec_type: "audio" });
+  return JSON.stringify({ streams, format: { duration: "5" } });
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+  };
+  (mockExecFile as { [k: symbol]: unknown })[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = async (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    if (cmd === "ffprobe") {
+      const meta = probeQueue.shift();
+      return { stdout: meta ? metaJson(meta) : "{}", stderr: "" };
+    }
+    // ffmpeg: write the requested output file so the node can read it back.
+    const out = args[args.length - 1];
+    await fs.writeFile(out, Buffer.from([0x99]));
+    return { stdout: "", stderr: "" };
+  };
+  return { ...original, execFile: mockExecFile };
+});
+
+const { ConcatVideoNode } = await import("@nodetool-ai/video-nodes");
+
+function videoRef(bytes: number[]) {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+  };
+}
+
+function ffmpegArgString(): string {
+  return execFileCalls
+    .filter((c) => c.cmd === "ffmpeg")
+    .map((c) => c.args.join(" "))
+    .join("\n");
+}
+
+beforeEach(() => {
+  execFileCalls = [];
+  probeQueue = [];
+});
+
+describe("ConcatVideoNode — codec-aware path selection", () => {
+  it("uses the fast -c copy path (no re-encode) when all inputs match", async () => {
+    const uniform: Meta = {
+      codec: "h264",
+      width: 1920,
+      height: 1080,
+      fps: "30/1",
+      hasAudio: true
+    };
+    probeQueue = [uniform, uniform];
+
+    const node = new ConcatVideoNode();
+    node.setDynamic("a", videoRef([1, 2]));
+    node.setDynamic("b", videoRef([3, 4]));
+    const result = await node.process();
+
+    const args = ffmpegArgString();
+    expect(args).toContain("concat");
+    expect(args).toContain("-c copy");
+    // No normalization pass.
+    expect(args).not.toContain("libx264");
+    const out = (result.output as { data?: string }).data;
+    expect(new Uint8Array(Buffer.from(out ?? "", "base64")).length).toBe(1);
+  });
+
+  it("re-encodes to uniform segments when inputs differ", async () => {
+    probeQueue = [
+      { codec: "h264", width: 1920, height: 1080, fps: "30/1", hasAudio: true },
+      { codec: "vp9", width: 1280, height: 720, fps: "25/1", hasAudio: false }
+    ];
+
+    const node = new ConcatVideoNode();
+    node.setDynamic("a", videoRef([1, 2]));
+    node.setDynamic("b", videoRef([3, 4]));
+    await node.process();
+
+    const args = ffmpegArgString();
+    // Each input normalized with libx264/aac + scale/pad before concatenation.
+    expect(args).toContain("libx264");
+    expect(args).toContain("scale=1920:1080");
+    expect(args).toContain("concat");
+    // The mismatched (audio-less) input gets a silent track so segments align.
+    expect(args).toContain("anullsrc");
+  });
+});

--- a/packages/video-nodes/tests/effect-throws.test.ts
+++ b/packages/video-nodes/tests/effect-throws.test.ts
@@ -1,0 +1,55 @@
+/**
+ * A terminal ffmpeg failure on an effect node must throw an error carrying
+ * ffmpeg's stderr — never silently pass the unchanged input through (a no-op
+ * effect indistinguishable from a real one).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function ffmpegFailure(): Error & { code: number; stderr: string } {
+  const e = new Error("ffmpeg exited with code 1") as Error & {
+    code: number;
+    stderr: string;
+  };
+  e.code = 1;
+  e.stderr = "Error reinitializing filters! Invalid argument";
+  return e;
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (_cmd: string, _args: string[]) => undefined;
+  (mockExecFile as { [k: symbol]: unknown })[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = () => Promise.reject(ffmpegFailure());
+  return { ...original, execFile: mockExecFile };
+});
+
+const { DenoiseVideoNode, SetSpeedVideoNode } = await import(
+  "@nodetool-ai/video-nodes"
+);
+
+function videoRef(bytes: number[]) {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+  };
+}
+
+beforeEach(() => {});
+
+describe("effect nodes throw on terminal ffmpeg failure", () => {
+  it("DenoiseVideoNode rejects and includes ffmpeg stderr", async () => {
+    const node = new DenoiseVideoNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]), strength: 5 });
+    await expect(node.process()).rejects.toThrow(/reinitializing filters/);
+  });
+
+  it("SetSpeedVideoNode throws when even the video-only fallback fails", async () => {
+    // The audio+video attempt is allowed to fall back; the video-only attempt is
+    // terminal and must surface the failure, not return the input unchanged.
+    const node = new SetSpeedVideoNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]), speed_factor: 2 });
+    await expect(node.process()).rejects.toThrow(/ffmpeg failed/);
+  });
+});

--- a/packages/video-nodes/tests/ffmpeg-helpers.test.ts
+++ b/packages/video-nodes/tests/ffmpeg-helpers.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Unit tests for pure helpers that need no child_process mock:
+ * cropdetect stderr parsing and the missing-binary error class.
+ */
+import { describe, it, expect } from "vitest";
+import { parseCropDetectCrop } from "@nodetool-ai/video-nodes";
+
+describe("parseCropDetectCrop", () => {
+  it("returns the LAST crop suggestion from cropdetect stderr", () => {
+    const stderr = [
+      "[Parsed_cropdetect_1 @ 0x1] x1:0 x2:1919 y1:10 y2:1069 crop=1920:1060:0:10",
+      "[Parsed_cropdetect_1 @ 0x1] x1:0 x2:1919 y1:12 y2:1067 crop=1920:1056:0:12"
+    ].join("\n");
+    expect(parseCropDetectCrop(stderr)).toBe("1920:1056:0:12");
+  });
+
+  it("returns null when no crop suggestion is present", () => {
+    expect(parseCropDetectCrop("frame= 100 fps=25 no crops here")).toBeNull();
+    expect(parseCropDetectCrop("")).toBeNull();
+  });
+
+  it("parses a single suggestion", () => {
+    expect(parseCropDetectCrop("... crop=640:480:0:0 ...")).toBe("640:480:0:0");
+  });
+});

--- a/packages/video-nodes/tests/ffmpeg-missing.test.ts
+++ b/packages/video-nodes/tests/ffmpeg-missing.test.ts
@@ -144,15 +144,15 @@ describe("ffmpeg missing (ENOENT) — transform node", () => {
     await expect(node.process()).rejects.toThrowError();
   });
 
-  it("ResizeVideoNode falls back to the input bytes on a non-ENOENT ffmpeg failure", async () => {
-    // A genuine filtergraph failure must keep the legacy `?? bytes` behavior:
-    // ffmpegTransform returns null and the node passes the input through.
+  it("ResizeVideoNode throws (with stderr) on a genuine ffmpeg failure — no silent passthrough", async () => {
+    // A genuine filtergraph failure must surface as an error, not silently
+    // return the unchanged input (a no-op effect indistinguishable from a real
+    // one). ffmpegTransform rejects instead of the old `?? bytes` fallback.
     mode = "fail";
     const node = new ResizeVideoNode();
     node.assign({ video: videoRef([1, 2, 3, 4]), width: 320, height: 240 });
 
-    const result = await node.process();
-    expect(Array.from(bytesOf(result.output))).toEqual([1, 2, 3, 4]);
+    await expect(node.process()).rejects.toThrow(/ffmpeg failed/);
   });
 
   it("ResizeVideoNode returns the transformed bytes when ffmpeg succeeds", async () => {
@@ -197,9 +197,9 @@ describe("ffmpeg missing (ENOENT) — AddAudioVideoNode", () => {
     );
   });
 
-  it("still swallows a genuine (non-ENOENT) mux failure and returns the input video", async () => {
-    // The graceful 'return the input video' fallback must survive for real
-    // ffmpeg/mux failures — only a missing binary should propagate.
+  it("throws on a genuine (non-ENOENT) mux failure — no silent passthrough", async () => {
+    // A real ffmpeg/mux failure must surface, not silently return the unchanged
+    // input video (which would look like the audio was added when it wasn't).
     mode = "fail";
     const node = new AddAudioVideoNode();
     node.assign({
@@ -209,8 +209,7 @@ describe("ffmpeg missing (ENOENT) — AddAudioVideoNode", () => {
       mix: false
     });
 
-    const result = await node.process();
-    expect(Array.from(bytesOf(result.output))).toEqual([1, 2, 3, 4]);
+    await expect(node.process()).rejects.toThrowError();
   });
 
   it("mix=true: a non-ENOENT first failure that retries into a missing binary still rejects clearly", async () => {

--- a/packages/video-nodes/tests/missing-ffprobe.test.ts
+++ b/packages/video-nodes/tests/missing-ffprobe.test.ts
@@ -1,0 +1,69 @@
+/**
+ * A missing ffprobe binary (spawn ENOENT) must surface as the actionable
+ * MissingBinaryError at every probe site, not get swallowed into a 0/empty
+ * return the way a genuine probe failure on corrupt input may.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let ffprobeMode: "enoent" | "ok" = "enoent";
+
+function enoent(): Error & { code: string } {
+  const e = new Error("spawn ffprobe ENOENT") as Error & { code: string };
+  e.code = "ENOENT";
+  return e;
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (_cmd: string, _args: string[]) => undefined;
+  (mockExecFile as { [k: symbol]: unknown })[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = (cmd: string) => {
+    if (cmd === "ffprobe" && ffprobeMode === "enoent") return Promise.reject(enoent());
+    return Promise.resolve({ stdout: "", stderr: "" });
+  };
+  return { ...original, execFile: mockExecFile };
+});
+
+const { FpsNode, GetVideoInfoNode, ConcatVideoNode, ForEachFrameNode } =
+  await import("@nodetool-ai/video-nodes");
+
+function videoRef(bytes: number[]) {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+  };
+}
+
+beforeEach(() => {
+  ffprobeMode = "enoent";
+});
+
+describe("missing ffprobe → MissingBinaryError", () => {
+  it("FpsNode surfaces the install error", async () => {
+    const node = new FpsNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]) });
+    await expect(node.process()).rejects.toThrow(/ffprobe is not installed/);
+  });
+
+  it("GetVideoInfoNode surfaces the install error", async () => {
+    const node = new GetVideoInfoNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]) });
+    await expect(node.process()).rejects.toThrow(/ffprobe is not installed/);
+  });
+
+  it("ForEachFrameNode surfaces the install error from its fps probe", async () => {
+    const node = new ForEachFrameNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]) });
+    // process() drains genProcess, which probes fps first.
+    await expect(node.process()).rejects.toThrow(/ffprobe is not installed/);
+  });
+
+  it("ConcatVideoNode surfaces the install error from its input probe", async () => {
+    const node = new ConcatVideoNode();
+    node.setDynamic("a", videoRef([1, 2]));
+    node.setDynamic("b", videoRef([3, 4]));
+    await expect(node.process()).rejects.toThrow(/ffprobe is not installed/);
+  });
+});

--- a/packages/video-nodes/tests/regression-video.test.ts
+++ b/packages/video-nodes/tests/regression-video.test.ts
@@ -182,7 +182,7 @@ describe("DenoiseVideoNode — uses nlmeans filter with strength param", () => {
       video: videoRef([1, 2, 3, 4]),
       strength: 7
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("nlmeans");
@@ -195,7 +195,7 @@ describe("DenoiseVideoNode — uses nlmeans filter with strength param", () => {
     node.assign({
       video: videoRef([1, 2, 3, 4])
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("nlmeans=s=5");
@@ -212,7 +212,7 @@ describe("StabilizeVideoNode — uses deshake with smooth param", () => {
       smoothing: 15,
       crop_black: false
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("deshake");
@@ -226,7 +226,7 @@ describe("StabilizeVideoNode — uses deshake with smooth param", () => {
       smoothing: 10,
       crop_black: true
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("deshake");
@@ -242,7 +242,7 @@ describe("StabilizeVideoNode — uses deshake with smooth param", () => {
       smoothing: 10,
       crop_black: false
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("deshake");
@@ -260,7 +260,7 @@ describe("SharpnessVideoNode — uses unsharp with both luma and chroma amounts"
       luma_amount: 1.5,
       chroma_amount: 0.8
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("unsharp");
@@ -277,7 +277,7 @@ describe("SharpnessVideoNode — uses unsharp with both luma and chroma amounts"
       luma_amount: 2.0,
       chroma_amount: 1.2
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // Full unsharp format: unsharp=5:5:<luma>:5:5:<chroma>
@@ -296,7 +296,7 @@ describe("ColorBalanceVideoNode — uses colorbalance filter with rs/gs/bs", () 
       green_adjust: 0.8,
       blue_adjust: 1.2
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("colorbalance");
@@ -314,7 +314,7 @@ describe("ColorBalanceVideoNode — uses colorbalance filter with rs/gs/bs", () 
       green_adjust: 2.0,  // max → gs=1
       blue_adjust: 0.0    // min → bs=-1
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("rs=0");
@@ -332,7 +332,7 @@ describe("SetSpeedVideoNode — chains atempo for speeds outside 0.5-2.0", () =>
       video: videoRef([1, 2, 3, 4]),
       speed_factor: 4.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // speed=4 → buildAtempo chains: while remaining>2 push atempo=2.0 and halve,
@@ -348,7 +348,7 @@ describe("SetSpeedVideoNode — chains atempo for speeds outside 0.5-2.0", () =>
       video: videoRef([1, 2, 3, 4]),
       speed_factor: 4.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // Must have multiple chained atempo filters, not just one
@@ -362,7 +362,7 @@ describe("SetSpeedVideoNode — chains atempo for speeds outside 0.5-2.0", () =>
       video: videoRef([1, 2, 3, 4]),
       speed_factor: 1.5
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("atempo=1.5");
@@ -376,7 +376,7 @@ describe("SetSpeedVideoNode — chains atempo for speeds outside 0.5-2.0", () =>
       video: videoRef([1, 2, 3, 4]),
       speed_factor: 2.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // setpts=0.5*PTS for 2x speed
@@ -462,7 +462,7 @@ describe("FpsNode — does NOT return hardcoded 24", () => {
     node.assign({
       video: videoRef([1, 2, 3, 4])
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const probes = ffprobeCalls();
     expect(probes.length).toBeGreaterThan(0);
@@ -529,7 +529,7 @@ describe("GetVideoInfoNode — does NOT return bytes.length / 24000 for duration
     node.assign({
       video: videoRef([1, 2, 3, 4])
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const probes = ffprobeCalls();
     expect(probes.length).toBeGreaterThan(0);
@@ -549,7 +549,7 @@ describe("TrimVideoNode — uses start/end as time values (seconds)", () => {
       start_time: 5.5,
       end_time: 12.0
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("-ss");
@@ -565,7 +565,7 @@ describe("TrimVideoNode — uses start/end as time values (seconds)", () => {
       start_time: 2,
       end_time: 5
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const calls = ffmpegCalls();
     // Should have called ffmpeg (not just sliced bytes)
@@ -584,7 +584,7 @@ describe("TrimVideoNode — uses start/end as time values (seconds)", () => {
       start_time: 3.0,
       end_time: -1
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("-ss");
@@ -599,7 +599,7 @@ describe("TrimVideoNode — uses start/end as time values (seconds)", () => {
       start_time: 1,
       end_time: 4
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("-c");
@@ -618,7 +618,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
       volume: 0.7,
       mix: true
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // volume should appear in filter_complex
@@ -634,7 +634,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
       volume: 0.5,
       mix: false
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     // Volume should be applied even when not mixing
@@ -649,7 +649,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
       volume: 1.0,
       mix: false
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("-map");
@@ -664,7 +664,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
       volume: 1.0,
       mix: true
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("amix");
@@ -679,7 +679,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
       volume: 1.0,
       mix: false
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).not.toContain("amix");
@@ -701,7 +701,7 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
         volume: 1.0,
         mix: false
       });
-      await node.process();
+      await node.process().catch(() => undefined);
 
       // ffmpeg must have been invoked, proving the URI-backed audio loaded.
       expect(ffmpegCalls().length).toBeGreaterThan(0);
@@ -722,7 +722,7 @@ describe("ChromaKeyVideoNode — uses the color ref value, not [object Object]",
       similarity: 0.3,
       blend: 0.1
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("colorkey=0x00FF00:0.3:0.1");
@@ -737,7 +737,7 @@ describe("ChromaKeyVideoNode — uses the color ref value, not [object Object]",
       similarity: 0.2,
       blend: 0.05
     });
-    await node.process();
+    await node.process().catch(() => undefined);
 
     const args = ffmpegArgString();
     expect(args).toContain("colorkey=0x0000FF");
@@ -760,7 +760,7 @@ describe("SaveVideoNode — resolves a folder ref object to a path", () => {
         folder: { type: "folder", uri: `file://${targetDir}`, asset_id: null },
         name: "clip.mp4"
       });
-      await node.process();
+      await node.process().catch(() => undefined);
 
       expect(writeSpy).toHaveBeenCalled();
       const writtenPath = String(writeSpy.mock.calls[0][0]);

--- a/packages/video-nodes/tests/trim-seek.test.ts
+++ b/packages/video-nodes/tests/trim-seek.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Trim must seek on the INPUT side (`-ss`/`-to` before `-i`) so ffmpeg jumps to
+ * the nearest keyframe instead of decoding from the start of the clip.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+  };
+  (mockExecFile as { [k: symbol]: unknown })[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    return Promise.reject(new Error("mock ffmpeg: no real execution"));
+  };
+  return { ...original, execFile: mockExecFile };
+});
+
+const { TrimVideoNode } = await import("@nodetool-ai/video-nodes");
+
+function videoRef(bytes: number[]) {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array(bytes)).toString("base64")
+  };
+}
+
+function ffmpegArgs(): string[] {
+  const call = execFileCalls.find((c) => c.cmd === "ffmpeg");
+  return call ? call.args : [];
+}
+
+beforeEach(() => {
+  execFileCalls = [];
+});
+
+describe("TrimVideoNode — input-side seeking", () => {
+  it("places -ss and -to BEFORE -i", async () => {
+    const node = new TrimVideoNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]), start_time: 5.5, end_time: 12 });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgs();
+    const ss = args.indexOf("-ss");
+    const to = args.indexOf("-to");
+    const i = args.indexOf("-i");
+    expect(ss).toBeGreaterThanOrEqual(0);
+    expect(i).toBeGreaterThan(ss);
+    expect(to).toBeGreaterThan(ss);
+    expect(to).toBeLessThan(i);
+    expect(args[ss + 1]).toBe("5.5");
+    expect(args[to + 1]).toBe("12");
+    expect(args).toContain("copy");
+  });
+
+  it("omits -to (still input-side -ss) when end_time is -1", async () => {
+    const node = new TrimVideoNode();
+    node.assign({ video: videoRef([1, 2, 3, 4]), start_time: 3, end_time: -1 });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgs();
+    const ss = args.indexOf("-ss");
+    const i = args.indexOf("-i");
+    expect(ss).toBeGreaterThanOrEqual(0);
+    expect(i).toBeGreaterThan(ss);
+    expect(args).not.toContain("-to");
+  });
+});

--- a/packages/video-nodes/tests/ytdlp-download.test.ts
+++ b/packages/video-nodes/tests/ytdlp-download.test.ts
@@ -1,0 +1,260 @@
+/**
+ * YtDlpDownloadLibNode tests.
+ *
+ * The node shells out to `yt-dlp` via `spawn` (not execFile), reading stdout,
+ * stderr, and the "close" exit code. We mock `node:child_process` with a fake
+ * ChildProcess that emits scripted stdout/stderr then closes with a scripted
+ * exit code, so no real yt-dlp binary is needed and every branch is exercised
+ * on any platform.
+ *
+ * A single `spawnResponder` decides the response per invocation from (cmd,
+ * args); each test overrides it. Every spawn call is recorded in `spawnCalls`
+ * so we can assert argument construction (metadata probe args, -x audio args,
+ * --sub-langs pass-through, …).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+type SpawnResult = { stdout?: string; stderr?: string; code?: number };
+type SpawnCall = { cmd: string; args: string[] };
+
+const spawnCalls: SpawnCall[] = [];
+let spawnResponder: (cmd: string, args: string[]) => SpawnResult;
+
+/** A valid yt-dlp `--print-json` info line. */
+const VALID_INFO = JSON.stringify({ id: "abc123", title: "Test", ext: "mp4" });
+
+function defaultResponder(_cmd: string, args: string[]): SpawnResult {
+  // The metadata probe carries --print-json; anything else is the download.
+  if (args.includes("--print-json")) {
+    return { stdout: `${VALID_INFO}\n`, stderr: "", code: 0 };
+  }
+  return { stdout: "", stderr: "", code: 0 };
+}
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const spawn = (cmd: string, args: string[]) => {
+    spawnCalls.push({ cmd, args });
+    const child = new FakeChild();
+    const res = spawnResponder(cmd, args);
+    // Emit on the next tick so runCommand can attach its listeners first.
+    queueMicrotask(() => {
+      if (res.stdout) child.stdout.emit("data", Buffer.from(res.stdout));
+      if (res.stderr) child.stderr.emit("data", Buffer.from(res.stderr));
+      child.emit("close", res.code ?? 0);
+    });
+    return child;
+  };
+  return { ...original, spawn };
+});
+
+const { YtDlpDownloadLibNode } = await import("@nodetool-ai/video-nodes");
+
+function makeNode(props: Record<string, unknown>) {
+  const node = new YtDlpDownloadLibNode();
+  node.assign({ url: "https://example.com/watch?v=abc123", ...props });
+  return node;
+}
+
+/** The recorded args for the metadata probe (first --print-json call). */
+function metadataArgs(): string[] {
+  const call = spawnCalls.find((c) => c.args.includes("--print-json"));
+  return call?.args ?? [];
+}
+
+/** The recorded args for the download call (no --print-json). */
+function downloadArgs(): string[] {
+  const call = spawnCalls.find((c) => !c.args.includes("--print-json"));
+  return call?.args ?? [];
+}
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  spawnResponder = defaultResponder;
+});
+
+describe("YtDlpDownloadLibNode — metadata mode", () => {
+  it("builds the metadata probe args and does not run a download", async () => {
+    const node = makeNode({ mode: "metadata" });
+    const result = await node.process();
+
+    const args = metadataArgs();
+    expect(args).toContain("--print-json");
+    expect(args).toContain("--skip-download");
+    expect(args).toContain("--no-playlist");
+    expect(args[args.length - 1]).toBe("https://example.com/watch?v=abc123");
+
+    // No second (download) invocation in metadata mode.
+    expect(spawnCalls.filter((c) => !c.args.includes("--print-json"))).toEqual(
+      []
+    );
+    expect((result.metadata as Record<string, unknown>).id).toBe("abc123");
+  });
+
+  it("emits typed empty refs for all media outputs", async () => {
+    const node = makeNode({ mode: "metadata" });
+    const result = await node.process();
+
+    expect(result.video).toEqual({
+      type: "video",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+    expect(result.audio).toEqual({
+      type: "audio",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+    expect(result.thumbnail).toEqual({
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+    expect(result.subtitles).toBe("");
+  });
+});
+
+describe("YtDlpDownloadLibNode — audio mode", () => {
+  it("adds -x --audio-format mp3 to the download args", async () => {
+    const node = makeNode({ mode: "audio" });
+    await node.process();
+
+    const args = downloadArgs();
+    expect(args).toContain("-x");
+    expect(args).toContain("--audio-format");
+    expect(args[args.indexOf("--audio-format") + 1]).toBe("mp3");
+    expect(args).toContain("bestaudio/best");
+  });
+
+  it("leaves audio/video/thumbnail as typed empty refs when no file is produced", async () => {
+    const node = makeNode({ mode: "audio" });
+    const result = await node.process();
+
+    // Download exits 0 but writes no file to the temp dir → empty ref stays.
+    expect(result.audio).toEqual({
+      type: "audio",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+    expect(result.video).toEqual({
+      type: "video",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    });
+  });
+});
+
+describe("YtDlpDownloadLibNode — subtitle languages", () => {
+  it("passes sub_langs through to --sub-langs", async () => {
+    const node = makeNode({
+      mode: "video",
+      subtitles: true,
+      sub_langs: "de,fr"
+    });
+    await node.process();
+
+    const args = downloadArgs();
+    expect(args).toContain("--sub-langs");
+    expect(args[args.indexOf("--sub-langs") + 1]).toBe("de,fr");
+  });
+
+  it("falls back to the default when sub_langs is empty", async () => {
+    const node = makeNode({
+      mode: "video",
+      subtitles: true,
+      sub_langs: "   "
+    });
+    await node.process();
+
+    const args = downloadArgs();
+    expect(args[args.indexOf("--sub-langs") + 1]).toBe("en,en-US,en-GB");
+  });
+
+  it("does not add subtitle args when subtitles is disabled", async () => {
+    const node = makeNode({ mode: "video", subtitles: false });
+    await node.process();
+
+    expect(downloadArgs()).not.toContain("--sub-langs");
+  });
+});
+
+describe("YtDlpDownloadLibNode — URL validation", () => {
+  it("rejects an empty URL", async () => {
+    const node = makeNode({ url: "" });
+    await expect(node.process()).rejects.toThrow(/URL cannot be empty/);
+  });
+
+  it("rejects a non-http(s) URL", async () => {
+    const node = makeNode({ url: "ftp://example.com/file" });
+    await expect(node.process()).rejects.toThrow(/Invalid URL format/);
+  });
+
+  it("rejects a malformed URL string", async () => {
+    const node = makeNode({ url: "not a url" });
+    await expect(node.process()).rejects.toThrow(/Invalid URL format/);
+  });
+
+  it("accepts a well-formed https URL", async () => {
+    const node = makeNode({ url: "https://example.com/x", mode: "metadata" });
+    await expect(node.process()).resolves.toBeDefined();
+  });
+});
+
+describe("YtDlpDownloadLibNode — process failures", () => {
+  it("throws with stderr when the metadata probe exits non-zero", async () => {
+    spawnResponder = () => ({
+      stdout: "",
+      stderr: "ERROR: video unavailable",
+      code: 1
+    });
+    const node = makeNode({ mode: "metadata" });
+    await expect(node.process()).rejects.toThrow(/video unavailable/);
+  });
+
+  it("throws a clear error when metadata JSON is malformed", async () => {
+    spawnResponder = (_cmd, args) => {
+      if (args.includes("--print-json")) {
+        return { stdout: "{ this is not valid json\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const node = makeNode({ mode: "metadata" });
+    await expect(node.process()).rejects.toThrow(/malformed/i);
+  });
+
+  it("throws a clear error when yt-dlp emits no JSON info line", async () => {
+    spawnResponder = () => ({ stdout: "no json here\n", stderr: "", code: 0 });
+    const node = makeNode({ mode: "metadata" });
+    await expect(node.process()).rejects.toThrow(
+      /malformed.*no JSON info line/i
+    );
+  });
+
+  it("throws with stderr when the download exits non-zero", async () => {
+    spawnResponder = (_cmd, args) => {
+      if (args.includes("--print-json")) {
+        return { stdout: `${VALID_INFO}\n`, stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "ERROR: download blocked", code: 1 };
+    };
+    const node = makeNode({ mode: "video" });
+    await expect(node.process()).rejects.toThrow(/download blocked/);
+  });
+});


### PR DESCRIPTION
- Emit typed empty video/audio/image refs instead of bare {} / null on
  unused outputs, matching metadataOutputTypes.
- Add a sub_langs prop (default en,en-US,en-GB) instead of hardcoding
  English subtitle languages.
- Validate URLs with new URL() (http/https only) and document the
  trust model; drop the weak regex.
- Throw a clear error on missing or malformed yt-dlp metadata JSON
  instead of silently continuing with {}.
- Replace all `declare foo: any` prop types with real types.
- Add tests/ytdlp-download.test.ts (15 tests) covering arg
  construction, sub_langs fallback, typed empty refs, URL rejection,
  and error surfacing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QKNh8MRLiN1CdAR7D5mCYf