### PR TITLE
Add Render 3D To Image node (nodetool.model3d.RenderToImage)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53484,11 +53484,17 @@
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/runtime": "*",
         "@nodetool-ai/timeline": "*",
+        "chrome-launcher": "^1.2.0",
+        "chrome-remote-interface": "^0.34.0",
         "manifold-3d": "^3.4.1",
-        "meshoptimizer": "^1.1.1"
+        "meshoptimizer": "^1.1.1",
+        "three": "^0.185.1"
       },
       "devDependencies": {
+        "@types/chrome-remote-interface": "^0.33.0",
         "@types/node": "^22.0.0",
+        "@types/three": "^0.185.0",
+        "esbuild": "^0.28.1",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       },

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -411,6 +411,7 @@ export {
   MergeMeshesNode,
   TextTo3DNode,
   ImageTo3DNode,
+  RenderToImageNode,
   MODEL3D_NODES
 } from "@nodetool-ai/video-nodes/nodes/model3d";
 export {

--- a/packages/config/src/package-asset-registry.ts
+++ b/packages/config/src/package-asset-registry.ts
@@ -37,7 +37,8 @@ export const PACKAGE_RUNTIME_ASSETS: readonly PackageAssetRef[] = [
   { pkg: "@nodetool-ai/replicate-nodes", path: "replicate-manifest.json" },
   { pkg: "@nodetool-ai/runtime", path: "providers/aki-manifest.json" },
   { pkg: "@nodetool-ai/together-nodes", path: "together-manifest.json" },
-  { pkg: "@nodetool-ai/topaz-nodes", path: "topaz-manifest.json" }
+  { pkg: "@nodetool-ai/topaz-nodes", path: "topaz-manifest.json" },
+  { pkg: "@nodetool-ai/video-nodes", path: "render3d-page.js" }
 ];
 
 /** Registry lookup by exact pkg + path. */

--- a/packages/video-nodes/package.json
+++ b/packages/video-nodes/package.json
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "node ../../scripts/build-typescript-workspace.mjs",
+    "build": "node ../../scripts/build-typescript-workspace.mjs && node scripts/bundle-render3d-page.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit"
@@ -18,16 +18,23 @@
     "@gltf-transform/core": "^4.3.0",
     "@gltf-transform/functions": "^4.3.0",
     "@nodetool-ai/audio-nodes": "*",
+    "@nodetool-ai/config": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/nodes-utils": "*",
     "@nodetool-ai/protocol": "*",
     "@nodetool-ai/runtime": "*",
     "@nodetool-ai/timeline": "*",
+    "chrome-launcher": "^1.2.0",
+    "chrome-remote-interface": "^0.34.0",
     "manifold-3d": "^3.4.1",
-    "meshoptimizer": "^1.1.1"
+    "meshoptimizer": "^1.1.1",
+    "three": "^0.185.1"
   },
   "devDependencies": {
+    "@types/chrome-remote-interface": "^0.33.0",
     "@types/node": "^22.0.0",
+    "@types/three": "^0.185.0",
+    "esbuild": "^0.28.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   },
@@ -42,6 +49,7 @@
       "import": "./dist/nodes/*.js",
       "default": "./dist/nodes/*.js"
     },
+    "./render3d-page.js": "./dist/render3d-page.js",
     "./lib/*": {
       "types": "./dist/lib/*.d.ts",
       "import": "./dist/lib/*.js",

--- a/packages/video-nodes/scripts/bundle-render3d-page.mjs
+++ b/packages/video-nodes/scripts/bundle-render3d-page.mjs
@@ -1,0 +1,24 @@
+/**
+ * Bundle the RenderToImage headless page (three.js + render core) into a
+ * single self-contained IIFE the Node backend injects into headless Chromium
+ * via CDP (`render3d-headless.ts`). Runs as part of `npm run build` after
+ * tsc; the output is a registered package runtime asset
+ * (`PACKAGE_RUNTIME_ASSETS` in @nodetool-ai/config), so the Electron
+ * packaging stages and verifies it.
+ */
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const pkgRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+await build({
+  entryPoints: [path.join(pkgRoot, "src/nodes/model3d/render3d-page.ts")],
+  outfile: path.join(pkgRoot, "dist/render3d-page.js"),
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "es2022",
+  minify: true,
+  logLevel: "warning"
+});

--- a/packages/video-nodes/src/nodes/model3d/index.ts
+++ b/packages/video-nodes/src/nodes/model3d/index.ts
@@ -7,6 +7,7 @@ export * from "./transforms.js";
 export * from "./cleanup.js";
 export * from "./ops.js";
 export * from "./generation.js";
+export * from "./render.js";
 
 import { LoadModel3DFileNode } from "./io.js";
 import { SaveModel3DFileNode } from "./io.js";
@@ -17,6 +18,7 @@ import { Transform3DNode, CenterMeshNode, NormalizeModel3DNode } from "./transfo
 import { DecimateNode, Boolean3DNode, MergeMeshesNode } from "./ops.js";
 import { RecalculateNormalsNode, FlipNormalsNode, ExtractLargestComponentNode, RepairMeshNode } from "./cleanup.js";
 import { TextTo3DNode, ImageTo3DNode } from "./generation.js";
+import { RenderToImageNode } from "./render.js";
 
 export const MODEL3D_NODES = [
   LoadModel3DFileNode,
@@ -35,5 +37,6 @@ export const MODEL3D_NODES = [
   RepairMeshNode,
   MergeMeshesNode,
   TextTo3DNode,
-  ImageTo3DNode
+  ImageTo3DNode,
+  RenderToImageNode
 ] as const;

--- a/packages/video-nodes/src/nodes/model3d/render.ts
+++ b/packages/video-nodes/src/nodes/model3d/render.ts
@@ -1,0 +1,182 @@
+/**
+ * `nodetool.model3d.RenderToImage` — 3D scene + camera → image.
+ *
+ * Hybrid node (issue #3532): in the browser runner it renders directly with
+ * three.js on an `OffscreenCanvas` (no headless Chrome involved); on the Node
+ * backend it drives a headless Chromium running the same render core
+ * (`render3d-headless.ts`). Both paths share `render3d-core.ts`, so a
+ * workflow produces the same pixels wherever it executes.
+ *
+ * The model bytes are resolved locally (not via `./utils.js`) because this
+ * module must bundle for the browser and `utils.ts` imports `node:path` at
+ * module scope.
+ */
+
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import { NODE_AND_BROWSER_PLATFORMS } from "@nodetool-ai/protocol";
+import { IS_NODE } from "@nodetool-ai/config";
+import { base64ToBytes, bytesToBase64 } from "@nodetool-ai/nodes-utils";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+import { DEFAULT_MODEL_3D } from "./defaults.js";
+import type { LightingPreset, Render3DOptions } from "./render3d-core.js";
+import type { Model3DRefLike } from "./types.js";
+
+const RENDERABLE_FORMATS = new Set(["", "glb", "gltf"]);
+
+/** Browser-safe model-bytes resolution (inline data → storage → uri fetch). */
+async function resolveModelBytes(
+  model: unknown,
+  context?: ProcessingContext
+): Promise<Uint8Array> {
+  if (!model || typeof model !== "object") return new Uint8Array();
+  const ref = model as Model3DRefLike;
+
+  if (ref.data instanceof Uint8Array && ref.data.length > 0) {
+    return ref.data;
+  }
+  if (typeof ref.data === "string" && ref.data.length > 0) {
+    return base64ToBytes(ref.data);
+  }
+
+  const uri = ref.uri ?? "";
+  if (!uri) return new Uint8Array();
+
+  if (uri.startsWith("data:")) {
+    const comma = uri.indexOf(",");
+    if (comma === -1) throw new Error(`Malformed data URI: ${uri.slice(0, 32)}…`);
+    return base64ToBytes(uri.slice(comma + 1));
+  }
+
+  if (context?.storage) {
+    const stored = await context.storage.retrieve(uri);
+    if (stored && stored.length > 0) return new Uint8Array(stored);
+  }
+
+  if (uri.startsWith("file://") && IS_NODE) {
+    const { readFile } = await import("node:fs/promises");
+    const { fileURLToPath } = await import("node:url");
+    return new Uint8Array(await readFile(fileURLToPath(uri)));
+  }
+
+  if (uri.startsWith("http://") || uri.startsWith("https://")) {
+    const res = await fetch(uri);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch model (${res.status}): ${uri}`);
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  }
+
+  return new Uint8Array();
+}
+
+export class RenderToImageNode extends BaseNode {
+  static readonly nodeType = "nodetool.model3d.RenderToImage";
+  static readonly title = "Render 3D To Image";
+  static readonly description =
+    "Render a 3D model (GLB/glTF) to an image with an orbit camera and studio lighting — no grid, axes, or gizmos.\n    3d, render, image, camera, light, snapshot, thumbnail, turntable\n\n    Use cases:\n    - Turn generated 3D models into shareable images\n    - Produce thumbnails for 3D asset libraries\n    - Feed rendered views into image models (img2img, upscaling)";
+  static readonly platforms = NODE_AND_BROWSER_PLATFORMS;
+  static readonly metadataOutputTypes = {
+    output: "image"
+  };
+  static readonly inlineFields = [];
+  static readonly inputFields = ["model"];
+
+  @prop({
+    type: "model_3d",
+    default: DEFAULT_MODEL_3D,
+    title: "Model",
+    description: "The 3D model to render (GLB or glTF with embedded buffers)"
+  })
+  declare model: any;
+
+  @prop({ type: "int", default: 1024, title: "Width", description: "Output image width in pixels", min: 16, max: 4096 })
+  declare width: any;
+
+  @prop({ type: "int", default: 1024, title: "Height", description: "Output image height in pixels", min: 16, max: 4096 })
+  declare height: any;
+
+  @prop({ type: "float", default: 45, title: "Azimuth", description: "Horizontal camera orbit angle in degrees (0 looks along -Z)", min: -360, max: 360 })
+  declare azimuth: any;
+
+  @prop({ type: "float", default: 25, title: "Elevation", description: "Camera angle above the horizon in degrees", min: -89, max: 89 })
+  declare elevation: any;
+
+  @prop({ type: "float", default: 35, title: "Field of View", description: "Vertical field of view in degrees", min: 5, max: 120 })
+  declare fov: any;
+
+  @prop({ type: "float", default: 1, title: "Zoom", description: "Distance multiplier on the auto-framed camera: above 1 moves closer, below 1 farther", min: 0.1, max: 10 })
+  declare zoom: any;
+
+  @prop({
+    type: "enum",
+    default: "studio",
+    title: "Lighting",
+    description: "Lighting preset: studio (key/fill/rim), soft (hemisphere), or flat (ambient only)",
+    values: ["studio", "soft", "flat"]
+  })
+  declare lighting: any;
+
+  @prop({ type: "float", default: 1, title: "Light Intensity", description: "Multiplier applied to all lights in the preset", min: 0, max: 10 })
+  declare light_intensity: any;
+
+  @prop({ type: "str", default: "#ffffff", title: "Background Color", description: "Background color (CSS color); ignored when Transparent is on" })
+  declare background_color: any;
+
+  @prop({ type: "bool", default: false, title: "Transparent", description: "Render on a transparent background (PNG alpha)" })
+  declare transparent: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const model = (this.model ?? {}) as Model3DRefLike;
+    const format = String(model.format ?? "").toLowerCase();
+    if (!RENDERABLE_FORMATS.has(format)) {
+      throw new Error(
+        `RenderToImage supports GLB/glTF, got "${format}" — convert it first (Format Converter)`
+      );
+    }
+
+    const bytes = await resolveModelBytes(model, context);
+    if (bytes.length === 0) {
+      throw new Error(
+        "RenderToImage: model input is empty — connect a 3D model (GLB)"
+      );
+    }
+
+    const options: Render3DOptions = {
+      width: Number(this.width ?? 1024),
+      height: Number(this.height ?? 1024),
+      azimuthDeg: Number(this.azimuth ?? 45),
+      elevationDeg: Number(this.elevation ?? 25),
+      fovDeg: Number(this.fov ?? 35),
+      zoom: Number(this.zoom ?? 1),
+      lighting: String(this.lighting ?? "studio") as LightingPreset,
+      lightIntensity: Number(this.light_intensity ?? 1),
+      backgroundColor: String(this.background_color ?? "#ffffff"),
+      transparent: this.transparent === true
+    };
+
+    let png: Uint8Array;
+    if (IS_NODE) {
+      // @vite-ignore keeps the headless driver (node:fs, chrome-launcher) out
+      // of browser bundles; esbuild still follows it for the server bundle.
+      const headless = (await import(
+        /* @vite-ignore */ "./render3d-headless.js"
+      )) as typeof import("./render3d-headless.js");
+      png = await headless.renderGlbHeadless(bytes, options);
+    } else {
+      const core = await import("./render3d-core.js");
+      png = await core.renderGlbToPng(bytes, options);
+    }
+
+    return {
+      output: {
+        type: "image",
+        uri: "",
+        asset_id: null,
+        data: bytesToBase64(png)
+      }
+    };
+  }
+}
+
+export const MODEL3D_RENDER_NODES = [RenderToImageNode] as const;

--- a/packages/video-nodes/src/nodes/model3d/render3d-core.ts
+++ b/packages/video-nodes/src/nodes/model3d/render3d-core.ts
@@ -1,0 +1,275 @@
+/// <reference lib="dom" />
+/**
+ * Shared three.js render core for `nodetool.model3d.RenderToImage`.
+ *
+ * Turns GLB/glTF bytes into a PNG using a WebGL context on an
+ * `OffscreenCanvas`. The same module runs in two hosts:
+ *
+ * - the in-browser workflow runner (main thread or worker), imported
+ *   directly by `render.ts`;
+ * - a headless Chromium page on the Node backend, via the esbuild bundle
+ *   `dist/render3d-page.js` (entry: `render3d-page.ts`).
+ *
+ * Editor-only clutter (grid, axes, gizmos) never exists here — the scene is
+ * built fresh from the model plus the requested lights and nothing else.
+ */
+
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { MeshoptDecoder } from "meshoptimizer";
+
+export type LightingPreset = "studio" | "soft" | "flat";
+
+export interface Render3DOptions {
+  /** Output image width in pixels. */
+  width: number;
+  /** Output image height in pixels. */
+  height: number;
+  /** Horizontal orbit angle around the model, degrees. 0 looks down -Z. */
+  azimuthDeg: number;
+  /** Vertical angle above the horizon, degrees. 90 is straight down. */
+  elevationDeg: number;
+  /** Vertical field of view, degrees. */
+  fovDeg: number;
+  /** Camera distance multiplier on the auto-framed fit: >1 closer, <1 farther. */
+  zoom: number;
+  lighting: LightingPreset;
+  /** Multiplier applied to every light in the preset. */
+  lightIntensity: number;
+  /** CSS color for the background; ignored when `transparent` is true. */
+  backgroundColor: string;
+  transparent: boolean;
+}
+
+export interface CameraFraming {
+  /** Distance from the bounding-sphere center to the camera. */
+  distance: number;
+  near: number;
+  far: number;
+}
+
+/**
+ * Distance that fits a bounding sphere of `radius` fully into a camera with
+ * the given vertical fov and aspect, then applies `zoom` (>1 moves closer).
+ * Pure math, exported for tests.
+ */
+export function computeFraming(
+  radius: number,
+  fovDeg: number,
+  aspect: number,
+  zoom: number
+): CameraFraming {
+  const safeRadius = Math.max(radius, 1e-6);
+  const vFov = (Math.max(fovDeg, 1) * Math.PI) / 180;
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * Math.max(aspect, 1e-6));
+  const fitV = safeRadius / Math.sin(vFov / 2);
+  const fitH = safeRadius / Math.sin(hFov / 2);
+  const distance = Math.max(fitV, fitH) / Math.max(zoom, 1e-3);
+  return {
+    distance,
+    near: Math.max(distance - safeRadius * 4, distance / 100, 1e-4),
+    far: distance + safeRadius * 10
+  };
+}
+
+/** Spherical → cartesian offset for the orbit camera. Exported for tests. */
+export function orbitOffset(
+  azimuthDeg: number,
+  elevationDeg: number,
+  distance: number
+): { x: number; y: number; z: number } {
+  const az = (azimuthDeg * Math.PI) / 180;
+  const el = (Math.min(Math.max(elevationDeg, -89.9), 89.9) * Math.PI) / 180;
+  return {
+    x: distance * Math.cos(el) * Math.sin(az),
+    y: distance * Math.sin(el),
+    z: distance * Math.cos(el) * Math.cos(az)
+  };
+}
+
+function addLights(
+  scene: THREE.Scene,
+  preset: LightingPreset,
+  intensity: number,
+  cameraPosition: THREE.Vector3,
+  target: THREE.Vector3
+): void {
+  const scaled = (base: number): number => base * intensity;
+  // Key/fill/rim ride along with the camera azimuth so the visible side of
+  // the model is always lit, whatever angle the user picked.
+  const toCamera = cameraPosition.clone().sub(target).normalize();
+  const up = new THREE.Vector3(0, 1, 0);
+  const side = new THREE.Vector3().crossVectors(up, toCamera).normalize();
+  if (side.lengthSq() < 1e-6) side.set(1, 0, 0);
+
+  const placeDirectional = (
+    color: number,
+    lightIntensity: number,
+    direction: THREE.Vector3
+  ): void => {
+    const light = new THREE.DirectionalLight(color, lightIntensity);
+    light.position.copy(target).add(direction);
+    light.target.position.copy(target);
+    scene.add(light);
+    scene.add(light.target);
+  };
+
+  switch (preset) {
+    case "studio": {
+      scene.add(new THREE.AmbientLight(0xffffff, scaled(0.5)));
+      const key = toCamera
+        .clone()
+        .add(side.clone().multiplyScalar(0.8))
+        .add(up.clone().multiplyScalar(0.9));
+      placeDirectional(0xffffff, scaled(2.2), key);
+      const fill = toCamera
+        .clone()
+        .sub(side.clone().multiplyScalar(1.1))
+        .add(up.clone().multiplyScalar(0.2));
+      placeDirectional(0xffffff, scaled(0.8), fill);
+      const rim = toCamera
+        .clone()
+        .negate()
+        .add(up.clone().multiplyScalar(1.2));
+      placeDirectional(0xffffff, scaled(1.4), rim);
+      break;
+    }
+    case "soft": {
+      const hemi = new THREE.HemisphereLight(0xffffff, 0x555566, scaled(1.6));
+      hemi.position.copy(target).add(up);
+      scene.add(hemi);
+      placeDirectional(0xffffff, scaled(0.9), toCamera.clone().add(up));
+      break;
+    }
+    case "flat":
+      scene.add(new THREE.AmbientLight(0xffffff, scaled(3)));
+      break;
+  }
+}
+
+function disposeMaterial(material: THREE.Material): void {
+  for (const value of Object.values(material)) {
+    if (value instanceof THREE.Texture) value.dispose();
+  }
+  material.dispose();
+}
+
+function disposeScene(scene: THREE.Scene): void {
+  scene.traverse((object) => {
+    const mesh = object as THREE.Mesh;
+    if (mesh.geometry) mesh.geometry.dispose();
+    const material = mesh.material as
+      | THREE.Material
+      | THREE.Material[]
+      | undefined;
+    if (Array.isArray(material)) {
+      material.forEach(disposeMaterial);
+    } else if (material) {
+      disposeMaterial(material);
+    }
+  });
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  // GLTFLoader wants an ArrayBuffer that starts at offset 0.
+  return bytes.buffer instanceof ArrayBuffer &&
+    bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength
+    ? bytes.buffer
+    : bytes.slice().buffer;
+}
+
+/**
+ * Render GLB (or embedded-buffer glTF JSON) bytes to PNG bytes. Must run in a
+ * browser context (window or worker) with WebGL and `OffscreenCanvas`.
+ */
+export async function renderGlbToPng(
+  glb: Uint8Array,
+  options: Render3DOptions
+): Promise<Uint8Array> {
+  if (typeof OffscreenCanvas === "undefined") {
+    throw new Error(
+      "RenderToImage needs a browser context with OffscreenCanvas support"
+    );
+  }
+  const width = Math.max(1, Math.round(options.width));
+  const height = Math.max(1, Math.round(options.height));
+
+  const loader = new GLTFLoader();
+  await MeshoptDecoder.ready;
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  const gltf = await loader.parseAsync(toArrayBuffer(glb), "");
+
+  const scene = new THREE.Scene();
+  scene.add(gltf.scene);
+  // Resolve the world matrix before measuring, or the box is stale.
+  scene.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(gltf.scene);
+  if (box.isEmpty()) {
+    disposeScene(scene);
+    throw new Error("RenderToImage: the model contains no visible geometry");
+  }
+  const sphere = box.getBoundingSphere(new THREE.Sphere());
+
+  const aspect = width / height;
+  const framing = computeFraming(
+    sphere.radius,
+    options.fovDeg,
+    aspect,
+    options.zoom
+  );
+  const camera = new THREE.PerspectiveCamera(
+    options.fovDeg,
+    aspect,
+    framing.near,
+    framing.far
+  );
+  const offset = orbitOffset(
+    options.azimuthDeg,
+    options.elevationDeg,
+    framing.distance
+  );
+  camera.position.set(
+    sphere.center.x + offset.x,
+    sphere.center.y + offset.y,
+    sphere.center.z + offset.z
+  );
+  camera.lookAt(sphere.center);
+  camera.updateMatrixWorld(true);
+
+  addLights(
+    scene,
+    options.lighting,
+    options.lightIntensity,
+    camera.position,
+    sphere.center
+  );
+
+  if (!options.transparent) {
+    scene.background = new THREE.Color(options.backgroundColor);
+  }
+
+  const canvas = new OffscreenCanvas(width, height);
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    preserveDrawingBuffer: true
+  });
+  try {
+    renderer.setSize(width, height, false);
+    renderer.toneMapping = THREE.NeutralToneMapping;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    if (options.transparent) {
+      renderer.setClearColor(0x000000, 0);
+    }
+    renderer.render(scene, camera);
+    const blob = await canvas.convertToBlob({ type: "image/png" });
+    return new Uint8Array(await blob.arrayBuffer());
+  } finally {
+    disposeScene(scene);
+    renderer.dispose();
+    renderer.forceContextLoss();
+  }
+}

--- a/packages/video-nodes/src/nodes/model3d/render3d-headless.ts
+++ b/packages/video-nodes/src/nodes/model3d/render3d-headless.ts
@@ -1,0 +1,164 @@
+/**
+ * Node-side driver for `nodetool.model3d.RenderToImage`.
+ *
+ * The backend has no WebGL, so it launches a headless Chromium, injects the
+ * self-contained render bundle (`dist/render3d-page.js`, built by
+ * `scripts/bundle-render3d-page.mjs`), and calls `__nodetoolRenderGlb` over
+ * CDP. SwiftShader flags keep WebGL working on GPU-less servers.
+ *
+ * Chrome discovery follows the automation nodes: `CHROME_PATH` when set,
+ * otherwise chrome-launcher's platform search. Everything here is
+ * lazy-imported so merely registering the node never requires Chrome.
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolvePackageAssetPath } from "@nodetool-ai/config";
+import type { Render3DOptions } from "./render3d-core.js";
+
+const RENDER_TIMEOUT_MS = 120_000;
+
+const CHROME_FLAGS = [
+  "--headless=new",
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  // Software WebGL: ANGLE on SwiftShader, explicitly allowed (Chrome 137+
+  // refuses software WebGL in headless without the unsafe opt-in).
+  "--use-angle=swiftshader",
+  "--enable-unsafe-swiftshader",
+  "--hide-scrollbars",
+  "--mute-audio"
+];
+
+interface RuntimeEvaluateResult {
+  result?: { type?: string; value?: unknown };
+  exceptionDetails?: {
+    text?: string;
+    exception?: { description?: string; value?: unknown };
+  };
+}
+
+interface CdpClient {
+  Runtime: {
+    enable(): Promise<unknown>;
+    evaluate(params: {
+      expression: string;
+      awaitPromise?: boolean;
+      returnByValue?: boolean;
+    }): Promise<RuntimeEvaluateResult>;
+  };
+  close(): Promise<void>;
+}
+
+let bundlePromise: Promise<string> | null = null;
+
+/** Load (and cache) the self-contained render page bundle. */
+async function loadRenderBundle(): Promise<string> {
+  if (!bundlePromise) {
+    bundlePromise = (async () => {
+      const path = resolvePackageAssetPath(
+        { pkg: "@nodetool-ai/video-nodes", path: "render3d-page.js" },
+        import.meta.url
+      );
+      return readFile(path, "utf-8");
+    })().catch((err) => {
+      bundlePromise = null;
+      throw err;
+    });
+  }
+  return bundlePromise;
+}
+
+function throwOnException(
+  result: RuntimeEvaluateResult,
+  stage: string
+): void {
+  if (!result.exceptionDetails) return;
+  const exception = result.exceptionDetails.exception;
+  const detail =
+    exception?.description ??
+    (exception?.value !== undefined ? String(exception.value) : undefined) ??
+    result.exceptionDetails.text ??
+    "unknown error";
+  throw new Error(`RenderToImage (${stage}): ${detail}`);
+}
+
+async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `RenderToImage: ${label} timed out after ${RENDER_TIMEOUT_MS}ms`
+          )
+        ),
+      RENDER_TIMEOUT_MS
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Render GLB bytes to PNG bytes in a fresh headless Chromium. One Chrome per
+ * call keeps the node stateless; launch cost (~1s) is negligible next to a
+ * typical workflow's model-generation steps.
+ */
+export async function renderGlbHeadless(
+  glb: Uint8Array,
+  options: Render3DOptions
+): Promise<Uint8Array> {
+  const bundle = await loadRenderBundle();
+
+  const { launch } = await import("chrome-launcher");
+  const chrome = await launch({
+    chromeFlags: CHROME_FLAGS,
+    chromePath: process.env.CHROME_PATH || undefined
+  });
+
+  let client: CdpClient | null = null;
+  try {
+    const CDP = (await import("chrome-remote-interface")).default;
+    client = (await CDP({ port: chrome.port })) as unknown as CdpClient;
+    await client.Runtime.enable();
+
+    const injected = await client.Runtime.evaluate({ expression: bundle });
+    throwOnException(injected, "inject bundle");
+
+    const glbBase64 = Buffer.from(glb).toString("base64");
+    const call = await withTimeout(
+      client.Runtime.evaluate({
+        expression: `globalThis.__nodetoolRenderGlb(${JSON.stringify(
+          glbBase64
+        )}, ${JSON.stringify(JSON.stringify(options))})`,
+        awaitPromise: true,
+        returnByValue: true
+      }),
+      "render"
+    );
+    throwOnException(call, "render");
+
+    const pngBase64 = call.result?.value;
+    if (typeof pngBase64 !== "string" || pngBase64.length === 0) {
+      throw new Error("RenderToImage: headless render returned no image data");
+    }
+    return new Uint8Array(Buffer.from(pngBase64, "base64"));
+  } finally {
+    if (client) {
+      try {
+        await client.close();
+      } catch {
+        // Chrome is being killed right after; a failed CDP close is harmless.
+      }
+    }
+    try {
+      await chrome.kill();
+    } catch {
+      // Process may already be gone.
+    }
+  }
+}

--- a/packages/video-nodes/src/nodes/model3d/render3d-page.ts
+++ b/packages/video-nodes/src/nodes/model3d/render3d-page.ts
@@ -1,0 +1,46 @@
+/// <reference lib="dom" />
+/**
+ * Headless-page entry for `nodetool.model3d.RenderToImage`.
+ *
+ * esbuild bundles this file (plus three.js) into `dist/render3d-page.js`
+ * (see `scripts/bundle-render3d-page.mjs`). The Node-side driver
+ * (`render3d-headless.ts`) evaluates the bundle in a blank headless-Chromium
+ * page, then calls `__nodetoolRenderGlb` over CDP with base64 in/out — the
+ * only data shapes that survive `Runtime.evaluate` round-trips.
+ */
+
+import { renderGlbToPng, type Render3DOptions } from "./render3d-core.js";
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  // Chunked to stay clear of argument-count limits on large images.
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+declare global {
+  var __nodetoolRenderGlb:
+    | ((glbBase64: string, optionsJson: string) => Promise<string>)
+    | undefined;
+}
+
+globalThis.__nodetoolRenderGlb = async (
+  glbBase64: string,
+  optionsJson: string
+): Promise<string> => {
+  const options = JSON.parse(optionsJson) as Render3DOptions;
+  const png = await renderGlbToPng(base64ToBytes(glbBase64), options);
+  return bytesToBase64(png);
+};

--- a/packages/video-nodes/tests/model3d-render.test.ts
+++ b/packages/video-nodes/tests/model3d-render.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for `nodetool.model3d.RenderToImage` (issue #3532).
+ *
+ * The camera math and platform tagging are always tested. The headless
+ * Chromium integration renders a real GLB to PNG and is skipped when no
+ * Chrome/Chromium binary can be found (CHROME_PATH or well-known locations),
+ * so CI environments without a browser still pass.
+ */
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  computeFraming,
+  orbitOffset
+} from "../src/nodes/model3d/render3d-core.js";
+import { RenderToImageNode } from "../src/nodes/model3d/render.js";
+
+function pad4(length: number): number {
+  return (4 - (length % 4)) % 4;
+}
+
+/** Minimal single-triangle GLB (embedded buffer, no indices). */
+function createTriangleGlb(): Uint8Array {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const bin = new Uint8Array(positions.buffer);
+  const json = {
+    asset: { version: "2.0" },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0 }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126,
+        count: 3,
+        type: "VEC3",
+        min: [0, 0, 0],
+        max: [1, 1, 0]
+      }
+    ],
+    bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: bin.byteLength }],
+    buffers: [{ byteLength: bin.byteLength }]
+  };
+
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const jsonPad = pad4(jsonBytes.byteLength);
+  const binPad = pad4(bin.byteLength);
+  const total =
+    12 + 8 + jsonBytes.byteLength + jsonPad + 8 + bin.byteLength + binPad;
+
+  const glb = new Uint8Array(total);
+  const view = new DataView(glb.buffer);
+  let offset = 0;
+  view.setUint32(offset, 0x46546c67, true); // "glTF"
+  view.setUint32(offset + 4, 2, true);
+  view.setUint32(offset + 8, total, true);
+  offset += 12;
+  view.setUint32(offset, jsonBytes.byteLength + jsonPad, true);
+  view.setUint32(offset + 4, 0x4e4f534a, true); // "JSON"
+  offset += 8;
+  glb.set(jsonBytes, offset);
+  glb.fill(0x20, offset + jsonBytes.byteLength, offset + jsonBytes.byteLength + jsonPad);
+  offset += jsonBytes.byteLength + jsonPad;
+  view.setUint32(offset, bin.byteLength + binPad, true);
+  view.setUint32(offset + 4, 0x004e4942, true); // "BIN"
+  offset += 8;
+  glb.set(bin, offset);
+  return glb;
+}
+
+function findChrome(): string | null {
+  if (process.env.CHROME_PATH && existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH;
+  }
+  const candidates = [
+    "/opt/pw-browsers/chromium",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/usr/bin/google-chrome"
+  ];
+  return candidates.find((p) => existsSync(p)) ?? null;
+}
+
+function pngSize(png: Uint8Array): { width: number; height: number } {
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47];
+
+describe("RenderToImage camera math", () => {
+  it("fits the bounding sphere for the limiting axis", () => {
+    // Square aspect: vertical fov limits.
+    const square = computeFraming(1, 60, 1, 1);
+    expect(square.distance).toBeCloseTo(1 / Math.sin(Math.PI / 6), 5);
+    // Tall aspect (< 1): horizontal fov is narrower and limits instead.
+    const tall = computeFraming(1, 60, 0.5, 1);
+    expect(tall.distance).toBeGreaterThan(square.distance);
+    // Zoom moves closer.
+    const zoomed = computeFraming(1, 60, 1, 2);
+    expect(zoomed.distance).toBeCloseTo(square.distance / 2, 5);
+    expect(square.near).toBeGreaterThan(0);
+    expect(square.far).toBeGreaterThan(square.distance);
+  });
+
+  it("orbits on a sphere of the requested radius", () => {
+    const front = orbitOffset(0, 0, 10);
+    expect(front.x).toBeCloseTo(0, 5);
+    expect(front.y).toBeCloseTo(0, 5);
+    expect(front.z).toBeCloseTo(10, 5);
+
+    const side = orbitOffset(90, 0, 10);
+    expect(side.x).toBeCloseTo(10, 5);
+    expect(side.z).toBeCloseTo(0, 5);
+
+    const raised = orbitOffset(45, 30, 10);
+    const length = Math.hypot(raised.x, raised.y, raised.z);
+    expect(length).toBeCloseTo(10, 5);
+    expect(raised.y).toBeCloseTo(5, 5);
+  });
+
+  it("clamps extreme elevation instead of flipping", () => {
+    const top = orbitOffset(0, 90, 10);
+    expect(top.y).toBeLessThan(10);
+    expect(top.y).toBeGreaterThan(9.9);
+  });
+});
+
+describe("RenderToImage node metadata", () => {
+  it("runs on node and browser platforms", () => {
+    expect(RenderToImageNode.platforms).toContain("node");
+    expect(RenderToImageNode.platforms).toContain("browser");
+  });
+
+  it("rejects non-glTF formats with a pointer to the converter", async () => {
+    const node = new RenderToImageNode();
+    node.model = { type: "model_3d", format: "stl", data: "AAAA" };
+    await expect(node.process()).rejects.toThrow(/glb\/gltf/i);
+  });
+
+  it("rejects an empty model input", async () => {
+    const node = new RenderToImageNode();
+    node.model = { type: "model_3d", uri: "", data: null };
+    await expect(node.process()).rejects.toThrow(/empty/i);
+  });
+});
+
+const chromePath = findChrome();
+
+describe.skipIf(!chromePath)("RenderToImage headless render", () => {
+  it("renders a GLB to a PNG of the requested size", async () => {
+    process.env.CHROME_PATH = chromePath!;
+    const node = new RenderToImageNode();
+    node.model = {
+      type: "model_3d",
+      format: "glb",
+      data: Buffer.from(createTriangleGlb()).toString("base64")
+    };
+    node.width = 320;
+    node.height = 240;
+    node.transparent = false;
+    node.background_color = "#102030";
+
+    const result = await node.process();
+    const output = result.output as { type: string; data: string };
+    expect(output.type).toBe("image");
+
+    const png = new Uint8Array(Buffer.from(output.data, "base64"));
+    expect([...png.slice(0, 4)]).toEqual(PNG_SIGNATURE);
+    expect(pngSize(png)).toEqual({ width: 320, height: 240 });
+    // A real render of a lit triangle on a colored background is never a
+    // near-empty PNG.
+    expect(png.byteLength).toBeGreaterThan(500);
+  }, 120_000);
+});

--- a/packages/video-nodes/tsconfig.json
+++ b/packages/video-nodes/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../config" },
     { "path": "../protocol" },
     { "path": "../runtime" },
     { "path": "../node-sdk" },

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -197,6 +197,15 @@ const NODE_MODULE_GROUPS: ReadonlyArray<
   // nodes; the latter are tagged server, so createBrowserRegistry keeps only
   // the transforms. It's sharp-free (lazy) and de-barreled, so it bundles.
   ["image", () => import("@nodetool-ai/image-nodes/nodes/image")],
+  // RenderToImage (nodetool.model3d) renders GLB → PNG with three.js on an
+  // OffscreenCanvas — a genuinely browser-native path (the server drives a
+  // headless Chromium for the same core). Imported via its own subpath so the
+  // rest of the model3d family (node:fs loaders, manifold/meshoptimizer ops —
+  // all node-platform-only) stays out of the browser bundle.
+  [
+    "model3d-render",
+    () => import("@nodetool-ai/video-nodes/nodes/model3d/render")
+  ],
   // Preview is a pure pass-through that renders any value; its own browser-safe
   // module (no audio-codec deps) lets pass-through graphs ending in a Preview
   // run client-side instead of forcing a server round-trip.


### PR DESCRIPTION
Closes #3532.

Adds `nodetool.model3d.RenderToImage` — 3D scene + camera → image. Renders GLB/glTF with three.js: orbit camera (azimuth/elevation/fov/zoom) auto-framed from the model's bounding sphere, lighting presets (studio / soft / flat) with an intensity multiplier, width/height, and background color or transparent PNG. No grid, axes, or gizmos — the scene is built fresh from the model plus the requested lights.

## How it renders

One shared render core (`render3d-core.ts`), two hosts:

- **Browser runner** — the node is tagged `node + browser`. In the in-browser workflow runner it renders directly on an `OffscreenCanvas` via WebGL (main thread or worker) — no headless Chrome involved. Registered as its own module group in `browserRunnerCore.ts`, imported via the `nodes/model3d/render` subpath so the rest of the model3d family (node:fs loaders, manifold/meshoptimizer ops) stays out of the browser bundle. The Node-only branch is behind a `/* @vite-ignore */` dynamic import, so Vite skips it while esbuild still follows it for the server bundle.
- **Node backend** — no WebGL on the server, so the node launches a headless Chromium (`CHROME_PATH` or chrome-launcher discovery, SwiftShader flags so WebGL works on GPU-less servers), injects a self-contained page bundle (three.js + the same core, built by esbuild during the package build), and drives it over CDP with base64 GLB in / base64 PNG out.

## Packaging

- `dist/render3d-page.js` is registered in `PACKAGE_RUNTIME_ASSETS` (`@nodetool-ai/config`), so the Electron backend packaging stages and verifies it, and it resolves through the package export `@nodetool-ai/video-nodes/render3d-page.js` in dev/npm layouts.
- New video-nodes deps: `three` (matching web's `^0.185.1`), `chrome-launcher`, `chrome-remote-interface` (the same launch approach the automation nodes use); dev deps `@types/three`, `esbuild`, `@types/chrome-remote-interface`.
- GLBs using `EXT_meshopt_compression` decode via the existing `meshoptimizer` dependency.

## Tests

`packages/video-nodes/tests/model3d-render.test.ts`: camera framing/orbit math, platform tags, input validation (empty model, non-glTF format), and a real end-to-end headless render asserting a valid PNG of the requested size (skipped when no Chromium binary is found).

Verified manually: rendered a cube GLB through the headless path — auto-framing, studio lighting, background color, and aspect ratio all correct. `npm run build:packages`, video-nodes/config/base-nodes lint + tests, web typecheck, web production build (the render chunk emits for both main and worker bundles), and the web browser-runner jest suites all pass. Pre-existing sandbox-only failures (better-sqlite3 bindings, mobile react-native types) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB66LcnVK67DwupfnLQsDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB66LcnVK67DwupfnLQsDZ)_