### PR TITLE
feat(costs): stack cost estimate under inspector, list only AI-model nodes

### DIFF
--- a/web/src/components/costs/WorkflowCostEstimatePanel.tsx
+++ b/web/src/components/costs/WorkflowCostEstimatePanel.tsx
@@ -1,10 +1,11 @@
 /**
  * WorkflowCostEstimatePanel
  *
- * The full plan-before-spend view for a workflow: a per-node estimate table
- * (provider / model / quantity / cost, with unknown-price nodes flagged), the
- * currency total, a budget-cap input, a draft-mode toggle, and a warning banner
- * when the estimate would break the budget.
+ * The full plan-before-spend view for a workflow: a per-node estimate table for
+ * the nodes that use an AI model (provider / model / quantity / cost, with
+ * unknown-price nodes flagged), the currency total, a budget-cap input, a
+ * draft-mode toggle, and a warning banner when the estimate would break the
+ * budget.
  */
 
 import React, { memo, useCallback, useMemo } from "react";
@@ -130,8 +131,8 @@ const WorkflowCostEstimatePanelInternal: React.FC<
         ) : estimate.items.length === 0 ? (
           <EmptyState
             variant="empty"
-            title="No nodes"
-            description="Add nodes to estimate a run's cost."
+            title="No AI-model nodes"
+            description="Add a node that uses an AI model to estimate a run's cost."
             size="small"
           />
         ) : (

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -86,11 +86,25 @@ const styles = (theme: Theme, bottomOffset: number, isVisible: boolean) =>
       }
     },
 
+    // Stack the inspector on top and the cost estimate panel underneath it.
     ".panel-inner-content": {
       display: "flex",
+      flexDirection: "column",
       flex: 1,
       height: "100%",
       overflow: "hidden"
+    },
+    ".inspector-region": {
+      flex: "1 1 auto",
+      minHeight: 0,
+      display: "flex",
+      overflow: "hidden"
+    },
+    ".cost-region": {
+      flex: "0 1 auto",
+      maxHeight: "45%",
+      overflow: "auto",
+      borderTop: `1px solid ${theme.vars.palette.divider}`
     }
   });
 
@@ -233,9 +247,11 @@ const PanelRight: React.FC = () => {
             tabIndex={-1}
           />
           <div className="panel-inner-content">
-            {inspectorBody}
+            <div className="inspector-region">{inspectorBody}</div>
             {currentWorkflowId && (
-              <WorkflowCostEstimatePanel workflowId={currentWorkflowId} />
+              <div className="cost-region">
+                <WorkflowCostEstimatePanel workflowId={currentWorkflowId} />
+              </div>
             )}
           </div>
         </div>

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -10,7 +10,10 @@ import { renderHook } from "@testing-library/react";
 const mockNodes = [
   { id: "n1", type: "fal.Image", data: {} },
   { id: "n2", type: "kie.Video", data: {} },
-  { id: "n3", type: "nodetool.text.Concat", data: {} }
+  // Uses an AI model via a language_model property but has no unit pricing.
+  { id: "n3", type: "nodetool.llm.Agent", data: {} },
+  // Plain data node — no model, no pricing. Excluded from the estimate.
+  { id: "n4", type: "nodetool.text.Concat", data: {} }
 ];
 
 const mockNodeStore = {
@@ -42,6 +45,12 @@ const mockMetadata: Record<string, unknown> = {
       usd_price: 0.02,
       source: "bundle"
     }
+  },
+  "nodetool.llm.Agent": {
+    properties: [{ name: "model", type: { type: "language_model" } }]
+  },
+  "nodetool.text.Concat": {
+    properties: [{ name: "a", type: { type: "str" } }]
   }
 };
 
@@ -56,19 +65,23 @@ jest.mock("../../stores/MetadataStore", () => ({
 import { useWorkflowCostEstimate } from "../useWorkflowCostEstimate";
 
 describe("useWorkflowCostEstimate", () => {
-  it("estimates cost from nodes + metadata", () => {
+  it("estimates cost from AI-model nodes + metadata", () => {
     const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
 
     const estimate = result.current;
     expect(estimate).not.toBeNull();
     expect(estimate!.currency).toBe("USD");
+    // Only the three AI-model nodes are listed; the plain Concat node is dropped.
     expect(estimate!.items).toHaveLength(3);
+    expect(
+      estimate!.items.some((i) => i.node_type === "nodetool.text.Concat")
+    ).toBe(false);
     // fal 0.05 (USD) + kie 0.02 (usd_price preferred over credits)
     expect(estimate!.total).toBeCloseTo(0.07, 5);
-    // the concat node has no pricing metadata
+    // the agent node uses a model but has no pricing metadata
     expect(estimate!.unknown_count).toBe(1);
     const unknown = estimate!.items.find(
-      (i) => i.node_type === "nodetool.text.Concat"
+      (i) => i.node_type === "nodetool.llm.Agent"
     );
     expect(unknown?.confidence).toBe("unknown");
   });

--- a/web/src/hooks/useWorkflowCostEstimate.ts
+++ b/web/src/hooks/useWorkflowCostEstimate.ts
@@ -2,9 +2,10 @@
  * useWorkflowCostEstimate — reactive pre-run cost estimate for a workflow.
  *
  * Reads the open workflow's nodes (from its NodeStore) and the node-type
- * metadata (which carries `fal_unit_pricing` / `kie_unit_pricing`), then runs
- * the pure {@link estimateWorkflowCost} estimator. Re-computes when the graph
- * or metadata changes. Returns `null` when the graph isn't available yet.
+ * metadata (which carries `fal_unit_pricing` / `kie_unit_pricing`), keeps only
+ * the nodes that use an AI model, then runs the pure {@link estimateWorkflowCost}
+ * estimator. Re-computes when the graph or metadata changes. Returns `null`
+ * when the graph isn't available yet.
  */
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
@@ -14,6 +15,7 @@ import type { WorkflowCostEstimate } from "@nodetool-ai/protocol";
 import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import useMetadataStore from "../stores/MetadataStore";
 import type { NodeData } from "../stores/NodeData";
+import { nodeMetadataUsesAiModel } from "../utils/aiModelNodes";
 
 const EMPTY_NODES: Node<NodeData>[] = [];
 
@@ -40,8 +42,11 @@ export function useWorkflowCostEstimate(
     if (!nodeStore) {
       return null;
     }
+    const aiNodes = nodes.filter((node) =>
+      node.type ? nodeMetadataUsesAiModel(getMetadata(node.type)) : false
+    );
     return estimateWorkflowCost({
-      nodes: nodes.map((node) => ({
+      nodes: aiNodes.map((node) => ({
         id: node.id,
         type: node.type ?? "",
         data: node.data as Record<string, unknown> | undefined

--- a/web/src/utils/aiModelNodes.ts
+++ b/web/src/utils/aiModelNodes.ts
@@ -1,0 +1,32 @@
+import { NodeMetadata } from "../stores/ApiTypes";
+
+/**
+ * Provider-backed model property types. A node exposing one of these is driven
+ * by an AI model (language, image, embedding, TTS, ASR, video). Local/HF model
+ * types (llama_model, hf.*, tjs.*) are intentionally excluded: they aren't
+ * provider-keyed. Shared source of truth for {@link nodeMetadataUsesAiModel}
+ * and `findMissingModelNodes`.
+ */
+export const PROVIDER_MODEL_TYPES = new Set([
+  "language_model",
+  "image_model",
+  "embedding_model",
+  "tts_model",
+  "asr_model",
+  "video_model"
+]);
+
+/**
+ * True when a node type uses an AI model — either it carries provider unit
+ * pricing (fal / kie) or it exposes a provider-backed model property. This is
+ * what the cost estimate panel lists; plain data/utility nodes are left out.
+ */
+export function nodeMetadataUsesAiModel(
+  metadata: NodeMetadata | undefined
+): boolean {
+  if (!metadata) return false;
+  if (metadata.fal_unit_pricing || metadata.kie_unit_pricing) return true;
+  return (metadata.properties ?? []).some((prop) =>
+    prop.type?.type ? PROVIDER_MODEL_TYPES.has(prop.type.type) : false
+  );
+}

--- a/web/src/utils/findMissingModelNodes.ts
+++ b/web/src/utils/findMissingModelNodes.ts
@@ -1,23 +1,7 @@
 import { Edge, Node } from "@xyflow/react";
 import { NodeData } from "../stores/NodeData";
 import { NodeMetadata } from "../stores/ApiTypes";
-
-/**
- * Provider-backed model property types. A node with one of these set to an
- * empty value can't run without a provider + model — the backend rejects it
- * with "Please specify a provider". These are the same types that
- * {@link applyDefaultModels} fills in. Local/HF model types (llama_model,
- * hf.*, tjs.*) are intentionally excluded: they aren't provider-keyed and
- * have a different empty-state story.
- */
-const PROVIDER_MODEL_TYPES = new Set([
-  "language_model",
-  "image_model",
-  "embedding_model",
-  "tts_model",
-  "asr_model",
-  "video_model"
-]);
+import { PROVIDER_MODEL_TYPES } from "./aiModelNodes";
 
 export interface MissingModelNode {
   nodeId: string;


### PR DESCRIPTION
## What

Two changes to the right-panel cost estimate:

1. **Layout** — the workflow cost estimate panel now sits **underneath** the inspector instead of beside it. `PanelRight`'s `.panel-inner-content` switches from a row to a column: the inspector gets a flexible top region and the cost panel a bounded, scrollable bottom region (top border, `max-height: 45%`).
2. **Filtering** — the estimate table now lists **only nodes that use an AI model**. A node qualifies when it carries provider unit pricing (`fal_unit_pricing` / `kie_unit_pricing`) or exposes a provider-backed model property (`language_model`, `image_model`, `embedding_model`, `tts_model`, `asr_model`, `video_model`). Plain data/utility nodes (e.g. text concat) are no longer listed.

## How

- `web/src/components/panels/PanelRight.tsx` — column layout with `.inspector-region` (flex, scrolls internally) and `.cost-region` (bounded, scrollable) wrappers.
- `web/src/hooks/useWorkflowCostEstimate.ts` — filters nodes through `nodeMetadataUsesAiModel` before running the pure estimator. The estimator itself is unchanged, so its "never hide a node" contract stays intact for other callers (agents, CLI); the AI-only policy lives on the web side.
- `web/src/utils/aiModelNodes.ts` (new) — single source of truth for `PROVIDER_MODEL_TYPES` plus the shared `nodeMetadataUsesAiModel` check. `findMissingModelNodes.ts` now imports the set from here instead of duplicating it.
- `WorkflowCostEstimatePanel.tsx` — empty-state copy updated to "No AI-model nodes".

## Testing

- `npm run typecheck` (web) — clean
- `npm run lint` on touched files — clean
- `useWorkflowCostEstimate` and `findMissingModelNodes` unit tests updated/passing; costs component tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMoZ5Givoc1Phvkwiwkazf)_