### PR TITLE
Refactor provider stream handling with typed events

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -216,6 +216,13 @@ export interface AgentOptions {
   workspace?: string;
   maxSteps?: number;
   maxStepIterations?: number;
+  /**
+   * Cap on output tokens per provider turn, threaded to every step executor
+   * and the final compiler pass. Undefined lets each provider use its own
+   * default. `maxSteps` (plan size) and `maxStepIterations` (tool-call rounds)
+   * are unrelated knobs and stay separate.
+   */
+  maxTokens?: number;
   outputSchema?: Record<string, unknown>;
   /**
    * Format for the agent's final result.
@@ -348,6 +355,7 @@ export class Agent {
   private readonly reasoningModel: string;
   private readonly maxSteps: number;
   private readonly maxStepIterations: number;
+  private readonly maxTokens?: number;
   private readonly outputSchema?: Record<string, unknown>;
   private readonly outputFormat: AgentOutputFormat;
   private readonly workspace?: string;
@@ -385,6 +393,7 @@ export class Agent {
     this.reasoningModel = opts.reasoningModel ?? opts.model;
     this.maxSteps = opts.maxSteps ?? 10;
     this.maxStepIterations = opts.maxStepIterations ?? 15;
+    this.maxTokens = opts.maxTokens;
     this.outputFormat = opts.outputFormat ?? "structured";
     // Non-structured formats imply a string result; outputSchema is ignored.
     this.outputSchema =
@@ -795,6 +804,7 @@ export class Agent {
       systemPrompt: mergedSystemPrompt,
       inputs: this.inputs,
       maxStepIterations: this.maxStepIterations,
+      maxTokens: this.maxTokens,
       checkpointStore: this.checkpointStore,
       runId: this.runId,
       planTools: this.tools.map((t) => t.name)
@@ -815,7 +825,8 @@ export class Agent {
       model: this.reasoningModel ?? this.model,
       context,
       taskPlan,
-      systemPrompt: mergedSystemPrompt
+      systemPrompt: mergedSystemPrompt,
+      maxTokens: this.maxTokens
     });
 
     let compiled: unknown = null;
@@ -1119,6 +1130,7 @@ export class Agent {
       inputs: this.inputs,
       maxSteps: this.maxSteps,
       maxStepIterations: this.maxStepIterations,
+      maxTokens: this.maxTokens,
       parallelExecution: true
     });
 

--- a/packages/agents/src/compiler-agent.ts
+++ b/packages/agents/src/compiler-agent.ts
@@ -120,6 +120,8 @@ export interface CompilerAgentOptions {
   /** Optional preamble layered above the default compiler system prompt. */
   systemPrompt?: string;
   maxRounds?: number;
+  /** Cap on output tokens per compile turn. Forwarded to `generateLoop`. */
+  maxTokens?: number;
   threadId?: string;
 }
 
@@ -133,6 +135,7 @@ export class CompilerAgent {
   private readonly taskPlan?: TaskPlan;
   private readonly systemPrompt: string;
   private readonly maxRounds: number;
+  private readonly maxTokens?: number;
   private readonly threadId?: string;
 
   constructor(opts: CompilerAgentOptions) {
@@ -144,6 +147,7 @@ export class CompilerAgent {
     this.context = opts.context;
     this.taskPlan = opts.taskPlan;
     this.maxRounds = opts.maxRounds ?? MAX_COMPILE_ROUNDS;
+    this.maxTokens = opts.maxTokens;
     this.threadId = opts.threadId;
 
     const base = this.outputSchema
@@ -335,6 +339,7 @@ export class CompilerAgent {
       tools: providerTools,
       threadId: this.threadId,
       maxIterations: this.maxRounds,
+      maxTokens: this.maxTokens,
       sequentialTools: true
     });
 

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -48,6 +48,8 @@ export interface ParallelTaskExecutorOptions {
   maxIterations?: number;
   /** Maximum iterations per step within a task. */
   maxStepIterations?: number;
+  /** Cap on output tokens per step turn. Forwarded to each TaskExecutor. */
+  maxTokens?: number;
   /**
    * Opt-in checkpoint store. When supplied with a {@link runId}, the executor
    * loads any checkpoint whose `planHash` matches this plan, marks its
@@ -77,6 +79,7 @@ export class ParallelTaskExecutor {
   private readonly systemPrompt: string | undefined;
   private readonly maxIterations: number;
   private readonly maxStepIterations: number;
+  private readonly maxTokens?: number;
   private readonly checkpointStore?: CheckpointStore;
   private readonly runId?: string;
   private readonly planTools?: string[];
@@ -100,6 +103,7 @@ export class ParallelTaskExecutor {
     this.maxIterations = opts.maxIterations ?? DEFAULT_MAX_TASK_ITERATIONS;
     this.maxStepIterations =
       opts.maxStepIterations ?? DEFAULT_MAX_STEP_ITERATIONS;
+    this.maxTokens = opts.maxTokens;
     this.checkpointStore = opts.checkpointStore;
     this.runId = opts.runId;
     this.planTools = opts.planTools;
@@ -307,6 +311,7 @@ export class ParallelTaskExecutor {
       inputs: this.inputs,
       maxSteps: task.steps.length + 5, // Allow some slack
       maxStepIterations: this.maxStepIterations,
+      maxTokens: this.maxTokens,
       parallelExecution: true, // Enable parallel step execution within each task
       upstreamMemoryKeys
     });

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -314,6 +314,12 @@ export interface StepExecutorOptions {
   tools?: Tool[];
   systemPrompt?: string;
   maxIterations?: number;
+  /**
+   * Cap on output tokens per provider turn. Forwarded to `generateLoop`;
+   * undefined lets the provider use its own default. Plan-mode Agent nodes
+   * thread the node's `max_tokens` here for parity with loop mode.
+   */
+  maxTokens?: number;
   useFinishTask?: boolean;
   threadId?: string;
   /**
@@ -337,6 +343,7 @@ export class StepExecutor {
   private context: ProcessingContext;
   private systemPrompt: string;
   private maxIterations: number;
+  private maxTokens?: number;
   private useFinishTask: boolean;
   private result: unknown = null;
   private finishStepTool: FinishStepTool | null = null;
@@ -360,6 +367,7 @@ export class StepExecutor {
     this.model = opts.model;
     this.tools = opts.tools ? [...opts.tools] : [];
     this.maxIterations = opts.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+    this.maxTokens = opts.maxTokens;
     this.useFinishTask = opts.useFinishTask ?? false;
     this.threadId = opts.threadId;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
@@ -1011,6 +1019,7 @@ export class StepExecutor {
         tools: providerTools.length > 0 ? providerTools : undefined,
         threadId: this.threadId,
         maxIterations: this.maxIterations,
+        maxTokens: this.maxTokens,
         sequentialTools: true,
         signal: abort.signal
       });

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -42,6 +42,8 @@ export interface TaskExecutorOptions {
   inputs?: Record<string, unknown>;
   maxSteps?: number;
   maxStepIterations?: number;
+  /** Cap on output tokens per step turn. Forwarded to each StepExecutor. */
+  maxTokens?: number;
   /** ID of the final aggregation step (will use useFinishTask=true). */
   finalStepId?: string;
   /** Execute independent steps in parallel (default: false). */
@@ -64,6 +66,7 @@ export class TaskExecutor {
   private systemPrompt: string | undefined;
   private maxSteps: number;
   private maxStepIterations: number;
+  private maxTokens?: number;
   private finalStepId: string | undefined;
   private parallelExecution: boolean;
   private upstreamMemoryKeys: string[];
@@ -80,6 +83,7 @@ export class TaskExecutor {
     this.maxSteps = opts.maxSteps ?? DEFAULT_MAX_STEPS;
     this.maxStepIterations =
       opts.maxStepIterations ?? DEFAULT_MAX_STEP_ITERATIONS;
+    this.maxTokens = opts.maxTokens;
     this.finalStepId = opts.finalStepId;
     this.parallelExecution = opts.parallelExecution ?? false;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
@@ -157,6 +161,7 @@ export class TaskExecutor {
           tools: [...this.tools],
           systemPrompt: this.systemPrompt,
           maxIterations: this.maxStepIterations,
+          maxTokens: this.maxTokens,
           useFinishTask: this.isFinishStep(step),
           upstreamMemoryKeys: this.upstreamMemoryKeys
         });
@@ -305,6 +310,7 @@ export class TaskExecutor {
         tools: [...this.tools],
         systemPrompt: this.systemPrompt,
         maxIterations: this.maxStepIterations,
+        maxTokens: this.maxTokens,
         useFinishTask: false,
         upstreamMemoryKeys: this.upstreamMemoryKeys
       });

--- a/packages/llm-nodes/src/nodes/agent-loop.ts
+++ b/packages/llm-nodes/src/nodes/agent-loop.ts
@@ -10,9 +10,7 @@ import { Tool as AgentTool } from "@nodetool-ai/agents";
 import { hydrateBuiltinAgentTools } from "./agent-tool-hydration.js";
 import type { ToolLike } from "./agent-utils.js";
 import {
-  isChunkItem,
-  isToolCallItem,
-  normalizeProviderStreamItem,
+  classifyProviderStream,
   serializeToolResult,
   toProviderTools,
   toolCallChunk
@@ -184,43 +182,38 @@ export async function runAgentLoop(
   let lastAssistantText = "";
   let currentTurnText = "";
 
-  for await (const raw of provider.generateLoop({
+  const stream = provider.generateLoop({
     messages,
     model: modelId,
     tools: providerTools,
     maxTokens,
     threadId: options.threadId,
     maxIterations
-  })) {
-    const item = normalizeProviderStreamItem(raw);
-    if (isToolCallItem(item)) {
-      options.onToolCall?.(toolCallChunk(item));
+  });
+  for await (const event of classifyProviderStream(stream)) {
+    if (event.kind === "tool_call") {
+      options.onToolCall?.(toolCallChunk(event.toolCall));
       continue;
     }
-    if (isChunkItem(item)) {
+    if (event.kind === "text") {
       // Only genuine text feeds the returned text / onText stream. Tool-call
       // chunks (and audio, agent_status, etc.) carry content_type !== "text"
       // and must not leak into the text output.
-      if (!item.thinking && item.content_type === "text") {
-        const delta = typeof item.content === "string" ? item.content : "";
-        if (delta) {
-          currentTurnText += delta;
-          options.onText?.(delta);
-        }
+      if (event.chunk.content_type === "text" && event.delta) {
+        currentTurnText += event.delta;
+        options.onText?.(event.delta);
       }
       continue;
     }
-    // A finalized message event (assistant turn or tool result). Append it to
-    // the returned trail; an assistant turn also closes the current text run so
-    // `text` reflects the model's last assistant message, not a concatenation.
-    if ("type" in item && (item as { type?: string }).type === "message") {
-      const message = (item as { message?: Message }).message;
-      if (message) {
-        outMessages.push(message);
-        if (message.role === "assistant") {
-          if (currentTurnText) lastAssistantText = currentTurnText;
-          currentTurnText = "";
-        }
+    // thinking / audio events carry no returned text — ignore them here.
+    if (event.kind === "assistant_message" || event.kind === "tool_message") {
+      // A finalized message event. Append it to the returned trail; an assistant
+      // turn also closes the current text run so `text` reflects the model's
+      // last assistant message, not a concatenation.
+      outMessages.push(event.message);
+      if (event.kind === "assistant_message") {
+        if (currentTurnText) lastAssistantText = currentTurnText;
+        currentTurnText = "";
       }
     }
   }

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -441,6 +441,67 @@ export function isToolCallItem(item: ProviderStreamItem): item is ToolCall {
   );
 }
 
+/**
+ * A single classified item from a provider's {@link BaseProvider.generateLoop}
+ * stream. Both {@link runAgentLoop} and the AgentNode's genProcess drive the
+ * same normalize → classify dance off generateLoop; keeping that classification
+ * in one place stops the two from drifting (they did once). Presentation and
+ * per-turn accumulation stay with each consumer — this only untangles the raw
+ * stream into typed events.
+ */
+export type ProviderStreamEvent =
+  | { kind: "tool_call"; toolCall: ToolCall }
+  | { kind: "thinking"; chunk: Chunk }
+  | { kind: "audio"; chunk: Chunk }
+  | { kind: "text"; chunk: Chunk; delta: string }
+  | { kind: "assistant_message"; message: Message }
+  | { kind: "tool_message"; message: Message };
+
+/**
+ * Normalize and classify a provider stream into {@link ProviderStreamEvent}s.
+ * Mirrors the branch structure both consumers previously inlined: tool-call
+ * announcements, thinking chunks, audio chunks, any other content chunk (as
+ * `text`, carrying the original chunk so a consumer can inspect content_type),
+ * and finalized `{ type: "message" }` events split by role. The `text` event's
+ * `delta` is the chunk's string content ("" for non-string payloads).
+ */
+export async function* classifyProviderStream(
+  stream: AsyncIterable<ProviderStreamItem>
+): AsyncGenerator<ProviderStreamEvent> {
+  for await (const raw of stream) {
+    const item = normalizeProviderStreamItem(raw);
+    if (isToolCallItem(item)) {
+      yield { kind: "tool_call", toolCall: item };
+      continue;
+    }
+    if (isChunkItem(item)) {
+      if (item.thinking) {
+        yield { kind: "thinking", chunk: item };
+        continue;
+      }
+      if (item.content_type === "audio") {
+        yield { kind: "audio", chunk: item };
+        continue;
+      }
+      const delta = typeof item.content === "string" ? item.content : "";
+      yield { kind: "text", chunk: item, delta };
+      continue;
+    }
+    if (
+      item &&
+      typeof item === "object" &&
+      "type" in item &&
+      (item as { type?: string }).type === "message"
+    ) {
+      const message = (item as { message?: Message }).message;
+      if (!message) continue;
+      yield message.role === "assistant"
+        ? { kind: "assistant_message", message }
+        : { kind: "tool_message", message };
+    }
+  }
+}
+
 export function normalizeTools(value: unknown): ToolLike[] {
   if (!Array.isArray(value)) return [];
   return value

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -109,22 +109,6 @@ export function hasProviderSupport(
   );
 }
 
-export async function generateProviderMessage(
-  provider: BaseProvider,
-  args: {
-    messages: Message[];
-    model: string;
-    maxTokens?: number;
-  }
-): Promise<string> {
-  const call =
-    typeof provider.generateMessageTraced === "function"
-      ? provider.generateMessageTraced.bind(provider)
-      : provider.generateMessage.bind(provider);
-  const result = await call(args);
-  return messageContentText(result.content);
-}
-
 /**
  * Call a provider with a result tool to get structured output.
  * The model is forced to call the tool via toolChoice, and the

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -874,7 +874,7 @@ export class AgentNode extends BaseNode {
     default: AGENT_DEFAULT_MAX_TOKENS,
     title: "Max Tokens",
     description:
-      "Upper bound on generated tokens per response, including visible output and any reasoning/thinking tokens used by reasoning models. Applies in loop mode; plan mode's step executor does not expose a per-call token budget, so this is ignored there. Higher values allow longer answers and more thinking headroom but cost more and take longer; very low values may truncate reasoning or the final answer. Typical values: 1024 for short answers, 8192–16384 for normal agent use, 32k+ for long-form or heavy reasoning. Must be within the chosen model's context window.",
+      "Upper bound on generated tokens per response, including visible output and any reasoning/thinking tokens used by reasoning models. Applies in both loop and plan mode (plan mode threads it to every step executor and the final compiler pass). Higher values allow longer answers and more thinking headroom but cost more and take longer; very low values may truncate reasoning or the final answer. Typical values: 1024 for short answers, 8192–16384 for normal agent use, 32k+ for long-form or heavy reasoning. Must be within the chosen model's context window.",
     min: 1,
     max: 100000
   })
@@ -1403,6 +1403,9 @@ export class AgentNode extends BaseNode {
       systemPrompt: system,
       outputSchema: structuredSchema ?? undefined,
       planningModel: modelId,
+      // Per-turn output-token cap, matching loop mode's use of max_tokens.
+      // Threaded to every step executor and the final compiler pass.
+      maxTokens: Number(this.max_tokens ?? AGENT_DEFAULT_MAX_TOKENS),
       // maxSteps caps the *number of plan steps* the executor will run
       // (`stepsTaken < maxSteps` in TaskExecutor), not the per-step tool-call
       // iteration count. The node's `max_turns` is a turn/iteration budget, so

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1560,6 +1560,11 @@ export class AgentStepNode extends BaseNode {
   static readonly metadataOutputTypes = {
     output: "str"
   };
+  // Hidden from the node palette/search: GraphPlanner and AgentWorkflowRunner
+  // insert this node; adding it by hand throws in process(). It stays
+  // registered so the registry, search_nodes, and get_node_info still resolve
+  // it for those agent runners.
+  static readonly hidden = true;
   static readonly inlineFields = ["instructions"];
   static readonly inputFields = ["input"];
 

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -31,9 +31,9 @@ import {
   normalizeTools,
   isChunkItem,
   isToolCallItem,
+  classifyProviderStream,
   toProviderTools,
   serializeToolResult,
-  normalizeProviderStreamItem,
   toolCallChunk,
   streamProviderMessages,
   getStructuredOutputSchema,
@@ -1177,7 +1177,7 @@ export class AgentNode extends BaseNode {
         thinkSplitter = new RedactedThinkingStreamSplitter();
       };
 
-      for await (const raw of provider.generateLoop({
+      const stream = provider.generateLoop({
         messages,
         model: modelId,
         tools: providerTools,
@@ -1185,20 +1185,20 @@ export class AgentNode extends BaseNode {
         maxIterations: maxTurns,
         sequentialTools: true,
         threadId: threadId || undefined
-      })) {
-        const item = normalizeProviderStreamItem(raw);
-
-        if (isToolCallItem(item)) {
+      });
+      for await (const event of classifyProviderStream(stream)) {
+        if (event.kind === "tool_call") {
+          const toolCall = event.toolCall;
           log.info("AgentNode received tool call", {
             nodeId: this.__node_id ?? null,
             providerId,
             modelId,
-            toolCallId: item.id,
-            toolName: item.name,
-            argKeys: Object.keys(item.args ?? {})
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            argKeys: Object.keys(toolCall.args ?? {})
           });
           yield {
-            chunk: toolCallChunk(item),
+            chunk: toolCallChunk(toolCall),
             thinking: null,
             text: null,
             audio: null
@@ -1206,35 +1206,38 @@ export class AgentNode extends BaseNode {
           continue;
         }
 
-        if (isChunkItem(item)) {
-          if (item.thinking) {
-            yield { chunk: null, thinking: item, text: null, audio: null };
-            continue;
-          }
-          if (item.content_type === "audio") {
-            yield { chunk: item, thinking: null, text: null, audio: null };
-            const audioBytes =
-              typeof item.content === "string" && item.content
-                ? Buffer.from(item.content, "base64")
-                : item.content instanceof Float32Array
-                  ? Buffer.from(
-                      item.content.buffer,
-                      item.content.byteOffset,
-                      item.content.byteLength
-                    )
-                  : Buffer.alloc(0);
-            yield {
-              chunk: null,
-              thinking: null,
-              text: null,
-              audio: { data: new Uint8Array(audioBytes) }
-            };
-            continue;
-          }
-          const rawPiece = typeof item.content === "string" ? item.content : "";
+        if (event.kind === "thinking") {
+          yield { chunk: null, thinking: event.chunk, text: null, audio: null };
+          continue;
+        }
+
+        if (event.kind === "audio") {
+          const chunk = event.chunk;
+          yield { chunk, thinking: null, text: null, audio: null };
+          const audioBytes =
+            typeof chunk.content === "string" && chunk.content
+              ? Buffer.from(chunk.content, "base64")
+              : chunk.content instanceof Float32Array
+                ? Buffer.from(
+                    chunk.content.buffer,
+                    chunk.content.byteOffset,
+                    chunk.content.byteLength
+                  )
+                : Buffer.alloc(0);
+          yield {
+            chunk: null,
+            thinking: null,
+            text: null,
+            audio: { data: new Uint8Array(audioBytes) }
+          };
+          continue;
+        }
+
+        if (event.kind === "text") {
+          const rawPiece = event.delta;
           assistantText += rawPiece;
           for (const y of yieldSplitThinkChunks(
-            item,
+            event.chunk,
             rawPiece,
             thinkSplitter
           )) {
@@ -1247,35 +1250,29 @@ export class AgentNode extends BaseNode {
         // A finalized message event (assistant turn or tool result). generateLoop
         // owns the message array; we mirror the old per-turn finalization +
         // thread persistence off these. Each assistant event closes a turn.
-        if (
-          item &&
-          typeof item === "object" &&
-          "type" in item &&
-          (item as { type?: string }).type === "message"
-        ) {
-          const message = (item as { message?: Message }).message;
-          if (!message) continue;
-          if (message.role === "assistant") {
-            // Rebuild the persisted assistant message from our own accumulated
-            // text (which excludes audio chunks) so saved history keeps its old
-            // array shape; carry tool calls / Gemini thought-signature parts from
-            // the event since generateLoop now owns the live message.
-            const hadToolCalls = (message.toolCalls?.length ?? 0) > 0;
-            const persistMessage: Message = {
-              role: "assistant",
-              content: [{ type: "text", text: assistantText }],
-              toolCalls: message.toolCalls ?? null
-            };
-            if (message._rawGeminiParts) {
-              persistMessage._rawGeminiParts = message._rawGeminiParts;
-            }
-            const shouldPersist = Boolean(assistantText) || hadToolCalls;
-            yield* finalizeAssistantTurn();
-            if (threadId && shouldPersist) {
-              await saveThreadMessage(context, threadId, persistMessage);
-            }
-          } else if (threadId) {
-            await saveThreadMessage(context, threadId, message);
+        if (event.kind === "assistant_message") {
+          const message = event.message;
+          // Rebuild the persisted assistant message from our own accumulated
+          // text (which excludes audio chunks) so saved history keeps its old
+          // array shape; carry tool calls / Gemini thought-signature parts from
+          // the event since generateLoop now owns the live message.
+          const hadToolCalls = (message.toolCalls?.length ?? 0) > 0;
+          const persistMessage: Message = {
+            role: "assistant",
+            content: [{ type: "text", text: assistantText }],
+            toolCalls: message.toolCalls ?? null
+          };
+          if (message._rawGeminiParts) {
+            persistMessage._rawGeminiParts = message._rawGeminiParts;
+          }
+          const shouldPersist = Boolean(assistantText) || hadToolCalls;
+          yield* finalizeAssistantTurn();
+          if (threadId && shouldPersist) {
+            await saveThreadMessage(context, threadId, persistMessage);
+          }
+        } else if (event.kind === "tool_message") {
+          if (threadId) {
+            await saveThreadMessage(context, threadId, event.message);
           }
         }
       }

--- a/packages/llm-nodes/tests/agent-loop.test.ts
+++ b/packages/llm-nodes/tests/agent-loop.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 // current runAgentLoop. registerBuiltinAgentToolClasses must come from the same
 // source module so it shares the builtin-tool registry runAgentLoop hydrates from.
 import { runAgentLoop } from "../src/nodes/agents.js";
+import { classifyProviderStream } from "../src/nodes/agent-utils.js";
 import { registerBuiltinAgentToolClasses } from "../src/nodes/agent-tool-hydration.js";
 import { BaseProvider } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
@@ -410,5 +411,35 @@ describe("runAgentLoop", () => {
     expect(result.text).toBe("Tool says 7");
     // The streamed tool-result message landed in the returned conversation.
     expect(result.messages.some((m: any) => m.role === "tool")).toBe(true);
+  });
+});
+
+describe("classifyProviderStream", () => {
+  it("maps each raw stream item to its typed event, splitting message roles", async () => {
+    async function* raw() {
+      yield { id: "t1", name: "search", args: { q: "x" } }; // tool call
+      yield { type: "chunk", content: "reasoning", thinking: true }; // thinking
+      yield { type: "chunk", content: "AAA", content_type: "audio" }; // audio
+      yield { type: "chunk", content: "hi", content_type: "text" }; // text
+      yield { type: "chunk", content: "no-type" }; // normalized to text
+      yield { type: "message", message: { role: "assistant", content: "done" } };
+      yield { type: "message", message: { role: "tool", content: "result" } };
+    }
+    const events: any[] = [];
+    for await (const ev of classifyProviderStream(raw())) events.push(ev);
+    expect(events.map((e) => e.kind)).toEqual([
+      "tool_call",
+      "thinking",
+      "audio",
+      "text",
+      "text",
+      "assistant_message",
+      "tool_message"
+    ]);
+    expect(events[0].toolCall.name).toBe("search");
+    expect(events[3].delta).toBe("hi");
+    // A chunk lacking content_type is normalized to text with content_type set.
+    expect(events[4].chunk.content_type).toBe("text");
+    expect(events[5].message.role).toBe("assistant");
   });
 });

--- a/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
+++ b/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
@@ -118,6 +118,12 @@ describe("AgentStepNode", () => {
     expect(meta.properties.find((p) => p.name === "model")).toBeUndefined();
   });
 
+  it("is hidden from the palette but stays registered for agent runners", () => {
+    const meta = getNodeMetadata(AgentStepNode);
+    expect(meta.hidden).toBe(true);
+    expect(AGENT_NODES).toContain(AgentStepNode);
+  });
+
   it("process() refuses to run via the standard kernel path", async () => {
     await expect(new AgentStepNode().process()).rejects.toThrow(
       /agent runner|configured provider/i

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -90,6 +90,15 @@ export type NodeClass = {
    */
   requiresGpu?: boolean;
   deprecated: boolean;
+  /**
+   * Hide from node-discovery UIs (palette, search) while keeping the node
+   * registered and runnable. Unlike `deprecated` (which down-ranks and badges
+   * a still-discoverable node), a hidden node is filtered out of the palette
+   * entirely. Used for internal nodes the user never adds by hand — e.g.
+   * `AgentStepNode`, which GraphPlanner/AgentWorkflowRunner insert. Set via a
+   * `static readonly hidden = true` on the node class.
+   */
+  hidden?: boolean;
   replacedBy?: string;
   metadataOutputTypes?: DeclaredOutputTypes;
   outputTypes: DeclaredOutputTypes;
@@ -238,6 +247,11 @@ export abstract class BaseNode {
    */
   static readonly requiresGpu: boolean | undefined = undefined;
   static readonly deprecated: boolean = false;
+  /**
+   * Hidden from node-discovery UIs but still registered/runnable (see the
+   * `hidden` field on NodeClass). Unset/false means normally discoverable.
+   */
+  static readonly hidden: boolean | undefined = undefined;
   static readonly replacedBy: string | undefined = undefined;
   static readonly metadataOutputTypes: DeclaredOutputTypes | undefined =
     undefined;

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -123,6 +123,12 @@ export interface NodeMetadata {
   platforms?: readonly Platform[];
   /** When true, the node remains runnable but should be deprioritized in search. */
   deprecated?: boolean;
+  /**
+   * When true, the node is registered and runnable but hidden from discovery
+   * UIs (palette, search) entirely — for internal nodes a user never adds by
+   * hand (e.g. agent-runner-inserted steps).
+   */
+  hidden?: boolean;
   /** Preferred replacement node_type when deprecated is true. */
   replaced_by?: string;
 }

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -297,6 +297,7 @@ export function getNodeMetadata(
     model_packs: nodeClass.modelPacks,
     platforms: normalizePlatforms(nodeClass.platforms),
     deprecated: nodeClass.deprecated || undefined,
+    hidden: nodeClass.hidden || undefined,
     replaced_by: nodeClass.replacedBy
   };
 

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -753,6 +753,12 @@ export interface NodeMetadata {
   fal_unit_pricing?: FalUnitPricing | null;
   /** When true, the node remains runnable but is hidden from default discovery. */
   deprecated?: boolean;
+  /**
+   * When true, the node is registered and runnable but filtered out of
+   * discovery UIs (palette, search) entirely — for internal nodes a user never
+   * adds by hand (e.g. agent-runner-inserted steps).
+   */
+  hidden?: boolean;
   /** Preferred replacement node_type when deprecated is true. */
   replaced_by?: string;
   /**

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -902,6 +902,36 @@ function createRuntimeContext(opts: {
       await asset.save();
       return asset;
     },
+    createMessage: async ({ userId, req }) => {
+      // Persist an AgentNode thread message. `content` / `tool_calls` are stored
+      // raw — the `content` column is a jsonText type that serializes them, so
+      // stringifying here would double-encode and break the getMessages read
+      // path (which feeds normalizeMessage, not a JSON-parsing response mapper).
+      return Message.create({
+        user_id: userId,
+        thread_id: req.thread_id,
+        role: req.role,
+        name: req.name ?? null,
+        content: req.content ?? null,
+        tool_calls: req.tool_calls ?? null,
+        tool_call_id: req.tool_call_id ?? null,
+        workflow_id: req.workflow_id ?? null
+      });
+    },
+    getMessages: async ({ userId, threadId, limit, startKey, reverse }) => {
+      const [msgs, cursor] = await Message.paginate(threadId, {
+        limit: limit ?? 1000,
+        startKey: startKey ?? undefined,
+        reverse: reverse ?? false
+      });
+      // Scope to the requesting user — thread_id has no ownership column of its
+      // own, so filter the rows the same way the tRPC messages router does.
+      const owned = msgs.filter((m) => m.user_id === userId);
+      return {
+        messages: owned as unknown as Array<Record<string, unknown>>,
+        next: cursor || null
+      };
+    },
     listFolderAssets: async ({ userId, folderId }) => {
       const folder = await Asset.find(userId, folderId);
       if (!folder || folder.content_type !== "folder") return null;

--- a/web/src/utils/nodeRanking.ts
+++ b/web/src/utils/nodeRanking.ts
@@ -70,6 +70,11 @@ function buildPrefilter(
   options: ScoreOptions
 ): (meta: NodeMetadata) => boolean {
   return (meta) => {
+    // Internal nodes (e.g. agent-runner-inserted steps) stay registered and
+    // runnable but never appear in the palette or search.
+    if (meta.hidden) {
+      return false;
+    }
     if (
       options.namespacePrefix &&
       !(meta.namespace ?? "").startsWith(options.namespacePrefix)


### PR DESCRIPTION
## Summary

Consolidates duplicated stream-classification logic from `AgentNode` and `runAgentLoop` into a single `classifyProviderStream()` function that yields typed `ProviderStreamEvent`s. This eliminates drift between the two consumers and simplifies the codebase.

## Key Changes

- **New `classifyProviderStream()` function** in `agent-utils.ts`: Normalizes and classifies raw provider stream items into typed events (`tool_call`, `thinking`, `audio`, `text`, `assistant_message`, `tool_message`). Both `AgentNode.genProcess()` and `runAgentLoop()` now use this shared function instead of inlining the same branch logic.

- **Refactored `AgentNode.genProcess()`**: Replaced inline `normalizeProviderStreamItem()` + type guards with `classifyProviderStream()` event matching. Cleaner, more maintainable event handling.

- **Refactored `runAgentLoop()`**: Simplified stream processing to use the same `classifyProviderStream()` function, reducing code duplication and ensuring consistent behavior.

- **Added `maxTokens` threading to plan mode**: 
  - `AgentNode` now passes `maxTokens` to `TaskExecutor` (plan mode)
  - `TaskExecutor` threads it to each `StepExecutor`
  - `StepExecutor` forwards it to `generateLoop()`
  - `CompilerAgent` accepts and forwards `maxTokens` to its `generateLoop()`
  - Updated `Agent` class to accept and propagate `maxTokens` through the planning pipeline
  - Updated AgentNode's `max_tokens` description to clarify it applies to both loop and plan modes

- **Marked `AgentStepNode` as hidden**: Added `static readonly hidden = true` so it's filtered from the palette/search but remains registered for agent runners to insert programmatically.

- **Added `hidden` field to node metadata system**:
  - `NodeClass` interface and `BaseNode` now support `hidden` property
  - `NodeMetadata` (SDK and protocol) includes `hidden` field
  - `nodeRanking.ts` filters hidden nodes from discovery UIs
  - Tests verify `AgentStepNode` is hidden but still registered

- **Added thread message persistence to websocket runtime**: Implemented `createMessage()` and `getMessages()` in the unified websocket runner's `ProcessingContext` to support AgentNode's thread persistence.

## Implementation Details

- `ProviderStreamEvent` is a discriminated union with `kind` field, making event handling type-safe and exhaustive.
- The `text` event includes both the original `chunk` (for inspection) and a `delta` string (the actual content).
- Message events are split by role (`assistant_message` vs `tool_message`) at classification time, eliminating runtime type checks in consumers.
- `maxTokens` is optional throughout the chain, allowing providers to use their defaults when unset.
- Hidden nodes remain fully functional and registered; they're only filtered from UI discovery.

https://claude.ai/code/session_01Ja4ZUX7vx3xkd2rtWwdry9