### PR TITLE
fix(costs): make the cost estimate panel functional

### DIFF
--- a/web/src/components/costs/CostTicker.tsx
+++ b/web/src/components/costs/CostTicker.tsx
@@ -18,6 +18,7 @@ import {
   FlexColumn,
   FlexRow,
   StatusIndicator,
+  TextLink,
   BORDER_RADIUS,
   Z_INDEX
 } from "../ui_primitives";
@@ -42,6 +43,7 @@ const CostTickerInternal: React.FC<CostTickerProps> = ({ workflowId }) => {
   const live = useLiveRunCost(workflowId);
   const estimate = useWorkflowCostEstimate(workflowId);
   const budget = useBudgetStore(useShallow(selectBudget));
+  const resetSpent = useBudgetStore((s) => s.reset);
 
   const remaining = useMemo(() => budgetRemaining(budget), [budget]);
   const overBudget = remaining <= 0 || (estimate ? estimate.total > remaining : false);
@@ -63,6 +65,14 @@ const CostTickerInternal: React.FC<CostTickerProps> = ({ workflowId }) => {
   }, []);
 
   const handleClose = useCallback(() => setAnchorEl(null), []);
+
+  const handleResetSpent = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      resetSpent();
+    },
+    [resetSpent]
+  );
 
   const tier = overBudget
     ? theme.vars.palette.warning
@@ -225,14 +235,31 @@ const CostTickerInternal: React.FC<CostTickerProps> = ({ workflowId }) => {
               size="small"
             />
           </FlexRow>
-          <Text
-            sx={{
-              fontSize: "var(--fontSizeSmaller)",
-              color: theme.vars.palette.text.secondary
-            }}
-          >
-            Cap {formatMoney(budget.cap)} · spent {formatMoney(budget.spent)}
-          </Text>
+          <FlexRow align="center" justify="space-between" gap={1}>
+            <Text
+              sx={{
+                fontSize: "var(--fontSizeSmaller)",
+                color: theme.vars.palette.text.secondary
+              }}
+            >
+              Cap {formatMoney(budget.cap)} · spent {formatMoney(budget.spent)}
+            </Text>
+            {budget.spent > 0 && (
+              <TextLink
+                asButton
+                underline="hover"
+                onClick={handleResetSpent}
+                sx={{
+                  fontSize: "var(--fontSizeSmaller)",
+                  color: theme.vars.palette.text.secondary,
+                  flexShrink: 0,
+                  "&:hover": { color: theme.vars.palette.text.primary }
+                }}
+              >
+                Reset spent
+              </TextLink>
+            )}
+          </FlexRow>
         </FlexColumn>
       </Popover>
     </>

--- a/web/src/components/costs/WorkflowCostEstimatePanel.tsx
+++ b/web/src/components/costs/WorkflowCostEstimatePanel.tsx
@@ -116,6 +116,10 @@ const WorkflowCostEstimatePanelInternal: React.FC<
                 </ToggleOption>
               ))}
             </ToggleGroup>
+            <Caption sx={{ maxWidth: 320, opacity: 0.7 }}>
+              Affects the estimate only: Draft assumes one preview per node;
+              Off / Final use each node&apos;s configured output count.
+            </Caption>
           </FlexColumn>
         </FlexRow>
 

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -7,7 +7,9 @@ import { renderHook } from "@testing-library/react";
 // which jest.config maps to the TypeScript source (the ESM dist barrel is not
 // transformable by ts-jest). No mock needed.
 
-const mockNodes = [
+type MockNode = { id: string; type: string; data: Record<string, unknown> };
+
+const baseNodes: MockNode[] = [
   { id: "n1", type: "fal.Image", data: {} },
   { id: "n2", type: "kie.Video", data: {} },
   // Uses an AI model via a language_model property but has no unit pricing.
@@ -15,6 +17,9 @@ const mockNodes = [
   // Plain data node — no model, no pricing. Excluded from the estimate.
   { id: "n4", type: "nodetool.text.Concat", data: {} }
 ];
+
+// Reassigned per-test to vary the graph the hook sees.
+let mockNodes: MockNode[] = baseNodes;
 
 const mockNodeStore = {
   subscribe: () => () => {},
@@ -63,8 +68,15 @@ jest.mock("../../stores/MetadataStore", () => ({
 }));
 
 import { useWorkflowCostEstimate } from "../useWorkflowCostEstimate";
+import { useBudgetStore } from "../../stores/BudgetStore";
 
 describe("useWorkflowCostEstimate", () => {
+  beforeEach(() => {
+    mockNodes = baseNodes;
+    // "off" so derived fan-out quantities are applied (the default is "draft").
+    useBudgetStore.setState({ draftMode: "off" });
+  });
+
   it("estimates cost from AI-model nodes + metadata", () => {
     const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
 
@@ -84,5 +96,29 @@ describe("useWorkflowCostEstimate", () => {
       (i) => i.node_type === "nodetool.llm.Agent"
     );
     expect(unknown?.confidence).toBe("unknown");
+  });
+
+  it("multiplies a node's cost by its fan-out output count", () => {
+    // fal.Image at 0.05/image with num_images: 3 → quantity 3, cost 0.15.
+    mockNodes = [{ id: "n1", type: "fal.Image", data: { num_images: 3 } }];
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    const item = result.current!.items.find((i) => i.node_id === "n1");
+    expect(item?.quantity).toBe(3);
+    expect(item?.estimated_cost).toBeCloseTo(0.15, 5);
+    expect(result.current!.total).toBeCloseTo(0.15, 5);
+  });
+
+  it("draft mode forces every quantity to 1, ignoring fan-out", () => {
+    mockNodes = [{ id: "n1", type: "fal.Image", data: { num_images: 3 } }];
+    useBudgetStore.setState({ draftMode: "draft" });
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    const item = result.current!.items.find((i) => i.node_id === "n1");
+    expect(item?.quantity).toBe(1);
+    expect(item?.estimated_cost).toBeCloseTo(0.05, 5);
+    expect(result.current!.total).toBeCloseTo(0.05, 5);
   });
 });

--- a/web/src/hooks/useLiveRunCost.ts
+++ b/web/src/hooks/useLiveRunCost.ts
@@ -10,11 +10,54 @@
 import { useMemo } from "react";
 import useResultsStore from "../stores/ResultsStore";
 import useWorkflowRunsStore from "../stores/WorkflowRunsStore";
+import useBudgetStore from "../stores/BudgetStore";
 import type { NodeKey } from "../stores/nodeKey";
+import type { ProviderCost } from "../stores/ApiTypes";
 
 export interface LiveRunCost {
   total: number;
   currency: string;
+}
+
+/** Is this charge a finite USD amount we can fold into a dollar figure? */
+function isUsdCharge(cost: ProviderCost): boolean {
+  // Mirror the guard below: credit-denominated providers (e.g. kie) still carry
+  // USD in `amount`, so treat an undefined currency as USD.
+  return (
+    typeof cost.amount === "number" &&
+    Number.isFinite(cost.amount) &&
+    (!cost.currency || cost.currency === "USD")
+  );
+}
+
+/**
+ * Sum every recorded USD provider charge across all runs this session. This is
+ * the source of truth for cumulative spend, so recomputing from it (rather than
+ * adding deltas) is idempotent when a node re-emits its `provider_cost`.
+ */
+export function sumSessionProviderSpend(
+  providerCosts: Record<string, ProviderCost>
+): number {
+  let sum = 0;
+  for (const key in providerCosts) {
+    const cost = providerCosts[key];
+    if (isUsdCharge(cost)) {
+      sum += cost.amount;
+    }
+  }
+  return sum;
+}
+
+/**
+ * Mirror BudgetStore's running `spent` onto the sum of the provider costs
+ * ResultsStore has recorded. Call from the update pipeline (non-React context)
+ * after writing a new `provider_cost`.
+ */
+export function syncBudgetSpentFromProviderCosts(): void {
+  const providerCosts = useResultsStore.getState().providerCosts;
+  useBudgetStore
+    .getState()
+    .setSpent(sumSessionProviderSpend(providerCosts));
 }
 
 export function useLiveRunCost(workflowId: string): LiveRunCost {

--- a/web/src/hooks/useWorkflowCostEstimate.ts
+++ b/web/src/hooks/useWorkflowCostEstimate.ts
@@ -14,8 +14,12 @@ import { estimateWorkflowCost } from "@nodetool-ai/node-sdk/cost-estimate";
 import type { WorkflowCostEstimate } from "@nodetool-ai/protocol";
 import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import useMetadataStore from "../stores/MetadataStore";
+import { useBudgetStore } from "../stores/BudgetStore";
 import type { NodeData } from "../stores/NodeData";
-import { nodeMetadataUsesAiModel } from "../utils/aiModelNodes";
+import {
+  nodeExpectedQuantity,
+  nodeMetadataUsesAiModel
+} from "../utils/aiModelNodes";
 
 const EMPTY_NODES: Node<NodeData>[] = [];
 
@@ -26,6 +30,7 @@ export function useWorkflowCostEstimate(
     state.getNodeStore(workflowId)
   );
   const getMetadata = useMetadataStore((state) => state.getMetadata);
+  const draftMode = useBudgetStore((state) => state.draftMode);
 
   const subscribe = useCallback(
     (onChange: () => void) =>
@@ -45,6 +50,20 @@ export function useWorkflowCostEstimate(
     const aiNodes = nodes.filter((node) =>
       node.type ? nodeMetadataUsesAiModel(getMetadata(node.type)) : false
     );
+    // Draft mode estimates a single cheap preview (one output per node); off /
+    // final use each node's configured fan-out. Branching lives here so the
+    // estimator itself stays pure.
+    const quantities: Record<string, number> =
+      draftMode === "draft"
+        ? {}
+        : Object.fromEntries(
+            aiNodes.map((node) => [
+              node.id,
+              nodeExpectedQuantity(
+                node.data as Record<string, unknown> | undefined
+              )
+            ])
+          );
     return estimateWorkflowCost({
       nodes: aiNodes.map((node) => ({
         id: node.id,
@@ -52,9 +71,10 @@ export function useWorkflowCostEstimate(
         data: node.data as Record<string, unknown> | undefined
       })),
       getMetadata: (nodeType) => getMetadata(nodeType),
+      quantities,
       currency: "USD"
     });
-  }, [nodeStore, nodes, getMetadata]);
+  }, [nodeStore, nodes, getMetadata, draftMode]);
 }
 
 export default useWorkflowCostEstimate;

--- a/web/src/stores/BudgetStore.ts
+++ b/web/src/stores/BudgetStore.ts
@@ -21,6 +21,13 @@ interface BudgetState {
   setCap: (cap: number) => void;
   setDraftMode: (mode: DraftMode) => void;
   addSpent: (amount: number) => void;
+  /**
+   * Set the running spend to an absolute total. Used by the update pipeline to
+   * mirror the sum of recorded provider costs (recompute-from-source avoids the
+   * double-counting a node re-emitting `provider_cost` would cause). A
+   * non-finite or negative total is ignored.
+   */
+  setSpent: (total: number) => void;
   reset: () => void;
 }
 
@@ -43,6 +50,11 @@ export const useBudgetStore = create<BudgetState>()(
             Number.isFinite(amount) && amount > 0
               ? state.spent + amount
               : state.spent
+        })),
+      setSpent: (total) =>
+        set((state) => ({
+          spent:
+            Number.isFinite(total) && total >= 0 ? total : state.spent
         })),
       reset: () => set({ spent: 0 })
     }),

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -24,8 +24,13 @@ import {
   Thread,
   LanguageModel,
   TodoItem,
-  PermissionMode
+  PermissionMode,
+  NodeUpdate
 } from "./ApiTypes";
+import useResultsStore from "./ResultsStore";
+import useWorkflowRunsStore from "./WorkflowRunsStore";
+import { syncBudgetSpentFromProviderCosts } from "../hooks/useLiveRunCost";
+import type { WebSocketMessage } from "../lib/websocket/GlobalWebSocketManager";
 import {
   sendPlanApprovalResponse,
   sendToolApprovalResponse
@@ -350,6 +355,52 @@ let connectPromise: Promise<void> | null = null;
 //   proceed independently.
 const inFlightMessageLoads = new Map<string, Promise<Message[]>>();
 
+/**
+ * Chat-initiated workflow runs stream `node_update`s over the chat socket, not
+ * through the editor's `handleUpdate` pipeline — so their run never registers as
+ * the focused job and their provider costs never land in ResultsStore under the
+ * workflow id. That left the CostTicker (rendered in Global Chat) stuck at $0.
+ *
+ * Mirror the editor path here: register the run so `useLiveRunCost(workflowId)`
+ * follows it, record any provider charge, and refresh the session budget spend.
+ */
+const captureChatRunSpend = (
+  data: WebSocketMessage,
+  threadId: string,
+  get: () => GlobalChatState
+): void => {
+  if (data.type !== "node_update") {
+    return;
+  }
+  // job_id / workflow_id are stamped onto the wire message by the relay; the
+  // NodeUpdate type carries provider_cost and node_id.
+  const update = data as unknown as NodeUpdate;
+  const jobId = data.job_id;
+  const workflowId =
+    data.workflow_id ?? get().threadWorkflowId[threadId] ?? undefined;
+  if (!workflowId || !jobId) {
+    return;
+  }
+
+  const runsStore = useWorkflowRunsStore.getState();
+  if (!runsStore.hasRun(workflowId, jobId)) {
+    runsStore.recordRun({
+      jobId,
+      workflowId,
+      state: "running",
+      startedAt: Date.now(),
+      label: jobId
+    });
+  }
+
+  if (update.provider_cost) {
+    useResultsStore
+      .getState()
+      .setProviderCost(workflowId, jobId, update.node_id, update.provider_cost);
+    syncBudgetSpentFromProviderCosts();
+  }
+};
+
 const useGlobalChatStore = create<GlobalChatState>()(
   persist<GlobalChatState>(
     (set, get) => ({
@@ -629,6 +680,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           threadSubscriptions[threadId] = globalWebSocketManager.subscribe(
             threadId,
             (data) => {
+              captureChatRunSpend(data, threadId, get);
               handleChatWebSocketMessage(data, set, get, threadId);
             }
           );
@@ -806,6 +858,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // otherwise streamed chunks/messages will be routed with no handler.
         if (!get().wsThreadSubscriptions[threadId]) {
           const unsub = globalWebSocketManager.subscribe(tid, (data) => {
+            captureChatRunSpend(data, tid, get);
             handleChatWebSocketMessage(data, set, get, tid);
           });
           set((state) => {
@@ -1045,6 +1098,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           existingUnsub();
         }
         const newUnsub = globalWebSocketManager.subscribe(id, (data) => {
+          captureChatRunSpend(data, id, get);
           handleChatWebSocketMessage(data, set, get, id);
         });
 
@@ -1085,6 +1139,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
         if (!get().wsThreadSubscriptions[threadId]) {
           const unsub = globalWebSocketManager.subscribe(threadId, (data) => {
+            captureChatRunSpend(data, threadId, get);
             handleChatWebSocketMessage(data, set, get, threadId);
           });
           set((state) => {

--- a/web/src/stores/__tests__/BudgetStore.test.ts
+++ b/web/src/stores/__tests__/BudgetStore.test.ts
@@ -1,0 +1,40 @@
+import useBudgetStore from "../BudgetStore";
+
+beforeEach(() => {
+  useBudgetStore.setState({ spent: 0, cap: 5, currency: "USD" });
+});
+
+describe("BudgetStore.setSpent", () => {
+  it("sets spent to an absolute finite total", () => {
+    useBudgetStore.getState().setSpent(1.25);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(1.25);
+
+    // Absolute, not additive: a smaller total overwrites the larger one.
+    useBudgetStore.getState().setSpent(0.5);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(0.5);
+  });
+
+  it("accepts zero", () => {
+    useBudgetStore.getState().setSpent(3);
+    useBudgetStore.getState().setSpent(0);
+    expect(useBudgetStore.getState().spent).toBe(0);
+  });
+
+  it("ignores negative and non-finite totals", () => {
+    useBudgetStore.getState().setSpent(2);
+    useBudgetStore.getState().setSpent(-1);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(2);
+
+    useBudgetStore.getState().setSpent(Number.NaN);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(2);
+
+    useBudgetStore.getState().setSpent(Number.POSITIVE_INFINITY);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(2);
+  });
+
+  it("reset() clears spent back to zero", () => {
+    useBudgetStore.getState().setSpent(4);
+    useBudgetStore.getState().reset();
+    expect(useBudgetStore.getState().spent).toBe(0);
+  });
+});

--- a/web/src/stores/__tests__/workflowUpdates.handlers.test.ts
+++ b/web/src/stores/__tests__/workflowUpdates.handlers.test.ts
@@ -11,6 +11,7 @@ import useResultsStore from "../ResultsStore";
 import useStatusStore from "../StatusStore";
 import useLogsStore from "../LogStore";
 import useErrorStore from "../ErrorStore";
+import useBudgetStore from "../BudgetStore";
 import { handleUpdate } from "../workflowUpdates";
 
 const mockAddNotification = jest.fn();
@@ -47,6 +48,7 @@ beforeEach(() => {
   useStatusStore.setState({ statuses: {} });
   useLogsStore.setState({ logs: [], logsByNode: {} });
   useErrorStore.setState({ errors: {} });
+  useBudgetStore.setState({ spent: 0, cap: 5, currency: "USD" });
   mockRunnerStore.setState.mockClear();
   mockAddNotification.mockClear();
   mockDequeueNextPendingRun.mockClear();
@@ -149,6 +151,32 @@ describe("handleUpdate", () => {
       amount: 12,
       unit: "credits"
     });
+  });
+
+  const usdCost = (nodeId: string, amount: number) =>
+    ({
+      type: "node_update",
+      node_id: nodeId,
+      node_name: nodeId,
+      node_type: "test.Node",
+      status: "completed",
+      provider_cost: { provider: "openai", amount, unit: "usd", currency: "USD" },
+      job_id: "job-1"
+    }) as unknown as NodeUpdate;
+
+  it("drives budget.spent from recorded provider costs", () => {
+    handleUpdate(mockWorkflow, usdCost("n1", 0.5), mockRunnerStore as never, () => undefined);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(0.5);
+
+    handleUpdate(mockWorkflow, usdCost("n2", 0.25), mockRunnerStore as never, () => undefined);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(0.75);
+  });
+
+  it("recomputes spent from source, so a re-emitted cost is not double counted", () => {
+    handleUpdate(mockWorkflow, usdCost("n1", 0.5), mockRunnerStore as never, () => undefined);
+    // Same node emits its provider_cost again (e.g. a reconciled charge).
+    handleUpdate(mockWorkflow, usdCost("n1", 0.5), mockRunnerStore as never, () => undefined);
+    expect(useBudgetStore.getState().spent).toBeCloseTo(0.5);
   });
 
   it("stores output result on output_update", () => {

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -48,6 +48,7 @@ import { getRunSignature, clearRunSignatures } from "./runSignatures";
 import { computeStampSignature } from "../utils/computeRunSignatures";
 import { getNodeGenerations } from "./nodeGenerationAccessor";
 import useMetadataStore from "./MetadataStore";
+import { syncBudgetSpentFromProviderCosts } from "../hooks/useLiveRunCost";
 
 /**
  * Pending audio-chunk store appends, coalesced per node and flushed on a
@@ -1160,6 +1161,11 @@ export const handleUpdate = (
           update.node_id,
           update.provider_cost
         );
+        // Reflect real recorded provider spend into the session budget so the
+        // over-budget banner and the ticker's "remaining" are meaningful.
+        // Recompute from ResultsStore (source of truth) to stay idempotent if a
+        // node re-emits its provider_cost.
+        syncBudgetSpentFromProviderCosts();
       }
 
       if (jobId) {

--- a/web/src/utils/aiModelNodes.ts
+++ b/web/src/utils/aiModelNodes.ts
@@ -30,3 +30,37 @@ export function nodeMetadataUsesAiModel(
     prop.type?.type ? PROVIDER_MODEL_TYPES.has(prop.type.type) : false
   );
 }
+
+/**
+ * Property names that multiply a node's output count (fan-out), in priority
+ * order — the first one present with a valid value wins. Confirmed against the
+ * generator manifests: `num_images` (280 FAL endpoints), `num_outputs` (33
+ * Replicate models), plus `num_samples` and `batch_size` (both FAL + Replicate).
+ * `num_frames` is deliberately excluded: it sets the length of a single video,
+ * not a batch of separate outputs.
+ */
+export const FAN_OUT_PROPERTY_NAMES = [
+  "num_images",
+  "num_outputs",
+  "num_samples",
+  "batch_size"
+] as const;
+
+/**
+ * Expected number of outputs a node produces, read from its data. Returns the
+ * first fan-out property present with a finite value greater than zero (floored
+ * to a whole count); otherwise 1. Conservative by design — an absent or invalid
+ * count falls back to a single output so the estimate never over-counts.
+ */
+export function nodeExpectedQuantity(
+  data: Record<string, unknown> | undefined
+): number {
+  if (!data) return 1;
+  for (const name of FAN_OUT_PROPERTY_NAMES) {
+    const value = data[name];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.floor(value);
+    }
+  }
+  return 1;
+}


### PR DESCRIPTION
## Summary

The cost-estimate panel had several pieces that were wired up in the UI but never connected to any data, so they didn't actually do anything. This connects them.

| # | Issue | Fix |
|---|-------|-----|
| 1 | `budget.spent` was stuck at `0` — `addSpent`/`reset` were defined but never called, so the over-budget banner and "remaining" compared against zero | Recompute `budget.spent` from `ResultsStore` provider costs on every `provider_cost` update (recompute-from-source is idempotent, so a node re-emitting its cost never double-counts). Adds a `setSpent` action and a subtle **Reset spent** link in the ticker popover. |
| 2 | The **draft-mode** toggle was inert — nothing read `draftMode` | The toggle now changes the **estimate**: `draft` assumes one preview per node; `off`/`final` use each node's configured output count. A caption states it affects the estimate only. Runner routing is intentionally unchanged. |
| 3 | Fan-out was never applied — a node set to produce N outputs was estimated as 1 | Derive an expected output count per node from its data (`num_images`, `num_outputs`, `num_samples`, `batch_size`, in priority order; conservative — unknown ⇒ 1) and pass it as `quantities` to the estimator. |
| 4 | The `CostTicker` in Global Chat read **$0** for chat-initiated runs | Chat runs stream `node_update`s over the chat socket, not the editor pipeline, so their provider costs never reached `ResultsStore`. Register the run and record its costs from `GlobalChatStore` under the workflow id the ticker is mounted with. |

### Not changed (deliberate)
- **Budget enforcement** stays advisory (a warning banner) — runs are not gated. Hard-blocking execution is a behavior change left for a separate decision; after #1 the banner is now accurate, which is the meaningful part.
- **kie credit-priced nodes without a USD conversion** remain reported as `unknown` and excluded from the total (existing, correct behavior — surfaced via `unknown_count`).

## Changes

- `web/src/stores/BudgetStore.ts` — add `setSpent(total)` (idempotent, guarded).
- `web/src/hooks/useLiveRunCost.ts` — add `sumSessionProviderSpend` + `syncBudgetSpentFromProviderCosts` helpers.
- `web/src/stores/workflowUpdates.ts` — sync budget spend after recording a provider cost (editor path).
- `web/src/stores/GlobalChatStore.ts` — `captureChatRunSpend`: register run + record provider costs for chat-initiated runs.
- `web/src/components/costs/CostTicker.tsx` — "Reset spent" control.
- `web/src/utils/aiModelNodes.ts` — `nodeExpectedQuantity` + `FAN_OUT_PROPERTY_NAMES`.
- `web/src/hooks/useWorkflowCostEstimate.ts` — pass per-node `quantities`; branch on `draftMode`.
- `web/src/components/costs/WorkflowCostEstimatePanel.tsx` — draft-mode caption.
- Tests: `BudgetStore.test.ts` (new), `workflowUpdates.handlers.test.ts`, `useWorkflowCostEstimate.test.tsx`.

## Testing

- `web` typecheck: clean on all changed files. (The suite still reports pre-existing `lexical`/`@lexical/react` duplicate-type errors from the `@lexical/react` `^0.47` vs `lexical` `^0.46` skew on `main` — unrelated to this PR.)
- `web` lint: clean on all changed files.
- Jest: 47 passing across the cost/budget/estimate suites, including new budget-drive, idempotency, fan-out, and draft-mode cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkAhJzVhxFwtJWoNJcf84A

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkAhJzVhxFwtJWoNJcf84A)_