### PR TITLE
Fix node editor bugs: edge reconnect, group color, duplicate, delete, quick add

### DIFF
--- a/web/src/components/node/BaseNode.tsx
+++ b/web/src/components/node/BaseNode.tsx
@@ -369,6 +369,9 @@ const getNodeColors = (metadata: NodeMetadata | undefined): string[] => {
       allColors.push(color);
     }
   }
+  if (allColors.length === 0) {
+    allColors.push(colorForType("any"));
+  }
   while (allColors.length < 5) {
     allColors.push(allColors[allColors.length - 1]);
   }

--- a/web/src/components/node/GroupNode.tsx
+++ b/web/src/components/node/GroupNode.tsx
@@ -438,6 +438,7 @@ const GroupNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       setColor(newColor);
       updateNodeData(props.id, {
         properties: {
+          ...propsDataRef.current.properties,
           group_color: newColor
         }
       });

--- a/web/src/components/node/HandleColumn.tsx
+++ b/web/src/components/node/HandleColumn.tsx
@@ -17,7 +17,8 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { Property, Edge } from "../../stores/ApiTypes";
+import { Property } from "../../stores/ApiTypes";
+import type { Edge } from "@xyflow/react";
 import HandleOnlyField from "./HandleOnlyField";
 import { Z_INDEX } from "../ui_primitives";
 

--- a/web/src/components/node/NodeContent.tsx
+++ b/web/src/components/node/NodeContent.tsx
@@ -20,6 +20,8 @@ import {
   arePropsEqual,
   type NodeContentProps
 } from "./NodeContent.helpers";
+import { useNodes } from "../../contexts/NodeContext";
+import { useConnectedEdgesSelector } from "../../hooks/nodes/useConnectedEdges";
 
 const FLEX_COLUMN_SX = {
   position: "relative" as const,
@@ -39,6 +41,9 @@ const NodeContent: React.FC<NodeContentProps> = ({
     id,
     data.dynamic_properties
   );
+
+  const connectedEdgesSelector = useConnectedEdgesSelector(id);
+  const connectedEdges = useNodes(connectedEdgesSelector);
 
   const properties = nodeMetadata.properties;
   const { allProperties, inlineProperties, inputProperties } = useMemo(() => {
@@ -122,6 +127,7 @@ const NodeContent: React.FC<NodeContentProps> = ({
         id={id}
         properties={inputProperties}
         layout="stacked"
+        connectedEdges={connectedEdges}
       />
       <NodeInputs
         id={id}

--- a/web/src/components/node_editor/ControlEdge.tsx
+++ b/web/src/components/node_editor/ControlEdge.tsx
@@ -56,7 +56,9 @@ const MemoizedControlEdge = memo(ControlEdge, (prevProps, nextProps) => {
     prevProps.sourceX === nextProps.sourceX &&
     prevProps.sourceY === nextProps.sourceY &&
     prevProps.targetX === nextProps.targetX &&
-    prevProps.targetY === nextProps.targetY
+    prevProps.targetY === nextProps.targetY &&
+    prevProps.sourcePosition === nextProps.sourcePosition &&
+    prevProps.targetPosition === nextProps.targetPosition
   );
 });
 

--- a/web/src/components/node_editor/FindInWorkflowDialog.tsx
+++ b/web/src/components/node_editor/FindInWorkflowDialog.tsx
@@ -268,9 +268,10 @@ const FindInWorkflowDialog: React.FC<FindInWorkflowDialogProps> = memo(
 
         if (event.key === "Enter") {
           event.preventDefault();
-          if (results.length > 0) {
-            goToSelected();
-            closeFind();
+          if (event.shiftKey) {
+            navigatePrevious();
+          } else {
+            navigateNext();
           }
           return;
         }
@@ -287,7 +288,7 @@ const FindInWorkflowDialog: React.FC<FindInWorkflowDialogProps> = memo(
           return;
         }
 
-        if (event.key === "F" && (event.ctrlKey || event.metaKey)) {
+        if (event.key.toLowerCase() === "f" && (event.ctrlKey || event.metaKey)) {
           event.preventDefault();
           return;
         }

--- a/web/src/components/node_editor/QuickAddNodeDialog.tsx
+++ b/web/src/components/node_editor/QuickAddNodeDialog.tsx
@@ -190,7 +190,7 @@ const QuickAddNodeDialog: React.FC<QuickAddNodeDialogProps> = ({
   }, []);
 
   const handleSelectNode = useCallback(() => {
-    const selectedNode = getSelectedNode();
+    const selectedNode = getSelectedNode() ?? searchResults[0];
     if (!selectedNode) {
       return;
     }
@@ -203,15 +203,15 @@ const QuickAddNodeDialog: React.FC<QuickAddNodeDialogProps> = ({
     let y = 0;
 
     if (wrapperBounds) {
-      x = (viewport.x + wrapperBounds.width / 2) / viewport.zoom - 100;
-      y = (viewport.y + wrapperBounds.height / 2) / viewport.zoom - 50;
+      x = (wrapperBounds.width / 2 - viewport.x) / viewport.zoom - 100;
+      y = (wrapperBounds.height / 2 - viewport.y) / viewport.zoom - 50;
     }
 
     const newNode = createNode(selectedNode, { x, y });
     addNode(newNode);
 
     handleClose();
-  }, [getSelectedNode, getViewport, reactFlowWrapper, createNode, addNode, handleClose]);
+  }, [getSelectedNode, getViewport, reactFlowWrapper, createNode, addNode, handleClose, searchResults]);
 
   const handleValueChange = useCallback((value: string) => {
     setSearchTerm(value);
@@ -274,7 +274,7 @@ const QuickAddNodeDialog: React.FC<QuickAddNodeDialogProps> = ({
   return (
     <Dialog open={open} onClose={handleClose} className="quick-add-node-dialog">
       <div css={styles(theme)}>
-        <Command label="Quick Add Node" className="command-menu">
+        <Command label="Quick Add Node" className="command-menu" shouldFilter={false}>
           <div className="command-input">
             <CommandInput
               ref={inputRef}

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -66,6 +66,7 @@ import {
   useNodeResultHistory
 } from "../../hooks/nodes/useNodeResultHistory";
 import { useNodes } from "../../contexts/NodeContext";
+import { useConnectedEdgesSelector } from "../../hooks/nodes/useConnectedEdges";
 
 import {
   getContentCardVariant,
@@ -649,6 +650,9 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
   status,
   isOutputNode
 }) => {
+  const connectedEdgesSelector = useConnectedEdgesSelector(id);
+  const connectedEdges = useNodes(connectedEdgesSelector);
+
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
 
@@ -792,7 +796,7 @@ const ContentCardBodyInner: React.FC<ContentCardBodyProps> = ({
         {/* Handle column lives inside the preview so its vertical extent
             is bounded by the preview — keeps `exposedInputs` handles from
             colliding with inline-field rows below. */}
-        <HandleColumn id={id} properties={handleProps} />
+        <HandleColumn id={id} properties={handleProps} connectedEdges={connectedEdges} />
       </div>
 
       {/* Inline fields: rendered as full editors in normal flow under preview.

--- a/web/src/hooks/__tests__/useFindInWorkflow.test.ts
+++ b/web/src/hooks/__tests__/useFindInWorkflow.test.ts
@@ -413,7 +413,7 @@ describe("useFindInWorkflow", () => {
       openFind();
     });
 
-    it("should call setCenter and fitView when result exists", () => {
+    it("should center the selected node at zoom 1 when result exists", () => {
       mockUseNodes.mockImplementation((selector: any) => {
         const state = { nodes: mockNodes, edges: [] };
         return selector ? selector(state) : state;
@@ -436,12 +436,8 @@ describe("useFindInWorkflow", () => {
           50,
           { zoom: 1, duration: 300 }
         );
-        expect(mockFitView).toHaveBeenCalledWith({
-          nodes: expect.arrayContaining([expect.objectContaining({ id: "node-1" })]),
-          duration: 300,
-          minZoom: 0.5,
-          maxZoom: 2
-        });
+        // fitView would override setCenter's zoom, so goToSelected must not call it.
+        expect(mockFitView).not.toHaveBeenCalled();
       }
     });
 

--- a/web/src/hooks/handlers/__tests__/useEdgeHandlers.test.ts
+++ b/web/src/hooks/handlers/__tests__/useEdgeHandlers.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import type { Edge } from "@xyflow/react";
 import { MouseEvent as ReactMouseEvent } from "react";
 import useEdgeHandlers from "../useEdgeHandlers";
-import { useNodes } from "../../../contexts/NodeContext";
+import { useNodes, useNodeStoreRef } from "../../../contexts/NodeContext";
 import useContextMenuStore from "../../../stores/ContextMenuStore";
 import useConnectionStore from "../../../stores/ConnectionStore";
 
@@ -19,11 +19,17 @@ describe("useEdgeHandlers", () => {
   const mockSetIsReconnecting = jest.fn();
 
   const mockedUseNodes = useNodes as unknown as jest.Mock;
+  const mockedUseNodeStoreRef = useNodeStoreRef as unknown as jest.Mock;
   const mockedUseContextMenuStore = useContextMenuStore as unknown as jest.Mock;
   const mockedUseConnectionStore = useConnectionStore as unknown as jest.Mock;
 
+  // onEdgeUpdateEnd reads edgeUpdateSuccessful fresh from the store (not the
+  // subscribed selector value), so the store ref drives that flag.
+  let storeEdgeUpdateSuccessful = true;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    storeEdgeUpdateSuccessful = true;
     mockedUseNodes.mockImplementation((selector: any) => {
       const state = {
         findEdge: mockFindEdge,
@@ -34,6 +40,9 @@ describe("useEdgeHandlers", () => {
       };
       return selector ? selector(state) : state;
     });
+    mockedUseNodeStoreRef.mockImplementation(() => ({
+      getState: () => ({ edgeUpdateSuccessful: storeEdgeUpdateSuccessful })
+    }));
     mockedUseContextMenuStore.mockImplementation((selector: any) => {
       const state = {
         openContextMenu: mockOpenContextMenu
@@ -263,16 +272,7 @@ describe("useEdgeHandlers", () => {
 
   describe("onEdgeUpdateEnd", () => {
     it("deletes edge when update was not successful", () => {
-      mockedUseNodes.mockImplementation((selector: any) => {
-        const state = {
-          findEdge: mockFindEdge,
-          updateEdge: mockUpdateEdge,
-          deleteEdge: mockDeleteEdge,
-          edgeUpdateSuccessful: false,
-          setEdgeUpdateSuccessful: mockSetEdgeUpdateSuccessful
-        };
-        return selector ? selector(state) : state;
-      });
+      storeEdgeUpdateSuccessful = false;
 
       const { result } = renderHook(() => useEdgeHandlers());
       const edge = { id: "edge-10" } as Edge;

--- a/web/src/hooks/handlers/useEdgeHandlers.ts
+++ b/web/src/hooks/handlers/useEdgeHandlers.ts
@@ -1,6 +1,6 @@
 import { useCallback, MouseEvent as ReactMouseEvent } from "react";
 import type { Edge } from "@xyflow/react";
-import { useNodes } from "../../contexts/NodeContext";
+import { useNodes, useNodeStoreRef } from "../../contexts/NodeContext";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import useConnectionStore from "../../stores/ConnectionStore";
 import { shallow } from "zustand/shallow";
@@ -28,15 +28,15 @@ export default function useEdgeHandlers(): EdgeHandlersResult {
     findEdge,
     updateEdge,
     deleteEdge,
-    edgeUpdateSuccessful,
     setEdgeUpdateSuccessful
   } = useNodes((state) => ({
     findEdge: state.findEdge,
     updateEdge: state.updateEdge,
     deleteEdge: state.deleteEdge,
-    edgeUpdateSuccessful: state.edgeUpdateSuccessful,
     setEdgeUpdateSuccessful: state.setEdgeUpdateSuccessful
   }), shallow);
+
+  const nodeStoreRef = useNodeStoreRef();
 
   const openContextMenu = useContextMenuStore((state) => state.openContextMenu);
   const setIsReconnecting = useConnectionStore(
@@ -108,14 +108,14 @@ export default function useEdgeHandlers(): EdgeHandlersResult {
 
   const onEdgeUpdateEnd = useCallback(
     (_event: MouseEvent | TouchEvent, edge: Edge) => {
-      if (!edgeUpdateSuccessful) {
+      if (!nodeStoreRef.getState().edgeUpdateSuccessful) {
         deleteEdge(edge.id);
       }
       setEdgeUpdateSuccessful(true);
       setIsReconnecting(false);
     },
     [
-      edgeUpdateSuccessful,
+      nodeStoreRef,
       setEdgeUpdateSuccessful,
       deleteEdge,
       setIsReconnecting

--- a/web/src/hooks/useFindInWorkflow.ts
+++ b/web/src/hooks/useFindInWorkflow.ts
@@ -46,7 +46,7 @@ export const useFindInWorkflow = (): UseFindInWorkflowResult => {
   const clearSearch = useFindInWorkflowStore((state) => state.clearSearch);
 
   const nodes = useNodes((state) => (isOpen ? state.nodes : EMPTY_NODES));
-  const { setCenter, fitView } = useReactFlow();
+  const { setCenter } = useReactFlow();
   const getMetadata = useMetadataStore((state) => state.getMetadata);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -153,14 +153,7 @@ export const useFindInWorkflow = (): UseFindInWorkflowResult => {
       node.position.y + (node.height || 100) / 2,
       { zoom: 1, duration: 300 }
     );
-
-    fitView({
-      nodes: [node],
-      duration: 300,
-      minZoom: 0.5,
-      maxZoom: 2
-    });
-  }, [results, selectedIndex, setCenter, fitView]);
+  }, [results, selectedIndex, setCenter]);
 
   const selectNode = useCallback(
     (index: number) => {

--- a/web/src/hooks/useSelectionActions.ts
+++ b/web/src/hooks/useSelectionActions.ts
@@ -282,16 +282,26 @@ export const useSelectionActions = (): SelectionActionsReturn => {
     const offset = 50;
 
     const nodeIdMap: Record<string, string> = {};
+    for (const node of selectedNodes) {
+      nodeIdMap[node.id] = crypto.randomUUID();
+    }
+
     const newNodes = selectedNodes.map((node) => {
-      const newId = crypto.randomUUID();
-      nodeIdMap[node.id] = newId;
+      const newId = nodeIdMap[node.id];
+      const isParentDuplicated = node.parentId
+        ? Object.prototype.hasOwnProperty.call(nodeIdMap, node.parentId)
+        : false;
+      const positionOffset = isParentDuplicated ? 0 : offset;
 
       return {
         ...node,
         id: newId,
+        parentId: isParentDuplicated
+          ? nodeIdMap[node.parentId as string]
+          : node.parentId,
         position: {
-          x: node.position.x + offset,
-          y: node.position.y + offset
+          x: node.position.x + positionOffset,
+          y: node.position.y + positionOffset
         },
         selected: true,
         data: { ...node.data }

--- a/web/src/stores/NodeStore.ts
+++ b/web/src/stores/NodeStore.ts
@@ -932,12 +932,25 @@ export const createNodeStore = (
             // editable element is focused), so programmatic callers (ui tools,
             // context menus, grouping) always work here.
             const foundIdSet = new Set(foundIds);
+            const deletedById = new Map(
+              existingNodes
+                .filter((n) => foundIdSet.has(n.id))
+                .map((n) => [n.id, n] as const)
+            );
             const nodes: Node<NodeData>[] = [];
 
             for (const node of existingNodes) {
               if (!foundIdSet.has(node.id)) {
                 if (node.parentId && foundIdSet.has(node.parentId)) {
-                  nodes.push({ ...node, parentId: undefined });
+                  const parent = deletedById.get(node.parentId);
+                  nodes.push({
+                    ...node,
+                    parentId: undefined,
+                    position: {
+                      x: (parent?.position?.x ?? 0) + (node.position?.x ?? 0),
+                      y: (parent?.position?.y ?? 0) + (node.position?.y ?? 0)
+                    }
+                  });
                 } else {
                   nodes.push(node);
                 }

--- a/web/src/stores/customEquality.ts
+++ b/web/src/stores/customEquality.ts
@@ -24,7 +24,8 @@ function compareNode(a: Node<NodeData>, b: Node<NodeData>): boolean {
     shallow(a.data.dynamic_properties, b.data.dynamic_properties) &&
     shallow(a.data.dynamic_outputs, b.data.dynamic_outputs) &&
     a.position.x === b.position.x &&
-    a.position.y === b.position.y
+    a.position.y === b.position.y &&
+    a.parentId === b.parentId
   );
 }
 


### PR DESCRIPTION
Edge reconnect (useEdgeHandlers): read edgeUpdateSuccessful fresh from the
store instead of the stale subscribed closure value, so onReconnectEnd no
longer deletes an edge that was just successfully reconnected.

GroupNode color: spread existing properties when setting group_color so
changing a group's color no longer wipes its headline (name).

duplicateSelected (toolbar/command menu): remap parentId through the id map
and skip the offset for children of duplicated parents, matching useDuplicate
so group+children duplication keeps its hierarchy.

deleteNodes: convert orphaned children's relative positions to absolute using
the deleted parent's position so deleting a group no longer scatters its
contents toward the origin.

QuickAddNodeDialog: fix the screen->flow transform sign (nodes were misplaced
when the canvas was panned), add shouldFilter={false} so cmdk doesn't
re-filter store results, and fall back to the first result on Enter.

FindInWorkflow: Enter/Shift+Enter now step through matches as the tooltips
advertise, Ctrl+F suppression is case-insensitive, and goToSelected centers
at zoom 1 without fitView overriding it.

HandleColumn: wire connectedEdges from callers so exposed input handles show
their connected state.

Also: ControlEdge memo compares handle positions; BaseNode gradient uses a
palette fallback instead of undefined for I/O-less nodes; undo/redo equality
compares parentId.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KgQSmaPhGMEQN7fjpRfgiw