### PR TITLE
Adjust QueueOverlay positioning and height calculations

### DIFF
--- a/web/src/components/panels/QueueOverlay.tsx
+++ b/web/src/components/panels/QueueOverlay.tsx
@@ -352,10 +352,10 @@ const HeaderCount = ({
 const overlayStyles = (theme: Theme) =>
   css({
     position: "fixed",
-    top: "104px",
+    top: "56px",
     left: "92px",
     width: "304px",
-    maxHeight: "calc(100vh - 160px)",
+    maxHeight: "calc(100vh - 112px)",
     display: "flex",
     flexDirection: "column",
     zIndex: theme.zIndex.drawer,


### PR DESCRIPTION
## Summary
Adjusted the fixed positioning and height calculations of the QueueOverlay component to better align with the updated layout structure.

## Changes
- **Top position**: Reduced from `104px` to `56px` to account for a smaller header height
- **Max height**: Updated from `calc(100vh - 160px)` to `calc(100vh - 112px)` to maintain proper spacing with the new top position

These adjustments ensure the overlay is positioned correctly relative to the header and doesn't overflow the viewport.

https://claude.ai/code/session_01T7go8Xea61Xua3r85rz5mz