### PR TITLE
Add PlanWorkflowGraphTool for AI-driven workflow graph generation

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -113,6 +113,7 @@ export {
   RunWorkflowTool,
   DebugWorkflowTool,
   ValidateWorkflowTool,
+  PlanWorkflowGraphTool,
   GetExampleWorkflowTool,
   ExportWorkflowDigraphTool,
   ListNodesTool,
@@ -127,6 +128,7 @@ export {
   ListModelsTool,
   getAllMcpTools
 } from "./tools/mcp-tools.js";
+export type { PlanWorkflowGraphToolOptions } from "./tools/mcp-tools.js";
 export {
   ExtractPDFTextTool,
   ExtractPDFTablesTool,

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -25,6 +25,9 @@ import {
   EmbedTextTool
 } from "./media-tools.js";
 import { SaveAssetTool, ReadAssetTool } from "./asset-tools.js";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { GraphPlanner } from "../graph-planner.js";
+import { TOOL_CALL_ID_FIELD } from "./subtask-fields.js";
 
 const DEFAULT_API_URL = "http://localhost:7777";
 
@@ -473,6 +476,119 @@ export class ValidateWorkflowTool extends Tool {
     return params["workflow_id"]
       ? `Validating workflow ${params["workflow_id"]}`
       : "Validating workflow graph";
+  }
+}
+
+export interface PlanWorkflowGraphToolOptions {
+  provider: BaseProvider;
+  model: string;
+  registry: NodeRegistry;
+  /** Configured providers by id — enables the planner's `find_model` tool. */
+  providers?: Record<string, BaseProvider>;
+  /**
+   * Forwards planner progress events (planning_update, tool_call_update,
+   * chunk) to the client. Events arrive tagged with `parent_tool_call_id`
+   * so the UI can nest them under this tool's call card.
+   */
+  forwardMessage?: (msg: ProcessingMessage) => Promise<void> | void;
+}
+
+export class PlanWorkflowGraphTool extends Tool {
+  readonly name = "plan_workflow_graph";
+  readonly needsToolCallId = true;
+  readonly description =
+    "Build a complete workflow graph ({nodes, edges}) from a natural-language " +
+    "objective using the backend GraphPlanner: it searches the node registry, " +
+    "inspects node metadata, and wires a validated DAG node-by-node. Returns " +
+    "the graph without saving or running it — pass the result to " +
+    "`create_workflow` to save, then `run_workflow` to execute.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      objective: {
+        type: "string" as const,
+        description:
+          "Natural-language description of what the workflow should do."
+      },
+      inputs: {
+        type: "object" as const,
+        description:
+          "Runtime parameters the workflow should accept, keyed by input " +
+          "name with example values. Each becomes an input node in the graph."
+      }
+    },
+    required: ["objective"]
+  };
+
+  constructor(private readonly opts: PlanWorkflowGraphToolOptions) {
+    super();
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const objective =
+      typeof params["objective"] === "string" ? params["objective"].trim() : "";
+    if (!objective) {
+      return {
+        error: "`objective` is required and must be a non-empty string."
+      };
+    }
+    const parentToolCallId =
+      typeof params[TOOL_CALL_ID_FIELD] === "string"
+        ? (params[TOOL_CALL_ID_FIELD] as string)
+        : null;
+
+    const planner = new GraphPlanner({
+      provider: this.opts.provider,
+      model: this.opts.model,
+      registry: this.opts.registry,
+      tools: [],
+      inputs: (params["inputs"] as Record<string, unknown>) ?? {},
+      providers: this.opts.providers
+    });
+
+    const gen = planner.plan(objective, context);
+    let next = await gen.next();
+    while (!next.done) {
+      if (this.opts.forwardMessage) {
+        const tagged = {
+          ...(next.value as unknown as Record<string, unknown>),
+          parent_tool_call_id: parentToolCallId
+        } as unknown as ProcessingMessage;
+        try {
+          await this.opts.forwardMessage(tagged);
+        } catch {
+          // A broken forwarder must not kill planning — the model still gets
+          // the graph via the tool return below.
+        }
+      }
+      next = await gen.next();
+    }
+
+    const graph = next.value;
+    if (!graph) {
+      return {
+        error:
+          "GraphPlanner failed to build a graph after multiple attempts. " +
+          "Refine the objective (name concrete inputs/outputs) and retry."
+      };
+    }
+
+    return {
+      graph,
+      node_count: graph.nodes.length,
+      edge_count: graph.edges.length
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const objective =
+      typeof params["objective"] === "string"
+        ? params["objective"].slice(0, 80)
+        : "workflow";
+    return `Planning workflow graph: ${objective}`;
   }
 }
 

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -114,6 +114,9 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // run_subtask spawns a child loop whose own tools are gated; the call
   // itself has no side effects, so it always runs.
   run_subtask: "read",
+  // plan_workflow_graph only builds and returns a graph — saving it goes
+  // through the gated `create_workflow`.
+  plan_workflow_graph: "read",
   // run_search spawns a read-only child loop (read_file/glob/grep/
   // list_directory/memory_read only); the call itself has no side effects, so
   // it always runs ungated.

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import {
+  PlanWorkflowGraphTool,
   ListWorkflowsTool,
   GetWorkflowTool,
   CreateWorkflowTool,
@@ -543,5 +545,75 @@ describe("request headers", () => {
     expect(headers["X-User-Id"]).toBe("user-1");
     expect(headers["Authorization"]).toBe("Bearer access-token");
     expect(headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanWorkflowGraphTool
+// ---------------------------------------------------------------------------
+
+describe("PlanWorkflowGraphTool", () => {
+  // A provider whose tool loop ends immediately without calling finish_graph,
+  // so the planner exhausts its retries and returns null.
+  function makeEmptyLoopProvider(): BaseProvider {
+    return {
+      provider: "mock",
+      generateLoop: () => (async function* () {})()
+    } as unknown as BaseProvider;
+  }
+
+  function makeTool(
+    forwardMessage?: (msg: ProcessingMessage) => void
+  ): PlanWorkflowGraphTool {
+    return new PlanWorkflowGraphTool({
+      provider: makeEmptyLoopProvider(),
+      model: "mock-model",
+      registry: {} as never,
+      forwardMessage
+    });
+  }
+
+  it("rejects a missing or empty objective", async () => {
+    const tool = makeTool();
+    expect(await tool.process(ctx, {})).toMatchObject({
+      error: expect.stringContaining("objective")
+    });
+    expect(await tool.process(ctx, { objective: "   " })).toMatchObject({
+      error: expect.stringContaining("objective")
+    });
+  });
+
+  it("returns an error when the planner fails to produce a graph", async () => {
+    const tool = makeTool();
+    const result = await tool.process(ctx, { objective: "do things" });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("failed to build a graph")
+    });
+  });
+
+  it("forwards planner events tagged with the parent tool_call_id", async () => {
+    const forwarded: ProcessingMessage[] = [];
+    const tool = makeTool((msg) => {
+      forwarded.push(msg);
+    });
+    await tool.process(ctx, {
+      objective: "do things",
+      _tool_call_id: "call-1"
+    });
+    expect(forwarded.length).toBeGreaterThan(0);
+    expect(forwarded.some((m) => m.type === "planning_update")).toBe(true);
+    for (const msg of forwarded) {
+      expect(
+        (msg as unknown as Record<string, unknown>).parent_tool_call_id
+      ).toBe("call-1");
+    }
+  });
+
+  it("survives a broken forwarder and still returns a result", async () => {
+    const tool = makeTool(() => {
+      throw new Error("forwarder down");
+    });
+    const result = await tool.process(ctx, { objective: "do things" });
+    expect(result).toMatchObject({ error: expect.any(String) });
   });
 });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -83,7 +83,11 @@ import type {
   RpcErrorPayload
 } from "@nodetool-ai/protocol";
 import { Tool } from "@nodetool-ai/agents";
-import { RunSubtaskTool, RunSearchTool } from "@nodetool-ai/agents";
+import {
+  RunSubtaskTool,
+  RunSearchTool,
+  PlanWorkflowGraphTool
+} from "@nodetool-ai/agents";
 import {
   ToolSearchTool,
   formatDeferredToolsReminder,
@@ -3511,6 +3515,26 @@ export class UnifiedWebSocketRunner {
         this.runSingleNode(nodeType, inputs, userId, threadId)
       )
     ];
+    // GraphPlanner as a chat tool: builds a workflow graph from an objective
+    // using the session's provider/model. Needs the in-process node registry.
+    if (this.nodeRegistry) {
+      rawToolbelt.push(
+        new PlanWorkflowGraphTool({
+          provider,
+          model,
+          registry: this.nodeRegistry,
+          providers: chatProviders,
+          forwardMessage: async (msg) => {
+            const enriched: Record<string, unknown> = {
+              ...(msg as unknown as Record<string, unknown>)
+            };
+            if (enriched.thread_id == null) enriched.thread_id = threadId;
+            if (enriched.workflow_id == null) enriched.workflow_id = workflowId;
+            await this.sendMessage(enriched);
+          }
+        })
+      );
+    }
     // When the active provider generates images natively (OpenAI Responses
     // `image_generation` tool), drop the redundant provider-specific
     // `openai_image_generation` tool — the native `image_generation` covers it

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1051,6 +1051,8 @@ You start with a resident core, always available without loading:
 - Delegation: \`run_subtask\` (and \`run_search\`).
 - Nodes and workflows: \`run_node\`, \`run_workflow\`, \`search_nodes\`,
   \`list_nodes\`, \`get_node_info\`, \`list_workflows\`, \`get_workflow\`.
+- Workflow building: \`plan_workflow_graph\`, \`validate_workflow\`,
+  \`create_workflow\`, \`debug_workflow\`.
 - Tool discovery: \`ToolSearch\`.
 
 Everything else is a DEFERRED tool you load on demand with \`ToolSearch\` (see
@@ -1073,6 +1075,24 @@ with the \`ToolSearch\` tool.
   - \`+substr words\` — require \`substr\` in the tool name, rank by the rest.
 - Load every tool you intend to use before calling it; one search can load
   several. If a call fails because a tool is unknown, ToolSearch it first.
+
+# Building workflows
+When the user wants a workflow built, drive this loop:
+1. \`plan_workflow_graph\` — turn the objective into a complete graph
+   ({nodes, edges}). Pass \`inputs\` for runtime parameters the workflow
+   should accept; each becomes an input node. Progress streams to the user.
+2. \`validate_workflow\` — statically re-check the graph (pass it inline as
+   \`graph\`) after any manual edit. Fix issues before saving.
+3. \`create_workflow\` — save the graph under a clear name. The returned id
+   is what the run and debug tools take.
+4. \`debug_workflow\` — run it and get final status, outputs, errors, and job
+   logs in one report. Use \`run_workflow\` for a plain run with params, or
+   \`run_node\` to probe a single suspect node in isolation.
+5. On failure, fix the graph JSON — or re-plan with a sharper objective —
+   and save again with \`create_workflow\`. There is no update tool: each fix
+   produces a new workflow, so tell the user which id is current.
+Prefer \`plan_workflow_graph\` over hand-authoring graphs from scratch, but
+hand-fix small issues in a planned graph rather than re-planning.
 
 # Image and media
 When tools return media URLs, embed them as markdown image / link tags.
@@ -1125,7 +1145,13 @@ const RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   "list_workflows",
   "get_workflow",
   "run_node",
-  "run_workflow"
+  "run_workflow",
+  // Workflow-building loop: plan → validate → create → debug. Resident so
+  // the loop the system prompt teaches needs no ToolSearch round-trip.
+  "plan_workflow_graph",
+  "validate_workflow",
+  "create_workflow",
+  "debug_workflow"
 ]);
 
 /**


### PR DESCRIPTION
## Summary
Introduces `PlanWorkflowGraphTool`, a new resident tool that leverages the `GraphPlanner` to build complete workflow graphs from natural-language objectives. This enables the agent to autonomously plan workflows without manual graph authoring, integrated into the workflow-building loop (plan → validate → create → debug).

## Key Changes

- **New `PlanWorkflowGraphTool` class** (`packages/agents/src/tools/mcp-tools.ts`):
  - Accepts an objective and optional runtime inputs; returns a complete `{nodes, edges}` graph
  - Wraps `GraphPlanner` and streams planning progress events (tagged with `parent_tool_call_id`) to the client for real-time UI feedback
  - Gracefully handles planner failures and broken message forwarders
  - Marked as `needsToolCallId = true` to track parent context for nested event forwarding

- **System prompt updates** (`packages/websocket/src/unified-websocket-runner.ts`):
  - Documents the workflow-building loop: plan → validate → create → debug
  - Teaches the agent to prefer `plan_workflow_graph` over hand-authoring, with guidance on when to re-plan vs. hand-fix
  - Adds `plan_workflow_graph`, `validate_workflow`, `create_workflow`, `debug_workflow` to resident tools (no ToolSearch round-trip needed)

- **Tool registration**:
  - Instantiated in `UnifiedWebSocketRunner` with the session's provider, model, node registry, and configured providers
  - Forwards planner events enriched with `thread_id` and `workflow_id` for proper message routing

- **Permissions & exports**:
  - Classified as `"read"` permission (builds graph only; saving goes through gated `create_workflow`)
  - Exported from `packages/agents/src/index.ts`

- **Comprehensive test coverage** (`packages/agents/tests/mcp-tools.test.ts`):
  - Validates objective validation (rejects empty/missing)
  - Tests planner failure handling
  - Verifies event forwarding with parent tool call ID tagging
  - Confirms resilience to broken forwarders

## Implementation Details

- Uses a generator-based loop to consume `GraphPlanner.plan()` output, allowing real-time event streaming without blocking
- Extracts `_tool_call_id` from params (via `TOOL_CALL_ID_FIELD`) to tag forwarded messages for UI nesting
- Returns `{graph, node_count, edge_count}` on success; `{error: "..."}` on failure
- `userMessage()` truncates objective to 80 chars for concise logging

https://claude.ai/code/session_01GunHdujzBrjBZGz5gVj7mE