### PR TITLE
fix(web/chat): fix 20 bugs across chat UI store, composer, rendering, and threads

### DIFF
--- a/web/src/components/chat/composer/ChatComposer.tsx
+++ b/web/src/components/chat/composer/ChatComposer.tsx
@@ -13,7 +13,6 @@ import { Caption, FlexRow, ToolbarIconButton } from "../../ui_primitives";
 import SendIcon from "@mui/icons-material/Send";
 import ClearIcon from "@mui/icons-material/Clear";
 import { MessageContent } from "../../../stores/ApiTypes";
-import { useKeyPressed } from "../../../stores/KeyPressedStore";
 import { FilePreview } from "./FilePreview";
 import { MessageInput } from "./MessageInput";
 import { ActionButtons } from "./ActionButtons";
@@ -47,14 +46,6 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [prompt, setPrompt] = useState("");
 
-  const { metaKeyPressed, altKeyPressed, shiftKeyPressed } = useKeyPressed(
-    (state) => ({
-      metaKeyPressed: state.isKeyPressed("meta"),
-      altKeyPressed: state.isKeyPressed("alt"),
-      shiftKeyPressed: state.isKeyPressed("shift")
-    })
-  );
-
   const { droppedFiles, addFiles, removeFile, clearFiles, getFileContents, addDroppedFiles } =
     useFileHandling();
 
@@ -77,38 +68,48 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
   );
 
   const handleSend = useCallback(() => {
-    if (prompt.length === 0) {
+    // Allow attachment-only sends; a whitespace-only prompt with no files
+    // is not a message. Trim so a spaces-only prompt never sends a text part.
+    if (prompt.trim().length === 0 && droppedFiles.length === 0) {
       return;
     }
 
-    const content: MessageContent[] = [
-      {
-        type: "text",
-        text: prompt
-      }
-    ];
+    const content: MessageContent[] = [];
+    if (prompt.trim().length > 0) {
+      content.push({ type: "text", text: prompt });
+    }
     const fileContents = getFileContents();
     const fullContent = [...content, ...fileContents];
 
-    sendMessage(fullContent, prompt);
-    setPrompt("");
-    clearFiles();
-  }, [prompt, getFileContents, sendMessage, clearFiles]);
+    // Only clear the input when the message was actually sent or queued;
+    // a dropped message (one already queued) keeps its text and attachments.
+    if (sendMessage(fullContent, prompt)) {
+      setPrompt("");
+      clearFiles();
+    }
+  }, [prompt, droppedFiles, getFileContents, sendMessage, clearFiles]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter") {
-        if (shiftKeyPressed) {
+        // Ignore the Enter that confirms an IME composition candidate — it
+        // fires keydown with isComposing/keyCode 229 and must not send.
+        if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) {
+          return;
+        }
+        // Read modifiers from the event, not the global KeyPressedStore, which
+        // is stale when the textarea was click-focused with a modifier held.
+        if (e.shiftKey) {
           // Shift+Enter inserts a newline (default behavior)
           return;
         }
-        if (!metaKeyPressed && !altKeyPressed) {
+        if (!e.metaKey && !e.altKey) {
           e.preventDefault();
           handleSend();
         }
       }
     },
-    [shiftKeyPressed, metaKeyPressed, altKeyPressed, handleSend]
+    [handleSend]
   );
 
   const isDisabled = disabled || isLoading || isStreaming;
@@ -223,7 +224,11 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
               onStop={onStop}
               onNewChat={onNewChat}
               isDisabled={isDisabled && !queuedMessage}
-              hasContent={prompt.trim() !== "" || !!queuedMessage}
+              hasContent={
+                prompt.trim() !== "" ||
+                droppedFiles.length > 0 ||
+                !!queuedMessage
+              }
             />
           </div>
         </>

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -76,7 +76,6 @@ import { useTextareaAssetMention } from "./useTextareaAssetMention";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
-import { useKeyPressed } from "../../../stores/KeyPressedStore";
 import { useMessageQueue } from "../../../hooks/useMessageQueue";
 import { createMediaComposerStyles } from "./MediaChatComposer.styles";
 import useModelPreferencesStore from "../../../stores/ModelPreferencesStore";
@@ -228,13 +227,6 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     useFileHandling();
   const { isDragging, handleDragOver, handleDragLeave, handleDrop } =
     useDragAndDrop(addFiles, addDroppedFiles);
-  const { shiftKeyPressed, metaKeyPressed, altKeyPressed } = useKeyPressed(
-    (state) => ({
-      shiftKeyPressed: state.isKeyPressed("shift"),
-      metaKeyPressed: state.isKeyPressed("meta"),
-      altKeyPressed: state.isKeyPressed("alt")
-    })
-  );
 
   // Typing `@` opens the asset picker; a picked asset is attached as an
   // `asset://` reference (like a drag from the asset library) rather than
@@ -470,9 +462,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     }
     const fileContents = getFileContents();
     const fullContent = [...content, ...fileContents];
-    sendMessage(fullContent, prompt);
-    setPrompt("");
-    clearFiles();
+    // Only clear the input when the message was actually sent or queued; a
+    // dropped message (one already queued) keeps its text and attachments.
+    if (sendMessage(fullContent, prompt)) {
+      setPrompt("");
+      clearFiles();
+    }
   }, [
     prompt,
     canGenerate,
@@ -503,21 +498,32 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Ignore the Enter that confirms an IME composition candidate — it fires
+      // keydown with isComposing/keyCode 229 and must neither send nor select a
+      // mention. Guard before the mention handler and the send logic.
+      if (
+        e.key === "Enter" &&
+        (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229)
+      ) {
+        return;
+      }
       // Let the asset-mention picker consume nav / select / dismiss keys first.
       if (handleMentionKeyDown(e)) {
         return;
       }
       if (e.key === "Enter") {
-        if (shiftKeyPressed) {
+        // Read modifiers from the event, not the global KeyPressedStore, which
+        // is stale when the textarea was click-focused with a modifier held.
+        if (e.shiftKey) {
           return;
         }
-        if (!metaKeyPressed && !altKeyPressed) {
+        if (!e.metaKey && !e.altKey) {
           e.preventDefault();
           handleSend();
         }
       }
     },
-    [handleMentionKeyDown, shiftKeyPressed, metaKeyPressed, altKeyPressed, handleSend]
+    [handleMentionKeyDown, handleSend]
   );
 
   const modeIcon = useMemo(() => {

--- a/web/src/components/chat/containers/GlobalChat.tsx
+++ b/web/src/components/chat/containers/GlobalChat.tsx
@@ -290,8 +290,11 @@ const GlobalChat: React.FC = () => {
       if (viewportTimeoutId !== null) { clearTimeout(viewportTimeoutId); }
       viewportTimeoutId = setTimeout(() => {
         if (chatContainerRef.current) {
+          // The scroll host is the message wrapper (the only overflowY:auto
+          // element, ChatThreadView.styles.ts messageWrapper), not the outer
+          // .chat-thread-container which does not scroll.
           const chatArea = chatContainerRef.current.querySelector(
-            ".chat-thread-container"
+            ".scrollable-message-wrapper"
           );
           if (chatArea) {
             const wasAtBottom =
@@ -407,14 +410,24 @@ const GlobalChat: React.FC = () => {
         (msg: Message) => msg.role === "user"
       );
       if (firstUserMessage) {
-        const content =
-          typeof firstUserMessage.content === "string"
-            ? firstUserMessage.content
-            : Array.isArray(firstUserMessage.content) &&
-              firstUserMessage.content[0]?.type === "text"
-              ? (firstUserMessage.content[0] as MessageTextContent).text
-              : "[Media message]";
-        return content?.substring(0, 50) + (content?.length > 50 ? "..." : "");
+        let content: string;
+        if (typeof firstUserMessage.content === "string") {
+          content = firstUserMessage.content;
+        } else if (
+          Array.isArray(firstUserMessage.content) &&
+          firstUserMessage.content[0]?.type === "text"
+        ) {
+          // `text` can be null/undefined even on a text block — never let that
+          // stringify into the literal "undefined".
+          content =
+            (firstUserMessage.content[0] as MessageTextContent).text ?? "";
+        } else {
+          content = "[Media message]";
+        }
+        if (!content) {
+          return "New conversation";
+        }
+        return content.substring(0, 50) + (content.length > 50 ? "..." : "");
       }
 
       return "New conversation";

--- a/web/src/components/chat/hooks/useDragAndDrop.ts
+++ b/web/src/components/chat/hooks/useDragAndDrop.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Asset } from "../../../stores/ApiTypes";
 import { DroppedFile } from "../types/chat.types";
 import { useAssetGridStore } from "../../../stores/AssetGridStore";
@@ -36,20 +36,43 @@ export const useDragAndDrop = (
   onAssetsDropped?: (files: DroppedFile[]) => void
 ) => {
   const [isDragging, setIsDragging] = useState(false);
+  // Enter/leave depth counter: a dragleave also fires when the pointer crosses
+  // from the drop zone onto one of its children, which would otherwise flip
+  // isDragging off for a frame and flicker the highlight.
+  const dragDepthRef = useRef(0);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDragging(true);
+  }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
+    // dragover fires continuously; keep the zone active even for consumers
+    // that don't wire onDragEnter — the depth counter (with the relatedTarget
+    // fallback below) stays authoritative for when to clear.
     setIsDragging(true);
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragging(false);
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    // Fallback for when onDragEnter isn't wired (depth stays 0): a leave whose
+    // related target is still inside the zone is a child crossing, not a real
+    // exit — don't clear.
+    const related = e.relatedTarget;
+    const stillInside =
+      related instanceof Node && e.currentTarget.contains(related);
+    if (dragDepthRef.current === 0 && !stillInside) {
+      setIsDragging(false);
+    }
   }, []);
 
   const handleDrop = useCallback(
     async (e: React.DragEvent) => {
       e.preventDefault();
+      dragDepthRef.current = 0;
       setIsDragging(false);
 
       const dragData = deserializeDragData(e.dataTransfer);
@@ -123,6 +146,7 @@ export const useDragAndDrop = (
 
   return {
     isDragging,
+    handleDragEnter,
     handleDragOver,
     handleDragLeave,
     handleDrop

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -65,28 +65,37 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
   const objectUrlRef = useRef<string | null>(null);
   const { isCanvasAvailable, addBlocksToCanvas } = useAddMediaToCanvas();
 
-  const createObjectUrl = useCallback(
-    (
-      source: string | Uint8Array | undefined,
-      type: string
-    ): string | undefined => {
-      if (!source) {
-        return undefined;
-      }
-      if (typeof source === "string") {
-        return source;
-      }
+  // Resolve the video source once, at the top level, so the blob URL below can
+  // be memoized on the actual source (Uint8Array/string) identity. A byte
+  // payload uses the inline `data`; otherwise the `uri` is used directly.
+  const videoSource: string | Uint8Array | undefined =
+    content.type === "video"
+      ? content.video?.uri === ""
+        ? (content.video?.data as Uint8Array)
+        : content.video?.uri
+      : undefined;
 
-      if (objectUrlRef.current) {
-        URL.revokeObjectURL(objectUrlRef.current);
-      }
-
-      const newObjectUrl = URL.createObjectURL(new Blob([source as BlobPart], { type }));
-      objectUrlRef.current = newObjectUrl;
-      return newObjectUrl;
-    },
-    []
-  );
+  // Mint the blob URL only when the source actually changes. Doing this in the
+  // render body (as before) revoked and re-created the URL on every render,
+  // resetting the <video> element to 0:00 on any parent re-render. A string uri
+  // passes through untouched — no blob is created or revoked for it.
+  const videoObjectUrl = useMemo<string | undefined>(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    if (!videoSource) {
+      return undefined;
+    }
+    if (typeof videoSource === "string") {
+      return videoSource;
+    }
+    const url = URL.createObjectURL(
+      new Blob([videoSource as BlobPart], { type: "video/mp4" })
+    );
+    objectUrlRef.current = url;
+    return url;
+  }, [videoSource]);
 
   useEffect(() => {
     return () => {
@@ -193,15 +202,15 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         </div>
       );
     case "video": {
-      const uri = createObjectUrl(
-        content.video?.uri === ""
-          ? (content.video?.data as Uint8Array)
-          : content.video?.uri,
-        "video/mp4"
-      );
       return (
         <div css={wrapperStyles} {...dragProps}>
-          <video ref={videoRef} controls style={videoStyle} src={uri} aria-label="Video content" />
+          <video
+            ref={videoRef}
+            controls
+            style={videoStyle}
+            src={videoObjectUrl}
+            aria-label="Video content"
+          />
           {addButton}
         </div>
       );

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -429,8 +429,11 @@ export const MessageView: React.FC<
     }
     if (Array.isArray(message.content)) {
       return message.content
-        .filter((c) => c.type === "text")
-        .map((c) => (c as MessageTextContent).text)
+        .filter(
+          (c): c is MessageTextContent =>
+            !!c && typeof c === "object" && c.type === "text"
+        )
+        .map((c) => c.text)
         .join("\n");
     }
     return "";
@@ -448,48 +451,13 @@ export const MessageView: React.FC<
     return handler;
   }, []);
 
-  if (message.role === "agent_execution") {
-    const key = message.agent_execution_id || "__ungrouped__";
-    const executionMessages = executionMessagesById?.get(key) ?? [];
-    if (executionMessages.length > 0) {
-      return <AgentExecutionView messages={executionMessages} />;
-    }
-    return null;
-  }
-
-    const baseClass = getMessageClass(message.role);
-    const hasToolCalls =
-      message.role === "assistant" &&
-      Array.isArray(message.tool_calls) &&
-      message.tool_calls.length > 0;
-    const hasNonEmptyContent =
-      (typeof message.content === "string" && message.content.trim().length > 0) ||
-      (Array.isArray(message.content) &&
-        message.content.some((block) => {
-          if (!block || typeof block !== "object") {
-            return false;
-          }
-          const contentBlock = block as MessageContent;
-          if (contentBlock.type === "text") {
-            return typeof (contentBlock as MessageTextContent).text === "string" &&
-              (contentBlock as MessageTextContent).text.trim().length > 0;
-          }
-          return true;
-        }));
-
-    const showRoleMeta =
-      showMeta && (message.role === "assistant" || message.role === "user");
-    const messageClass = [
-      baseClass,
-      (message as Message & { error_type?: string }).error_type ? "error-message" : null,
-      hasToolCalls ? "has-tool-calls" : null,
-      hasToolCalls && !hasNonEmptyContent ? "tool-calls-only" : null,
-      showRoleMeta ? "chat-message--meta" : null
-    ]
-      .filter(Boolean)
-      .join(" ");
-
-    const renderTextContent = (content: string, index: string | number) => {
+  // Memoized so its reference is stable across renders. It is passed to every
+  // React.memo'd MessageContentRenderer; a fresh closure each render would
+  // defeat that memo and force all media children (e.g. <video>) to re-render.
+  // Deps are exactly the non-stable values it closes over — createToggleHandler
+  // is already stable via useCallback.
+  const renderTextContent = useCallback(
+    (content: string, index: string | number) => {
       if (hasHarmonyTokens(content)) {
         const { messages, rawText } = parseHarmonyContent(content);
 
@@ -561,7 +529,50 @@ export const MessageView: React.FC<
         onInsertCode ||
         (insertIntoEditor ? (t: string) => insertIntoEditor(t) : undefined);
       return <ChatMarkdown content={parsedContent} onInsertCode={handler} />;
-    };
+    },
+    [isThoughtExpanded, createToggleHandler, onInsertCode, insertIntoEditor]
+  );
+
+  if (message.role === "agent_execution") {
+    const key = message.agent_execution_id || "__ungrouped__";
+    const executionMessages = executionMessagesById?.get(key) ?? [];
+    if (executionMessages.length > 0) {
+      return <AgentExecutionView messages={executionMessages} />;
+    }
+    return null;
+  }
+
+    const baseClass = getMessageClass(message.role);
+    const hasToolCalls =
+      message.role === "assistant" &&
+      Array.isArray(message.tool_calls) &&
+      message.tool_calls.length > 0;
+    const hasNonEmptyContent =
+      (typeof message.content === "string" && message.content.trim().length > 0) ||
+      (Array.isArray(message.content) &&
+        message.content.some((block) => {
+          if (!block || typeof block !== "object") {
+            return false;
+          }
+          const contentBlock = block as MessageContent;
+          if (contentBlock.type === "text") {
+            return typeof (contentBlock as MessageTextContent).text === "string" &&
+              (contentBlock as MessageTextContent).text.trim().length > 0;
+          }
+          return true;
+        }));
+
+    const showRoleMeta =
+      showMeta && (message.role === "assistant" || message.role === "user");
+    const messageClass = [
+      baseClass,
+      (message as Message & { error_type?: string }).error_type ? "error-message" : null,
+      hasToolCalls ? "has-tool-calls" : null,
+      hasToolCalls && !hasNonEmptyContent ? "tool-calls-only" : null,
+      showRoleMeta ? "chat-message--meta" : null
+    ]
+      .filter(Boolean)
+      .join(" ");
 
     const content = message.content as
       | Array<MessageTextContent | MessageImageContent>
@@ -618,14 +629,21 @@ export const MessageView: React.FC<
                     mediaContents={content as MessageContent[]}
                   />
                 ) : (
-                  content.map((c: MessageContent, i: number) => (
-                    <MessageContentRenderer
-                      key={`${message.id}-content-${c.type}-${i}`}
-                      content={c}
-                      renderTextContent={renderTextContent}
-                      index={i}
-                    />
-                  ))
+                  content.map((c: MessageContent, i: number) => {
+                    // Guard against null / non-object blocks so the renderer's
+                    // switch on `c.type` can't crash on a malformed block.
+                    if (!c || typeof c !== "object") {
+                      return null;
+                    }
+                    return (
+                      <MessageContentRenderer
+                        key={`${message.id}-content-${c.type}-${i}`}
+                        content={c}
+                        renderTextContent={renderTextContent}
+                        index={i}
+                      />
+                    );
+                  })
                 ))}
             </>
           )}

--- a/web/src/components/chat/message/thought/ThoughtSection.tsx
+++ b/web/src/components/chat/message/thought/ThoughtSection.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import ChatMarkdown from "../ChatMarkdown";
 import { ReasoningToggle } from "../../../common/ReasoningToggle";
 import { useTheme } from "@mui/material/styles";
@@ -16,16 +16,14 @@ interface ThoughtSectionProps {
 
 export const ThoughtSection: React.FC<ThoughtSectionProps> = React.memo(({
   thoughtContent,
-  isExpanded: initialExpanded,
-  onToggle: externalToggle,
+  isExpanded,
+  onToggle,
   textBefore,
   textAfter
 }) => {
-  const [isExpanded, setExpanded] = useState(initialExpanded);
-  const onToggle = useCallback(() => {
-    setExpanded((v) => !v);
-    externalToggle();
-  }, [externalToggle]);
+  // Fully controlled: render from the `isExpanded` prop (owned by the parent's
+  // expansion store) and report clicks via `onToggle`. A local useState mirror
+  // would desync from an external "expand/collapse all" mutation.
   const theme = useTheme();
   const thoughtContentStyles = useMemo(() => css({
     margin: "0 0 1em 00",

--- a/web/src/components/chat/message/toolResults/parseSearchResults.ts
+++ b/web/src/components/chat/message/toolResults/parseSearchResults.ts
@@ -134,7 +134,13 @@ export function normalizeSearchResults(content: unknown): SearchResultItem[] | n
       }
     }
     const parsed = parseNumberedText(trimmed);
-    return parsed.length > 0 ? parsed : null;
+    // A bare numbered list is ambiguous: real search output (google_search)
+    // always pairs each entry with a URL line, whereas plain numbered prose
+    // ("1. Preheat oven\n2. Mix flour") never does. Only treat it as search
+    // results when at least one entry carries a URL, so ordinary numbered text
+    // isn't rendered as search-result cards.
+    const hasUrl = parsed.some((item) => item.url);
+    return parsed.length > 0 && hasUrl ? parsed : null;
   }
 
   if (Array.isArray(content)) {

--- a/web/src/components/chat/sidebar/TodoSidebar.tsx
+++ b/web/src/components/chat/sidebar/TodoSidebar.tsx
@@ -128,7 +128,7 @@ export const TodoSidebar: React.FC<TodoSidebarProps> = memo(({ todos }) => {
             {todos.map((todo, i) => {
               const Icon = STATUS_ICONS[todo.status];
               return (
-                <div key={todo.content || i} className={`todo-item ${todo.status}`}>
+                <div key={`${i}-${todo.content}`} className={`todo-item ${todo.status}`}>
                   <Icon className={`todo-icon ${todo.status}`} />
                   <Text size="small" className={`todo-text ${todo.status}`}>
                     {todo.content}

--- a/web/src/components/chat/thread/ChatThreadView.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.tsx
@@ -303,6 +303,8 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
   const userHasScrolledUpRef = useRef(false);
   const previousMessageCountRef = useRef(messages.length);
   const lastScrollTopRef = useRef(0);
+  const lastScrollHeightRef = useRef(0);
+  const scrollRafRef = useRef<number | null>(null);
 
   const componentStyles = useMemo(() => createStyles(theme), [theme]);
 
@@ -419,12 +421,20 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
     if (!el) return;
     const prev = lastScrollTopRef.current;
     const curr = el.scrollTop;
+    const prevHeight = lastScrollHeightRef.current;
+    const currHeight = el.scrollHeight;
     lastScrollTopRef.current = curr;
+    lastScrollHeightRef.current = currHeight;
 
     // Only a decrease in scrollTop indicates the user scrolled up.
     // A growing distance-to-bottom from content expansion or programmatic
-    // catch-up must not flip this flag.
-    if (curr < prev - 1) userHasScrolledUpRef.current = true;
+    // catch-up must not flip this flag. Nor may a browser-forced downward
+    // clamp when rendered content shrinks (e.g. a thought collapses
+    // mid-stream) — a genuine scroll-up decreases scrollTop while the
+    // scrollHeight is unchanged or larger.
+    if (curr < prev - 1 && currHeight >= prevHeight) {
+      userHasScrolledUpRef.current = true;
+    }
 
     const nearBottom =
       el.scrollHeight - curr - el.clientHeight < SCROLL_THRESHOLD;
@@ -435,9 +445,23 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
   useEffect(() => {
     const el = scrollHost;
     if (!el) return;
-    const onScroll = () => updateScrollState();
+    // Coalesce scroll events to at most one measurement per frame — each call
+    // reads scrollTop/scrollHeight/clientHeight (a forced reflow) and setStates.
+    const onScroll = () => {
+      if (scrollRafRef.current != null) return;
+      scrollRafRef.current = requestAnimationFrame(() => {
+        scrollRafRef.current = null;
+        updateScrollState();
+      });
+    };
     el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      if (scrollRafRef.current != null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
+    };
   }, [scrollHost, updateScrollState]);
 
   const scrollToBottom = useCallback(() => {

--- a/web/src/components/chat/utils/__tests__/harmonyUtils.test.ts
+++ b/web/src/components/chat/utils/__tests__/harmonyUtils.test.ts
@@ -72,6 +72,39 @@ describe("harmonyUtils", () => {
 
       expect(result.messages[0].content).toBe("Line 1\nLine 2\nLine 3");
     });
+
+    it("removes every occurrence of byte-identical blocks from rawText", () => {
+      const block = "<|start|>assistant<|channel|>final<|message|>hi<|end|>";
+      const content = `${block} between ${block} tail`;
+      const result = parseHarmonyContent(content);
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.rawText).toBe("between  tail");
+    });
+
+    it("hides raw control tokens of an unterminated streaming block", () => {
+      const content =
+        "<|start|>assistant<|channel|>analysis<|message|>Thinking so far";
+      const result = parseHarmonyContent(content);
+
+      // No complete block yet, so nothing is emitted as a message...
+      expect(result.messages).toHaveLength(0);
+      // ...but the partial control tokens are stripped from the displayed text.
+      expect(result.rawText).toBe("Thinking so far");
+      expect(result.rawText).not.toContain("<|start|>");
+      expect(result.rawText).not.toContain("<|message|>");
+    });
+
+    it("keeps completed blocks and strips a trailing partial block", () => {
+      const content =
+        "<|start|>assistant<|channel|>final<|message|>Done<|end|>" +
+        "<|start|>assistant<|channel|>analysis<|message|>still going";
+      const result = parseHarmonyContent(content);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toBe("Done");
+      expect(result.rawText).toBe("still going");
+    });
   });
 
   describe("hasHarmonyTokens", () => {

--- a/web/src/components/chat/utils/harmonyUtils.ts
+++ b/web/src/components/chat/utils/harmonyUtils.ts
@@ -16,29 +16,46 @@ export interface ParsedHarmonyContent {
  */
 export const parseHarmonyContent = (content: string): ParsedHarmonyContent => {
   const messages: HarmonyMessage[] = [];
-  let remainingText = content;
 
   // Harmony format pattern: <|start|>role<|channel|>channel<|message|>content<|end|>
   const harmonyPattern = /<\|start\|>([^<]+)(?:<\|channel\|>([^<]+))?<\|message\|>([^]*?)<\|end\|>/g;
   let match;
+  // Collect the text between/around complete blocks by slicing at the matched
+  // ranges rather than string-replacing match[0]. A string `replace` only
+  // removes the first occurrence, so byte-identical blocks would leak a raw
+  // copy; index slicing removes every processed segment exactly.
+  let lastIndex = 0;
+  const rawParts: string[] = [];
 
   while ((match = harmonyPattern.exec(content)) !== null) {
-    const [, role, channel, messageContent] = match;
-    
+    const [full, role, channel, messageContent] = match;
+    rawParts.push(content.slice(lastIndex, match.index));
+    lastIndex = match.index + full.length;
+
     messages.push({
       role: role as HarmonyMessage['role'],
       channel: channel as HarmonyMessage['channel'],
       content: messageContent
     });
-
-    remainingText = remainingText.replace(match[0], '');
   }
 
-  remainingText = remainingText.trim();
-  
+  // Text after the last complete block. During streaming this can be a partial
+  // block ("<|start|>...<|message|>partial" with no closing <|end|> yet). Strip
+  // the control-token scaffolding so the raw markers don't render verbatim,
+  // keeping any prefix text and the partial message body.
+  let trailing = content.slice(lastIndex);
+  const partialMatch =
+    /^([^]*?)<\|start\|>[^<]*(?:<\|channel\|>[^<]*)?(?:<\|message\|>([^]*))?$/.exec(
+      trailing
+    );
+  if (partialMatch) {
+    trailing = partialMatch[1] + (partialMatch[2] ?? "");
+  }
+  rawParts.push(trailing);
+
   return {
     messages,
-    rawText: remainingText
+    rawText: rawParts.join("").trim()
   };
 };
 

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -11,71 +11,18 @@
 
 import { visibleToolArgs } from "./toolCallFields";
 
-/**
- * Chunk deduplication cache to prevent duplicate chunks from being processed
- * multiple times due to duplicate WebSocket handlers or message routing.
- * Tracks last processed chunk per thread with a short TTL for cleanup.
- */
-const chunkDeduplicationCache = new Map<
-  string, // threadId
-  { content: string; timestamp: number; messageLength: number }
->();
-const CHUNK_DEDUP_TTL_MS = 100; // Short TTL - chunks should arrive in quick succession
-
-/**
- * Check if a chunk is a duplicate of the last processed chunk for a thread.
- * Also cleans up stale cache entries.
- */
-function isChunkDuplicate(
-  threadId: string,
-  chunkContent: string,
-  currentMessageLength: number
-): boolean {
-  const now = Date.now();
-  const cached = chunkDeduplicationCache.get(threadId);
-
-  // Clean up stale entry
-  if (cached && now - cached.timestamp > CHUNK_DEDUP_TTL_MS) {
-    chunkDeduplicationCache.delete(threadId);
-    return false;
-  }
-
-  // Check for duplicate: same content AND same message length (position)
-  if (
-    cached &&
-    cached.content === chunkContent &&
-    cached.messageLength === currentMessageLength
-  ) {
-    console.debug(
-      `Chunk dedup: Skipping duplicate chunk for thread ${threadId}: "${chunkContent.substring(0, 50)}..."`
-    );
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Record a processed chunk in the deduplication cache.
- */
-function recordProcessedChunk(
-  threadId: string,
-  chunkContent: string,
-  newMessageLength: number
-): void {
-  chunkDeduplicationCache.set(threadId, {
-    content: chunkContent,
-    timestamp: Date.now(),
-    messageLength: newMessageLength
-  });
-}
-
-/**
- * Clear the deduplication cache for a thread (e.g., when streaming ends).
- */
-function clearChunkCache(threadId: string): void {
-  chunkDeduplicationCache.delete(threadId);
-}
+// NOTE: There is deliberately no content-based chunk deduplication here.
+// The old cache keyed a chunk by (content, message-length-before-append) with a
+// 100ms TTL. That collided on genuinely-repeated consecutive tokens — two "\n"
+// deltas, repeated spaces, a "- " list bullet — silently dropping the second and
+// corrupting the streamed text. The Chunk protocol type carries no id/sequence
+// to distinguish a real repeat from an accidental double-delivery, so no
+// content heuristic can tell them apart without false positives.
+// True double-delivery is already prevented upstream: GlobalWebSocketManager
+// routes each message to every handler at most once (see its `calledHandlers`
+// set), and the store keeps exactly one subscription per thread, so a chunk can
+// never reach applyChunk twice. Appending every chunk verbatim is therefore
+// correct.
 
 import {
   Chunk,
@@ -196,37 +143,26 @@ export interface ToolResultMessage {
 }
 
 const makeMessageContent = (type: string, data: Uint8Array): MessageContent => {
-  let mimeType = "application/octet-stream";
-  if (type === "image") {
-    mimeType = "image/png";
-  } else if (type === "audio") {
-    mimeType = "audio/mp3";
-  } else if (type === "video") {
-    mimeType = "video/mp4";
-  }
-
-  const arrayBuffer = data.buffer.slice(
-    data.byteOffset,
-    data.byteOffset + data.byteLength
-  ) as ArrayBuffer;
-  const dataUri = URL.createObjectURL(
-    new Blob([arrayBuffer], { type: mimeType })
-  );
-
+  // Hand the raw bytes to the renderer rather than minting an object URL here.
+  // MessageContentRenderer (via ImageView / AudioPlayer, and its own <video>
+  // blob) creates AND revokes its own object URL, tied to component lifecycle.
+  // A URL created in this reducer could never be revoked — nothing tracks it —
+  // so it would leak for every streamed image/audio/video output. An empty
+  // `uri` makes the renderer take its `data` path.
   if (type === "image") {
     return {
       type: "image_url" as const,
-      image: { type: "image" as const, uri: dataUri }
+      image: { type: "image" as const, uri: "", data }
     };
   } else if (type === "audio") {
     return {
       type: "audio" as const,
-      audio: { type: "audio" as const, uri: dataUri }
+      audio: { type: "audio" as const, uri: "", data }
     };
   } else if (type === "video") {
     return {
       type: "video" as const,
-      video: { type: "video" as const, uri: dataUri }
+      video: { type: "video" as const, uri: "", data }
     };
   }
   throw new Error(`Unknown message content type: ${type}`);
@@ -408,35 +344,10 @@ const applyChunk = (
   // only text contributes to the assistant message stream.
   const chunkText = typeof chunk.content === "string" ? chunk.content : "";
 
-  // Get current message length for deduplication check
-  const currentMessageLength =
-    lastMessage && lastMessage.role === "assistant"
-      ? String(lastMessage.content || "").length
-      : 0;
-
-  // Check for duplicate chunk (can happen with multiple WebSocket handlers)
-  if (isChunkDuplicate(threadId, chunkText, currentMessageLength)) {
-    // Still update status if this is the final chunk
-    if (chunk.done) {
-      clearChunkCache(threadId);
-      return {
-        update: threadRuntimeUpdate(state, threadId, {
-          status: "idle",
-          planningUpdate: null,
-          taskUpdate: null,
-          logUpdate: null
-        })
-      };
-    }
-    return noopUpdate;
-  }
-
   let updatedMessages: Message[];
-  let newMessageLength: number;
 
   if (lastMessage && lastMessage.role === "assistant") {
     const newContent = (lastMessage.content || "") + chunkText;
-    newMessageLength = newContent.length;
     const updatedMessage: Message = {
       ...lastMessage,
       content: newContent
@@ -446,7 +357,6 @@ const applyChunk = (
     const localStreamId = `local-stream-${Date.now()}-${Math.random()
       .toString(16)
       .slice(2)}`;
-    newMessageLength = chunkText.length;
     const message: Message = {
       id: localStreamId,
       role: "assistant",
@@ -455,9 +365,6 @@ const applyChunk = (
     };
     updatedMessages = [...messages, message];
   }
-
-  // Record this chunk as processed for deduplication
-  recordProcessedChunk(threadId, chunkText, newMessageLength);
 
   // Preserve statusMessage during media generation (it's set from
   // content_metadata.media_generation in the chunk handler above).
@@ -489,9 +396,6 @@ const applyChunk = (
   if (!chunk.done) {
     return { update: baseUpdate };
   }
-
-  // Clear deduplication cache when streaming ends
-  clearChunkCache(threadId);
 
   const postAction = (get: ChatStateGetter) => {
     const { selectedModel, summarizeThread, updateThreadTitle } = get();
@@ -566,9 +470,32 @@ const applyOutputUpdate = (
       if (update.value === "<nodetool_end_of_stream>") {
         return noopUpdate;
       }
+      // When the assistant's last message already holds array content (an
+      // image/audio/video block from the media branch below), a string output
+      // must be appended as a text block: `array + string` coerces the array to
+      // "[object Object],…". Merge into a trailing text block when one exists;
+      // otherwise keep the original string-concat behavior.
+      const existingContent = lastMessage.content;
+      let nextContent: Message["content"];
+      if (Array.isArray(existingContent)) {
+        const lastBlock = existingContent[existingContent.length - 1];
+        nextContent =
+          lastBlock && lastBlock.type === "text"
+            ? [
+                ...existingContent.slice(0, -1),
+                { type: "text", text: lastBlock.text + update.value }
+              ]
+            : [...existingContent, { type: "text", text: update.value }];
+      } else if (typeof existingContent === "string" || existingContent == null) {
+        nextContent = (existingContent ?? "") + update.value;
+      } else {
+        // Record-shaped content shouldn't occur for a streaming assistant text
+        // message; leave it untouched rather than coerce it into a string.
+        nextContent = existingContent;
+      }
       const updatedMessage: Message = {
         ...lastMessage,
-        content: lastMessage.content + update.value
+        content: nextContent
       };
       return {
         update: {

--- a/web/src/hooks/useMessageQueue.ts
+++ b/web/src/hooks/useMessageQueue.ts
@@ -16,7 +16,12 @@ interface UseMessageQueueOptions {
 
 interface UseMessageQueueReturn {
   queuedMessage: QueuedMessage | null;
-  sendMessage: (content: MessageContent[], prompt: string) => void;
+  /**
+   * Send or queue a message. Returns `true` when the message was sent or
+   * queued, `false` when it was dropped because one is already queued (so the
+   * caller can keep the prompt/attachments instead of clearing them).
+   */
+  sendMessage: (content: MessageContent[], prompt: string) => boolean;
   cancelQueued: () => void;
   sendQueuedNow: () => void;
 }
@@ -51,10 +56,11 @@ export function useMessageQueue({
   );
 
   const sendMessage = useCallback(
-    (content: MessageContent[], messagePrompt: string) => {
-      // A queued message is already pending; drop this one.
+    (content: MessageContent[], messagePrompt: string): boolean => {
+      // A queued message is already pending; drop this one and report it so
+      // the caller does not clear the prompt/attachments it still holds.
       if (queuedMessage) {
-        return;
+        return false;
       }
 
       if (!isLoading && !isStreaming) {
@@ -65,6 +71,7 @@ export function useMessageQueue({
           prompt: messagePrompt
         });
       }
+      return true;
     },
     [isLoading, isStreaming, queuedMessage, sendMessageNow]
   );

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -1157,6 +1157,22 @@ const useGlobalChatStore = create<GlobalChatState>()(
                 const newCurrentThreadId = threadIds[threadIds.length - 1];
                 newState.currentThreadId = newCurrentThreadId;
                 newState.lastUsedThreadId = newCurrentThreadId;
+                // Project the newly-current thread's runtime onto the legacy
+                // top-level mirrors (status/statusMessage/progress/task etc.).
+                // Without this the mirrors keep reflecting the just-deleted
+                // (possibly streaming) thread — same reason switchThread and
+                // createNewThread call mirrorsForThread.
+                Object.assign(
+                  newState,
+                  mirrorsForThread(
+                    {
+                      ...state,
+                      threadRuntime: remainingRuntime,
+                      currentThreadId: newCurrentThreadId
+                    } as GlobalChatState,
+                    newCurrentThreadId
+                  )
+                );
                 // Clear any existing loadMessages timeout before setting a new one
                 const existingTimeout = get().loadMessagesTimeoutId;
                 if (existingTimeout !== null) {
@@ -1177,6 +1193,19 @@ const useGlobalChatStore = create<GlobalChatState>()(
                 // No threads left, clear current thread (we will create a new one below)
                 newState.currentThreadId = null;
                 newState.lastUsedThreadId = null;
+                // Reset the top-level mirrors to idle defaults so they stop
+                // reflecting the deleted thread's runtime.
+                Object.assign(
+                  newState,
+                  mirrorsForThread(
+                    {
+                      ...state,
+                      threadRuntime: {},
+                      currentThreadId: null
+                    } as GlobalChatState,
+                    "__no_thread__"
+                  )
+                );
               }
             }
             // If the deleted thread was the last used, but not current, pick another if available
@@ -1463,10 +1492,17 @@ const useGlobalChatStore = create<GlobalChatState>()(
               console.error("Failed to send stop signal:", error);
             });
 
+          // Enter "stopping" (not "idle") until the server's `generation_stopped`
+          // arrives. The straggler guard in handleChatWebSocketMessage swallows
+          // queued chunks/outputs for a thread whose runtime status is
+          // "stopping"; going straight to "idle" here would let those late
+          // chunks flip the thread back to "streaming" and re-append text after
+          // the user hit Stop. `applyGenerationStopped` resets the status to
+          // "idle", so a subsequent new generation starts cleanly.
           set((state) => ({
             loadMessagesTimeoutId: null,
             ...threadRuntimeUpdate(state, tid, {
-              status: "idle",
+              status: "stopping",
               progress: { current: 0, total: 0 },
               statusMessage: null,
               planningUpdate: null,

--- a/web/src/stores/__tests__/GlobalChatStore.test.ts
+++ b/web/src/stores/__tests__/GlobalChatStore.test.ts
@@ -1235,7 +1235,7 @@ describe("GlobalChatStore", () => {
       expect(messages[0].content).toEqual([
         {
           type: "image_url",
-          image: { type: "image", uri: "blob:mock" }
+          image: { type: "image", uri: "", data: mockData }
         }
       ]);
 
@@ -1260,7 +1260,7 @@ describe("GlobalChatStore", () => {
       expect(messages[0].content).toEqual([
         {
           type: "audio",
-          audio: { type: "audio", uri: "blob:mock" }
+          audio: { type: "audio", uri: "", data: mockData }
         }
       ]);
 
@@ -1285,7 +1285,7 @@ describe("GlobalChatStore", () => {
       expect(messages[0].content).toEqual([
         {
           type: "video",
-          video: { type: "video", uri: "blob:mock" }
+          video: { type: "video", uri: "", data: mockData }
         }
       ]);
     });


### PR DESCRIPTION
Streaming/protocol (chatProtocol.ts, GlobalChatStore.ts):
- Remove content-based chunk dedup that dropped legitimately-repeated
  consecutive tokens (e.g. "\n" then "\n"); routeMessage already prevents
  double-delivery, so appending verbatim is safe.
- stopGeneration now sets thread status "stopping" (not "idle") so the
  existing straggler guard actually swallows post-Stop chunks; the stream
  no longer resurrects after Stop. generation_stopped resets to idle.
- makeMessageContent no longer mints object URLs in the reducer (they could
  never be revoked and leaked); it hands raw bytes to the renderer, which
  owns URL lifecycle.
- String output_update onto array content now appends a text block instead
  of coercing array + string into "[object Object]".
- deleteThread re-projects top-level mirrors for the new current thread.

Composer (ChatComposer, MediaChatComposer, useMessageQueue):
- Guard Enter on IME composition (isComposing / keyCode 229) so confirming a
  candidate no longer sends a half-composed message or picks a mention.
- sendMessage returns whether it was accepted; handleSend only clears the
  input/attachments when the message was actually sent/queued (no more
  silent data loss on a second message during streaming).
- Plain ChatComposer can send attachment-only messages and no longer sends
  whitespace-only text.
- Read modifier keys from the event, not the global KeyPressedStore (which is
  stale after click-focus / window blur).

Rendering (MessageContentRenderer, MessageView, ThoughtSection, harmonyUtils):
- Memoize the video blob URL by source so re-renders no longer reset playback.
- Memoize renderTextContent so MessageContentRenderer's React.memo works.
- ThoughtSection is fully controlled; external expand/collapse now propagates.
- Guard null/non-object content blocks in copyText and the render path.
- Harmony: strip partial control tokens while streaming; remove processed
  blocks by index so identical blocks don't leak raw tokens.

Threads/containers (ChatThreadView, GlobalChat, TodoSidebar, useDragAndDrop,
parseSearchResults):
- Mobile keyboard re-pin targets the real scroll host (.scrollable-message-wrapper).
- Thread preview no longer renders the literal string "undefined".
- Content-shrink no longer latches "user scrolled up" and kills auto-follow.
- Throttle the scroll handler with requestAnimationFrame.
- Stable TodoSidebar keys; drag-highlight no longer flickers over children.
- Numbered prose is only rendered as search results when items carry URLs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01346dd1TKrPgHAQViWhkrah