### PR TITLE
feat(image-nodes): add anchor and fill color to CanvasResize node

### DIFF
--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -49,7 +49,7 @@ import {
   mixerOverV1
 } from "@nodetool-ai/gpu/pool";
 import { IS_NODE } from "@nodetool-ai/config";
-import { runShaderNode, runRecipeNode } from "./lib-shader-utils.js";
+import { runShaderNode, runRecipeNode, colorValueToVec4, premultiplyVec4 } from "./lib-shader-utils.js";
 import {
   decodeRgba,
   rawRgbaImageRef,
@@ -1196,16 +1196,35 @@ export class ResizeNode extends TransformImageNode {
   }
 }
 
+function anchorOffset(
+  anchor: string,
+  canvasW: number,
+  canvasH: number,
+  srcW: number,
+  srcH: number
+): [number, number] {
+  let x: number;
+  let y: number;
+  if (anchor.includes("left")) x = 0;
+  else if (anchor.includes("right")) x = canvasW - srcW;
+  else x = Math.floor((canvasW - srcW) / 2);
+  if (anchor.includes("top")) y = 0;
+  else if (anchor.includes("bottom")) y = canvasH - srcH;
+  else y = Math.floor((canvasH - srcH) / 2);
+  return [x, y];
+}
+
 export class CanvasResizeNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.CanvasResize";
   static readonly title = "Canvas Resize";
   static readonly description =
-    "Expand the canvas around an image without scaling its pixels.\n    canvas, resize, pad, outpaint, expand";
+    "Expand the canvas around an image without scaling its pixels.\n    canvas, resize, pad, outpaint, expand, anchor";
   static readonly metadataOutputTypes = {
     output: "image"
   };
   static readonly inlineFields = [
     "mode",
+    "anchor",
     "width",
     "height",
     "scale",
@@ -1213,7 +1232,8 @@ export class CanvasResizeNode extends TransformImageNode {
     "top",
     "bottom",
     "left",
-    "right"
+    "right",
+    "color"
   ];
   static readonly inputFields = ["image"];
 
@@ -1239,6 +1259,26 @@ export class CanvasResizeNode extends TransformImageNode {
     description: "How to resize the canvas."
   })
   declare mode: any;
+
+  @prop({
+    type: "enum",
+    default: "center",
+    values: [
+      "top-left",
+      "top",
+      "top-right",
+      "left",
+      "center",
+      "right",
+      "bottom-left",
+      "bottom",
+      "bottom-right"
+    ],
+    title: "Anchor",
+    description:
+      "Where to place the original image on the new canvas (fixed/scale modes)."
+  })
+  declare anchor: any;
 
   @prop({
     type: "int",
@@ -1319,11 +1359,20 @@ export class CanvasResizeNode extends TransformImageNode {
   })
   declare right: any;
 
+  @prop({
+    type: "color",
+    default: { type: "color", value: "#00000000" },
+    title: "Fill Color",
+    description: "Background color for the expanded canvas area."
+  })
+  declare color: any;
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const image = (this.image ?? {}) as ImageRefLike;
     const { width: srcW, height: srcH } = await decodeRgba(image, context);
     if (!srcW || !srcH) return { output: image };
     const mode = String(this.mode ?? "padding");
+    const anchor = String(this.anchor ?? "center");
 
     let canvasW: number;
     let canvasH: number;
@@ -1333,14 +1382,12 @@ export class CanvasResizeNode extends TransformImageNode {
     if (mode === "fixed") {
       canvasW = Math.max(1, Math.floor(Number(this.width ?? srcW)));
       canvasH = Math.max(1, Math.floor(Number(this.height ?? srcH)));
-      offsetX = Math.floor((canvasW - srcW) / 2);
-      offsetY = Math.floor((canvasH - srcH) / 2);
+      [offsetX, offsetY] = anchorOffset(anchor, canvasW, canvasH, srcW, srcH);
     } else if (mode === "scale") {
       const scale = Number(this.scale ?? 0) > 0 ? Number(this.scale ?? 1) : 1;
       canvasW = Math.max(1, Math.round(srcW * scale));
       canvasH = Math.max(1, Math.round(srcH * scale));
-      offsetX = Math.floor((canvasW - srcW) / 2);
-      offsetY = Math.floor((canvasH - srcH) / 2);
+      [offsetX, offsetY] = anchorOffset(anchor, canvasW, canvasH, srcW, srcH);
     } else {
       const unit = String(this.padding_unit ?? "px");
       const toPx = (val: number, dim: number): number =>
@@ -1357,19 +1404,28 @@ export class CanvasResizeNode extends TransformImageNode {
       offsetY = top;
     }
 
-    // When the requested canvas is smaller than the source on an axis, padding
-    // alone can't shrink it — crop the source centrally to the canvas on that
-    // axis first (converting px → the crop shader's normalized-UV params the
-    // same way CropNode does), so fixed/scale modes always yield exactly
-    // canvasW × canvasH instead of silently returning the source size.
+    const [cr, cg, cb, ca] = premultiplyVec4(
+      colorValueToVec4(this.color, [0, 0, 0, 0])
+    );
+    const fillColor = d.vec4f(cr, cg, cb, ca);
+
+    // When the requested canvas is smaller than the source on an axis, crop
+    // the source to fit, anchored according to the anchor setting.
     let source: unknown = image;
     let baseW = srcW;
     let baseH = srcH;
     const cropW = Math.min(srcW, canvasW);
     const cropH = Math.min(srcH, canvasH);
     if (cropW < srcW || cropH < srcH) {
-      const cropX = Math.floor((srcW - cropW) / 2);
-      const cropY = Math.floor((srcH - cropH) / 2);
+      const [cropOffX, cropOffY] = anchorOffset(
+        anchor,
+        srcW,
+        srcH,
+        cropW,
+        cropH
+      );
+      const cropX = cropOffX;
+      const cropY = cropOffY;
       source = await runShaderNode(
         transformCropV1,
         {
@@ -1384,16 +1440,15 @@ export class CanvasResizeNode extends TransformImageNode {
       );
       baseW = cropW;
       baseH = cropH;
-      // Re-centre the placement against the cropped source so the pads below
-      // stay non-negative on every axis.
-      offsetX = Math.floor((canvasW - baseW) / 2);
-      offsetY = Math.floor((canvasH - baseH) / 2);
+      [offsetX, offsetY] = anchorOffset(
+        anchor,
+        canvasW,
+        canvasH,
+        baseW,
+        baseH
+      );
     }
 
-    // Pad placing the (possibly cropped) source at (offsetX, offsetY) in the
-    // larger canvas. The pad shader works in normalized-UV units relative to the
-    // source; output dims are derived from those (we also pass the absolute
-    // target as the host size).
     const leftPad = Math.max(0, offsetX);
     const topPad = Math.max(0, offsetY);
     const rightPad = Math.max(0, canvasW - baseW - offsetX);
@@ -1405,7 +1460,7 @@ export class CanvasResizeNode extends TransformImageNode {
         top: topPad / baseH,
         right: rightPad / baseW,
         bottom: bottomPad / baseH,
-        color: d.vec4f(0, 0, 0, 0)
+        color: fillColor
       },
       source,
       {

--- a/packages/image-nodes/tests/canvas-resize.test.ts
+++ b/packages/image-nodes/tests/canvas-resize.test.ts
@@ -77,4 +77,85 @@ describe("CanvasResizeNode", () => {
     expect(data[centerIdx]).toBeGreaterThan(200); // centre is red
     expect(data[3]).toBe(0); // top-left corner is transparent padding
   });
+
+  it("anchor top-left places source at top-left corner", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(4, 4, 255, 0, 0),
+      mode: "fixed",
+      width: 8,
+      height: 8,
+      anchor: "top-left"
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(8);
+    expect(output.height).toBe(8);
+    const data = output.data as Uint8Array;
+    // Top-left pixel should be the source (red)
+    expect(data[0]).toBeGreaterThan(200);
+    expect(data[3]).toBeGreaterThan(200);
+    // Bottom-right pixel should be padding (transparent)
+    const brIdx = (7 * 8 + 7) * 4;
+    expect(data[brIdx + 3]).toBe(0);
+  });
+
+  it("anchor bottom-right places source at bottom-right corner", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(4, 4, 255, 0, 0),
+      mode: "fixed",
+      width: 8,
+      height: 8,
+      anchor: "bottom-right"
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(8);
+    expect(output.height).toBe(8);
+    const data = output.data as Uint8Array;
+    // Top-left pixel should be padding (transparent)
+    expect(data[3]).toBe(0);
+    // Bottom-right area should be the source (red)
+    const brIdx = (7 * 8 + 7) * 4;
+    expect(data[brIdx]).toBeGreaterThan(200);
+    expect(data[brIdx + 3]).toBeGreaterThan(200);
+  });
+
+  it("fill color applies to expanded area", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(4, 4, 255, 0, 0),
+      mode: "fixed",
+      width: 8,
+      height: 8,
+      color: { type: "color", value: "#0000FFFF" }
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(8);
+    expect(output.height).toBe(8);
+    const data = output.data as Uint8Array;
+    // Top-left corner should be blue fill (not transparent)
+    expect(data[2]).toBeGreaterThan(200); // blue channel
+    expect(data[3]).toBeGreaterThan(200); // alpha
+  });
+
+  it("padding percent mode with fill color", async () => {
+    const node = new CanvasResizeNode();
+    node.assign({
+      image: await makeTestImage(10, 10),
+      mode: "padding",
+      padding_unit: "percent",
+      top: 50,
+      bottom: 50,
+      left: 50,
+      right: 50,
+      color: { type: "color", value: "#FF0000FF" }
+    });
+    const result = await node.process();
+    const output = result.output as Record<string, unknown>;
+    expect(output.width).toBe(20);
+    expect(output.height).toBe(20);
+  });
 });


### PR DESCRIPTION
Closes #3540

The CanvasResizeNode already supported three modes (fixed, scale, padding with px/percent) but was missing two standard features:

- **Anchor**: 9-point alignment grid for image placement in fixed/scale modes
- **Fill Color**: configurable background color for expanded canvas area

Generated with [Claude Code](https://claude.ai/code)