### PR TITLE
Fix race conditions and security issues across providers and UI

### DIFF
--- a/electron/src/utils.ts
+++ b/electron/src/utils.ts
@@ -1,4 +1,4 @@
-import { constants, promises as fs } from "fs";
+import { constants, promises as fs, realpathSync } from "fs";
 import os from "os";
 import path from "path";
 import { serverState } from "./state";
@@ -135,14 +135,46 @@ function assertSafeReadablePath(filePath: unknown): string {
     throw new Error("Path must be absolute");
   }
 
+  if (isDeniedPath(resolved)) {
+    throw new Error("Access to this path is not permitted");
+  }
+
+  // Re-check the denylist after resolving symlinks: a symlink at a non-denied
+  // path (e.g. /tmp/x -> ~/.ssh/id_rsa) passes the lexical check above, but the
+  // caller's fs.readFile follows it. Realpath the deepest existing ancestor and
+  // re-run the denylist against the real location. Mirrors the file-api and
+  // tRPC file-router hardening.
+  let probe = resolved;
+  for (;;) {
+    let real: string;
+    try {
+      real = realpathSync.native(probe);
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) break; // reached fs root without resolving
+      probe = parent;
+      continue;
+    }
+    if (isDeniedPath(real)) {
+      throw new Error("Access to this path is not permitted");
+    }
+    break;
+  }
+
+  return resolved;
+}
+
+/**
+ * True when `resolved` sits at or under a sensitive user-credential directory
+ * or a disallowed absolute system prefix. Callers check both the lexical and
+ * the symlink-resolved path.
+ */
+function isDeniedPath(resolved: string): boolean {
   const home = os.homedir();
   for (const sub of SENSITIVE_HOME_SUBDIRS) {
     const forbidden = path.resolve(home, sub);
-    if (
-      resolved === forbidden ||
-      resolved.startsWith(forbidden + path.sep)
-    ) {
-      throw new Error("Access to this path is not permitted");
+    if (resolved === forbidden || resolved.startsWith(forbidden + path.sep)) {
+      return true;
     }
   }
 
@@ -151,11 +183,11 @@ function assertSafeReadablePath(filePath: unknown): string {
       resolved === prefix ||
       resolved.toLowerCase().startsWith(prefix.toLowerCase() + path.sep)
     ) {
-      throw new Error("Access to this path is not permitted");
+      return true;
     }
   }
 
-  return resolved;
+  return false;
 }
 
 /** Type guard for Node.js errno exceptions (ENOENT, ESRCH, EACCES, etc.). */

--- a/mobile/src/stores/WorkflowRunner.ts
+++ b/mobile/src/stores/WorkflowRunner.ts
@@ -366,7 +366,7 @@ function handleMessage(
         statusMessage: `${msg.node_name || msg.node_id} ${msg.status}`,
       };
 
-      if (msg.result) {
+      if (msg.result !== undefined) {
         updates.nodeResults = {
           ...state.nodeResults,
           [msg.node_id]: msg.result,

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -467,7 +467,10 @@ export class StepExecutor {
       if (Array.isArray(requiredKeys)) {
         const obj = normalized as Record<string, unknown>;
         for (const key of requiredKeys) {
-          if (!((key as string) in obj)) {
+          // `requiredKeys` is LLM/planner-authored; use Object.hasOwn so a
+          // required key like "toString"/"constructor" can't be satisfied by
+          // the prototype chain when the model never produced it.
+          if (!Object.hasOwn(obj, key as string)) {
             return [false, `Missing required key: ${key}`, normalized];
           }
         }

--- a/packages/agents/src/tools/pdf-tools.ts
+++ b/packages/agents/src/tools/pdf-tools.ts
@@ -4,14 +4,75 @@
  * Port of src/nodetool/agents/tools/pdf_tools.py
  */
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { readFile, writeFile, mkdir, lstat, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, relative } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { Tool } from "./base-tool.js";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * True when `candidate`'s real (symlink-resolved) path stays within the real
+ * workspace root. `context.resolveWorkspacePath` only checks containment
+ * lexically, so an in-workspace symlink pointing outside the root would
+ * otherwise be dereferenced and leak host files. Mirrors the shared helper in
+ * edit-search-tools.ts (kept local — that copy is module-private there).
+ */
+async function isRealPathWithinRoot(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  try {
+    const realRoot = await realpath(root);
+    const realCandidate = await realpath(candidate);
+    if (realCandidate === realRoot) return true;
+    const rel = relative(realRoot, realCandidate);
+    return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Like {@link isRealPathWithinRoot} but tolerant of a not-yet-created output
+ * file: when the candidate does not exist, its parent directory is
+ * realpath-checked instead, so writing through a symlinked-out directory is
+ * still blocked. Uses lstat (not access) so a dangling in-workspace symlink is
+ * treated as existing-but-out-of-root rather than absent.
+ */
+async function isWriteTargetWithinRoot(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  if (await isRealPathWithinRoot(root, candidate)) return true;
+  const parent = dirname(candidate);
+  if (parent === candidate) return false;
+  try {
+    await lstat(candidate);
+    return false;
+  } catch {
+    return isRealPathWithinRoot(root, parent);
+  }
+}
+
+/**
+ * Verify a workspace-resolved path stays inside the workspace after resolving
+ * symlinks, throwing on escape. Uses the not-yet-created-tolerant check for
+ * both reads and writes (matching edit-search-tools): a missing read target
+ * passes containment here and then fails naturally with the tool's own
+ * "not found" error, rather than being mislabeled as an escape.
+ */
+async function assertWithinWorkspace(
+  context: ProcessingContext,
+  resolvedPath: string
+): Promise<void> {
+  const root = context.resolveWorkspacePath(".");
+  if (!(await isWriteTargetWithinRoot(root, resolvedPath))) {
+    throw new Error(`Path resolves outside the workspace: ${resolvedPath}`);
+  }
+}
 
 interface PdfExtraction {
   /** Per-page text arrays (one entry per page). */
@@ -61,6 +122,7 @@ export class ExtractPDFTextTool extends Tool {
   ): Promise<unknown> {
     try {
       const filePath = context.resolveWorkspacePath(params["path"] as string);
+      await assertWithinWorkspace(context, filePath);
       const buffer = await readFile(filePath);
       const { pages } = await extractPdfPages(buffer);
 
@@ -123,6 +185,7 @@ export class ExtractPDFTablesTool extends Tool {
       const outputFile = context.resolveWorkspacePath(
         params["output_file"] as string
       );
+      await assertWithinWorkspace(context, filePath);
       const buffer = await readFile(filePath);
       const { pages } = await extractPdfPages(buffer);
 
@@ -166,6 +229,7 @@ export class ExtractPDFTablesTool extends Tool {
         }
       }
 
+      await assertWithinWorkspace(context, outputFile);
       const parentDir = dirname(outputFile);
       await mkdir(parentDir, { recursive: true });
       await writeFile(outputFile, JSON.stringify(allTables), "utf-8");
@@ -226,6 +290,7 @@ export class ConvertPDFToMarkdownTool extends Tool {
         params["output_file"] as string
       );
 
+      await assertWithinWorkspace(context, inputFile);
       const buffer = await readFile(inputFile);
       const { pages } = await extractPdfPages(buffer);
 
@@ -240,6 +305,7 @@ export class ConvertPDFToMarkdownTool extends Tool {
         mdText = pages.join("\n");
       }
 
+      await assertWithinWorkspace(context, outputFile);
       const parentDir = dirname(outputFile);
       await mkdir(parentDir, { recursive: true });
       await writeFile(outputFile, mdText, "utf-8");

--- a/packages/agents/tests/pdf-tools.test.ts
+++ b/packages/agents/tests/pdf-tools.test.ts
@@ -43,7 +43,12 @@ vi.mock("node:child_process", () => ({
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn(),
   writeFile: vi.fn(),
-  mkdir: vi.fn()
+  mkdir: vi.fn(),
+  // Non-symlinked filesystem: realpath echoes the path, lstat reports a file.
+  // The workspace-containment guard uses these to re-check paths after
+  // resolving symlinks; with no symlinks the resolved path equals the input.
+  realpath: vi.fn(async (p: string) => p),
+  lstat: vi.fn(async () => ({ isDirectory: () => false, isSymbolicLink: () => false }))
 }));
 
 const workspaceDir = "/tmp/test-workspace";

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -408,7 +408,9 @@ export class WorkflowRunner {
         if (sourceHandle && edge.sourceHandle !== sourceHandle) {
           continue;
         }
-        const hasHandleValue = nodeOutputs[edge.sourceHandle] !== undefined;
+        const hasHandleValue =
+          Object.hasOwn(nodeOutputs, edge.sourceHandle) &&
+          nodeOutputs[edge.sourceHandle] !== undefined;
         if (!outputsEmpty && !hasHandleValue) continue;
         const targetInbox = this._inboxes.get(edge.target);
         if (!targetInbox) continue;
@@ -1048,7 +1050,9 @@ export class WorkflowRunner {
         .findOutgoingEdges(node.id)
         .filter(isDataEdge);
       for (const edge of outgoing) {
-        const hasHandleValue = nodeOutputs[edge.sourceHandle] !== undefined;
+        const hasHandleValue =
+          Object.hasOwn(nodeOutputs, edge.sourceHandle) &&
+          nodeOutputs[edge.sourceHandle] !== undefined;
         if (!outputsEmpty && !hasHandleValue) continue;
         const targetInbox = this._inboxes.get(edge.target);
         if (targetInbox) {

--- a/packages/runtime/src/providers/huggingface-provider.ts
+++ b/packages/runtime/src/providers/huggingface-provider.ts
@@ -48,8 +48,14 @@ type HfBinary = Uint8Array | ArrayBuffer | { arrayBuffer(): Promise<ArrayBuffer>
 
 /** Minimal shape of the HfInference client used by this provider. */
 interface HfClient {
-  chatCompletion(params: Record<string, unknown>): Promise<HfChatResponse>;
-  chatCompletionStream(params: Record<string, unknown>): AsyncIterable<HfChatResponse>;
+  chatCompletion(
+    params: Record<string, unknown>,
+    options?: { signal?: AbortSignal }
+  ): Promise<HfChatResponse>;
+  chatCompletionStream(
+    params: Record<string, unknown>,
+    options?: { signal?: AbortSignal }
+  ): AsyncIterable<HfChatResponse>;
   textToImage(params: Record<string, unknown>): Promise<HfBinary>;
   imageToImage(params: Record<string, unknown>): Promise<HfBinary>;
   textToVideo(params: Record<string, unknown>): Promise<HfBinary>;
@@ -306,6 +312,7 @@ export class HuggingFaceProvider extends BaseProvider {
     topP?: number;
     presencePenalty?: number;
     frequencyPenalty?: number;
+    signal?: AbortSignal;
   }): Promise<Message> {
     const client = await this.getClient();
 
@@ -324,7 +331,9 @@ export class HuggingFaceProvider extends BaseProvider {
       ...(args.topP != null ? { top_p: args.topP } : {})
     };
     this.recordRequestPayload(requestPayload);
-    const response = await client.chatCompletion(requestPayload);
+    const response = await client.chatCompletion(requestPayload, {
+      signal: args.signal
+    });
 
     const choice = response?.choices?.[0];
     if (!choice) {
@@ -356,6 +365,7 @@ export class HuggingFaceProvider extends BaseProvider {
     presencePenalty?: number;
     frequencyPenalty?: number;
     audio?: Record<string, unknown>;
+    signal?: AbortSignal;
   }): AsyncGenerator<ProviderStreamItem> {
     const client = await this.getClient();
 
@@ -374,7 +384,9 @@ export class HuggingFaceProvider extends BaseProvider {
       ...(args.topP != null ? { top_p: args.topP } : {})
     };
     this.recordRequestPayload(requestPayload);
-    const stream = client.chatCompletionStream(requestPayload);
+    const stream = client.chatCompletionStream(requestPayload, {
+      signal: args.signal
+    });
 
     for await (const chunk of stream) {
       // OpenAI-compatible streams (which the HF Inference SDK proxies) carry

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -122,8 +122,28 @@ function headers(apiKey: string): Record<string, string> {
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+/** Resolve the abort reason as an Error (mirrors the gemini provider). */
+function abortError(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error("Aborted");
+}
+
+/** Sleep that rejects promptly when `signal` aborts instead of running full. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError(signal));
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -288,7 +308,8 @@ function defaultForField(field: ModelInputField): unknown {
  */
 async function uploadImageBytes(
   apiKey: string,
-  bytes: Uint8Array
+  bytes: Uint8Array,
+  signal?: AbortSignal
 ): Promise<string> {
   const { mime, ext } = sniffImageType(bytes);
   const fileName = `upload-${Date.now()}.${ext}`;
@@ -299,7 +320,8 @@ async function uploadImageBytes(
   const res = await fetch(KIE_UPLOAD_URL, {
     method: "POST",
     headers: { Authorization: `Bearer ${apiKey}` },
-    body: form
+    body: form,
+    signal
   });
   const data = await parseKieJson(res, "upload");
   if (!res.ok || !data.success) {
@@ -316,12 +338,14 @@ async function uploadImageBytes(
 async function submitTask(
   apiKey: string,
   model: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<string> {
   const res = await fetch(`${KIE_API_BASE}/api/v1/jobs/createTask`, {
     method: "POST",
     headers: headers(apiKey),
-    body: JSON.stringify({ model, input })
+    body: JSON.stringify({ model, input }),
+    signal
   });
   const data = await parseKieJson(res, "submit");
   if (!res.ok) {
@@ -338,7 +362,8 @@ async function pollUntilDone(
   apiKey: string,
   taskId: string,
   pollInterval = 4000,
-  maxAttempts = 300
+  maxAttempts = 300,
+  signal?: AbortSignal
 ): Promise<void> {
   const url = `${KIE_API_BASE}/api/v1/jobs/recordInfo?taskId=${taskId}`;
   // KIE reports failures two ways that both look like "still running" to a naive
@@ -350,7 +375,7 @@ async function pollUntilDone(
   const MAX_CONSECUTIVE_ERRORS = 5;
   let consecutiveErrors = 0;
   for (let i = 0; i < maxAttempts; i++) {
-    const res = await fetch(url, { headers: headers(apiKey) });
+    const res = await fetch(url, { headers: headers(apiKey), signal });
     if (!res.ok) {
       consecutiveErrors += 1;
       if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
@@ -359,7 +384,7 @@ async function pollUntilDone(
           `Kie recordInfo failed ${consecutiveErrors}× (HTTP ${res.status}) for taskId ${taskId}: ${body.slice(0, 200)}`
         );
       }
-      await sleep(pollInterval);
+      await sleep(pollInterval, signal);
       continue;
     }
     consecutiveErrors = 0;
@@ -371,7 +396,7 @@ async function pollUntilDone(
         (data.data as Record<string, unknown>)?.failMsg || "Unknown error";
       throw new Error(`Kie task failed: ${msg} (taskId: ${taskId})`);
     }
-    await sleep(pollInterval);
+    await sleep(pollInterval, signal);
   }
   const timeoutSeconds = (maxAttempts * pollInterval) / 1000;
   throw new Error(
@@ -382,10 +407,11 @@ async function pollUntilDone(
 
 async function downloadResultBytes(
   apiKey: string,
-  taskId: string
+  taskId: string,
+  signal?: AbortSignal
 ): Promise<Uint8Array> {
   const url = `${KIE_API_BASE}/api/v1/jobs/recordInfo?taskId=${taskId}`;
-  const res = await fetch(url, { headers: headers(apiKey) });
+  const res = await fetch(url, { headers: headers(apiKey), signal });
   if (!res.ok) throw new Error(`Failed to get Kie result: ${res.status}`);
   const data = await parseKieJson(res, "recordInfo");
   const resultJsonStr = (data.data as Record<string, unknown>)
@@ -394,7 +420,7 @@ async function downloadResultBytes(
   const resultData = JSON.parse(resultJsonStr) as Record<string, unknown>;
   const resultUrls = resultData.resultUrls as string[];
   if (!resultUrls?.length) throw new Error("No resultUrls in Kie resultJson");
-  const dlRes = await safeFetch(resultUrls[0]);
+  const dlRes = await safeFetch(resultUrls[0], { signal });
   if (!dlRes.ok) {
     throw new Error(`Failed to download from ${resultUrls[0]}`);
   }
@@ -408,13 +434,15 @@ async function downloadResultBytes(
 async function submitSuno(
   apiKey: string,
   endpoint: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<string> {
   const body = { ...input, callBackUrl: KIE_SUNO_CALLBACK };
   const res = await fetch(`${KIE_API_BASE}${endpoint}`, {
     method: "POST",
     headers: headers(apiKey),
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
+    signal
   });
   const data = await parseKieJson(res, "submit");
   if (!res.ok) {
@@ -432,7 +460,8 @@ async function pollSuno(
   apiKey: string,
   taskId: string,
   pollInterval: number,
-  maxAttempts: number
+  maxAttempts: number,
+  signal?: AbortSignal
 ): Promise<Record<string, unknown>> {
   const url = `${KIE_API_BASE}/api/v1/generate/record-info?taskId=${taskId}`;
   const failed = new Set([
@@ -442,14 +471,14 @@ async function pollSuno(
     "SENSITIVE_WORD_ERROR"
   ]);
   for (let i = 0; i < maxAttempts; i++) {
-    const res = await fetch(url, { headers: headers(apiKey) });
+    const res = await fetch(url, { headers: headers(apiKey), signal });
     const data = await parseKieJson(res, "record-info");
     const status = (data.data as Record<string, unknown>)?.status as string;
     if (status === "SUCCESS") return data;
     if (failed.has(status)) {
       throw new Error(`Kie Suno task failed: ${status} (taskId: ${taskId})`);
     }
-    await sleep(pollInterval);
+    await sleep(pollInterval, signal);
   }
   const timeoutSeconds = (maxAttempts * pollInterval) / 1000;
   throw new Error(
@@ -694,6 +723,19 @@ export class KieProvider extends BaseProvider {
   }
 
   /**
+   * Per-call timeout signal (mirrors the gemini provider): threaded into the
+   * poll-loop fetches and sleeps so an expired budget aborts the in-flight
+   * request promptly instead of leaking it until the loop exhausts.
+   */
+  private timeoutSignal(
+    timeoutSeconds?: number | null
+  ): AbortSignal | undefined {
+    return timeoutSeconds && timeoutSeconds > 0
+      ? AbortSignal.timeout(timeoutSeconds * 1000)
+      : undefined;
+  }
+
+  /**
    * Generate music as an encoded audio file. The advertised KIE music models
    * (generate-music, generate-sounds) run through the Suno API — a separate
    * submit endpoint and record-info poll, not the generic jobs task API. A
@@ -707,17 +749,24 @@ export class KieProvider extends BaseProvider {
     const modelId = params.model.id;
     log.debug("Kie textToMusic", { model: modelId });
 
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const meta = getManifestNodeMeta(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, modelId);
     if (meta?.useSuno && meta.sunoEndpoint) {
       const input = this.buildSunoInput(modelId, params);
-      const taskId = await submitSuno(apiKey, meta.sunoEndpoint, input);
+      const taskId = await submitSuno(apiKey, meta.sunoEndpoint, input, signal);
       const { pollInterval, maxAttempts } = this.sunoPollConfig(
         meta.pollInterval,
         meta.maxAttempts,
         params.timeoutSeconds
       );
-      const record = await pollSuno(apiKey, taskId, pollInterval, maxAttempts);
-      const bytes = await this.downloadSunoAudio(record);
+      const record = await pollSuno(
+        apiKey,
+        taskId,
+        pollInterval,
+        maxAttempts,
+        signal
+      );
+      const bytes = await this.downloadSunoAudio(record, signal);
       return { data: bytes, mimeType: sniffAudioMime(bytes) };
     }
 
@@ -731,9 +780,9 @@ export class KieProvider extends BaseProvider {
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
-    const bytes = await downloadResultBytes(apiKey, taskId);
+    const taskId = await submitTask(apiKey, modelId, input, signal);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    const bytes = await downloadResultBytes(apiKey, taskId, signal);
     return { data: bytes, mimeType: sniffAudioMime(bytes) };
   }
 
@@ -788,7 +837,8 @@ export class KieProvider extends BaseProvider {
 
   /** Download the first audio track from a Suno record-info response. */
   private async downloadSunoAudio(
-    record: Record<string, unknown>
+    record: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
     const response = (record.data as Record<string, unknown>)?.response as
       | Record<string, unknown>
@@ -798,7 +848,7 @@ export class KieProvider extends BaseProvider {
       | undefined;
     const audioUrl = sunoData?.[0]?.audioUrl as string | undefined;
     if (!audioUrl) throw new Error("No audioUrl in Kie Suno response");
-    const dlRes = await safeFetch(audioUrl);
+    const dlRes = await safeFetch(audioUrl, { signal });
     if (!dlRes.ok) {
       throw new Error(`Failed to download from ${audioUrl}`);
     }
@@ -842,13 +892,14 @@ export class KieProvider extends BaseProvider {
 
     log.debug("Kie textToVideo", { model: modelId });
     const apiKey = this.requireApiKey();
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const { pollInterval, maxAttempts } = this.pollConfig(
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
-    return downloadResultBytes(apiKey, taskId);
+    const taskId = await submitTask(apiKey, modelId, input, signal);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    return downloadResultBytes(apiKey, taskId, signal);
   }
 
   /**
@@ -1048,7 +1099,8 @@ export class KieProvider extends BaseProvider {
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
     const apiKey = this.requireApiKey();
-    const imageUrls = await this.uploadImages(apiKey, images);
+    const signal = this.timeoutSignal(params.timeoutSeconds);
+    const imageUrls = await this.uploadImages(apiKey, images, signal);
     if (imageUrls.length === 0) {
       throw new Error("The input image is empty.");
     }
@@ -1066,9 +1118,9 @@ export class KieProvider extends BaseProvider {
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
-    return downloadResultBytes(apiKey, taskId);
+    const taskId = await submitTask(apiKey, modelId, input, signal);
+    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    return downloadResultBytes(apiKey, taskId, signal);
   }
 
   /**
@@ -1095,9 +1147,10 @@ export class KieProvider extends BaseProvider {
   /** Upload every non-empty image to KIE's file store, returning hosted URLs. */
   private async uploadImages(
     apiKey: string,
-    images: Uint8Array[]
+    images: Uint8Array[],
+    signal?: AbortSignal
   ): Promise<string[]> {
     const valid = images.filter((b) => b && b.length > 0);
-    return Promise.all(valid.map((b) => uploadImageBytes(apiKey, b)));
+    return Promise.all(valid.map((b) => uploadImageBytes(apiKey, b, signal)));
   }
 }

--- a/packages/runtime/src/providers/meshy-provider.ts
+++ b/packages/runtime/src/providers/meshy-provider.ts
@@ -166,29 +166,32 @@ export class MeshyProvider extends BaseProvider {
     if (!this.apiKey) throw new Error("Meshy API key is not configured");
 
     const maxAttempts = this.computeMaxAttempts(params.timeoutSeconds);
-    const previewTaskId = await this.submitTextTo3D(params);
+    const signal = this.timeoutSignal(params.timeoutSeconds);
+    const previewTaskId = await this.submitTextTo3D(params, signal);
     // Stryker disable next-line StringLiteral: diagnostic log message.
     log.debug(`Meshy text-to-3D preview task submitted: ${previewTaskId}`);
 
     const previewResult = await this.pollTaskStatus(
       previewTaskId,
       "/v2/text-to-3d",
-      maxAttempts
+      maxAttempts,
+      signal
     );
 
     if (params.enableTextures) {
-      const refineTaskId = await this.submitRefine(previewTaskId);
+      const refineTaskId = await this.submitRefine(previewTaskId, signal);
       // Stryker disable next-line StringLiteral: diagnostic log message.
       log.debug(`Meshy text-to-3D refine task submitted: ${refineTaskId}`);
       const refineResult = await this.pollTaskStatus(
         refineTaskId,
         "/v2/text-to-3d",
-        maxAttempts
+        maxAttempts,
+        signal
       );
-      return this.downloadResultMesh(refineResult, params.outputFormat);
+      return this.downloadResultMesh(refineResult, params.outputFormat, signal);
     }
 
-    return this.downloadResultMesh(previewResult, params.outputFormat);
+    return this.downloadResultMesh(previewResult, params.outputFormat, signal);
   }
 
   override async imageTo3D(
@@ -200,17 +203,19 @@ export class MeshyProvider extends BaseProvider {
     if (!this.apiKey) throw new Error("Meshy API key is not configured");
 
     const maxAttempts = this.computeMaxAttempts(params.timeoutSeconds);
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const imageUrl = this.encodeImageAsDataUri(image);
-    const taskId = await this.submitImageTo3D(imageUrl);
+    const taskId = await this.submitImageTo3D(imageUrl, signal);
     // Stryker disable next-line StringLiteral: diagnostic log message.
     log.debug(`Meshy image-to-3D task submitted: ${taskId}`);
 
     const result = await this.pollTaskStatus(
       taskId,
       "/v1/image-to-3d",
-      maxAttempts
+      maxAttempts,
+      signal
     );
-    return this.downloadResultMesh(result, params.outputFormat);
+    return this.downloadResultMesh(result, params.outputFormat, signal);
   }
 
   // --- internals ---
@@ -230,35 +235,68 @@ export class MeshyProvider extends BaseProvider {
     return Math.max(1, Math.floor((timeoutSeconds * 1000) / this.pollIntervalMs));
   }
 
+  /**
+   * Per-call timeout signal (mirrors the gemini provider): threaded into the
+   * submit / poll / download fetches so an expired budget aborts the in-flight
+   * request instead of leaking it. The inter-poll sleep is left on the loop's
+   * own attempt cap, which surfaces the friendly "timed out" message.
+   */
+  private timeoutSignal(
+    timeoutSeconds: number | null | undefined
+  ): AbortSignal | undefined {
+    return timeoutSeconds && timeoutSeconds > 0
+      ? AbortSignal.timeout(timeoutSeconds * 1000)
+      : undefined;
+  }
+
   private encodeImageAsDataUri(image: Uint8Array): string {
     const mime = detectImageMime(image);
     return `data:${mime};base64,${bytesToBase64(image)}`;
   }
 
-  private async submitTextTo3D(params: TextTo3DParams): Promise<string> {
-    return this.submitTask("/v2/text-to-3d", buildTextTo3DPayload(params));
+  private async submitTextTo3D(
+    params: TextTo3DParams,
+    signal?: AbortSignal
+  ): Promise<string> {
+    return this.submitTask(
+      "/v2/text-to-3d",
+      buildTextTo3DPayload(params),
+      signal
+    );
   }
 
-  private async submitImageTo3D(imageUrl: string): Promise<string> {
-    return this.submitTask("/v1/image-to-3d", { image_url: imageUrl });
+  private async submitImageTo3D(
+    imageUrl: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    return this.submitTask("/v1/image-to-3d", { image_url: imageUrl }, signal);
   }
 
-  private async submitRefine(previewTaskId: string): Promise<string> {
-    return this.submitTask("/v2/text-to-3d", {
-      mode: "refine",
-      preview_task_id: previewTaskId
-    });
+  private async submitRefine(
+    previewTaskId: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    return this.submitTask(
+      "/v2/text-to-3d",
+      {
+        mode: "refine",
+        preview_task_id: previewTaskId
+      },
+      signal
+    );
   }
 
   private async submitTask(
     endpoint: string,
-    payload: Record<string, unknown>
+    payload: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<string> {
     const url = `${MESHY_API_BASE_URL}${endpoint}`;
     const res = await fetch(url, {
       method: "POST",
       headers: this.headers(),
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal
     });
     if (res.status !== 200 && res.status !== 202) {
       const errText = await res.text();
@@ -277,11 +315,12 @@ export class MeshyProvider extends BaseProvider {
   private async pollTaskStatus(
     taskId: string,
     endpoint: string,
-    maxAttempts: number
+    maxAttempts: number,
+    signal?: AbortSignal
   ): Promise<Record<string, unknown>> {
     const url = `${MESHY_API_BASE_URL}${endpoint}/${taskId}`;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const res = await fetch(url, { headers: this.headers() });
+      const res = await fetch(url, { headers: this.headers(), signal });
       if (res.status !== 200) {
         const errText = await res.text();
         throw new Error(`Meshy API poll error (${res.status}): ${errText}`);
@@ -310,7 +349,8 @@ export class MeshyProvider extends BaseProvider {
 
   private async downloadResultMesh(
     result: Record<string, unknown>,
-    requestedFormat: string | undefined
+    requestedFormat: string | undefined,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
     const format = (requestedFormat ?? DEFAULT_OUTPUT_FORMAT).toLowerCase();
     const modelUrls = result.model_urls as
@@ -322,7 +362,7 @@ export class MeshyProvider extends BaseProvider {
         `No model URL found in Meshy response for format: ${format}`
       );
     }
-    const dlRes = await safeFetch(modelUrl);
+    const dlRes = await safeFetch(modelUrl, { signal });
     if (!dlRes.ok) {
       const errText = await dlRes.text().catch(() => "");
       throw new Error(

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -146,6 +146,30 @@ interface MinimaxBaseResp {
   status_msg?: string;
 }
 
+/** Resolve the abort reason as an Error (mirrors the gemini provider). */
+function abortError(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error("Aborted");
+}
+
+/** Sleep that rejects promptly when `signal` aborts instead of running full. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError(signal));
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /** MiniMax embeds a `base_resp` on most responses; surface failures as errors. */
 function assertBaseResp(data: Record<string, unknown>, context: string): void {
   const baseResp = data.base_resp as MinimaxBaseResp | undefined;
@@ -564,7 +588,8 @@ export class MinimaxProvider extends OpenAICompatProvider {
     return this._generateVideo(params.model.id, {
       prompt: params.prompt,
       durationSeconds: params.durationSeconds,
-      resolution: params.resolution
+      resolution: params.resolution,
+      signal: this._timeoutSignal(params.timeoutSeconds)
     });
   }
 
@@ -576,8 +601,22 @@ export class MinimaxProvider extends OpenAICompatProvider {
       prompt: params.prompt ?? undefined,
       durationSeconds: params.durationSeconds,
       resolution: params.resolution,
-      firstFrame: images[0]
+      firstFrame: images[0],
+      signal: this._timeoutSignal(params.timeoutSeconds)
     });
+  }
+
+  /**
+   * Per-call timeout signal (mirrors the gemini provider): threaded into the
+   * poll-loop fetch and sleep so an expired budget aborts the in-flight request
+   * promptly instead of leaking it until the fixed poll cap.
+   */
+  private _timeoutSignal(
+    timeoutSeconds?: number | null
+  ): AbortSignal | undefined {
+    return timeoutSeconds && timeoutSeconds > 0
+      ? AbortSignal.timeout(timeoutSeconds * 1000)
+      : undefined;
   }
 
   private async _generateVideo(
@@ -587,6 +626,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
       durationSeconds?: number | null;
       resolution?: string | null;
       firstFrame?: Uint8Array;
+      signal?: AbortSignal;
     }
   ): Promise<Uint8Array> {
     const body: Record<string, unknown> = { model: modelId };
@@ -643,7 +683,8 @@ export class MinimaxProvider extends OpenAICompatProvider {
       {
         method: "POST",
         headers: this.headers(),
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        signal: opts.signal
       }
     );
     if (!submit.ok) {
@@ -661,20 +702,24 @@ export class MinimaxProvider extends OpenAICompatProvider {
       );
     }
 
-    const fileId = await this._pollVideoTask(taskId);
-    return this._downloadFile(fileId);
+    const fileId = await this._pollVideoTask(taskId, 5000, 360, opts.signal);
+    return this._downloadFile(fileId, opts.signal);
   }
 
   private async _pollVideoTask(
     taskId: string,
     pollIntervalMs = 5000,
-    maxAttempts = 360
+    maxAttempts = 360,
+    signal?: AbortSignal
   ): Promise<string> {
     const url = `${MINIMAX_BASE_URL}/v1/query/video_generation?task_id=${encodeURIComponent(
       taskId
     )}`;
     for (let i = 0; i < maxAttempts; i++) {
-      const res = await this._minimaxFetch(url, { headers: this.headers() });
+      const res = await this._minimaxFetch(url, {
+        headers: this.headers(),
+        signal
+      });
       if (!res.ok) {
         throw new Error(
           `MiniMax video status failed: ${res.status} ${await res.text()}`
@@ -697,18 +742,24 @@ export class MinimaxProvider extends OpenAICompatProvider {
           `MiniMax video task failed: ${JSON.stringify(data.base_resp ?? data)}`
         );
       }
-      await new Promise((r) => setTimeout(r, pollIntervalMs));
+      await abortableSleep(pollIntervalMs, signal);
     }
     throw new Error(
       `MiniMax video task timed out after ${maxAttempts * pollIntervalMs}ms`
     );
   }
 
-  private async _downloadFile(fileId: string): Promise<Uint8Array> {
+  private async _downloadFile(
+    fileId: string,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
     const url = `${MINIMAX_BASE_URL}/v1/files/retrieve?file_id=${encodeURIComponent(
       fileId
     )}`;
-    const res = await this._minimaxFetch(url, { headers: this.headers() });
+    const res = await this._minimaxFetch(url, {
+      headers: this.headers(),
+      signal
+    });
     if (!res.ok) {
       throw new Error(
         `MiniMax files/retrieve failed: ${res.status} ${await res.text()}`
@@ -728,7 +779,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
     // safeFetch: download_url is provider-returned (externally influenced), so
     // route it through the SSRF guard rather than the raw API fetch. Use the
     // injected fetch so the guard stays testable.
-    const dl = await safeFetch(downloadUrl, undefined, 5, this._minimaxFetch);
+    const dl = await safeFetch(downloadUrl, { signal }, 5, this._minimaxFetch);
     if (!dl.ok) {
       throw new Error(`Failed to download MiniMax file from ${downloadUrl}`);
     }

--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -359,12 +359,14 @@ export class OllamaProvider extends BaseProvider {
 
   private async postJson<T>(
     path: string,
-    body: Record<string, unknown>
+    body: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<T> {
     const response = await this._fetch(`${this.apiUrl}${path}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal
     });
     if (!response.ok) {
       throw new Error(`Ollama API request failed (${response.status})`);
@@ -451,6 +453,7 @@ export class OllamaProvider extends BaseProvider {
     topP?: number;
     presencePenalty?: number;
     frequencyPenalty?: number;
+    signal?: AbortSignal;
   }): Promise<Message> {
     const tools = args.tools ?? [];
     const useToolEmulation =
@@ -477,7 +480,8 @@ export class OllamaProvider extends BaseProvider {
     this.recordRequestPayload(request);
     const response = await this.postJson<{ message?: OllamaChatMessage }>(
       "/api/chat",
-      request
+      request,
+      args.signal
     );
     const message = response.message ?? {};
     const content = typeof message.content === "string" ? message.content : "";
@@ -559,6 +563,7 @@ export class OllamaProvider extends BaseProvider {
     presencePenalty?: number;
     frequencyPenalty?: number;
     audio?: Record<string, unknown>;
+    signal?: AbortSignal;
   }): AsyncGenerator<ProviderStreamItem> {
     const tools = args.tools ?? [];
     const useToolEmulation =
@@ -586,7 +591,8 @@ export class OllamaProvider extends BaseProvider {
     const response = await this._fetch(`${this.apiUrl}/api/chat`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(request)
+      body: JSON.stringify(request),
+      signal: args.signal
     });
 
     if (!response.ok || !response.body) {
@@ -664,6 +670,9 @@ export class OllamaProvider extends BaseProvider {
         }
       }
     } finally {
+      // Stop the underlying connection if the consumer bails early (abort /
+      // break); releasing the lock alone leaves the HTTP body undrained.
+      await reader.cancel().catch(() => undefined);
       reader.releaseLock();
     }
   }

--- a/packages/runtime/src/providers/rodin-provider.ts
+++ b/packages/runtime/src/providers/rodin-provider.ts
@@ -187,16 +187,17 @@ export class RodinProvider extends BaseProvider {
     if (!this.apiKey) throw new Error("Rodin API key is not configured");
 
     const maxAttempts = this.computeMaxAttempts(params.timeoutSeconds);
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const format = rodinOutputFormat(params.outputFormat);
 
     const payload = buildRodinTextPayload(params.prompt, format, params.seed);
 
-    const submit = await this.submitTask(payload);
+    const submit = await this.submitTask(payload, signal);
     // Stryker disable next-line StringLiteral: diagnostic log message.
     log.debug(`Rodin text-to-3D task submitted: ${submit.uuid}`);
 
-    await this.pollTaskStatus(submit.subscriptionKey, maxAttempts);
-    return this.downloadResult(submit.uuid);
+    await this.pollTaskStatus(submit.subscriptionKey, maxAttempts, signal);
+    return this.downloadResult(submit.uuid, signal);
   }
 
   override async imageTo3D(
@@ -208,6 +209,7 @@ export class RodinProvider extends BaseProvider {
     if (!this.apiKey) throw new Error("Rodin API key is not configured");
 
     const maxAttempts = this.computeMaxAttempts(params.timeoutSeconds);
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const format = rodinOutputFormat(params.outputFormat);
     const encoded = encodeImageForRodin(image);
 
@@ -218,12 +220,12 @@ export class RodinProvider extends BaseProvider {
       params.seed
     );
 
-    const submit = await this.submitTask(payload);
+    const submit = await this.submitTask(payload, signal);
     // Stryker disable next-line StringLiteral: diagnostic log message.
     log.debug(`Rodin image-to-3D task submitted: ${submit.uuid}`);
 
-    await this.pollTaskStatus(submit.subscriptionKey, maxAttempts);
-    return this.downloadResult(submit.uuid);
+    await this.pollTaskStatus(submit.subscriptionKey, maxAttempts, signal);
+    return this.downloadResult(submit.uuid, signal);
   }
 
   // --- internals ---
@@ -243,14 +245,30 @@ export class RodinProvider extends BaseProvider {
     return Math.max(1, Math.floor((timeoutSeconds * 1000) / this.pollIntervalMs));
   }
 
+  /**
+   * Per-call timeout signal (mirrors the gemini provider): threaded into the
+   * submit / poll / download fetches so an expired budget aborts the in-flight
+   * request instead of leaking it. The inter-poll sleep is left on the loop's
+   * own attempt cap, which surfaces the friendly "timed out" message.
+   */
+  private timeoutSignal(
+    timeoutSeconds: number | null | undefined
+  ): AbortSignal | undefined {
+    return timeoutSeconds && timeoutSeconds > 0
+      ? AbortSignal.timeout(timeoutSeconds * 1000)
+      : undefined;
+  }
+
   private async submitTask(
-    payload: Record<string, unknown>
+    payload: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<RodinSubmitResponse> {
     const url = `${RODIN_API_BASE_URL}/v2/rodin`;
     const res = await fetch(url, {
       method: "POST",
       headers: this.headers(),
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      signal
     });
     if (res.status !== 200 && res.status !== 202) {
       const errText = await res.text();
@@ -275,14 +293,16 @@ export class RodinProvider extends BaseProvider {
 
   private async pollTaskStatus(
     subscriptionKey: string,
-    maxAttempts: number
+    maxAttempts: number,
+    signal?: AbortSignal
   ): Promise<Record<string, unknown>> {
     const url = `${RODIN_API_BASE_URL}/v2/status`;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const res = await fetch(url, {
         method: "POST",
         headers: this.headers(),
-        body: JSON.stringify({ subscription_key: subscriptionKey })
+        body: JSON.stringify({ subscription_key: subscriptionKey }),
+        signal
       });
       if (res.status !== 200) {
         const errText = await res.text();
@@ -318,11 +338,15 @@ export class RodinProvider extends BaseProvider {
     );
   }
 
-  private async downloadResult(taskUuid: string): Promise<Uint8Array> {
+  private async downloadResult(
+    taskUuid: string,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
     const downloadInfoRes = await fetch(`${RODIN_API_BASE_URL}/v2/download`, {
       method: "POST",
       headers: this.headers(),
-      body: JSON.stringify({ task_uuid: taskUuid })
+      body: JSON.stringify({ task_uuid: taskUuid }),
+      signal
     });
     if (downloadInfoRes.status !== 200) {
       const errText = await downloadInfoRes.text();
@@ -338,7 +362,7 @@ export class RodinProvider extends BaseProvider {
         `No download URL in Rodin response: ${JSON.stringify(info)}`
       );
     }
-    const dlRes = await safeFetch(downloadUrl);
+    const dlRes = await safeFetch(downloadUrl, { signal });
     if (!dlRes.ok) {
       const errText = await dlRes.text().catch(() => "");
       throw new Error(

--- a/packages/runtime/src/providers/together-provider.ts
+++ b/packages/runtime/src/providers/together-provider.ts
@@ -166,6 +166,32 @@ function parseWavPCM(bytes: Uint8Array): {
   };
 }
 
+// ─── Abortable sleep ──────────────────────────────────────────────────────────
+
+/** Resolve the abort reason as an Error (mirrors the gemini provider). */
+function abortError(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error ? signal.reason : new Error("Aborted");
+}
+
+/** Sleep that rejects promptly when `signal` aborts instead of running full. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError(signal));
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 // ─── Provider ─────────────────────────────────────────────────────────────────
 
 export class TogetherProvider extends OpenAICompatProvider {
@@ -577,7 +603,23 @@ export class TogetherProvider extends OpenAICompatProvider {
    * Poll Together's video job endpoint until it reaches a terminal state.
    * Returns the final response payload.
    */
-  private async pollVideoJob(jobId: string): Promise<{
+  /**
+   * Per-call timeout signal (mirrors the gemini provider): threaded into the
+   * poll-loop fetch and sleep so an expired budget aborts the in-flight request
+   * promptly instead of leaking it until the internal poll cap.
+   */
+  private timeoutSignal(
+    timeoutSeconds?: number | null
+  ): AbortSignal | undefined {
+    return timeoutSeconds && timeoutSeconds > 0
+      ? AbortSignal.timeout(timeoutSeconds * 1000)
+      : undefined;
+  }
+
+  private async pollVideoJob(
+    jobId: string,
+    signal?: AbortSignal
+  ): Promise<{
     status: string;
     outputs?: { video_url?: string };
     error?: { message?: string };
@@ -593,11 +635,11 @@ export class TogetherProvider extends OpenAICompatProvider {
         );
       }
 
-      await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+      await abortableSleep(intervalMs, signal);
 
       const statusResponse = await this._togetherFetch(
         `https://api.together.xyz/v2/videos/${jobId}`,
-        { headers: { Authorization: `Bearer ${this.apiKey}` } }
+        { headers: { Authorization: `Bearer ${this.apiKey}` }, signal }
       );
 
       if (!statusResponse.ok) {
@@ -626,7 +668,8 @@ export class TogetherProvider extends OpenAICompatProvider {
    */
   private async downloadVideo(
     status: { outputs?: { video_url?: string }; error?: { message?: string } },
-    label: string
+    label: string,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
     const videoUrl = status.outputs?.video_url;
     if (!videoUrl) {
@@ -634,7 +677,7 @@ export class TogetherProvider extends OpenAICompatProvider {
       throw new Error(`Together ${label} failed: ${reason}`);
     }
 
-    const videoResponse = await this._togetherFetch(videoUrl);
+    const videoResponse = await this._togetherFetch(videoUrl, { signal });
     if (!videoResponse.ok) {
       throw new Error(
         `Failed to download Together video: ${videoResponse.status}`
@@ -673,6 +716,7 @@ export class TogetherProvider extends OpenAICompatProvider {
     if (params.seed != null) body.seed = params.seed;
     if (params.negativePrompt) body.negative_prompt = params.negativePrompt;
 
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const createResponse = await this._togetherFetch(
       "https://api.together.xyz/v2/videos",
       {
@@ -681,7 +725,8 @@ export class TogetherProvider extends OpenAICompatProvider {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json"
         },
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        signal
       }
     );
 
@@ -691,7 +736,7 @@ export class TogetherProvider extends OpenAICompatProvider {
     }
 
     const job = (await createResponse.json()) as { id: string; status: string };
-    const finalStatus = await this.pollVideoJob(job.id);
+    const finalStatus = await this.pollVideoJob(job.id, signal);
 
     if (finalStatus.status !== "completed") {
       const reason =
@@ -700,7 +745,7 @@ export class TogetherProvider extends OpenAICompatProvider {
       throw new Error(`Together text-to-video failed: ${reason}`);
     }
 
-    return this.downloadVideo(finalStatus, "text-to-video");
+    return this.downloadVideo(finalStatus, "text-to-video", signal);
   }
 
   /**
@@ -740,6 +785,7 @@ export class TogetherProvider extends OpenAICompatProvider {
     if (params.seed != null) body.seed = params.seed;
     if (params.negativePrompt) body.negative_prompt = params.negativePrompt;
 
+    const signal = this.timeoutSignal(params.timeoutSeconds);
     const createResponse = await this._togetherFetch(
       "https://api.together.xyz/v2/videos",
       {
@@ -748,7 +794,8 @@ export class TogetherProvider extends OpenAICompatProvider {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json"
         },
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        signal
       }
     );
 
@@ -758,7 +805,7 @@ export class TogetherProvider extends OpenAICompatProvider {
     }
 
     const job = (await createResponse.json()) as { id: string; status: string };
-    const finalStatus = await this.pollVideoJob(job.id);
+    const finalStatus = await this.pollVideoJob(job.id, signal);
 
     if (finalStatus.status !== "completed") {
       const reason =
@@ -767,6 +814,6 @@ export class TogetherProvider extends OpenAICompatProvider {
       throw new Error(`Together image-to-video failed: ${reason}`);
     }
 
-    return this.downloadVideo(finalStatus, "image-to-video");
+    return this.downloadVideo(finalStatus, "image-to-video", signal);
   }
 }

--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -195,9 +195,21 @@ export class PythonNodeExecutor {
     result: ExecuteResult,
     context?: ProcessingContext
   ): Promise<Record<string, unknown>> {
-    const outputs: Record<string, unknown> = { ...result.outputs };
+    // Output names come across the Python bridge (node-controlled), so build a
+    // null-prototype object: a blob/output named "__proto__" or "constructor"
+    // then lands as a plain own key and can't reach the prototype setter.
+    // Downstream only does own-key ops (Object.keys, spread, msgpack/JSON), so a
+    // null-prototype object behaves identically for legitimate names.
+    const outputs: Record<string, unknown> = Object.assign(
+      Object.create(null),
+      result.outputs
+    );
     for (const [name, blobData] of Object.entries(result.blobs)) {
-      const mediaType = normalizeMediaOutputType(this.outputTypes[name]);
+      // Guard the outputTypes lookup with Object.hasOwn so an external name like
+      // "constructor" can't resolve to an inherited Object.prototype member.
+      const mediaType = Object.hasOwn(this.outputTypes, name)
+        ? normalizeMediaOutputType(this.outputTypes[name])
+        : null;
       if (mediaType && context?.storage) {
         const ext = EXTENSION_MAP[mediaType] ?? "";
         const contentType = MIME_MAP[mediaType];

--- a/packages/runtime/tests/providers/huggingface-provider.test.ts
+++ b/packages/runtime/tests/providers/huggingface-provider.test.ts
@@ -107,7 +107,28 @@ describe("HuggingFaceProvider", () => {
         expect.objectContaining({
           model: "meta-llama/Llama-3.1-8B-Instruct",
           messages: [{ role: "user", content: "hello" }]
-        })
+        }),
+        expect.objectContaining({ signal: undefined })
+      );
+    });
+
+    it("forwards the abort signal to the client", async () => {
+      const mockClient = makeMockHfClient();
+      const provider = new HuggingFaceProvider(
+        { HF_TOKEN: "hf_test" },
+        { hfClient: mockClient }
+      );
+
+      const controller = new AbortController();
+      await provider.generateMessage({
+        messages: [{ role: "user", content: "hello" }],
+        model: "meta-llama/Llama-3.1-8B-Instruct",
+        signal: controller.signal
+      });
+
+      expect(mockClient.chatCompletion).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ signal: controller.signal })
       );
     });
 
@@ -173,7 +194,8 @@ describe("HuggingFaceProvider", () => {
         expect.objectContaining({
           temperature: 0.5,
           top_p: 0.9
-        })
+        }),
+        expect.objectContaining({ signal: undefined })
       );
     });
 

--- a/packages/websocket/src/file-api.ts
+++ b/packages/websocket/src/file-api.ts
@@ -169,6 +169,19 @@ async function handleLocalFileStream(
     return errorResponse(403, "Access to this path is not permitted");
   }
 
+  // Re-run the denylist against the symlink-resolved path: a symlink at a
+  // non-denied location (e.g. /tmp/x -> ~/.ssh/id_rsa) passes the lexical check
+  // above but the stat/stream below follow it. A missing file still 404s.
+  let realResolved: string;
+  try {
+    realResolved = await fs.realpath(resolved);
+  } catch {
+    return errorResponse(404, "File not found");
+  }
+  if (isDeniedPath(realResolved)) {
+    return errorResponse(403, "Access to this path is not permitted");
+  }
+
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {
     stat = await fs.stat(resolved);

--- a/packages/websocket/src/file-api.ts
+++ b/packages/websocket/src/file-api.ts
@@ -34,17 +34,37 @@ function errorResponse(status: number, detail: string): Response {
  * Resolve a user-provided path within the sandbox root.
  * Returns the resolved absolute path, or null if the path escapes the sandbox.
  */
-function resolveSandboxed(rootDir: string, userPath: string): string | null {
+async function resolveSandboxed(
+  rootDir: string,
+  userPath: string
+): Promise<string | null> {
   const resolved = path.resolve(
     rootDir,
     userPath.startsWith("/") ? "." + userPath : userPath
   );
   const normalizedRoot = path.resolve(rootDir);
-  if (
-    !resolved.startsWith(normalizedRoot + path.sep) &&
-    resolved !== normalizedRoot
-  ) {
+  const isContained = (p: string): boolean =>
+    p === normalizedRoot || p.startsWith(normalizedRoot + path.sep);
+  if (!isContained(resolved)) {
     return null;
+  }
+
+  // Resolve symlinks on the deepest existing ancestor and re-check containment:
+  // a symlink that lives under the root but points outside it passes the lexical
+  // prefix check yet resolves elsewhere. Mirrors the tRPC `files` router.
+  let probe = resolved;
+  for (;;) {
+    try {
+      const real = await fs.realpath(probe);
+      if (!isContained(real)) {
+        return null;
+      }
+      break;
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) break; // reached filesystem root without resolving
+      probe = parent;
+    }
   }
   return resolved;
 }
@@ -53,7 +73,7 @@ async function handleDownload(url: URL, rootDir: string): Promise<Response> {
   const userPath = url.searchParams.get("path");
   if (!userPath) return errorResponse(400, "path parameter is required");
 
-  const resolved = resolveSandboxed(rootDir, userPath);
+  const resolved = await resolveSandboxed(rootDir, userPath);
   if (!resolved) return errorResponse(403, "Path traversal not allowed");
 
   try {

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -556,13 +556,15 @@ async function updateWorkflow(
     if (body.thumbnail !== undefined) existing.thumbnail = body.thumbnail;
     existing.access = body.access === "public" ? "public" : "private";
     existing.graph = graph;
-    existing.settings = body.settings ?? null;
+    // Only touch optional columns when the caller sends them, so partial saves
+    // (e.g. graph autosave) don't wipe stored values. A deliberate clear still
+    // sends an explicit null.
+    if (body.settings !== undefined) existing.settings = body.settings ?? null;
     if (body.run_mode !== undefined && body.run_mode !== null)
       existing.run_mode = body.run_mode;
-    existing.workspace_id = body.workspace_id ?? null;
-    existing.html_app = body.html_app ?? null;
-    // Only touch app_doc when the caller sends it, so partial saves (graph
-    // autosave) don't wipe the app-builder document.
+    if (body.workspace_id !== undefined)
+      existing.workspace_id = body.workspace_id ?? null;
+    if (body.html_app !== undefined) existing.html_app = body.html_app ?? null;
     if (body.app_doc !== undefined) existing.app_doc = body.app_doc;
     await existing.save();
     return existing;

--- a/packages/websocket/src/trpc/routers/workflows.ts
+++ b/packages/websocket/src/trpc/routers/workflows.ts
@@ -605,12 +605,15 @@ export const workflowsRouter = router({
           existing.access = input.access === "public" ? "public" : "private";
         }
         existing.graph = graph;
-        existing.settings = input.settings ?? null;
+        // Only touch optional columns when the caller sent them, so a partial
+        // update (a body omitting these keys) doesn't wipe stored values. A
+        // deliberate clear still sends an explicit null.
+        if (input.settings !== undefined) existing.settings = input.settings;
         if (input.run_mode !== undefined && input.run_mode !== null)
           existing.run_mode = input.run_mode;
-        existing.workspace_id = input.workspace_id ?? null;
-        existing.html_app = input.html_app ?? null;
-        // Only touch app_doc when sent, so partial saves don't wipe the app.
+        if (input.workspace_id !== undefined)
+          existing.workspace_id = input.workspace_id;
+        if (input.html_app !== undefined) existing.html_app = input.html_app;
         if (input.app_doc !== undefined) existing.app_doc = input.app_doc;
         await existing.save();
         return toWorkflowResponse(existing);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2207,6 +2207,11 @@ export class UnifiedWebSocketRunner {
         if (existing.status === "cancelled") {
           log.info("Skipping start of cancelled job", { jobId });
           this.activeJobs.delete(jobId);
+          // Freeing this slot must promote any queued run, matching every
+          // other activeJobs.delete site (streamJobMessages finally, the
+          // chat-run finally). Without it a cancelled-while-queued job leaves
+          // its slot idle and the next queued run stalls.
+          this.drainQueue();
           this.sendDetached({
             type: "job_update",
             status: "cancelled",

--- a/packages/websocket/tests/file-api.test.ts
+++ b/packages/websocket/tests/file-api.test.ts
@@ -81,6 +81,24 @@ describe("path traversal protection", () => {
     // The sandbox resolution should catch this
     expect([403, 404]).toContain(res.status);
   });
+
+  it("blocks a symlink under the root that points outside it", async () => {
+    // A symlink living inside the sandbox but resolving to an external target
+    // passes a lexical prefix check yet must be rejected after realpath.
+    const secret = path.join(os.tmpdir(), "file-api-secret.txt");
+    await fs.writeFile(secret, "top secret");
+    const link = path.join(tmpDir, "escape.txt");
+    await fs.symlink(secret, link);
+
+    const res = await handleFileRequest(
+      makeRequest("/api/files/download?path=escape.txt"),
+      { rootDir: tmpDir }
+    );
+    await fs.rm(secret, { force: true });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.detail).toContain("traversal");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/costs/CostsDashboard.tsx
+++ b/web/src/components/costs/CostsDashboard.tsx
@@ -197,7 +197,9 @@ const CostsDashboard: React.FC = () => {
     document.body.appendChild(a);
     a.click();
     a.remove();
-    URL.revokeObjectURL(url);
+    // Defer the revoke: releasing the blob synchronously cancels the download
+    // in Firefox and for large files.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [tableExecs, range]);
 
   return (

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -154,6 +154,9 @@ const WorkflowCommands = memo(function WorkflowCommands() {
     link.download = `${currentWorkflow.name}.json`;
     link.href = url;
     link.click();
+    // Defer the revoke past the download; releasing it synchronously can cancel
+    // the download, and never revoking leaks the blob URL for the page's life.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [workflowJSON, currentWorkflow]);
 
   const copyWorkflow = useCallback(() => {

--- a/web/src/components/node/DataTable/TableActions.tsx
+++ b/web/src/components/node/DataTable/TableActions.tsx
@@ -403,7 +403,9 @@ const TableActions: React.FC<TableActionsProps> = memo(({
     link.href = url;
     link.download = "dataframe.csv";
     link.click();
-    URL.revokeObjectURL(url);
+    // Defer the revoke: releasing the blob synchronously cancels the download
+    // in Firefox and for large files.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
 
     addNotification({
       content: "Exported as CSV",

--- a/web/src/components/node_types/editing/CropBody.tsx
+++ b/web/src/components/node_types/editing/CropBody.tsx
@@ -318,6 +318,22 @@ const CropBodyInner: React.FC<CropBodyProps> = ({
 
   const sourceSrc = useMemo(() => toSource(sourceImage), [sourceImage]);
 
+  // Revoke the blob URL minted by `toSource` when the source changes / on
+  // unmount. Only revoke URLs we created — passthrough http/data URIs from
+  // `img.uri` must not be revoked.
+  const blobUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (sourceSrc && sourceSrc.startsWith("blob:")) {
+      blobUrlRef.current = sourceSrc;
+    }
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [sourceSrc]);
+
   // Track the source image's natural dimensions. Prefer the metadata
   // already on the ImageRef; fall back to the `<img>`'s naturalWidth
   // on load (covers URI-only refs without dimension metadata).

--- a/web/src/components/panels/TracePanel.tsx
+++ b/web/src/components/panels/TracePanel.tsx
@@ -275,7 +275,9 @@ const TracePanel: React.FC = () => {
     a.href = url;
     a.download = `trace-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
     a.click();
-    URL.revokeObjectURL(url);
+    // Defer the revoke: releasing the blob synchronously cancels the download
+    // in Firefox and for large files.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [exportJSON]);
 
   const copyValue = useMemo(

--- a/web/src/components/properties/TextEditorModal.tsx
+++ b/web/src/components/properties/TextEditorModal.tsx
@@ -941,7 +941,9 @@ const TextEditorModal = ({
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    // Defer the revoke: releasing the blob synchronously cancels the download
+    // in Firefox and for large files.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [currentText, language, propertyName]);
 
   const insertIntoLexical = useCallback(

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -254,7 +254,13 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
             "data-testid": "sketch-gen-prompt"
           }}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey && !actionDisabled) {
+            if (
+              e.key === "Enter" &&
+              !e.shiftKey &&
+              !actionDisabled &&
+              !e.nativeEvent.isComposing &&
+              e.nativeEvent.keyCode !== 229
+            ) {
               e.preventDefault();
               void handleGenerate();
             }

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -168,7 +168,12 @@ export const TopBarPrompt: React.FC = memo(() => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (
+        e.key === "Enter" &&
+        !e.shiftKey &&
+        !e.nativeEvent.isComposing &&
+        e.nativeEvent.keyCode !== 229
+      ) {
         e.preventDefault();
         void handleSubmit();
       }

--- a/web/src/hooks/sketch/__tests__/useGenerateLayer.test.ts
+++ b/web/src/hooks/sketch/__tests__/useGenerateLayer.test.ts
@@ -286,6 +286,41 @@ describe("useGenerateLayer", () => {
     expect(getWorkflowRunnerStoreMock).not.toHaveBeenCalled();
   });
 
+  it("is single-flight: a concurrent double-invoke runs only one job", async () => {
+    jest.spyOn(queryClient, "fetchQuery").mockResolvedValue(workflow as never);
+
+    let counter = 0;
+    const runnerState = {
+      job_id: null as string | null,
+      run: jest.fn(async () => {
+        const id = `job-sf-${++counter}`;
+        runnerState.job_id = id;
+        return id;
+      })
+    };
+    getWorkflowRunnerStoreMock.mockReturnValue({
+      getState: () => runnerState,
+      setState: jest.fn()
+    });
+
+    const { result } = renderHook(() =>
+      useGenerateLayer({ binding: baseBinding })
+    );
+
+    // Fire twice without awaiting the first, as a rapid double-click would.
+    await act(async () => {
+      await Promise.all([
+        result.current.generateLayer(),
+        result.current.generateLayer()
+      ]);
+    });
+
+    expect(runnerState.run).toHaveBeenCalledTimes(1);
+    expect(
+      useSketchGenerationStore.getState().layerJobs["layer-1"]?.jobId
+    ).toBe("job-sf-1");
+  });
+
   it("cancels an active layer generation job", async () => {
     useSketchGenerationStore
       .getState()

--- a/web/src/hooks/sketch/useGenerateLayer.ts
+++ b/web/src/hooks/sketch/useGenerateLayer.ts
@@ -82,6 +82,10 @@ const jobSubscriptions = new Map<string, () => void>();
 const jobContexts = new Map<string, JobSubscriptionContext>();
 const jobOutputs = new Map<string, unknown>();
 const jobNodeErrors = new Map<string, string>();
+// Single-flight per layer: covers the async window between generateLayer being
+// called and registerJob writing the job into the store. Mirrors the Timeline's
+// `startingClips` guard in useGenerateClip.
+const startingLayers = new Set<string>();
 
 const loadImageAsDataUrl = (url: string): Promise<string> =>
   new Promise((resolve, reject) => {
@@ -405,12 +409,23 @@ const subscribeJob = async (
     return;
   }
 
-  await globalWebSocketManager.ensureConnection();
+  // Reserve the slot synchronously, before the `ensureConnection` await below,
+  // so a concurrent call for the same jobId sees `has()` return true and bails
+  // instead of both subscribing and leaking a listener.
+  jobSubscriptions.set(jobId, () => {});
   jobContexts.set(jobId, context);
-  const unsubscribe = globalWebSocketManager.subscribe(jobId, (message) => {
-    void handleJobMessage(jobId, message);
-  });
-  jobSubscriptions.set(jobId, unsubscribe);
+
+  try {
+    await globalWebSocketManager.ensureConnection();
+    const unsubscribe = globalWebSocketManager.subscribe(jobId, (message) => {
+      void handleJobMessage(jobId, message);
+    });
+    jobSubscriptions.set(jobId, unsubscribe);
+  } catch (error) {
+    // Undo the reservation so a later retry can subscribe.
+    jobSubscriptions.delete(jobId);
+    throw error;
+  }
 
   if (reconnect) {
     await globalWebSocketManager.send({
@@ -461,54 +476,76 @@ export const useGenerateLayer = (
       throw new Error("Layer is not bound to a workflow");
     }
 
+    // Single-flight per layer: if a job is already queued or running for this
+    // layer, do nothing. Without this guard a rapid double-click registers a
+    // second job that overwrites the first in the store, orphans its
+    // subscription, and leaves the original job running on the server.
+    // `startingLayers` covers the async window before registerJob runs.
+    if (startingLayers.has(binding.layerId)) {
+      return;
+    }
+    const existingJob =
+      useSketchGenerationStore.getState().layerJobs[binding.layerId];
+    if (
+      existingJob &&
+      (existingJob.status === "queued" || existingJob.status === "running")
+    ) {
+      return;
+    }
+
     // No pre-run error clear: each run uses a fresh job id, so its per-job error
     // slice (keyed by workflowId, jobId, nodeId) starts empty and a stale
     // failure can't carry over. A workflow-wide clear here would wipe other
     // concurrent runs' errors, breaking run isolation.
 
-    const workflow = await queryClient.fetchQuery({
-      queryKey: workflowQueryKey(binding.workflowId),
-      queryFn: () => fetchWorkflowById(binding.workflowId),
-      staleTime: 0
-    });
+    startingLayers.add(binding.layerId);
+    try {
+      const workflow = await queryClient.fetchQuery({
+        queryKey: workflowQueryKey(binding.workflowId),
+        queryFn: () => fetchWorkflowById(binding.workflowId),
+        staleTime: 0
+      });
 
-    const graphNodes = workflow.graph?.nodes ?? [];
-    const graphEdges = workflow.graph?.edges ?? [];
-    const nodes = graphNodes.map((node: WorkflowGraphNode) =>
-      graphNodeToReactFlowNode(workflow, node)
-    );
-    const edges = graphEdges.map(graphEdgeToReactFlowEdge);
+      const graphNodes = workflow.graph?.nodes ?? [];
+      const graphEdges = workflow.graph?.edges ?? [];
+      const nodes = graphNodes.map((node: WorkflowGraphNode) =>
+        graphNodeToReactFlowNode(workflow, node)
+      );
+      const edges = graphEdges.map(graphEdgeToReactFlowEdge);
 
-    const runnerStore = getWorkflowRunnerStore(binding.workflowId);
-    // Use the id run() returns, not runnerStore.job_id: when the runner is
-    // already busy the run is queued under a fresh id while the store keeps
-    // pointing at the active run, so reading it back would subscribe this
-    // layer to the wrong job and strand its updates.
-    const jobId = await runnerStore
-      .getState()
-      .run(binding.paramOverrides ?? {}, workflow, nodes, edges, undefined, undefined, true);
+      const runnerStore = getWorkflowRunnerStore(binding.workflowId);
+      // Use the id run() returns, not runnerStore.job_id: when the runner is
+      // already busy the run is queued under a fresh id while the store keeps
+      // pointing at the active run, so reading it back would subscribe this
+      // layer to the wrong job and strand its updates.
+      const jobId = await runnerStore
+        .getState()
+        .run(binding.paramOverrides ?? {}, workflow, nodes, edges, undefined, undefined, true);
 
-    if (!jobId) {
-      throw new Error("Workflow runner did not return a job id");
+      if (!jobId) {
+        throw new Error("Workflow runner did not return a job id");
+      }
+
+      registerJob(binding.layerId, jobId, binding.workflowId);
+      await subscribeJob(
+        jobId,
+        {
+          layerId: binding.layerId,
+          documentId: binding.documentId,
+          workflowId: binding.workflowId,
+          selectedOutputNodeId: binding.selectedOutputNodeId,
+          dependencyHash: binding.dependencyHash,
+          workflowUpdatedAt:
+            binding.workflowUpdatedAt ?? workflow.updated_at ?? "",
+          paramOverridesSnapshot: binding.paramOverrides,
+          onComplete,
+          onFailed
+        },
+        false
+      );
+    } finally {
+      startingLayers.delete(binding.layerId);
     }
-
-    registerJob(binding.layerId, jobId, binding.workflowId);
-    await subscribeJob(
-      jobId,
-      {
-        layerId: binding.layerId,
-        documentId: binding.documentId,
-        workflowId: binding.workflowId,
-        selectedOutputNodeId: binding.selectedOutputNodeId,
-        dependencyHash: binding.dependencyHash,
-        workflowUpdatedAt:
-          binding.workflowUpdatedAt ?? workflow.updated_at ?? "",
-        paramOverridesSnapshot: binding.paramOverrides,
-        onComplete,
-        onFailed
-      },
-      false
-    );
   }, [binding, onComplete, onFailed, registerJob]);
 
   const cancelLayerGeneration = useCallback(async () => {

--- a/web/src/hooks/useFloatingToolbarActions.ts
+++ b/web/src/hooks/useFloatingToolbarActions.ts
@@ -297,6 +297,9 @@ export const useFloatingToolbarActions = (): FloatingToolbarActions => {
     link.download = `${workflow.name}.json`;
     link.href = url;
     link.click();
+    // Defer the revoke past the download; releasing it synchronously can cancel
+    // the download, and never revoking leaks the blob URL for the page's life.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [workflow, workflowJSON]);
 
   const handleAutoLayout = useCallback(() => {

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -489,7 +489,9 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
         document.body.appendChild(anchorElement);
         anchorElement.click();
         anchorElement.remove();
-        window.URL.revokeObjectURL(downloadUrl);
+        // Defer the revoke: releasing the blob synchronously cancels the
+        // download in Firefox and for large files (e.g. asset ZIP exports).
+        setTimeout(() => window.URL.revokeObjectURL(downloadUrl), 1000);
       }
 
       get().invalidateQueries(["assets"]);

--- a/web/src/stores/chatPi.ts
+++ b/web/src/stores/chatPi.ts
@@ -69,6 +69,13 @@ const liveSessions = new Set<string>();
 // Per-thread guard so a "result" message doesn't duplicate the assistant text
 // already streamed in the same turn.
 const turnHasAssistant = new Map<string, boolean>();
+// Per-thread in-flight guard for session creation. Two concurrent
+// sendPiMessage calls for the SAME thread must await ONE createSession, not
+// create two server-side Pi sessions (the second would overwrite the mapping
+// and orphan the first, which keeps streaming and can't be stopped). Mirrors
+// the `connectPromise` idiom in GlobalChatStore.ts; cleared in `finally` so a
+// failed create lets a retry re-create.
+const pendingPiSessions = new Map<string, Promise<string>>();
 
 function upsertMessage(list: Message[], converted: Message): Message[] {
   const idx = list.findLastIndex((m) => m.id === converted.id);
@@ -149,22 +156,40 @@ async function ensurePiSession(
     return existing;
   }
 
-  ensurePiStream(set, get);
+  // A concurrent call for this thread awaits the same createSession instead of
+  // starting a second one.
+  const inFlight = pendingPiSessions.get(threadId);
+  if (inFlight) {
+    return inFlight;
+  }
 
-  const client = getAgentSocketClient();
-  const sessionId = await client.createSession({
-    provider: "pi",
-    model: piModel,
-    workspacePath: piWorkspacePath ?? undefined,
-    // Reattach to a persisted session after reload instead of starting fresh.
-    resumeSessionId: existing ?? undefined
-  });
-  liveSessions.add(sessionId);
-  set((state) => ({
-    piSessionByThread: { ...state.piSessionByThread, [threadId]: sessionId },
-    piThreadBySession: { ...state.piThreadBySession, [sessionId]: threadId }
-  }));
-  return sessionId;
+  const create = (async (): Promise<string> => {
+    ensurePiStream(set, get);
+
+    const client = getAgentSocketClient();
+    const sessionId = await client.createSession({
+      provider: "pi",
+      model: piModel,
+      workspacePath: piWorkspacePath ?? undefined,
+      // Reattach to a persisted session after reload instead of starting fresh.
+      resumeSessionId: existing ?? undefined
+    });
+    liveSessions.add(sessionId);
+    set((state) => ({
+      piSessionByThread: { ...state.piSessionByThread, [threadId]: sessionId },
+      piThreadBySession: { ...state.piThreadBySession, [sessionId]: threadId }
+    }));
+    return sessionId;
+  })();
+
+  pendingPiSessions.set(threadId, create);
+  try {
+    return await create;
+  } finally {
+    // Clear whether it resolved or rejected, so an error lets a retry
+    // re-create rather than awaiting a settled, failed promise.
+    pendingPiSessions.delete(threadId);
+  }
 }
 
 export function createChatPiSlice(set: Set, get: Get): ChatPiSlice {

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -1093,7 +1093,7 @@ export const handleUpdate = (
         workflowName: workflow.name,
         nodeId: update.node_id,
         nodeName: update.node_name || update.node_id,
-        content: `${update.node_name || update.node_id} error: ${update.error}`,
+        content: `${update.node_name || update.node_id} error: ${nodeErrorDisplay}`,
         severity: "error",
         timestamp: Date.now()
       });

--- a/web/src/utils/workflowBundle.ts
+++ b/web/src/utils/workflowBundle.ts
@@ -48,7 +48,9 @@ function triggerDownload(blob: Blob, filename: string): void {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Defer the revoke: releasing the blob synchronously cancels the download in
+  // Firefox and for large files (bundle ZIPs can be large).
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function sanitizeBundleName(name: string): string {


### PR DESCRIPTION
## Summary

This PR hardens the codebase against race conditions, symlink-based path traversal attacks, and prototype pollution. It adds single-flight guards to prevent duplicate job submissions, implements abort-signal-aware timeouts in async providers, validates symlink resolution in file operations, and protects against malicious output keys from untrusted sources.

## Key Changes

### Race Condition Fixes

- **Layer generation** (`useGenerateLayer.ts`): Added `startingLayers` Set to guard the async window before `registerJob` writes to the store, preventing rapid double-clicks from spawning duplicate jobs. Mirrors the `startingClips` pattern in `useGenerateClip`.
- **Pi chat sessions** (`chatPi.ts`): Added `pendingPiSessions` Map to ensure concurrent calls for the same thread await a single `createSession` instead of creating orphaned server-side sessions.
- **Job subscription** (`useGenerateLayer.ts`): Reserve the subscription slot synchronously before `ensureConnection` awaits, and clean up on error so retries can re-subscribe.

### Abort Signal & Timeout Hardening

Threaded `AbortSignal` through async provider operations (submit, poll, download) so expired timeouts abort in-flight requests promptly instead of leaking them:

- **KIE provider** (`kie-provider.ts`): Updated `sleep()` to reject on abort; added signal to `uploadImageBytes`, `submitTask`, `pollUntilDone`, `downloadResultBytes`, `submitSuno`, `pollSuno`.
- **Meshy provider** (`meshy-provider.ts`): Added `timeoutSignal()` method; threaded signal through `submitTextTo3D`, `submitImageTo3D`, `submitRefine`, `pollTaskStatus`, `downloadResultMesh`.
- **MiniMax provider** (`minimax-provider.ts`): Added `abortableSleep()` and `_timeoutSignal()` methods; threaded signal through video generation submit, poll, and download.
- **Rodin provider** (`rodin-provider.ts`): Added `timeoutSignal()` method; threaded signal through submit, poll, and download.
- **Together provider** (`together-provider.ts`): Added `abortableSleep()` and `timeoutSignal()` methods; threaded signal through poll and download.
- **Ollama provider** (`ollama-provider.ts`): Added signal parameter to `postJson()`.
- **HuggingFace provider** (`huggingface-provider.ts`): Updated client interface to accept signal in options; forwarded signal from `generateMessage`.

### Symlink Path Traversal Protection

Validate that symlink-resolved paths stay within workspace/sandbox boundaries:

- **PDF tools** (`pdf-tools.ts`): Added `isRealPathWithinRoot()`, `isWriteTargetWithinRoot()`, and `assertWithinWorkspace()` helpers; check both read and write targets.
- **File API** (`file-api.ts`): Updated `resolveSandboxed()` to async and resolve symlinks on the deepest existing ancestor, re-checking containment.
- **Electron utils** (`utils.ts`): Refactored `assertSafeReadablePath()` to check symlink-resolved paths against denylist; extracted `isDeniedPath()` helper.
- **File API tests** (`file-api.test.ts`): Added test for symlink-under-root-pointing-outside scenario.

### Prototype Pollution Prevention

- **Python executor** (`python-node-executor.ts`): Build outputs object with `Object.create(null)` so malicious keys like `__proto__` or `constructor` land as plain own keys and can't reach prototype setters.

### Blob URL Lifecycle Fixes

Defer `URL.revokeObjectURL()` calls past the download/render to prevent cancellation:

- **CropBody** (`CropBody.tsx`): Track blob URLs in `useRef` and revoke in cleanup effect.
- **CostsDashboard**, **TableActions**, **TracePanel**, **TextEditorModal**, **AssetStore**, **workflowBundle**, **CommandMenu**, **useFlo

https://claude.ai/code/session_012j7qHZas6whkfEqEXJxzHm