### PR TITLE
fix(marketing): remove remaining scroll-reveal flicker sources

### DIFF
--- a/marketing/src/app/agents/page.tsx
+++ b/marketing/src/app/agents/page.tsx
@@ -61,33 +61,6 @@ export default function AgentsPage() {
   const parallaxRef = useRef<HTMLDivElement>(null);
   const reducedMotion = usePrefersReducedMotion();
 
-  // Global section fly-in using IntersectionObserver + CSS transitions
-  useEffect(() => {
-    if (reducedMotion) return;
-    const root = document.getElementById("content");
-    if (!root) return;
-    const sections = Array.from(root.querySelectorAll<HTMLElement>("section"));
-    sections.forEach((el, i) => {
-      el.classList.add("fly-in");
-      const delay = Math.min(i * 60, 300);
-      el.style.setProperty("--fly-delay", `${delay}ms`);
-    });
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const el = entry.target as HTMLElement;
-            el.classList.add("is-visible");
-            obs.unobserve(el);
-          }
-        });
-      },
-      { root: null, threshold: 0.12, rootMargin: "0px 0px -10% 0px" }
-    );
-    sections.forEach((el) => obs.observe(el));
-    return () => obs.disconnect();
-  }, [reducedMotion]);
-
   // Fetch GitHub stars
   useEffect(() => {
     fetch("https://api.github.com/repos/nodetool-ai/nodetool")

--- a/marketing/src/app/developers/page.tsx
+++ b/marketing/src/app/developers/page.tsx
@@ -55,33 +55,6 @@ export default function DevelopersPage() {
   const parallaxRef = useRef<HTMLDivElement>(null);
   const reducedMotion = usePrefersReducedMotion();
 
-  // Global section fly-in using IntersectionObserver + CSS transitions
-  useEffect(() => {
-    if (reducedMotion) return;
-    const root = document.getElementById("content");
-    if (!root) return;
-    const sections = Array.from(root.querySelectorAll<HTMLElement>("section"));
-    sections.forEach((el, i) => {
-      el.classList.add("fly-in");
-      const delay = Math.min(i * 60, 300);
-      el.style.setProperty("--fly-delay", `${delay}ms`);
-    });
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const el = entry.target as HTMLElement;
-            el.classList.add("is-visible");
-            obs.unobserve(el);
-          }
-        });
-      },
-      { root: null, threshold: 0.12, rootMargin: "0px 0px -10% 0px" }
-    );
-    sections.forEach((el) => obs.observe(el));
-    return () => obs.disconnect();
-  }, [reducedMotion]);
-
   // Fetch GitHub stars
   useEffect(() => {
     fetch("https://api.github.com/repos/nodetool-ai/nodetool")
@@ -198,16 +171,16 @@ export default function DevelopersPage() {
         </section>
 
         {/* Features */}
-        <DeveloperFeaturesSection reducedMotion={reducedMotion} />
+        <DeveloperFeaturesSection />
 
         {/* Core Engine */}
-        <DeveloperCoreSection reducedMotion={reducedMotion} />
+        <DeveloperCoreSection />
 
         {/* CLI & API */}
-        <DeveloperCLISection reducedMotion={reducedMotion} />
+        <DeveloperCLISection />
 
         {/* Integrations */}
-        <DeveloperIntegrationsSection reducedMotion={reducedMotion} />
+        <DeveloperIntegrationsSection />
 
         {/* Community */}
         <CommunitySection stars={stars} />

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -24,7 +24,7 @@ export default function ComparisonSection({
           </div>
           <motion.h2
             id="differences-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
+            initial={false}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -33,7 +33,7 @@ export default function ComparisonSection({
             Where NodeTool fits among your tools
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
+            initial={false}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -67,7 +67,7 @@ export default function ComparisonSection({
 
         {/* Position panel */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+          initial={false}
           whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, delay: 0.08 }}
@@ -138,7 +138,7 @@ function ComparisonCard({
 
   return (
     <motion.article
-      initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
+      initial={false}
       whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.25, delay }}

--- a/marketing/src/components/EditionsCompareSection.tsx
+++ b/marketing/src/components/EditionsCompareSection.tsx
@@ -175,7 +175,7 @@ export default function EditionsCompareSection({
           </div>
           <motion.h2
             id="editions-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
+            initial={false}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -186,7 +186,7 @@ export default function EditionsCompareSection({
             <span className="text-slate-300">Cloud runs in your browser.</span>
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 16 }}
+            initial={false}
             whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}

--- a/marketing/src/components/developers/DeveloperCLISection.tsx
+++ b/marketing/src/components/developers/DeveloperCLISection.tsx
@@ -102,13 +102,7 @@ const tsExamples = [
   },
 ];
 
-interface DeveloperCLISectionProps {
-  reducedMotion: boolean;
-}
-
-export default function DeveloperCLISection({
-  reducedMotion,
-}: DeveloperCLISectionProps) {
+export default function DeveloperCLISection() {
   return (
     <section
       id="cli-api"
@@ -119,7 +113,7 @@ export default function DeveloperCLISection({
         {/* Section Header */}
         <div className="text-center mb-16">
           <motion.span
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -130,7 +124,7 @@ export default function DeveloperCLISection({
           </motion.span>
           <motion.h2
             id="cli-api-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -139,7 +133,7 @@ export default function DeveloperCLISection({
 Build, run, and extend from code
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -153,7 +147,7 @@ Build, run, and extend from code
 
         {/* DSL Example */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}
@@ -177,7 +171,7 @@ Build, run, and extend from code
 
         {/* CLI Commands */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}
@@ -193,7 +187,7 @@ Build, run, and extend from code
             {cliCommands.map((cmd, idx) => (
               <motion.div
                 key={cmd.title}
-                initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+                initial={false}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: idx * 0.05 }}
@@ -212,7 +206,7 @@ Build, run, and extend from code
           {tsExamples.map((example, idx) => (
             <motion.div
               key={example.title}
-              initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.25, delay: idx * 0.08 }}
@@ -234,7 +228,7 @@ Build, run, and extend from code
 
         {/* Get Started */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}

--- a/marketing/src/components/developers/DeveloperCoreSection.tsx
+++ b/marketing/src/components/developers/DeveloperCoreSection.tsx
@@ -99,13 +99,7 @@ const coreFeatures = [
   },
 ];
 
-interface DeveloperCoreSectionProps {
-  reducedMotion: boolean;
-}
-
-export default function DeveloperCoreSection({
-  reducedMotion,
-}: DeveloperCoreSectionProps) {
+export default function DeveloperCoreSection() {
   return (
     <section
       id="core"
@@ -116,7 +110,7 @@ export default function DeveloperCoreSection({
         {/* Section Header */}
         <div className="text-center mb-16">
           <motion.span
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -127,7 +121,7 @@ export default function DeveloperCoreSection({
           </motion.span>
           <motion.h2
             id="core-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -136,7 +130,7 @@ export default function DeveloperCoreSection({
             Open source, end to end
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -146,7 +140,7 @@ export default function DeveloperCoreSection({
             the CLI, or run the same code that powers Studio and Cloud on your own boxes.
           </motion.p>
           <motion.div
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.08 }}
@@ -184,7 +178,7 @@ export default function DeveloperCoreSection({
           {coreFeatures.map((feature, idx) => (
             <motion.div
               key={feature.title}
-              initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.4, delay: idx * 0.05 }}
@@ -205,7 +199,7 @@ export default function DeveloperCoreSection({
         <div className="grid gap-8 lg:grid-cols-2">
           {/* Installation */}
           <motion.div
-            initial={reducedMotion ? {} : { opacity: 0, x: -30 }}
+            initial={false}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -236,7 +230,7 @@ export default function DeveloperCoreSection({
 
           {/* Basic Usage */}
           <motion.div
-            initial={reducedMotion ? {} : { opacity: 0, x: 30 }}
+            initial={false}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -262,7 +256,7 @@ export default function DeveloperCoreSection({
 
         {/* DSL Explanation */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}
@@ -281,7 +275,7 @@ export default function DeveloperCoreSection({
             {dslExplanation.map((point, idx) => (
               <motion.div
                 key={point.title}
-                initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+                initial={false}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.3, delay: idx * 0.05 }}
@@ -296,7 +290,7 @@ export default function DeveloperCoreSection({
 
 {/* Links */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}

--- a/marketing/src/components/developers/DeveloperFeaturesSection.tsx
+++ b/marketing/src/components/developers/DeveloperFeaturesSection.tsx
@@ -62,13 +62,7 @@ export class MyNode extends BaseNode {
   },
 ];
 
-interface DeveloperFeaturesSectionProps {
-  reducedMotion: boolean;
-}
-
-export default function DeveloperFeaturesSection({
-  reducedMotion,
-}: DeveloperFeaturesSectionProps) {
+export default function DeveloperFeaturesSection() {
   return (
     <section
       id="features"
@@ -79,7 +73,7 @@ export default function DeveloperFeaturesSection({
         {/* Section Header */}
         <div className="text-center mb-16">
           <motion.span
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -89,7 +83,7 @@ export default function DeveloperFeaturesSection({
           </motion.span>
           <motion.h2
             id="features-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -98,7 +92,7 @@ export default function DeveloperFeaturesSection({
             Drive the workspace from code
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -115,7 +109,7 @@ export default function DeveloperFeaturesSection({
           {features.map((feature, idx) => (
             <motion.div
               key={feature.title}
-              initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.25, delay: idx * 0.05 }}

--- a/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
+++ b/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
@@ -52,13 +52,7 @@ const nodeCategories = [
   { name: "Utils", count: "60+", icon: Search },
 ];
 
-interface DeveloperIntegrationsSectionProps {
-  reducedMotion: boolean;
-}
-
-export default function DeveloperIntegrationsSection({
-  reducedMotion,
-}: DeveloperIntegrationsSectionProps) {
+export default function DeveloperIntegrationsSection() {
   return (
     <section
       id="integrations"
@@ -69,7 +63,7 @@ export default function DeveloperIntegrationsSection({
         {/* Section Header */}
         <div className="text-center mb-16">
           <motion.span
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25 }}
@@ -79,7 +73,7 @@ export default function DeveloperIntegrationsSection({
           </motion.span>
           <motion.h2
             id="integrations-title"
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -88,7 +82,7 @@ export default function DeveloperIntegrationsSection({
             Every model. Your keys.
           </motion.h2>
           <motion.p
-            initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+            initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.25, delay: 0.05 }}
@@ -100,7 +94,7 @@ export default function DeveloperIntegrationsSection({
 
         {/* Node Categories Stats */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 20 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           className="grid grid-cols-4 sm:grid-cols-8 gap-4 mb-16"
@@ -108,7 +102,7 @@ export default function DeveloperIntegrationsSection({
           {nodeCategories.map((cat, idx) => (
             <motion.div
               key={cat.name}
-              initial={reducedMotion ? {} : { opacity: 0, scale: 0.9 }}
+              initial={false}
               whileInView={{ opacity: 1, scale: 1 }}
               viewport={{ once: true }}
               transition={{ duration: 0.3, delay: idx * 0.05 }}
@@ -126,7 +120,7 @@ export default function DeveloperIntegrationsSection({
           {integrations.map((integration, idx) => (
             <motion.div
               key={integration.category}
-              initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.25, delay: idx * 0.05 }}
@@ -153,7 +147,7 @@ export default function DeveloperIntegrationsSection({
 
         {/* Open Source CTA */}
         <motion.div
-          initial={reducedMotion ? {} : { opacity: 0, y: 30 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.25 }}


### PR DESCRIPTION
Follow-up to f48b45a, which missed several reveal patterns:

- ComparisonSection (landing page), EditionsCompareSection, and the four
  developers/* sections still hid content with
  initial={reducedMotion ? {} : { opacity: 0, ... }} and faded it in on
  scroll — the same blink the earlier commit removed elsewhere. All 35
  sites now use initial={false}.
- The agents and developers pages still ran the .fly-in
  IntersectionObserver whose CSS was already deleted; drop the dead
  effects.
- Drop the now-unused reducedMotion prop from the four developer
  sections.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RcSQC9nyAMQa26pLDzVMis