### PR TITLE
Fix MiniMax video request params: S2V-01 payload, model knobs, poll errors

### DIFF
--- a/packages/minimax-nodes/src/minimax-base.ts
+++ b/packages/minimax-nodes/src/minimax-base.ts
@@ -251,7 +251,6 @@ export const MINIMAX_IMAGE_ASPECTS: string[] = [
 
 export const MINIMAX_T2V_MODELS: string[] = [
   "MiniMax-Hailuo-2.3",
-  "MiniMax-Hailuo-2.3-Fast",
   "MiniMax-Hailuo-02",
   "T2V-01-Director"
 ];
@@ -266,6 +265,27 @@ export const MINIMAX_I2V_MODELS: string[] = [
 
 export const MINIMAX_VIDEO_RESOLUTIONS: string[] = ["512P", "768P", "1080P"];
 export const MINIMAX_VIDEO_DURATIONS: number[] = [6, 10];
+
+/**
+ * Sanitize duration/resolution for a video request. They are Hailuo-only
+ * knobs — the 01-series models (T2V-01-Director, I2V-01-Director, S2V-01)
+ * are fixed at 6s/720P and reject both parameters. Within the Hailuo family,
+ * 512P exists only on Hailuo-02 and 10s clips render only at 768P; invalid
+ * combinations fall back to 768P (the API default) so MiniMax doesn't reject
+ * the request.
+ */
+export function videoRenderSettings(
+  model: string,
+  duration: number,
+  resolution: string
+): { duration?: number; resolution?: string } {
+  if (!model.startsWith("MiniMax-Hailuo")) return {};
+  const d = duration >= 9 ? 10 : 6;
+  let r = resolution;
+  if (r === "512P" && model !== "MiniMax-Hailuo-02") r = "768P";
+  if (r === "1080P" && d === 10) r = "768P";
+  return { duration: d, resolution: r };
+}
 
 // ---------------------------------------------------------------------------
 // Async video generation (submit → poll → download)
@@ -328,6 +348,9 @@ async function pollVideoTask(
       );
     }
     const data = (await res.json()) as Record<string, unknown>;
+    // Surface API-level failures (expired task, auth, rate limit) instead of
+    // polling an empty status until the timeout.
+    assertBaseResp(data, "video status");
     const status = String(data.status ?? "").toLowerCase();
     if (status === "success") {
       const fileId = data.file_id as string | undefined;

--- a/packages/minimax-nodes/src/nodes/image-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/image-to-video.ts
@@ -10,7 +10,8 @@ import {
   MINIMAX_I2V_MODELS,
   MINIMAX_VIDEO_DURATIONS,
   MINIMAX_VIDEO_RESOLUTIONS,
-  videoRefFromBytes
+  videoRefFromBytes,
+  videoRenderSettings
 } from "../minimax-base.js";
 
 export class MinimaxImageToVideoNode extends BaseNode {
@@ -19,7 +20,8 @@ export class MinimaxImageToVideoNode extends BaseNode {
   static readonly title = "MiniMax Image to Video";
   static readonly description =
     "Animate a still image into a video using MiniMax Hailuo and Director " +
-    "models. The image becomes the first frame.\n" +
+    "models. The image becomes the first frame (or the character reference " +
+    "for S2V-01).\n" +
     "video, generation, image-to-video, i2v, hailuo, minimax\n\n" +
     "Use cases:\n" +
     "- Bring a photo or render to life\n" +
@@ -44,7 +46,9 @@ export class MinimaxImageToVideoNode extends BaseNode {
     type: "image",
     default: { type: "image", uri: "", asset_id: null, data: null },
     title: "Image",
-    description: "The image to use as the first frame of the video."
+    description:
+      "The image to use as the first frame of the video (S2V-01 uses it as " +
+      "a character reference instead)."
   })
   declare image: any;
 
@@ -85,12 +89,23 @@ export class MinimaxImageToVideoNode extends BaseNode {
     }
     const mime = inferImageMime(imageBytes);
 
+    const model = String(this.model ?? "MiniMax-Hailuo-02");
+    const dataUrl = `data:${mime};base64,${bytesToBase64(imageBytes)}`;
     const body: Record<string, unknown> = {
-      model: String(this.model ?? "MiniMax-Hailuo-02"),
-      first_frame_image: `data:${mime};base64,${bytesToBase64(imageBytes)}`,
-      duration: Number(this.duration ?? 6),
-      resolution: String(this.resolution ?? "768P")
+      model,
+      ...videoRenderSettings(
+        model,
+        Number(this.duration ?? 6),
+        String(this.resolution ?? "768P")
+      )
     };
+    if (model === "S2V-01") {
+      // S2V-01 animates a character reference, not a first frame, and
+      // rejects first_frame_image.
+      body.subject_reference = [{ type: "character", image: [dataUrl] }];
+    } else {
+      body.first_frame_image = dataUrl;
+    }
     const prompt = String(this.prompt ?? "");
     if (prompt) body.prompt = prompt;
 

--- a/packages/minimax-nodes/src/nodes/text-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-video.ts
@@ -6,7 +6,8 @@ import {
   MINIMAX_T2V_MODELS,
   MINIMAX_VIDEO_DURATIONS,
   MINIMAX_VIDEO_RESOLUTIONS,
-  videoRefFromBytes
+  videoRefFromBytes,
+  videoRenderSettings
 } from "../minimax-base.js";
 
 export class MinimaxTextToVideoNode extends BaseNode {
@@ -70,11 +71,15 @@ export class MinimaxTextToVideoNode extends BaseNode {
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt is required");
 
+    const model = String(this.model ?? "MiniMax-Hailuo-02");
     const body: Record<string, unknown> = {
-      model: String(this.model ?? "MiniMax-Hailuo-02"),
+      model,
       prompt,
-      duration: Number(this.duration ?? 6),
-      resolution: String(this.resolution ?? "768P")
+      ...videoRenderSettings(
+        model,
+        Number(this.duration ?? 6),
+        String(this.resolution ?? "768P")
+      )
     };
 
     const bytes = await generateVideo(apiKey, body);

--- a/packages/minimax-nodes/tests/video.test.ts
+++ b/packages/minimax-nodes/tests/video.test.ts
@@ -70,6 +70,57 @@ describe("MinimaxTextToVideoNode", () => {
     expect(result.output).toMatchObject({ type: "video", data: videoB64 });
   });
 
+  it("omits duration/resolution for the 01-series Director model", async () => {
+    queueVideoSuccess();
+    const node = new MinimaxTextToVideoNode({
+      model: "T2V-01-Director",
+      prompt: "[Pan left] a beach",
+      duration: 10,
+      resolution: "1080P"
+    });
+    await node.process();
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as RequestInit).body as string
+    ) as Record<string, unknown>;
+    // T2V-01-Director is fixed at 6s/720P; the API rejects the parameters.
+    expect(body.duration).toBeUndefined();
+    expect(body.resolution).toBeUndefined();
+  });
+
+  it("clamps invalid Hailuo duration/resolution combos to 768P", async () => {
+    queueVideoSuccess();
+    const node = new MinimaxTextToVideoNode({
+      model: "MiniMax-Hailuo-2.3",
+      prompt: "a beach",
+      duration: 10,
+      resolution: "1080P"
+    });
+    await node.process();
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as RequestInit).body as string
+    ) as Record<string, unknown>;
+    expect(body.duration).toBe(10);
+    expect(body.resolution).toBe("768P");
+  });
+
+  it("aborts polling when the status query reports a base_resp error", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ task_id: "task-1", base_resp: { status_code: 0 } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          base_resp: { status_code: 1004, status_msg: "auth failed" }
+        })
+      });
+    await expect(
+      new MinimaxTextToVideoNode({ prompt: "x" }).process()
+    ).rejects.toThrow(/auth failed/);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("requires a prompt", async () => {
     await expect(
       new MinimaxTextToVideoNode({ prompt: "" }).process()
@@ -116,6 +167,30 @@ describe("MinimaxImageToVideoNode", () => {
     expect(String(body.first_frame_image)).toContain("base64,");
     expect(body.prompt).toBe("[Push in] zoom");
     expect(result.output).toMatchObject({ type: "video", data: videoB64 });
+  });
+
+  it("sends a subject_reference instead of first_frame_image for S2V-01", async () => {
+    queueVideoSuccess();
+    const imageB64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    const node = new MinimaxImageToVideoNode({
+      model: "S2V-01",
+      image: { type: "image", data: imageB64 },
+      prompt: "wave",
+      duration: 10,
+      resolution: "1080P"
+    });
+    await node.process();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as RequestInit).body as string
+    ) as Record<string, unknown>;
+    expect(body.first_frame_image).toBeUndefined();
+    expect(body.duration).toBeUndefined();
+    expect(body.resolution).toBeUndefined();
+    const ref = body.subject_reference as Array<Record<string, unknown>>;
+    expect(ref).toHaveLength(1);
+    expect(ref[0].type).toBe("character");
+    expect(String((ref[0].image as string[])[0])).toContain("base64,");
   });
 
   it("throws when no input image is provided", async () => {

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -254,7 +254,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
         id: "MiniMax-Hailuo-2.3-Fast",
         name: "MiniMax Hailuo 2.3 Fast",
         provider: "minimax",
-        supportedTasks: both
+        supportedTasks: ["image_to_video"]
       },
       {
         id: "MiniMax-Hailuo-02",
@@ -481,10 +481,16 @@ export class MinimaxProvider extends OpenAICompatProvider {
       ? `${params.prompt.trim()}\n\nDo not include: ${params.negativePrompt.trim()}`
       : params.prompt;
 
+    if (numImages > 9) {
+      throw new Error(
+        `MiniMax image_generation supports at most 9 images per request (got ${numImages})`
+      );
+    }
+
     const body: Record<string, unknown> = {
       model: params.model.id || "image-01",
       prompt,
-      n: Math.max(1, Math.min(9, numImages)),
+      n: Math.max(1, numImages),
       response_format: "base64",
       prompt_optimizer: true
     };
@@ -585,17 +591,49 @@ export class MinimaxProvider extends OpenAICompatProvider {
   ): Promise<Uint8Array> {
     const body: Record<string, unknown> = { model: modelId };
     if (opts.prompt) body.prompt = opts.prompt;
-    if (opts.durationSeconds) {
-      body.duration = opts.durationSeconds >= 9 ? 10 : 6;
+
+    // duration/resolution are Hailuo-only knobs; the 01-series models
+    // (T2V-01-Director, I2V-01-Director, S2V-01) are fixed at 6s/720P and
+    // reject the parameters outright.
+    const isHailuo = modelId.startsWith("MiniMax-Hailuo");
+    if (isHailuo) {
+      let duration: number | null = null;
+      if (opts.durationSeconds) {
+        // Hailuo models only render 6s or 10s clips.
+        duration = opts.durationSeconds >= 9 ? 10 : 6;
+        body.duration = duration;
+      }
+      if (opts.resolution) {
+        const r = opts.resolution.toLowerCase();
+        let resolution: string | null = null;
+        if (r.includes("1080")) resolution = "1080P";
+        else if (r.includes("768") || r.includes("720")) resolution = "768P";
+        else if (r.includes("512")) resolution = "512P";
+        // 512P only exists on Hailuo-02; 1080P only renders 6s clips. Keep the
+        // requested duration and fall back to 768P (the API default) rather
+        // than letting MiniMax reject the combination.
+        if (resolution === "512P" && modelId !== "MiniMax-Hailuo-02") {
+          resolution = "768P";
+        }
+        if (resolution === "1080P" && duration === 10) {
+          log.warn(
+            "MiniMax Hailuo renders 10s clips only at 768P; downgrading from 1080P"
+          );
+          resolution = "768P";
+        }
+        if (resolution) body.resolution = resolution;
+      }
     }
-    if (opts.resolution) {
-      const r = opts.resolution.toLowerCase();
-      if (r.includes("1080")) body.resolution = "1080P";
-      else if (r.includes("768") || r.includes("720")) body.resolution = "768P";
-      else if (r.includes("512")) body.resolution = "512P";
-    }
+
     if (opts.firstFrame) {
-      body.first_frame_image = `data:image/png;base64,${b64(opts.firstFrame)}`;
+      const dataUrl = `data:image/png;base64,${b64(opts.firstFrame)}`;
+      if (modelId === "S2V-01") {
+        // S2V-01 animates a character reference, not a first frame, and
+        // rejects first_frame_image.
+        body.subject_reference = [{ type: "character", image: [dataUrl] }];
+      } else {
+        body.first_frame_image = dataUrl;
+      }
     }
 
     log.debug("MiniMax textToVideo submit", { model: modelId });
@@ -643,6 +681,9 @@ export class MinimaxProvider extends OpenAICompatProvider {
         );
       }
       const data = (await res.json()) as Record<string, unknown>;
+      // Surface API-level failures (expired task, auth, rate limit) instead of
+      // polling an empty status until the timeout.
+      assertBaseResp(data, "video status");
       const status = String(data.status ?? "").toLowerCase();
       if (status === "success") {
         const fileId = data.file_id as string | undefined;

--- a/packages/runtime/tests/providers/minimax-provider.test.ts
+++ b/packages/runtime/tests/providers/minimax-provider.test.ts
@@ -235,6 +235,197 @@ describe("MinimaxProvider", () => {
     expect(urls[4]).toBe("https://cdn.minimax.io/video.mp4");
   });
 
+  it("rejects image requests for more than 9 images", async () => {
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any, fetchFn: vi.fn() as any }
+    );
+    const model: ImageModel = {
+      id: "image-01",
+      name: "image-01",
+      provider: "minimax"
+    };
+    await expect(
+      provider.textToImages({ model, prompt: "cat" }, 10)
+    ).rejects.toThrow(/at most 9 images/);
+  });
+
+  it("marks Hailuo 2.3 Fast as image-to-video only", async () => {
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any }
+    );
+    const models = await provider.getAvailableVideoModels();
+    const fast = models.find((m) => m.id === "MiniMax-Hailuo-2.3-Fast");
+    expect(fast?.supportedTasks).toEqual(["image_to_video"]);
+  });
+
+  it("sends a subject_reference instead of first_frame_image for S2V-01", async () => {
+    const responses: Array<() => Promise<any>> = [
+      async () => ({
+        ok: true,
+        json: async () => ({ task_id: "t", base_resp: { status_code: 0 } })
+      }),
+      async () => ({
+        ok: true,
+        json: async () => ({ status: "Success", file_id: "f" })
+      }),
+      async () => ({
+        ok: true,
+        json: async () => ({
+          file: { download_url: "https://cdn.minimax.io/v.mp4" },
+          base_resp: { status_code: 0 }
+        })
+      }),
+      async () => ({
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => new Uint8Array([1]).buffer
+      })
+    ];
+    const mockFetch = vi.fn(async () => {
+      const next = responses.shift();
+      if (!next) throw new Error("unexpected fetch call");
+      return next();
+    });
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+    const model: VideoModel = {
+      id: "S2V-01",
+      name: "Subject",
+      provider: "minimax"
+    };
+    await provider.imageToVideo([new Uint8Array([1, 2, 3])], {
+      model,
+      prompt: "wave",
+      durationSeconds: 10,
+      resolution: "1080p"
+    });
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as { body: string }).body
+    );
+    expect(body.first_frame_image).toBeUndefined();
+    // S2V-01 is fixed at 6s/720P; the API rejects these parameters.
+    expect(body.duration).toBeUndefined();
+    expect(body.resolution).toBeUndefined();
+    expect(body.subject_reference).toEqual([
+      {
+        type: "character",
+        image: [expect.stringContaining("data:image/png;base64,")]
+      }
+    ]);
+  });
+
+  it("omits duration/resolution for 01-series models and clamps Hailuo combos", async () => {
+    const submitBodies: Array<Record<string, unknown>> = [];
+    const mockFetch = vi.fn(async (url: string, init?: { body?: string }) => {
+      if (url.endsWith("/v1/video_generation")) {
+        submitBodies.push(JSON.parse(init!.body!));
+        return {
+          ok: true,
+          json: async () => ({ task_id: "t", base_resp: { status_code: 0 } })
+        };
+      }
+      if (url.includes("/v1/query/")) {
+        return {
+          ok: true,
+          json: async () => ({ status: "Success", file_id: "f" })
+        };
+      }
+      if (url.includes("/v1/files/retrieve")) {
+        return {
+          ok: true,
+          json: async () => ({
+            file: { download_url: "https://cdn.minimax.io/v.mp4" },
+            base_resp: { status_code: 0 }
+          })
+        };
+      }
+      return {
+        ok: true,
+        headers: { get: () => null },
+        arrayBuffer: async () => new Uint8Array([1]).buffer
+      };
+    });
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const director: VideoModel = {
+      id: "T2V-01-Director",
+      name: "Director",
+      provider: "minimax"
+    };
+    await provider.textToVideo({
+      model: director,
+      prompt: "x",
+      durationSeconds: 10,
+      resolution: "1080p"
+    });
+    expect(submitBodies[0].duration).toBeUndefined();
+    expect(submitBodies[0].resolution).toBeUndefined();
+
+    const hailuo23: VideoModel = {
+      id: "MiniMax-Hailuo-2.3",
+      name: "Hailuo 2.3",
+      provider: "minimax"
+    };
+    // 10s clips only render at 768P → 1080P downgrades.
+    await provider.textToVideo({
+      model: hailuo23,
+      prompt: "x",
+      durationSeconds: 10,
+      resolution: "1080p"
+    });
+    expect(submitBodies[1].duration).toBe(10);
+    expect(submitBodies[1].resolution).toBe("768P");
+
+    // 512P only exists on Hailuo-02 → falls back to 768P on 2.3.
+    await provider.textToVideo({
+      model: hailuo23,
+      prompt: "x",
+      durationSeconds: 6,
+      resolution: "512p"
+    });
+    expect(submitBodies[2].resolution).toBe("768P");
+  });
+
+  it("aborts polling when the status query reports a base_resp error", async () => {
+    const responses: Array<() => Promise<any>> = [
+      async () => ({
+        ok: true,
+        json: async () => ({ task_id: "t", base_resp: { status_code: 0 } })
+      }),
+      async () => ({
+        ok: true,
+        json: async () => ({
+          base_resp: { status_code: 1004, status_msg: "auth failed" }
+        })
+      })
+    ];
+    const mockFetch = vi.fn(async () => {
+      const next = responses.shift();
+      if (!next) throw new Error("unexpected fetch call");
+      return next();
+    });
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+    const model: VideoModel = {
+      id: "MiniMax-Hailuo-02",
+      name: "Hailuo 02",
+      provider: "minimax"
+    };
+    await expect(
+      provider.textToVideo({ model, prompt: "x" })
+    ).rejects.toThrow(/auth failed/);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("encodes MP3 audio via the t2a_v2 endpoint", async () => {
     const audioHex = "01020304";
     const mockFetch = vi.fn().mockResolvedValueOnce({


### PR DESCRIPTION
Verified against the current MiniMax API reference
(platform.minimax.io/docs/api-reference):

- Send S2V-01 the subject_reference parameter ({type: "character",
  image: [<data-url>]}) instead of first_frame_image, which that model
  rejects. Applies to both the runtime provider and the ImageToVideo node.
- Only send duration/resolution to Hailuo models; the 01-series models
  (T2V-01-Director, I2V-01-Director, S2V-01) are fixed at 6s/720P and
  reject both parameters.
- Clamp invalid Hailuo combinations client-side: 10s clips only render
  at 768P (1080P downgrades), and 512P exists only on Hailuo-02.
- Mark MiniMax-Hailuo-2.3-Fast as image-to-video only; the text-to-video
  endpoint does not accept it. Removed from the T2V node's model list too.
- Check base_resp on the video status poll so API-level failures (expired
  task, auth, rate limit) abort immediately instead of polling an empty
  status for 30 minutes until timeout.
- Reject textToImages requests for more than the 9 images MiniMax allows
  per call, instead of silently returning fewer images than asked.

Co-Authored-By: Claude <noreply@anthropic.com>