### PR TITLE
feat(storyboard): server-side storyboard persistence

### DIFF
--- a/docs/ui-primitives-overhaul.md
+++ b/docs/ui-primitives-overhaul.md
@@ -1,0 +1,240 @@
+# ui_primitives overhaul — implementation brief
+
+Audit finding: `web/src/components/ui_primitives/` is a naming layer over MUI,
+not a design system. The import policy is enforced (never import raw MUI) but
+the visual decisions were never made, so screens built 100% from primitives
+still look amateur by default. This brief lists the verified defects with
+file:line evidence, then the fixes in priority order.
+
+Ground rules for the implementing agent:
+
+- All work in `web/`. After changes: `cd web && npm run typecheck && npm run lint && npm test`.
+- Keep the 4px grid (`spacing.ts`), design tokens (`docs/DESIGN.md`), and the
+  primitives-first policy (`web/src/components/ui_primitives/STRATEGY.md`).
+- Fix defaults *in the primitives*, not by adding props at call sites. The
+  measure of success: a bare `<Panel><FlexColumn><TextInput/><SelectField/></FlexColumn></Panel>`
+  with no styling props should look like a professional form.
+- Reference implementation of the target form look: the storyboard header in
+  `web/src/components/storyboard/StoryboardBoard.tsx` (local `Field` wrapper,
+  labels above controls, uniform 36px control heights, bordered panel). That
+  file hand-fixes everything this brief systematizes; once the primitives are
+  fixed, migrate it to the shared versions and delete the local workarounds.
+
+## Defect inventory (verified)
+
+### 1. No control-level tokens
+
+`tokens.ts` exports `FONT_WEIGHT`, `FONT_SIZE_*`, `TYPOGRAPHY`, `MOTION`,
+`Z_INDEX`, `BORDER_RADIUS` — but no control height, control padding, or field
+radius. Every primitive invents its own:
+
+| Component | Value | Source |
+|---|---|---|
+| EditorButton | `24` / `28` raw px | `editor_ui/EditorButton.tsx:55` |
+| Editor selects | `28px` / `32px` | `theme.editor.heightNode/heightInspector`, `themes/components/editorControls.ts:104,124` |
+| TagInput | `48px` | `ui_primitives/TagInput.tsx:51` |
+| SearchInput radius | `8px` | `ui_primitives/SearchInput.tsx:46` |
+| Editor control radius | `6px` | `themes/ThemeNodetool.tsx:76` |
+| MuiButton radius | `theme.rounded.buttonLarge` | `themes/ThemeNodetool.tsx:241` |
+
+Consequences: a compact EditorButton (24px) next to an editor select (28px)
+misaligns by 4px; next to an inspector select by 8px. Four independent radius
+sources. A second, parallel control scale lives on `theme.editor` that
+`EditorButton` does not read.
+
+Off-grid values inside the primitives whose own docs ban them
+(`spacing.ts:23` forbids 0.25/0.75/1.25 steps):
+
+- `Slider.tsx:45` — `13px` padding
+- `NodeSlider.tsx:56` — `3px` margin
+- `Panel.tsx:39` — `comfortable: 2.5` units; `Panel.tsx:151` divides padding to `1.25` units (5px)
+
+### 2. Unrelated defaults across primitives
+
+- `TextInput.tsx:52` → `variant="outlined"`, `size="medium"`
+- `SelectField.tsx:98` → `size="medium"`, **`variant="standard"`**
+
+A no-props TextInput above a no-props SelectField renders a boxed field above
+an underline-only field — the default composition is broken.
+
+Surfaces:
+
+- `Panel.tsx:88-90` → `background.default`, `bordered=false`. Dark
+  `background.default` is `#08090A` (`themes/paletteDark.ts:268`) — same as the
+  page. **A default Panel is invisible.**
+- `Surface.tsx:64-68` → `background.paper`, `bordered=false`, `elevation=0`,
+  explicit `boxShadow: "none"`. Different background and radius source
+  (`theme.rounded[...]`) than Panel (`theme.shape.borderRadius`).
+
+`size` semantics diverge: `TextInput` maps `compact`→MUI small;
+`SelectField`'s standard variant barely responds to `size`;
+`EditorButton.tsx:65` does `height: size ? undefined : height` — passing
+`size` silently discards the density height.
+
+Flex containers: `FlexRow.tsx:55`, `FlexColumn.tsx:53`, `Stack.tsx:61` all
+default `gap`/`spacing` to `0`, so naive composition glues controls together.
+
+### 3. Four label treatments, none shared
+
+1. MUI floating label — `TextInput`, hand-correcting MUI's transform
+   (`TextInput.tsx:96` `translate(14px, 17px)`), forced to 15px, `opacity: 0.6`.
+2. MUI `InputLabel` — `SelectField.tsx:123-129`, 15px, no opacity, no
+   transform fix. Renders differently from TextInput's at rest.
+3. `Label.tsx:79-90` — `Typography component="label"`, 13px, weight 500,
+   `text.secondary`, baked `marginBottom: 2px`.
+4. `FormField.tsx:85-95` — reimplements the same thing (does NOT use `Label`),
+   duplicating the required-asterisk logic (`FormField.tsx:98-108` vs
+   `Label.tsx:16`).
+
+The theme sets a fifth treatment on `MuiFormLabel`
+(`ThemeNodetool.tsx:249-259`): `capitalize`, 13px, `padding: 0 0 8px 0` —
+which TextInput/SelectField then override back to 15px, defeating the theme's
+label token exactly where labels matter.
+
+The floating-label choice is also a bug class: the shrunk label renders above
+the input box, and `Panel.tsx:136` is `overflow: hidden`, so a TextInput at
+the top of a Panel gets its label clipped. (This shipped: the storyboard
+title. Worked around in `StoryboardBoard.tsx` with `overflow: visible`.)
+
+### 4. No usable form composition primitive
+
+- `FormField` exists but per `STRATEGY.md:47` is used in **1 file**, with 14+
+  places doing label+input+helper by hand.
+- `FormField` double-labels: it renders its own label while
+  TextInput/SelectField render theirs. `SelectField` has `hideLabel`
+  (`SelectField.tsx:48`); `TextInput` has no escape hatch.
+- No `FormRow`, `FormSection`, `FieldGroup`, or grid primitive. Only flex
+  helpers.
+- Spacing ownership is incoherent: `SelectField.tsx:117` comments "spacing is
+  the parent's job" while `Label.tsx:88`, `FormField.tsx:120`,
+  `AutocompleteTagInput.tsx:110`, `EmptyState`, `ProgressBar`,
+  `SectionHeader`, and `Panel` bake their own margins. Stacking three fields
+  yields four different gaps. TextInput additionally inherits MUI's default
+  helper-text margin (`3px 14px 0`) which nothing overrides — off-grid and
+  different from SelectField's `mt: 0.5` (`SelectField.tsx:158`).
+
+### 5. The type scale is fake
+
+`Text.tsx:14` advertises 8 sizes; `ThemeNodetool.tsx:40-46` collapses them to
+~4 real values: `fontSizeBigger` = `fontSizeBig` = `18px`; `fontSizeSmaller` =
+`fontSizeTiny` = `fontSizeTinyer` = `11px`. `<Text size="tiny">` and
+`<Text size="smaller">` are indistinguishable.
+
+### 6. Zero-opinion passthroughs masquerading as primitives
+
+- `Box.tsx` — 2-line re-export.
+- `muiReexports.ts:108-137` re-exports `Tabs`, `ToggleButton`, `Accordion`,
+  `LinearProgress`, `Modal` etc. with a comment claiming "ThemeNodetool
+  already styles them" — but the theme has no `MuiTabs`, `MuiToggleButton`,
+  `MuiAccordion`, or `MuiLinearProgress` overrides (only `MuiButton`,
+  `MuiFormLabel`, `MuiFormControl`, `MuiPopover`, `MuiModal`, `MuiToolbar`,
+  `MuiDialogTitle`, `MuiTooltip`, `MuiDivider` — `ThemeNodetool.tsx:234-324`).
+  Those re-exports render stock MUI.
+- Contrast: `MuiTooltip` (`ThemeNodetool.tsx:301-312`) gets backdrop blur, a
+  divider border, and a layered shadow — more surface craft than any panel,
+  card, or input receives.
+
+Inputs have no default field background: only editor-scoped controls get
+`Paper.overlay` (`editorControls.ts:23`, gated on a marker class).
+`SearchInput.tsx:48` gives itself `action.hover` — so search boxes read as
+fields and plain text inputs don't.
+
+## Fixes, in priority order
+
+Do them as separate commits/PRs in this order. 1–3 are mechanical and improve
+every existing screen without call-site changes.
+
+### Fix 1: control tokens
+
+Add to `tokens.ts`:
+
+```ts
+export const CONTROL = {
+  height: { compact: 28, normal: 36, comfortable: 44 },   // px
+  paddingX: { compact: 8, normal: 12 },                    // px, on-grid
+  radius: BORDER_RADIUS.sm,                                // one field radius
+} as const;
+```
+
+Wire it into: `EditorButton` (replace raw 24/28), `SelectField`, `TextInput`,
+`SearchInput` (replace `8px` radius), `TagInput` (replace `48px`), and
+`theme.editor.heightNode/heightInspector/controlRadius` (derive from `CONTROL`
+so the two scales can't drift). Fix the off-grid values in `Slider.tsx:45`,
+`NodeSlider.tsx:56`, `Panel.tsx:39/151` while touching them.
+
+Acceptance: a compact EditorButton, a small SelectField, a small TextInput,
+and the ModelSelectButton in one FlexRow all share one height, one radius,
+one horizontal padding.
+
+### Fix 2: one label treatment
+
+Standardize on **label above the control**: 13px (`fontSizeSmall`), weight
+500, `text.secondary`, no text-transform, 4px gap to the control.
+
+- Remove the floating-label path: `TextInput` no longer forwards `label` to
+  MUI; it renders the standard label above (via the shared `Label`). Delete
+  the transform-correction sx (`TextInput.tsx:88-101`).
+- `SelectField` same: drop `InputLabel`, render the shared label above.
+- `FormField` uses `Label` instead of its own `Typography` block; delete the
+  duplicated asterisk logic.
+- Remove `textTransform: "capitalize"` and the 8px label padding from
+  `MuiFormLabel` in `ThemeNodetool.tsx:249-259` (labels are no longer MUI-managed).
+- This kills the clipped-label bug class; the `overflow: visible` workaround
+  in `StoryboardBoard.tsx` styles can then go.
+
+Acceptance: TextInput, SelectField, and a labelled ModelSelectButton render
+pixel-identical labels; no label ever renders outside the control's box.
+
+### Fix 3: coherent defaults
+
+- `SelectField`: default `variant="outlined"` (matches TextInput). Audit the
+  ~few call sites that relied on `standard`.
+- Inputs get a default field background (`Paper.overlay` in dark; verify
+  light) so fields read as fields outside the editor scope, matching
+  SearchInput.
+- `Panel`: default `background="paper"` **and** `bordered` — a default Panel
+  must be visible on the page background. Align its radius source with
+  `Surface` (pick one: `theme.rounded` or `shape.borderRadius`).
+- `FlexRow`/`FlexColumn`/`Stack`: keep `gap=0` default (too many call sites
+  assume it) — instead fix via Fix 4's form primitives which own their gaps.
+- `EditorButton`: passing `size` must not discard density height — make
+  `size` map onto the `CONTROL.height` scale or remove the prop.
+
+Acceptance: the bare no-props composition in the ground rules renders as a
+visible bordered panel containing two identically-styled fields.
+
+### Fix 4: real form primitives
+
+- Rework `FormField`: it owns the label (children render label-less), the
+  4px label gap, and the helper/error line with a fixed on-grid margin.
+  Ensure `TextInput`/`SelectField` compose without double labels (either via
+  context flag or by convention: never pass `label` to a control inside
+  `FormField`).
+- Add `FormSection` (optional uppercase group label — see `.group-label` in
+  `StoryboardBoard.tsx` — plus a `FlexColumn gap={3}` body) and `FormGrid`
+  (n-column CSS grid with a stack breakpoint, like `.header-grid` there).
+- Migrate `StoryboardBoard.tsx` to these, deleting its local `Field` and
+  grid CSS. Migrate 2–3 of the 14+ hand-rolled label+input sites listed in
+  STRATEGY.md as proof.
+
+### Fix 5: honest type scale
+
+Either give the collapsed sizes real values (a modular scale: e.g. 11/12/13/15/18/22)
+or remove the aliased size names from `Text` and fix call sites. Don't leave
+8 names for 4 values.
+
+### Fix 6: passthrough honesty
+
+For each raw re-export in `muiReexports.ts` that the theme does not style
+(`Tabs`, `ToggleButton`, `Accordion`, `LinearProgress` at minimum): either add
+the theme override or move it out of the "themed" comment block so the file
+stops claiming coverage it doesn't have. Low priority; do last.
+
+## Verification
+
+- `cd web && npm run typecheck && npm run lint && npm test`
+- Visual: storyboard header (`/workspace` storyboard tab), node inspector,
+  settings dialogs — before/after screenshots for each fix.
+- Grep gates after Fix 1: no raw `minHeight: "2[48]px"` in primitives; no
+  `borderRadius: "8px"`/`"6px"` literals in `ui_primitives/` or
+  `editor_ui/`; no `13px`/`3px`/`5px` paddings in primitives.

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -132,6 +132,12 @@ export type {
 } from "./timeline-sequence.js";
 
 export { ImageDocument, ImageDocumentConflictError } from "./image-document.js";
+export {
+  Storyboard,
+  StoryboardConflictError,
+  emptyStoryboardDocument
+} from "./storyboard.js";
+export type { StoryboardDocument, StoryboardResponse } from "./storyboard.js";
 export type {
   ImageDocumentData,
   ImageDocumentMutationResult,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -1816,5 +1816,45 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_wshare_workflow_id");
       await db.execute("DROP TABLE IF EXISTS nodetool_workflow_shares");
     }
+  },
+
+  // ── Create storyboards ──────────────────────────────────────
+  {
+    version: "20260718_000000",
+    name: "create_storyboards",
+    createsTables: ["storyboards"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS storyboards (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL,
+          project_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          document TEXT NOT NULL,
+          timeline_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_storyboard_user
+        ON storyboards (user_id)
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_storyboard_project
+        ON storyboards (project_id)
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_storyboard_updated
+        ON storyboards (updated_at)
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_storyboard_user");
+      await db.execute("DROP INDEX IF EXISTS idx_storyboard_project");
+      await db.execute("DROP INDEX IF EXISTS idx_storyboard_updated");
+      await db.execute("DROP TABLE IF EXISTS storyboards");
+    }
   }
 ];

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -16,6 +16,7 @@ export { teamTasks } from "./team-tasks.js";
 export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
 export { imageDocuments } from "./image-documents.js";
+export { storyboards } from "./storyboards.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";
 export { triggerRegistrations } from "./trigger-registrations.js";

--- a/packages/models/src/schema-pg/storyboards.ts
+++ b/packages/models/src/schema-pg/storyboards.ts
@@ -1,0 +1,23 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+import type { StoryboardDocument } from "../storyboard.js";
+
+export const storyboards = pgTable(
+  "storyboards",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    project_id: text("project_id").notNull(),
+    name: text("name").notNull(),
+    document: jsonText<StoryboardDocument>()("document").notNull(),
+    /** Timeline sequence this board was assembled into, if any. */
+    timeline_id: text("timeline_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_storyboard_user").on(table.user_id),
+    index("idx_storyboard_project").on(table.project_id),
+    index("idx_storyboard_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -16,6 +16,7 @@ export { teamTasks } from "./team-tasks.js";
 export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
 export { imageDocuments } from "./image-documents.js";
+export { storyboards } from "./storyboards.js";
 export { workerProfiles, workerInstances } from "./workers.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";

--- a/packages/models/src/schema/storyboards.ts
+++ b/packages/models/src/schema/storyboards.ts
@@ -1,0 +1,21 @@
+import { sqliteTable, text, index } from "drizzle-orm/sqlite-core";
+
+export const storyboards = sqliteTable(
+  "storyboards",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    project_id: text("project_id").notNull(),
+    name: text("name").notNull(),
+    document: text("document").notNull(),
+    /** Timeline sequence this board was assembled into, if any. */
+    timeline_id: text("timeline_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_storyboard_user").on(table.user_id),
+    index("idx_storyboard_project").on(table.project_id),
+    index("idx_storyboard_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/src/storyboard.ts
+++ b/packages/models/src/storyboard.ts
@@ -1,0 +1,188 @@
+import { eq, desc, and } from "drizzle-orm";
+import type { Screenplay, Shot } from "@nodetool-ai/protocol";
+import {
+  DBModel,
+  ModelChangeEvent,
+  ModelObserver,
+  createTimeOrderedUuid
+} from "./base-model.js";
+import { getDb } from "./db.js";
+import { storyboards } from "./schema/storyboards.js";
+
+/**
+ * The persisted storyboard payload: everything the web board carries except
+ * identity/timestamps (columns) and transient UI state (active shot).
+ */
+export interface StoryboardDocument {
+  screenplay: Screenplay | null;
+  shots: Shot[];
+  brief: string;
+  style: string;
+  aspectRatio: string;
+  /** Model selections; loosely typed — validated by the router schemas. */
+  directorModel: Record<string, unknown> | null;
+  imageModel: Record<string, unknown> | null;
+  videoModel: Record<string, unknown> | null;
+}
+
+export interface StoryboardResponse {
+  id: string;
+  projectId: string;
+  name: string;
+  document: StoryboardDocument;
+  timelineId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class StoryboardConflictError extends Error {
+  constructor(id: string) {
+    super(`Storyboard ${id} was modified concurrently`);
+    this.name = "StoryboardConflictError";
+  }
+}
+
+export const emptyStoryboardDocument = (): StoryboardDocument => ({
+  screenplay: null,
+  shots: [],
+  brief: "",
+  style: "",
+  aspectRatio: "16:9",
+  directorModel: null,
+  imageModel: null,
+  videoModel: null
+});
+
+function assertValidDocument(doc: StoryboardDocument): void {
+  if (!doc || typeof doc !== "object" || !Array.isArray(doc.shots)) {
+    throw new Error("storyboard document must contain a shots array");
+  }
+}
+
+function nextUpdatedAtAfter(previous: string): string {
+  const now = new Date();
+  const previousMs = Date.parse(previous);
+  if (Number.isFinite(previousMs) && now.getTime() <= previousMs) {
+    return new Date(previousMs + 1).toISOString();
+  }
+  return now.toISOString();
+}
+
+export class Storyboard extends DBModel {
+  static override table = storyboards;
+
+  declare id: string;
+  declare user_id: string;
+  declare project_id: string;
+  declare name: string;
+  declare document: string;
+  declare timeline_id: string | null;
+  declare created_at: string;
+  declare updated_at: string;
+
+  constructor(data: Record<string, unknown>) {
+    super(data);
+    const now = new Date().toISOString();
+    this.id ??= createTimeOrderedUuid();
+    this.project_id ??= "default";
+    this.name ??= "Untitled storyboard";
+    this.document ??= JSON.stringify(emptyStoryboardDocument());
+    this.timeline_id ??= null;
+    this.created_at ??= now;
+    this.updated_at ??= now;
+  }
+
+  override beforeSave(): void {
+    this.updated_at = nextUpdatedAtAfter(this.updated_at);
+    assertValidDocument(JSON.parse(this.document) as StoryboardDocument);
+  }
+
+  toDocument(): StoryboardDocument {
+    return JSON.parse(this.document) as StoryboardDocument;
+  }
+
+  toResponse(): StoryboardResponse {
+    return {
+      id: this.id,
+      projectId: this.project_id,
+      name: this.name,
+      document: this.toDocument(),
+      timelineId: this.timeline_id ?? undefined,
+      createdAt: this.created_at,
+      updatedAt: this.updated_at
+    };
+  }
+
+  static async findById(id: string): Promise<Storyboard | null> {
+    return Storyboard.get<Storyboard>(id);
+  }
+
+  static async listByUser(userId: string, limit = 50): Promise<Storyboard[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(storyboards)
+      .where(eq(storyboards.user_id, userId))
+      .orderBy(desc(storyboards.updated_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Storyboard(r));
+  }
+
+  static async listByProject(
+    projectId: string,
+    userId: string,
+    limit = 50
+  ): Promise<Storyboard[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(storyboards)
+      .where(
+        and(
+          eq(storyboards.project_id, projectId),
+          eq(storyboards.user_id, userId)
+        )
+      )
+      .orderBy(desc(storyboards.updated_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Storyboard(r));
+  }
+
+  /**
+   * Atomic compare-and-swap save. Applies only when the row's `updated_at`
+   * still equals `expectedUpdatedAt`; returns null on conflict so the caller
+   * reports it instead of clobbering a concurrent write.
+   */
+  static async updateFieldsIfUnchanged(
+    id: string,
+    expectedUpdatedAt: string,
+    fields: Partial<{
+      name: string;
+      document: string;
+      timeline_id: string | null;
+    }>
+  ): Promise<Storyboard | null> {
+    if (fields.document !== undefined) {
+      assertValidDocument(JSON.parse(fields.document) as StoryboardDocument);
+    }
+    const db = getDb();
+    const now = nextUpdatedAtAfter(expectedUpdatedAt);
+    const rows = await db
+      .update(storyboards)
+      .set({ ...fields, updated_at: now })
+      .where(
+        and(
+          eq(storyboards.id, id),
+          eq(storyboards.updated_at, expectedUpdatedAt)
+        )
+      )
+      .returning();
+
+    const row = rows[0] as Record<string, unknown> | undefined;
+    if (!row) return null;
+
+    const updated = new Storyboard(row);
+    ModelObserver.notify(updated, ModelChangeEvent.UPDATED);
+    return updated;
+  }
+}

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 45;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 46;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/protocol/src/api-schemas/index.ts
+++ b/packages/protocol/src/api-schemas/index.ts
@@ -16,6 +16,7 @@ export * as storage from "./storage.js";
 export * as threads from "./threads.js";
 export * as users from "./users.js";
 export * as sketch from "./sketch.js";
+export * as storyboards from "./storyboards.js";
 export * as timeline from "./timeline.js";
 export * as workflows from "./workflows.js";
 export * as workspace from "./workspace.js";

--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+// ── Shot / screenplay ───────────────────────────────────────────────────────
+// Mirrors the interfaces in `creative.ts`. Loose objects: the shapes evolve
+// with the Director agent, and the storyboard document is a client-owned
+// payload — the schema pins the structural keys and lets the rest travel.
+
+const mediaRef = z
+  .object({
+    type: z.string(),
+    uri: z.string().optional(),
+    asset_id: z.string().nullable().optional()
+  })
+  .passthrough();
+
+export const storyboardShot = z
+  .object({
+    type: z.literal("shot"),
+    id: z.string(),
+    index: z.number(),
+    action: z.string(),
+    status: z.string(),
+    slug: z.string().optional(),
+    motion: z.string().optional(),
+    duration_seconds: z.number().optional(),
+    keyframe: mediaRef.nullable().optional(),
+    clip: mediaRef.nullable().optional()
+  })
+  .passthrough();
+export type StoryboardShot = z.infer<typeof storyboardShot>;
+
+export const storyboardScreenplay = z
+  .object({
+    type: z.literal("screenplay"),
+    id: z.string(),
+    title: z.string(),
+    shots: z.array(storyboardShot)
+  })
+  .passthrough();
+
+/** A model selection (language/image/video) as the pickers emit it. */
+const modelSelection = z
+  .object({
+    type: z.string(),
+    id: z.string(),
+    provider: z.string(),
+    name: z.string().optional()
+  })
+  .passthrough();
+
+// ── Document ────────────────────────────────────────────────────────────────
+
+export const storyboardDocument = z.object({
+  screenplay: storyboardScreenplay.nullable(),
+  shots: z.array(storyboardShot),
+  brief: z.string(),
+  style: z.string(),
+  aspectRatio: z.string(),
+  directorModel: modelSelection.nullable(),
+  imageModel: modelSelection.nullable(),
+  videoModel: modelSelection.nullable()
+});
+export type StoryboardDocumentSchema = z.infer<typeof storyboardDocument>;
+
+// ── API shapes ──────────────────────────────────────────────────────────────
+
+export const storyboardResponse = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  document: storyboardDocument,
+  timelineId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+export type StoryboardResponse = z.infer<typeof storyboardResponse>;
+
+export const storyboardListItem = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  shotCount: z.number(),
+  updatedAt: z.string()
+});
+export type StoryboardListItem = z.infer<typeof storyboardListItem>;
+
+export const createStoryboardInput = z.object({
+  /** Client-supplied id: lets a tab-ref'd local board upsert itself. */
+  id: z.string().optional(),
+  name: z.string().min(1).default("Untitled storyboard"),
+  projectId: z.string().default("default"),
+  document: storyboardDocument.optional()
+});
+export type CreateStoryboardInput = z.infer<typeof createStoryboardInput>;
+
+export const patchStoryboardInput = z
+  .object({
+    name: z.string().min(1).optional(),
+    document: storyboardDocument.optional(),
+    timelineId: z.string().nullable().optional()
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field must be provided"
+  });
+export type PatchStoryboardInput = z.infer<typeof patchStoryboardInput>;

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -126,8 +126,10 @@ export interface Shot {
   location_id?: string | null;
   /** Cheap still anchoring the shot (the storyboard frame). */
   keyframe?: ImageRef | null;
-  /** Final animated clip. */
+  /** The selected clip — what assembly/export uses. */
   clip?: VideoRef | null;
+  /** Every rendered take for this shot, oldest first. `clip` is one of them. */
+  clip_versions?: VideoRef[];
   status: ShotStatus;
   /** Estimated cost to render this shot's clip, for the gate. */
   cost_estimate?: number | null;

--- a/packages/websocket/src/trpc/router.ts
+++ b/packages/websocket/src/trpc/router.ts
@@ -17,6 +17,7 @@ import { skillsRouter, fontsRouter } from "./routers/skills.js";
 import { storageRouter } from "./routers/storage.js";
 import { threadsRouter } from "./routers/threads.js";
 import { sketchRouter } from "./routers/sketch.js";
+import { storyboardsRouter } from "./routers/storyboards.js";
 import { timelineRouter } from "./routers/timeline.js";
 import { usersRouter } from "./routers/users.js";
 import { workerRouter } from "./routers/worker.js";
@@ -42,6 +43,7 @@ export const appRouter = router({
   sandboxes: sandboxesRouter,
   settings: settingsRouter,
   sketch: sketchRouter,
+  storyboards: storyboardsRouter,
   skills: skillsRouter,
   storage: storageRouter,
   threads: threadsRouter,

--- a/packages/websocket/src/trpc/routers/storyboards.ts
+++ b/packages/websocket/src/trpc/routers/storyboards.ts
@@ -1,0 +1,151 @@
+/**
+ * Storyboards router — tRPC.
+ *
+ * Procedures:
+ *   list    (query)    — StoryboardListItem[]
+ *   get     (query)    — StoryboardResponse
+ *   create  (mutation) — StoryboardResponse
+ *   update  (mutation) — StoryboardResponse (CAS via baseUpdatedAt)
+ *   delete  (mutation) — { ok: true }
+ */
+
+import { z } from "zod";
+import { Storyboard, emptyStoryboardDocument } from "@nodetool-ai/models";
+import {
+  createStoryboardInput,
+  patchStoryboardInput,
+  storyboardListItem,
+  storyboardResponse
+} from "@nodetool-ai/protocol/api-schemas/storyboards.js";
+import { ApiErrorCode } from "../../error-codes.js";
+import { router } from "../index.js";
+import { protectedProcedure } from "../middleware.js";
+import { throwApiError } from "../error-formatter.js";
+
+const listInput = z.object({
+  projectId: z.string().optional()
+});
+
+const idInput = z.object({ id: z.string() });
+
+const updateInput = patchStoryboardInput.and(
+  z.object({
+    id: z.string(),
+    baseUpdatedAt: z.string().optional()
+  })
+);
+
+const okOutput = z.object({ ok: z.literal(true) });
+
+function toListItem(board: Storyboard) {
+  return {
+    id: board.id,
+    projectId: board.project_id,
+    name: board.name,
+    shotCount: board.toDocument().shots.length,
+    updatedAt: board.updated_at
+  };
+}
+
+async function loadOwned(
+  ctxUserId: string | null,
+  id: string
+): Promise<Storyboard> {
+  if (!ctxUserId) throwApiError(ApiErrorCode.UNAUTHORIZED, "Unauthorized");
+  const board = await Storyboard.findById(id);
+  if (!board || board.user_id !== ctxUserId) {
+    throwApiError(ApiErrorCode.NOT_FOUND, "Storyboard not found");
+  }
+  return board;
+}
+
+export const storyboardsRouter = router({
+  list: protectedProcedure
+    .input(listInput)
+    .output(z.array(storyboardListItem))
+    .query(async ({ ctx, input }) => {
+      const boards = input.projectId
+        ? await Storyboard.listByProject(input.projectId, ctx.userId)
+        : await Storyboard.listByUser(ctx.userId);
+      return boards.map(toListItem);
+    }),
+
+  get: protectedProcedure
+    .input(idInput)
+    .output(storyboardResponse)
+    .query(async ({ ctx, input }) => {
+      const board = await loadOwned(ctx.userId, input.id);
+      return storyboardResponse.parse(board.toResponse());
+    }),
+
+  create: protectedProcedure
+    .input(createStoryboardInput)
+    .output(storyboardResponse)
+    .mutation(async ({ ctx, input }) => {
+      if (input.id) {
+        const existing = await Storyboard.findById(input.id);
+        if (existing) {
+          if (existing.user_id !== ctx.userId) {
+            throwApiError(ApiErrorCode.NOT_FOUND, "Storyboard not found");
+          }
+          return storyboardResponse.parse(existing.toResponse());
+        }
+      }
+      const board = new Storyboard({
+        id: input.id,
+        user_id: ctx.userId,
+        project_id: input.projectId,
+        name: input.name,
+        document: JSON.stringify(input.document ?? emptyStoryboardDocument())
+      });
+      await board.save();
+      return storyboardResponse.parse(board.toResponse());
+    }),
+
+  update: protectedProcedure
+    .input(updateInput)
+    .output(storyboardResponse)
+    .mutation(async ({ ctx, input }) => {
+      const board = await loadOwned(ctx.userId, input.id);
+
+      // CAS on updated_at so the conflict check and the write are atomic.
+      const expectedUpdatedAt = input.baseUpdatedAt ?? board.updated_at;
+      if (input.baseUpdatedAt && board.updated_at !== input.baseUpdatedAt) {
+        throwApiError(
+          ApiErrorCode.ALREADY_EXISTS,
+          "Storyboard was modified since last read (optimistic concurrency conflict)"
+        );
+      }
+
+      const fields: Parameters<
+        typeof Storyboard.updateFieldsIfUnchanged
+      >[2] = {};
+      if (input.name !== undefined) fields.name = input.name;
+      if (input.document !== undefined)
+        fields.document = JSON.stringify(input.document);
+      if (input.timelineId !== undefined)
+        fields.timeline_id = input.timelineId;
+
+      const updated = await Storyboard.updateFieldsIfUnchanged(
+        input.id,
+        expectedUpdatedAt,
+        fields
+      );
+      if (!updated) {
+        throwApiError(
+          ApiErrorCode.ALREADY_EXISTS,
+          "Storyboard was modified since last read (optimistic concurrency conflict)"
+        );
+      }
+      return storyboardResponse.parse(updated.toResponse());
+    }),
+
+  delete: protectedProcedure
+    .input(idInput)
+    .output(okOutput)
+    .mutation(async ({ ctx, input }) => {
+      const board = await loadOwned(ctx.userId, input.id);
+      await board.delete();
+      return { ok: true as const };
+    })
+});

--- a/web/src/components/properties/VideoModelSelect.tsx
+++ b/web/src/components/properties/VideoModelSelect.tsx
@@ -2,18 +2,16 @@ import React, { useState, useCallback, useMemo, useRef } from "react";
 import isEqual from "../../utils/isEqual";
 import VideoModelMenuDialog from "../model_menu/VideoModelMenuDialog";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
-import type { ModelPack, UnifiedModel, VideoModel } from "../../stores/ApiTypes";
+import type {
+  ModelPack,
+  UnifiedModel,
+  VideoModel,
+  VideoModelValue
+} from "../../stores/ApiTypes";
 import { trpc } from "../../lib/trpc";
 import { useQuery } from "@tanstack/react-query";
 import type { VideoModelTask } from "../../hooks/useModelsByProvider";
 import ModelSelectButton from "./shared/ModelSelectButton";
-
-interface VideoModelValue {
-  type: "video_model";
-  id: string;
-  provider: string;
-  name: string;
-}
 
 interface VideoModelSelectProps {
   onChange: (value: VideoModelValue) => void;

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -27,6 +27,7 @@ import {
   SPACING,
   getSpacingPx,
   BORDER_RADIUS,
+  MOTION,
   type StatusType
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
@@ -93,7 +94,7 @@ const styles = (theme: Theme) =>
       "50%": { boxShadow: `0 0 14px 1px ${theme.vars.palette.primary.main}55` }
     },
     "&.generating": {
-      animation: "shot-breathe 2s ease-in-out infinite"
+      animation: `shot-breathe ${MOTION.pulse} infinite`
     },
     ".conjure": {
       position: "absolute",
@@ -105,11 +106,11 @@ const styles = (theme: Theme) =>
       gap: getSpacingPx(SPACING.sm),
       backgroundImage: `linear-gradient(100deg, transparent 40%, ${theme.vars.palette.action.selected} 50%, transparent 60%)`,
       backgroundSize: "200% 100%",
-      animation: "shot-shimmer 1.8s linear infinite",
+      animation: `shot-shimmer ${MOTION.spin} infinite`,
       ".spark": {
-        fontSize: "22px",
+        fontSize: "1.5em",
         color: theme.vars.palette.primary.main,
-        animation: "shot-spark 1.8s ease-in-out infinite"
+        animation: `shot-spark ${MOTION.pulse} infinite`
       },
       ".conjure-label": {
         color: theme.vars.palette.text.secondary

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -31,6 +31,7 @@ import {
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { syncShotClipToTimeline } from "../../stores/storyboard/timelineSync";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 
 interface ShotCardProps {
@@ -77,6 +78,45 @@ const styles = (theme: Theme) =>
     },
     ".camera": {
       color: theme.vars.palette.text.secondary
+    },
+    // ── Generating: shimmer sweep + spark over the preview, glow on the card ──
+    "@keyframes shot-shimmer": {
+      from: { backgroundPosition: "200% 0" },
+      to: { backgroundPosition: "-200% 0" }
+    },
+    "@keyframes shot-spark": {
+      "0%, 100%": { opacity: 0.4, transform: "scale(0.9) rotate(0deg)" },
+      "50%": { opacity: 1, transform: "scale(1.2) rotate(90deg)" }
+    },
+    "@keyframes shot-breathe": {
+      "0%, 100%": { boxShadow: `0 0 0 1px ${theme.vars.palette.primary.main}33` },
+      "50%": { boxShadow: `0 0 14px 1px ${theme.vars.palette.primary.main}55` }
+    },
+    "&.generating": {
+      animation: "shot-breathe 2s ease-in-out infinite"
+    },
+    ".conjure": {
+      position: "absolute",
+      inset: 0,
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: getSpacingPx(SPACING.sm),
+      backgroundImage: `linear-gradient(100deg, transparent 40%, ${theme.vars.palette.action.selected} 50%, transparent 60%)`,
+      backgroundSize: "200% 100%",
+      animation: "shot-shimmer 1.8s linear infinite",
+      ".spark": {
+        fontSize: "22px",
+        color: theme.vars.palette.primary.main,
+        animation: "shot-spark 1.8s ease-in-out infinite"
+      },
+      ".conjure-label": {
+        color: theme.vars.palette.text.secondary
+      }
+    },
+    "@media (prefers-reduced-motion: reduce)": {
+      "&.generating, .conjure, .conjure .spark": { animation: "none" }
     }
   });
 
@@ -93,6 +133,9 @@ const cameraLine = (shot: Shot): string =>
 const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => {
   const theme = useTheme();
   const approveShot = useStoryboardStore((state) => state.approveShot);
+  const selectClipVersion = useStoryboardStore(
+    (state) => state.selectClipVersion
+  );
   const { generateKeyframe, generateClip, generateRevisedClip } =
     useGenerateShot();
 
@@ -101,6 +144,24 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
     shot.status === "keyframe_generating" || shot.status === "clip_generating";
   const camera = cameraLine(shot);
   const clipUri = shot.clip?.uri;
+  const takes = shot.clip_versions ?? (shot.clip ? [shot.clip] : []);
+  const selectedTake = takes.findIndex(
+    (v) =>
+      (shot.clip?.asset_id && v.asset_id === shot.clip.asset_id) ||
+      (!shot.clip?.asset_id && v.uri === shot.clip?.uri)
+  );
+
+  const handleSelectTake = useCallback(
+    (index: number) => {
+      selectClipVersion(boardId, shot.id, index);
+      // Keep a linked, already-assembled timeline on the newly chosen take.
+      const assetId = (shot.clip_versions ?? [])[index]?.asset_id;
+      if (assetId) {
+        void syncShotClipToTimeline(boardId, shot.id, assetId);
+      }
+    },
+    [selectClipVersion, boardId, shot.id, shot.clip_versions]
+  );
 
   const handleGenerateStill = useCallback(() => {
     void generateKeyframe(boardId, shot);
@@ -124,7 +185,12 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
   }, [generateRevisedClip, boardId, shot]);
 
   return (
-    <Card variant="outlined" padding="compact" css={styles(theme)} className="shot-card">
+    <Card
+      variant="outlined"
+      padding="compact"
+      css={styles(theme)}
+      className={`shot-card${isGenerating ? " generating" : ""}`}
+    >
       <FlexRow align="center" justify="space-between" gap={1}>
         <Text size="small" weight={600} truncate>
           {`${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`}
@@ -147,6 +213,16 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
             }
           />
         )}
+        {isGenerating && (
+          <div className="conjure">
+            <span className="spark">✦</span>
+            <Caption className="conjure-label">
+              {shot.status === "clip_generating"
+                ? "Rendering clip…"
+                : "Conjuring still…"}
+            </Caption>
+          </div>
+        )}
       </div>
 
       <Text size="small" lineClamp={3}>
@@ -157,6 +233,22 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
         <Caption className="camera" noWrap>
           {camera}
         </Caption>
+      )}
+
+      {takes.length > 1 && (
+        <FlexRow gap={0.5} align="center" wrap className="takes">
+          <Caption color="secondary">Takes</Caption>
+          {takes.map((take, i) => (
+            <Chip
+              key={take.asset_id ?? take.uri ?? i}
+              compact
+              clickable={!readOnly}
+              color={i === selectedTake ? "primary" : "default"}
+              label={`${i + 1}`}
+              onClick={readOnly ? undefined : () => handleSelectTake(i)}
+            />
+          ))}
+        </FlexRow>
       )}
 
       {typeof shot.cost_estimate === "number" && (
@@ -183,10 +275,14 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
           </FlexRow>
           <EditorButton
             onClick={handleGenerateClip}
-            disabled={shot.status !== "approved"}
+            disabled={
+              isGenerating ||
+              !shot.keyframe ||
+              (shot.status !== "approved" && shot.status !== "rendered")
+            }
             fullWidth
           >
-            Generate clip
+            {shot.clip ? "New take" : "Generate clip"}
           </EditorButton>
           {shot.clip && (
             <EditorButton

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -25,7 +25,8 @@ import {
   Text,
   SPACING,
   getSpacingPx,
-  BORDER_RADIUS
+  BORDER_RADIUS,
+  MOTION
 } from "../ui_primitives";
 import { useBoard, useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
@@ -114,7 +115,7 @@ const styles = (theme: Theme) =>
       backgroundClip: "text",
       WebkitBackgroundClip: "text",
       WebkitTextFillColor: "transparent",
-      animation: "storyboard-shimmer 2.4s linear infinite"
+      animation: `storyboard-shimmer ${MOTION.spin} infinite`
     },
     ".ghost-card": {
       border: `1px solid ${theme.vars.palette.divider}`,
@@ -124,7 +125,7 @@ const styles = (theme: Theme) =>
       flexDirection: "column",
       gap: getSpacingPx(SPACING.sm),
       opacity: 0,
-      animation: "storyboard-ghost-in 500ms ease both"
+      animation: `storyboard-ghost-in ${MOTION.slow} both`
     },
     ".ghost-frame": {
       aspectRatio: "16 / 9",
@@ -133,19 +134,19 @@ const styles = (theme: Theme) =>
       placeItems: "center",
       backgroundImage: `linear-gradient(100deg, ${theme.vars.palette.c_overlay_subtle} 40%, ${theme.vars.palette.action.selected} 50%, ${theme.vars.palette.c_overlay_subtle} 60%)`,
       backgroundSize: "200% 100%",
-      animation: "storyboard-shimmer 1.8s linear infinite"
+      animation: `storyboard-shimmer ${MOTION.spin} infinite`
     },
     ".ghost-line": {
       height: "10px",
-      borderRadius: "5px",
+      borderRadius: BORDER_RADIUS.pill,
       backgroundImage: `linear-gradient(100deg, ${theme.vars.palette.c_overlay_subtle} 40%, ${theme.vars.palette.action.selected} 50%, ${theme.vars.palette.c_overlay_subtle} 60%)`,
       backgroundSize: "200% 100%",
-      animation: "storyboard-shimmer 1.8s linear infinite"
+      animation: `storyboard-shimmer ${MOTION.spin} infinite`
     },
     ".spark": {
-      fontSize: "20px",
+      fontSize: "1.5em",
       color: theme.vars.palette.primary.main,
-      animation: "storyboard-spark 1.8s ease-in-out infinite"
+      animation: `storyboard-spark ${MOTION.pulse} infinite`
     },
     "@media (prefers-reduced-motion: reduce)": {
       ".ghost-frame, .ghost-line, .directing-line, .spark": {

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -24,11 +24,14 @@ import {
   Divider,
   Text,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  BORDER_RADIUS
 } from "../ui_primitives";
 import { useBoard, useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import LanguageModelSelect from "../properties/LanguageModelSelect";
 import ImageModelSelect from "../properties/ImageModelSelect";
+import VideoModelSelect from "../properties/VideoModelSelect";
 import ShotCard from "./ShotCard";
 
 interface StoryboardBoardProps {
@@ -91,6 +94,65 @@ const styles = (theme: Theme) =>
       gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
       gap: getSpacingPx(SPACING.md)
     },
+    // ── Directing: ghost cards materializing while the screenplay is written ──
+    "@keyframes storyboard-ghost-in": {
+      from: { opacity: 0, transform: "translateY(8px) scale(0.98)" },
+      to: { opacity: 1, transform: "translateY(0) scale(1)" }
+    },
+    "@keyframes storyboard-shimmer": {
+      from: { backgroundPosition: "200% 0" },
+      to: { backgroundPosition: "-200% 0" }
+    },
+    "@keyframes storyboard-spark": {
+      "0%, 100%": { opacity: 0.35, transform: "scale(0.9) rotate(0deg)" },
+      "50%": { opacity: 0.9, transform: "scale(1.15) rotate(90deg)" }
+    },
+    ".directing-line": {
+      color: theme.vars.palette.primary.main,
+      backgroundImage: `linear-gradient(90deg, ${theme.vars.palette.primary.main}, ${theme.vars.palette.text.secondary}, ${theme.vars.palette.primary.main})`,
+      backgroundSize: "200% 100%",
+      backgroundClip: "text",
+      WebkitBackgroundClip: "text",
+      WebkitTextFillColor: "transparent",
+      animation: "storyboard-shimmer 2.4s linear infinite"
+    },
+    ".ghost-card": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: theme.shape.borderRadius,
+      padding: getSpacingPx(SPACING.md),
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.sm),
+      opacity: 0,
+      animation: "storyboard-ghost-in 500ms ease both"
+    },
+    ".ghost-frame": {
+      aspectRatio: "16 / 9",
+      borderRadius: BORDER_RADIUS.sm,
+      display: "grid",
+      placeItems: "center",
+      backgroundImage: `linear-gradient(100deg, ${theme.vars.palette.c_overlay_subtle} 40%, ${theme.vars.palette.action.selected} 50%, ${theme.vars.palette.c_overlay_subtle} 60%)`,
+      backgroundSize: "200% 100%",
+      animation: "storyboard-shimmer 1.8s linear infinite"
+    },
+    ".ghost-line": {
+      height: "10px",
+      borderRadius: "5px",
+      backgroundImage: `linear-gradient(100deg, ${theme.vars.palette.c_overlay_subtle} 40%, ${theme.vars.palette.action.selected} 50%, ${theme.vars.palette.c_overlay_subtle} 60%)`,
+      backgroundSize: "200% 100%",
+      animation: "storyboard-shimmer 1.8s linear infinite"
+    },
+    ".spark": {
+      fontSize: "20px",
+      color: theme.vars.palette.primary.main,
+      animation: "storyboard-spark 1.8s ease-in-out infinite"
+    },
+    "@media (prefers-reduced-motion: reduce)": {
+      ".ghost-frame, .ghost-line, .directing-line, .spark": {
+        animation: "none"
+      },
+      ".ghost-card": { animation: "none", opacity: 1 }
+    },
     ".header-fields": {
       color: theme.vars.palette.text.secondary,
       // Panel clips its content; the shrunk "Title" label sits above the input
@@ -147,8 +209,16 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   assembleError
 }) => {
   const theme = useTheme();
-  const { title, brief, style, aspectRatio, directorModel, imageModel, shots } =
-    useBoard(boardId);
+  const {
+    title,
+    brief,
+    style,
+    aspectRatio,
+    directorModel,
+    imageModel,
+    videoModel,
+    shots
+  } = useBoard(boardId);
 
   const setTitle = useStoryboardStore((state) => state.setTitle);
   const setBrief = useStoryboardStore((state) => state.setBrief);
@@ -156,6 +226,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const setAspectRatio = useStoryboardStore((state) => state.setAspectRatio);
   const setDirectorModel = useStoryboardStore((state) => state.setDirectorModel);
   const setImageModel = useStoryboardStore((state) => state.setImageModel);
+  const setVideoModel = useStoryboardStore((state) => state.setVideoModel);
 
   const [shotCount, setShotCount] = useState<number>(6);
 
@@ -166,6 +237,29 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const hasRenderedShot = shots.some(
     (s) => s.status === "rendered" && !!s.clip?.asset_id
   );
+
+  // Shots still waiting for their first still (or whose last attempt failed).
+  const pendingStills = shots.filter(
+    (s) =>
+      !s.keyframe && (s.status === "planned" || s.status === "failed")
+  );
+
+  // Approved shots with a still, cleared for video spend but not yet rendered.
+  const pendingClips = shots.filter(
+    (s) => s.status === "approved" && !!s.keyframe
+  );
+
+  const { generateKeyframe, generateClip } = useGenerateShot();
+  const handleGenerateAllStills = useCallback(() => {
+    for (const shot of pendingStills) {
+      void generateKeyframe(boardId, shot);
+    }
+  }, [pendingStills, generateKeyframe, boardId]);
+  const handleGenerateAllClips = useCallback(() => {
+    for (const shot of pendingClips) {
+      void generateClip(boardId, shot);
+    }
+  }, [pendingClips, generateClip, boardId]);
 
   return (
     <div css={styles(theme)} className="storyboard-board">
@@ -222,6 +316,13 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                     onChange={(value) => setImageModel(boardId, value)}
                   />
                 </Field>
+                <Field label="Clip model">
+                  <VideoModelSelect
+                    value={videoModel?.id ?? ""}
+                    task="image_to_video"
+                    onChange={(value) => setVideoModel(boardId, value)}
+                  />
+                </Field>
                 <Field label="Aspect ratio">
                   <SelectField
                     label="Aspect ratio"
@@ -258,6 +359,20 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               <FlexRow gap={2} align="center">
                 <EditorButton
                   variant="outlined"
+                  onClick={handleGenerateAllStills}
+                  disabled={pendingStills.length === 0 || directing}
+                >
+                  {`✦ Generate all stills${pendingStills.length > 0 ? ` (${pendingStills.length})` : ""}`}
+                </EditorButton>
+                <EditorButton
+                  variant="outlined"
+                  onClick={handleGenerateAllClips}
+                  disabled={pendingClips.length === 0 || directing}
+                >
+                  {`✦ Generate all clips${pendingClips.length > 0 ? ` (${pendingClips.length})` : ""}`}
+                </EditorButton>
+                <EditorButton
+                  variant="outlined"
                   onClick={onAssemble}
                   disabled={!onAssemble || assembling || !hasRenderedShot}
                 >
@@ -277,7 +392,28 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
         </Panel>
       )}
 
-      {shots.length === 0 ? (
+      {directing ? (
+        <>
+          <Text size="small" className="directing-line">
+            ✦ The director is writing your screenplay…
+          </Text>
+          <div className="grid">
+            {Array.from({ length: shotCount }).map((_, i) => (
+              <div
+                key={i}
+                className="ghost-card"
+                style={{ animationDelay: `${i * 140}ms` }}
+              >
+                <div className="ghost-frame">
+                  <span className="spark">✦</span>
+                </div>
+                <div className="ghost-line" style={{ width: "80%" }} />
+                <div className="ghost-line" style={{ width: "55%" }} />
+              </div>
+            ))}
+          </div>
+        </>
+      ) : shots.length === 0 ? (
         <EmptyState
           variant="empty"
           title="No shots yet"

--- a/web/src/components/storyboard/StoryboardSidebar.tsx
+++ b/web/src/components/storyboard/StoryboardSidebar.tsx
@@ -1,0 +1,182 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * StoryboardSidebar
+ *
+ * Lists the user's server-persisted storyboards, newest first. Clicking a
+ * board opens/focuses its workspace tab; hovering exposes a delete. Boards
+ * autosave (see useStoryboardServerSync), so this doubles as the
+ * "recent work" view.
+ */
+
+import React, { memo, useCallback, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  Caption,
+  ToolbarIconButton,
+  LoadingSpinner,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import {
+  useStoryboards,
+  useCreateStoryboard,
+  useDeleteStoryboard
+} from "../../hooks/storyboard/useStoryboards";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { tabId, useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+
+interface StoryboardSidebarProps {
+  /** Board shown in the surface this sidebar belongs to. */
+  activeBoardId: string;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    width: "220px",
+    flexShrink: 0,
+    height: "100%",
+    overflowY: "auto",
+    borderRight: `1px solid ${theme.vars.palette.divider}`,
+    padding: getSpacingPx(SPACING.md),
+    display: "flex",
+    flexDirection: "column",
+    gap: getSpacingPx(SPACING.md),
+    ".sidebar-title": {
+      textTransform: "uppercase",
+      letterSpacing: "0.08em",
+      color: theme.vars.palette.text.disabled
+    },
+    ".board-row": {
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`,
+      borderRadius: theme.shape.borderRadius,
+      cursor: "pointer",
+      "&:hover": { backgroundColor: theme.vars.palette.action.hover },
+      "&.active": { backgroundColor: theme.vars.palette.action.selected },
+      ".delete-button": { opacity: 0, transition: "opacity 120ms ease" },
+      "&:hover .delete-button": { opacity: 1 }
+    }
+  });
+
+const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
+  activeBoardId
+}) => {
+  const theme = useTheme();
+  const { data: boards, isLoading } = useStoryboards();
+  const createStoryboard = useCreateStoryboard();
+  const deleteStoryboard = useDeleteStoryboard();
+  const removeLocalBoard = useStoryboardStore((state) => state.removeBoard);
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
+
+  const openBoard = useCallback(
+    (id: string, title: string) => {
+      openTab({
+        type: "storyboard",
+        ref: id,
+        mode: "edit",
+        title: title || "Untitled storyboard"
+      });
+    },
+    [openTab]
+  );
+
+  const newBoard = useCallback(async () => {
+    try {
+      const created = await createStoryboard.mutateAsync({
+        name: "Untitled storyboard",
+        projectId: "default"
+      });
+      openBoard(created.id, created.name);
+    } catch (error) {
+      console.error("Failed to create storyboard", error);
+    }
+  }, [createStoryboard, openBoard]);
+
+  const deleteBoard = useCallback(
+    (id: string) => {
+      deleteStoryboard.mutate({ id });
+      removeLocalBoard(id);
+      closeTab(tabId("storyboard", id));
+    },
+    [deleteStoryboard, removeLocalBoard, closeTab]
+  );
+
+  const formatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit"
+      }),
+    []
+  );
+
+  return (
+    <div css={styles(theme)} className="storyboard-sidebar">
+      <FlexRow align="center" justify="space-between">
+        <Text size="tiny" className="sidebar-title">
+          Storyboards
+        </Text>
+        <ToolbarIconButton
+          icon={<AddRoundedIcon fontSize="small" />}
+          tooltip="New storyboard"
+          onClick={() => void newBoard()}
+        />
+      </FlexRow>
+
+      {isLoading ? (
+        <LoadingSpinner size={20} />
+      ) : (
+        <FlexColumn gap={0.5}>
+          {(boards ?? []).map((board) => (
+            <FlexRow
+              key={board.id}
+              align="center"
+              justify="space-between"
+              gap={1}
+              className={`board-row${board.id === activeBoardId ? " active" : ""}`}
+              onClick={() => openBoard(board.id, board.name)}
+            >
+              <FlexColumn gap={0} sx={{ minWidth: 0 }}>
+                <Text size="small" truncate>
+                  {board.name || "Untitled storyboard"}
+                </Text>
+                <Caption size="tiny" color="secondary">
+                  {board.shotCount > 0
+                    ? `${board.shotCount} shots · ${formatter.format(new Date(board.updatedAt))}`
+                    : formatter.format(new Date(board.updatedAt))}
+                </Caption>
+              </FlexColumn>
+              <ToolbarIconButton
+                className="delete-button"
+                icon={<DeleteOutlineRoundedIcon fontSize="small" />}
+                tooltip="Delete storyboard"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteBoard(board.id);
+                }}
+              />
+            </FlexRow>
+          ))}
+          {(boards ?? []).length === 0 && (
+            <Caption size="tiny" color="secondary">
+              No storyboards yet.
+            </Caption>
+          )}
+        </FlexColumn>
+      )}
+    </div>
+  );
+};
+
+const StoryboardSidebar = memo(StoryboardSidebarInner);
+export default StoryboardSidebar;

--- a/web/src/components/storyboard/StoryboardSidebar.tsx
+++ b/web/src/components/storyboard/StoryboardSidebar.tsx
@@ -23,7 +23,8 @@ import {
   ToolbarIconButton,
   LoadingSpinner,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  MOTION
 } from "../ui_primitives";
 import {
   useStoryboards,
@@ -60,7 +61,7 @@ const styles = (theme: Theme) =>
       cursor: "pointer",
       "&:hover": { backgroundColor: theme.vars.palette.action.hover },
       "&.active": { backgroundColor: theme.vars.palette.action.selected },
-      ".delete-button": { opacity: 0, transition: "opacity 120ms ease" },
+      ".delete-button": { opacity: 0, transition: MOTION.opacity },
       "&:hover .delete-button": { opacity: 1 }
     }
   });

--- a/web/src/components/storyboard/__tests__/assembleTimeline.test.ts
+++ b/web/src/components/storyboard/__tests__/assembleTimeline.test.ts
@@ -36,6 +36,8 @@ const board = (overrides: Partial<StoryboardBoard>): StoryboardBoard => ({
   aspectRatio: "16:9",
   directorModel: null,
   imageModel: null,
+  videoModel: null,
+  updatedAt: 0,
   activeShotId: null,
   timelineId: null,
   ...overrides

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -21,6 +21,7 @@ import {
 import { trpcClient } from "../../trpc/client";
 import { useAssetSearch } from "../../serverState/useAssetSearch";
 import { useCreateTimeline } from "../../hooks/useTimelineSequence";
+import { useCreateStoryboard } from "../../hooks/storyboard/useStoryboards";
 import { useAssetStore } from "../../stores/AssetStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
@@ -146,6 +147,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const createNewThread = useGlobalChatStore((state) => state.createNewThread);
   const createAsset = useAssetStore((state) => state.createAsset);
   const createTimeline = useCreateTimeline();
+  const createStoryboard = useCreateStoryboard();
   const { searchAssets } = useAssetSearch();
 
   const close = useCallback(() => {
@@ -222,16 +224,23 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
     }
   }, [createTimeline, openTab, close]);
 
-  const handleNewStoryboard = useCallback(() => {
-    // The board is a client-side singleton keyed by ref; no backend document.
-    openTab({
-      type: "storyboard",
-      ref: crypto.randomUUID(),
-      mode: "edit",
-      title: "Untitled storyboard"
-    });
-    close();
-  }, [openTab, close]);
+  const handleNewStoryboard = useCallback(async () => {
+    try {
+      const created = await createStoryboard.mutateAsync({
+        name: "Untitled storyboard",
+        projectId: "default"
+      });
+      openTab({
+        type: "storyboard",
+        ref: created.id,
+        mode: "edit",
+        title: created.name
+      });
+      close();
+    } catch (error) {
+      console.error("Failed to create storyboard", error);
+    }
+  }, [createStoryboard, openTab, close]);
 
   const handleNewChat = useCallback(async () => {
     try {
@@ -388,7 +397,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
             <MenuItemPrimitive
               label="New storyboard"
               icon={<DashboardOutlinedIcon fontSize="small" />}
-              onClick={handleNewStoryboard}
+              onClick={() => void handleNewStoryboard()}
             />
             <MenuItemPrimitive
               label="New 3D model"

--- a/web/src/components/workspace/StoryboardSurface.tsx
+++ b/web/src/components/workspace/StoryboardSurface.tsx
@@ -1,12 +1,17 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useEffect } from "react";
-import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  type WorkspaceTabMode
+} from "../../stores/WorkspaceTabsStore";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useStoryboardGenerationSubscriptions } from "../../stores/storyboard/StoryboardGenerationStore";
 import { useStoryboardAgentBridge } from "../../hooks/storyboard/useStoryboardAgentBridge";
 import { useDirectScreenplay } from "../../hooks/storyboard/useDirectScreenplay";
+import { useStoryboardServerSync } from "../../hooks/storyboard/useStoryboardServerSync";
 import { useAssembleTimeline } from "../../hooks/storyboard/useAssembleTimeline";
 import StoryboardBoard from "../storyboard/StoryboardBoard";
+import StoryboardSidebar from "../storyboard/StoryboardSidebar";
 
 interface StoryboardSurfaceProps {
   refId: string;
@@ -22,10 +27,21 @@ interface StoryboardSurfaceProps {
  */
 const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
   const ensureBoard = useStoryboardStore((state) => state.ensureBoard);
+  const boardTitle = useStoryboardStore(
+    (state) => state.boards[refId]?.title ?? ""
+  );
+  const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
 
   useEffect(() => {
     ensureBoard(refId);
   }, [ensureBoard, refId]);
+
+  useStoryboardServerSync(refId);
+
+  // Keep the tab label in sync with the board's title field.
+  useEffect(() => {
+    setTabTitle(refId, "storyboard", boardTitle || "Untitled storyboard");
+  }, [setTabTitle, refId, boardTitle]);
 
   useStoryboardAgentBridge(refId, active);
   useStoryboardGenerationSubscriptions();
@@ -48,16 +64,21 @@ const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
   }, [assemble, refId]);
 
   return (
-    <StoryboardBoard
-      boardId={refId}
-      readOnly={mode === "view"}
-      onDirect={handleDirect}
-      directing={directing}
-      directError={error}
-      onAssemble={handleAssemble}
-      assembling={assembling}
-      assembleError={assembleError}
-    />
+    <div style={{ display: "flex", height: "100%", minHeight: 0 }}>
+      {mode !== "view" && <StoryboardSidebar activeBoardId={refId} />}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <StoryboardBoard
+          boardId={refId}
+          readOnly={mode === "view"}
+          onDirect={handleDirect}
+          directing={directing}
+          directError={error}
+          onAssemble={handleAssemble}
+          assembling={assembling}
+          assembleError={assembleError}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -217,7 +217,9 @@ export const useGenerateShot = (): UseGenerateShotResult => {
             image: shot.keyframe,
             prompt: clipPrompt(shot),
             aspect_ratio: aspectRatio,
-            duration: shot.duration_seconds
+            duration: shot.duration_seconds,
+            // Board-level clip model; omitted = the node's default model.
+            ...(board?.videoModel ? { model: board.videoModel } : {})
           },
           workflowId
         ),
@@ -243,6 +245,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       if (prompt.length === 0) {
         throw new Error("A revision instruction is required.");
       }
+      const board = useStoryboardStore.getState().getBoard(boardId);
       const workflowId = runnerIdForShot(shot.id);
       const nodes: Node<NodeData>[] = [
         makeNode(
@@ -251,7 +254,9 @@ export const useGenerateShot = (): UseGenerateShotResult => {
           0,
           {
             video: shot.clip,
-            prompt
+            prompt,
+            // Board-level clip model; omitted = the node's default model.
+            ...(board?.videoModel ? { model: board.videoModel } : {})
           },
           workflowId
         ),

--- a/web/src/hooks/storyboard/useStoryboardServerSync.ts
+++ b/web/src/hooks/storyboard/useStoryboardServerSync.ts
@@ -1,0 +1,177 @@
+/**
+ * useStoryboardServerSync
+ *
+ * Server persistence for one storyboard tab. On mount: load the board's
+ * server document into the store (or upsert-create it when the tab refs a
+ * board the server doesn't know — new tabs and pre-server local boards).
+ * After load: watch the store and autosave with a debounce, using the
+ * server's `updatedAt` as a CAS token (`baseUpdatedAt`). On a conflict the
+ * server copy wins and is reloaded.
+ */
+
+import { useEffect, useRef } from "react";
+import { trpc, trpcClient } from "../../trpc/client";
+import {
+  useStoryboardStore,
+  type StoryboardBoard
+} from "../../stores/storyboard/StoryboardStore";
+import type { Screenplay, Shot } from "@nodetool-ai/protocol";
+
+const AUTOSAVE_DEBOUNCE_MS = 750;
+const RETRY_DELAY_MS = 5_000;
+
+type StoryboardResponse = Awaited<
+  ReturnType<typeof trpcClient.storyboards.get.query>
+>;
+type StoryboardWireDocument = StoryboardResponse["document"];
+
+/** The saved payload: the board minus identity and transient UI state. */
+const boardToDocument = (board: StoryboardBoard): StoryboardWireDocument =>
+  ({
+    screenplay: board.screenplay,
+    shots: board.shots,
+    brief: board.brief,
+    style: board.style,
+    aspectRatio: board.aspectRatio,
+    directorModel: board.directorModel,
+    imageModel: board.imageModel,
+    videoModel: board.videoModel
+  }) as unknown as StoryboardWireDocument;
+
+const responseToBoard = (
+  res: StoryboardResponse
+): Omit<StoryboardBoard, "id" | "updatedAt"> => {
+  const doc = res.document;
+  return {
+    screenplay: doc.screenplay as unknown as Screenplay | null,
+    shots: doc.shots as unknown as Shot[],
+    title: res.name === "Untitled storyboard" ? "" : res.name,
+    brief: doc.brief,
+    style: doc.style,
+    aspectRatio: doc.aspectRatio,
+    directorModel:
+      doc.directorModel as StoryboardBoard["directorModel"],
+    imageModel: doc.imageModel as StoryboardBoard["imageModel"],
+    videoModel: doc.videoModel as StoryboardBoard["videoModel"],
+    activeShotId: null,
+    timelineId: res.timelineId ?? null
+  };
+};
+
+const isNotFound = (error: unknown): boolean =>
+  !!error &&
+  typeof error === "object" &&
+  /not found/i.test((error as Error).message ?? "");
+
+export const useStoryboardServerSync = (boardId: string): void => {
+  const utils = trpc.useUtils();
+  // The board object reference last written to / read from the server; any
+  // other reference in the store means unsaved local edits.
+  const syncedRef = useRef<StoryboardBoard | null>(null);
+  const inFlightRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const utilsRef = useRef(utils);
+  utilsRef.current = utils;
+
+  useEffect(() => {
+    let disposed = false;
+    const store = useStoryboardStore;
+
+    const applyResponse = (res: StoryboardResponse): void => {
+      if (disposed) return;
+      store.getState().loadBoard(boardId, responseToBoard(res));
+      store.getState().setServerRevision(boardId, res.updatedAt);
+      syncedRef.current = store.getState().boards[boardId] ?? null;
+    };
+
+    const load = async (): Promise<void> => {
+      try {
+        applyResponse(await trpcClient.storyboards.get.query({ id: boardId }));
+      } catch (error) {
+        if (!isNotFound(error)) {
+          console.error("Failed to load storyboard", error);
+          return;
+        }
+        // Unknown to the server: upsert-create carrying any local content
+        // (new tab, or a board from the pre-server localStorage era).
+        const local = store.getState().boards[boardId];
+        try {
+          const created = await trpcClient.storyboards.create.mutate({
+            id: boardId,
+            name: local?.title || "Untitled storyboard",
+            document: local ? boardToDocument(local) : undefined
+          });
+          if (disposed) return;
+          store.getState().setServerRevision(boardId, created.updatedAt);
+          syncedRef.current = store.getState().boards[boardId] ?? null;
+          void utilsRef.current.storyboards.list.invalidate();
+        } catch (createError) {
+          console.error("Failed to create storyboard", createError);
+        }
+      }
+    };
+
+    const save = async (): Promise<void> => {
+      if (disposed || inFlightRef.current) return;
+      const board = store.getState().boards[boardId];
+      const revision = store.getState().serverRevisions[boardId];
+      if (!board || !revision || board === syncedRef.current) return;
+
+      inFlightRef.current = true;
+      try {
+        const updated = await trpcClient.storyboards.update.mutate({
+          id: boardId,
+          baseUpdatedAt: revision,
+          name: board.title || "Untitled storyboard",
+          document: boardToDocument(board),
+          timelineId: board.timelineId
+        });
+        if (disposed) return;
+        store.getState().setServerRevision(boardId, updated.updatedAt);
+        syncedRef.current = board;
+        void utilsRef.current.storyboards.list.invalidate();
+        // Edits landed while the save was in flight — go again.
+        if (store.getState().boards[boardId] !== syncedRef.current) {
+          schedule();
+        }
+      } catch (error) {
+        if (disposed) return;
+        console.error("Storyboard autosave failed", error);
+        if (/modified since last read/i.test((error as Error).message ?? "")) {
+          // CAS conflict: the server copy wins.
+          await load();
+        } else {
+          // Transient failure: keep local edits, retry later.
+          schedule(RETRY_DELAY_MS);
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    const schedule = (delayMs: number = AUTOSAVE_DEBOUNCE_MS): void => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        void save();
+      }, delayMs);
+    };
+
+    const unsubscribe = store.subscribe((state, prev) => {
+      if (state.boards[boardId] === prev.boards[boardId]) return;
+      if (state.boards[boardId] === syncedRef.current) return;
+      // Only autosave once the server revision is known (initial load done).
+      if (!state.serverRevisions[boardId]) return;
+      schedule();
+    });
+
+    void load();
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [boardId]);
+};
+
+export default useStoryboardServerSync;

--- a/web/src/hooks/storyboard/useStoryboards.ts
+++ b/web/src/hooks/storyboard/useStoryboards.ts
@@ -1,0 +1,34 @@
+/**
+ * tRPC hooks for server-persisted storyboards. Mirrors useTimelineSequence:
+ * list/get queries plus a create mutation that seeds the detail cache.
+ */
+
+import { trpc } from "../../trpc/client";
+
+export const useStoryboards = () =>
+  trpc.storyboards.list.useQuery({}, { staleTime: 30_000 });
+
+export const useStoryboard = (id: string | null | undefined) =>
+  trpc.storyboards.get.useQuery(
+    { id: id ?? "" },
+    { enabled: !!id, staleTime: 30_000 }
+  );
+
+export const useCreateStoryboard = () => {
+  const utils = trpc.useUtils();
+  return trpc.storyboards.create.useMutation({
+    onSuccess: (created) => {
+      void utils.storyboards.list.invalidate();
+      utils.storyboards.get.setData({ id: created.id }, created);
+    }
+  });
+};
+
+export const useDeleteStoryboard = () => {
+  const utils = trpc.useUtils();
+  return trpc.storyboards.delete.useMutation({
+    onSuccess: () => {
+      void utils.storyboards.list.invalidate();
+    }
+  });
+};

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -409,6 +409,13 @@ export interface ImageModelValue {
   resolutions?: string[];
 }
 
+export interface VideoModelValue {
+  type: "video_model";
+  id: string;
+  provider: Provider;
+  name: string;
+}
+
 export interface TTSModelValue {
   type: "tts_model";
   id: string;

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -25,7 +25,11 @@ import type {
   ShotStatus,
   VideoRef
 } from "@nodetool-ai/protocol";
-import type { ImageModelValue, LanguageModelValue } from "../ApiTypes";
+import type {
+  ImageModelValue,
+  LanguageModelValue,
+  VideoModelValue
+} from "../ApiTypes";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -41,16 +45,30 @@ export interface StoryboardBoard {
   directorModel: LanguageModelValue | null;
   /** Image model every keyframe still is generated with. Null = node default. */
   imageModel: ImageModelValue | null;
+  /** Video model every clip is generated with. Null = node default. */
+  videoModel: VideoModelValue | null;
   activeShotId: string | null;
   /** Persisted timeline sequence this board was assembled into, if any. */
   timelineId: string | null;
+  /** Epoch ms of the last mutation; drives the sidebar's recency sort. */
+  updatedAt: number;
 }
 
 interface StoryboardStoreState {
   boards: Record<string, StoryboardBoard>;
+  /** Server `updated_at` token per board — the CAS base for the next save. */
+  serverRevisions: Record<string, string>;
+  setServerRevision: (boardId: string, revision: string | null) => void;
 
   /** Create an empty board for `id` if one does not already exist. */
   ensureBoard: (id: string) => void;
+  /** Delete a board outright (its generated assets stay in the asset library). */
+  removeBoard: (id: string) => void;
+  /**
+   * Hydrate a board from its server document. Overwrites local state for that
+   * board and records the server revision for CAS autosaves.
+   */
+  loadBoard: (id: string, board: Omit<StoryboardBoard, "id" | "updatedAt">) => void;
 
   /** Load a screenplay into a board, seeding `shots` from `screenplay.shots`. */
   setScreenplay: (boardId: string, screenplay: Screenplay) => void;
@@ -61,6 +79,7 @@ interface StoryboardStoreState {
   setAspectRatio: (boardId: string, aspectRatio: string) => void;
   setDirectorModel: (boardId: string, model: LanguageModelValue | null) => void;
   setImageModel: (boardId: string, model: ImageModelValue | null) => void;
+  setVideoModel: (boardId: string, model: VideoModelValue | null) => void;
   /** Record the persisted timeline sequence this board assembles into. */
   setTimelineLink: (boardId: string, timelineId: string | null) => void;
 
@@ -71,6 +90,12 @@ interface StoryboardStoreState {
   setShotStatus: (boardId: string, shotId: string, status: ShotStatus) => void;
   setShotKeyframe: (boardId: string, shotId: string, keyframe: ImageRef) => void;
   setShotClip: (boardId: string, shotId: string, clip: VideoRef) => void;
+  /** Make one of the shot's preserved takes the selected/export clip. */
+  selectClipVersion: (
+    boardId: string,
+    shotId: string,
+    versionIndex: number
+  ) => void;
   approveShot: (boardId: string, shotId: string) => void;
   removeShot: (boardId: string, shotId: string) => void;
   /** Reorder shots to match `orderedIds`; re-stamps each shot's `index`. */
@@ -92,8 +117,10 @@ const emptyBoard = (id: string): StoryboardBoard => ({
   aspectRatio: "16:9",
   directorModel: null,
   imageModel: null,
+  videoModel: null,
   activeShotId: null,
-  timelineId: null
+  timelineId: null,
+  updatedAt: Date.now()
 });
 
 /**
@@ -114,7 +141,9 @@ const withBoard = (
   if (!next || next === board) {
     return state;
   }
-  return { boards: { ...state.boards, [boardId]: next } };
+  return {
+    boards: { ...state.boards, [boardId]: { ...next, updatedAt: Date.now() } }
+  };
 };
 
 /** Patch the single shot with `shotId`; returns the same board on a no-op. */
@@ -142,6 +171,40 @@ const patchShot = (
 
 export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
   boards: {},
+  serverRevisions: {},
+
+  setServerRevision: (boardId, revision) =>
+    set((state) => {
+      const serverRevisions = { ...state.serverRevisions };
+      if (revision === null) {
+        delete serverRevisions[boardId];
+      } else {
+        serverRevisions[boardId] = revision;
+      }
+      return { serverRevisions };
+    }),
+
+  loadBoard: (id, board) =>
+    set((state) => ({
+      boards: {
+        ...state.boards,
+        [id]: {
+          ...emptyBoard(id),
+          ...board,
+          id,
+          // Jobs don't survive a reload — settle in-flight statuses back to
+          // the state they'd retry from.
+          shots: board.shots.map((s) =>
+            s.status === "keyframe_generating"
+              ? { ...s, status: "planned" as const }
+              : s.status === "clip_generating"
+                ? { ...s, status: "approved" as const }
+                : s
+          ),
+          updatedAt: Date.now()
+        }
+      }
+    })),
 
   ensureBoard: (id) =>
     set((state) =>
@@ -149,6 +212,16 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         ? state
         : { boards: { ...state.boards, [id]: emptyBoard(id) } }
     ),
+
+  removeBoard: (id) =>
+    set((state) => {
+      if (!state.boards[id]) {
+        return state;
+      }
+      const boards = { ...state.boards };
+      delete boards[id];
+      return { boards };
+    }),
 
   setScreenplay: (boardId, screenplay) =>
     set((state) => {
@@ -159,7 +232,8 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         shots: [...screenplay.shots],
         title: screenplay.title || board.title,
         aspectRatio: screenplay.aspect_ratio ?? board.aspectRatio,
-        style: screenplay.style_bible ?? board.style
+        style: screenplay.style_bible ?? board.style,
+        updatedAt: Date.now()
       };
       return { boards: { ...state.boards, [boardId]: next } };
     }),
@@ -212,6 +286,16 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
       )
     ),
 
+  setVideoModel: (boardId, model) =>
+    set((state) =>
+      withBoard(state, boardId, (b) =>
+        b.videoModel?.id === model?.id &&
+        b.videoModel?.provider === model?.provider
+          ? null
+          : { ...b, videoModel: model }
+      )
+    ),
+
   setTimelineLink: (boardId, timelineId) =>
     set((state) =>
       withBoard(state, boardId, (b) =>
@@ -247,7 +331,37 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   setShotClip: (boardId, shotId, clip) =>
     set((state) =>
-      withBoard(state, boardId, (b) => patchShot(b, shotId, { clip }))
+      withBoard(state, boardId, (b) => {
+        const target = b.shots.find((s) => s.id === shotId);
+        if (!target) {
+          return b;
+        }
+        // Preserve every take; the new render becomes the selected clip.
+        const versions = target.clip_versions ?? (target.clip ? [target.clip] : []);
+        const exists = versions.some(
+          (v) =>
+            (clip.asset_id && v.asset_id === clip.asset_id) ||
+            (!clip.asset_id && v.uri === clip.uri)
+        );
+        return patchShot(b, shotId, {
+          clip,
+          clip_versions: exists ? versions : [...versions, clip]
+        });
+      })
+    ),
+
+  selectClipVersion: (boardId, shotId, versionIndex) =>
+    set((state) =>
+      withBoard(state, boardId, (b) => {
+        const target = b.shots.find((s) => s.id === shotId);
+        const versions =
+          target?.clip_versions ?? (target?.clip ? [target.clip] : []);
+        const clip = versions[versionIndex];
+        if (!clip || clip === target?.clip) {
+          return null;
+        }
+        return patchShot(b, shotId, { clip });
+      })
     ),
 
   approveShot: (boardId, shotId) =>
@@ -302,6 +416,27 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
   getBoard: (id) => get().boards[id]
 }));
 
+/**
+ * One-time migration: boards saved by the short-lived localStorage
+ * persistence land in the in-memory store, and the server-sync upsert
+ * publishes them the next time their tab is opened.
+ */
+try {
+  const legacy = localStorage.getItem("storyboard-boards");
+  if (legacy) {
+    const parsed = JSON.parse(legacy) as {
+      state?: { boards?: Record<string, StoryboardBoard> };
+    };
+    const boards = parsed.state?.boards ?? {};
+    for (const [id, b] of Object.entries(boards)) {
+      useStoryboardStore.getState().loadBoard(id, { ...emptyBoard(id), ...b });
+    }
+    localStorage.removeItem("storyboard-boards");
+  }
+} catch {
+  // Corrupt legacy blob — nothing worth keeping.
+}
+
 // ── Selector hooks ───────────────────────────────────────────────────────────
 
 const EMPTY_SHOTS: Shot[] = [];
@@ -322,6 +457,7 @@ export const useBoard = (
   aspectRatio: string;
   directorModel: LanguageModelValue | null;
   imageModel: ImageModelValue | null;
+  videoModel: VideoModelValue | null;
   activeShotId: string | null;
 } =>
   useStoryboardStore(
@@ -336,6 +472,7 @@ export const useBoard = (
         aspectRatio: b?.aspectRatio ?? "16:9",
         directorModel: b?.directorModel ?? null,
         imageModel: b?.imageModel ?? null,
+        videoModel: b?.videoModel ?? null,
         activeShotId: b?.activeShotId ?? null
       };
     })


### PR DESCRIPTION
## Summary
- Add `storyboards` table: SQLite + Postgres Drizzle schemas and a migration (`20260718_000000_create_storyboards`)
- Add `Storyboard` model with optimistic-concurrency conflict detection (`StoryboardConflictError`)
- Add protocol API schemas and a `storyboards` tRPC router on the websocket server
- Web: `useStoryboards` / `useStoryboardServerSync` hooks to persist storyboard documents to the server, plus `StoryboardSidebar` and OpenMenu integration
- Includes `docs/ui-primitives-overhaul.md` notes

## Test plan
- `packages/models` migration tests updated for the new table
- `web` assembleTimeline tests updated
- Manual: create/edit a storyboard in the workspace, reload, confirm it persists and lists in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)