### PR TITLE
Add nodetool-code-review skill; sharpen troubleshooter, unslop, e2e skills

### DIFF
--- a/.claude/skills/nodetool-code-review/SKILL.md
+++ b/.claude/skills/nodetool-code-review/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: nodetool-code-review
+description: Review a diff, branch, or PR in this repo for correctness bugs and NodeTool-specific landmines — cross-package imports, ESM .js extensions, MsgPack WebSocket framing, Zustand subscriptions, ui_primitives and design tokens, decorator-package builds, packaged-Electron path flattening, IPC security. Use when the user asks to review changes, review a PR/branch/diff, check work before commit or merge, or audit code someone else wrote. For stripping AI slop from your own diff, use the unslop skill; a full pre-merge pass runs both.
+---
+
+# NodeTool Code Review
+
+A correctness-first review of a change set, tuned to the bugs this codebase actually produces. Division of labor with the sibling skills:
+
+- **This skill**: does the change work, and does it step on a NodeTool landmine?
+- **[`unslop`](../unslop/SKILL.md)**: is the change free of AI-generated filler? Run it after this one for a full pre-merge pass.
+
+The rules referenced here live in [`CLAUDE.md`](../../../CLAUDE.md), [`docs/DEVELOPMENT_STANDARDS.md`](../../../docs/DEVELOPMENT_STANDARDS.md), and the area `AGENTS.md` files. This skill turns them into things to hunt for in a diff.
+
+## Process
+
+1. **Scope the diff.**
+   - Working tree: `git diff` + `git diff --cached` (and untracked files via `git status`).
+   - Branch: `git diff $(git merge-base main HEAD)...HEAD` — never `git diff main` (picks up drift on main).
+   - PR: fetch the branch, then the same merge-base diff.
+2. **Map the blast radius.** `npm run dev:nodetool -- affected --base main --json` lists the workspaces to typecheck/test and tells you whether a decorator package (loads from `dist/`) forces `npm run build:packages`. Don't guess.
+3. **Read hunks in context.** For every changed function, read the whole function and its callers — `Grep` for the symbol. A hunk that looks fine in isolation is where signature drift, missed call sites, and broken invariants hide. For changed types in `packages/protocol`, check every package that imports them.
+4. **Hunt** with the checklists below, most-severe first.
+5. **Verify.** Run the targeted commands from step 2. Per-package that's `npm run test --workspace=packages/<name>` and `npm run lint --workspace=packages/<name>` (packages typecheck via `build`, not a `typecheck` script); root `npm run typecheck` covers web/electron/mobile. If the diff is wide, `npm run check`. Report the actual output — never "should pass".
+6. **Report** findings in the output format at the bottom.
+
+## Severity
+
+| Tier | Meaning | Bar |
+|------|---------|-----|
+| **Blocker** | Wrong behavior, crash, data loss, security hole, broken build | You can name the input/state that triggers it |
+| **Should-fix** | Violates a written repo rule (CLAUDE.md, DEVELOPMENT_STANDARDS.md, AGENTS.md) | Cite the rule |
+| **Nit** | Everything else worth a sentence | Only if you found nothing bigger in that file; never pad |
+
+A finding without a failure scenario or a citable rule is not a finding. When unsure whether something is a bug, say so explicitly instead of inflating the severity.
+
+## Checklists
+
+### Cross-package (any `packages/` change)
+
+- **Imports**: inter-package imports use `@nodetool-ai/<pkg>` — never `../other-pkg/` or anything containing `/dist/`.
+- **ESM extensions**: relative imports need `.js` in compiled output. A missing extension typechecks but dies at runtime in built packages.
+- **Dependency direction**: does the import respect the order `protocol → config → security/auth/storage → runtime → kernel → node-sdk → base-nodes → models → agents → chat → websocket/cli`? A lower package importing a higher one is a cycle waiting to happen.
+- **Decorator packages** (`base-nodes`, `node-sdk`, `fal-nodes`, `replicate-nodes`, `elevenlabs-nodes`) load from `dist/`. A change here that isn't followed by `build:packages` silently tests stale code — confirm the verify step rebuilt.
+- **Runtime data files**: anything loaded relative to `import.meta.url` (manifests, examples, `package://` assets) breaks in the packaged Electron app (backend is bundled into one `server.mjs`). Such files must be registered in `PACKAGE_RUNTIME_ASSETS` (`packages/config/src/package-asset-registry.ts`) and loaded via `loadPackageAssetJson`.
+- **Protocol types**: new message/data shapes belong in `packages/protocol`, not re-declared locally.
+- **Errors**: `throw new Error(...)`, never strings. Empty catch blocks need a comment saying why.
+- **WebSocket framing**: WS messages are **MsgPack**, REST is JSON. `JSON.stringify` on a WS send path, or a msgpack decode missing on a receive path, is a blocker.
+- **Streaming nodes**: `genProcess` must `yield`, not accumulate-and-return; check backpressure-sensitive paths don't buffer unbounded.
+
+### Web (`web/src/`)
+
+- **Raw MUI imports** outside `ui_primitives/` and `editor_ui/` — should-fix, migrate to primitives. Quick sweep of the diff's files:
+  `rg "from ['\"]@mui/material" <changed files>`
+- **Design tokens**: hardcoded border radii, font sizes, transition strings, off-4px-grid spacing, raw z-indexes → `BORDER_RADIUS`, `TYPOGRAPHY`/`var(--fontSize*)`, `MOTION`, `SPACING`, `Z_INDEX` from `ui_primitives` ([docs/DESIGN.md](../../../docs/DESIGN.md)).
+- **Zustand**: whole-store subscription (`useFooStore()` with no selector) — blocker-adjacent, it re-renders on every store write. Multi-key object selectors need `useShallow`. `getState()` in render bodies is a bug; in handlers/effects it's fine.
+- **New `WebSocket(...)`** anywhere — use the `GlobalWebSocketManager` singleton.
+- **TanStack Query**: server data via `useQuery`/`useMutation`, hierarchical keys (`["workflows", id]`), `enabled` for conditional fetches, mutations invalidate affected keys. `useEffect`+`fetch` for backend data is should-fix.
+- **ReactFlow**: unstable references passed as `nodes`/`edges`/`nodeTypes` props (fresh array/object each render) tank canvas performance — hoist or memoize `nodeTypes`, derive nodes/edges via selectors.
+- **Effects**: check every new `useEffect` dependency array against what the body reads; a stale-closure over a store value or prop is a classic bug here.
+
+### Electron (`electron/src/`)
+
+Non-negotiable ([electron/src/AGENTS.md](../../../electron/src/AGENTS.md) § Security):
+
+- `contextIsolation: true`, `nodeIntegration: false`, no `webSecurity: false`, no remote-content `BrowserWindow` without a strict preload.
+- Every new IPC handler validates its inputs — renderer input is untrusted. Channel names typed, no `ipcMain.handle` passing raw args into `fs`/`child_process`/`shell.openExternal` without allow-listing.
+- Paths resolved relative to `import.meta.url` or `__dirname`: verify against the packaged layout (§ Packaged file layout), not just dev.
+
+### Mobile (`mobile/`)
+
+- `mobile/` is **not** a root workspace. Scripts must use `npm --prefix mobile ...`; a diff that "standardizes" this to `--workspace=mobile` breaks it.
+- Mobile typecheck needs `packages/protocol` built first.
+
+### Tests
+
+- New behavior in the diff without a test, or a changed behavior whose old test still passes unmodified — ask why.
+- Vitest in `packages/`, Jest in `web/`/`electron/`, files in `__tests__/`.
+- RTL queries by role/label, `userEvent`, `waitFor`/`findBy*` — no `setTimeout` sleeps, no `getByTestId` where a role query works.
+- A test that mocks the unit under review, or re-implements its logic in the fixture, verifies nothing.
+
+### Config / CI / docs
+
+- `package.json` script or dependency changes: check the lockfile moved with it, and that sandboxed-install caveats (CLAUDE.md § Common Pitfalls) still hold.
+- Changes to commands, architecture, or rules documented in `CLAUDE.md`/`AGENTS.md`: the doc must move in the same PR — that's a written rule, cite it.
+- Prose follows [docs/WRITING_STYLE.md](../../../docs/WRITING_STYLE.md); flag slop words but leave the full prose pass to `unslop`.
+
+## Quick greps
+
+Run these over the changed files (not the whole repo — pre-existing hits are out of scope):
+
+```bash
+rg "@nodetool-ai/[a-z-]+/dist"            # dist imports (always wrong)
+rg "new WebSocket\("                       # bypassing GlobalWebSocketManager
+rg "JSON\.(stringify|parse)" packages/websocket packages/runtime   # on WS paths only
+rg "from ['\"]@mui/material" web/src       # outside ui_primitives/, editor_ui/
+rg ": any\b|as any\b|as unknown as"        # strict mode escapes
+rg "console\.log"                          # leftover debug output
+```
+
+A grep hit is a lead, not a finding — read the site before reporting.
+
+## What not to flag
+
+- Anything `npm run lint` or `npm run typecheck` already rejects — run them and report the output instead of duplicating it as prose findings.
+- Style preferences with no backing in the repo docs. "I'd have written it differently" is not a finding.
+- Pre-existing problems outside the diff. Mention once at the end if serious, don't mix into the findings list.
+- Slop (comments, dead abstractions, prose filler) — one pointer to `unslop`, not itemized findings.
+
+## Output format
+
+Order findings blockers → should-fix → nits. Each one:
+
+```
+[BLOCKER] packages/kernel/src/actor.ts:142 — `pending` is never cleared on error
+When a node throws, `handleError` returns early before `this.pending.delete(id)`,
+so the runner waits forever on the next `sync_mode: on_any` join.
+Fix: move the delete into a `finally`.
+```
+
+One line of location + claim, the failure scenario, the fix. End with the verification you actually ran and its result:
+
+```
+Verified: npm run build --workspace=packages/kernel ✓, npm run test --workspace=packages/kernel ✓ (34 passed)
+```
+
+If nothing is wrong, say so plainly and list what you checked — a clean review is a valid result, not a failure to find something.

--- a/.claude/skills/nodetool-troubleshooter/SKILL.md
+++ b/.claude/skills/nodetool-troubleshooter/SKILL.md
@@ -1,9 +1,43 @@
 ---
 name: nodetool-troubleshooter
-description: Debug NodeTool workflow failures, node errors, performance issues, stuck executions, type mismatches, and deployment problems. Use when user reports a bug, workflow failure, node error, performance issue, stuck execution, or needs help diagnosing any NodeTool problem.
+description: Debug NodeTool workflow failures, node errors, performance issues, stuck executions, type mismatches, and deployment problems. Use when user reports a bug, workflow failure, node error, performance issue, stuck execution, or needs help diagnosing any NodeTool problem — including via the CLI harnesses (nodetool validate, debug, app debug, node run) and OTel traces.
 ---
 
 You are a NodeTool troubleshooter. Diagnose issues systematically using this guide.
+
+# CLI Debug Harnesses (start here when you have shell access)
+
+The `nodetool` CLI has purpose-built harnesses that beat manual poking. Escalate in cost order:
+
+```bash
+# 1. Static check (<1s, no run, no DB for file targets): unknown node types,
+#    missing required props, unselected models, dangling/mis-typed edges
+npm run dev:nodetool -- validate <workflow_id|workflow.json|workflow.ts>
+
+# 2. Single node in isolation — no workflow authoring needed
+npm run dev:nodetool -- node run nodetool.text.Concat --props '{"a":"hi"}' --no-secrets
+
+# 3. Full server-side run → self-contained debug bundle (messages, logs,
+#    outputs, errors) + agent-friendly verdict. --json prints the full report.
+npm run dev:nodetool -- debug <workflow_id|workflow.json> --params '{"prompt":"hi"}'
+npm run dev:nodetool -- debug workflow.json --watch     # re-run on save, print verdict diff
+
+# 4. Opt-in expensive surfaces
+npm run dev:nodetool -- debug <id> --trace              # OTel spans: timing, tokens, cost
+npm run dev:nodetool -- debug <id> --browser --stages   # real browser + per-stage screenshots
+
+# App-builder mini apps (workflow.app_doc): binding validation + headless run
+npm run dev:nodetool -- app debug <id> --json
+```
+
+The bundle lands in `nodetool-debug/<id>-<ts>/` (`report.md`, `server/messages.jsonl`, …). Loop: run `debug` → read the verdict → edit → re-run. Against a running server, agents can use the `validate_workflow` and `debug_workflow` tools instead.
+
+For agent/LLM issues, capture a trace and inspect the spans (`llm.chat` carries `gen_ai.usage.*` token/cost attributes):
+
+```bash
+NODETOOL_TRACE_FILE=/tmp/trace.jsonl npm run dev:chat -- --agent
+npm run dev:nodetool -- --trace-file trace.jsonl run workflow.ts
+```
 
 # Quick Diagnostic Checklist
 

--- a/.claude/skills/unslop/SKILL.md
+++ b/.claude/skills/unslop/SKILL.md
@@ -9,6 +9,8 @@ A pre-commit pass that removes patterns LLMs add reflexively but humans wouldn't
 
 This skill complements (does not replace) [`AGENTS.md`](../../../AGENTS.md), [`CLAUDE.md`](../../../CLAUDE.md), and [`web/src/components/ui_primitives/STRATEGY.md`](../../../web/src/components/ui_primitives/STRATEGY.md). Those define the rules. This skill defines the patterns to actively hunt and remove.
 
+Unslop is a quality pass, not a bug hunt. For correctness review of a diff, branch, or PR — including the NodeTool-specific landmines — use [`nodetool-code-review`](../nodetool-code-review/SKILL.md); a full pre-merge pass runs both.
+
 ## How to use
 
 1. After making changes, run `git diff` and read every added line through the lenses below.
@@ -243,6 +245,7 @@ NodeTool uses MUI v7 **wrapped by `web/src/components/ui_primitives/`**. Raw MUI
 - `import { Typography, Button, IconButton, Tooltip, CircularProgress, Chip, Dialog, Alert, Divider, Paper, Skeleton, Tabs, Drawer, Breadcrumbs, Select, Switch, TextField } from "@mui/material"` outside `ui_primitives/` and `editor_ui/`. Use the primitives.
 - Inline `sx={{ display: "flex", flexDirection: "column" }}` — use `<FlexColumn>` / `<FlexRow>`.
 - Hardcoded hex colors, pixel paddings, or font sizes — use theme values, `SPACING`, `GAP`, `PADDING`.
+- Hardcoded border radii (`4`, `10`, `18px`), transition strings (`"all 200ms ease"`), or z-indexes (`9999`) — use `BORDER_RADIUS`, `MOTION`, `Z_INDEX` from `ui_primitives` (token reference: [`docs/DESIGN.md`](../../../docs/DESIGN.md)).
 - `styled()` calls in component files — `styled()` only belongs inside `ui_primitives/`.
 - New `<Typography variant="...">` — use `Text`, `Label`, or `Caption`.
 - Reaching past primitives into MUI internals (e.g., `MuiButton-root` overrides) when a primitive prop already exists.
@@ -375,7 +378,7 @@ Run through this before declaring a task done. Treat any "yes" as a slop sightin
 - [ ] Did I add `useEffect` to compute a value from props/state I already have?
 - [ ] Did I `useCallback`/`useMemo`/`React.memo` without a memoized consumer or measurable cost?
 - [ ] Did I subscribe to a whole Zustand store (`const s = useFooStore()`) or skip `useShallow` on a multi-key selector?
-- [ ] Did I import a raw MUI component into a non-primitive file, or hardcode a color/spacing?
+- [ ] Did I import a raw MUI component into a non-primitive file, or hardcode a color, spacing, radius, font size, or transition?
 - [ ] Did I write a `useEffect`+`fetch` instead of `useQuery`?
 - [ ] Does any new test assert implementation rather than user-visible behavior?
 - [ ] Are there `// TODO`, `// removed`, `// added by`, or "useful elsewhere" leftovers?

--- a/.claude/skills/yts806379-everything-claude-code-e2e-testing/SKILL.md
+++ b/.claude/skills/yts806379-everything-claude-code-e2e-testing/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: e2e-testing
-description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.
+description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies. Use when writing, fixing, or deflaking Playwright tests in this repo — the web E2E suites under web/tests/ (e2e-runner, debug-harness, visual) and the Electron E2E setup.
 origin: ECC
 ---
 
 # E2E Testing Patterns
+
+> **This repo**: Playwright suites live in `web/tests/` with per-suite configs at the `web/` root — `playwright.config.ts`, `playwright.e2e-runner.config.ts`, `playwright.debug-harness.config.ts`, `playwright.visual.config.ts`. Run the harness suites via `cd web && npm run test:debug-harness` (see root `CLAUDE.md` § nodetool debug). Electron E2E setup: `electron/src/AGENTS.md` § E2E Test Setup. The generic patterns below apply on top of that layout — prefer the repo's existing fixtures and configs over the scaffold shown here.
 
 Comprehensive Playwright patterns for building stable, fast, and maintainable E2E test suites.
 


### PR DESCRIPTION
New nodetool-code-review skill: correctness-first diff/branch/PR review
tuned to this repo's landmines (dist imports, ESM .js extensions, MsgPack
WS framing, Zustand subscriptions, ui_primitives/design tokens, decorator
package builds, packaged-Electron paths, IPC security), with a scoped
process (merge-base diff, nodetool affected, targeted verification) and a
severity-tiered output format. Complements unslop: review finds bugs,
unslop strips slop.

Existing skills:
- nodetool-troubleshooter: add the CLI debug harnesses (validate, debug,
  app debug, node run, --watch, traces) as the first diagnostic step —
  they postdate the skill and were missing entirely.
- unslop: cross-link the review skill; complete the design-token list
  (BORDER_RADIUS, MOTION, Z_INDEX) in the MUI section and checklist.
- e2e-testing: point the generic ECC content at this repo's actual
  Playwright suites and configs so it triggers and applies correctly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HAFZLLQ2BjvG2VB3eBrKh8