### PR TITLE
Add a render queue overlay to the storyboard surface

### DIFF
--- a/web/src/components/menus/__tests__/ProviderCard.test.tsx
+++ b/web/src/components/menus/__tests__/ProviderCard.test.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
 
 import { ProviderCard } from "../APIKeysTab";
 import type { SecretResponse } from "../../../stores/ApiTypes";
@@ -56,7 +57,7 @@ const plainMeta = {
 
 const renderCard = (meta: typeof oauthMeta | typeof plainMeta, isConfigured = false) =>
   render(
-    <ThemeProvider theme={createTheme({ cssVariables: true })}>
+    <ThemeProvider theme={mockTheme}>
       <ProviderCard
         secret={secret(isConfigured)}
         meta={meta}

--- a/web/src/components/storyboard/StoryboardQueueOverlay.tsx
+++ b/web/src/components/storyboard/StoryboardQueueOverlay.tsx
@@ -1,0 +1,470 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * StoryboardQueueOverlay
+ *
+ * Floating render queue for the Storyboard surface, mirroring the node
+ * editor's {@link QueueOverlay}: shows the board's still and clip jobs that
+ * are queued or rendering, with per-job cancel and a cancel-all action.
+ * Collapses to a compact summary bar and hides entirely when the board is
+ * idle.
+ */
+import { css, keyframes } from "@emotion/react";
+import { useTheme, type Theme } from "@mui/material/styles";
+import { memo, useCallback, useMemo, useState } from "react";
+import {
+  Box,
+  FlexColumn,
+  FlexRow,
+  Text,
+  Tooltip,
+  MOTION,
+  reducedMotion,
+  BORDER_RADIUS
+} from "../ui_primitives";
+import type { SxProps } from "@mui/material/styles";
+import TheatersIcon from "@mui/icons-material/Theaters";
+import PlayArrowOutlinedIcon from "@mui/icons-material/PlayArrowOutlined";
+import ScheduleIcon from "@mui/icons-material/Schedule";
+import RemoveIcon from "@mui/icons-material/Remove";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import CloseIcon from "@mui/icons-material/Close";
+import { trpcClient } from "../../trpc/client";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import {
+  useStoryboardGenerationStore,
+  settleCancelledShotJob,
+  type ShotJobKind,
+  type ShotJobState
+} from "../../stores/storyboard/StoryboardGenerationStore";
+
+interface StoryboardQueueOverlayProps {
+  boardId: string;
+}
+
+interface JobRow extends ShotJobState {
+  /** "1. Slug" display name resolved from the board's shots. */
+  name: string;
+  index: number;
+}
+
+const KIND_LABEL: Record<ShotJobKind, string> = {
+  keyframe: "Still",
+  clip: "Clip"
+};
+
+const sweep = keyframes`
+  0% { transform: translateX(-110%); }
+  100% { transform: translateX(320%); }
+`;
+
+const panelEnter = keyframes`
+  from { opacity: 0; transform: translateY(6px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+`;
+
+const progressStyles = (theme: Theme) =>
+  css({
+    position: "relative",
+    height: "4px",
+    borderRadius: BORDER_RADIUS.pill,
+    overflow: "hidden",
+    backgroundColor: theme.vars.palette.c_overlay,
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      inset: 0,
+      width: "35%",
+      borderRadius: "inherit",
+      background: `linear-gradient(90deg, ${theme.vars.palette.primary.main}, ${theme.vars.palette.secondary.main})`,
+      animation: `${sweep} ${MOTION.pulse} infinite`
+    },
+    ...reducedMotion({
+      "&::after": { animation: "none", width: "100%", opacity: 0.5 }
+    })
+  });
+
+/**
+ * Progress bar under a rendering job: determinate when the run reports
+ * progress, an indeterminate sweep otherwise.
+ */
+const RenderBar = memo(function RenderBar({ progress }: { progress?: number }) {
+  const theme = useTheme();
+  if (typeof progress === "number" && progress > 0 && progress < 100) {
+    return (
+      <Box
+        sx={{
+          position: "relative",
+          height: "4px",
+          borderRadius: BORDER_RADIUS.pill,
+          overflow: "hidden",
+          backgroundColor: theme.vars.palette.c_overlay
+        }}
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            width: `${progress}%`,
+            borderRadius: "inherit",
+            background: `linear-gradient(90deg, ${theme.vars.palette.primary.main}, ${theme.vars.palette.secondary.main})`,
+            transition: `width ${MOTION.normal}`
+          }}
+        />
+      </Box>
+    );
+  }
+  return <Box css={progressStyles(theme)} />;
+});
+
+const cardSx: SxProps<Theme> = {
+  backgroundColor: "grey.800",
+  border: "1px solid var(--palette-c_overlay)",
+  borderRadius: BORDER_RADIUS.lg,
+  px: 1.5,
+  py: 1
+};
+
+const Dot = ({ color = "primary.main" }: { color?: string }) => (
+  <Box
+    sx={{
+      width: 8,
+      height: 8,
+      flex: "0 0 auto",
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: color
+    }}
+  />
+);
+
+const IconButton = ({
+  icon,
+  label,
+  onClick,
+  hoverColor = "text.primary"
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  hoverColor?: string;
+}) => (
+  <Tooltip title={label}>
+    <Box
+      component="button"
+      aria-label={label}
+      onClick={onClick}
+      sx={{
+        display: "flex",
+        flex: "0 0 auto",
+        border: "none",
+        background: "transparent",
+        color: "text.secondary",
+        cursor: "pointer",
+        p: 0.25,
+        borderRadius: BORDER_RADIUS.sm,
+        "&:hover": { color: hoverColor }
+      }}
+    >
+      {icon}
+    </Box>
+  </Tooltip>
+);
+
+const KindTag = ({ kind }: { kind: ShotJobKind }) => (
+  <Text
+    size="smaller"
+    color="secondary"
+    family="secondary"
+    sx={{ flex: "0 0 auto", textTransform: "uppercase", letterSpacing: "0.05em" }}
+  >
+    {KIND_LABEL[kind]}
+  </Text>
+);
+
+const RenderingCard = memo(function RenderingCard({
+  row,
+  onCancel
+}: {
+  row: JobRow;
+  onCancel: (shotId: string) => void;
+}) {
+  return (
+    <Box sx={cardSx}>
+      <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+        <Dot />
+        <Text size="small" weight={500} truncate sx={{ flex: 1, minWidth: 0 }}>
+          {row.name}
+        </Text>
+        <KindTag kind={row.kind} />
+        <IconButton
+          icon={<CloseIcon sx={{ fontSize: 15 }} />}
+          label="Cancel render"
+          onClick={() => onCancel(row.shotId)}
+          hoverColor="error.main"
+        />
+      </FlexRow>
+      <Box sx={{ mt: 1 }}>
+        <RenderBar progress={row.progress} />
+      </Box>
+    </Box>
+  );
+});
+
+const EnqueuedCard = memo(function EnqueuedCard({
+  row,
+  position,
+  onCancel
+}: {
+  row: JobRow;
+  position: number;
+  onCancel: (shotId: string) => void;
+}) {
+  return (
+    <Box sx={cardSx}>
+      <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+        <Text
+          size="smaller"
+          color="secondary"
+          family="secondary"
+          sx={{ flex: "0 0 auto" }}
+        >
+          #{position + 1}
+        </Text>
+        <Text size="small" truncate sx={{ flex: 1, minWidth: 0 }}>
+          {row.name}
+        </Text>
+        <KindTag kind={row.kind} />
+        <IconButton
+          icon={<CloseIcon sx={{ fontSize: 15 }} />}
+          label="Remove from queue"
+          onClick={() => onCancel(row.shotId)}
+          hoverColor="error.main"
+        />
+      </FlexRow>
+    </Box>
+  );
+});
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <Text
+    size="smaller"
+    color="secondary"
+    weight={600}
+    sx={{
+      display: "block",
+      px: 0.5,
+      pt: 2,
+      pb: 1,
+      textTransform: "uppercase",
+      letterSpacing: "0.07em"
+    }}
+  >
+    {children}
+  </Text>
+);
+
+const HeaderCount = ({
+  icon,
+  count
+}: {
+  icon: React.ReactNode;
+  count: number;
+}) => (
+  <FlexRow align="center" gap={0.4} sx={{ color: "text.secondary" }}>
+    {icon}
+    <Text size="smaller" color="secondary" family="secondary">
+      {count}
+    </Text>
+  </FlexRow>
+);
+
+const overlayStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    bottom: "16px",
+    right: "16px",
+    width: "304px",
+    maxHeight: "min(420px, calc(100% - 32px))",
+    display: "flex",
+    flexDirection: "column",
+    zIndex: theme.zIndex.drawer,
+    backgroundColor: theme.vars.palette.grey[900],
+    border: `1px solid ${theme.vars.palette.grey[800]}`,
+    borderRadius: BORDER_RADIUS.xl,
+    boxShadow: `0 8px 24px ${theme.vars.palette.c_scrim}, 0 0 0 1px ${theme.vars.palette.c_overlay_subtle}`,
+    overflow: "hidden",
+    transformOrigin: "bottom right",
+    animation: `${panelEnter} ${MOTION.normal} both`,
+    ...reducedMotion({
+      animation: "none",
+      opacity: 1,
+      transform: "none"
+    })
+  });
+
+const StoryboardQueueOverlay = memo(function StoryboardQueueOverlay({
+  boardId
+}: StoryboardQueueOverlayProps) {
+  const theme = useTheme();
+  const [expanded, setExpanded] = useState(false);
+
+  const shots = useStoryboardStore((state) => state.boards[boardId]?.shots);
+  const shotJobs = useStoryboardGenerationStore((state) => state.shotJobs);
+
+  const { rendering, queued } = useMemo(() => {
+    const byId = new Map((shots ?? []).map((s) => [s.id, s]));
+    const rows: JobRow[] = Object.values(shotJobs)
+      .filter((job) => job.boardId === boardId)
+      .map((job) => {
+        const shot = byId.get(job.shotId);
+        return {
+          ...job,
+          name: shot
+            ? `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`
+            : "Shot",
+          index: shot?.index ?? Number.MAX_SAFE_INTEGER
+        };
+      })
+      .sort((a, b) => a.index - b.index);
+    return {
+      rendering: rows.filter((row) => row.status === "running"),
+      queued: rows.filter((row) => row.status === "queued")
+    };
+  }, [shotJobs, shots, boardId]);
+
+  const handleCancel = useCallback(async (shotId: string) => {
+    const job = useStoryboardGenerationStore.getState().shotJobs[shotId];
+    if (!job) {
+      return;
+    }
+    try {
+      await trpcClient.jobs.cancel.mutate({ id: job.jobId });
+      // Settle immediately rather than waiting for the cancelled job_update —
+      // a job cancelled before it starts may never emit one.
+      settleCancelledShotJob(shotId);
+    } catch (err) {
+      // Keep tracking the job: if the cancel failed because the run already
+      // finished, the completion message settles the shot on its own.
+      console.error("Failed to cancel storyboard render:", err);
+    }
+  }, []);
+
+  const handleCancelAll = useCallback(() => {
+    for (const row of [...rendering, ...queued]) {
+      void handleCancel(row.shotId);
+    }
+  }, [rendering, queued, handleCancel]);
+
+  if (rendering.length === 0 && queued.length === 0) {
+    return null;
+  }
+
+  if (!expanded) {
+    const single = rendering.length === 1 ? rendering[0] : null;
+    return (
+      <Box css={overlayStyles(theme)}>
+        <FlexColumn gap={1} sx={{ p: 1.5 }}>
+          <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+            <Dot color={rendering.length ? "primary.main" : "grey.600"} />
+            <Text
+              size="small"
+              weight={500}
+              truncate
+              sx={{ flex: 1, minWidth: 0 }}
+            >
+              {single
+                ? single.name
+                : rendering.length
+                  ? `${rendering.length} shots rendering`
+                  : "Render queue"}
+            </Text>
+            {single && <KindTag kind={single.kind} />}
+            <IconButton
+              icon={<KeyboardArrowUpIcon sx={{ fontSize: 18 }} />}
+              label="Expand render queue"
+              onClick={() => setExpanded(true)}
+            />
+          </FlexRow>
+          {rendering.length > 0 && (
+            <RenderBar progress={single?.progress} />
+          )}
+          {queued.length > 0 && (
+            <FlexRow align="center" gap={0.5} sx={{ color: "text.secondary" }}>
+              <ScheduleIcon sx={{ fontSize: 13 }} />
+              <Text size="smaller" color="secondary">
+                {queued.length} queued
+              </Text>
+            </FlexRow>
+          )}
+        </FlexColumn>
+      </Box>
+    );
+  }
+
+  return (
+    <Box css={overlayStyles(theme)}>
+      <FlexRow align="center" gap={1} sx={{ px: 2, py: 1.5, flex: "0 0 auto" }}>
+        <TheatersIcon sx={{ fontSize: 17, color: "text.secondary" }} />
+        <Text size="normal" weight={600} sx={{ flex: 1 }}>
+          Render queue
+        </Text>
+        <FlexRow align="center" gap={1.25}>
+          <HeaderCount
+            icon={<PlayArrowOutlinedIcon sx={{ fontSize: 15 }} />}
+            count={rendering.length}
+          />
+          <HeaderCount
+            icon={<ScheduleIcon sx={{ fontSize: 14 }} />}
+            count={queued.length}
+          />
+        </FlexRow>
+        <IconButton
+          icon={<CloseIcon sx={{ fontSize: 15 }} />}
+          label="Cancel all renders"
+          onClick={handleCancelAll}
+          hoverColor="error.main"
+        />
+        <IconButton
+          icon={<RemoveIcon sx={{ fontSize: 16 }} />}
+          label="Collapse render queue"
+          onClick={() => setExpanded(false)}
+        />
+      </FlexRow>
+
+      <Box sx={{ flex: 1, minHeight: 0, overflow: "auto", px: 2, pb: 2 }}>
+        {rendering.length > 0 && (
+          <>
+            <SectionLabel>Rendering</SectionLabel>
+            <FlexColumn gap={1}>
+              {rendering.map((row) => (
+                <RenderingCard
+                  key={row.jobId}
+                  row={row}
+                  onCancel={handleCancel}
+                />
+              ))}
+            </FlexColumn>
+          </>
+        )}
+        {queued.length > 0 && (
+          <>
+            <SectionLabel>Enqueued</SectionLabel>
+            <FlexColumn gap={1}>
+              {queued.map((row, position) => (
+                <EnqueuedCard
+                  key={row.jobId}
+                  row={row}
+                  position={position}
+                  onCancel={handleCancel}
+                />
+              ))}
+            </FlexColumn>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+});
+
+StoryboardQueueOverlay.displayName = "StoryboardQueueOverlay";
+
+export default StoryboardQueueOverlay;

--- a/web/src/components/storyboard/__tests__/StoryboardQueueOverlay.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardQueueOverlay.test.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    ensureConnection: jest.fn().mockResolvedValue(undefined),
+    subscribe: jest.fn().mockReturnValue(() => {}),
+    send: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: { jobs: { cancel: { mutate: jest.fn().mockResolvedValue({}) } } }
+}));
+
+import StoryboardQueueOverlay from "../StoryboardQueueOverlay";
+import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
+import { useStoryboardGenerationStore } from "../../../stores/storyboard/StoryboardGenerationStore";
+import { trpcClient } from "../../../trpc/client";
+
+const mockCancel = trpcClient.jobs.cancel.mutate as jest.Mock;
+
+const BOARD = "qo-board";
+
+const seedShot = (id: string, index: number, slug: string): void => {
+  const store = useStoryboardStore.getState();
+  store.ensureBoard(BOARD);
+  store.upsertShot(BOARD, {
+    type: "shot",
+    id,
+    index,
+    slug,
+    action: "test action",
+    status: "planned"
+  } as never);
+};
+
+const renderOverlay = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <StoryboardQueueOverlay boardId={BOARD} />
+    </ThemeProvider>
+  );
+
+describe("StoryboardQueueOverlay", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useStoryboardGenerationStore.setState({
+      shotJobs: {},
+      jobToShot: {},
+      generatingShotIds: [],
+      failedShotIds: []
+    });
+  });
+
+  it("renders nothing when the board has no active jobs", () => {
+    seedShot("s-idle", 0, "Opening");
+    const { container } = renderOverlay();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("collapsed: summarizes a single rendering shot with its kind", () => {
+    seedShot("s1", 0, "Opening");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s1", BOARD, "job-1", "wf-1", "keyframe");
+    gen.updateJobStatus("job-1", "running");
+
+    renderOverlay();
+    expect(screen.getByText("1. Opening")).toBeInTheDocument();
+    expect(screen.getByText("Still")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /expand render queue/i })
+    ).toBeInTheDocument();
+  });
+
+  it("expands into Rendering and Enqueued sections", () => {
+    seedShot("s1", 0, "Opening");
+    seedShot("s2", 1, "Chase");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s1", BOARD, "job-1", "wf-1", "keyframe");
+    gen.updateJobStatus("job-1", "running");
+    gen.registerJob("s2", BOARD, "job-2", "wf-2", "clip");
+
+    renderOverlay();
+    fireEvent.click(
+      screen.getByRole("button", { name: /expand render queue/i })
+    );
+
+    expect(screen.getByText("Rendering")).toBeInTheDocument();
+    expect(screen.getByText("Enqueued")).toBeInTheDocument();
+    expect(screen.getByText("1. Opening")).toBeInTheDocument();
+    expect(screen.getByText("2. Chase")).toBeInTheDocument();
+  });
+
+  it("cancels a queued job and settles the shot", async () => {
+    seedShot("s1", 0, "Opening");
+    seedShot("s2", 1, "Chase");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s1", BOARD, "job-1", "wf-1", "keyframe");
+    gen.updateJobStatus("job-1", "running");
+    gen.registerJob("s2", BOARD, "job-2", "wf-2", "clip");
+
+    renderOverlay();
+    fireEvent.click(
+      screen.getByRole("button", { name: /expand render queue/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove from queue/i }));
+
+    await waitFor(() =>
+      expect(mockCancel).toHaveBeenCalledWith({ id: "job-2" })
+    );
+    await waitFor(() =>
+      expect(
+        useStoryboardGenerationStore.getState().shotJobs["s2"]
+      ).toBeUndefined()
+    );
+    const shot = useStoryboardStore
+      .getState()
+      .getBoard(BOARD)
+      ?.shots.find((s) => s.id === "s2");
+    expect(shot?.status).toBe("approved");
+  });
+
+  it("cancels every active job via Cancel all", async () => {
+    seedShot("s1", 0, "Opening");
+    seedShot("s2", 1, "Chase");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s1", BOARD, "job-1", "wf-1", "keyframe");
+    gen.updateJobStatus("job-1", "running");
+    gen.registerJob("s2", BOARD, "job-2", "wf-2", "clip");
+
+    renderOverlay();
+    fireEvent.click(
+      screen.getByRole("button", { name: /expand render queue/i })
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /cancel all renders/i })
+    );
+
+    await waitFor(() => expect(mockCancel).toHaveBeenCalledTimes(2));
+    expect(mockCancel).toHaveBeenCalledWith({ id: "job-1" });
+    expect(mockCancel).toHaveBeenCalledWith({ id: "job-2" });
+  });
+
+  it("keeps tracking a job when the cancel call fails", async () => {
+    seedShot("s1", 0, "Opening");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s1", BOARD, "job-1", "wf-1", "keyframe");
+    gen.updateJobStatus("job-1", "running");
+    mockCancel.mockRejectedValueOnce(new Error("nope"));
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    renderOverlay();
+    fireEvent.click(
+      screen.getByRole("button", { name: /expand render queue/i })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel render/i }));
+
+    await waitFor(() => expect(mockCancel).toHaveBeenCalled());
+    expect(
+      useStoryboardGenerationStore.getState().shotJobs["s1"]?.status
+    ).toBe("running");
+    consoleSpy.mockRestore();
+  });
+});

--- a/web/src/components/workspace/StoryboardSurface.tsx
+++ b/web/src/components/workspace/StoryboardSurface.tsx
@@ -12,6 +12,7 @@ import { useStoryboardServerSync } from "../../hooks/storyboard/useStoryboardSer
 import { useAssembleTimeline } from "../../hooks/storyboard/useAssembleTimeline";
 import StoryboardBoard from "../storyboard/StoryboardBoard";
 import StoryboardSidebar from "../storyboard/StoryboardSidebar";
+import StoryboardQueueOverlay from "../storyboard/StoryboardQueueOverlay";
 
 interface StoryboardSurfaceProps {
   refId: string;
@@ -64,8 +65,16 @@ const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
   }, [assemble, refId]);
 
   return (
-    <div style={{ display: "flex", height: "100%", minHeight: 0 }}>
+    <div
+      style={{
+        display: "flex",
+        height: "100%",
+        minHeight: 0,
+        position: "relative"
+      }}
+    >
       {mode !== "view" && <StoryboardSidebar activeBoardId={refId} />}
+      <StoryboardQueueOverlay boardId={refId} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <StoryboardBoard
           boardId={refId}

--- a/web/src/stores/storyboard/StoryboardGenerationStore.ts
+++ b/web/src/stores/storyboard/StoryboardGenerationStore.ts
@@ -15,7 +15,7 @@
 
 import { useEffect } from "react";
 import { create } from "zustand";
-import type { ImageRef, VideoRef } from "@nodetool-ai/protocol";
+import type { ImageRef, ShotStatus, VideoRef } from "@nodetool-ai/protocol";
 import {
   globalWebSocketManager,
   type WebSocketMessage
@@ -309,6 +309,36 @@ const extractAssetId = (value: unknown): string | undefined => {
   return undefined;
 };
 
+/**
+ * Settle a shot whose job was cancelled: restore the shot's status from what
+ * it already holds (a kept keyframe/clip beats resetting to planned), drop
+ * the job from the store, and tear down the WebSocket subscription. Safe to
+ * call for a shot with no tracked job.
+ */
+export const settleCancelledShotJob = (shotId: string): void => {
+  const job = useStoryboardGenerationStore.getState().shotJobs[shotId];
+  if (!job) {
+    return;
+  }
+  const storyboard = useStoryboardStore.getState();
+  const shot = storyboard
+    .getBoard(job.boardId)
+    ?.shots.find((s) => s.id === shotId);
+  if (shot) {
+    const status: ShotStatus =
+      job.kind === "keyframe"
+        ? shot.keyframe
+          ? "keyframe_ready"
+          : "planned"
+        : shot.clip
+          ? "rendered"
+          : "approved";
+    storyboard.setShotStatus(job.boardId, shotId, status);
+  }
+  useStoryboardGenerationStore.getState().clear(shotId);
+  unsubscribeShotJob(job.jobId);
+};
+
 export const unsubscribeShotJob = (jobId: string): void => {
   const unsubscribe = jobSubscriptions.get(jobId);
   if (unsubscribe) {
@@ -439,7 +469,9 @@ const handleShotJobMessage = (jobId: string, message: WebSocketMessage): void =>
   }
 
   if (status === "cancelled") {
-    generationStore.clear(context.shotId);
+    // Settle restores the shot's status (a cancelled regenerate keeps its
+    // existing still/clip) besides clearing the job and subscription.
+    settleCancelledShotJob(context.shotId);
     unsubscribeShotJob(jobId);
   }
 };

--- a/web/src/stores/storyboard/__tests__/StoryboardGenerationStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardGenerationStore.test.ts
@@ -15,6 +15,7 @@ jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
 
 import {
   useStoryboardGenerationStore,
+  settleCancelledShotJob,
   __handleShotJobMessageForTests,
   __resetStoryboardSubscriptionsForTests,
   type StoryboardJobContext
@@ -97,6 +98,75 @@ describe("inline data outputs", () => {
     expect(
       useStoryboardGenerationStore.getState().failedShotIds
     ).not.toContain("s-vid");
+  });
+});
+
+describe("cancelled jobs", () => {
+  it("settles a cancelled keyframe job back to planned when the shot has no still", () => {
+    seedShot("s-cxl");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s-cxl", BOARD, "job-cxl", "wf", "keyframe");
+
+    __handleShotJobMessageForTests("job-cxl", context("s-cxl", "keyframe"), {
+      type: "job_update",
+      status: "cancelled"
+    } as never);
+
+    const shot = useStoryboardStore
+      .getState()
+      .getBoard(BOARD)
+      ?.shots.find((s) => s.id === "s-cxl");
+    expect(shot?.status).toBe("planned");
+    expect(
+      useStoryboardGenerationStore.getState().shotJobs["s-cxl"]
+    ).toBeUndefined();
+  });
+
+  it("keeps an existing still when a cancelled regenerate settles", () => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    store.upsertShot(BOARD, {
+      type: "shot",
+      id: "s-regen",
+      index: 0,
+      action: "test shot",
+      status: "keyframe_ready",
+      keyframe: { type: "image", uri: "asset://still" }
+    } as never);
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s-regen", BOARD, "job-regen", "wf", "keyframe");
+
+    settleCancelledShotJob("s-regen");
+
+    const shot = useStoryboardStore
+      .getState()
+      .getBoard(BOARD)
+      ?.shots.find((s) => s.id === "s-regen");
+    expect(shot?.status).toBe("keyframe_ready");
+    expect(shot?.keyframe?.uri).toBe("asset://still");
+  });
+
+  it("settles a cancelled clip job back to approved", () => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    store.upsertShot(BOARD, {
+      type: "shot",
+      id: "s-clip-cxl",
+      index: 0,
+      action: "test shot",
+      status: "approved",
+      keyframe: { type: "image", uri: "asset://still" }
+    } as never);
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s-clip-cxl", BOARD, "job-clip-cxl", "wf", "clip");
+
+    settleCancelledShotJob("s-clip-cxl");
+
+    const shot = useStoryboardStore
+      .getState()
+      .getBoard(BOARD)
+      ?.shots.find((s) => s.id === "s-clip-cxl");
+    expect(shot?.status).toBe("approved");
   });
 });
 


### PR DESCRIPTION
Mirrors the node editor's `QueueOverlay` for storyboard still and clip rendering, so you can see what's in flight on a board and cancel it.

## What's new

- **`StoryboardQueueOverlay`** (`web/src/components/storyboard/`): a floating panel on the storyboard surface, bottom-right, driven by `StoryboardGenerationStore`. Collapsed it shows a one-line summary (the shot name for a single render, a count otherwise, plus queued total) with a progress bar; expanded it lists **Rendering** and **Enqueued** sections with the shot name (`1. Slug`), a Still/Clip tag, and per-job progress (determinate when the run reports it, indeterminate sweep otherwise). Hides entirely when the board is idle.
- **Cancel**: each row has a cancel button, and the expanded header has **Cancel all renders**. Cancelling calls `jobs.cancel` and settles the shot immediately (a queued job may never emit a `cancelled` job_update). On a failed cancel call the job stays tracked so a completed run can still settle normally.
- **`settleCancelledShotJob`** in `StoryboardGenerationStore`: restores the shot's status from what it already holds — a cancelled regenerate keeps its existing still (`keyframe_ready`) or clip (`rendered`) instead of resetting to `planned`/`approved` — then clears the job and tears down the WebSocket subscription.
- **Bug fix**: the WebSocket `cancelled` branch previously only cleared the job, leaving the shot stuck on "Generating still…"/"Rendering…" when a storyboard job was cancelled from the editor's queue overlay. It now settles through the same helper.

## Tests

- New `StoryboardQueueOverlay.test.tsx`: hidden when idle, collapsed summary, expanded sections, per-job cancel (verifies the store settles and the shot status is restored), cancel-all, and failed-cancel keeps tracking.
- Extended `StoryboardGenerationStore.test.ts` with cancelled-settle coverage for keyframe, regenerate-with-existing-still, and clip jobs.

`npm run typecheck` (web) passes, eslint on changed files is clean, and all storyboard + QueueOverlay suites pass (10 suites, 56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkH6wmNPhKcwKLkRmPFK46

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkH6wmNPhKcwKLkRmPFK46)_