### PR TITLE
Fix WorkflowCard text sizing by using em units instead of rem

### DIFF
--- a/web/src/components/workflows/WorkflowCard.tsx
+++ b/web/src/components/workflows/WorkflowCard.tsx
@@ -183,8 +183,10 @@ const cardStyles = (theme: Theme) =>
       overflow: "hidden",
       textOverflow: "ellipsis",
       // Lock to one line of height so the flex parent can't clip the
-      // descender of the line and swallow the ellipsis.
-      maxHeight: "calc(0.9rem * 1.25)",
+      // descender of the line and swallow the ellipsis. Use em (the element's
+      // own font-size) so the cap tracks --fontSizeNormal; a hardcoded rem
+      // smaller than the actual line height clips the whole title away.
+      maxHeight: "1.25em",
       margin: 0
     },
     ".card-description": {
@@ -197,8 +199,10 @@ const cardStyles = (theme: Theme) =>
       overflow: "hidden",
       textOverflow: "ellipsis",
       // Lock the visible description to N full lines so the parent flex
-      // container can't shave the bottom of the last line.
-      maxHeight: "calc(0.75rem * 1.4 * 3)",
+      // container can't shave the bottom of the last line. em tracks the
+      // element's own font-size (--fontSizeSmall); a hardcoded rem below the
+      // real line height clips text.
+      maxHeight: "calc(1.4em * 3)",
       margin: 0
     },
     ".chips-container": {
@@ -372,7 +376,7 @@ const WorkflowCard = ({
               className="card-description"
               style={{
                 WebkitLineClamp: descriptionLines,
-                maxHeight: `calc(0.75rem * 1.4 * ${descriptionLines})`
+                maxHeight: `calc(1.4em * ${descriptionLines})`
               }}
             >
               {workflow.description}


### PR DESCRIPTION
## Summary
Fixed text clipping issues in WorkflowCard by switching from hardcoded `rem`-based `maxHeight` calculations to `em`-based units that properly track the element's own font-size.

## Changes
- **Card title** (`.card-title`): Changed `maxHeight` from `calc(0.9rem * 1.25)` to `1.25em` to properly respect the element's font-size and prevent clipping of the entire title
- **Card description** (`.card-description`): Changed `maxHeight` from `calc(0.75rem * 1.4 * 3)` to `calc(1.4em * 3)` to track `--fontSizeSmall` instead of a hardcoded rem value
- **Dynamic description height**: Updated inline style calculation in the description element to use `calc(1.4em * ${descriptionLines})` instead of `calc(0.75rem * 1.4 * ${descriptionLines})`

## Implementation Details
The issue was that hardcoded `rem` values (0.9rem, 0.75rem) were smaller than the actual line heights of the text, causing the `maxHeight` constraint to clip entire lines of text away rather than just truncating with ellipsis. By switching to `em` units, the `maxHeight` now scales with each element's own `font-size` property, ensuring proper text truncation behavior while respecting design tokens like `--fontSizeNormal` and `--fontSizeSmall`.

https://claude.ai/code/session_01J7a7wu6muM1f1Zdc12HFpo