### PR TITLE
Landing page fixes: remove flickering fade-ins, tighter copy, Cloud CTA

### DIFF
--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -115,7 +115,7 @@ export default function CreativesPage() {
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <div className="mx-auto max-w-5xl text-center">
               <motion.div
-                initial={{ opacity: 0, y: 20 }}
+                initial={false}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6 }}
               >
@@ -184,7 +184,7 @@ export default function CreativesPage() {
 
             {/* Hero Visual */}
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
               className="mt-20 relative"
@@ -217,7 +217,7 @@ export default function CreativesPage() {
         <section className="py-20 relative">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-12 max-w-3xl mx-auto"
@@ -236,7 +236,7 @@ export default function CreativesPage() {
             </motion.div>
 
             <motion.figure
-              initial={{ opacity: 0, y: 30 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
@@ -277,7 +277,7 @@ export default function CreativesPage() {
               ].map((highlight, index) => (
                 <motion.div
                   key={highlight.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.1 }}
@@ -302,7 +302,7 @@ export default function CreativesPage() {
         <section className="py-20 relative">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-12 max-w-3xl mx-auto"
@@ -322,7 +322,7 @@ export default function CreativesPage() {
             </motion.div>
 
             <motion.figure
-              initial={{ opacity: 0, y: 30 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
@@ -363,7 +363,7 @@ export default function CreativesPage() {
               ].map((highlight, index) => (
                 <motion.div
                   key={highlight.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.1 }}
@@ -390,7 +390,7 @@ export default function CreativesPage() {
 
           <div className="mx-auto max-w-7xl px-6 lg:px-8 relative z-10">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-16"
@@ -415,7 +415,7 @@ export default function CreativesPage() {
               {creativeFeatures.map((feature, index) => (
                 <motion.div
                   key={feature.title}
-                  initial={{ opacity: 0, y: 40 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-100px" }}
                   transition={{ duration: 0.6 }}
@@ -484,7 +484,7 @@ export default function CreativesPage() {
 
           <div className="mx-auto max-w-7xl px-6 lg:px-8 relative z-10">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-16"
@@ -529,7 +529,7 @@ export default function CreativesPage() {
               ].map((benefit, index) => (
                 <motion.div
                   key={benefit.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.1 }}
@@ -559,7 +559,7 @@ export default function CreativesPage() {
         <section className="py-24 relative">
           <div className="mx-auto max-w-4xl px-6 lg:px-8 text-center">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
             >

--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -280,25 +280,6 @@
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
   }
-  /* Fly-in reveal controlled by IntersectionObserver */
-  .fly-in {
-    opacity: 0;
-    transform: translateY(16px);
-    transition: transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1),
-      opacity 300ms ease;
-    transition-delay: var(--fly-delay, 0ms);
-    will-change: transform, opacity;
-  }
-  .fly-in[data-fly-direction="left"] {
-    transform: translateX(-20px);
-  }
-  .fly-in[data-fly-direction="right"] {
-    transform: translateX(20px);
-  }
-  .fly-in.is-visible {
-    opacity: 1;
-    transform: none;
-  }
   /* Tone down images inside cards */
   .card img,
   .card picture img {
@@ -438,35 +419,12 @@
 }
 
 /*
- * Hero entrance — pure CSS so it plays at first paint instead of waiting for
- * JS hydration. Framer-motion's `initial={{opacity:0}}` server-renders the LCP
- * image as opacity:0, which pushed LCP out to ~4s (it only cleared after the
- * bundle hydrated). A CSS animation reaches the visible state without JS.
+ * Hero entrance animations retired — content renders in place at first paint.
+ * The .hero-rise classes stay as no-ops so section markup doesn't churn.
  */
-@keyframes heroRise {
-  from {
-    opacity: 0;
-    transform: translateY(16px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.hero-rise {
-  animation: heroRise 350ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
-}
-
+.hero-rise,
 .hero-rise-delayed {
-  animation: heroRise 400ms cubic-bezier(0.2, 0.8, 0.2, 1) 80ms both;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero-rise,
-  .hero-rise-delayed {
-    animation: none;
-  }
+  animation: none;
 }
 
 /* Legal pages (Privacy / Terms) — minimal long-form prose styling */

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -118,7 +118,7 @@ export default function MarketingSegmentPage() {
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <div className="mx-auto max-w-5xl text-center">
               <motion.div
-                initial={{ opacity: 0, y: 20 }}
+                initial={false}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6 }}
               >
@@ -186,7 +186,7 @@ export default function MarketingSegmentPage() {
         <section className="py-20 relative">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-16 max-w-3xl mx-auto"
@@ -209,7 +209,7 @@ export default function MarketingSegmentPage() {
               {marketingBenefits.map((benefit, index) => (
                 <motion.div
                   key={benefit.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.1 }}
@@ -234,7 +234,7 @@ export default function MarketingSegmentPage() {
         <section id="product-video" className="relative scroll-mt-28 py-20">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-100px" }}
               transition={{ duration: 0.6 }}
@@ -305,7 +305,7 @@ export default function MarketingSegmentPage() {
         <section className="py-20 relative">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="text-center mb-12 max-w-2xl mx-auto"
@@ -323,7 +323,7 @@ export default function MarketingSegmentPage() {
               {upcomingWorkflows.map((wf, index) => (
                 <motion.div
                   key={wf.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.08 }}
@@ -353,7 +353,7 @@ export default function MarketingSegmentPage() {
         <section className="py-24 relative">
           <div className="mx-auto max-w-4xl px-6 lg:px-8 text-center">
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
             >

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -118,68 +118,11 @@ function usePrefersReducedMotion() {
   return reduced;
 }
 
-// Legacy reveal hook for backward compatibility
-function useReveal() {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    el.style.opacity = "0";
-    el.style.transform = "translateY(8px)";
-    el.style.willChange = "transform, opacity";
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            el.style.transition = "opacity 300ms ease, transform 300ms ease";
-            el.style.opacity = "1";
-            el.style.transform = "translateY(0)";
-            obs.disconnect();
-          }
-        });
-      },
-      { threshold: 0.15 }
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-  return ref;
-}
-
 export default function Home() {
   const [selectedFeature, setSelectedFeature] = useState<Feature | null>(null);
   const stars = useGithubStars();
   const parallaxRef = useRef<HTMLDivElement>(null);
   const reducedMotion = usePrefersReducedMotion();
-  const heroRevealRef = useReveal();
-
-  // Global section fly-in using IntersectionObserver + CSS transitions
-  useEffect(() => {
-    if (reducedMotion) return;
-    const root = document.getElementById("content");
-    if (!root) return;
-    const sections = Array.from(root.querySelectorAll<HTMLElement>("section"));
-    // Initialize base class + slight stagger via CSS var
-    sections.forEach((el, i) => {
-      el.classList.add("fly-in");
-      const delay = Math.min(i * 30, 120);
-      el.style.setProperty("--fly-delay", `${delay}ms`);
-    });
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const el = entry.target as HTMLElement;
-            el.classList.add("is-visible");
-            obs.unobserve(el);
-          }
-        });
-      },
-      { root: null, threshold: 0.12, rootMargin: "0px 0px -10% 0px" }
-    );
-    sections.forEach((el) => obs.observe(el));
-    return () => obs.disconnect();
-  }, [reducedMotion]);
 
   // Parallax with reduced-motion guard and passive scroll
   useEffect(() => {
@@ -300,7 +243,7 @@ export default function Home() {
         {/* Hero */}
         <section aria-labelledby="hero-title" className="pt-2 relative">
           <div className={`${sectionContainer}`}>
-            <div ref={heroRevealRef}>
+            <div>
               <NodeToolHero />
             </div>
           </div>
@@ -310,7 +253,7 @@ export default function Home() {
         <section id="demo-video" aria-label="NodeTool Demo" className="rhythm-section relative scroll-mt-24">
           <div className={`${sectionContainer}`}>
             <motion.div
-              initial={{ opacity: 0, y: 30 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.35, delay: 0.05, ease: "easeOut" }}
               className="relative group"

--- a/marketing/src/app/use-cases/movie-poster/page.tsx
+++ b/marketing/src/app/use-cases/movie-poster/page.tsx
@@ -133,7 +133,7 @@ export default function MoviePosterUseCase() {
             </a>
 
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6 }}
               className="mt-8 max-w-3xl"
@@ -156,7 +156,7 @@ export default function MoviePosterUseCase() {
 
             {/* Hero triptych */}
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.15 }}
               className="relative mt-12"
@@ -219,7 +219,7 @@ export default function MoviePosterUseCase() {
 
             {/* Live graph — the real workflow, rendered from the node UI components */}
             <motion.div
-              initial={{ opacity: 0, y: 24 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.6 }}
@@ -245,7 +245,7 @@ export default function MoviePosterUseCase() {
               {steps.map((step, i) => (
                 <motion.div
                   key={step.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}
@@ -290,7 +290,7 @@ export default function MoviePosterUseCase() {
               {posters.map((p) => (
                 <motion.div
                   key={p.src}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5 }}
@@ -329,7 +329,7 @@ export default function MoviePosterUseCase() {
               {tweaks.map((tweak, i) => (
                 <motion.div
                   key={tweak.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}

--- a/marketing/src/app/use-cases/movie-trailer/page.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/page.tsx
@@ -140,7 +140,7 @@ export default function MovieTrailerUseCase() {
             </a>
 
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6 }}
               className="mt-8 max-w-3xl"
@@ -163,7 +163,7 @@ export default function MovieTrailerUseCase() {
 
             {/* Hero video */}
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.15 }}
               className="relative mt-12"
@@ -221,7 +221,7 @@ export default function MovieTrailerUseCase() {
 
             {/* Live graph — the real workflow, rendered from the node UI components */}
             <motion.div
-              initial={{ opacity: 0, y: 24 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.6 }}
@@ -247,7 +247,7 @@ export default function MovieTrailerUseCase() {
               {steps.map((step, i) => (
                 <motion.div
                   key={step.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}
@@ -291,7 +291,7 @@ export default function MovieTrailerUseCase() {
               {shots.map((shot, i) => (
                 <motion.div
                   key={shot.src}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: (i % 3) * 0.05 }}
@@ -323,7 +323,7 @@ export default function MovieTrailerUseCase() {
             </div>
 
             <motion.div
-              initial={{ opacity: 0, y: 24 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.6 }}
@@ -363,7 +363,7 @@ export default function MovieTrailerUseCase() {
               {tweaks.map((tweak, i) => (
                 <motion.div
                   key={tweak.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}

--- a/marketing/src/app/use-cases/product-video/page.tsx
+++ b/marketing/src/app/use-cases/product-video/page.tsx
@@ -126,7 +126,7 @@ export default function ProductVideoUseCase() {
             </a>
 
             <motion.div
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6 }}
               className="mt-8 max-w-3xl"
@@ -148,7 +148,7 @@ export default function ProductVideoUseCase() {
 
             {/* Hero video */}
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.15 }}
               className="relative mt-12"
@@ -206,7 +206,7 @@ export default function ProductVideoUseCase() {
 
             {/* Live graph — the real workflow, rendered from the node UI components */}
             <motion.div
-              initial={{ opacity: 0, y: 24 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.6 }}
@@ -232,7 +232,7 @@ export default function ProductVideoUseCase() {
               {steps.map((step, i) => (
                 <motion.div
                   key={step.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}
@@ -327,7 +327,7 @@ export default function ProductVideoUseCase() {
               {tweaks.map((tweak, i) => (
                 <motion.div
                   key={tweak.title}
-                  initial={{ opacity: 0, y: 20 }}
+                  initial={false}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true, margin: "-60px" }}
                   transition={{ duration: 0.5, delay: i * 0.05 }}

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -18,7 +18,7 @@ export default function ChatUISection() {
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 shadow-lg shadow-emerald-500/10"
@@ -28,7 +28,7 @@ export default function ChatUISection() {
 
           <motion.h2
             id="chat-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -41,7 +41,7 @@ export default function ChatUISection() {
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -52,7 +52,7 @@ export default function ChatUISection() {
         </div>
 
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}

--- a/marketing/src/components/CommunitySection.tsx
+++ b/marketing/src/components/CommunitySection.tsx
@@ -83,7 +83,7 @@ export default function CommunitySection({
           <div className={v.topBar} />
 
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             className="max-w-2xl mx-auto"

--- a/marketing/src/components/ContactSection.tsx
+++ b/marketing/src/components/ContactSection.tsx
@@ -16,7 +16,7 @@ export default function ContactSection() {
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.h2
             id="contact-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -29,7 +29,7 @@ export default function ContactSection() {
           </motion.h2>
           
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -80,7 +80,7 @@ export default function ContactSection() {
           ].map((card, i) => (
             <motion.div
               key={card.title}
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.05 }}

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -110,7 +110,7 @@ export default function CostDashboardSection() {
 
         {/* Dashboard window */}
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
@@ -253,7 +253,7 @@ export default function CostDashboardSection() {
                             key={i}
                             className="flex flex-1 origin-bottom flex-col-reverse overflow-hidden rounded-t-[2px]"
                             style={{ height: (total / Y_MAX) * CHART_H }}
-                            initial={{ scaleY: 0 }}
+                            initial={false}
                             whileInView={{ scaleY: 1 }}
                             viewport={{ once: true }}
                             transition={{
@@ -342,7 +342,7 @@ export default function CostDashboardSection() {
                         <motion.div
                           className="h-full origin-left rounded-full bg-[#4d8bff]"
                           style={{ width: `${row.share}%` }}
-                          initial={{ scaleX: 0 }}
+                          initial={false}
                           whileInView={{ scaleX: 1 }}
                           viewport={{ once: true }}
                           transition={{

--- a/marketing/src/components/DeploySection.tsx
+++ b/marketing/src/components/DeploySection.tsx
@@ -20,7 +20,7 @@ export default function DeploySection({
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
           {/* Left Column: Text Content */}
           <motion.div
-            initial={{ opacity: 0, x: -20 }}
+            initial={false}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -108,7 +108,7 @@ export default function DeploySection({
 
           {/* Right Column: Visual */}
           <motion.div
-            initial={{ opacity: 0, x: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -30,7 +30,7 @@ export default function FeaturesSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-blue-500/10 border border-blue-500/20 shadow-lg shadow-blue-500/10"
@@ -40,7 +40,7 @@ export default function FeaturesSection({
 
           <motion.h2
             id="features-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -53,7 +53,7 @@ export default function FeaturesSection({
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -67,7 +67,7 @@ export default function FeaturesSection({
 
         {/* Screenshot with Tilt */}
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
@@ -151,7 +151,7 @@ export default function FeaturesSection({
             <motion.div
               key={feature.title}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >

--- a/marketing/src/components/ModelManagerSection.tsx
+++ b/marketing/src/components/ModelManagerSection.tsx
@@ -18,7 +18,7 @@ export default function ModelManagerSection() {
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-blue-500/10 border border-blue-500/20 shadow-lg shadow-blue-500/10"
@@ -28,7 +28,7 @@ export default function ModelManagerSection() {
 
           <motion.h2
             id="model-manager-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -41,7 +41,7 @@ export default function ModelManagerSection() {
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -54,7 +54,7 @@ export default function ModelManagerSection() {
         </div>
 
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -80,7 +80,7 @@ export default function ModelSupportSection({
                 {/* Header */}
                 <div className="mb-12 text-center max-w-3xl mx-auto">
                     <motion.div
-                        initial={{ opacity: 0, scale: 0.9 }}
+                        initial={false}
                         whileInView={{ opacity: 1, scale: 1 }}
                         viewport={{ once: true }}
                         className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-gradient-to-br from-emerald-500/10 to-blue-500/10 border border-emerald-500/20 shadow-lg shadow-emerald-500/5"
@@ -90,7 +90,7 @@ export default function ModelSupportSection({
 
                     <motion.h2
                         id="model-support-title"
-                        initial={{ opacity: 0, y: 20 }}
+                        initial={false}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.25 }}
@@ -103,7 +103,7 @@ export default function ModelSupportSection({
                     </motion.h2>
 
                     <motion.p
-                        initial={{ opacity: 0, y: 20 }}
+                        initial={false}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true }}
                         transition={{ duration: 0.25, delay: 0.05 }}

--- a/marketing/src/components/NodeMenuSection.tsx
+++ b/marketing/src/components/NodeMenuSection.tsx
@@ -24,7 +24,7 @@ export default function NodeMenuSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-blue-500/10 border border-blue-500/20 shadow-lg shadow-blue-500/10"
@@ -34,7 +34,7 @@ export default function NodeMenuSection({
 
           <motion.h2
             id="nodes-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -47,7 +47,7 @@ export default function NodeMenuSection({
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -59,7 +59,7 @@ export default function NodeMenuSection({
 
         {/* Screenshot with Tilt */}
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -41,7 +41,7 @@ export default function OwnershipSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-2xl mx-auto">
           <motion.h2
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -51,7 +51,7 @@ export default function OwnershipSection({
             <span className="text-slate-300">Your roadmap.</span>
           </motion.h2>
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -78,7 +78,7 @@ export default function OwnershipSection({
             <motion.div
               key={item.title}
               variants={{
-                hidden: { opacity: 0, y: 16 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
               className="h-full"

--- a/marketing/src/components/ProvidersSection.tsx
+++ b/marketing/src/components/ProvidersSection.tsx
@@ -24,7 +24,7 @@ export default function ProvidersSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-blue-500/10 border border-blue-500/20 shadow-lg shadow-blue-500/10"
@@ -34,7 +34,7 @@ export default function ProvidersSection({
 
           <motion.h2
             id="providers-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -47,7 +47,7 @@ export default function ProvidersSection({
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -59,7 +59,7 @@ export default function ProvidersSection({
 
         {/* Screenshot with Tilt */}
         <motion.div
-          initial={{ opacity: 0, y: 40 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
@@ -119,7 +119,7 @@ export default function ProvidersSection({
             <motion.div
               key={feature.title}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >

--- a/marketing/src/components/SketchEditorSection.tsx
+++ b/marketing/src/components/SketchEditorSection.tsx
@@ -39,7 +39,7 @@ export default function SketchEditorSection() {
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-12 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-violet-500/10 border border-violet-500/20 shadow-lg shadow-violet-500/10"
@@ -49,7 +49,7 @@ export default function SketchEditorSection() {
 
           <motion.h2
             id="sketch-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -59,7 +59,7 @@ export default function SketchEditorSection() {
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -73,7 +73,7 @@ export default function SketchEditorSection() {
         </div>
 
         <motion.figure
-          initial={{ opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3 }}

--- a/marketing/src/components/TimelineEditorSection.tsx
+++ b/marketing/src/components/TimelineEditorSection.tsx
@@ -39,7 +39,7 @@ export default function TimelineEditorSection() {
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-12 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-sky-500/10 border border-sky-500/20 shadow-lg shadow-sky-500/10"
@@ -49,7 +49,7 @@ export default function TimelineEditorSection() {
 
           <motion.h2
             id="timeline-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -59,7 +59,7 @@ export default function TimelineEditorSection() {
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -72,7 +72,7 @@ export default function TimelineEditorSection() {
         </div>
 
         <motion.figure
-          initial={{ opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3 }}

--- a/marketing/src/components/UseCasesSection.tsx
+++ b/marketing/src/components/UseCasesSection.tsx
@@ -28,7 +28,7 @@ export default function UseCasesSection({
         <div className="mb-16 text-center max-w-2xl mx-auto">
           <motion.h2
             id="use-cases-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -37,7 +37,7 @@ export default function UseCasesSection({
             What people build
           </motion.h2>
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -60,7 +60,7 @@ export default function UseCasesSection({
             <motion.div
               key={item.name}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
@@ -104,7 +104,7 @@ export default function UseCasesSection({
         <div className="mt-16 text-center">
           <motion.a
             href="/templates"
-            initial={{ opacity: 0 }}
+            initial={false}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ delay: 0.05 }}

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -51,7 +51,7 @@ export default function UseCasesShowcase() {
           </div>
           <motion.h2
             id="use-cases-title"
-            initial={{ opacity: 0, y: 16 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -60,7 +60,7 @@ export default function UseCasesShowcase() {
             From a brief to a finished asset
           </motion.h2>
           <motion.p
-            initial={{ opacity: 0, y: 16 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -79,7 +79,7 @@ export default function UseCasesShowcase() {
               <motion.a
                 key={item.slug}
                 href={`/use-cases/${item.slug}`}
-                initial={{ opacity: 0, y: 24 }}
+                initial={false}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-40px" }}
                 transition={{ duration: 0.3 }}

--- a/marketing/src/components/VideoGenerationSection.tsx
+++ b/marketing/src/components/VideoGenerationSection.tsx
@@ -22,7 +22,7 @@ export default function VideoGenerationSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 shadow-lg shadow-emerald-500/10"
@@ -32,7 +32,7 @@ export default function VideoGenerationSection({
 
           <motion.h2
             id="video-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -45,7 +45,7 @@ export default function VideoGenerationSection({
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -56,7 +56,7 @@ export default function VideoGenerationSection({
           </motion.p>
 
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -77,7 +77,7 @@ export default function AgentFeaturesSection({
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
+            initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
             viewport={{ once: true }}
             className="inline-flex items-center justify-center p-3 mb-6 rounded-2xl bg-rose-500/10 border border-rose-500/20 shadow-lg shadow-rose-500/10"
@@ -87,7 +87,7 @@ export default function AgentFeaturesSection({
 
           <motion.h2
             id="features-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -100,7 +100,7 @@ export default function AgentFeaturesSection({
           </motion.h2>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -126,7 +126,7 @@ export default function AgentFeaturesSection({
             <motion.div
               key={feature.title}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -100,7 +100,7 @@ export default function AgentIntegrationsSection({
         <div className="mb-16 text-center max-w-3xl mx-auto">
           <motion.h2
             id="integrations-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -112,7 +112,7 @@ export default function AgentIntegrationsSection({
             </span>
           </motion.h2>
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -138,7 +138,7 @@ export default function AgentIntegrationsSection({
             <motion.div
               key={category.category}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
               className="group relative rounded-2xl border border-white/5 bg-slate-900/40 backdrop-blur-sm p-6 transition-all duration-300 hover:bg-slate-900/60 hover:border-white/10"
@@ -184,7 +184,7 @@ export default function AgentIntegrationsSection({
 
         {/* Bottom Banner */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25, delay: 0.08 }}

--- a/marketing/src/components/agents/AgentUseCasesSection.tsx
+++ b/marketing/src/components/agents/AgentUseCasesSection.tsx
@@ -130,7 +130,7 @@ export default function AgentUseCasesSection({
         <div className="mb-16 text-center max-w-2xl mx-auto">
           <motion.h2
             id="use-cases-title"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -142,7 +142,7 @@ export default function AgentUseCasesSection({
             </span>
           </motion.h2>
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -174,7 +174,7 @@ export default function AgentUseCasesSection({
             <motion.div
               key={item.name}
               variants={{
-                hidden: { opacity: 0, y: 20 },
+                hidden: { opacity: 1, y: 0 },
                 show: { opacity: 1, y: 0, transition: { duration: 0.25 } },
               }}
             >
@@ -213,7 +213,7 @@ export default function AgentUseCasesSection({
         {/* CTA */}
         <motion.div
           className="mt-16 text-center"
-          initial={{ opacity: 0 }}
+          initial={false}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
           transition={{ delay: 0.05 }}

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -93,7 +93,7 @@ export default function AgentsGraphHero() {
                 {/* Header Section */}
                 <div className="mx-auto max-w-3xl text-center mb-24">
                     <motion.div
-                        initial={{ opacity: 0, y: 20 }}
+                        initial={false}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ duration: 0.25 }}
                     >
@@ -345,7 +345,7 @@ function ConnectionLine({ from, to, containerWidth }: { from: NodeData; to: Node
                 strokeWidth="3"
                 strokeLinecap="round"
                 vectorEffect="non-scaling-stroke"
-                initial={{ strokeDasharray: "0 1", pathLength: 0.3, strokeDashoffset: 0, opacity: 0 }}
+                initial={false}
                 animate={{
                     pathLength: [0.1, 0.3, 0.1], // Pulse length
                     strokeDashoffset: [0, -1], // Moves forward along the path
@@ -383,7 +383,7 @@ function Node({ data, index }: { data: NodeData, index: number }) {
 
     return (
         <motion.div
-            initial={{ opacity: 0, scale: 0.8, z: 0 }}
+            initial={false}
             animate={{ opacity: 1, scale: 1, z: 20 }}
             transition={{ delay: 0.05 + (index * 0.05), duration: 0.25 }}
             style={{

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -10,7 +10,7 @@ export default function DevelopersHero() {
       <div className="text-center max-w-4xl mx-auto">
         {/* Badge */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25 }}
           className="mb-6"
@@ -24,7 +24,7 @@ export default function DevelopersHero() {
         {/* Title */}
         <motion.h1
           id="hero-title"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.05 }}
           className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
@@ -37,7 +37,7 @@ export default function DevelopersHero() {
 
         {/* Subtitle */}
         <motion.p
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
@@ -50,7 +50,7 @@ export default function DevelopersHero() {
 
         {/* Feature Pills */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.08 }}
           className="mt-8 flex flex-wrap justify-center gap-3"
@@ -73,7 +73,7 @@ export default function DevelopersHero() {
 
         {/* CTA Buttons */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"


### PR DESCRIPTION
Fixes from a screenshot-driven review of nodetool.ai's landing page.

## Animations: entrance fade-ins removed

Sections server-render visible, then client JS hid them (framer `initial={{opacity:0}}` on hydrate, the global `.fly-in` IntersectionObserver, `heroRise` keyframes) and faded them back in — a visible flicker on load, and content that lagged behind the reader on scroll.

- `initial={{ opacity: 0, … }}` → `initial={false}` across all marketing components (chart `scaleX/scaleY` grow-ins included) — elements render directly in their final state.
- Stagger variants' `hidden` state now matches `show`, so card cascades no longer start invisible.
- The `.fly-in` observer + CSS and the legacy `useReveal` hook are deleted; `heroRise` keyframes retired (classes stay as no-ops).
- Ambient loops (marquees, background glow drift, terminal-typing mock) are untouched.
- New `MotionProvider` wraps the layout with `MotionConfig reducedMotion="user"` for the remaining motion.

## Copy and CTAs

- Hero subhead leads with what you make ("Make films, posters, product videos, and music…") instead of billing mechanics.
- The "Every model. Your keys. Your canvas." tagline was repeated in five-plus places; it now has one home (the comparison deep-dive) plus the footer brand line. The models section is retitled "The newest models, the day they ship."
- The demo video gets a caption saying NodeTool produced it end-to-end.
- Closing CTA block adds **Try NodeTool Cloud** (→ app.nodetool.ai) alongside the download button.
- Footer compare link reads "vs Weavy (Figma Weave)" via a `footerName` override, matching the homepage naming.

## Plumbing and a11y

- The GitHub star count fetch (header + homepage fetched separately per view) is deduped into a shared `useGithubStars` hook with an in-flight guard and a one-hour session cache.
- Marquee rows duplicate their items for the loop effect; duplicates are now `aria-hidden` (and `tabIndex={-1}` on links) so screen readers and keyboard users hit each item once.

## Verification

- `tsc --noEmit` clean; `next lint` shows only pre-existing warnings.
- Headless-browser passes against `next dev`: DOM audit finds no content below full opacity at any scroll position, and screenshots taken ~100ms after jumping to each section show everything already rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCDrZRA53HwdUJneif6iMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCDrZRA53HwdUJneif6iMN)_