### PR TITLE
fix(runtime): fix five provider bugs found in review

### DIFF
--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -173,6 +173,7 @@ function toAnthropicCitation(citation: MessageCitation): AnthropicRawBlock {
         cited_text: citation.citedText,
         document_index: citation.documentIndex,
         document_title: citation.documentTitle ?? null,
+        file_id: citation.fileId ?? null,
         start_char_index: citation.startCharIndex,
         end_char_index: citation.endCharIndex
       };
@@ -182,6 +183,7 @@ function toAnthropicCitation(citation: MessageCitation): AnthropicRawBlock {
         cited_text: citation.citedText,
         document_index: citation.documentIndex,
         document_title: citation.documentTitle ?? null,
+        file_id: citation.fileId ?? null,
         start_page_number: citation.startPageNumber,
         end_page_number: citation.endPageNumber
       };
@@ -191,6 +193,7 @@ function toAnthropicCitation(citation: MessageCitation): AnthropicRawBlock {
         cited_text: citation.citedText,
         document_index: citation.documentIndex,
         document_title: citation.documentTitle ?? null,
+        file_id: citation.fileId ?? null,
         start_block_index: citation.startBlockIndex,
         end_block_index: citation.endBlockIndex
       };
@@ -199,6 +202,7 @@ function toAnthropicCitation(citation: MessageCitation): AnthropicRawBlock {
         type: citation.type,
         cited_text: citation.citedText,
         encrypted_index: citation.encryptedIndex,
+        url: citation.url,
         title: citation.title ?? null
       };
     case "search_result_location":

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -1294,7 +1294,9 @@ export abstract class BaseProvider {
    */
   isRateLimitError(error: unknown): boolean {
     const msg = error instanceof Error ? error.message : String(error);
-    return /429|rate.?limit|too many requests/i.test(msg);
+    // Match 429 as a standalone token, not as digits inside a larger number
+    // (e.g. "request 4290", a byte count, or a model id like "gpt-4-0429").
+    return /\b429\b|rate.?limit|too many requests/i.test(msg);
   }
 
   /**
@@ -1303,7 +1305,10 @@ export abstract class BaseProvider {
    */
   isAuthError(error: unknown): boolean {
     const msg = error instanceof Error ? error.message : String(error);
-    return /401|403|unauthorized|forbidden|invalid.*api.*key|authentication/i.test(
+    // Match 401/403 as standalone tokens, not as digits inside a larger number
+    // (e.g. "model gpt-4-0403 not found") which would misclassify unrelated
+    // errors as auth failures and skip a retry that should have happened.
+    return /\b401\b|\b403\b|unauthorized|forbidden|invalid.*api.*key|authentication/i.test(
       msg
     );
   }

--- a/packages/runtime/src/providers/elevenlabs-provider.ts
+++ b/packages/runtime/src/providers/elevenlabs-provider.ts
@@ -180,6 +180,13 @@ export class ElevenLabsProvider extends BaseProvider {
   }): Promise<EncodedAudioResult | null> {
     if (!args.text) throw new Error("text must not be empty");
     log.debug("ElevenLabs textToSpeechEncoded", { model: args.model });
+    const fmt = (args.audioFormat ?? "mp3").toLowerCase();
+    if (fmt !== "mp3" && fmt !== "mpeg") {
+      // This encoded path only produces MP3. For any other requested format
+      // (pcm/wav/flac/…) defer to the streaming PCM path instead of silently
+      // handing back MP3 bytes mislabeled as the requested format.
+      return null;
+    }
     const bytes = await this.requestSpeech(args, "mp3_44100_128");
     return { data: bytes, mimeType: "audio/mpeg" };
   }

--- a/packages/runtime/src/providers/evolink-provider.ts
+++ b/packages/runtime/src/providers/evolink-provider.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@nodetool-ai/config";
 import { safeFetch } from "./safe-url.js";
+import { detectImageMime } from "./image-mime.js";
 import {
   OpenAICompatProvider,
   type OpenAICompatProviderOptions
@@ -344,7 +345,9 @@ export class EvolinkProvider extends OpenAICompatProvider {
   /** Upload raw image bytes and return a hosted URL Evolink can reference. */
   private async uploadImage(
     image: Uint8Array,
-    mimeType = "image/png"
+    // Sniff the container by default so a JPEG/WebP source isn't mislabeled as
+    // PNG (which a strict file store would reject or store with a wrong type).
+    mimeType = detectImageMime(image)
   ): Promise<string> {
     const base64 = Buffer.from(image).toString("base64");
     const response = await this._evolinkFetch(EVOLINK_FILE_UPLOAD_URL, {

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -948,7 +948,7 @@ export class GeminiProvider extends BaseProvider {
     const toolCalls: ToolCall[] = [];
 
     for (const part of parts) {
-      if (part.text !== undefined) {
+      if (part.text !== undefined && !part.thought) {
         textParts.push(part.text);
       } else if (part.functionCall) {
         const originalName =

--- a/packages/runtime/src/providers/huggingface-provider.ts
+++ b/packages/runtime/src/providers/huggingface-provider.ts
@@ -402,6 +402,15 @@ export class HuggingFaceProvider extends BaseProvider {
         };
         yield item;
       }
+
+      // Emit a terminal `done: true` chunk for every non-"stop" terminal reason
+      // (length, eos_token, tool_calls, content_filter) too, so consumers that
+      // finalize on `done` get a consistent end-of-stream marker. "stop" already
+      // emitted its terminal chunk above.
+      if (choice.finish_reason && choice.finish_reason !== "stop") {
+        const doneChunk: Chunk = { type: "chunk", content: "", done: true };
+        yield doneChunk;
+      }
     }
   }
 

--- a/packages/runtime/src/providers/image-mime.ts
+++ b/packages/runtime/src/providers/image-mime.ts
@@ -1,0 +1,59 @@
+/**
+ * Sniff an image container type from its magic bytes so image inputs keep the
+ * correct MIME in the `data:` URIs providers embed them in. Hardcoding a single
+ * type (e.g. `image/jpeg`) mislabels PNG/WebP/GIF inputs, which strict decoders
+ * reject on a declared-vs-actual mismatch.
+ */
+export function detectImageMime(bytes: Uint8Array): string {
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  // PNG: 89 50 4E 47
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  // WebP: "RIFF"…"WEBP"
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  // GIF: "GIF8"
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  // Unknown — default to PNG, the most widely accepted lossless container.
+  return "image/png";
+}
+
+/** Encode image bytes as a base64 `data:` URI with a sniffed MIME type. */
+export function bytesToImageDataUri(bytes: Uint8Array): string {
+  const base64 = Buffer.from(bytes).toString("base64");
+  return `data:${detectImageMime(bytes)};base64,${base64}`;
+}

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -540,7 +540,10 @@ export function buildImageModels(
     const id = nodeId(n);
     if (!id || seen.has(id)) continue;
     const name = nodeName(n);
-    const tasks = explicitTasks(n) ?? inferImageTasks(name, id);
+    // Copy so the mask-input augmentation below never mutates the manifest
+    // node's own `supportedTasks` array (which `loadManifest` memoizes and
+    // shares across every caller).
+    const tasks = [...(explicitTasks(n) ?? inferImageTasks(name, id))];
     // Endpoints that declare a mask image input support inpainting (mask-guided
     // editing). Tag them so the inpaint capability/picker can find them.
     if (

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -638,28 +638,45 @@ export class OllamaProvider extends BaseProvider {
 
           const content =
             typeof message.content === "string" ? message.content : "";
-          if (useToolEmulation) {
-            accumulatedText += content;
-          }
 
-          if (content.length > 0 || event.done) {
+          if (useToolEmulation) {
+            // Buffer content instead of streaming it verbatim: the emulated
+            // tool-call syntax (e.g. `get_weather(city='Paris')`) must be
+            // stripped from the visible text before it re-enters history, and
+            // that can only happen once the full response is assembled. Mirrors
+            // the non-streaming generateMessage path, which had this fix (#1)
+            // while the streaming path leaked the raw call syntax as prose.
+            accumulatedText += content;
+            if (event.done) {
+              const [emulatedCalls, cleaned] = this._parseEmulatedToolCalls(
+                accumulatedText,
+                tools
+              );
+              const finalContent =
+                emulatedCalls.length > 0 ? cleaned : accumulatedText;
+              if (finalContent.length > 0) {
+                const contentChunk: Chunk = {
+                  type: "chunk",
+                  content: finalContent,
+                  done: false
+                };
+                yield contentChunk;
+              }
+              // Tool calls before the terminal chunk so consumers that finalize
+              // on `done: true` don't drop them.
+              for (const tc of emulatedCalls) {
+                yield tc;
+              }
+              const doneChunk: Chunk = { type: "chunk", content: "", done: true };
+              yield doneChunk;
+            }
+          } else if (content.length > 0 || event.done) {
             const chunk: Chunk = {
               type: "chunk",
               content,
               done: event.done ?? false
             };
             yield chunk;
-          }
-
-          // When done and using emulation, parse accumulated text for tool calls
-          if (event.done && useToolEmulation) {
-            const [emulatedCalls] = this._parseEmulatedToolCalls(
-              accumulatedText,
-              tools
-            );
-            for (const tc of emulatedCalls) {
-              yield tc;
-            }
           }
         }
       }

--- a/packages/runtime/src/providers/openai-compat-provider.ts
+++ b/packages/runtime/src/providers/openai-compat-provider.ts
@@ -285,7 +285,11 @@ export class OpenAICompatProvider extends OpenAIProvider {
     const responseMessage = choice.message;
     const toolCalls = Array.isArray(responseMessage?.tool_calls)
       ? responseMessage.tool_calls
-          .filter((tc) => tc.type === "function")
+          // Keep function calls, and entries with no `type` at all — some
+          // gateways omit it (the wire type marks `type` optional). The
+          // streaming path likewise accepts every tool-call delta. Only drop
+          // entries that explicitly declare a non-function type.
+          .filter((tc) => tc.type === "function" || tc.type === undefined)
           .map((tc) =>
             this.buildToolCall(
               String(tc.id ?? ""),

--- a/packages/runtime/src/providers/together-provider.ts
+++ b/packages/runtime/src/providers/together-provider.ts
@@ -3,6 +3,7 @@ import {
   type OpenAICompatProviderOptions
 } from "./openai-compat-provider.js";
 import { loadImageModels, loadVideoModels } from "./manifest-models.js";
+import { bytesToImageDataUri } from "./image-mime.js";
 import type {
   ASRModel,
   EmbeddingModel,
@@ -335,8 +336,7 @@ export class TogetherProvider extends OpenAICompatProvider {
       throw new Error("The input prompt cannot be empty.");
     }
 
-    const base64 = Buffer.from(image).toString("base64");
-    const imageUrl = `data:image/jpeg;base64,${base64}`;
+    const imageUrl = bytesToImageDataUri(image);
 
     const body: Record<string, unknown> = {
       model: params.model.id,
@@ -569,7 +569,26 @@ export class TogetherProvider extends OpenAICompatProvider {
       return { width: dims[0], height: dims[1] };
     }
 
-    // Together's MiniMax default
+    // Fallback for aspect ratios / resolutions outside the preset table: derive
+    // the pixel size from the requested ratio so orientation is preserved (a
+    // portrait `2:3` request must not silently become a landscape video). Scale
+    // to a ~720p long edge, snapped to an even number as video encoders expect.
+    const ratio = ar.match(/^(\d+):(\d+)$/);
+    if (ratio) {
+      const rw = parseInt(ratio[1], 10);
+      const rh = parseInt(ratio[2], 10);
+      if (rw > 0 && rh > 0) {
+        const longEdge =
+          res === "480p" ? 854 : res === "1080p" ? 1920 : 1280;
+        const even = (n: number) => Math.max(2, Math.round(n / 2) * 2);
+        if (rw >= rh) {
+          return { width: even(longEdge), height: even((longEdge * rh) / rw) };
+        }
+        return { width: even((longEdge * rw) / rh), height: even(longEdge) };
+      }
+    }
+
+    // Together's MiniMax default (landscape) when the ratio can't be parsed.
     return { width: 1366, height: 768 };
   }
 
@@ -721,8 +740,7 @@ export class TogetherProvider extends OpenAICompatProvider {
       params.resolution
     );
 
-    const base64 = Buffer.from(image).toString("base64");
-    const inputImage = `data:image/jpeg;base64,${base64}`;
+    const inputImage = bytesToImageDataUri(image);
 
     const body: Record<string, unknown> = {
       model: params.model.id,


### PR DESCRIPTION
- gemini: strip "thought" summary text from non-streaming assistant
  content (extractMessage), matching the streaming path's `!part.thought`
  guard. Previously a thinking model's reasoning trace leaked into the
  visible answer on non-streamed calls.
- anthropic: preserve `url` (web_search_result_location) and `file_id`
  (char/page/content_block locations) when re-serializing citations back
  to the API. mapCitation read these fields in but toAnthropicCitation
  dropped them, corrupting citations on multi-turn round-trips.
- huggingface: emit a terminal `done: true` chunk for non-"stop" finish
  reasons (length, eos_token, tool_calls, content_filter), matching the
  base OpenAI-compat provider. Consumers finalizing on `done` previously
  never saw end-of-stream when a TGI endpoint returned "length".
- manifest-models: copy the tasks array before pushing "inpainting" so
  buildImageModels no longer mutates the memoized manifest node's shared
  `supportedTasks` array.
- openai-compat: keep tool calls whose `type` is absent (some gateways
  omit it; the wire type marks it optional) instead of filtering them
  out, matching the streaming path. Only drop explicit non-function
  types.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R41Lo9Z6s7dXJRqLuqT5B3