### PR TITLE
feat(marketing): faster landing reveals, star count reuse, tighter copy

### DIFF
--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -284,8 +284,8 @@
   .fly-in {
     opacity: 0;
     transform: translateY(16px);
-    transition: transform 600ms cubic-bezier(0.2, 0.8, 0.2, 1),
-      opacity 600ms ease;
+    transition: transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      opacity 300ms ease;
     transition-delay: var(--fly-delay, 0ms);
     will-change: transform, opacity;
   }
@@ -455,11 +455,11 @@
 }
 
 .hero-rise {
-  animation: heroRise 600ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  animation: heroRise 350ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 .hero-rise-delayed {
-  animation: heroRise 700ms cubic-bezier(0.2, 0.8, 0.2, 1) 150ms both;
+  animation: heroRise 400ms cubic-bezier(0.2, 0.8, 0.2, 1) 80ms both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import Script from "next/script";
+import MotionProvider from "../components/MotionProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -260,7 +261,9 @@ export default function RootLayout({
           `}
         </Script>
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <MotionProvider>{children}</MotionProvider>
+      </body>
     </html>
   );
 }

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -26,6 +26,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Download } from "lucide-react";
 import { SmartDownloadButton } from "./SmartDownloadButton";
 import { track } from "../lib/analytics";
+import { useGithubStars } from "../lib/useGithubStars";
 
 import { Feature, features } from "./features";
 
@@ -130,7 +131,7 @@ function useReveal() {
       (entries) => {
         entries.forEach((e) => {
           if (e.isIntersecting) {
-            el.style.transition = "opacity 600ms ease, transform 600ms ease";
+            el.style.transition = "opacity 300ms ease, transform 300ms ease";
             el.style.opacity = "1";
             el.style.transform = "translateY(0)";
             obs.disconnect();
@@ -147,7 +148,7 @@ function useReveal() {
 
 export default function Home() {
   const [selectedFeature, setSelectedFeature] = useState<Feature | null>(null);
-  const [stars, setStars] = useState<number | null>(null);
+  const stars = useGithubStars();
   const parallaxRef = useRef<HTMLDivElement>(null);
   const reducedMotion = usePrefersReducedMotion();
   const heroRevealRef = useReveal();
@@ -161,7 +162,7 @@ export default function Home() {
     // Initialize base class + slight stagger via CSS var
     sections.forEach((el, i) => {
       el.classList.add("fly-in");
-      const delay = Math.min(i * 60, 300);
+      const delay = Math.min(i * 30, 120);
       el.style.setProperty("--fly-delay", `${delay}ms`);
     });
     const obs = new IntersectionObserver(
@@ -179,18 +180,6 @@ export default function Home() {
     sections.forEach((el) => obs.observe(el));
     return () => obs.disconnect();
   }, [reducedMotion]);
-
-  // Fetch GitHub stars (consumed by CommunitySection)
-  useEffect(() => {
-    fetch("https://api.github.com/repos/nodetool-ai/nodetool")
-      .then((r) => r.json())
-      .then((j) => {
-        if (typeof j.stargazers_count === "number") {
-          setStars(j.stargazers_count);
-        }
-      })
-      .catch(() => { });
-  }, []);
 
   // Parallax with reduced-motion guard and passive scroll
   useEffect(() => {
@@ -323,7 +312,7 @@ export default function Home() {
             <motion.div
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
+              transition={{ duration: 0.35, delay: 0.05, ease: "easeOut" }}
               className="relative group"
             >
               <div
@@ -345,6 +334,10 @@ export default function Home() {
                   preload="none"
                 />
               </div>
+              <p className="mt-4 text-center text-sm text-slate-400">
+                A trailer generated end-to-end in NodeTool — script, key art,
+                animation, and sound from one workflow on the canvas.
+              </p>
             </motion.div>
           </div>
         </section>
@@ -451,14 +444,23 @@ export default function Home() {
               Put every model on one canvas.
             </h2>
             <p className="mt-4 text-lg text-slate-300">
-              Free, open source, and yours to run. Download Studio and build
-              your first workflow in minutes.
+              Free, open source, and yours to run. Download Studio — or try
+              Cloud in the browser, nothing to install.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton
                 icon={<Download className="h-5 w-5" />}
                 classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 hover:shadow-blue-900/60 focus-ring"
               />
+              <a
+                href="https://app.nodetool.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => track("Try Cloud")}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-blue-500/40 bg-blue-500/10 px-6 py-3.5 text-sm font-semibold text-blue-200 transition-all hover:border-blue-400 hover:bg-blue-500/20 focus-ring"
+              >
+                Try NodeTool Cloud
+              </a>
               <a
                 href="https://github.com/nodetool-ai/nodetool"
                 target="_blank"

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -31,7 +31,7 @@ export default function ChatUISection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Run your workflows <br />
@@ -44,7 +44,7 @@ export default function ChatUISection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Skip the canvas when you don&apos;t need it. Ask in plain English, the right workflow runs, results stream back inline.
@@ -55,7 +55,7 @@ export default function ChatUISection() {
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl"
         >
           <Tilt3D>

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -27,7 +27,7 @@ export default function ComparisonSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
             Where NodeTool fits among your tools
@@ -36,7 +36,7 @@ export default function ComparisonSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.05 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
             You&apos;re probably using two or three of these already. Here&apos;s
@@ -70,7 +70,7 @@ export default function ComparisonSection({
           initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6, delay: 0.15 }}
+          transition={{ duration: 0.3, delay: 0.08 }}
           className="relative mt-10 rounded-2xl border border-slate-800/80 bg-slate-950/40 px-8 py-10 md:px-12 md:py-12"
         >
           {/* Warm corner glow — single, subtle */}
@@ -141,7 +141,7 @@ function ComparisonCard({
       initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
       whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.5, delay }}
+      transition={{ duration: 0.25, delay }}
       className="relative bg-slate-950/70 p-8 lg:p-10 flex flex-col"
     >
       <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 mb-6">

--- a/marketing/src/components/ContactSection.tsx
+++ b/marketing/src/components/ContactSection.tsx
@@ -19,7 +19,7 @@ export default function ContactSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Get in <br />
@@ -32,7 +32,7 @@ export default function ContactSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300"
           >
             Questions, bug reports, feature requests — we answer.
@@ -83,7 +83,7 @@ export default function ContactSection() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={{ delay: i * 0.1 }}
+              transition={{ delay: i * 0.05 }}
             >
               <Tilt3D className="h-full">
                 <div className="group relative h-full flex flex-col items-center justify-center text-center rounded-2xl border border-white/5 bg-slate-900/40 backdrop-blur-sm p-10 transition-all duration-300 hover:bg-slate-900/60 hover:border-white/10 hover:shadow-2xl">

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -113,7 +113,7 @@ export default function CostDashboardSection() {
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl"
         >
           <div className="relative overflow-hidden rounded-xl border border-white/[0.06] bg-[#0b0d12] shadow-strong">
@@ -257,8 +257,8 @@ export default function CostDashboardSection() {
                             whileInView={{ scaleY: 1 }}
                             viewport={{ once: true }}
                             transition={{
-                              duration: 0.5,
-                              delay: 0.2 + i * 0.012,
+                              duration: 0.25,
+                              delay: 0.05 + i * 0.012,
                               ease: [0.2, 0.8, 0.2, 1],
                             }}
                           >
@@ -346,8 +346,8 @@ export default function CostDashboardSection() {
                           whileInView={{ scaleX: 1 }}
                           viewport={{ once: true }}
                           transition={{
-                            duration: 0.6,
-                            delay: 0.3 + i * 0.06,
+                            duration: 0.3,
+                            delay: 0.08 + i * 0.06,
                             ease: [0.2, 0.8, 0.2, 1],
                           }}
                         />

--- a/marketing/src/components/DeploySection.tsx
+++ b/marketing/src/components/DeploySection.tsx
@@ -23,7 +23,7 @@ export default function DeploySection({
             initial={{ opacity: 0, x: -20 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
           >
             <h2 className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6">
               Self host <br />
@@ -111,7 +111,7 @@ export default function DeploySection({
             initial={{ opacity: 0, x: 20 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="relative hidden lg:block"
           >
             <Tilt3D>

--- a/marketing/src/components/EditionsCompareSection.tsx
+++ b/marketing/src/components/EditionsCompareSection.tsx
@@ -178,7 +178,7 @@ export default function EditionsCompareSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
             Studio runs on your machine.
@@ -189,7 +189,7 @@ export default function EditionsCompareSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.05 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
             Same workflows, same nodes, same providers. Pick the runtime that

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -43,7 +43,7 @@ export default function FeaturesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             One canvas <br />
@@ -56,7 +56,7 @@ export default function FeaturesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Image, video, audio, and text on a single node-based canvas — with
@@ -70,7 +70,7 @@ export default function FeaturesSection({
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl mb-20"
         >
           <Tilt3D>
@@ -105,7 +105,7 @@ export default function FeaturesSection({
           className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.1 } },
           }}
@@ -152,7 +152,7 @@ export default function FeaturesSection({
               key={feature.title}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
               <Tilt3D className="h-full">

--- a/marketing/src/components/ModelManagerSection.tsx
+++ b/marketing/src/components/ModelManagerSection.tsx
@@ -31,7 +31,7 @@ export default function ModelManagerSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Hello <br />
@@ -44,7 +44,7 @@ export default function ModelManagerSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Search, download, and manage models straight from Hugging Face.
@@ -57,7 +57,7 @@ export default function ModelManagerSection() {
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl"
         >
           <Tilt3D>

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -93,12 +93,12 @@ export default function ModelSupportSection({
                         initial={{ opacity: 0, y: 20 }}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true }}
-                        transition={{ duration: 0.5 }}
+                        transition={{ duration: 0.25 }}
                         className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
                     >
-                        Every model.{" "}
+                        The newest models,{" "}
                         <span className="text-white">
-                            Your keys.
+                            the day they ship.
                         </span>
                     </motion.h2>
 
@@ -106,13 +106,12 @@ export default function ModelSupportSection({
                         initial={{ opacity: 0, y: 20 }}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true }}
-                        transition={{ duration: 0.5, delay: 0.1 }}
+                        transition={{ duration: 0.25, delay: 0.05 }}
                         className="text-lg text-slate-400 leading-relaxed"
                     >
-                        The newest models from every major provider, called
-                        with the keys you already pay for. Swap models the day
-                        they launch. Run them on your own machine when you
-                        want to.
+                        Frontier image, video, audio, and language models from
+                        every major provider — or running on your own machine
+                        when you want them local.
                     </motion.p>
                 </div>
 
@@ -131,6 +130,7 @@ export default function ModelSupportSection({
                             {[...frontierModels, ...frontierModels].map((model, idx) => (
                                 <span
                                     key={`${model.name}-${idx}`}
+                                    aria-hidden={idx >= frontierModels.length || undefined}
                                     className={`flex-shrink-0 mx-4 text-lg font-semibold whitespace-nowrap ${model.color}`}
                                 >
                                     {model.name}
@@ -155,6 +155,8 @@ export default function ModelSupportSection({
                             {[...cloudProviders, ...cloudProviders].map((provider, idx) => (
                                 <a
                                     key={`${provider.title}-${idx}`}
+                                    aria-hidden={idx >= cloudProviders.length || undefined}
+                                    tabIndex={idx >= cloudProviders.length ? -1 : undefined}
                                     href={provider.url}
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -187,6 +189,8 @@ export default function ModelSupportSection({
                             {[...localEngines, ...localEngines, ...localEngines, ...localEngines].map((engine, idx) => (
                                 <a
                                     key={`${engine.title}-${idx}`}
+                                    aria-hidden={idx >= localEngines.length || undefined}
+                                    tabIndex={idx >= localEngines.length ? -1 : undefined}
                                     href={engine.url}
                                     target="_blank"
                                     rel="noopener noreferrer"

--- a/marketing/src/components/MotionProvider.tsx
+++ b/marketing/src/components/MotionProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { MotionConfig } from "framer-motion";
+
+// Disables framer-motion animations for users with prefers-reduced-motion.
+export default function MotionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/marketing/src/components/NodeMenuSection.tsx
+++ b/marketing/src/components/NodeMenuSection.tsx
@@ -37,7 +37,7 @@ export default function NodeMenuSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             All the <br />
@@ -50,7 +50,7 @@ export default function NodeMenuSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Hundreds of nodes for models, data, and files — plus auto-generated nodes for every Replicate, FAL, and Kie.ai model.
@@ -62,7 +62,7 @@ export default function NodeMenuSection({
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl mb-20"
         >
           <Tilt3D>

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -34,10 +34,10 @@ export default function NodeToolHero() {
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            One canvas. Every major model from every major provider, called
-            with your own keys. Pay providers what they charge — no credits, no
-            markup, no locked-down model list. When the next model ships, swap one node
-            and you&apos;re on it the same day.
+            Make films, posters, product videos, and music on one node-based
+            canvas, with every major model from every major provider. Your own
+            keys, provider prices — and when the next model ships, you&apos;re
+            one node swap away.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -58,7 +58,7 @@ export default function NodeToolHero() {
           <ul className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-medium text-slate-300">
             <li className="flex items-center gap-1.5">
               <Layers className="h-3.5 w-3.5 text-fuchsia-400" />
-              Every model. Your keys. Your canvas.
+              Image, video, audio, and text
             </li>
             <li className="text-slate-700">•</li>
             <li className="flex items-center gap-1.5">

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -44,7 +44,7 @@ export default function OwnershipSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Your keys. Your files. <br />
@@ -54,7 +54,7 @@ export default function OwnershipSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Every closed AI tool ends the same way: a price hike, fewer
@@ -69,7 +69,7 @@ export default function OwnershipSection({
           className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4 rounded-2xl overflow-hidden bg-white/5 ring-1 ring-white/5"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.08 } },
           }}
@@ -79,7 +79,7 @@ export default function OwnershipSection({
               key={item.title}
               variants={{
                 hidden: { opacity: 0, y: 16 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
               className="h-full"
             >

--- a/marketing/src/components/ProvidersSection.tsx
+++ b/marketing/src/components/ProvidersSection.tsx
@@ -37,7 +37,7 @@ export default function ProvidersSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Use any provider <br />
@@ -50,7 +50,7 @@ export default function ProvidersSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Bring your own API keys — no markup, no middleman.
@@ -62,7 +62,7 @@ export default function ProvidersSection({
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.7, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           className="relative mx-auto max-w-5xl mb-20"
         >
           <Tilt3D>
@@ -85,7 +85,7 @@ export default function ProvidersSection({
           className="grid grid-cols-1 gap-6 md:grid-cols-3 mb-16"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.1 } },
           }}
@@ -120,7 +120,7 @@ export default function ProvidersSection({
               key={feature.title}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
               <Tilt3D className="h-full">

--- a/marketing/src/components/SiteHeader.tsx
+++ b/marketing/src/components/SiteHeader.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 import { track } from "../lib/analytics";
+import { useGithubStars, formatStars } from "../lib/useGithubStars";
 
 /**
  * Single shared site header used by every route (P3). Replaces the per-page
@@ -53,16 +54,7 @@ function Wordmark() {
 export default function SiteHeader() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [stars, setStars] = useState<number | null>(null);
-
-  useEffect(() => {
-    fetch(`https://api.github.com/repos/nodetool-ai/nodetool`)
-      .then((r) => r.json())
-      .then((j) => {
-        if (typeof j.stargazers_count === "number") setStars(j.stargazers_count);
-      })
-      .catch(() => {});
-  }, []);
+  const stars = useGithubStars();
 
   useEffect(() => {
     if (!mobileOpen) return;
@@ -144,7 +136,7 @@ export default function SiteHeader() {
                 <span>Star on GitHub</span>
                 {stars !== null && (
                   <span className="ml-1 rounded-md bg-slate-800 px-1.5 py-0.5 text-xs font-medium text-slate-300">
-                    {stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : stars}
+                    {formatStars(stars)}
                   </span>
                 )}
               </a>

--- a/marketing/src/components/SketchEditorSection.tsx
+++ b/marketing/src/components/SketchEditorSection.tsx
@@ -52,7 +52,7 @@ export default function SketchEditorSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Built-in <span className="text-white">sketch editor</span>
@@ -62,7 +62,7 @@ export default function SketchEditorSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
             A full layer-based image editor with generation built in. Paint with
@@ -76,7 +76,7 @@ export default function SketchEditorSection() {
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: 0.3 }}
           className="relative"
         >
           <div className="relative rounded-2xl border border-slate-700/60 bg-slate-900/80 overflow-hidden shadow-2xl shadow-violet-900/20 ring-1 ring-white/5 backdrop-blur-sm">

--- a/marketing/src/components/TimelineEditorSection.tsx
+++ b/marketing/src/components/TimelineEditorSection.tsx
@@ -52,7 +52,7 @@ export default function TimelineEditorSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Built-in <span className="text-white">video editor</span>
@@ -62,7 +62,7 @@ export default function TimelineEditorSection() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
             Generate AI video and audio straight onto a multi-track timeline.
@@ -75,7 +75,7 @@ export default function TimelineEditorSection() {
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: 0.3 }}
           className="relative"
         >
           <div className="relative rounded-2xl border border-slate-700/60 bg-slate-900/80 overflow-hidden shadow-2xl shadow-sky-900/20 ring-1 ring-white/5 backdrop-blur-sm">

--- a/marketing/src/components/UseCasesSection.tsx
+++ b/marketing/src/components/UseCasesSection.tsx
@@ -31,7 +31,7 @@ export default function UseCasesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             What people build
@@ -40,7 +40,7 @@ export default function UseCasesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Image, video, audio, text, agents, RAG — all on the same canvas. Wire the models you want, switch when better ones ship.
@@ -51,7 +51,7 @@ export default function UseCasesSection({
           className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.1 } },
           }}
@@ -61,7 +61,7 @@ export default function UseCasesSection({
               key={item.name}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
               <Tilt3D className="h-full">
@@ -107,7 +107,7 @@ export default function UseCasesSection({
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            transition={{ delay: 0.4 }}
+            transition={{ delay: 0.05 }}
             className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-white/5 border border-white/10 text-slate-300 hover:bg-white/10 hover:text-white transition-all hover:scale-105"
           >
             Explore all templates

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -54,7 +54,7 @@ export default function UseCasesShowcase() {
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
             From a brief to a finished asset
@@ -63,7 +63,7 @@ export default function UseCasesShowcase() {
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.05 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed"
           >
             Real workflows you can open, run, and rewire. Each one is complete,
@@ -81,8 +81,8 @@ export default function UseCasesShowcase() {
                 href={`/use-cases/${item.slug}`}
                 initial={{ opacity: 0, y: 24 }}
                 whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: "-80px" }}
-                transition={{ duration: 0.6 }}
+                viewport={{ once: true, margin: "-40px" }}
+                transition={{ duration: 0.3 }}
                 className="group relative grid items-center gap-8 rounded-3xl border border-white/10 bg-slate-900/40 p-6 backdrop-blur-sm transition-all duration-300 hover:border-white/20 hover:bg-slate-900/60 lg:grid-cols-2 lg:gap-12 lg:p-8"
               >
                 {/* Media */}

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -35,7 +35,7 @@ export default function VideoGenerationSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             AI Video <br />
@@ -48,7 +48,7 @@ export default function VideoGenerationSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
             Generate video from text or images with Google Veo, Kling, Hailuo,
@@ -59,7 +59,7 @@ export default function VideoGenerationSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-8"
           >
             <video

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -90,7 +90,7 @@ export default function AgentFeaturesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Built to{" "}
@@ -103,7 +103,7 @@ export default function AgentFeaturesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Agents are nodes on the same canvas as your image, video, and audio
@@ -117,7 +117,7 @@ export default function AgentFeaturesSection({
           className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.1 } },
           }}
@@ -127,7 +127,7 @@ export default function AgentFeaturesSection({
               key={feature.title}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
               <Tilt3D className="h-full">

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -103,7 +103,7 @@ export default function AgentIntegrationsSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Every tool in the{" "}
@@ -115,7 +115,7 @@ export default function AgentIntegrationsSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             The same models the studios use — wired into agents that know when to
@@ -129,7 +129,7 @@ export default function AgentIntegrationsSection({
           className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.1 } },
           }}
@@ -139,7 +139,7 @@ export default function AgentIntegrationsSection({
               key={category.category}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
               className="group relative rounded-2xl border border-white/5 bg-slate-900/40 backdrop-blur-sm p-6 transition-all duration-300 hover:bg-slate-900/60 hover:border-white/10"
             >
@@ -187,7 +187,7 @@ export default function AgentIntegrationsSection({
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5, delay: 0.3 }}
+          transition={{ duration: 0.25, delay: 0.08 }}
           className="mt-16 rounded-2xl border border-white/10 bg-gradient-to-r from-teal-900/20 via-slate-900/50 to-blue-900/20 p-8 md:p-12 text-center"
         >
           <h3 className="text-2xl md:text-3xl font-bold text-white mb-4">

--- a/marketing/src/components/agents/AgentUseCasesSection.tsx
+++ b/marketing/src/components/agents/AgentUseCasesSection.tsx
@@ -133,7 +133,7 @@ export default function AgentUseCasesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
             Agents your studio{" "}
@@ -145,7 +145,7 @@ export default function AgentUseCasesSection({
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
             Open one, swap in your style guide, point it at the providers you already pay
@@ -165,7 +165,7 @@ export default function AgentUseCasesSection({
           className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
           initial="hidden"
           whileInView="show"
-          viewport={{ once: true, margin: "-100px" }}
+          viewport={{ once: true, margin: "-40px" }}
           variants={{
             show: { transition: { staggerChildren: 0.08 } },
           }}
@@ -175,7 +175,7 @@ export default function AgentUseCasesSection({
               key={item.name}
               variants={{
                 hidden: { opacity: 0, y: 20 },
-                show: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+                show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
               <Tilt3D className="h-full">
@@ -216,7 +216,7 @@ export default function AgentUseCasesSection({
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
-          transition={{ delay: 0.4 }}
+          transition={{ delay: 0.05 }}
         >
           <a
             href="https://github.com/nodetool-ai/nodetool/tree/main/examples/workflows"

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -95,7 +95,7 @@ export default function AgentsGraphHero() {
                     <motion.div
                         initial={{ opacity: 0, y: 20 }}
                         animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.5 }}
+                        transition={{ duration: 0.25 }}
                     >
                         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-rose-500/10 border border-rose-500/20 mb-6">
                             <Sparkles className="w-4 h-4 text-rose-300" />
@@ -385,7 +385,7 @@ function Node({ data, index }: { data: NodeData, index: number }) {
         <motion.div
             initial={{ opacity: 0, scale: 0.8, z: 0 }}
             animate={{ opacity: 1, scale: 1, z: 20 }}
-            transition={{ delay: 0.2 + (index * 0.1), duration: 0.5 }}
+            transition={{ delay: 0.05 + (index * 0.05), duration: 0.25 }}
             style={{
                 left: `${data.x}%`,
                 top: `${data.y}%`,

--- a/marketing/src/components/developers/DeveloperCLISection.tsx
+++ b/marketing/src/components/developers/DeveloperCLISection.tsx
@@ -122,7 +122,7 @@ export default function DeveloperCLISection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1.5 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/20 mb-4"
           >
             <Terminal className="h-4 w-4" />
@@ -133,7 +133,7 @@ export default function DeveloperCLISection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
 Build, run, and extend from code
@@ -142,7 +142,7 @@ Build, run, and extend from code
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
             Declare graphs, write custom nodes, and run workflows from code.
@@ -156,7 +156,7 @@ Build, run, and extend from code
           initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mb-16 rounded-2xl bg-gradient-to-br from-teal-900/20 to-violet-900/20 p-8 ring-1 ring-teal-500/20"
         >
           <div className="flex items-center gap-3 mb-4">
@@ -180,7 +180,7 @@ Build, run, and extend from code
           initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mb-16 rounded-2xl bg-slate-800/40 p-8 ring-1 ring-slate-700/50"
         >
           <div className="flex items-center gap-3 mb-6">
@@ -196,7 +196,7 @@ Build, run, and extend from code
                 initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                transition={{ duration: 0.4, delay: idx * 0.1 }}
+                transition={{ duration: 0.4, delay: idx * 0.05 }}
                 className="rounded-xl bg-slate-900/60 p-5"
               >
                 <h4 className="font-semibold text-white mb-1">{cmd.title}</h4>
@@ -215,7 +215,7 @@ Build, run, and extend from code
               initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: idx * 0.15 }}
+              transition={{ duration: 0.25, delay: idx * 0.08 }}
               className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50"
             >
               <div className="flex items-center gap-3 mb-4">
@@ -237,7 +237,7 @@ Build, run, and extend from code
           initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mt-12 text-center rounded-2xl bg-gradient-to-br from-violet-900/20 to-teal-900/20 p-8 ring-1 ring-violet-500/20"
         >
           <Workflow className="h-12 w-12 text-violet-400 mx-auto mb-4" />

--- a/marketing/src/components/developers/DeveloperCoreSection.tsx
+++ b/marketing/src/components/developers/DeveloperCoreSection.tsx
@@ -119,7 +119,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-4 py-1.5 text-sm font-medium text-blue-300 ring-1 ring-inset ring-blue-500/20 mb-4"
           >
             <Code2 className="h-4 w-4" />
@@ -130,7 +130,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
             Open source, end to end
@@ -139,7 +139,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
             Workflows run on an async Node.js runtime. Embed NodeTool as a library, drive it from
@@ -149,7 +149,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.3 }}
+            transition={{ duration: 0.25, delay: 0.08 }}
             className="mt-4 flex flex-wrap justify-center gap-2"
           >
             <Image
@@ -208,7 +208,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, x: -30 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50"
           >
             <div className="flex items-center gap-3 mb-4">
@@ -239,7 +239,7 @@ export default function DeveloperCoreSection({
             initial={reducedMotion ? {} : { opacity: 0, x: 30 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50"
           >
             <div className="flex items-center gap-3 mb-4">
@@ -265,7 +265,7 @@ export default function DeveloperCoreSection({
           initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mt-8 rounded-2xl bg-gradient-to-br from-teal-900/20 to-purple-900/20 p-8 ring-1 ring-teal-500/20"
         >
           <div className="flex items-center gap-3 mb-6">
@@ -284,7 +284,7 @@ export default function DeveloperCoreSection({
                 initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                transition={{ duration: 0.3, delay: idx * 0.1 }}
+                transition={{ duration: 0.3, delay: idx * 0.05 }}
                 className="rounded-xl bg-slate-800/40 p-5 ring-1 ring-slate-700/50"
               >
                 <h4 className="font-semibold text-white mb-2">{point.title}</h4>
@@ -299,7 +299,7 @@ export default function DeveloperCoreSection({
           initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
         >
           <a

--- a/marketing/src/components/developers/DeveloperFeaturesSection.tsx
+++ b/marketing/src/components/developers/DeveloperFeaturesSection.tsx
@@ -82,7 +82,7 @@ export default function DeveloperFeaturesSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="inline-flex items-center gap-2 rounded-full bg-violet-500/10 px-4 py-1.5 text-sm font-medium text-violet-300 ring-1 ring-inset ring-violet-500/20 mb-4"
           >
             From the canvas to your code
@@ -92,7 +92,7 @@ export default function DeveloperFeaturesSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
             Drive the workspace from code
@@ -101,7 +101,7 @@ export default function DeveloperFeaturesSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
             The same workflows you build on the canvas, callable from a TypeScript SDK and CLI.
@@ -118,7 +118,7 @@ export default function DeveloperFeaturesSection({
               initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: idx * 0.1 }}
+              transition={{ duration: 0.25, delay: idx * 0.05 }}
               className={`group relative rounded-2xl ${feature.bgColor} border ${feature.borderColor} p-6 sm:p-8 backdrop-blur-sm`}
             >
               <div className="grid gap-6 md:grid-cols-5 md:gap-8 items-start">

--- a/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
+++ b/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
@@ -72,7 +72,7 @@ export default function DeveloperIntegrationsSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
+            transition={{ duration: 0.25 }}
             className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1.5 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/20 mb-4"
           >
             Integrations
@@ -82,7 +82,7 @@ export default function DeveloperIntegrationsSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
             Every model. Your keys.
@@ -91,7 +91,7 @@ export default function DeveloperIntegrationsSection({
             initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto"
           >
             340+ built-in nodes covering every major provider and media type. Bring your own keys across the board.
@@ -129,7 +129,7 @@ export default function DeveloperIntegrationsSection({
               initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: idx * 0.1 }}
+              transition={{ duration: 0.25, delay: idx * 0.05 }}
               className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50"
             >
               <div className="flex items-center gap-3 mb-4">
@@ -156,7 +156,7 @@ export default function DeveloperIntegrationsSection({
           initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mt-16 text-center rounded-2xl bg-gradient-to-br from-violet-900/20 to-teal-900/20 p-10 ring-1 ring-violet-500/20"
         >
           <h3 className="text-2xl font-bold text-white mb-4">

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -12,7 +12,7 @@ export default function DevelopersHero() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.25 }}
           className="mb-6"
         >
           <span className="inline-flex items-center gap-2 rounded-full bg-violet-500/10 px-4 py-1.5 text-sm font-medium text-violet-300 ring-1 ring-inset ring-violet-500/20">
@@ -26,7 +26,7 @@ export default function DevelopersHero() {
           id="hero-title"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.1 }}
+          transition={{ duration: 0.25, delay: 0.05 }}
           className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
         >
           <span className="text-white">Extend the </span>
@@ -39,7 +39,7 @@ export default function DevelopersHero() {
         <motion.p
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.2 }}
+          transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
           TypeScript-first, async Node.js under the hood, the same open-source
@@ -52,7 +52,7 @@ export default function DevelopersHero() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.3 }}
+          transition={{ duration: 0.25, delay: 0.08 }}
           className="mt-8 flex flex-wrap justify-center gap-3"
         >
           {[
@@ -75,7 +75,7 @@ export default function DevelopersHero() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.4 }}
+          transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
         >
           <a

--- a/marketing/src/data/competitorEntries.ts
+++ b/marketing/src/data/competitorEntries.ts
@@ -129,6 +129,8 @@ export type Competitor = {
 
   /** First-wave addition (drives footer curation and index gating). */
   isNew?: boolean;
+  /** Footer link label override, e.g. to note a product rename. */
+  footerName?: string;
 };
 
 export const competitors: Competitor[] = [
@@ -209,6 +211,7 @@ export const competitors: Competitor[] = [
   {
     slug: "weavy",
     name: "Weavy",
+    footerName: "Weavy (Figma Weave)",
     theme: "blue",
     category: "Creative canvas",
     vsTitle: "NodeTool vs Weavy (now Figma Weave) — open source, BYOK, no credits",
@@ -1162,4 +1165,4 @@ export const competitorEntries: PageEntry[] = [
  */
 export const footerCompareLinks: { name: string; href: string }[] = competitors
   .filter((c) => !c.isNew)
-  .map((c) => ({ name: `vs ${c.name}`, href: `/vs/${c.slug}` }));
+  .map((c) => ({ name: `vs ${c.footerName ?? c.name}`, href: `/vs/${c.slug}` }));

--- a/marketing/src/lib/useGithubStars.ts
+++ b/marketing/src/lib/useGithubStars.ts
@@ -1,0 +1,72 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const REPO_API = "https://api.github.com/repos/nodetool-ai/nodetool";
+const CACHE_KEY = "nt-gh-stars";
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+let inflight: Promise<number | null> | null = null;
+
+function readCache(): number | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const { count, ts } = JSON.parse(raw) as { count: number; ts: number };
+    if (typeof count !== "number" || Date.now() - ts > CACHE_TTL_MS)
+      return null;
+    return count;
+  } catch {
+    return null;
+  }
+}
+
+function fetchStars(): Promise<number | null> {
+  if (!inflight) {
+    inflight = fetch(REPO_API)
+      .then((r) => r.json())
+      .then((j) => {
+        if (typeof j.stargazers_count !== "number") return null;
+        try {
+          sessionStorage.setItem(
+            CACHE_KEY,
+            JSON.stringify({ count: j.stargazers_count, ts: Date.now() })
+          );
+        } catch {
+          // sessionStorage unavailable (private mode) — count still returned
+        }
+        return j.stargazers_count as number;
+      })
+      .catch(() => null);
+  }
+  return inflight;
+}
+
+/**
+ * GitHub star count for the NodeTool repo, deduped across components
+ * (one request per page view) and cached per session.
+ */
+export function useGithubStars(): number | null {
+  const [stars, setStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    const cached = readCache();
+    if (cached !== null) {
+      setStars(cached);
+      return;
+    }
+    let alive = true;
+    fetchStars().then((n) => {
+      if (alive && n !== null) setStars(n);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return stars;
+}
+
+/** Compact "12.3k" formatting used by the star badges. */
+export function formatStars(stars: number): string {
+  return stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : String(stars);
+}


### PR DESCRIPTION
Fixes from a landing-page review pass:

- Halve scroll-reveal timings everywhere: framer whileInView durations
  (0.5-0.8s -> 0.25-0.35s), stagger delays, section fly-in (600ms ->
  300ms with tighter stagger), hero rise, and reveal viewport margins,
  so content is readable at normal scroll speed instead of mid-fade.
- Honor prefers-reduced-motion globally via MotionConfig in the layout.
- Dedupe the GitHub star fetch into a shared useGithubStars hook
  (one request per view, session-cached) used by header and homepage.
- Hero subhead now leads with what you make; the repeated
  "Every model. Your keys." tagline keeps one home (ComparisonSection)
  and the ModelSupport heading gets its own message.
- Caption the demo video so visitors know NodeTool produced it.
- Add a "Try NodeTool Cloud" CTA to the closing block.
- Footer compare link now reads "vs Weavy (Figma Weave)" to match the
  homepage naming.
- Screen readers skip duplicated marquee items (aria-hidden + tabIndex).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YCDrZRA53HwdUJneif6iMN