### PR TITLE
feat(marketing): scroll-driven fade-in reveals on the landing page

### DIFF
--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -398,6 +398,48 @@
   }
 }
 
+/*
+ * Scroll-driven entrance reveal. Unlike the retired JS reveals (framer
+ * initial-opacity-0, the .fly-in IntersectionObserver), this is resolved by
+ * the style engine before first paint — anything already in the viewport at
+ * load sits past its entry range and renders fully visible, so there is no
+ * hydration blink. Browsers without scroll-timeline support skip the
+ * @supports block and render everything static.
+ */
+/*
+ * Crop like overflow-hidden without becoming a scroll container. view()
+ * timelines bind to the nearest scroll-container ancestor, and an
+ * overflow-hidden wrapper is one — it never scrolls, so any .scroll-fade
+ * inside it would sit on a dead timeline and never animate. Browsers without
+ * overflow: clip keep the hidden fallback (they don't run the @supports
+ * block below anyway).
+ */
+.overflow-clip-safe {
+  overflow: hidden;
+  overflow: clip;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .scroll-fade {
+      animation: scroll-fade-in ease-out both;
+      animation-timeline: view();
+      animation-range: entry 5% entry 50%;
+    }
+  }
+}
+
+@keyframes scroll-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 @keyframes slideUp {
   from {
     opacity: 0;

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -162,7 +162,7 @@ export default function Home() {
 
   return (
     <main
-      className="relative min-h-screen overflow-hidden text-white"
+      className="relative min-h-screen overflow-clip-safe text-white"
       onKeyDown={onKeyDown}
     >
       {/* Background */}
@@ -238,7 +238,7 @@ export default function Home() {
 
       <div
         id="content"
-        className="relative isolate overflow-hidden pt-24 sm:pt-36 md:pt-24"
+        className="relative isolate overflow-clip-safe pt-24 sm:pt-36 md:pt-24"
       >
         {/* Hero */}
         <section aria-labelledby="hero-title" className="pt-2 relative">
@@ -256,7 +256,7 @@ export default function Home() {
               initial={false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.35, delay: 0.05, ease: "easeOut" }}
-              className="relative group"
+              className="scroll-fade relative group"
             >
               <div
                 className="absolute -inset-4 rounded-3xl opacity-60 blur-3xl transition-opacity duration-500 group-hover:opacity-80"
@@ -379,7 +379,7 @@ export default function Home() {
 
         {/* Closing CTA — end the page on the product, not the mailbox */}
         <section aria-labelledby="closing-cta-title" className="relative py-24">
-          <div className={`${sectionNarrow} text-center`}>
+          <div className={`scroll-fade ${sectionNarrow} text-center`}>
             <h2
               id="closing-cta-title"
               className="text-3xl md:text-4xl font-bold tracking-tight text-white"

--- a/marketing/src/components/AssetManagerSection.tsx
+++ b/marketing/src/components/AssetManagerSection.tsx
@@ -44,9 +44,9 @@ export default function AssetManagerSection() {
     <section
       id="asset-manager"
       aria-labelledby="asset-title"
-      className="section-relative isolate overflow-hidden pb-16 pt-14 sm:pb-20"
+      className="section-relative isolate overflow-clip-safe pb-16 pt-14 sm:pb-20"
     >
-      <div className={`${sectionNarrow} text-center`}>
+      <div className={`scroll-fade ${sectionNarrow} text-center`}>
         <h2 className="text-base font-medium leading-7 text-blue-400">
           Organize Everything
         </h2>
@@ -59,7 +59,7 @@ export default function AssetManagerSection() {
       </div>
 
       <div className={`${sectionContainer} relative mt-12`}>
-        <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
+        <div className="scroll-fade grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
           <div>
             <div
               className={`overflow-hidden rounded-lg border border-blue-800/30 ${strongShadow}`}
@@ -107,7 +107,7 @@ export default function AssetManagerSection() {
           </div>
         </div>
 
-        <div className="mt-16 grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div className="scroll-fade mt-16 grid grid-cols-1 gap-6 md:grid-cols-3">
           {[
             {
               icon: PhotoIcon,

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -42,7 +42,7 @@ const accents: Record<
 export default function BuildRunDeploy() {
   return (
     <div id="how-title" className="relative w-full py-12">
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
           title="Wire your canvas"

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -10,13 +10,13 @@ export default function ChatUISection() {
     <section
       id="chat"
       aria-labelledby="chat-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background Glow */}
       <div className="absolute top-1/2 left-0 -translate-y-1/2 w-[600px] h-[600px] bg-emerald-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -56,7 +56,7 @@ export default function ChatUISection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="relative mx-auto max-w-5xl"
+          className="scroll-fade relative mx-auto max-w-5xl"
         >
           <Tilt3D>
             <div className="relative rounded-xl border border-white/10 bg-slate-900/50 backdrop-blur-xl shadow-2xl overflow-hidden group">

--- a/marketing/src/components/CommunitySection.tsx
+++ b/marketing/src/components/CommunitySection.tsx
@@ -68,7 +68,7 @@ export default function CommunitySection({
     <section
       id={id}
       aria-labelledby="community-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {variant === "home" && (
         <>
@@ -86,7 +86,7 @@ export default function CommunitySection({
             initial={false}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            className="max-w-2xl mx-auto"
+            className="scroll-fade max-w-2xl mx-auto"
           >
             <h2
               id="community-title"

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -17,7 +17,7 @@ export default function ComparisonSection({
       className="relative py-24"
     >
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <header className="mb-14 max-w-3xl">
+        <header className="scroll-fade mb-14 max-w-3xl">
           <div className="mb-3 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.18em] text-blue-300/80">
             <span className="h-px w-8 bg-amber-300/60" />
             Comparison
@@ -44,7 +44,7 @@ export default function ComparisonSection({
           </motion.p>
         </header>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
+        <div className="scroll-fade grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
             competitor="ComfyUI"
             sentence="ComfyUI is a node editor for image-generation models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away."
@@ -71,7 +71,7 @@ export default function ComparisonSection({
           whileInView={reducedMotion ? {} : { opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, delay: 0.08 }}
-          className="relative mt-10 rounded-2xl border border-slate-800/80 bg-slate-950/40 px-8 py-10 md:px-12 md:py-12"
+          className="scroll-fade relative mt-10 rounded-2xl border border-slate-800/80 bg-slate-950/40 px-8 py-10 md:px-12 md:py-12"
         >
           {/* Warm corner glow — single, subtle */}
           <div

--- a/marketing/src/components/ContactSection.tsx
+++ b/marketing/src/components/ContactSection.tsx
@@ -10,10 +10,10 @@ export default function ContactSection() {
     <section
       id="contact"
       aria-labelledby="contact-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-3xl mx-auto">
           <motion.h2
             id="contact-title"
             initial={false}
@@ -39,7 +39,7 @@ export default function ContactSection() {
           </motion.p>
         </div>
 
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 max-w-4xl mx-auto">
+        <div className="scroll-fade grid grid-cols-1 gap-8 md:grid-cols-2 max-w-4xl mx-auto">
           {[
             {
               icon: Mail,

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -84,14 +84,14 @@ export default function CostDashboardSection() {
     <section
       id="costs"
       aria-labelledby="costs-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background glow, emerald to echo the "money saved" read */}
       <div className="absolute top-1/2 left-0 -translate-y-1/2 w-[600px] h-[600px] bg-emerald-900/15 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         {/* Header */}
-        <div className="mx-auto mb-14 max-w-3xl text-center">
+        <div className="scroll-fade mx-auto mb-14 max-w-3xl text-center">
           <h2 className="text-base font-medium leading-7 text-blue-400">
             Cost transparency
           </h2>
@@ -114,7 +114,7 @@ export default function CostDashboardSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="relative mx-auto max-w-5xl"
+          className="scroll-fade relative mx-auto max-w-5xl"
         >
           <div className="relative overflow-hidden rounded-xl border border-white/[0.06] bg-[#0b0d12] shadow-strong">
             {/* Window chrome */}

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -22,13 +22,13 @@ export default function FeaturesSection({
     <section
       id="features"
       aria-labelledby="features-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background Glow */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[600px] bg-blue-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -71,7 +71,7 @@ export default function FeaturesSection({
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="relative mx-auto max-w-5xl mb-20"
+          className="scroll-fade relative mx-auto max-w-5xl mb-20"
         >
           <Tilt3D>
             <div className="relative rounded-xl border border-white/10 bg-slate-900/50 backdrop-blur-xl shadow-2xl overflow-hidden group">
@@ -102,7 +102,7 @@ export default function FeaturesSection({
 
         {/* Features Grid */}
         <motion.div
-          className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"
+          className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, margin: "-40px" }}

--- a/marketing/src/components/ModelManagerSection.tsx
+++ b/marketing/src/components/ModelManagerSection.tsx
@@ -10,13 +10,13 @@ export default function ModelManagerSection() {
     <section
       id="models"
       aria-labelledby="model-manager-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background Glow */}
       <div className="absolute top-1/2 right-0 -translate-y-1/2 w-[600px] h-[600px] bg-blue-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -58,7 +58,7 @@ export default function ModelManagerSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="relative mx-auto max-w-5xl"
+          className="scroll-fade relative mx-auto max-w-5xl"
         >
           <Tilt3D>
             <div className="relative rounded-xl border border-white/[0.04] bg-slate-900/50 backdrop-blur-xl shadow-2xl overflow-hidden group">

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -70,7 +70,7 @@ export default function ModelSupportSection({
     return (
         <section
             aria-labelledby="model-support-title"
-            className="relative py-16 overflow-hidden"
+            className="relative py-16 overflow-clip-safe"
         >
             {/* Background Glow */}
             <div className="absolute top-1/2 left-0 -translate-y-1/2 w-[800px] h-[500px] bg-emerald-900/20 blur-[120px] rounded-full pointer-events-none" />
@@ -78,7 +78,7 @@ export default function ModelSupportSection({
 
             <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
                 {/* Header */}
-                <div className="mb-12 text-center max-w-3xl mx-auto">
+                <div className="scroll-fade mb-12 text-center max-w-3xl mx-auto">
                     <motion.div
                         initial={false}
                         whileInView={{ opacity: 1, scale: 1 }}

--- a/marketing/src/components/NodeMenuSection.tsx
+++ b/marketing/src/components/NodeMenuSection.tsx
@@ -16,13 +16,13 @@ export default function NodeMenuSection({
     <section
       id="nodes"
       aria-labelledby="nodes-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background Glow */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[600px] bg-blue-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -63,7 +63,7 @@ export default function NodeMenuSection({
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3, ease: "easeOut" }}
-          className="relative mx-auto max-w-5xl mb-20"
+          className="scroll-fade relative mx-auto max-w-5xl mb-20"
         >
           <Tilt3D>
             <div className="relative rounded-2xl border border-white/10 bg-slate-900/30 shadow-2xl overflow-hidden group">

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -35,11 +35,11 @@ export default function OwnershipSection({
   reducedMotion: _reducedMotion = false,
 }: OwnershipSectionProps) {
   return (
-    <section className="relative py-24 overflow-hidden">
+    <section className="relative py-24 overflow-clip-safe">
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-slate-500/5 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 text-center max-w-2xl mx-auto">
+        <div className="scroll-fade mb-16 text-center max-w-2xl mx-auto">
           <motion.h2
             initial={false}
             whileInView={{ opacity: 1, y: 0 }}
@@ -66,7 +66,7 @@ export default function OwnershipSection({
         </div>
 
         <motion.div
-          className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4 rounded-2xl overflow-hidden bg-white/5 ring-1 ring-white/5"
+          className="scroll-fade grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4 rounded-2xl overflow-hidden bg-white/5 ring-1 ring-white/5"
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, margin: "-40px" }}

--- a/marketing/src/components/SketchEditorSection.tsx
+++ b/marketing/src/components/SketchEditorSection.tsx
@@ -31,13 +31,13 @@ export default function SketchEditorSection() {
     <section
       id="sketch-editor"
       aria-labelledby="sketch-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background glow */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[900px] h-[500px] bg-violet-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-12 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-12 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -77,7 +77,7 @@ export default function SketchEditorSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3 }}
-          className="relative"
+          className="scroll-fade relative"
         >
           <div className="relative rounded-2xl border border-slate-700/60 bg-slate-900/80 overflow-hidden shadow-2xl shadow-violet-900/20 ring-1 ring-white/5 backdrop-blur-sm">
             <Image

--- a/marketing/src/components/TimelineEditorSection.tsx
+++ b/marketing/src/components/TimelineEditorSection.tsx
@@ -31,13 +31,13 @@ export default function TimelineEditorSection() {
     <section
       id="timeline-editor"
       aria-labelledby="timeline-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       {/* Background Glow */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[900px] h-[500px] bg-sky-900/20 blur-[120px] rounded-full pointer-events-none" />
 
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-12 text-center max-w-3xl mx-auto">
+        <div className="scroll-fade mb-12 text-center max-w-3xl mx-auto">
           <motion.div
             initial={false}
             whileInView={{ opacity: 1, scale: 1 }}
@@ -76,7 +76,7 @@ export default function TimelineEditorSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.3 }}
-          className="relative"
+          className="scroll-fade relative"
         >
           <div className="relative rounded-2xl border border-slate-700/60 bg-slate-900/80 overflow-hidden shadow-2xl shadow-sky-900/20 ring-1 ring-white/5 backdrop-blur-sm">
             <Image

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -41,10 +41,10 @@ export default function UseCasesShowcase() {
     <section
       id="use-cases"
       aria-labelledby="use-cases-title"
-      className="relative py-24 overflow-hidden"
+      className="relative py-24 overflow-clip-safe"
     >
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mb-16 max-w-2xl">
+        <div className="scroll-fade mb-16 max-w-2xl">
           <div className="mb-3 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.18em] text-blue-300/80">
             <span className="h-px w-8 bg-amber-300/60" />
             Use cases
@@ -83,7 +83,7 @@ export default function UseCasesShowcase() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-40px" }}
                 transition={{ duration: 0.3 }}
-                className="group relative grid items-center gap-8 rounded-3xl border border-white/10 bg-slate-900/40 p-6 backdrop-blur-sm transition-all duration-300 hover:border-white/20 hover:bg-slate-900/60 lg:grid-cols-2 lg:gap-12 lg:p-8"
+                className="scroll-fade group relative grid items-center gap-8 rounded-3xl border border-white/10 bg-slate-900/40 p-6 backdrop-blur-sm transition-all duration-300 hover:border-white/20 hover:bg-slate-900/60 lg:grid-cols-2 lg:gap-12 lg:p-8"
               >
                 {/* Media */}
                 <div


### PR DESCRIPTION
## What

Re-adds tasteful entrance animation to the marketing landing page, without reintroducing the flicker that got the old JS reveals removed (f48b45a, 3f43ba6).

## How

- New `.scroll-fade` utility in `globals.css` using **CSS scroll-driven animations** (`animation-timeline: view()`): each block scrubs a 16px rise + fade over its viewport entry (`animation-range: entry 5% entry 50%`). Because the style engine resolves this before first paint, content already in the viewport at load sits past its entry range and renders fully visible — no hydration hide, no IntersectionObserver, no blink. Guards:
  - `@supports (animation-timeline: view())` — browsers without support (older Safari/Firefox) render everything static.
  - `@media (prefers-reduced-motion: no-preference)` — reduced-motion users see no animation.
- Applied `scroll-fade` to the landing sections' header blocks, media frames, and card grids (34 sites) — block-level reveals rather than per-element, so blocks at different depths stagger naturally.
- New `.overflow-clip-safe` (`overflow: hidden` fallback, then `overflow: clip`) replaces `overflow-hidden` on the animated elements' ancestors (`main`, `#content`, section wrappers). `view()` binds to the nearest scroll-container ancestor and `overflow: hidden` creates one — a wrapper that never scrolls, leaving the timeline inert. `overflow: clip` crops identically without becoming a scroll container.

## Verification

- Headless Chromium checks against the production build: above-fold `.scroll-fade` elements fully visible at first paint; below-fold elements start hidden and are fully revealed after scrolling past; with reduced-motion emulated, nothing is hidden.
- CLS gate (`tests/e2e/cls.spec.ts`) passes at **0.04** (budget 0.1) — the fade animates only opacity/transform.
- Full marketing e2e suite: 206 passed. `tsc --noEmit` and `next lint` clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLwdtovpgcFcJGjdK3tr1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLwdtovpgcFcJGjdK3tr1G)_