### PR TITLE
feat(storyboard): browse every generated still and clip per shot

### DIFF
--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -124,8 +124,10 @@ export interface Shot {
   entity_ids?: string[];
   /** Location entity for this shot. */
   location_id?: string | null;
-  /** Cheap still anchoring the shot (the storyboard frame). */
+  /** The selected still anchoring the shot (the storyboard frame). */
   keyframe?: ImageRef | null;
+  /** Every generated still for this shot, oldest first. `keyframe` is one of them. */
+  keyframe_versions?: ImageRef[];
   /** The selected clip — what assembly/export uses. */
   clip?: VideoRef | null;
   /** Every rendered take for this shot, oldest first. `clip` is one of them. */

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -31,8 +31,8 @@ import {
   type StatusType
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
+import ShotTakesGallery from "./ShotTakesGallery";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
-import { syncShotClipToTimeline } from "../../stores/storyboard/timelineSync";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 
 interface ShotCardProps {
@@ -134,9 +134,6 @@ const cameraLine = (shot: Shot): string =>
 const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => {
   const theme = useTheme();
   const approveShot = useStoryboardStore((state) => state.approveShot);
-  const selectClipVersion = useStoryboardStore(
-    (state) => state.selectClipVersion
-  );
   const { generateKeyframe, generateClip, generateRevisedClip } =
     useGenerateShot();
 
@@ -145,24 +142,6 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
     shot.status === "keyframe_generating" || shot.status === "clip_generating";
   const camera = cameraLine(shot);
   const clipUri = shot.clip?.uri;
-  const takes = shot.clip_versions ?? (shot.clip ? [shot.clip] : []);
-  const selectedTake = takes.findIndex(
-    (v) =>
-      (shot.clip?.asset_id && v.asset_id === shot.clip.asset_id) ||
-      (!shot.clip?.asset_id && v.uri === shot.clip?.uri)
-  );
-
-  const handleSelectTake = useCallback(
-    (index: number) => {
-      selectClipVersion(boardId, shot.id, index);
-      // Keep a linked, already-assembled timeline on the newly chosen take.
-      const assetId = (shot.clip_versions ?? [])[index]?.asset_id;
-      if (assetId) {
-        void syncShotClipToTimeline(boardId, shot.id, assetId);
-      }
-    },
-    [selectClipVersion, boardId, shot.id, shot.clip_versions]
-  );
 
   const handleGenerateStill = useCallback(() => {
     void generateKeyframe(boardId, shot);
@@ -236,21 +215,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
         </Caption>
       )}
 
-      {takes.length > 1 && (
-        <FlexRow gap={0.5} align="center" wrap className="takes">
-          <Caption color="secondary">Takes</Caption>
-          {takes.map((take, i) => (
-            <Chip
-              key={take.asset_id ?? take.uri ?? i}
-              compact
-              clickable={!readOnly}
-              color={i === selectedTake ? "primary" : "default"}
-              label={`${i + 1}`}
-              onClick={readOnly ? undefined : () => handleSelectTake(i)}
-            />
-          ))}
-        </FlexRow>
-      )}
+      <ShotTakesGallery boardId={boardId} shot={shot} readOnly={readOnly} />
 
       {typeof shot.cost_estimate === "number" && (
         <FlexRow>

--- a/web/src/components/storyboard/ShotTakesGallery.tsx
+++ b/web/src/components/storyboard/ShotTakesGallery.tsx
@@ -1,0 +1,194 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ShotTakesGallery
+ *
+ * The takes browser for one shot: every generated still and every rendered
+ * clip, viewable in place. The galleries reuse {@link OutputRenderer} — the
+ * same component that renders node results — so an array of stills gets the
+ * asset grid (double-click opens the fullscreen viewer) and clips get the
+ * standard video players. Chips above each gallery pick the selected
+ * still/clip the card and export use.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import type { ImageRef, Shot, VideoRef } from "@nodetool-ai/protocol";
+
+import {
+  Caption,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import OutputRenderer from "../node/OutputRenderer";
+import {
+  sameMediaRef,
+  useStoryboardStore
+} from "../../stores/storyboard/StoryboardStore";
+import { syncShotClipToTimeline } from "../../stores/storyboard/timelineSync";
+
+interface ShotTakesGalleryProps {
+  boardId: string;
+  shot: Shot;
+  readOnly?: boolean;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    display: "flex",
+    flexDirection: "column",
+    gap: getSpacingPx(SPACING.xs),
+    ".takes-viewer": {
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.xs),
+      // OutputRenderer's video path sizes to its container; give clips their
+      // natural height inside the card instead of a collapsed 100%-of-auto.
+      "& video": {
+        width: "100%",
+        height: "auto"
+      }
+    },
+    ".takes-label": {
+      color: theme.vars.palette.text.secondary
+    }
+  });
+
+const versionKey = (ref: ImageRef | VideoRef, index: number): string =>
+  ref.asset_id ?? ref.uri ?? String(index);
+
+const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
+  boardId,
+  shot,
+  readOnly
+}) => {
+  const theme = useTheme();
+  const [expanded, setExpanded] = useState(false);
+  const selectKeyframeVersion = useStoryboardStore(
+    (state) => state.selectKeyframeVersion
+  );
+  const selectClipVersion = useStoryboardStore(
+    (state) => state.selectClipVersion
+  );
+
+  const stills = useMemo(
+    () => shot.keyframe_versions ?? (shot.keyframe ? [shot.keyframe] : []),
+    [shot.keyframe_versions, shot.keyframe]
+  );
+  const clips = useMemo(
+    () => shot.clip_versions ?? (shot.clip ? [shot.clip] : []),
+    [shot.clip_versions, shot.clip]
+  );
+
+  const selectedStill = shot.keyframe
+    ? stills.findIndex((v) => sameMediaRef(v, shot.keyframe as ImageRef))
+    : -1;
+  const selectedClip = shot.clip
+    ? clips.findIndex((v) => sameMediaRef(v, shot.clip as VideoRef))
+    : -1;
+
+  const handleSelectStill = useCallback(
+    (index: number) => {
+      selectKeyframeVersion(boardId, shot.id, index);
+    },
+    [selectKeyframeVersion, boardId, shot.id]
+  );
+
+  const handleSelectClip = useCallback(
+    (index: number) => {
+      selectClipVersion(boardId, shot.id, index);
+      // Keep a linked, already-assembled timeline on the newly chosen take.
+      const assetId = clips[index]?.asset_id;
+      if (assetId) {
+        void syncShotClipToTimeline(boardId, shot.id, assetId);
+      }
+    },
+    [selectClipVersion, boardId, shot.id, clips]
+  );
+
+  const handleToggle = useCallback(() => {
+    setExpanded((prev) => !prev);
+  }, []);
+
+  // Nothing to browse until a shot has more than one version of something.
+  if (stills.length <= 1 && clips.length <= 1) {
+    return null;
+  }
+
+  const countLabel = [
+    stills.length > 1 ? `${stills.length} stills` : null,
+    clips.length > 1 ? `${clips.length} clips` : null
+  ]
+    .filter((p): p is string => p !== null)
+    .join(" · ");
+
+  return (
+    <div css={styles(theme)} className="takes">
+      <FlexRow align="center" justify="space-between" gap={1}>
+        <Caption className="takes-label">{`Takes — ${countLabel}`}</Caption>
+        <EditorButton onClick={handleToggle}>
+          {expanded ? "Hide takes" : "View takes"}
+        </EditorButton>
+      </FlexRow>
+
+      {stills.length > 1 && (
+        <FlexRow gap={0.5} align="center" wrap className="still-chips">
+          <Caption color="secondary">Stills</Caption>
+          {stills.map((still, i) => (
+            <Chip
+              key={versionKey(still, i)}
+              compact
+              clickable={!readOnly}
+              color={i === selectedStill ? "primary" : "default"}
+              label={`${i + 1}`}
+              onClick={readOnly ? undefined : () => handleSelectStill(i)}
+            />
+          ))}
+        </FlexRow>
+      )}
+
+      {clips.length > 1 && (
+        <FlexRow gap={0.5} align="center" wrap className="clip-chips">
+          <Caption color="secondary">Clips</Caption>
+          {clips.map((clip, i) => (
+            <Chip
+              key={versionKey(clip, i)}
+              compact
+              clickable={!readOnly}
+              color={i === selectedClip ? "primary" : "default"}
+              label={`${i + 1}`}
+              onClick={readOnly ? undefined : () => handleSelectClip(i)}
+            />
+          ))}
+        </FlexRow>
+      )}
+
+      {expanded && (
+        <FlexColumn gap={0.5} className="takes-viewer">
+          {stills.length > 0 && (
+            <>
+              <Caption color="secondary">Stills</Caption>
+              <OutputRenderer value={stills} showTextActions={false} />
+            </>
+          )}
+          {clips.length > 0 && (
+            <>
+              <Caption color="secondary">Clips</Caption>
+              <OutputRenderer value={clips} showTextActions={false} />
+            </>
+          )}
+        </FlexColumn>
+      )}
+    </div>
+  );
+};
+
+export const ShotTakesGallery = memo(ShotTakesGalleryInner);
+ShotTakesGallery.displayName = "ShotTakesGallery";
+
+export default ShotTakesGallery;

--- a/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { ImageRef, Shot, VideoRef } from "@nodetool-ai/protocol";
+import mockTheme from "../../../__mocks__/themeMock";
+
+// The gallery reuses the node-results renderer; stub it so this test asserts
+// wiring (what value it receives), not the renderer's own media pipeline.
+jest.mock("../../node/OutputRenderer", () => ({
+  __esModule: true,
+  default: ({ value }: { value: unknown[] }) => (
+    <div data-testid="output-renderer">{`items:${(value as unknown[]).length}`}</div>
+  )
+}));
+
+const syncShotClipToTimelineMock = jest.fn();
+jest.mock("../../../stores/storyboard/timelineSync", () => ({
+  syncShotClipToTimeline: (...args: unknown[]) =>
+    syncShotClipToTimelineMock(...args)
+}));
+
+import ShotTakesGallery from "../ShotTakesGallery";
+import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
+
+const BOARD = "board-gallery";
+
+const image = (n: number): ImageRef => ({
+  type: "image",
+  uri: `http://example.com/still-${n}.png`,
+  asset_id: `img-${n}`
+});
+
+const video = (n: number): VideoRef => ({
+  type: "video",
+  uri: `http://example.com/clip-${n}.mp4`,
+  asset_id: `vid-${n}`
+});
+
+const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
+  type: "shot",
+  id: "shot-1",
+  index: 0,
+  action: "A lighthouse at dusk",
+  status: "rendered",
+  ...overrides
+});
+
+const seedShot = (shot: Shot): void => {
+  const store = useStoryboardStore.getState();
+  store.ensureBoard(BOARD);
+  store.upsertShot(BOARD, shot);
+};
+
+const renderGallery = (shot: Shot, readOnly = false) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ShotTakesGallery boardId={BOARD} shot={shot} readOnly={readOnly} />
+    </ThemeProvider>
+  );
+
+afterEach(() => {
+  useStoryboardStore.getState().removeBoard(BOARD);
+  syncShotClipToTimelineMock.mockClear();
+});
+
+describe("ShotTakesGallery", () => {
+  it("renders nothing when the shot has at most one still and one clip", () => {
+    const { container } = renderGallery(
+      makeShot({ keyframe: image(1), clip: video(1) })
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows counts and reveals both galleries via the node-results renderer", async () => {
+    const shot = makeShot({
+      keyframe: image(2),
+      keyframe_versions: [image(1), image(2)],
+      clip: video(3),
+      clip_versions: [video(1), video(2), video(3)]
+    });
+    renderGallery(shot);
+
+    expect(screen.getByText("Takes — 2 stills · 3 clips")).toBeInTheDocument();
+    expect(screen.queryByTestId("output-renderer")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "View takes" }));
+
+    const renderers = screen.getAllByTestId("output-renderer");
+    expect(renderers).toHaveLength(2);
+    expect(renderers[0]).toHaveTextContent("items:2");
+    expect(renderers[1]).toHaveTextContent("items:3");
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide takes" }));
+    expect(screen.queryByTestId("output-renderer")).not.toBeInTheDocument();
+  });
+
+  it("selects a still version through the store", async () => {
+    const shot = makeShot({
+      keyframe: image(2),
+      keyframe_versions: [image(1), image(2)]
+    });
+    seedShot(shot);
+    renderGallery(shot);
+
+    const chips = screen.getAllByText("1");
+    await userEvent.click(chips[0]);
+
+    const updated = useStoryboardStore
+      .getState()
+      .boards[BOARD]?.shots.find((s) => s.id === shot.id);
+    expect(updated?.keyframe).toEqual(image(1));
+  });
+
+  it("selects a clip take and syncs it to a linked timeline", async () => {
+    const shot = makeShot({
+      clip: video(2),
+      clip_versions: [video(1), video(2)]
+    });
+    seedShot(shot);
+    renderGallery(shot);
+
+    const chips = screen.getAllByText("1");
+    await userEvent.click(chips[0]);
+
+    const updated = useStoryboardStore
+      .getState()
+      .boards[BOARD]?.shots.find((s) => s.id === shot.id);
+    expect(updated?.clip).toEqual(video(1));
+    expect(syncShotClipToTimelineMock).toHaveBeenCalledWith(
+      BOARD,
+      shot.id,
+      "vid-1"
+    );
+  });
+
+  it("does not select on click when read-only", async () => {
+    const shot = makeShot({
+      keyframe: image(2),
+      keyframe_versions: [image(1), image(2)]
+    });
+    seedShot(shot);
+    renderGallery(shot, true);
+
+    await userEvent.click(screen.getAllByText("1")[0]);
+
+    const updated = useStoryboardStore
+      .getState()
+      .boards[BOARD]?.shots.find((s) => s.id === shot.id);
+    expect(updated?.keyframe).toEqual(image(2));
+  });
+});

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -90,6 +90,12 @@ interface StoryboardStoreState {
   setShotStatus: (boardId: string, shotId: string, status: ShotStatus) => void;
   setShotKeyframe: (boardId: string, shotId: string, keyframe: ImageRef) => void;
   setShotClip: (boardId: string, shotId: string, clip: VideoRef) => void;
+  /** Make one of the shot's preserved stills the selected keyframe. */
+  selectKeyframeVersion: (
+    boardId: string,
+    shotId: string,
+    versionIndex: number
+  ) => void;
   /** Make one of the shot's preserved takes the selected/export clip. */
   selectClipVersion: (
     boardId: string,
@@ -145,6 +151,13 @@ const withBoard = (
     boards: { ...state.boards, [boardId]: { ...next, updatedAt: Date.now() } }
   };
 };
+
+/** Same generated asset: matched by asset_id when present, else by uri. */
+export const sameMediaRef = (
+  a: { asset_id?: string | null; uri?: string },
+  b: { asset_id?: string | null; uri?: string }
+): boolean =>
+  b.asset_id ? a.asset_id === b.asset_id : a.uri === b.uri;
 
 /** Patch the single shot with `shotId`; returns the same board on a no-op. */
 const patchShot = (
@@ -326,7 +339,20 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   setShotKeyframe: (boardId, shotId, keyframe) =>
     set((state) =>
-      withBoard(state, boardId, (b) => patchShot(b, shotId, { keyframe }))
+      withBoard(state, boardId, (b) => {
+        const target = b.shots.find((s) => s.id === shotId);
+        if (!target) {
+          return b;
+        }
+        // Preserve every still; the new render becomes the selected keyframe.
+        const versions =
+          target.keyframe_versions ?? (target.keyframe ? [target.keyframe] : []);
+        const exists = versions.some((v) => sameMediaRef(v, keyframe));
+        return patchShot(b, shotId, {
+          keyframe,
+          keyframe_versions: exists ? versions : [...versions, keyframe]
+        });
+      })
     ),
 
   setShotClip: (boardId, shotId, clip) =>
@@ -338,15 +364,26 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         }
         // Preserve every take; the new render becomes the selected clip.
         const versions = target.clip_versions ?? (target.clip ? [target.clip] : []);
-        const exists = versions.some(
-          (v) =>
-            (clip.asset_id && v.asset_id === clip.asset_id) ||
-            (!clip.asset_id && v.uri === clip.uri)
-        );
+        const exists = versions.some((v) => sameMediaRef(v, clip));
         return patchShot(b, shotId, {
           clip,
           clip_versions: exists ? versions : [...versions, clip]
         });
+      })
+    ),
+
+  selectKeyframeVersion: (boardId, shotId, versionIndex) =>
+    set((state) =>
+      withBoard(state, boardId, (b) => {
+        const target = b.shots.find((s) => s.id === shotId);
+        const versions =
+          target?.keyframe_versions ??
+          (target?.keyframe ? [target.keyframe] : []);
+        const keyframe = versions[versionIndex];
+        if (!keyframe || keyframe === target?.keyframe) {
+          return null;
+        }
+        return patchShot(b, shotId, { keyframe });
       })
     ),
 

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ *
+ * Version-preserving media on shots: every generated still/clip is kept in
+ * `keyframe_versions` / `clip_versions`, and the select* actions switch the
+ * active one without dropping the rest.
+ */
+
+import type { ImageRef, VideoRef } from "@nodetool-ai/protocol";
+import { useStoryboardStore } from "../StoryboardStore";
+
+const BOARD = "board-versions";
+const SHOT = "shot-1";
+
+const image = (n: number): ImageRef => ({
+  type: "image",
+  uri: `http://example.com/still-${n}.png`,
+  asset_id: `img-${n}`
+});
+
+const video = (n: number): VideoRef => ({
+  type: "video",
+  uri: `http://example.com/clip-${n}.mp4`,
+  asset_id: `vid-${n}`
+});
+
+const seed = (): void => {
+  const store = useStoryboardStore.getState();
+  store.ensureBoard(BOARD);
+  store.upsertShot(BOARD, {
+    type: "shot",
+    id: SHOT,
+    index: 0,
+    action: "test shot",
+    status: "planned"
+  });
+};
+
+const getShot = () =>
+  useStoryboardStore.getState().boards[BOARD]?.shots.find((s) => s.id === SHOT);
+
+afterEach(() => {
+  useStoryboardStore.getState().removeBoard(BOARD);
+});
+
+describe("setShotKeyframe", () => {
+  it("accumulates every still into keyframe_versions", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.setShotKeyframe(BOARD, SHOT, image(1));
+    store.setShotKeyframe(BOARD, SHOT, image(2));
+
+    const shot = getShot();
+    expect(shot?.keyframe).toEqual(image(2));
+    expect(shot?.keyframe_versions).toEqual([image(1), image(2)]);
+  });
+
+  it("does not duplicate an already-known still", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.setShotKeyframe(BOARD, SHOT, image(1));
+    store.setShotKeyframe(BOARD, SHOT, image(2));
+    store.setShotKeyframe(BOARD, SHOT, image(1));
+
+    const shot = getShot();
+    expect(shot?.keyframe).toEqual(image(1));
+    expect(shot?.keyframe_versions).toEqual([image(1), image(2)]);
+  });
+
+  it("seeds versions from a pre-existing single keyframe", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.updateShot(BOARD, SHOT, { keyframe: image(1) });
+    store.setShotKeyframe(BOARD, SHOT, image(2));
+
+    expect(getShot()?.keyframe_versions).toEqual([image(1), image(2)]);
+  });
+});
+
+describe("selectKeyframeVersion", () => {
+  it("switches the selected still without dropping versions", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.setShotKeyframe(BOARD, SHOT, image(1));
+    store.setShotKeyframe(BOARD, SHOT, image(2));
+
+    store.selectKeyframeVersion(BOARD, SHOT, 0);
+
+    const shot = getShot();
+    expect(shot?.keyframe).toEqual(image(1));
+    expect(shot?.keyframe_versions).toEqual([image(1), image(2)]);
+  });
+
+  it("ignores an out-of-range index", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.setShotKeyframe(BOARD, SHOT, image(1));
+
+    store.selectKeyframeVersion(BOARD, SHOT, 5);
+
+    expect(getShot()?.keyframe).toEqual(image(1));
+  });
+});
+
+describe("setShotClip / selectClipVersion", () => {
+  it("accumulates takes and switches between them", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.setShotClip(BOARD, SHOT, video(1));
+    store.setShotClip(BOARD, SHOT, video(2));
+
+    let shot = getShot();
+    expect(shot?.clip).toEqual(video(2));
+    expect(shot?.clip_versions).toEqual([video(1), video(2)]);
+
+    store.selectClipVersion(BOARD, SHOT, 0);
+    shot = getShot();
+    expect(shot?.clip).toEqual(video(1));
+    expect(shot?.clip_versions).toEqual([video(1), video(2)]);
+  });
+});


### PR DESCRIPTION
Shots now keep keyframe_versions alongside clip_versions: every generated
still is preserved, with keyframe as the selected one. The new
ShotTakesGallery on each shot card shows selection chips for stills and
clips and an expandable viewer that reuses OutputRenderer — the same
component that renders node results — so stills get the asset grid with
the fullscreen viewer and clips get the standard video players.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G24ScqyMzMvVSPFqh2QBkJ