### PR TITLE
core-nodes: type props, validate select options, retitle FilterCode

### DIFF
--- a/packages/core-nodes/src/nodes/constant.ts
+++ b/packages/core-nodes/src/nodes/constant.ts
@@ -553,7 +553,14 @@ export class ConstantSelectNode extends BaseNode {
   declare enum_type_name: string;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: this.value ?? "" };
+    const value = this.value ?? "";
+    const options = Array.isArray(this.options) ? this.options : [];
+    if (value !== "" && options.length > 0 && !options.includes(value)) {
+      throw new Error(
+        `Select value "${value}" is not one of the allowed options: ${options.join(", ")}`
+      );
+    }
+    return { output: value };
   }
 }
 

--- a/packages/core-nodes/src/nodes/control.ts
+++ b/packages/core-nodes/src/nodes/control.ts
@@ -27,7 +27,7 @@ export class IfNode extends BaseNode {
     title: "Condition",
     description: "The condition to evaluate"
   })
-  declare condition: any;
+  declare condition: boolean;
 
   @prop({
     type: "any",
@@ -35,7 +35,7 @@ export class IfNode extends BaseNode {
     title: "Value",
     description: "The value to pass to the next node"
   })
-  declare value: any;
+  declare value: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const condition = Boolean(this.condition ?? false);
@@ -73,7 +73,7 @@ export class ForEachNode extends BaseNode {
     title: "Input List",
     description: "The list of items to iterate over."
   })
-  declare input_list: any;
+  declare input_list: unknown[];
 
   @prop({
     type: "int",
@@ -83,7 +83,7 @@ export class ForEachNode extends BaseNode {
       "Maximum number of items to emit. -1 (default) emits the full list. " +
       "Useful for testing pipelines on a small subset."
   })
-  declare limit: any;
+  declare limit: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -129,7 +129,7 @@ export class AssetCollectionNode extends BaseNode {
       "The curated items, all of a single asset type. Emitted one at a time, " +
       "in order. Usually populated by drag-and-drop in the editor."
   })
-  declare items: any;
+  declare items: unknown[];
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -169,7 +169,7 @@ export class RepeatCountNode extends BaseNode {
     title: "Count",
     description: "Number of ticks to emit (0 emits nothing)."
   })
-  declare count: any;
+  declare count: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -207,7 +207,7 @@ export class RepeatValueStreamNode extends BaseNode {
     title: "Value",
     description: "Single value to emit on each tick."
   })
-  declare value: any;
+  declare value: unknown;
 
   @prop({
     type: "int",
@@ -216,7 +216,7 @@ export class RepeatValueStreamNode extends BaseNode {
     title: "Count",
     description: "Number of times to emit the value (0 emits nothing)."
   })
-  declare count: any;
+  declare count: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -256,7 +256,7 @@ export class TakeNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — each item is forwarded until the limit is reached."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "int",
@@ -264,7 +264,7 @@ export class TakeNode extends BaseNode {
     title: "N",
     description: "Number of items to take from the head of the stream."
   })
-  declare n: any;
+  declare n: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -317,7 +317,7 @@ export class CollectNode extends BaseNode {
     title: "Input Item",
     description: "The input item to collect."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     return { output: [] };
@@ -356,7 +356,7 @@ export class RerouteNode extends BaseNode {
     title: "Input Value",
     description: "Value to pass through unchanged"
   })
-  declare input_value: any;
+  declare input_value: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     return { output: this.input_value ?? null };
@@ -388,7 +388,7 @@ export class SwitchNode extends BaseNode {
     title: "Value",
     description: "The value to match against cases."
   })
-  declare value: any;
+  declare value: unknown;
 
   @prop({
     type: "list[any]",
@@ -396,7 +396,7 @@ export class SwitchNode extends BaseNode {
     title: "Cases",
     description: "List of values to match against. The first match wins."
   })
-  declare cases: any;
+  declare cases: unknown[];
 
   @prop({
     type: "any",
@@ -404,7 +404,7 @@ export class SwitchNode extends BaseNode {
     title: "Input",
     description: "The data to route to the matched output."
   })
-  declare input: any;
+  declare input: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const value = this.value;
@@ -447,7 +447,7 @@ export class TryCatchNode extends BaseNode {
     title: "Value",
     description: "The value to pass through. When null/undefined, the fallback is used."
   })
-  declare value: any;
+  declare value: unknown;
 
   @prop({
     type: "any",
@@ -455,7 +455,7 @@ export class TryCatchNode extends BaseNode {
     title: "Fallback",
     description: "Value to return when the input value is null/undefined."
   })
-  declare fallback: any;
+  declare fallback: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const value = this.value;
@@ -495,7 +495,7 @@ export class DropNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — items after the first N are forwarded."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "int",
@@ -503,7 +503,7 @@ export class DropNode extends BaseNode {
     title: "N",
     description: "Number of items to drop from the head of the stream."
   })
-  declare n: any;
+  declare n: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -563,7 +563,7 @@ export class FilterEqualNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — items pass through if they equal the target value."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "any",
@@ -571,7 +571,7 @@ export class FilterEqualNode extends BaseNode {
     title: "Value",
     description: "Target value. Items deep-equal to this are passed through."
   })
-  declare value: any;
+  declare value: unknown;
 
   @prop({
     type: "bool",
@@ -579,7 +579,7 @@ export class FilterEqualNode extends BaseNode {
     title: "Invert",
     description: "When true, pass items NOT equal to the target value."
   })
-  declare invert: any;
+  declare invert: boolean;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -602,7 +602,7 @@ export class FilterEqualNode extends BaseNode {
 
 export class FilterCodeNode extends BaseNode {
   static readonly nodeType = "nodetool.control.FilterCode";
-  static readonly title = "Filter (Code)";
+  static readonly title = "Filter (Expression)";
   static readonly description =
     "Pass items through when a safe expression returns truthy (comparisons, boolean logic, arithmetic, property access on `item`).\n    filter, predicate, expression, condition, stream, where\n\n    Use cases:\n    - Keep items matching arbitrary criteria (e.g. item.score > 0.5)\n    - Drop empty or malformed records\n    - Custom field-based filtering";
   static readonly metadataOutputTypes = {
@@ -623,7 +623,7 @@ export class FilterCodeNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — each item is tested against the predicate."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "str",
@@ -632,7 +632,7 @@ export class FilterCodeNode extends BaseNode {
     description:
       "Safe expression evaluated per item (comparisons, boolean logic, arithmetic, property access). The current value is bound to `item`. Examples: `item > 0`, `item.score > 0.5`, `typeof item === 'string'`."
   })
-  declare predicate: any;
+  declare predicate: string;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -676,7 +676,7 @@ export class ChunkNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — items are buffered into batches of size N."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "int",
@@ -684,7 +684,7 @@ export class ChunkNode extends BaseNode {
     title: "Size",
     description: "Number of items per batch."
   })
-  declare size: any;
+  declare size: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -739,7 +739,7 @@ export class LastNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — only the final value is forwarded."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -784,7 +784,7 @@ export class CountStreamNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — items are counted but not forwarded."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     return { output: 0 };
@@ -857,7 +857,7 @@ export class DistinctNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — duplicate items are dropped."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "str",
@@ -866,7 +866,7 @@ export class DistinctNode extends BaseNode {
     description:
       "Optional safe expression for the dedup key (property access on `item`, plus comparisons, boolean logic, and arithmetic). Examples: `item.id`, `item.url`. Empty means use the whole item."
   })
-  declare key: any;
+  declare key: string;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -912,7 +912,7 @@ export class TakeWhileNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "str",
@@ -921,7 +921,7 @@ export class TakeWhileNode extends BaseNode {
     description:
       "Safe expression evaluated per item (comparisons, boolean logic, arithmetic, property access on `item`). Stream stops at the first item where the predicate is falsy."
   })
-  declare predicate: any;
+  declare predicate: string;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -968,7 +968,7 @@ export class DropWhileNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "str",
@@ -977,7 +977,7 @@ export class DropWhileNode extends BaseNode {
     description:
       "Safe expression evaluated per item (comparisons, boolean logic, arithmetic, property access on `item`). Items are dropped until the predicate first returns falsy; everything after is passed through."
   })
-  declare predicate: any;
+  declare predicate: string;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -1022,7 +1022,7 @@ export class TapNode extends BaseNode {
     title: "Input Item",
     description: "Streaming input — forwarded unchanged after logging."
   })
-  declare input_item: any;
+  declare input_item: unknown;
 
   @prop({
     type: "str",
@@ -1030,7 +1030,7 @@ export class TapNode extends BaseNode {
     title: "Label",
     description: "Label printed alongside each logged item."
   })
-  declare label: any;
+  declare label: string;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -1096,7 +1096,7 @@ export class ZipNode extends BaseNode {
     title: "Left",
     description: "Left iteration source."
   })
-  declare left: any;
+  declare left: unknown;
 
   @prop({
     type: "any",
@@ -1104,7 +1104,7 @@ export class ZipNode extends BaseNode {
     title: "Right",
     description: "Right iteration source."
   })
-  declare right: any;
+  declare right: unknown;
 
   @prop({
     type: "int",
@@ -1113,7 +1113,7 @@ export class ZipNode extends BaseNode {
     description:
       "Maximum number of unmatched items to buffer before failing. §7."
   })
-  declare max_unmatched_pairs: any;
+  declare max_unmatched_pairs: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};
@@ -1285,7 +1285,7 @@ export class CrossNode extends BaseNode {
     title: "Left",
     description: "Left iteration source."
   })
-  declare left: any;
+  declare left: unknown;
 
   @prop({
     type: "any",
@@ -1293,7 +1293,7 @@ export class CrossNode extends BaseNode {
     title: "Right",
     description: "Right iteration source."
   })
-  declare right: any;
+  declare right: unknown;
 
   @prop({
     type: "int",
@@ -1302,7 +1302,7 @@ export class CrossNode extends BaseNode {
     description:
       "Maximum number of pairs to emit. Buffering both sides without a cap can blow memory."
   })
-  declare max_output_count: any;
+  declare max_output_count: number;
 
   async process(): Promise<Record<string, unknown>> {
     return {};

--- a/packages/core-nodes/src/nodes/input.ts
+++ b/packages/core-nodes/src/nodes/input.ts
@@ -189,7 +189,14 @@ export class SelectInputNode extends BaseNode {
   declare enum_type_name: string;
 
   async process(): Promise<Record<string, unknown>> {
-    return { output: this.value ?? "" };
+    const value = this.value ?? "";
+    const options = Array.isArray(this.options) ? this.options : [];
+    if (value !== "" && options.length > 0 && !options.includes(value)) {
+      throw new Error(
+        `SelectInput value "${value}" is not one of the allowed options: ${options.join(", ")}`
+      );
+    }
+    return { output: value };
   }
 }
 

--- a/packages/core-nodes/src/nodes/lib-datetime.ts
+++ b/packages/core-nodes/src/nodes/lib-datetime.ts
@@ -407,7 +407,7 @@ export class FormatDateNode extends BaseNode {
     title: "Date",
     description: "Date string, number (epoch ms), or Date."
   })
-  declare date: any;
+  declare date: unknown;
 
   @prop({
     type: "str",
@@ -415,7 +415,7 @@ export class FormatDateNode extends BaseNode {
     title: "Pattern",
     description: "Format pattern (YYYY, MM, DD, HH, mm, ss, SSS, Z)."
   })
-  declare pattern: any;
+  declare pattern: string;
 
   async process(): Promise<Record<string, unknown>> {
     const d = parseDate(this.date);
@@ -447,7 +447,7 @@ export class DateAddNode extends BaseNode {
     title: "Date",
     description: "Input date."
   })
-  declare date: any;
+  declare date: unknown;
 
   @prop({
     type: "int",
@@ -455,7 +455,7 @@ export class DateAddNode extends BaseNode {
     title: "Amount",
     description: "Amount to add (use negative to subtract)."
   })
-  declare amount: any;
+  declare amount: number;
 
   @prop({
     type: "enum",
@@ -464,7 +464,7 @@ export class DateAddNode extends BaseNode {
     description: "Unit of time.",
     values: DATE_UNITS
   })
-  declare unit: any;
+  declare unit: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const d = parseDate(this.date);
@@ -497,10 +497,10 @@ export class DateDiffNode extends BaseNode {
   static readonly inputFields = ["date_a", "date_b"];
 
   @prop({ type: "any", default: "", title: "Date A" })
-  declare date_a: any;
+  declare date_a: unknown;
 
   @prop({ type: "any", default: "", title: "Date B" })
-  declare date_b: any;
+  declare date_b: unknown;
 
   @prop({
     type: "enum",
@@ -509,7 +509,7 @@ export class DateDiffNode extends BaseNode {
     description: "Unit for the returned diff.",
     values: DATE_UNITS
   })
-  declare unit: any;
+  declare unit: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const a = parseDate(this.date_a);
@@ -542,7 +542,7 @@ export class DateStartEndNode extends BaseNode {
   static readonly inputFields = ["date"];
 
   @prop({ type: "any", default: "", title: "Date" })
-  declare date: any;
+  declare date: unknown;
 
   @prop({
     type: "enum",
@@ -550,7 +550,7 @@ export class DateStartEndNode extends BaseNode {
     title: "Unit",
     values: DATE_UNITS
   })
-  declare unit: any;
+  declare unit: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const d = parseDate(this.date);

--- a/packages/core-nodes/src/nodes/list.ts
+++ b/packages/core-nodes/src/nodes/list.ts
@@ -81,7 +81,7 @@ export class RangeNode extends BaseNode {
     title: "Start",
     description: "First value (inclusive)."
   })
-  declare start: any;
+  declare start: number;
 
   @prop({
     type: "int",
@@ -90,7 +90,7 @@ export class RangeNode extends BaseNode {
     description:
       "Exclusive end. When -1 (default), uses Count instead to produce [0, 1, ..., count-1]."
   })
-  declare stop: any;
+  declare stop: number;
 
   @prop({
     type: "int",
@@ -98,7 +98,7 @@ export class RangeNode extends BaseNode {
     title: "Count",
     description: "Used when Stop is -1. Produces [0, 1, ..., count-1]."
   })
-  declare count: any;
+  declare count: number;
 
   @prop({
     type: "int",
@@ -106,7 +106,7 @@ export class RangeNode extends BaseNode {
     title: "Step",
     description: "Increment between values."
   })
-  declare step: any;
+  declare step: number;
 
   @prop({
     type: "int",
@@ -114,7 +114,7 @@ export class RangeNode extends BaseNode {
     title: "Max Output Length",
     description: "Maximum number of integers to produce."
   })
-  declare max_output_length: any;
+  declare max_output_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const rawStop = Number(this.stop ?? -1);
@@ -154,7 +154,7 @@ export class TileNode extends BaseNode {
     title: "Input List",
     description: "List to repeat."
   })
-  declare input_list: any;
+  declare input_list: unknown[];
 
   @prop({
     type: "int",
@@ -163,7 +163,7 @@ export class TileNode extends BaseNode {
     title: "Times",
     description: "How many times to repeat the full list."
   })
-  declare times: any;
+  declare times: number;
 
   @prop({
     type: "int",
@@ -171,7 +171,7 @@ export class TileNode extends BaseNode {
     title: "Max Output Length",
     description: "Maximum number of items in the output list."
   })
-  declare max_output_length: any;
+  declare max_output_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const list = asList(this.input_list);
@@ -210,7 +210,7 @@ export class RepeatEachNode extends BaseNode {
     title: "Input List",
     description: "List whose items are repeated individually."
   })
-  declare input_list: any;
+  declare input_list: unknown[];
 
   @prop({
     type: "int",
@@ -219,7 +219,7 @@ export class RepeatEachNode extends BaseNode {
     title: "Times",
     description: "How many times to repeat each item."
   })
-  declare times: any;
+  declare times: number;
 
   @prop({
     type: "int",
@@ -227,7 +227,7 @@ export class RepeatEachNode extends BaseNode {
     title: "Max Output Length",
     description: "Maximum number of items in the output list."
   })
-  declare max_output_length: any;
+  declare max_output_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const list = asList(this.input_list);
@@ -268,7 +268,7 @@ export class RepeatValueNode extends BaseNode {
     title: "Value",
     description: "Single value to repeat."
   })
-  declare value: any;
+  declare value: unknown;
 
   @prop({
     type: "int",
@@ -277,7 +277,7 @@ export class RepeatValueNode extends BaseNode {
     title: "Times",
     description: "How many copies to produce."
   })
-  declare times: any;
+  declare times: number;
 
   @prop({
     type: "int",
@@ -285,7 +285,7 @@ export class RepeatValueNode extends BaseNode {
     title: "Max Output Length",
     description: "Maximum number of items in the output list."
   })
-  declare max_output_length: any;
+  declare max_output_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const value = this.value ?? null;

--- a/packages/core-nodes/src/nodes/vector.ts
+++ b/packages/core-nodes/src/nodes/vector.ts
@@ -11,7 +11,8 @@ import {
   OllamaEmbeddingFunction,
   type RecordMetadata,
   type VectorCollection,
-  type VectorMatch
+  type VectorMatch,
+  type VectorRecord
 } from "@nodetool-ai/vectorstore";
 
 async function getCollectionByName(name: string): Promise<VectorCollection> {
@@ -98,7 +99,7 @@ export class CollectionNode extends BaseNode {
     title: "Name",
     description: "The name of the collection to create"
   })
-  declare name: any;
+  declare name: string;
 
   @prop({
     type: "llama_model",
@@ -115,7 +116,7 @@ export class CollectionNode extends BaseNode {
     description:
       "Model to use for embedding, search for nomic-embed-text and download it"
   })
-  declare embedding_model: any;
+  declare embedding_model: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const name = String(this.name ?? "");
@@ -157,7 +158,7 @@ export class CountNode extends BaseNode {
     title: "Collection",
     description: "The collection to count"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -187,7 +188,7 @@ export class GetDocumentsNode extends BaseNode {
     title: "Collection",
     description: "The collection to get"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "list[str]",
@@ -195,7 +196,7 @@ export class GetDocumentsNode extends BaseNode {
     title: "Ids",
     description: "The ids of the documents to get"
   })
-  declare ids: any;
+  declare ids: string[];
 
   @prop({
     type: "int",
@@ -203,7 +204,7 @@ export class GetDocumentsNode extends BaseNode {
     title: "Limit",
     description: "The limit of the documents to get"
   })
-  declare limit: any;
+  declare limit: number;
 
   @prop({
     type: "int",
@@ -211,7 +212,7 @@ export class GetDocumentsNode extends BaseNode {
     title: "Offset",
     description: "The offset of the documents to get"
   })
-  declare offset: any;
+  declare offset: number;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -231,7 +232,7 @@ export class GetDocumentsNode extends BaseNode {
       offset
     });
 
-    return { output: records.map((r) => r.document ?? null) };
+    return { output: records.map((r: VectorRecord) => r.document ?? null) };
   }
 }
 
@@ -252,7 +253,7 @@ export class PeekNode extends BaseNode {
     title: "Collection",
     description: "The collection to peek"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "int",
@@ -260,7 +261,7 @@ export class PeekNode extends BaseNode {
     title: "Limit",
     description: "The limit of the documents to peek"
   })
-  declare limit: any;
+  declare limit: number;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -271,7 +272,7 @@ export class PeekNode extends BaseNode {
 
     const collection = await getCollectionByName(name);
     const records = await collection.get({ limit });
-    return { output: records.map((r) => r.document ?? null) };
+    return { output: records.map((r: VectorRecord) => r.document ?? null) };
   }
 }
 
@@ -289,7 +290,7 @@ export class IndexImageNode extends BaseNode {
     title: "Collection",
     description: "The collection to index"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "image",
@@ -303,7 +304,7 @@ export class IndexImageNode extends BaseNode {
     title: "Image",
     description: "The image asset to index"
   })
-  declare image: any;
+  declare image: unknown;
 
   @prop({
     type: "str",
@@ -312,7 +313,7 @@ export class IndexImageNode extends BaseNode {
     description:
       "The ID to associate with the image, defaults to the URI of the image"
   })
-  declare index_id: any;
+  declare index_id: string;
 
   @prop({
     type: "dict",
@@ -320,7 +321,7 @@ export class IndexImageNode extends BaseNode {
     title: "Metadata",
     description: "The metadata to associate with the image"
   })
-  declare metadata: any;
+  declare metadata: Record<string, unknown>;
 
   @prop({
     type: "bool",
@@ -328,7 +329,7 @@ export class IndexImageNode extends BaseNode {
     title: "Upsert",
     description: "Whether to upsert the images"
   })
-  declare upsert: any;
+  declare upsert: boolean;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -381,7 +382,7 @@ export class IndexEmbeddingNode extends BaseNode {
     title: "Collection",
     description: "The collection to index"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "list",
@@ -389,7 +390,7 @@ export class IndexEmbeddingNode extends BaseNode {
     title: "Embedding",
     description: "The embedding to index"
   })
-  declare embedding: any;
+  declare embedding: unknown;
 
   @prop({
     type: "union[str, list[str]]",
@@ -397,7 +398,7 @@ export class IndexEmbeddingNode extends BaseNode {
     title: "Index Id",
     description: "The ID to associate with the embedding"
   })
-  declare index_id: any;
+  declare index_id: string | string[];
 
   @prop({
     type: "union[dict, list[dict]]",
@@ -405,7 +406,7 @@ export class IndexEmbeddingNode extends BaseNode {
     title: "Metadata",
     description: "The metadata to associate with the embedding"
   })
-  declare metadata: any;
+  declare metadata: Record<string, unknown> | Record<string, unknown>[];
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -505,7 +506,7 @@ export class IndexTextChunkNode extends BaseNode {
     title: "Collection",
     description: "The collection to index"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "str",
@@ -513,7 +514,7 @@ export class IndexTextChunkNode extends BaseNode {
     title: "Document Id",
     description: "The document ID to associate with the text chunk"
   })
-  declare document_id: any;
+  declare document_id: string;
 
   @prop({
     type: "str",
@@ -521,7 +522,7 @@ export class IndexTextChunkNode extends BaseNode {
     title: "Text",
     description: "The text to index"
   })
-  declare text: any;
+  declare text: string;
 
   @prop({
     type: "dict",
@@ -529,7 +530,7 @@ export class IndexTextChunkNode extends BaseNode {
     title: "Metadata",
     description: "The metadata to associate with the text chunk"
   })
-  declare metadata: any;
+  declare metadata: Record<string, unknown>;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -567,7 +568,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     title: "Collection",
     description: "The collection to index"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "str",
@@ -575,7 +576,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     title: "Document",
     description: "The document to index"
   })
-  declare document: any;
+  declare document: string;
 
   @prop({
     type: "str",
@@ -583,7 +584,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     title: "Document Id",
     description: "The document ID to associate with the text"
   })
-  declare document_id: any;
+  declare document_id: string;
 
   @prop({
     type: "dict",
@@ -591,7 +592,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     title: "Metadata",
     description: "The metadata to associate with the text"
   })
-  declare metadata: any;
+  declare metadata: Record<string, unknown>;
 
   @prop({
     type: "list[union[text_chunk, str]]",
@@ -599,7 +600,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     title: "Text Chunks",
     description: "List of text chunks to index"
   })
-  declare text_chunks: any;
+  declare text_chunks: unknown[];
 
   @prop({
     type: "enum",
@@ -608,7 +609,7 @@ export class IndexAggregatedTextNode extends BaseNode {
     description: "The aggregation method to use for the embeddings.",
     values: ["mean", "max", "min", "sum"]
   })
-  declare aggregation: any;
+  declare aggregation: string;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -702,7 +703,7 @@ export class IndexStringNode extends BaseNode {
     title: "Collection",
     description: "The collection to index"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "str",
@@ -710,7 +711,7 @@ export class IndexStringNode extends BaseNode {
     title: "Text",
     description: "Text content to index"
   })
-  declare text: any;
+  declare text: string;
 
   @prop({
     type: "str",
@@ -718,7 +719,7 @@ export class IndexStringNode extends BaseNode {
     title: "Document Id",
     description: "Document ID to associate with the text content"
   })
-  declare document_id: any;
+  declare document_id: string;
 
   @prop({
     type: "dict",
@@ -726,7 +727,7 @@ export class IndexStringNode extends BaseNode {
     title: "Metadata",
     description: "The metadata to associate with the text"
   })
-  declare metadata: any;
+  declare metadata: Record<string, unknown>;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -765,7 +766,7 @@ export class QueryImageNode extends BaseNode {
     title: "Collection",
     description: "The collection to query"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "image",
@@ -779,7 +780,7 @@ export class QueryImageNode extends BaseNode {
     title: "Image",
     description: "The image to query"
   })
-  declare image: any;
+  declare image: unknown;
 
   @prop({
     type: "int",
@@ -787,7 +788,7 @@ export class QueryImageNode extends BaseNode {
     title: "N Results",
     description: "The number of results to return"
   })
-  declare n_results: any;
+  declare n_results: number;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -834,7 +835,7 @@ export class QueryTextNode extends BaseNode {
     title: "Collection",
     description: "The collection to query"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "str",
@@ -842,7 +843,7 @@ export class QueryTextNode extends BaseNode {
     title: "Text",
     description: "The text to query"
   })
-  declare text: any;
+  declare text: string;
 
   @prop({
     type: "int",
@@ -850,7 +851,7 @@ export class QueryTextNode extends BaseNode {
     title: "N Results",
     description: "The number of results to return"
   })
-  declare n_results: any;
+  declare n_results: number;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
@@ -891,7 +892,7 @@ export class RemoveOverlapNode extends BaseNode {
     title: "Documents",
     description: "List of strings to process for overlap removal"
   })
-  declare documents: any;
+  declare documents: string[];
 
   @prop({
     type: "int",
@@ -899,7 +900,7 @@ export class RemoveOverlapNode extends BaseNode {
     title: "Min Overlap Words",
     description: "Minimum number of words that must overlap to be considered"
   })
-  declare min_overlap_words: any;
+  declare min_overlap_words: number;
 
   async process(): Promise<Record<string, unknown>> {
     const documents = (this.documents ?? []) as string[];
@@ -954,7 +955,7 @@ export class HybridSearchNode extends BaseNode {
     title: "Collection",
     description: "The collection to query"
   })
-  declare collection: any;
+  declare collection: unknown;
 
   @prop({
     type: "str",
@@ -962,7 +963,7 @@ export class HybridSearchNode extends BaseNode {
     title: "Text",
     description: "The text to query"
   })
-  declare text: any;
+  declare text: string;
 
   @prop({
     type: "int",
@@ -970,7 +971,7 @@ export class HybridSearchNode extends BaseNode {
     title: "N Results",
     description: "The number of final results to return"
   })
-  declare n_results: any;
+  declare n_results: number;
 
   @prop({
     type: "float",
@@ -978,7 +979,7 @@ export class HybridSearchNode extends BaseNode {
     title: "K Constant",
     description: "Constant for reciprocal rank fusion (default: 60.0)"
   })
-  declare k_constant: any;
+  declare k_constant: number;
 
   @prop({
     type: "int",
@@ -986,7 +987,7 @@ export class HybridSearchNode extends BaseNode {
     title: "Min Keyword Length",
     description: "Minimum length for keyword tokens"
   })
-  declare min_keyword_length: any;
+  declare min_keyword_length: number;
 
   async process(): Promise<Record<string, unknown>> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };

--- a/packages/core-nodes/tests/select-validation.test.ts
+++ b/packages/core-nodes/tests/select-validation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Validation tests for select-style nodes: SelectInputNode
+ * (nodetool.input.SelectInput) and ConstantSelectNode
+ * (nodetool.constant.Select) reject a configured value that is not one of the
+ * allowed options, while leaving empty/unconfigured cases untouched.
+ */
+
+import { describe, it, expect } from "vitest";
+import { SelectInputNode } from "../src/nodes/input.js";
+import { ConstantSelectNode } from "../src/nodes/constant.js";
+
+describe("SelectInputNode value validation", () => {
+  it("returns the value when it is one of the options", async () => {
+    const node = new SelectInputNode();
+    node.assign({ value: "b", options: ["a", "b", "c"] });
+    await expect(node.process()).resolves.toEqual({ output: "b" });
+  });
+
+  it("throws when the value is not one of the non-empty options", async () => {
+    const node = new SelectInputNode();
+    node.assign({ value: "z", options: ["a", "b", "c"] });
+    await expect(node.process()).rejects.toThrow(/not one of the allowed options/);
+  });
+
+  it("passes through an empty value even with non-empty options", async () => {
+    const node = new SelectInputNode();
+    node.assign({ value: "", options: ["a", "b", "c"] });
+    await expect(node.process()).resolves.toEqual({ output: "" });
+  });
+
+  it("returns the value unchanged when options are empty", async () => {
+    const node = new SelectInputNode();
+    node.assign({ value: "anything", options: [] });
+    await expect(node.process()).resolves.toEqual({ output: "anything" });
+  });
+});
+
+describe("ConstantSelectNode value validation", () => {
+  it("returns the value when it is one of the options", async () => {
+    const node = new ConstantSelectNode();
+    node.assign({ value: "b", options: ["a", "b", "c"] });
+    await expect(node.process()).resolves.toEqual({ output: "b" });
+  });
+
+  it("throws when the value is not one of the non-empty options", async () => {
+    const node = new ConstantSelectNode();
+    node.assign({ value: "z", options: ["a", "b", "c"] });
+    await expect(node.process()).rejects.toThrow(/not one of the allowed options/);
+  });
+
+  it("passes through an empty value even with non-empty options", async () => {
+    const node = new ConstantSelectNode();
+    node.assign({ value: "", options: ["a", "b", "c"] });
+    await expect(node.process()).resolves.toEqual({ output: "" });
+  });
+
+  it("returns the value unchanged when options are empty", async () => {
+    const node = new ConstantSelectNode();
+    node.assign({ value: "anything", options: [] });
+    await expect(node.process()).resolves.toEqual({ output: "anything" });
+  });
+});


### PR DESCRIPTION
Follow-ups from the core-nodes critique handover:

- De-any sweep: replace `declare x: any` prop annotations with precise
  types (mapped from each @prop `type`) across control.ts, vector.ts,
  list.ts, lib-datetime.ts. Decorator config, prop order, and static
  metadata are untouched, so node metadata is unchanged; only the
  TypeScript surface is tightened.
- SelectInput / ConstantSelect now validate `value ∈ options`: throw
  only when a non-empty value violates a non-empty options list. Empty
  or unconfigured cases still pass through, so saved workflows are
  unaffected. Adds tests/select-validation.test.ts (8 cases).
- FilterCode retitled "Filter (Code)" → "Filter (Expression)"; it runs a
  safe expression subset, not arbitrary code. nodeType is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014aWGuBEoH9GhnF7HNmU1rM