### PR TITLE
video-nodes: workspace defaults, accurate trim, fps input

### DIFF
--- a/packages/video-nodes/HANDOVER.md
+++ b/packages/video-nodes/HANDOVER.md
@@ -16,10 +16,13 @@ file once the items below are ticked off or turned into issues.
   output validation, streaming raw-frame writes. 16 new tests.
 - `a727bc1` — timeline.ts deduped against `ffmpeg-helpers.ts`; base-nodes
   tests updated for the throw-on-missing-binary contract.
+- Small follow-ups (item 5 below): `FrameToVideo` declares `fps` as a wireable
+  input (the previously-dead stream branch is now reachable); Save nodes default
+  the folder to the run's workspace dir instead of the server cwd; `Trim` gained
+  an `accurate` toggle that re-encodes with output-side seeking for frame-exact
+  cuts. 7 new tests.
 
-Verified: video-nodes 144/144; downstream per `nodetool affected` all green
-(base-nodes 1320, cli 357, deploy 851, dsl 138, websocket 1576,
-workflow-runner).
+Verified: video-nodes 151/151; typecheck clean.
 
 ## Remaining work
 
@@ -68,15 +71,22 @@ regardless of what the selected model supports; mismatches surface only as
 provider errors mid-run. The model manifests in `packages/runtime` providers
 know per-model capabilities — validate (or filter the UI choices) against them.
 
-### 5. Small follow-ups
+Note for the next session: none of the current `*-manifest.json` files carry
+per-model aspect-ratio/resolution/duration constraints (checked 2026-07-17), so
+this needs that capability data added to the manifests first — it's a runtime
+change, not a video-nodes drive-by.
 
-- `FrameToVideoNode.run` has an `fps` stream-handle branch but `fps` is not in
-  `inputFields`. Verify whether a wired `fps` ever arrives via `inputs.any()`;
-  either declare the input or delete the branch.
-- Save nodes default `folder` to `"."` (the server cwd). Pick a sane default
-  (workspace dir or assets) instead.
-- Trim keeps `-c copy` (fast, keyframe-aligned). Consider an "accurate"
-  toggle that re-encodes for frame-exact cuts.
+### 5. Small follow-ups — DONE
+
+- ~~`FrameToVideoNode.run` has an `fps` stream-handle branch but `fps` is not in
+  `inputFields`.~~ Declared `fps` in `inputFields`; the branch is now reachable
+  when an `fps` value is wired in.
+- ~~Save nodes default `folder` to `"."` (the server cwd).~~ They now fall back
+  to `context.workspaceDir` (then `"."` only when no workspace is assigned) via
+  the shared `saveFolder()` helper.
+- ~~Trim keeps `-c copy`.~~ Added an `accurate` bool: off keeps the fast
+  keyframe-aligned stream copy; on re-encodes with output-side `-ss`/`-to` for
+  frame-exact cuts.
 
 ## Environment notes for the next session
 

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -636,6 +636,15 @@ export class LoadVideoFileNode extends BaseNode {
   }
 }
 
+/**
+ * Resolve the destination folder for a save node. An explicit folder wins;
+ * otherwise fall back to the run's workspace directory rather than the server
+ * process cwd (`.`), which is rarely where a user wants their output.
+ */
+function saveFolder(rawFolder: unknown, context?: ProcessingContext): string {
+  return folderPath(rawFolder) || context?.workspaceDir || ".";
+}
+
 export class SaveVideoFileVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.SaveVideoFile";
   static readonly title = "Save Video File";
@@ -673,7 +682,7 @@ export class SaveVideoFileVideoNode extends BaseNode {
   declare filename: string;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const folder = folderPath(this.folder) || ".";
+    const folder = saveFolder(this.folder, context);
     const fname = dateName(String(this.filename || "video.mp4"));
     await fs.mkdir(path.resolve(folder), { recursive: true });
     // dateName resolves to second granularity, so two saves in the same second
@@ -817,7 +826,7 @@ export class SaveVideoNode extends BaseNode {
   declare name: string;
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
-    const folder = folderPath(this.folder) || ".";
+    const folder = saveFolder(this.folder, context);
     const filename = dateName(String(this.name || "video.mp4"));
     await fs.mkdir(path.resolve(folder), { recursive: true });
     // dateName resolves to second granularity, so two saves in the same second
@@ -1019,7 +1028,7 @@ export class FrameToVideoNode extends VideoTransformNode {
     output: "video"
   };
   static readonly inlineFields: string[] = [];
-  static readonly inputFields: string[] = ["frame"];
+  static readonly inputFields: string[] = ["frame", "fps"];
 
   @prop({
     type: "image",
@@ -1319,12 +1328,33 @@ export class TrimVideoNode extends VideoTransformNode {
   })
   declare end_time: number;
 
+  @prop({
+    type: "bool",
+    default: false,
+    title: "Accurate",
+    description:
+      "Re-encode for frame-exact cuts. Off (default) stream-copies and snaps to the nearest keyframe — fast, but the cut points may be off by up to one GOP."
+  })
+  declare accurate: boolean;
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: videoRef(bytes) };
 
     const start = Math.max(0, Number(this.start_time ?? 0));
     const end = Number(this.end_time ?? -1);
+
+    if (this.accurate) {
+      // Output-side seek (after -i): ffmpeg decodes every frame up to `start`
+      // and re-encodes, so the cut lands on the exact requested time instead of
+      // the nearest keyframe. Slower, but frame-accurate.
+      const seekArgs: string[] = ["-ss", String(start)];
+      if (end >= 0) {
+        seekArgs.push("-to", String(end));
+      }
+      const transformed = await ffmpegTransform(bytes, seekArgs);
+      return { output: videoRef(transformed) };
+    }
 
     // Input-side seek (before -i): ffmpeg jumps to the nearest keyframe instead
     // of decoding from the start, so trimming a long clip is near-instant.

--- a/packages/video-nodes/tests/save-folder-default.test.ts
+++ b/packages/video-nodes/tests/save-folder-default.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Save nodes with an empty `folder` should write into the run's workspace
+ * directory, not the server process cwd (`.`).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let writtenPaths: string[] = [];
+let mkdirPaths: string[] = [];
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const promises = {
+    mkdir: async (p: string) => {
+      mkdirPaths.push(p);
+    },
+    writeFile: async (p: string) => {
+      writtenPaths.push(p);
+    },
+    // Nothing exists → uniqueTargetPath keeps the first candidate.
+    access: async () => {
+      throw new Error("ENOENT");
+    }
+  };
+  return { ...original, promises };
+});
+
+const { SaveVideoNode, SaveVideoFileVideoNode, FrameToVideoNode } =
+  await import("@nodetool-ai/video-nodes");
+
+function inlineVideo() {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(new Uint8Array([1, 2, 3, 4])).toString("base64")
+  };
+}
+
+beforeEach(() => {
+  writtenPaths = [];
+  mkdirPaths = [];
+});
+
+describe("save-folder default", () => {
+  it("SaveVideo writes under the workspace dir when folder is empty", async () => {
+    const node = new SaveVideoNode();
+    node.assign({ video: inlineVideo(), name: "clip.mp4" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await node.process({ workspaceDir: "/ws" } as any);
+
+    expect(writtenPaths).toHaveLength(1);
+    expect(writtenPaths[0].startsWith("/ws/")).toBe(true);
+    expect(mkdirPaths[0]).toBe("/ws");
+  });
+
+  it("SaveVideoFile writes under the workspace dir when folder is empty", async () => {
+    const node = new SaveVideoFileVideoNode();
+    node.assign({ video: inlineVideo(), filename: "clip.mp4" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await node.process({ workspaceDir: "/ws" } as any);
+
+    expect(writtenPaths).toHaveLength(1);
+    expect(writtenPaths[0].startsWith("/ws/")).toBe(true);
+  });
+
+  it("an explicit folder still wins over the workspace dir", async () => {
+    const node = new SaveVideoNode();
+    node.assign({ video: inlineVideo(), name: "clip.mp4", folder: "/out" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await node.process({ workspaceDir: "/ws" } as any);
+
+    expect(writtenPaths[0].startsWith("/out/")).toBe(true);
+  });
+
+  it("falls back to cwd when no workspace is set", async () => {
+    const node = new SaveVideoNode();
+    node.assign({ video: inlineVideo(), name: "clip.mp4" });
+    await node.process();
+
+    // Resolved against cwd, so not the workspace path.
+    expect(writtenPaths[0].startsWith("/ws/")).toBe(false);
+  });
+});
+
+describe("FrameToVideo fps input", () => {
+  it("exposes fps as a wireable input handle", () => {
+    expect(FrameToVideoNode.inputFields).toContain("fps");
+  });
+});

--- a/packages/video-nodes/tests/trim-seek.test.ts
+++ b/packages/video-nodes/tests/trim-seek.test.ts
@@ -71,3 +71,46 @@ describe("TrimVideoNode — input-side seeking", () => {
     expect(args).not.toContain("-to");
   });
 });
+
+describe("TrimVideoNode — accurate (re-encode) mode", () => {
+  it("places -ss and -to AFTER -i and drops stream-copy for frame-exact cuts", async () => {
+    const node = new TrimVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      start_time: 5.5,
+      end_time: 12,
+      accurate: true
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgs();
+    const ss = args.indexOf("-ss");
+    const to = args.indexOf("-to");
+    const i = args.indexOf("-i");
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(ss).toBeGreaterThan(i);
+    expect(to).toBeGreaterThan(ss);
+    expect(args[ss + 1]).toBe("5.5");
+    expect(args[to + 1]).toBe("12");
+    // Re-encoding, not stream-copying.
+    expect(args).not.toContain("copy");
+  });
+
+  it("omits -to when end_time is -1", async () => {
+    const node = new TrimVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      start_time: 3,
+      end_time: -1,
+      accurate: true
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgs();
+    const ss = args.indexOf("-ss");
+    const i = args.indexOf("-i");
+    expect(ss).toBeGreaterThan(i);
+    expect(args).not.toContain("-to");
+    expect(args).not.toContain("copy");
+  });
+});


### PR DESCRIPTION
## Summary

Three small follow-ups to the video-nodes refactor:

1. Save nodes now default to the run's workspace directory instead of the server process cwd
2. TrimVideoNode gained an `accurate` toggle for frame-exact cuts via re-encoding
3. FrameToVideoNode now exposes `fps` as a wireable input

## Changes

- **Save folder defaults**: `SaveVideoNode` and `SaveVideoFileVideoNode` now use `saveFolder()` helper that falls back to `context.workspaceDir` before `"."`, ensuring output lands in the workspace rather than the server's cwd. Explicit `folder` values still take precedence.

- **TrimVideoNode accurate mode**: Added `accurate: bool` property (default `false`). When enabled, uses output-side seeking (`-ss`/`-to` after `-i`) with re-encoding instead of stream-copy, yielding frame-exact cuts at the cost of speed. Input-side seeking (fast, keyframe-aligned) remains the default.

- **FrameToVideoNode fps input**: Added `"fps"` to `inputFields` so the existing stream-handle branch in `run()` is now reachable when `fps` is wired in.

## Tests

Added 7 new tests:
- 4 tests for save-folder defaults (workspace dir, explicit folder override, cwd fallback)
- 2 tests for accurate trim mode (with and without end_time)
- 1 test for fps input exposure

All 151 video-nodes tests pass; typecheck clean.

https://claude.ai/code/session_01Q1RuW48w44vD26CRSoMMhr