### PR TITLE
Provider-level entity reference wiring (text + images)

### DIFF
--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -1627,6 +1627,15 @@ export class TextToImageNode extends BaseNode {
   declare negative_prompt: any;
 
   @prop({
+    type: "list[dict]",
+    default: [],
+    title: "Entities",
+    description:
+      "Consistency entities (characters, styles, locations) whose descriptors are injected into the prompt"
+  })
+  declare entities: any;
+
+  @prop({
     type: "str",
     default: "1:1",
     title: "Aspect Ratio",
@@ -1665,7 +1674,8 @@ export class TextToImageNode extends BaseNode {
         height,
         aspect_ratio: aspectRatio,
         resolution,
-        negative_prompt: this.negative_prompt
+        negative_prompt: this.negative_prompt,
+        entities: this.entities
       }
     })) as Uint8Array;
     const meta = await metadataFor(output);
@@ -1731,6 +1741,15 @@ export class ImageToImageNode extends BaseNode {
     description: "Text prompt describing what to avoid"
   })
   declare negative_prompt: any;
+
+  @prop({
+    type: "list[dict]",
+    default: [],
+    title: "Entities",
+    description:
+      "Consistency entities (characters, styles, locations) whose descriptors are injected into the prompt and whose reference images are appended to the input images"
+  })
+  declare entities: any;
 
   @prop({
     type: "float",
@@ -1799,7 +1818,14 @@ export class ImageToImageNode extends BaseNode {
     const bytesList = (
       await Promise.all(images.map((img) => imageBytesAsync(img, context)))
     ).filter((b) => b.length > 0);
-    if (bytesList.length === 0) {
+    // Entities may supply the source images: their reference images are
+    // appended to the list at the provider layer, so an empty wired input is
+    // fine as long as an entity carries an image.
+    const entities = Array.isArray(this.entities) ? this.entities : [];
+    const entityHasImage = entities.some(
+      (e: any) => !!e?.image || (e?.reference_images?.length ?? 0) > 0
+    );
+    if (bytesList.length === 0 && !entityHasImage) {
       throw new Error("The input image is empty.");
     }
     const aspectRatio = String(this.aspect_ratio ?? "1:1");
@@ -1817,6 +1843,7 @@ export class ImageToImageNode extends BaseNode {
         images: bytesList,
         prompt,
         negative_prompt: this.negative_prompt,
+        entities,
         target_width: width,
         target_height: height,
         aspect_ratio: aspectRatio,

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -14,6 +14,10 @@ import type { AssetRef, ProcessingMessage, ProviderCost } from "@nodetool-ai/pro
 import { packageAssetHttpPath, parsePackageAssetUri } from "@nodetool-ai/protocol";
 import { AgentMemory } from "./agent-memory.js";
 import { VariableChannel } from "./variable-channel.js";
+import {
+  loadMediaRefBytes,
+  type MediaRefValue
+} from "./media-ref-bytes.js";
 import { encodeRawImageRef } from "./image-codec.js";
 import {
   expandAssetReferences,
@@ -115,6 +119,7 @@ const pathToFileURL = (p: string): URL =>
 import type { BaseProvider } from "./providers/base-provider.js";
 import type {
   EncodedAudioResult,
+  EntityReference,
   Message,
   MessageContent,
   ProviderStreamItem
@@ -438,6 +443,56 @@ function coerceImageList(params: Record<string, unknown>): Uint8Array[] {
   }
   const single = params.image;
   return single instanceof Uint8Array ? [single] : [];
+}
+
+/**
+ * Normalize `params.entities` into provider-level {@link EntityReference}s.
+ *
+ * Consumers send entities in whatever shape they hold: a full protocol Entity
+ * (`reference_images` list), a lean `{name, descriptor, image}` where `image`
+ * is bytes, an ImageRef-like object, or a bare URI string. Images are resolved
+ * to bytes here — the last point with a ProcessingContext — so providers only
+ * ever see `Uint8Array`s. Entities without a name are dropped; an unresolvable
+ * image degrades to a text-only entity (the descriptor still applies).
+ */
+async function coerceEntityList(
+  params: Record<string, unknown>,
+  context: ProcessingContext
+): Promise<EntityReference[] | undefined> {
+  const raw = params.entities;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+
+  const out: EntityReference[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const entity = item as Record<string, unknown>;
+    const name = typeof entity.name === "string" ? entity.name.trim() : "";
+    if (!name) continue;
+    const descriptor =
+      typeof entity.descriptor === "string" ? entity.descriptor : undefined;
+
+    const imageSource =
+      entity.image ??
+      (Array.isArray(entity.reference_images)
+        ? entity.reference_images[0]
+        : undefined);
+    let image: Uint8Array | undefined;
+    if (imageSource instanceof Uint8Array) {
+      image = imageSource;
+    } else if (typeof imageSource === "string" && imageSource.length > 0) {
+      image =
+        (await loadMediaRefBytes(
+          { type: "image", uri: imageSource },
+          context
+        )) ?? undefined;
+    } else if (imageSource && typeof imageSource === "object") {
+      image =
+        (await loadMediaRefBytes(imageSource as MediaRefValue, context)) ??
+        undefined;
+    }
+    out.push({ name, descriptor, image });
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 function normalizeStorageKey(key: string): string {
@@ -2518,6 +2573,7 @@ export class ProcessingContext {
       case "text_to_image":
         return provider.textToImage({
           prompt: String(params.prompt ?? ""),
+          entities: await coerceEntityList(params, this),
           model: { id: req.model, name: req.model, provider: req.provider },
           width: params.width as number | undefined,
           height: params.height as number | undefined,
@@ -2529,6 +2585,7 @@ export class ProcessingContext {
       case "image_to_image":
         return provider.imageToImage(coerceImageList(params), {
           prompt: String(params.prompt ?? ""),
+          entities: await coerceEntityList(params, this),
           model: { id: req.model, name: req.model, provider: req.provider },
           negativePrompt: params.negative_prompt as string | undefined,
           targetWidth: params.target_width as number | undefined,
@@ -2541,6 +2598,7 @@ export class ProcessingContext {
       case "inpainting":
         return provider.inpaint(coerceImageList(params), {
           prompt: String(params.prompt ?? ""),
+          entities: await coerceEntityList(params, this),
           model: { id: req.model, name: req.model, provider: req.provider },
           mask: params.mask as Uint8Array,
           negativePrompt: params.negative_prompt as string | undefined,
@@ -2554,6 +2612,7 @@ export class ProcessingContext {
       case "text_to_video":
         return provider.textToVideo({
           prompt: String(params.prompt ?? ""),
+          entities: await coerceEntityList(params, this),
           model: { id: req.model, name: req.model, provider: req.provider },
           negativePrompt: params.negative_prompt as string | undefined,
           numFrames: params.num_frames as number | undefined,
@@ -2565,6 +2624,7 @@ export class ProcessingContext {
       case "image_to_video":
         return provider.imageToVideo(coerceImageList(params), {
           prompt: params.prompt as string | undefined,
+          entities: await coerceEntityList(params, this),
           model: { id: req.model, name: req.model, provider: req.provider },
           negativePrompt: params.negative_prompt as string | undefined,
           numFrames: params.num_frames as number | undefined,
@@ -2600,6 +2660,7 @@ export class ProcessingContext {
         return provider.videoToVideo(params.video as Uint8Array, {
           model: { id: req.model, name: req.model, provider: req.provider },
           prompt: params.prompt as string | undefined,
+          entities: await coerceEntityList(params, this),
           negativePrompt: params.negative_prompt as string | undefined,
           strength: params.strength as number | undefined,
           durationSeconds: params.duration_seconds as number | undefined,

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -54,6 +54,7 @@ import {
   type LlmUsage
 } from "../tracing-helpers.js";
 import { logProviderRequestFailure } from "./provider-request-log.js";
+import { applyEntityReferences } from "./entity-references.js";
 import type { Span } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
@@ -313,8 +314,11 @@ export abstract class BaseProvider {
       const fn = self[name];
       if (typeof fn !== "function" || fn === proto[name]) continue;
       const original = fn as (...args: unknown[]) => Promise<unknown>;
-      self[name] = (...args: unknown[]): Promise<unknown> =>
+      self[name] = (...rawArgs: unknown[]): Promise<unknown> =>
         withModalityCapture(async (alreadyActive) => {
+          // Central entity expansion: descriptors into the prompt, reference
+          // images onto the source list, before the concrete provider runs.
+          const args = applyEntityReferences(name, rawArgs);
           try {
             return await original.apply(this, args);
           } catch (err) {

--- a/packages/runtime/src/providers/entity-references.ts
+++ b/packages/runtime/src/providers/entity-references.ts
@@ -1,0 +1,131 @@
+/**
+ * Central expansion of {@link EntityReference}s attached to modality params.
+ *
+ * Consumers (nodes, the chat WebSocket, CLI) attach `entities` to generation
+ * params; {@link BaseProvider} calls {@link applyEntityReferences} on the call
+ * arguments before the concrete provider runs, so every provider gets the same
+ * behavior without knowing entities exist:
+ *
+ *   - descriptors are appended to the prompt as a `Consistency references:`
+ *     block — the same shape the Apply Entities node and the runtime's
+ *     entity-mention expansion produce;
+ *   - on image-editing methods, reference image bytes are appended to the
+ *     source-image list after the caller's own images (multi-image providers
+ *     use them as references; single-image providers ignore them), and each
+ *     appended image's line names its 1-based position in the final list
+ *     (`- Image 2 (Harbor): …`) so the model can tell which image is which;
+ *   - the `entities` field is stripped so nested delegation (e.g. the base
+ *     `imageToImages` fallback calling `imageToImage`) never applies twice.
+ */
+
+import type { EntityReference } from "./types.js";
+
+/** Methods whose first argument is a `Uint8Array[]` that accepts references. */
+const IMAGE_LIST_METHODS = new Set([
+  "imageToImage",
+  "imageToImages",
+  "inpaint",
+  "inpaintImages"
+]);
+
+/**
+ * Position of the params argument per entity-bearing method. Video methods
+ * take media positionally too, but only get the text expansion — appending
+ * entity images to `imageToVideo`'s list would change which frame animates.
+ */
+const PARAMS_INDEX: Record<string, number> = {
+  textToImage: 0,
+  textToImages: 0,
+  imageToImage: 1,
+  imageToImages: 1,
+  inpaint: 1,
+  inpaintImages: 1,
+  textToVideo: 0,
+  imageToVideo: 1,
+  videoToVideo: 1
+};
+
+interface EntityBearingParams {
+  prompt?: string | null;
+  entities?: EntityReference[] | null;
+}
+
+const hasEntityParams = (value: unknown): value is EntityBearingParams =>
+  !!value &&
+  typeof value === "object" &&
+  Array.isArray((value as EntityBearingParams).entities);
+
+const appendConsistencyBlock = (prompt: string, lines: string[]): string => {
+  if (lines.length === 0) {
+    return prompt;
+  }
+  const block = `Consistency references:\n${lines.join("\n")}`;
+  return prompt.trim().length > 0 ? `${prompt}\n\n${block}` : block;
+};
+
+/** Append the entities' descriptors to a prompt as a consistency block. */
+export const injectEntityDescriptors = (
+  prompt: string,
+  entities: EntityReference[]
+): string =>
+  appendConsistencyBlock(
+    prompt,
+    entities
+      .filter((e) => !!e.descriptor && e.descriptor.trim().length > 0)
+      .map((e) => `- ${e.name}: ${e.descriptor!.trim()}`)
+  );
+
+/**
+ * Expand `params.entities` in a modality method's call arguments. Returns the
+ * original array untouched when the method doesn't take entities or none are
+ * attached; otherwise returns a new args array with the prompt expanded, the
+ * reference images appended (image-editing methods only), and `entities`
+ * stripped from the params.
+ */
+export function applyEntityReferences(
+  method: string,
+  args: unknown[]
+): unknown[] {
+  const paramsIndex = PARAMS_INDEX[method];
+  if (paramsIndex === undefined) return args;
+  const params = args[paramsIndex];
+  if (!hasEntityParams(params) || params.entities!.length === 0) return args;
+  const entities = params.entities!;
+
+  const next = [...args];
+  let prompt: string;
+  if (IMAGE_LIST_METHODS.has(method)) {
+    // Appended reference images are attributed in the prompt by their 1-based
+    // position in the final image list, counting the caller's own images.
+    const images = Array.isArray(args[0]) ? (args[0] as Uint8Array[]) : [];
+    const appended: Uint8Array[] = [];
+    const lines: string[] = [];
+    for (const entity of entities) {
+      const image =
+        entity.image instanceof Uint8Array && entity.image.length > 0
+          ? entity.image
+          : null;
+      const descriptor = entity.descriptor?.trim();
+      if (image) {
+        appended.push(image);
+        const position = images.length + appended.length;
+        lines.push(
+          `- Image ${position} (${entity.name})${descriptor ? `: ${descriptor}` : ""}`
+        );
+      } else if (descriptor) {
+        lines.push(`- ${entity.name}: ${descriptor}`);
+      }
+    }
+    prompt = appendConsistencyBlock(params.prompt ?? "", lines);
+    if (appended.length > 0) {
+      next[0] = [...images, ...appended];
+    }
+  } else {
+    prompt = injectEntityDescriptors(params.prompt ?? "", entities);
+  }
+
+  const nextParams: EntityBearingParams = { ...params, prompt };
+  delete nextParams.entities;
+  next[paramsIndex] = nextParams;
+  return next;
+}

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -195,6 +195,7 @@ export type {
   InpaintingParams,
   TextToVideoParams,
   ImageToVideoParams,
+  EntityReference,
   ProviderStreamItem,
   ProviderSession,
   ProviderSessionUpdate,
@@ -204,6 +205,10 @@ export type {
   AudioChunk,
   ASRResult
 } from "./types.js";
+export {
+  applyEntityReferences,
+  injectEntityDescriptors
+} from "./entity-references.js";
 export {
   isProviderSessionUpdate,
   isProviderMessageEvent,

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -457,7 +457,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
   ): Promise<Uint8Array> {
     const [first] = await this._generateImages(
       this._imageToImageAsTextParams(params),
-      images[0] ?? null,
+      images,
       1
     );
     return first;
@@ -470,7 +470,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
   ): Promise<Uint8Array[]> {
     return this._generateImages(
       this._imageToImageAsTextParams(params),
-      images[0] ?? null,
+      images,
       numImages
     );
   }
@@ -494,7 +494,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
 
   private async _generateImages(
     params: TextToImageParams,
-    referenceImage: Uint8Array | null,
+    referenceImages: Uint8Array[] | null,
     numImages: number
   ): Promise<Uint8Array[]> {
     if (!params.prompt) {
@@ -526,13 +526,15 @@ export class MinimaxProvider extends OpenAICompatProvider {
     if (aspect) body.aspect_ratio = aspect;
     if (params.seed != null) body.seed = params.seed;
 
-    if (referenceImage) {
-      body.subject_reference = [
-        {
-          type: "character",
-          image_file: `data:image/png;base64,${b64(referenceImage)}`
-        }
-      ];
+    // MiniMax i2i accepts multiple subject/reference images via a
+    // subject_reference array; each entry carries a base64 Data URL. The first
+    // image is the primary subject, the rest are additional references. The API
+    // docs document no maximum count, so we forward all provided images.
+    if (referenceImages && referenceImages.length > 0) {
+      body.subject_reference = referenceImages.map((image) => ({
+        type: "character",
+        image_file: `data:image/png;base64,${b64(image)}`
+      }));
     }
 
     log.debug("MiniMax textToImage", { model: body.model, n: body.n });

--- a/packages/runtime/src/providers/reve-provider.ts
+++ b/packages/runtime/src/providers/reve-provider.ts
@@ -5,11 +5,20 @@
  * in Settings → API Keys.
  *
  *   - textToImage  → POST /v1/image/create
- *   - imageToImage → POST /v1/image/edit
+ *   - imageToImage → POST /v1/image/edit   (one source image)
+ *                  → POST /v1/image/remix  (two or more reference images)
  *
- * The Remix endpoint (1–6 reference images, indexed `<img>` prompt tags) does
- * not map cleanly onto the single-image `imageToImage` shape, so it is exposed
- * only via the `@nodetool-ai/reve-nodes` `reve.RemixImage` node.
+ * imageToImage routes by image count: a single source image uses the Edit
+ * endpoint (`edit_instruction` + one base64 `reference_image`); two or more use
+ * the Remix endpoint (`prompt` + a base64 `reference_images` array, capped at
+ * 6 — the only Reve endpoint that accepts more than one reference image).
+ * Remix's indexed `<img>` prompt tags remain the domain of the
+ * `@nodetool-ai/reve-nodes` `reve.RemixImage` node.
+ *
+ * These are Reve's v1 endpoints. Reve's v2 API
+ * (https://api.reve.com/console/docs/v2/) reportedly lifts the reference-image
+ * ceiling to 8 on a unified create/edit endpoint; migrating there is future
+ * work and is not wired here.
  *
  * Wire spec (https://api.reve.com/console/docs):
  *  - Auth:    `Authorization: Bearer <api_key>`.
@@ -35,6 +44,9 @@ const REVE_API_BASE = "https://api.reve.com";
 /** Model ids exposed to the generic image composer. */
 const REVE_CREATE_MODEL = "reve-create";
 const REVE_EDIT_MODEL = "reve-edit";
+
+/** Max reference images accepted by the Remix endpoint. */
+const REVE_MAX_REMIX_IMAGES = 6;
 
 const VALID_ASPECT_RATIOS = new Set([
   "16:9",
@@ -109,7 +121,7 @@ export class ReveProvider extends BaseProvider {
   }
 
   private async post(
-    endpoint: "create" | "edit",
+    endpoint: "create" | "edit" | "remix",
     body: Record<string, unknown>
   ): Promise<Uint8Array> {
     const response = await fetch(`${REVE_API_BASE}/v1/image/${endpoint}`, {
@@ -150,19 +162,43 @@ export class ReveProvider extends BaseProvider {
     images: Uint8Array[],
     params: ImageToImageParams
   ): Promise<Uint8Array> {
-    const image = images[0];
-    if (!image || image.length === 0) {
+    const sources = images.filter((b) => b && b.length > 0);
+    if (sources.length === 0) {
       throw new Error("image must not be empty");
     }
-    const body: Record<string, unknown> = {
-      edit_instruction: params.prompt,
-      reference_image: Buffer.from(image).toString("base64")
-    };
-    if (params.aspectRatio && VALID_ASPECT_RATIOS.has(params.aspectRatio)) {
-      body.aspect_ratio = params.aspectRatio;
+    if (sources.length > REVE_MAX_REMIX_IMAGES) {
+      throw new Error(
+        `Reve accepts at most ${REVE_MAX_REMIX_IMAGES} reference images, got ${sources.length}.`
+      );
     }
+    const aspectRatio =
+      params.aspectRatio && VALID_ASPECT_RATIOS.has(params.aspectRatio)
+        ? params.aspectRatio
+        : undefined;
+
+    // One source image uses Edit; two or more use Remix — the only Reve
+    // endpoint that accepts multiple reference images.
+    if (sources.length === 1) {
+      const body: Record<string, unknown> = {
+        edit_instruction: params.prompt,
+        reference_image: Buffer.from(sources[0]).toString("base64")
+      };
+      if (aspectRatio) body.aspect_ratio = aspectRatio;
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log, not asserted.
+      log.debug("Reve imageToImage (edit)", { model: params.model.id });
+      return this.post("edit", body);
+    }
+
+    const body: Record<string, unknown> = {
+      prompt: params.prompt,
+      reference_images: sources.map((b) => Buffer.from(b).toString("base64"))
+    };
+    if (aspectRatio) body.aspect_ratio = aspectRatio;
     // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log, not asserted.
-    log.debug("Reve imageToImage", { model: params.model.id });
-    return this.post("edit", body);
+    log.debug("Reve imageToImage (remix)", {
+      model: params.model.id,
+      images: sources.length
+    });
+    return this.post("remix", body);
   }
 }

--- a/packages/runtime/src/providers/together-provider.ts
+++ b/packages/runtime/src/providers/together-provider.ts
@@ -345,32 +345,41 @@ export class TogetherProvider extends OpenAICompatProvider {
   }
 
   /**
-   * Image-to-image editing via Together's Kontext models.
-   * The image is encoded as a base64 data URI and passed as `image_url`.
-   * This requires a model that supports the `image_url` parameter
-   * (e.g. FLUX.1-kontext-pro, FLUX.1-kontext-max, FLUX.2-pro/dev/flex).
+   * Image-to-image editing via Together's Kontext / FLUX.2 models.
+   * Images are encoded as base64 data URIs. A single image is sent as
+   * `image_url` (supported by FLUX.1-kontext-pro/max and FLUX.2-pro/flex);
+   * multiple reference images are sent as the `reference_images` array
+   * (supported by FLUX.2 and Google image models). The first image is the
+   * primary subject and the rest are additional references.
    */
   override async imageToImage(
     images: Uint8Array[],
     params: ImageToImageParams
   ): Promise<Uint8Array> {
-    const image = images[0];
-    if (!image || image.length === 0) {
+    const sources = images.filter((b) => b && b.length > 0);
+    if (sources.length === 0) {
       throw new Error("image must not be empty.");
     }
     if (!params.prompt) {
       throw new Error("The input prompt cannot be empty.");
     }
 
-    const imageUrl = bytesToImageDataUri(image);
+    const imageUrls = sources.map((b) => bytesToImageDataUri(b));
 
     const body: Record<string, unknown> = {
       model: params.model.id,
       prompt: params.prompt,
-      image_url: imageUrl,
       n: 1,
       response_format: "b64_json"
     };
+
+    // One image → `image_url` (widest model support); multiple → the
+    // `reference_images` array that FLUX.2 / Google models accept.
+    if (imageUrls.length === 1) {
+      body.image_url = imageUrls[0];
+    } else {
+      body.reference_images = imageUrls;
+    }
 
     if (params.targetWidth != null) body.width = params.targetWidth;
     if (params.targetHeight != null) body.height = params.targetHeight;

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -304,9 +304,28 @@ export interface Message {
   _anthropicThinkingBlocks?: AnthropicThinkingBlock[];
 }
 
+/**
+ * A reusable entity (character, prop, location, style) riding along with a
+ * generation call for cross-shot consistency. Any provider consumer — nodes,
+ * the chat WebSocket, CLI — can attach these to the params; {@link BaseProvider}
+ * expands them centrally before the concrete provider runs: the descriptor
+ * joins the prompt as a `Consistency references:` block, and on image-editing
+ * tasks the reference image bytes are appended to the source-image list.
+ */
+export interface EntityReference {
+  /** Display name, referenced from the prompt text. */
+  name: string;
+  /** Canonical visual descriptor injected into the prompt. */
+  descriptor?: string | null;
+  /** Encoded reference image bytes (routed to image inputs on editing tasks). */
+  image?: Uint8Array | null;
+}
+
 export interface TextToImageParams {
   model: ImageModel;
   prompt: string;
+  /** Consistency entities; descriptors join the prompt (t2i takes no images). */
+  entities?: EntityReference[] | null;
   negativePrompt?: string | null;
   width?: number;
   height?: number;
@@ -323,6 +342,11 @@ export interface TextToImageParams {
 export interface ImageToImageParams {
   model: ImageModel;
   prompt: string;
+  /**
+   * Consistency entities; descriptors join the prompt and reference images are
+   * appended to the source-image list (after the caller's own images).
+   */
+  entities?: EntityReference[] | null;
   negativePrompt?: string | null;
   targetWidth?: number | null;
   targetHeight?: number | null;
@@ -406,6 +430,8 @@ export interface TextToMusicParams {
 export interface TextToVideoParams {
   model: VideoModel;
   prompt: string;
+  /** Consistency entities; descriptors join the prompt (text-only for video). */
+  entities?: EntityReference[] | null;
   negativePrompt?: string | null;
   numFrames?: number | null;
   /** Requested duration in seconds (provider decides fps). */
@@ -422,6 +448,12 @@ export interface TextToVideoParams {
 export interface ImageToVideoParams {
   model: VideoModel;
   prompt?: string | null;
+  /**
+   * Consistency entities; descriptors join the prompt. Images are NOT appended
+   * here — the image list's first frame drives the animation, so extra images
+   * would change its meaning.
+   */
+  entities?: EntityReference[] | null;
   negativePrompt?: string | null;
   numFrames?: number | null;
   /** Requested duration in seconds (provider decides fps). */
@@ -443,6 +475,8 @@ export interface ImageToVideoParams {
 export interface VideoToVideoParams {
   model: VideoModel;
   prompt?: string | null;
+  /** Consistency entities; descriptors join the prompt (text-only for video). */
+  entities?: EntityReference[] | null;
   negativePrompt?: string | null;
   strength?: number | null;
   durationSeconds?: number | null;

--- a/packages/runtime/tests/entity-references.test.ts
+++ b/packages/runtime/tests/entity-references.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyEntityReferences,
+  injectEntityDescriptors
+} from "../src/providers/entity-references.js";
+import { FakeProvider } from "../src/providers/fake-provider.js";
+import type {
+  EntityReference,
+  ImageToImageParams,
+  TextToImageParams
+} from "../src/providers/types.js";
+
+const model = { id: "m", name: "m", provider: "fake" };
+
+const marta: EntityReference = {
+  name: "Marta",
+  descriptor: "red-haired detective in a beige trench coat"
+};
+const harborImage = new Uint8Array([1, 2, 3]);
+const harbor: EntityReference = {
+  name: "Harbor",
+  descriptor: "foggy industrial harbor at night",
+  image: harborImage
+};
+
+describe("injectEntityDescriptors", () => {
+  it("appends a consistency block", () => {
+    expect(injectEntityDescriptors("a shot", [marta])).toBe(
+      "a shot\n\nConsistency references:\n- Marta: red-haired detective in a beige trench coat"
+    );
+  });
+
+  it("stands alone on an empty prompt and skips descriptor-less entities", () => {
+    expect(injectEntityDescriptors("", [marta])).toBe(
+      "Consistency references:\n- Marta: red-haired detective in a beige trench coat"
+    );
+    expect(injectEntityDescriptors("a shot", [{ name: "X" }])).toBe("a shot");
+  });
+});
+
+describe("applyEntityReferences", () => {
+  it("expands the prompt and strips entities on textToImage", () => {
+    const params: TextToImageParams = {
+      model,
+      prompt: "a shot",
+      entities: [marta, harbor]
+    };
+    const [out] = applyEntityReferences("textToImage", [params]) as [
+      TextToImageParams
+    ];
+    expect(out.prompt).toContain("Consistency references:");
+    expect(out.prompt).toContain("- Harbor: foggy industrial harbor at night");
+    expect(out.entities).toBeUndefined();
+    // Original params untouched.
+    expect(params.prompt).toBe("a shot");
+    expect(params.entities).toHaveLength(2);
+  });
+
+  it("appends reference images and attributes descriptors to their image position", () => {
+    const source = new Uint8Array([9]);
+    const params: ImageToImageParams = {
+      model,
+      prompt: "restyle",
+      entities: [marta, harbor]
+    };
+    const [images, out] = applyEntityReferences("imageToImage", [
+      [source],
+      params
+    ]) as [Uint8Array[], ImageToImageParams];
+    expect(images).toEqual([source, harborImage]);
+    // Position counts the caller's source image: harbor lands at Image 2.
+    expect(out.prompt).toBe(
+      "restyle\n\nConsistency references:\n" +
+        "- Marta: red-haired detective in a beige trench coat\n" +
+        "- Image 2 (Harbor): foggy industrial harbor at night"
+    );
+    expect(out.entities).toBeUndefined();
+  });
+
+  it("attributes an image-only entity without a descriptor tail", () => {
+    const [images, out] = applyEntityReferences("imageToImage", [
+      [],
+      { model, prompt: "compose", entities: [{ name: "Harbor", image: harborImage }] }
+    ]) as [Uint8Array[], ImageToImageParams];
+    expect(images).toEqual([harborImage]);
+    expect(out.prompt).toBe(
+      "compose\n\nConsistency references:\n- Image 1 (Harbor)"
+    );
+  });
+
+  it("does not touch the image list on imageToVideo (text-only)", () => {
+    const frame = new Uint8Array([7]);
+    const args = applyEntityReferences("imageToVideo", [
+      [frame],
+      { model, prompt: "pan left", entities: [harbor] }
+    ]);
+    expect(args[0]).toEqual([frame]);
+    expect((args[1] as { prompt: string }).prompt).toContain(
+      "Consistency references:"
+    );
+  });
+
+  it("passes through untouched without entities or on unrelated methods", () => {
+    const args = [{ model, prompt: "a shot" }];
+    expect(applyEntityReferences("textToImage", args)).toBe(args);
+    const upscale = [new Uint8Array([1]), { model, entities: [marta] }];
+    expect(applyEntityReferences("upscaleImage", upscale)).toBe(upscale);
+  });
+
+  it("applies exactly once through the provider's batch fallback", async () => {
+    const seen: Array<{ images: Uint8Array[]; params: ImageToImageParams }> =
+      [];
+    class Probe extends FakeProvider {
+      override async imageToImage(
+        images: Uint8Array[],
+        params: ImageToImageParams
+      ): Promise<Uint8Array> {
+        seen.push({ images, params });
+        return new Uint8Array([0]);
+      }
+    }
+    const provider = new Probe();
+    await provider.imageToImages(
+      [new Uint8Array([9])],
+      { model, prompt: "restyle", entities: [harbor] },
+      2
+    );
+    expect(seen).toHaveLength(2);
+    for (const call of seen) {
+      expect(call.images).toHaveLength(2);
+      expect(call.params.entities).toBeUndefined();
+      const block = call.params.prompt.indexOf("Consistency references:");
+      expect(block).toBeGreaterThan(-1);
+      expect(
+        call.params.prompt.indexOf("Consistency references:", block + 1)
+      ).toBe(-1);
+    }
+  });
+});

--- a/packages/runtime/tests/providers/minimax-provider.test.ts
+++ b/packages/runtime/tests/providers/minimax-provider.test.ts
@@ -140,6 +140,42 @@ describe("MinimaxProvider", () => {
     expect(body.response_format).toBe("base64");
   });
 
+  it("forwards every reference image as a subject_reference entry for image-to-image", async () => {
+    const base64Png = Buffer.from("abcd").toString("base64");
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { image_base64: [base64Png] },
+        base_resp: { status_code: 0 }
+      })
+    });
+
+    const provider = new MinimaxProvider(
+      { MINIMAX_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const model: ImageModel = {
+      id: "image-01",
+      name: "image-01",
+      provider: "minimax"
+    };
+    await provider.imageToImage(
+      [new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])],
+      { model, prompt: "restyle" }
+    );
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0][1] as { body: string }).body
+    );
+    expect(body.subject_reference).toHaveLength(3);
+    expect(body.subject_reference).toEqual([
+      { type: "character", image_file: expect.stringContaining("data:image/png;base64,") },
+      { type: "character", image_file: expect.stringContaining("data:image/png;base64,") },
+      { type: "character", image_file: expect.stringContaining("data:image/png;base64,") }
+    ]);
+  });
+
   it("surfaces MiniMax base_resp errors", async () => {
     const mockFetch = vi.fn().mockResolvedValueOnce({
       ok: true,

--- a/packages/runtime/tests/providers/reve-provider.test.ts
+++ b/packages/runtime/tests/providers/reve-provider.test.ts
@@ -103,6 +103,42 @@ describe("ReveProvider — generation", () => {
     expect(body.reference_image).toBe(Buffer.from(input).toString("base64"));
   });
 
+  it("imageToImage posts to /v1/image/remix with N reference images when given multiple", async () => {
+    const fetchMock = mockOkImage();
+    const p = new ReveProvider({ REVE_API_KEY: "secret" });
+    const inputs = [
+      Uint8Array.from([1, 2]),
+      Uint8Array.from([3, 4]),
+      Uint8Array.from([5, 6])
+    ];
+    await p.imageToImage(inputs, {
+      model: EDIT_MODEL,
+      prompt: "blend these",
+      aspectRatio: "1:1"
+    });
+
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe("https://api.reve.com/v1/image/remix");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.prompt).toBe("blend these");
+    expect(body.aspect_ratio).toBe("1:1");
+    expect(body.reference_image).toBeUndefined();
+    expect(body.reference_images).toEqual(
+      inputs.map((b) => Buffer.from(b).toString("base64"))
+    );
+  });
+
+  it("imageToImage throws when given more than 6 reference images", async () => {
+    const p = new ReveProvider({ REVE_API_KEY: "k" });
+    const inputs = Array.from({ length: 7 }, (_, i) =>
+      Uint8Array.from([i + 1])
+    );
+    await expect(
+      p.imageToImage(inputs, { model: EDIT_MODEL, prompt: "too many" })
+    ).rejects.toThrow("Reve accepts at most 6 reference images, got 7.");
+  });
+
   it("textToImage throws on an API error", async () => {
     global.fetch = vi
       .fn()

--- a/packages/runtime/tests/providers/together-provider.test.ts
+++ b/packages/runtime/tests/providers/together-provider.test.ts
@@ -369,8 +369,45 @@ describe("TogetherProvider", () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
     expect(body.image_url).toMatch(/^data:image\/jpeg;base64,/);
+    expect(body.reference_images).toBeUndefined();
     expect(body.prompt).toBe("make it blue");
     expect(body.guidance_scale).toBe(3.5);
+  });
+
+  it("imageToImage sends reference_images array for multiple inputs", async () => {
+    const imageBytes = new Uint8Array([13, 14, 15, 16]);
+    const b64 = Buffer.from(imageBytes).toString("base64");
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ b64_json: b64 }] })
+    });
+
+    const provider = new TogetherProvider(
+      { TOGETHER_API_KEY: "k" },
+      { client: {} as any, fetchFn: mockFetch as any }
+    );
+
+    const first = new Uint8Array([0xff, 0xd8, 0xff]); // fake JPEG header
+    const second = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // fake PNG header
+    const params: ImageToImageParams = {
+      model: {
+        id: "black-forest-labs/FLUX.2-pro",
+        name: "FLUX.2 Pro",
+        provider: "together"
+      },
+      prompt: "combine these"
+    };
+
+    const result = await provider.imageToImage([first, second], params);
+    expect(result).toEqual(imageBytes);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.image_url).toBeUndefined();
+    expect(body.reference_images).toHaveLength(2);
+    expect(body.reference_images[0]).toMatch(/^data:image\/jpeg;base64,/);
+    expect(body.reference_images[1]).toMatch(/^data:image\/png;base64,/);
+    expect(body.prompt).toBe("combine these");
   });
 
   // ─── TTS ────────────────────────────────────────────────────────────────────

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -518,6 +518,15 @@ export class ImageToVideoNode extends BaseNode {
   declare negative_prompt: string;
 
   @prop({
+    type: "list[dict]",
+    default: [],
+    title: "Entities",
+    description:
+      "Consistency entities (characters, styles, locations) whose descriptors are injected into the prompt"
+  })
+  declare entities: unknown[];
+
+  @prop({
     type: "str",
     default: "16:9",
     title: "Aspect Ratio",
@@ -597,6 +606,7 @@ export class ImageToVideoNode extends BaseNode {
         images: bytesList,
         prompt,
         negative_prompt: this.negative_prompt,
+        entities: this.entities,
         duration_seconds: Number(this.duration ?? 0) || undefined,
         aspect_ratio: this.aspect_ratio,
         resolution: this.resolution,

--- a/web/src/components/entities/EntityLibrary.tsx
+++ b/web/src/components/entities/EntityLibrary.tsx
@@ -19,7 +19,8 @@ import {
   FlexColumn,
   EditorButton,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  BORDER_RADIUS
 } from "../ui_primitives";
 import type { Asset } from "../../stores/ApiTypes";
 import { trpcClient } from "../../trpc/client";
@@ -82,7 +83,7 @@ const AssetPickerDialog: React.FC<{
               onClick={() => onPick(asset.id)}
               style={{
                 border: `1px solid ${theme.vars.palette.divider}`,
-                borderRadius: getSpacingPx(SPACING.xs),
+                borderRadius: BORDER_RADIUS.sm,
                 padding: 0,
                 background: "transparent",
                 cursor: "pointer",

--- a/web/src/components/model_menu/ImageModelMenuDialog.tsx
+++ b/web/src/components/model_menu/ImageModelMenuDialog.tsx
@@ -11,7 +11,7 @@ export interface ImageModelMenuDialogProps {
   open: boolean;
   onClose: () => void;
   onModelChange?: (model: ImageModel) => void;
-  task?: ImageModelTask;
+  task?: ImageModelTask | ImageModelTask[];
   anchorEl?: HTMLElement | null;
   recommendedModels?: UnifiedModel[];
   modelPacks?: ModelPack[];

--- a/web/src/components/properties/ImageModelSelect.tsx
+++ b/web/src/components/properties/ImageModelSelect.tsx
@@ -17,7 +17,7 @@ import ModelSelectButton from "./shared/ModelSelectButton";
 interface ImageModelSelectProps {
   onChange: (value: ImageModelValue) => void;
   value: string;
-  task?: ImageModelTask;
+  task?: ImageModelTask | ImageModelTask[];
   recommendedModels?: UnifiedModel[];
   modelPacks?: ModelPack[];
 }

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -34,6 +34,10 @@ import {
 } from "../ui_primitives";
 import { useBoard, useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import {
+  useImageModelsByProvider,
+  type ImageModelTask
+} from "../../hooks/useModelsByProvider";
 import LanguageModelSelect from "../properties/LanguageModelSelect";
 import ImageModelSelect from "../properties/ImageModelSelect";
 import VideoModelSelect from "../properties/VideoModelSelect";
@@ -70,6 +74,10 @@ const SHOT_COUNT_OPTIONS = [3, 4, 5, 6, 8, 10, 12].map((n) => ({
   label: `${n} shots`
 }));
 
+// Stills can come from a plain generator or an editing model; the latter can
+// take entity reference images, so the picker offers both.
+const STILL_MODEL_TASKS: ImageModelTask[] = ["text_to_image", "image_to_image"];
+
 // The model pickers are custom buttons, not InputBase controls; hold them at
 // the shared form-control height. Scoped to the picker's own class so no
 // other button that ends up inside the field is affected.
@@ -85,6 +93,9 @@ const styles = (theme: Theme) =>
     display: "flex",
     flexDirection: "column",
     gap: getSpacingPx(SPACING.lg),
+    // Children must keep their natural height so the container scrolls;
+    // otherwise the header panel gets flex-shrunk under the grid.
+    "> *": { flexShrink: 0 },
     ".grid": {
       display: "grid",
       gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
@@ -114,7 +125,7 @@ const styles = (theme: Theme) =>
     },
     ".ghost-card": {
       border: `1px solid ${theme.vars.palette.divider}`,
-      borderRadius: theme.shape.borderRadius,
+      borderRadius: BORDER_RADIUS.md,
       padding: getSpacingPx(SPACING.md),
       display: "flex",
       flexDirection: "column",
@@ -198,6 +209,16 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
 
   const [shotCount, setShotCount] = useState<number>(6);
 
+  // Entity reference images only reach generation through an editing model;
+  // warn when entities are attached but the still model can't take them.
+  const { models: imageModels } = useImageModelsByProvider();
+  const stillModelDetails = imageModel?.id
+    ? imageModels.find((m) => m.id === imageModel.id)
+    : undefined;
+  const entitiesNeedEditModel =
+    entityIds.length > 0 &&
+    !stillModelDetails?.supported_tasks?.includes("image_to_image");
+
   const handleDirect = useCallback(() => {
     onDirect?.(shotCount);
   }, [onDirect, shotCount]);
@@ -277,9 +298,15 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                 <FormField label="Still model" sx={modelFieldSx}>
                   <ImageModelSelect
                     value={imageModel?.id ?? ""}
-                    task="text_to_image"
+                    task={STILL_MODEL_TASKS}
                     onChange={(value) => setImageModel(boardId, value)}
                   />
+                  {entitiesNeedEditModel && (
+                    <Text size="small" color="warning">
+                      Entities carry reference images, but this model only
+                      takes text. Pick an image-to-image model to use them.
+                    </Text>
+                  )}
                 </FormField>
                 <FormField label="Clip model" sx={modelFieldSx}>
                   <VideoModelSelect

--- a/web/src/components/storyboard/StoryboardEntitiesField.tsx
+++ b/web/src/components/storyboard/StoryboardEntitiesField.tsx
@@ -19,7 +19,8 @@ import {
   FlexRow,
   MenuItemPrimitive,
   Popover,
-  Text
+  Text,
+  BORDER_RADIUS
 } from "../ui_primitives";
 import { useEntities } from "../../serverState/useEntities";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
@@ -43,7 +44,7 @@ const EntityAvatar: React.FC<{ entity: Entity; size?: number }> = ({
   const frame: React.CSSProperties = {
     width: size,
     height: size,
-    borderRadius: "50%",
+    borderRadius: BORDER_RADIUS.circle,
     flex: "0 0 auto",
     display: "flex",
     alignItems: "center",

--- a/web/src/components/storyboard/StoryboardSidebar.tsx
+++ b/web/src/components/storyboard/StoryboardSidebar.tsx
@@ -24,6 +24,7 @@ import {
   LoadingSpinner,
   SPACING,
   getSpacingPx,
+  BORDER_RADIUS,
   MOTION
 } from "../ui_primitives";
 import {
@@ -57,7 +58,7 @@ const styles = (theme: Theme) =>
     },
     ".board-row": {
       padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`,
-      borderRadius: theme.shape.borderRadius,
+      borderRadius: BORDER_RADIUS.md,
       cursor: "pointer",
       "&:hover": { backgroundColor: theme.vars.palette.action.hover },
       "&.active": { backgroundColor: theme.vars.palette.action.selected },

--- a/web/src/components/ui_primitives/Card.tsx
+++ b/web/src/components/ui_primitives/Card.tsx
@@ -98,7 +98,10 @@ const CardInternal = forwardRef<HTMLDivElement, CardProps>(({
         padding: theme.spacing(paddingValue),
         backgroundColor: theme.vars.palette.background.paper,
         border: getBorder(),
-        borderRadius: theme.shape.borderRadius,
+        // String token, not the numeric theme.shape.borderRadius: sx multiplies
+        // bare numbers by the theme radius (6 × 6 = 36px), which is what made
+        // cards balloon off-brand.
+        borderRadius: theme.rounded.md,
         boxShadow: getBoxShadow(),
         cursor: clickable ? "pointer" : undefined,
         transition: hoverable || clickable

--- a/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
@@ -21,6 +21,11 @@ jest.mock("../../../stores/storyboard/StoryboardGenerationStore", () => {
 jest.mock("../../../serverState/useEntities", () => ({
   useEntities: () => ({ data: [] })
 }));
+// Model catalog lookup (still-model image_to_image support) is irrelevant to
+// the single-flight behavior under test.
+jest.mock("../../useModelsByProvider", () => ({
+  useImageModelsByProvider: () => ({ models: [] })
+}));
 
 import { useGenerateShot, __resetStartingShotsForTests } from "../useGenerateShot";
 import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -23,11 +23,9 @@ import type { NodeData } from "../../stores/NodeData";
 import type { WorkflowAttributes } from "../../stores/ApiTypes";
 import { getWorkflowRunnerStore } from "../../stores/WorkflowRunner";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
-import {
-  entitiesForShot,
-  injectShotEntities
-} from "../../stores/storyboard/shotEntities";
+import { entitiesForShot } from "../../stores/storyboard/shotEntities";
 import { useEntities } from "../../serverState/useEntities";
+import { useImageModelsByProvider } from "../useModelsByProvider";
 import {
   subscribeShotJob,
   useStoryboardGenerationStore,
@@ -101,13 +99,10 @@ const outputEdge = (): Edge => ({
 
 /**
  * Compose an image prompt from a shot's action, camera framing, and board
- * style, plus the applicable board entities' consistency descriptors.
+ * style. Entity descriptors/reference images are NOT injected here — they ride
+ * along as an `entities` node property and expand at the provider layer.
  */
-const keyframePrompt = (
-  shot: Shot,
-  style: string,
-  entities: Entity[]
-): string => {
+const keyframePrompt = (shot: Shot, style: string): string => {
   const parts = [shot.action.trim()];
   if (shot.camera?.framing) {
     parts.push(`${shot.camera.framing} shot`);
@@ -115,16 +110,27 @@ const keyframePrompt = (
   if (style.trim().length > 0) {
     parts.push(style.trim());
   }
-  const base = parts.filter((p) => p.length > 0).join(", ");
-  return injectShotEntities(base, entitiesForShot(shot, entities));
+  return parts.filter((p) => p.length > 0).join(", ");
 };
 
-const clipPrompt = (shot: Shot, entities: Entity[]): string => {
-  const base = [shot.motion, shot.action]
+const clipPrompt = (shot: Shot): string =>
+  [shot.motion, shot.action]
     .filter((p) => !!p && p.trim().length > 0)
     .join(", ");
-  return injectShotEntities(base, entitiesForShot(shot, entities));
-};
+
+/**
+ * The wire shape of an entity attached to a generation node: name +
+ * descriptor + at most one reference image. The runtime resolves the ref to
+ * bytes and the provider layer injects descriptor text / appends the image.
+ */
+const wireEntity = (entity: Entity) => ({
+  name: entity.name,
+  descriptor: entity.descriptor,
+  reference_images: entity.reference_images?.slice(0, 1) ?? []
+});
+
+const hasReferenceImage = (entities: Entity[]): boolean =>
+  entities.some((e) => (e.reference_images?.length ?? 0) > 0);
 
 export interface UseGenerateShotResult {
   generateKeyframe: (boardId: string, shot: Shot) => Promise<void>;
@@ -140,6 +146,9 @@ export const useGenerateShot = (): UseGenerateShotResult => {
   const registerJob = useStoryboardGenerationStore((state) => state.registerJob);
   // Library entities; a board's `entityIds` picks which ones season prompts.
   const { data: allEntities } = useEntities();
+  // Model catalog, for checking whether the still model can take entity
+  // reference images (image_to_image support).
+  const { models: imageModels } = useImageModelsByProvider();
 
   const boardEntities = useCallback(
     (entityIds: string[] | undefined): Entity[] => {
@@ -206,13 +215,27 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       const style = board?.style ?? "";
       const aspectRatio = board?.aspectRatio ?? "16:9";
       const workflowId = runnerIdForShot(shot.id);
+      const entities = entitiesForShot(shot, boardEntities(board?.entityIds));
+      // Entities with reference images route through Image To Image when the
+      // board's still model can edit — the provider layer appends the images
+      // as references. Otherwise stay on Text To Image (descriptors only).
+      const stillModel = board?.imageModel?.id
+        ? imageModels.find((m) => m.id === board.imageModel?.id)
+        : undefined;
+      const useEditModel =
+        hasReferenceImage(entities) &&
+        !!stillModel?.supported_tasks?.includes("image_to_image");
       const nodes: Node<NodeData>[] = [
         makeNode(
           GEN_NODE_ID,
-          "nodetool.image.TextToImage",
+          useEditModel
+            ? "nodetool.image.ImageToImage"
+            : "nodetool.image.TextToImage",
           0,
           {
-            prompt: keyframePrompt(shot, style, boardEntities(board?.entityIds)),
+            ...(useEditModel ? { image: [] } : {}),
+            prompt: keyframePrompt(shot, style),
+            entities: entities.map(wireEntity),
             aspect_ratio: aspectRatio,
             // Board-level still model; omitted = the node's default model.
             ...(board?.imageModel ? { model: board.imageModel } : {})
@@ -229,7 +252,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       ];
       await startJob(boardId, shot, "keyframe", nodes, [outputEdge()], workflowId);
     },
-    [startJob, boardEntities]
+    [startJob, boardEntities, imageModels]
   );
 
   const generateClip = useCallback(
@@ -247,7 +270,11 @@ export const useGenerateShot = (): UseGenerateShotResult => {
           0,
           {
             image: shot.keyframe,
-            prompt: clipPrompt(shot, boardEntities(board?.entityIds)),
+            prompt: clipPrompt(shot),
+            entities: entitiesForShot(
+              shot,
+              boardEntities(board?.entityIds)
+            ).map(wireEntity),
             aspect_ratio: aspectRatio,
             duration: shot.duration_seconds,
             // Board-level clip model; omitted = the node's default model.

--- a/web/src/hooks/useModelsByProvider.ts
+++ b/web/src/hooks/useModelsByProvider.ts
@@ -193,7 +193,7 @@ const modelMatchesTask = (
   return supportedTasks.includes(task);
 };
 
-export const useImageModelsByProvider = (opts?: { task?: ImageModelTask }): ModelsByProviderResult<ImageModel> => {
+export const useImageModelsByProvider = (opts?: { task?: ImageModelTask | ImageModelTask[] }): ModelsByProviderResult<ImageModel> => {
   const { providers, isLoading: providersLoading, error: providersError } = useImageModelProviders();
 
   const queries = useQueries({
@@ -226,12 +226,18 @@ export const useImageModelsByProvider = (opts?: { task?: ImageModelTask }): Mode
   const error = providersError || queries.find((q) => q.error)?.error;
 
   const task = opts?.task;
+  // Key by content so an inline task array doesn't recompute every render.
+  const taskKey = Array.isArray(task) ? task.join(",") : task;
   const allModels = useMemo(() => {
     const aggregated = queries.flatMap((q) => q.data?.models ?? []);
-    return task
-      ? aggregated.filter((m) => modelMatchesTask(m.supported_tasks, task))
-      : aggregated;
-  }, [queries, task]);
+    if (!taskKey) {
+      return aggregated;
+    }
+    const tasks = taskKey.split(",");
+    return aggregated.filter((m) =>
+      tasks.some((t) => modelMatchesTask(m.supported_tasks, t))
+    );
+  }, [queries, taskKey]);
 
   const refetch = useMemo(
     () => async () => {

--- a/web/src/stores/storyboard/__tests__/shotEntities.test.ts
+++ b/web/src/stores/storyboard/__tests__/shotEntities.test.ts
@@ -1,5 +1,5 @@
 import type { Entity, Shot } from "@nodetool-ai/protocol";
-import { entitiesForShot, injectShotEntities } from "../shotEntities";
+import { entitiesForShot } from "../shotEntities";
 
 const entity = (over: Partial<Entity> & Pick<Entity, "id" | "kind" | "name">): Entity => ({
   type: "entity",
@@ -73,23 +73,5 @@ describe("entitiesForShot", () => {
     expect(entitiesForShot(shot({ entity_ids: [] }), [marta, noir])).toEqual(
       []
     );
-  });
-});
-
-describe("injectShotEntities", () => {
-  it("appends a consistency block with each descriptor", () => {
-    const out = injectShotEntities("a shot, noir style", [marta, noir]);
-    expect(out).toBe(
-      "a shot, noir style\n\nConsistency references:\n" +
-        "- Marta: red-haired detective in a beige trench coat\n" +
-        "- Noir: high-contrast black and white, hard shadows"
-    );
-  });
-
-  it("returns the prompt unchanged with no descriptors to add", () => {
-    expect(injectShotEntities("a shot", [])).toBe("a shot");
-    expect(
-      injectShotEntities("a shot", [entity({ id: "x", kind: "prop", name: "X" })])
-    ).toBe("a shot");
   });
 });

--- a/web/src/stores/storyboard/shotEntities.ts
+++ b/web/src/stores/storyboard/shotEntities.ts
@@ -1,8 +1,8 @@
 /**
- * Which board entities apply to a shot, and how their descriptors enter the
- * shot's still/clip prompts. Pure functions so the rule is unit-testable and
- * identical between the generation path (useGenerateShot) and the UI
- * (ShotCard's entity chips).
+ * Which board entities apply to a shot. Pure so the rule is unit-testable and
+ * identical between the generation path (useGenerateShot, which sends the
+ * selected entities to the provider layer for descriptor/reference-image
+ * expansion) and the UI (ShotCard's entity chips).
  */
 
 import type { Entity, Shot } from "@nodetool-ai/protocol";
@@ -42,22 +42,4 @@ export const entitiesForShot = (
     const name = entity.name.trim().toLowerCase();
     return name.length > 0 && text.includes(name);
   });
-};
-
-/**
- * Append the entities' canonical descriptors to a generation prompt as a
- * `Consistency references:` block — the same shape the Apply Entities node
- * and the runtime's entity-mention expansion produce.
- */
-export const injectShotEntities = (
-  prompt: string,
-  entities: Entity[]
-): string => {
-  const lines = entities
-    .filter((e) => e.descriptor.trim().length > 0)
-    .map((e) => `- ${e.name}: ${e.descriptor.trim()}`);
-  if (lines.length === 0) {
-    return prompt;
-  }
-  return `${prompt}\n\nConsistency references:\n${lines.join("\n")}`;
 };


### PR DESCRIPTION
## Summary

Makes consistency entities a first-class provider-level concept and wires them end to end.

- **Provider layer**: `EntityReference {name, descriptor?, image?}` on text-to-image, image-to-image, inpainting, and video params. `BaseProvider` expands them centrally before any concrete provider runs: descriptors are appended to the prompt as a `Consistency references:` block, and on image-editing tasks reference images are appended after the caller's images with positional attribution (`- Image 2 (Harbor): …`). Stripped after application so nested batch fallbacks apply exactly once.
- **Dispatch**: `runProviderPrediction` accepts `params.entities` in any consumer shape (protocol `Entity`, lean `{name, descriptor, image}`, ImageRef-like, bare URI) and resolves images to bytes — so the chat WebSocket and other API consumers can send entities directly.
- **Multi-image providers**: Reve now routes 2–6 images to `/v1/image/remix` (v1 cap; v2 create API noted for the 8-image ceiling), MiniMax sends all images as `subject_reference` entries, Together switches to `reference_images` for 2+ images.
- **Nodes**: `TextToImage`, `ImageToImage`, `ImageToVideo` gain an `entities` property; `ImageToImage` accepts entity-supplied source images (empty wired input allowed).
- **Storyboard**: shots attach entities instead of pre-injecting descriptor text; keyframes route through ImageToImage when the still model declares `image_to_image` and an entity carries a reference image; the still-model picker offers both t2i and i2i models with a warning when entities can't reach an image-capable model.
- **UI fixes**: storyboard header form no longer flex-shrinks under the shot grid; `Card` primitive radius fixed (numeric `theme.shape.borderRadius` in `sx` was multiplied to 36px — now the 6px brand token); storyboard/entities radii moved to `BORDER_RADIUS` tokens.

## Test plan

- `packages/runtime`: full suite (2301 tests) including new `entity-references` unit tests (attribution format, batch single-application, video text-only) and provider request-payload tests for Reve/MiniMax/Together multi-image.
- `packages/image-nodes` / `packages/video-nodes`: suites pass.
- web: storyboard Jest suites pass; typecheck + lint clean across all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)