### PR TITLE
fix(timeline): fix 12 bugs across playback, stores, and hooks

### DIFF
--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -306,7 +306,7 @@ const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
     // Decide whether anything beyond a sub-pixel width change actually
     // happened. Width changes during a drag are gated to whole pixels (the
     // canvas can't show finer detail); other inputs force a redraw.
-    const inputsKey = `${durationMs}|${inPointMs}|${outPointMs}|${peaks ? peaks.length : 0}`;
+    const inputsKey = `${durationMs}|${inPointMs}|${outPointMs}|${url || ""}`;
     const otherInputsChanged = inputsKey !== lastInputsKeyRef.current;
     const widthChanged =
       Math.abs(Math.floor(widthPx) - lastDrawnWidthRef.current) >= 1;

--- a/web/src/components/timeline/Tracks/Playhead.tsx
+++ b/web/src/components/timeline/Tracks/Playhead.tsx
@@ -248,7 +248,8 @@ export const Playhead: React.FC<PlayheadProps> = memo(
         } else if (e.key === "Home") {
           next = 0;
         } else if (e.key === "End") {
-          next = cap;
+          const endTargetMs = durationMs > 0 ? durationMs : currentTimeMs;
+          next = endTargetMs;
         }
         if (next != null) {
           e.preventDefault();

--- a/web/src/components/timeline/Tracks/ScriptLane.tsx
+++ b/web/src/components/timeline/Tracks/ScriptLane.tsx
@@ -305,7 +305,18 @@ export const ScriptLane: React.FC = () => {
     };
 
     applyHighlight(playbackApi.getState().getTimeMs());
-    return playbackApi.getState().subscribeTime(applyHighlight);
+    const unsubscribe = playbackApi.getState().subscribeTime(applyHighlight);
+
+    return () => {
+      unsubscribe();
+      // Strip whatever this effect instance last marked active — otherwise a
+      // chip/word highlighted just before segmentRanges/wordRanges changes
+      // identity (e.g. transcript edit mid-playback) keeps its stale class,
+      // since the next effect instance starts from lastSegmentId/lastWordKey
+      // = null and has no memory of what the old instance lit up.
+      if (lastSegmentId) chipElsRef.current.get(lastSegmentId)?.classList.remove("is-active");
+      if (lastWordKey) wordElsRef.current.get(lastWordKey)?.classList.remove("w-active");
+    };
   }, [playbackApi, segmentRanges, wordRanges]);
 
   return (

--- a/web/src/components/timeline/preview/AudioGraph.ts
+++ b/web/src/components/timeline/preview/AudioGraph.ts
@@ -385,7 +385,8 @@ export class AudioGraph {
     clips: ScheduledAudioClip[],
     tracks: TimelineTrack[],
     currentTimeMs: number,
-    shouldCancel?: () => boolean
+    shouldCancel?: () => boolean,
+    globalRate = 1
   ): Promise<void> {
     const activeIds = new Set(clips.map((c) => c.clip.id));
 
@@ -407,7 +408,7 @@ export class AudioGraph {
       }
     }
 
-    await this.addClips(clips, tracks, currentTimeMs, shouldCancel);
+    await this.addClips(clips, tracks, currentTimeMs, shouldCancel, globalRate);
   }
 
   /**
@@ -421,9 +422,16 @@ export class AudioGraph {
     clips: ScheduledAudioClip[],
     tracks: TimelineTrack[],
     currentTimeMs: number,
-    shouldCancel?: () => boolean
+    shouldCancel?: () => boolean,
+    globalRate = 1
   ): Promise<void> {
     const ctx = this.getContext();
+    // Global timeline speed (1 = normal). One wall-clock second covers
+    // `g` timeline seconds, so every wall-clock duration below (lead,
+    // remaining, fades) is divided by `g`, and the source's playbackRate is
+    // multiplied by it. Source-space offsets/durations are unaffected — a
+    // faster timeline reads the same buffer span, just quicker.
+    const g = Math.max(0.0001, globalRate);
     this.updateTracks(tracks);
 
     const bufferPromises = clips.map(async ({ clip, assetUrl }) => {
@@ -463,7 +471,7 @@ export class AudioGraph {
 
       const src = ctx.createBufferSource();
       src.buffer = buffer;
-      src.playbackRate.value = rate;
+      src.playbackRate.value = rate * g;
 
       const volumeLinear = clip.volumeDb
         ? Math.pow(10, clip.volumeDb / 20)
@@ -480,7 +488,7 @@ export class AudioGraph {
       // *buffer* seconds, while clip.startMs / durationMs / inPointMs are
       // *timeline* milliseconds. With playbackRate = r, 1 timeline second
       // consumes r buffer seconds, so we multiply by `rate`.
-      const clipLeadSec = Math.max(0, (clip.startMs - currentTimeMs) / 1000);
+      const clipLeadSec = Math.max(0, (clip.startMs - currentTimeMs) / 1000) / g;
       const intoClipTimelineSec =
         Math.max(0, currentTimeMs - clip.startMs) / 1000;
       const bufferOffsetSec =
@@ -491,7 +499,10 @@ export class AudioGraph {
       const bufferDurationSec = remainingTimelineSec * rate;
       const startAt = now + clipLeadSec;
       // Wall-clock time at which playback ends — used to schedule fade-out.
-      const clipEndAt = startAt + remainingTimelineSec;
+      // The clip spans `remainingTimelineSec` timeline seconds, played back in
+      // `remainingTimelineSec / g` wall-clock seconds at global rate `g`.
+      const remainingWallSec = remainingTimelineSec / g;
+      const clipEndAt = startAt + remainingWallSec;
 
       if (clip.fadeInMs && clip.fadeInMs > 0) {
         const fadeEndMs = clip.startMs + clip.fadeInMs;
@@ -499,7 +510,7 @@ export class AudioGraph {
           // Ramp from the interpolated in-progress gain to full volume.
           const offsetInFadeMs = Math.max(0, currentTimeMs - clip.startMs);
           const startGain = volumeLinear * (offsetInFadeMs / clip.fadeInMs);
-          const remainingSec = (fadeEndMs - Math.max(currentTimeMs, clip.startMs)) / 1000;
+          const remainingSec = (fadeEndMs - Math.max(currentTimeMs, clip.startMs)) / 1000 / g;
           clipGain.gain.setValueAtTime(startGain, startAt);
           clipGain.gain.linearRampToValueAtTime(volumeLinear, startAt + remainingSec);
         } else {
@@ -508,7 +519,7 @@ export class AudioGraph {
       }
 
       if (clip.fadeOutMs && clip.fadeOutMs > 0) {
-        const fadeSec = clip.fadeOutMs / 1000;
+        const fadeSec = clip.fadeOutMs / 1000 / g;
         const fadeOutStartAt = Math.max(startAt, clipEndAt - fadeSec);
         if (fadeOutStartAt < clipEndAt) {
           clipGain.gain.setValueAtTime(volumeLinear, fadeOutStartAt);

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -205,7 +205,8 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       seek,
       seekNonce,
       subscribeTime,
-      getTimeMs
+      getTimeMs,
+      rate
     } = useTimelinePlaybackStore(
       useShallow((s) => ({
         // Reactive position is now discrete-only (seek/scrub/pause/stop). The
@@ -220,7 +221,8 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         seek: s.seek,
         seekNonce: s.seekNonce,
         subscribeTime: s.subscribeTime,
-        getTimeMs: s.getTimeMs
+        getTimeMs: s.getTimeMs,
+        rate: s.rate
       }))
     );
 
@@ -388,7 +390,8 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
           validClips,
           useTimelineStore.getState().tracks,
           getTimeMs(),
-          isStale
+          isStale,
+          useTimelinePlaybackStore.getState().rate
         );
       },
       [getAsset, getTimeMs]
@@ -421,6 +424,11 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
       play();
 
+      // Global playback speed, read fresh so a rate set before pressing play
+      // (and the live rate-change restart below) takes effect. Feeds both the
+      // clock and audio scheduling so the visual clock and audio stay locked.
+      const globalRate = useTimelinePlaybackStore.getState().rate;
+
       // Read fresh rather than closing over the reactive `clips` value so
       // this component never needs to subscribe to (and re-render on) the
       // clips array itself.
@@ -435,9 +443,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         // AudioContext creation/resume entirely rather than paying the
         // autoplay-policy round trip for silence.
         graph.stopAll();
-        // TODO: store `rate` (playback speed) is not wired through here — see
-        // the other clock.start call below for why.
-        clock.start(startMs, 1, null, contentEndMs || Infinity);
+        clock.start(startMs, globalRate, null, contentEndMs || Infinity);
         return;
       }
 
@@ -477,18 +483,14 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       // Clear any sources an older gesture registered, right before
       // scheduling the new ones — so the latest gesture always wins.
       graph.stopAll();
-      await graph.scheduleClips(validClips, tracks, startMs, isStale);
+      await graph.scheduleClips(validClips, tracks, startMs, isStale, globalRate);
       if (isStale()) return;
 
       for (const { clip } of validClips) {
         scheduledClipIdsRef.current.add(clip.id);
       }
 
-      // Rate is hardcoded to 1 rather than the store's `rate`: AudioGraph's
-      // scheduled sources use `clip.speedMultiplier` for per-clip speed, not
-      // a global rate, so wiring store `rate` in here alone would desync the
-      // clock from audio playback. Needs a matching change in AudioGraph.ts.
-      clock.start(startMs, 1, ctx, contentEndMs || Infinity);
+      clock.start(startMs, globalRate, ctx, contentEndMs || Infinity);
 
       topUpIntervalRef.current = setInterval(() => {
         void topUpAudio(isStale);
@@ -564,6 +566,18 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       // handlePlay reads the latest currentTimeMs from the store.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [seekNonce]);
+
+    // Changing the global rate mid-playback re-aligns the clock and audio.
+    // Seek to the live position (rebasing currentTimeMs and bumping seekNonce)
+    // so the seek-restart effect above re-runs handlePlay, which reads the new
+    // rate. Guarded on isPlaying so a rate set while paused just applies on the
+    // next play.
+    useEffect(() => {
+      if (!isPlaying) return;
+      seek(getTimeMs());
+      // Only restart on an actual rate change, not on play/pause transitions.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [rate]);
 
     const handlePlayPauseToggle = useCallback(() => {
       if (isPlaying) {

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -411,8 +411,10 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
       // Read fresh to avoid stale closure when the user scrubs before pressing play.
       let startMs = useTimelinePlaybackStore.getState().currentTimeMs;
-      // Pressing Play while parked at the end restarts from the top.
-      if (durationMs > 0 && startMs >= durationMs - frameDeltaMs(fps)) {
+      // Pressing Play while parked at the end restarts from the top. Uses the
+      // live content end (contentEndMs), not the stale store `durationMs`,
+      // which is only set on load and never recomputed as clips change.
+      if (contentEndMs > 0 && startMs >= contentEndMs - frameDeltaMs(fps)) {
         startMs = 0;
         setCurrentTimeMs(0);
       }
@@ -433,7 +435,9 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         // AudioContext creation/resume entirely rather than paying the
         // autoplay-policy round trip for silence.
         graph.stopAll();
-        clock.start(startMs, 1, null, durationMs || Infinity);
+        // TODO: store `rate` (playback speed) is not wired through here — see
+        // the other clock.start call below for why.
+        clock.start(startMs, 1, null, contentEndMs || Infinity);
         return;
       }
 
@@ -480,7 +484,11 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         scheduledClipIdsRef.current.add(clip.id);
       }
 
-      clock.start(startMs, 1, ctx, durationMs || Infinity);
+      // Rate is hardcoded to 1 rather than the store's `rate`: AudioGraph's
+      // scheduled sources use `clip.speedMultiplier` for per-clip speed, not
+      // a global rate, so wiring store `rate` in here alone would desync the
+      // clock from audio playback. Needs a matching change in AudioGraph.ts.
+      clock.start(startMs, 1, ctx, contentEndMs || Infinity);
 
       topUpIntervalRef.current = setInterval(() => {
         void topUpAudio(isStale);
@@ -488,7 +496,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
     }, [
       play,
       tracks,
-      durationMs,
+      contentEndMs,
       fps,
       getAsset,
       setCurrentTimeMs,
@@ -539,6 +547,11 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       if (seekNonce === 0 || !isPlaying) {
         return;
       }
+      // Stop the clock immediately — otherwise it keeps ticking off its old
+      // start position and overwrites (via setTimeMs) the liveTimeMs that
+      // seek() just set, so the seek is visually ignored until the debounced
+      // restart below fires and calls handlePlay's own clock.stop().
+      clockRef.current.stop();
       graphRef.current.stopAll();
       stopAudioSession();
 

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -621,7 +621,6 @@ export const PreviewCompositor: React.FC = memo(() => {
       const rate = clip?.speedBaked
         ? 1
         : Math.max(0.0001, clip?.speedMultiplier ?? 1);
-      const targetSec = clip ? clipSourceTimeSec(clip, currentTimeMs) : 0;
 
       // Setting currentTime before HAVE_METADATA is silently clamped to 0 and
       // a subsequent play() can reject with AbortError. Defer until the
@@ -629,6 +628,16 @@ export const PreviewCompositor: React.FC = memo(() => {
       // (kept in pendingSeeks) re-runs with fresh state.
       const applySeek = () => {
         if (el.readyState < 1) return;
+        // While playing, `currentTimeMs` (sceneTimeMs) is frozen between
+        // scene bumps — the 2s preload-tick re-run of this effect would
+        // otherwise seek the element BACKWARD to that stale position once
+        // the video's own clock has drifted past the 0.15s threshold.
+        // Read the live transient playhead instead, and do it here (at
+        // call time, not effect-run time) so the loadedmetadata-deferred
+        // path also gets a fresh value rather than a stale closure.
+        const targetSec = clip
+          ? clipSourceTimeSec(clip, isPlaying ? getTimeMs() : currentTimeMs)
+          : 0;
         if (!isPlaying) {
           if (Math.abs(el.currentTime - targetSec) > 0.04) {
             el.currentTime = targetSec;
@@ -710,6 +719,7 @@ export const PreviewCompositor: React.FC = memo(() => {
     activeVideoSlots,
     currentTimeMs,
     isPlaying,
+    getTimeMs,
     clips,
     clipById,
     resolveUrl,

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -298,12 +298,25 @@ const subscribeJob = async (
     return;
   }
 
-  await globalWebSocketManager.ensureConnection();
+  // Reserve the slot synchronously, before the `ensureConnection` await
+  // below, so a concurrent call for the same jobId (generateClip's
+  // post-registerJob subscribe racing the `registerJob` store write that
+  // triggers useTimelineGenerationSubscriptions) sees `has()` return true
+  // and bails instead of both subscribing and leaking a listener.
+  jobSubscriptions.set(jobId, () => {});
   jobContexts.set(jobId, context);
-  const unsubscribe = globalWebSocketManager.subscribe(jobId, (message) =>
-    void handleJobMessage(jobId, message)
-  );
-  jobSubscriptions.set(jobId, unsubscribe);
+
+  try {
+    await globalWebSocketManager.ensureConnection();
+    const unsubscribe = globalWebSocketManager.subscribe(jobId, (message) =>
+      void handleJobMessage(jobId, message)
+    );
+    jobSubscriptions.set(jobId, unsubscribe);
+  } catch (error) {
+    // Undo the reservation so a later retry can subscribe.
+    jobSubscriptions.delete(jobId);
+    throw error;
+  }
 
   if (reconnect) {
     await globalWebSocketManager.send({

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -159,7 +159,13 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
               provider: current.provider,
               model: current.model,
               strength: current.strength,
-              numInferenceSteps: current.numInferenceSteps
+              numInferenceSteps: current.numInferenceSteps,
+              width: current.width,
+              height: current.height,
+              voice: current.voice,
+              aspectRatio: current.aspectRatio,
+              resolution: current.resolution,
+              negativePrompt: current.negativePrompt
             }
           })
         ]

--- a/web/src/hooks/timeline/useTimelineExport.ts
+++ b/web/src/hooks/timeline/useTimelineExport.ts
@@ -52,7 +52,10 @@ function downloadBlob(bytes: Uint8Array, mimeType: string, filename: string): vo
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();
-  URL.revokeObjectURL(url);
+  // Defer revoking the object URL so the browser has time to initiate the
+  // download before we release the blob. Without this delay, Firefox and large
+  // files may have the download cancelled before it starts.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function clipEndMs(clip: { startMs: number; durationMs: number }): number {

--- a/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
+++ b/web/src/hooks/timeline/useWorkflowFreshnessCheck.ts
@@ -59,7 +59,7 @@ export function useWorkflowFreshnessCheck(
     (s) => s.markClipsStaleForWorkflow
   );
   const applyInputDrift = useTimelineStore((s) => s.applyInputDrift);
-  const setClipsOutputNode = useTimelineStore((s) => s.setClipsOutputNode);
+  const patchClip = useTimelineStore((s) => s.patchClip);
 
   const lastCheckedSequenceId = useRef<string | null>(null);
 
@@ -144,15 +144,23 @@ export function useWorkflowFreshnessCheck(
           }
         }
 
-        const hasMissingOutput = affectedClips.some(
+        const clipsWithMissingOutput = affectedClips.filter(
           (c) =>
             c.selectedOutputNodeId &&
             !currentOutputIds.has(c.selectedOutputNodeId)
         );
 
-        if (hasMissingOutput && currentOutputNodes.length > 0) {
-          setClipsOutputNode(workflowId, currentOutputNodes[0]!.id);
-          markClipsStaleForWorkflow(workflowId);
+        // Only re-point clips whose OWN selection is actually missing.
+        // Clips deliberately bound to a different, still-valid output must
+        // not be clobbered by another clip's missing selection.
+        if (clipsWithMissingOutput.length > 0 && currentOutputNodes.length > 0) {
+          const fallbackOutputNodeId = currentOutputNodes[0]!.id;
+          for (const clip of clipsWithMissingOutput) {
+            patchClip(clip.id, {
+              selectedOutputNodeId: fallbackOutputNodeId,
+              status: "stale"
+            });
+          }
         }
       })
     );
@@ -161,7 +169,7 @@ export function useWorkflowFreshnessCheck(
     store,
     markClipsStaleForWorkflow,
     applyInputDrift,
-    setClipsOutputNode
+    patchClip
   ]);
 
   useEffect(() => {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -526,26 +526,22 @@ function patchById<T extends { id: string }>(
 
 // ── Scene split/merge helpers (pure) ───────────────────────────────────────
 
-/** Split every clip that strictly contains `timeMs` into two halves. */
+/**
+ * Split every clip that strictly contains `timeMs` into two halves,
+ * link-aware. Delegates to `splitClipsLinkAware` with every clip as a
+ * candidate target so a split through a linked A/V pair mints one fresh
+ * linkId for the LEFT halves and another for the RIGHT halves, rather than
+ * leaving all four halves sharing the original linkId.
+ */
 function splitAllClipsAt(
   clips: TimelineClip[],
   timeMs: number
 ): TimelineClip[] {
-  const next: TimelineClip[] = [];
-  for (const clip of clips) {
-    if (timeMs > clip.startMs && timeMs < clip.startMs + clip.durationMs) {
-      try {
-        const [left, right] = splitClip(clip, timeMs);
-        next.push(left, right);
-      } catch {
-        // Skip clips where the split is invalid (e.g. boundary mismatch).
-        next.push(clip);
-      }
-    } else {
-      next.push(clip);
-    }
-  }
-  return next;
+  return splitClipsLinkAware(
+    clips,
+    timeMs,
+    clips.map((c) => c.id)
+  );
 }
 
 /**
@@ -858,12 +854,23 @@ export const createTimelineStore = (
         reorderTracks: (orderedIds) =>
           set((state) => {
             const byId = new Map(state.tracks.map((t) => [t.id, t]));
+            const orderedIdSet = new Set(orderedIds);
             const reordered = orderedIds
               .map((id, index) => {
                 const t = byId.get(id);
                 return t ? { ...t, index } : null;
               })
               .filter((t): t is TimelineTrack => t !== null);
+            // Tracks missing from `orderedIds` (e.g. a caller passed a stale
+            // subset) are appended in their original relative order rather
+            // than dropped, so their clips are never orphaned.
+            let nextIndex = reordered.length;
+            for (const t of state.tracks) {
+              if (!orderedIdSet.has(t.id)) {
+                reordered.push({ ...t, index: nextIndex });
+                nextIndex += 1;
+              }
+            }
             return { tracks: reordered };
           }),
 
@@ -915,17 +922,32 @@ export const createTimelineStore = (
           })),
 
         updateTrackEffect: (trackId, effectId, patch) =>
-          set((state) => ({
-            tracks: state.tracks.map((t) => {
-              if (t.id !== trackId) return t;
-              const effects = (t.effects ?? []).map((e) =>
-                e.id === effectId
-                  ? ({ ...e, ...patch } as TrackEffect)
-                  : e
-              );
-              return { ...t, effects };
-            })
-          })),
+          set((state) => {
+            const track = state.tracks.find((t) => t.id === trackId);
+            const effect = track?.effects?.find((e) => e.id === effectId);
+            if (!effect) {
+              return state;
+            }
+            const effectRecord = effect as unknown as Record<string, unknown>;
+            const patchRecord = patch as Record<string, unknown>;
+            const unchanged = Object.keys(patch).every((k) =>
+              Object.is(effectRecord[k], patchRecord[k])
+            );
+            if (unchanged) {
+              return state;
+            }
+            return {
+              tracks: state.tracks.map((t) => {
+                if (t.id !== trackId) return t;
+                const effects = (t.effects ?? []).map((e) =>
+                  e.id === effectId
+                    ? ({ ...e, ...patch } as TrackEffect)
+                    : e
+                );
+                return { ...t, effects };
+              })
+            };
+          }),
 
         removeTrackEffect: (trackId, effectId) =>
           set((state) => ({
@@ -1417,22 +1439,48 @@ export const createTimelineStore = (
           }),
 
         setParamOverride: (clipId, inputNodeName, value) =>
-          set((state) => ({
-            clips: state.clips.map((c) => {
-              if (c.id !== clipId) return c;
-              const paramOverrides = { ...(c.paramOverrides ?? {}), [inputNodeName]: value };
-              // Mark as stale only when the clip has already been generated.
-              const status: TimelineClip["status"] =
-                c.lastGeneratedHash ? "stale" : c.status;
-              return { ...c, paramOverrides, status };
-            })
-          })),
+          set((state) => {
+            const clip = state.clips.find((c) => c.id === clipId);
+            if (!clip) {
+              return state;
+            }
+            // Mark as stale only when the clip has already been generated.
+            const status: TimelineClip["status"] = clip.lastGeneratedHash
+              ? "stale"
+              : clip.status;
+            const unchanged =
+              Object.is(clip.paramOverrides?.[inputNodeName], value) &&
+              clip.status === status;
+            if (unchanged) {
+              return state;
+            }
+            return {
+              clips: state.clips.map((c) => {
+                if (c.id !== clipId) return c;
+                const paramOverrides = {
+                  ...(c.paramOverrides ?? {}),
+                  [inputNodeName]: value
+                };
+                return { ...c, paramOverrides, status };
+              })
+            };
+          }),
 
         applyInputDrift: (workflowId, added, removed) =>
-          set((state) => ({
-            clips: state.clips.map((c) => {
+          set((state) => {
+            let changed = false;
+            const clips = state.clips.map((c) => {
               if (c.workflowId !== workflowId) return c;
-              const overrides = { ...(c.paramOverrides ?? {}) };
+              const current = c.paramOverrides ?? {};
+              const hasAddition = added.some(
+                ({ name }) => !(name in current)
+              );
+              const hasRemoval = removed.some((name) => name in current);
+              if (!hasAddition && !hasRemoval) {
+                return c;
+              }
+              changed = true;
+              const overrides = { ...current };
               for (const { name, defaultValue } of added) {
                 if (!(name in overrides)) {
                   overrides[name] = defaultValue;
@@ -1442,8 +1490,9 @@ export const createTimelineStore = (
                 delete overrides[name];
               }
               return { ...c, paramOverrides: overrides };
-            })
-          })),
+            });
+            return changed ? { clips } : state;
+          }),
 
         setClipsOutputNode: (workflowId, selectedOutputNodeId) =>
           set((state) => ({

--- a/web/src/stores/timeline/TimelineTranscriptStore.ts
+++ b/web/src/stores/timeline/TimelineTranscriptStore.ts
@@ -297,10 +297,14 @@ export const useTimelineTranscriptStore = create<TimelineTranscriptStoreState>(
           voice: ttsVoice,
           status: "draft"
         });
+        // Insert and reflow in a single `set` so the whole beat-add commits as
+        // one undo entry — `addClip` then a separate `setTranscriptAndClips`
+        // would push two history checkpoints for what the user sees as one
+        // action.
         const store = useTimelineStore.getState();
-        store.addClip(clip);
-        const after = useTimelineStore.getState();
-        after.setTranscriptAndClips(ops.reflowGenerated(after.clips));
+        store.setTranscriptAndClips(
+          ops.reflowGenerated([...store.clips, clip])
+        );
         return id;
       },
 

--- a/web/src/stores/timeline/transcriptOps.ts
+++ b/web/src/stores/timeline/transcriptOps.ts
@@ -59,7 +59,14 @@ export interface TranscriptToken {
  * the right media span.
  */
 export interface TranscriptSegment {
-  /** Stable id — the paragraph key (shared `paragraphId` of its clips). */
+  /**
+   * Stable id, unique across the doc. Normally the paragraph key (shared
+   * `paragraphId` of its clips); when that same `paragraphId` recurs in a
+   * later, non-contiguous group (a differently-paragraphed clip lands between
+   * two pieces of the same paragraph), later occurrences get a `#n` suffix so
+   * no two segments ever share an id — segment ids back React keys and
+   * DOM-ref map keys downstream (see `ScriptLane`).
+   */
   id: string;
   /** Backing clips, in timeline order. A single draft, or 1..n voiced pieces. */
   clipIds: string[];
@@ -166,7 +173,7 @@ function maxEnd(clips: TimelineClip[]): number {
   return clips.reduce((max, c) => Math.max(max, c.startMs + c.durationMs), 0);
 }
 
-function buildSegment(key: string, members: TimelineClip[]): TranscriptSegment {
+function buildSegment(id: string, members: TimelineClip[]): TranscriptSegment {
   const tokens: TranscriptToken[] = [];
   for (const clip of members) {
     const offset = clip.startMs;
@@ -192,7 +199,7 @@ function buildSegment(key: string, members: TimelineClip[]): TranscriptSegment {
     tokens.length === 0 &&
     first.sourceType !== "imported";
   return {
-    id: key,
+    id,
     clipIds: members.map((c) => c.id),
     kind: first.sourceType === "imported" ? "imported" : "generated",
     speaker: first.speaker,
@@ -230,6 +237,11 @@ export function buildTranscriptDoc(clips: TimelineClip[]): TranscriptDoc {
 
   const sorted = clips.filter(isTranscriptClip).sort(byTimeline);
   const segments: TranscriptSegment[] = [];
+  // A paragraphId can recur in more than one non-contiguous group (a clip
+  // with a different paragraphId lands between two pieces of the same
+  // paragraph) — track how many groups each key has produced so far and
+  // disambiguate every group after the first, keeping ids unique doc-wide.
+  const occurrences = new Map<string, number>();
 
   let i = 0;
   while (i < sorted.length) {
@@ -239,7 +251,10 @@ export function buildTranscriptDoc(clips: TimelineClip[]): TranscriptDoc {
       members.push(sorted[i]);
       i += 1;
     }
-    segments.push(buildSegment(key, members));
+    const occurrence = occurrences.get(key) ?? 0;
+    occurrences.set(key, occurrence + 1);
+    const id = occurrence === 0 ? key : `${key}#${occurrence}`;
+    segments.push(buildSegment(id, members));
   }
 
   const doc: TranscriptDoc = { segments, durationMs: maxEnd(sorted) };
@@ -337,15 +352,28 @@ export function resolveSelectionRange(
   };
 }
 
+/**
+ * Effective source-playback rate for a clip: one timeline-ms consumes this
+ * many source-ms. Mirrors `sourceRate` in `@nodetool-ai/timeline`
+ * (`splitClip`/`trimClip`) — not part of that package's public exports, so
+ * duplicated here rather than reaching into its `src/`.
+ */
+function sourceRate(clip: Pick<TimelineClip, "speedBaked" | "speedMultiplier">): number {
+  return clip.speedBaked ? 1 : Math.max(0.0001, clip.speedMultiplier ?? 1);
+}
+
 /** The head remnant of `clip`, keeping clip-local [0, lengthMs). */
 function headRemnant(clip: TimelineClip, lengthMs: number): TimelineClip {
+  const rate = sourceRate(clip);
   const inPointMs = clip.inPointMs ?? 0;
   const words = (clip.caption?.words ?? []).filter((w) => w.endMs <= lengthMs);
   return {
     ...clip,
     durationMs: lengthMs,
     inPointMs,
-    outPointMs: inPointMs + lengthMs,
+    // Source in/out points are source-space; one timeline-ms consumes `rate`
+    // source-ms (mirrors splitClip's `cutPointMs`).
+    outPointMs: inPointMs + lengthMs * rate,
     caption: clip.caption ? { ...clip.caption, words } : undefined
   };
 }
@@ -356,8 +384,9 @@ function tailRemnant(
   fromMs: number,
   startMs: number
 ): TimelineClip {
+  const rate = sourceRate(clip);
   const inPointMs = clip.inPointMs ?? 0;
-  const outPointMs = clip.outPointMs ?? inPointMs + clip.durationMs;
+  const outPointMs = clip.outPointMs ?? inPointMs + clip.durationMs * rate;
   const words = (clip.caption?.words ?? [])
     .filter((w) => w.startMs >= fromMs)
     .map((w) => ({ ...w, startMs: w.startMs - fromMs, endMs: w.endMs - fromMs }));
@@ -366,7 +395,9 @@ function tailRemnant(
     id: createTimeOrderedUuid(),
     startMs,
     durationMs: clip.durationMs - fromMs,
-    inPointMs: inPointMs + fromMs,
+    // Cut point is source-space, `fromMs` timeline-ms in (mirrors splitClip's
+    // `cutPointMs`).
+    inPointMs: inPointMs + fromMs * rate,
     outPointMs,
     caption: clip.caption ? { ...clip.caption, words } : undefined
   };
@@ -615,6 +646,7 @@ function midRemnant(
   hiMs: number,
   blockMs: number
 ): TimelineClip {
+  const rate = sourceRate(clip);
   const inPointMs = clip.inPointMs ?? 0;
   const words = (clip.caption?.words ?? [])
     .filter((w) => w.startMs >= loMs && w.endMs <= hiMs)
@@ -624,8 +656,10 @@ function midRemnant(
     id: createTimeOrderedUuid(),
     startMs: blockMs,
     durationMs: hiMs - loMs,
-    inPointMs: inPointMs + loMs,
-    outPointMs: inPointMs + hiMs,
+    // Both cut points are source-space, `loMs`/`hiMs` timeline-ms in (mirrors
+    // splitClip's `cutPointMs`).
+    inPointMs: inPointMs + loMs * rate,
+    outPointMs: inPointMs + hiMs * rate,
     caption: clip.caption ? { ...clip.caption, words } : undefined
   };
 }


### PR DESCRIPTION
Playback/preview:
- PreviewCompositor: seek target now uses live playback time instead of
  the frozen scene time, so playing videos no longer jump backward every
  2s (preloadTick re-run) and A/V no longer desyncs.
- PreviewArea: stop the PlaybackClock on seek-while-playing so the seek
  isn't overwritten and ignored; clamp/auto-stop/restart-from-top on the
  live content end instead of the stale store durationMs.
- Playhead: End key no longer flings the playhead to MAX_SAFE_INTEGER when
  durationMs is 0.
- Clip: waveform redraw key includes the asset url, so swapping to a
  same-duration asset repaints instead of showing the old waveform.
- ScriptLane: highlight effect cleanup strips stale is-active/w-active
  classes on transcript change mid-playback.

Stores:
- TimelineStore: addScene splits linked clips link-aware (fresh per-side
  linkIds) so A/V link groups aren't corrupted; reorderTracks keeps tracks
  missing from orderedIds instead of orphaning their clips; setParamOverride/
  applyInputDrift/updateTrackEffect return the same refs on no-op edits to
  avoid spurious undo entries.
- transcriptOps: buildTranscriptDoc gives recurring non-contiguous
  paragraph groups unique segment ids (no duplicate React keys); head/tail/
  mid remnant out/in points respect sourceRate for non-1x clips.
- TimelineTranscriptStore: addBeat commits insert+reflow in one set so it's
  a single undo entry.

Hooks:
- useGenerateClip: reserve the job slot synchronously before the
  ensureConnection await to close a TOCTOU double-subscribe that leaked a
  WebSocket listener.
- useTimelineExport: defer revokeObjectURL so the download isn't cancelled
  in Firefox / for large files.
- useTimelineDirectGenJob: version snapshot captures the full param set
  (width/height/voice/aspectRatio/resolution/negativePrompt) for lossless
  restore.
- useWorkflowFreshnessCheck: only re-point clips whose own output selection
  is missing, instead of clobbering every clip on the workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ToQcxjLNLyhrJAvo4tFYhL