### PR TITLE
Fix Gemini image-to-video 400 by sending raw image bytes

### DIFF
--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -1698,10 +1698,8 @@ export class GeminiProvider extends BaseProvider {
         {
           prompt,
           image: {
-            inlineData: {
-              data: Buffer.from(image).toString("base64"),
-              mimeType: "image/png"
-            }
+            bytesBase64Encoded: Buffer.from(image).toString("base64"),
+            mimeType: "image/png"
           }
         }
       ]

--- a/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
@@ -1268,10 +1268,8 @@ describe("GeminiProvider – imageToVideo", () => {
     );
     const body = JSON.parse(fetchFn.mock.calls[0][1].body);
     expect(body.instances[0].image).toEqual({
-      inlineData: {
-        data: Buffer.from([1, 2, 3]).toString("base64"),
-        mimeType: "image/png"
-      }
+      bytesBase64Encoded: Buffer.from([1, 2, 3]).toString("base64"),
+      mimeType: "image/png"
     });
     expect(body.parameters.durationSeconds).toBe(8);
   });


### PR DESCRIPTION
Veo's predictLongRunning endpoint expects the input image as
image.bytesBase64Encoded + image.mimeType directly, not wrapped in
inlineData. The imageToVideo provider method wrapped the bytes in
inlineData, which the Veo model rejects with:

  400 INVALID_ARGUMENT: `inlineData` isn't supported by this model.

Send bytesBase64Encoded directly, matching the working llm-nodes
ImageToVideoGeminiNode, and update the test expectation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C21eDuX3yQQd12QXhVmFsj