### PR TITLE
Add Script editor (Phase 1: author + voice)

### DIFF
--- a/docs/script-editor-concept.md
+++ b/docs/script-editor-concept.md
@@ -200,9 +200,13 @@ existing editor is a rewrite, not a feature.
 
 ## Phasing
 
-1. **Author + voice** — protocol schema, `scripts` table + tRPC, store +
-   autosave, workspace surface, cast panel, per-line voicing, take gallery,
-   play-through.
+1. **Author + voice** *(implemented)* — protocol schema
+   (`api-schemas/scripts.ts`), `scripts` table + tRPC (`scripts` router), store
+   + autosave (`ScriptStore`, `useScriptServerSync`), workspace surface
+   (`ScriptSurface`, `script` tab type), cast panel, per-line voicing
+   (`scriptVoicing`, reusing `generate_media` / `transcribe_audio`), take
+   gallery, play-through. The document pane is a plain per-line editor rather
+   than the Lexical transcript editor — that reuse is deferred to a later pass.
 2. **To timeline** — assemble with linkage keys, staleness, per-line
    back-sync, re-assemble on structural drift, extract-as-script.
 3. **Automation** — `ui_script_*` agent tools + assistant panel, `ScriptRef` +

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -965,6 +965,20 @@ function getCreateSchemaSql(): string {
     CREATE INDEX IF NOT EXISTS "idx_storyboard_user" ON "storyboards" ("user_id");
     CREATE INDEX IF NOT EXISTS "idx_storyboard_project" ON "storyboards" ("project_id");
     CREATE INDEX IF NOT EXISTS "idx_storyboard_updated" ON "storyboards" ("updated_at");
+
+    CREATE TABLE IF NOT EXISTS "scripts" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "project_id" text NOT NULL,
+      "name" text NOT NULL,
+      "document" text NOT NULL,
+      "timeline_id" text,
+      "created_at" text NOT NULL,
+      "updated_at" text NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "idx_script_user" ON "scripts" ("user_id");
+    CREATE INDEX IF NOT EXISTS "idx_script_project" ON "scripts" ("project_id");
+    CREATE INDEX IF NOT EXISTS "idx_script_updated" ON "scripts" ("updated_at");
   `;
 }
 

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -138,6 +138,22 @@ export {
   emptyStoryboardDocument
 } from "./storyboard.js";
 export type { StoryboardDocument, StoryboardResponse } from "./storyboard.js";
+export {
+  Script,
+  ScriptConflictError,
+  emptyScriptDocument,
+  countScriptLines
+} from "./script.js";
+export type {
+  ScriptDocument,
+  ScriptResponse,
+  ScriptSection,
+  ScriptLine,
+  ScriptTake,
+  ScriptSpeaker,
+  VoiceBinding as ScriptVoiceBinding,
+  ScriptCaptionWord
+} from "./script.js";
 export type {
   ImageDocumentData,
   ImageDocumentMutationResult,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -1856,5 +1856,45 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_storyboard_updated");
       await db.execute("DROP TABLE IF EXISTS storyboards");
     }
+  },
+
+  // ── Create scripts ──────────────────────────────────────────
+  {
+    version: "20260719_000000",
+    name: "create_scripts",
+    createsTables: ["scripts"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS scripts (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL,
+          project_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          document TEXT NOT NULL,
+          timeline_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_script_user
+        ON scripts (user_id)
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_script_project
+        ON scripts (project_id)
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_script_updated
+        ON scripts (updated_at)
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_script_user");
+      await db.execute("DROP INDEX IF EXISTS idx_script_project");
+      await db.execute("DROP INDEX IF EXISTS idx_script_updated");
+      await db.execute("DROP TABLE IF EXISTS scripts");
+    }
   }
 ];

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -17,6 +17,7 @@ export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
 export { imageDocuments } from "./image-documents.js";
 export { storyboards } from "./storyboards.js";
+export { scripts } from "./scripts.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";
 export { triggerRegistrations } from "./trigger-registrations.js";

--- a/packages/models/src/schema-pg/scripts.ts
+++ b/packages/models/src/schema-pg/scripts.ts
@@ -1,0 +1,23 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+import type { ScriptDocument } from "../script.js";
+
+export const scripts = pgTable(
+  "scripts",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    project_id: text("project_id").notNull(),
+    name: text("name").notNull(),
+    document: jsonText<ScriptDocument>()("document").notNull(),
+    /** Timeline sequence this script was assembled into, if any. */
+    timeline_id: text("timeline_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_script_user").on(table.user_id),
+    index("idx_script_project").on(table.project_id),
+    index("idx_script_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -17,6 +17,7 @@ export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
 export { imageDocuments } from "./image-documents.js";
 export { storyboards } from "./storyboards.js";
+export { scripts } from "./scripts.js";
 export { workerProfiles, workerInstances } from "./workers.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";

--- a/packages/models/src/schema/scripts.ts
+++ b/packages/models/src/schema/scripts.ts
@@ -1,0 +1,21 @@
+import { sqliteTable, text, index } from "drizzle-orm/sqlite-core";
+
+export const scripts = sqliteTable(
+  "scripts",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    project_id: text("project_id").notNull(),
+    name: text("name").notNull(),
+    document: text("document").notNull(),
+    /** Timeline sequence this script was assembled into, if any. */
+    timeline_id: text("timeline_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_script_user").on(table.user_id),
+    index("idx_script_project").on(table.project_id),
+    index("idx_script_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/src/script.ts
+++ b/packages/models/src/script.ts
@@ -1,0 +1,231 @@
+import { eq, desc, and } from "drizzle-orm";
+import {
+  DBModel,
+  ModelChangeEvent,
+  ModelObserver,
+  createTimeOrderedUuid
+} from "./base-model.js";
+import { getDb } from "./db.js";
+import { scripts } from "./schema/scripts.js";
+
+/** One word of a take with clip-local timing (mirrors timeline CaptionWord). */
+export interface ScriptCaptionWord {
+  word: string;
+  startMs: number;
+  endMs: number;
+}
+
+/** Provider/model/voice selection a speaker or line is voiced with. */
+export interface VoiceBinding {
+  provider: string;
+  model: string;
+  voice: string;
+  settings?: Record<string, unknown>;
+}
+
+/** A voiced audio version of a line — the clipVersion idea, relocated. */
+export interface ScriptTake {
+  id: string;
+  assetId: string;
+  durationMs: number;
+  words: ScriptCaptionWord[];
+  textSnapshot: string;
+  voiceSnapshot: VoiceBinding | null;
+  createdAt: string;
+  favorite?: boolean;
+  costCredits?: number;
+}
+
+export interface ScriptLine {
+  id: string;
+  speakerId?: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  voiceOverride?: VoiceBinding | null;
+  takes: ScriptTake[];
+  currentTakeId?: string | null;
+}
+
+export interface ScriptSection {
+  id: string;
+  title?: string;
+  lines: ScriptLine[];
+}
+
+export interface ScriptSpeaker {
+  id: string;
+  name: string;
+  color?: string;
+  voice?: VoiceBinding | null;
+}
+
+/**
+ * The persisted script payload: text is the source of truth, audio is derived.
+ * Everything the editor carries except identity/timestamps (columns).
+ */
+export interface ScriptDocument {
+  cast: ScriptSpeaker[];
+  sections: ScriptSection[];
+}
+
+export interface ScriptResponse {
+  id: string;
+  projectId: string;
+  name: string;
+  document: ScriptDocument;
+  timelineId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class ScriptConflictError extends Error {
+  constructor(id: string) {
+    super(`Script ${id} was modified concurrently`);
+    this.name = "ScriptConflictError";
+  }
+}
+
+export const emptyScriptDocument = (): ScriptDocument => ({
+  cast: [],
+  sections: []
+});
+
+function assertValidDocument(doc: ScriptDocument): void {
+  if (
+    !doc ||
+    typeof doc !== "object" ||
+    !Array.isArray(doc.sections) ||
+    !Array.isArray(doc.cast)
+  ) {
+    throw new Error("script document must contain cast and sections arrays");
+  }
+}
+
+function nextUpdatedAtAfter(previous: string): string {
+  const now = new Date();
+  const previousMs = Date.parse(previous);
+  if (Number.isFinite(previousMs) && now.getTime() <= previousMs) {
+    return new Date(previousMs + 1).toISOString();
+  }
+  return now.toISOString();
+}
+
+/** Total lines across sections — the cheap list summary. */
+export function countScriptLines(doc: ScriptDocument): number {
+  return doc.sections.reduce((sum, section) => sum + section.lines.length, 0);
+}
+
+export class Script extends DBModel {
+  static override table = scripts;
+
+  declare id: string;
+  declare user_id: string;
+  declare project_id: string;
+  declare name: string;
+  declare document: string;
+  declare timeline_id: string | null;
+  declare created_at: string;
+  declare updated_at: string;
+
+  constructor(data: Record<string, unknown>) {
+    super(data);
+    const now = new Date().toISOString();
+    this.id ??= createTimeOrderedUuid();
+    this.project_id ??= "default";
+    this.name ??= "Untitled script";
+    this.document ??= JSON.stringify(emptyScriptDocument());
+    this.timeline_id ??= null;
+    this.created_at ??= now;
+    this.updated_at ??= now;
+  }
+
+  override beforeSave(): void {
+    this.updated_at = nextUpdatedAtAfter(this.updated_at);
+    assertValidDocument(JSON.parse(this.document) as ScriptDocument);
+  }
+
+  toDocument(): ScriptDocument {
+    const doc = JSON.parse(this.document) as ScriptDocument;
+    doc.cast ??= [];
+    doc.sections ??= [];
+    return doc;
+  }
+
+  toResponse(): ScriptResponse {
+    return {
+      id: this.id,
+      projectId: this.project_id,
+      name: this.name,
+      document: this.toDocument(),
+      timelineId: this.timeline_id ?? undefined,
+      createdAt: this.created_at,
+      updatedAt: this.updated_at
+    };
+  }
+
+  static async findById(id: string): Promise<Script | null> {
+    return Script.get<Script>(id);
+  }
+
+  static async listByUser(userId: string, limit = 50): Promise<Script[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(scripts)
+      .where(eq(scripts.user_id, userId))
+      .orderBy(desc(scripts.updated_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Script(r));
+  }
+
+  static async listByProject(
+    projectId: string,
+    userId: string,
+    limit = 50
+  ): Promise<Script[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(scripts)
+      .where(
+        and(eq(scripts.project_id, projectId), eq(scripts.user_id, userId))
+      )
+      .orderBy(desc(scripts.updated_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Script(r));
+  }
+
+  /**
+   * Atomic compare-and-swap save. Applies only when the row's `updated_at`
+   * still equals `expectedUpdatedAt`; returns null on conflict so the caller
+   * reports it instead of clobbering a concurrent write.
+   */
+  static async updateFieldsIfUnchanged(
+    id: string,
+    expectedUpdatedAt: string,
+    fields: Partial<{
+      name: string;
+      document: string;
+      timeline_id: string | null;
+    }>
+  ): Promise<Script | null> {
+    if (fields.document !== undefined) {
+      assertValidDocument(JSON.parse(fields.document) as ScriptDocument);
+    }
+    const db = getDb();
+    const now = nextUpdatedAtAfter(expectedUpdatedAt);
+    const rows = await db
+      .update(scripts)
+      .set({ ...fields, updated_at: now })
+      .where(and(eq(scripts.id, id), eq(scripts.updated_at, expectedUpdatedAt)))
+      .returning();
+
+    const row = rows[0] as Record<string, unknown> | undefined;
+    if (!row) return null;
+
+    const updated = new Script(row);
+    ModelObserver.notify(updated, ModelChangeEvent.UPDATED);
+    return updated;
+  }
+}

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 46;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 47;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/script.test.ts
+++ b/packages/models/tests/script.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the Script model.
+ *
+ * Covers: create with defaults, JSON round-trip, list-by-user/project,
+ * countScriptLines, and the compare-and-swap update (applies on a matching
+ * token, returns null on a stale one).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { initTestDb } from "../src/db.js";
+import {
+  Script,
+  emptyScriptDocument,
+  countScriptLines,
+  type ScriptDocument
+} from "../src/script.js";
+
+function setup() {
+  initTestDb();
+}
+
+function makeDocument(overrides: Partial<ScriptDocument> = {}): ScriptDocument {
+  return { ...emptyScriptDocument(), ...overrides };
+}
+
+async function createScript(
+  userId = "u1",
+  projectId = "p1",
+  name = "My Script",
+  doc: ScriptDocument = makeDocument()
+): Promise<Script> {
+  const script = new Script({
+    user_id: userId,
+    project_id: projectId,
+    name,
+    document: JSON.stringify(doc)
+  });
+  await script.save();
+  return script;
+}
+
+describe("Script model", () => {
+  beforeEach(setup);
+
+  it("creates with defaults and round-trips the document", async () => {
+    const doc = makeDocument({
+      cast: [{ id: "s1", name: "Narrator", voice: null }],
+      sections: [
+        {
+          id: "sec1",
+          title: "Intro",
+          lines: [{ id: "l1", text: "Hello", takes: [] }]
+        }
+      ]
+    });
+    const created = await createScript("u1", "p1", "Doc", doc);
+    const loaded = await Script.findById(created.id);
+    expect(loaded).not.toBeNull();
+    const response = loaded!.toResponse();
+    expect(response.name).toBe("Doc");
+    expect(response.document.cast).toHaveLength(1);
+    expect(response.document.sections[0].lines[0].text).toBe("Hello");
+  });
+
+  it("counts lines across sections", () => {
+    const doc = makeDocument({
+      sections: [
+        { id: "a", lines: [{ id: "1", text: "x", takes: [] }] },
+        {
+          id: "b",
+          lines: [
+            { id: "2", text: "y", takes: [] },
+            { id: "3", text: "z", takes: [] }
+          ]
+        }
+      ]
+    });
+    expect(countScriptLines(doc)).toBe(3);
+  });
+
+  it("lists by user and by project", async () => {
+    await createScript("u1", "p1", "A");
+    await createScript("u1", "p2", "B");
+    await createScript("u2", "p1", "C");
+
+    const byUser = await Script.listByUser("u1");
+    expect(byUser).toHaveLength(2);
+
+    const byProject = await Script.listByProject("p1", "u1");
+    expect(byProject).toHaveLength(1);
+    expect(byProject[0].name).toBe("A");
+  });
+
+  it("applies a CAS update on a matching token", async () => {
+    const created = await createScript("u1", "p1", "Old");
+    const updated = await Script.updateFieldsIfUnchanged(
+      created.id,
+      created.updated_at,
+      { name: "New" }
+    );
+    expect(updated).not.toBeNull();
+    expect(updated!.name).toBe("New");
+    expect(updated!.updated_at).not.toBe(created.updated_at);
+  });
+
+  it("rejects a CAS update on a stale token", async () => {
+    const created = await createScript("u1", "p1", "Old");
+    // First write advances the token.
+    await Script.updateFieldsIfUnchanged(created.id, created.updated_at, {
+      name: "First"
+    });
+    // Second write with the original (now stale) token must fail.
+    const conflict = await Script.updateFieldsIfUnchanged(
+      created.id,
+      created.updated_at,
+      { name: "Second" }
+    );
+    expect(conflict).toBeNull();
+  });
+});

--- a/packages/protocol/src/api-schemas/index.ts
+++ b/packages/protocol/src/api-schemas/index.ts
@@ -10,6 +10,7 @@ export * as mcpConfig from "./mcp-config.js";
 export * as messages from "./messages.js";
 export * as models from "./models.js";
 export * as nodes from "./nodes.js";
+export * as scripts from "./scripts.js";
 export * as settings from "./settings.js";
 export * as skills from "./skills.js";
 export * as storage from "./storage.js";

--- a/packages/protocol/src/api-schemas/scripts.ts
+++ b/packages/protocol/src/api-schemas/scripts.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { captionWord } from "./timeline.js";
+
+// ── Cast / voices ────────────────────────────────────────────────────────────
+// A Script owns its text; audio is derived. The cast binds each speaker to a
+// TTS voice so a line inherits its speaker's voice unless it overrides one.
+
+/** A provider/model/voice selection, mirroring how the model pickers emit it. */
+export const voiceBinding = z.object({
+  provider: z.string(),
+  model: z.string(),
+  voice: z.string(),
+  /** Provider-specific synthesis knobs (stability, similarity, speed, …). */
+  settings: z.record(z.string(), z.unknown()).optional()
+});
+export type VoiceBinding = z.infer<typeof voiceBinding>;
+
+export const speaker = z.object({
+  id: z.string(),
+  name: z.string(),
+  /** Gutter chip color; free-form so the UI can theme it. */
+  color: z.string().optional(),
+  voice: voiceBinding.nullable().optional()
+});
+export type Speaker = z.infer<typeof speaker>;
+
+// ── Takes ────────────────────────────────────────────────────────────────────
+// A take is the `clipVersion` idea relocated onto a line: an audio asset with
+// word timings plus the text/voice snapshot it was voiced from, so staleness is
+// derivable without storing it.
+
+export const take = z.object({
+  id: z.string(),
+  assetId: z.string(),
+  durationMs: z.number(),
+  words: z.array(captionWord).default([]),
+  /** The line text this take was voiced from (staleness comparison). */
+  textSnapshot: z.string(),
+  /** The voice this take was voiced with (staleness comparison). */
+  voiceSnapshot: voiceBinding.nullable(),
+  createdAt: z.string(),
+  favorite: z.boolean().optional(),
+  costCredits: z.number().optional()
+});
+export type Take = z.infer<typeof take>;
+
+// ── Lines / sections ─────────────────────────────────────────────────────────
+
+export const scriptLine = z.object({
+  id: z.string(),
+  speakerId: z.string().nullable().optional(),
+  text: z.string().default(""),
+  /** Free-form performance note ("whispering, tired"); passed to providers
+   * that accept a direction, no structured tag schema. */
+  direction: z.string().optional(),
+  /** Authored silence after this line, used when laying out a timeline. */
+  pauseAfterMs: z.number().optional(),
+  /** Per-line voice override; falls back to the speaker's voice when absent. */
+  voiceOverride: voiceBinding.nullable().optional(),
+  takes: z.array(take).default([]),
+  currentTakeId: z.string().nullable().optional()
+});
+export type ScriptLine = z.infer<typeof scriptLine>;
+
+export const scriptSection = z.object({
+  id: z.string(),
+  title: z.string().optional(),
+  lines: z.array(scriptLine).default([])
+});
+export type ScriptSection = z.infer<typeof scriptSection>;
+
+// ── Document ─────────────────────────────────────────────────────────────────
+
+export const scriptDocument = z.object({
+  cast: z.array(speaker).default([]),
+  sections: z.array(scriptSection).default([])
+});
+export type ScriptDocumentSchema = z.infer<typeof scriptDocument>;
+
+// ── API shapes ───────────────────────────────────────────────────────────────
+
+export const scriptResponse = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  document: scriptDocument,
+  /** Timeline sequence this script was assembled into, if any. */
+  timelineId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+export type ScriptResponse = z.infer<typeof scriptResponse>;
+
+export const scriptListItem = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  lineCount: z.number(),
+  updatedAt: z.string()
+});
+export type ScriptListItem = z.infer<typeof scriptListItem>;
+
+export const createScriptInput = z.object({
+  /** Client-supplied id: lets a tab-ref'd local script upsert itself. */
+  id: z.string().optional(),
+  name: z.string().min(1).default("Untitled script"),
+  projectId: z.string().default("default"),
+  document: scriptDocument.optional()
+});
+export type CreateScriptInput = z.infer<typeof createScriptInput>;
+
+export const patchScriptInput = z
+  .object({
+    name: z.string().min(1).optional(),
+    document: scriptDocument.optional(),
+    timelineId: z.string().nullable().optional()
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field must be provided"
+  });
+export type PatchScriptInput = z.infer<typeof patchScriptInput>;

--- a/packages/websocket/src/trpc/router.ts
+++ b/packages/websocket/src/trpc/router.ts
@@ -12,6 +12,7 @@ import { modelsRouter } from "./routers/models.js";
 import { nodesRouter } from "./routers/nodes.js";
 import { packsRouter } from "./routers/packs.js";
 import { sandboxesRouter } from "./routers/sandboxes.js";
+import { scriptsRouter } from "./routers/scripts.js";
 import { settingsRouter } from "./routers/settings.js";
 import { skillsRouter, fontsRouter } from "./routers/skills.js";
 import { storageRouter } from "./routers/storage.js";
@@ -41,6 +42,7 @@ export const appRouter = router({
   nodes: nodesRouter,
   packs: packsRouter,
   sandboxes: sandboxesRouter,
+  scripts: scriptsRouter,
   settings: settingsRouter,
   sketch: sketchRouter,
   storyboards: storyboardsRouter,

--- a/packages/websocket/src/trpc/routers/scripts.ts
+++ b/packages/websocket/src/trpc/routers/scripts.ts
@@ -1,0 +1,152 @@
+/**
+ * Scripts router — tRPC.
+ *
+ * A script is a first-class resource whose text owns its derived audio takes.
+ * Mirrors the storyboards router shape.
+ *
+ * Procedures:
+ *   list    (query)    — ScriptListItem[]
+ *   get     (query)    — ScriptResponse
+ *   create  (mutation) — ScriptResponse
+ *   update  (mutation) — ScriptResponse (CAS via baseUpdatedAt)
+ *   delete  (mutation) — { ok: true }
+ */
+
+import { z } from "zod";
+import { Script, countScriptLines, emptyScriptDocument } from "@nodetool-ai/models";
+import {
+  createScriptInput,
+  patchScriptInput,
+  scriptListItem,
+  scriptResponse
+} from "@nodetool-ai/protocol/api-schemas/scripts.js";
+import { ApiErrorCode } from "../../error-codes.js";
+import { router } from "../index.js";
+import { protectedProcedure } from "../middleware.js";
+import { throwApiError } from "../error-formatter.js";
+
+const listInput = z.object({
+  projectId: z.string().optional()
+});
+
+const idInput = z.object({ id: z.string() });
+
+const updateInput = patchScriptInput.and(
+  z.object({
+    id: z.string(),
+    baseUpdatedAt: z.string().optional()
+  })
+);
+
+const okOutput = z.object({ ok: z.literal(true) });
+
+function toListItem(script: Script) {
+  return {
+    id: script.id,
+    projectId: script.project_id,
+    name: script.name,
+    lineCount: countScriptLines(script.toDocument()),
+    updatedAt: script.updated_at
+  };
+}
+
+async function loadOwned(
+  ctxUserId: string | null,
+  id: string
+): Promise<Script> {
+  if (!ctxUserId) throwApiError(ApiErrorCode.UNAUTHORIZED, "Unauthorized");
+  const script = await Script.findById(id);
+  if (!script || script.user_id !== ctxUserId) {
+    throwApiError(ApiErrorCode.NOT_FOUND, "Script not found");
+  }
+  return script;
+}
+
+export const scriptsRouter = router({
+  list: protectedProcedure
+    .input(listInput)
+    .output(z.array(scriptListItem))
+    .query(async ({ ctx, input }) => {
+      const items = input.projectId
+        ? await Script.listByProject(input.projectId, ctx.userId)
+        : await Script.listByUser(ctx.userId);
+      return items.map(toListItem);
+    }),
+
+  get: protectedProcedure
+    .input(idInput)
+    .output(scriptResponse)
+    .query(async ({ ctx, input }) => {
+      const script = await loadOwned(ctx.userId, input.id);
+      return scriptResponse.parse(script.toResponse());
+    }),
+
+  create: protectedProcedure
+    .input(createScriptInput)
+    .output(scriptResponse)
+    .mutation(async ({ ctx, input }) => {
+      if (input.id) {
+        const existing = await Script.findById(input.id);
+        if (existing) {
+          if (existing.user_id !== ctx.userId) {
+            throwApiError(ApiErrorCode.NOT_FOUND, "Script not found");
+          }
+          return scriptResponse.parse(existing.toResponse());
+        }
+      }
+      const script = new Script({
+        id: input.id,
+        user_id: ctx.userId,
+        project_id: input.projectId,
+        name: input.name,
+        document: JSON.stringify(input.document ?? emptyScriptDocument())
+      });
+      await script.save();
+      return scriptResponse.parse(script.toResponse());
+    }),
+
+  update: protectedProcedure
+    .input(updateInput)
+    .output(scriptResponse)
+    .mutation(async ({ ctx, input }) => {
+      const script = await loadOwned(ctx.userId, input.id);
+
+      // CAS on updated_at so the conflict check and the write are atomic.
+      const expectedUpdatedAt = input.baseUpdatedAt ?? script.updated_at;
+      if (input.baseUpdatedAt && script.updated_at !== input.baseUpdatedAt) {
+        throwApiError(
+          ApiErrorCode.ALREADY_EXISTS,
+          "Script was modified since last read (optimistic concurrency conflict)"
+        );
+      }
+
+      const fields: Parameters<typeof Script.updateFieldsIfUnchanged>[2] = {};
+      if (input.name !== undefined) fields.name = input.name;
+      if (input.document !== undefined)
+        fields.document = JSON.stringify(input.document);
+      if (input.timelineId !== undefined)
+        fields.timeline_id = input.timelineId;
+
+      const updated = await Script.updateFieldsIfUnchanged(
+        input.id,
+        expectedUpdatedAt,
+        fields
+      );
+      if (!updated) {
+        throwApiError(
+          ApiErrorCode.ALREADY_EXISTS,
+          "Script was modified since last read (optimistic concurrency conflict)"
+        );
+      }
+      return scriptResponse.parse(updated.toResponse());
+    }),
+
+  delete: protectedProcedure
+    .input(idInput)
+    .output(okOutput)
+    .mutation(async ({ ctx, input }) => {
+      const script = await loadOwned(ctx.userId, input.id);
+      await script.delete();
+      return { ok: true as const };
+    })
+});

--- a/web/src/components/script/ScriptCastPanel.tsx
+++ b/web/src/components/script/ScriptCastPanel.tsx
@@ -1,0 +1,190 @@
+/** @jsxImportSource @emotion/react */
+import { useCallback } from "react";
+import PersonAddIcon from "@mui/icons-material/PersonAddAlt";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  TextInput,
+  EditorButton,
+  ToolbarIconButton,
+  Divider,
+  EmptyState,
+  SPACING
+} from "../ui_primitives";
+import TTSModelSelect from "../properties/TTSModelSelect";
+import type { TTSModelValue } from "../../stores/ApiTypes";
+import {
+  useScriptStore,
+  type ScriptSpeaker,
+  type VoiceBinding
+} from "../../stores/script/ScriptStore";
+
+interface ScriptCastPanelProps {
+  scriptId: string;
+  cast: ScriptSpeaker[];
+  readOnly: boolean;
+}
+
+const SPEAKER_COLORS = [
+  "#6ea8fe",
+  "#f7a072",
+  "#a0e7a0",
+  "#e79ad0",
+  "#f2d17c",
+  "#8fd6d6"
+];
+
+let speakerCounter = 0;
+const newSpeakerId = (): string =>
+  `spk_${Date.now().toString(36)}_${(speakerCounter++).toString(36)}`;
+
+/** VoiceBinding → the TTSModelValue shape the picker consumes. */
+const voiceToModelValue = (voice: VoiceBinding | null): TTSModelValue => ({
+  type: "tts_model",
+  id: voice?.model ?? "",
+  provider: (voice?.provider ?? "empty") as TTSModelValue["provider"],
+  name: voice?.model ?? "",
+  voices: voice?.voice ? [voice.voice] : [],
+  selected_voice: voice?.voice ?? ""
+});
+
+const modelValueToVoice = (value: TTSModelValue): VoiceBinding => ({
+  provider: String(value.provider),
+  model: value.id,
+  voice: value.selected_voice || value.voices?.[0] || ""
+});
+
+const SpeakerRow = ({
+  scriptId,
+  speaker,
+  readOnly
+}: {
+  scriptId: string;
+  speaker: ScriptSpeaker;
+  readOnly: boolean;
+}) => {
+  const updateSpeaker = useScriptStore((s) => s.updateSpeaker);
+  const removeSpeaker = useScriptStore((s) => s.removeSpeaker);
+
+  const onVoiceChange = useCallback(
+    (value: TTSModelValue) =>
+      updateSpeaker(scriptId, speaker.id, {
+        voice: modelValueToVoice(value)
+      }),
+    [updateSpeaker, scriptId, speaker.id]
+  );
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      <FlexRow align="center" gap={SPACING.sm} fullWidth>
+        <span
+          aria-hidden
+          style={{
+            width: 12,
+            height: 12,
+            borderRadius: "50%",
+            backgroundColor: speaker.color ?? "#888",
+            flexShrink: 0
+          }}
+        />
+        <TextInput
+          value={speaker.name}
+          onChange={(e) =>
+            updateSpeaker(scriptId, speaker.id, { name: e.target.value })
+          }
+          hideLabel
+          label="Speaker name"
+          compact
+          fullWidth
+          disabled={readOnly}
+        />
+        {!readOnly && (
+          <ToolbarIconButton
+            tooltip="Remove speaker"
+            onClick={() => removeSpeaker(scriptId, speaker.id)}
+            icon={<DeleteOutlineIcon fontSize="small" />}
+          />
+        )}
+      </FlexRow>
+      {!readOnly && (
+        <TTSModelSelect
+          value={voiceToModelValue(speaker.voice ?? null)}
+          onChange={onVoiceChange}
+        />
+      )}
+      {readOnly && speaker.voice && (
+        <Text size="smaller" color="secondary">
+          {speaker.voice.model} · {speaker.voice.voice}
+        </Text>
+      )}
+    </FlexColumn>
+  );
+};
+
+const ScriptCastPanel = ({
+  scriptId,
+  cast,
+  readOnly
+}: ScriptCastPanelProps) => {
+  const addSpeaker = useScriptStore((s) => s.addSpeaker);
+
+  const onAdd = useCallback(() => {
+    addSpeaker(scriptId, {
+      id: newSpeakerId(),
+      name: `Speaker ${cast.length + 1}`,
+      color: SPEAKER_COLORS[cast.length % SPEAKER_COLORS.length],
+      voice: null
+    });
+  }, [addSpeaker, scriptId, cast.length]);
+
+  return (
+    <FlexColumn
+      gap={SPACING.md}
+      sx={{
+        width: 300,
+        flexShrink: 0,
+        borderLeft: "1px solid",
+        borderColor: "divider",
+        padding: SPACING.md,
+        height: "100%",
+        overflowY: "auto"
+      }}
+    >
+      <FlexRow align="center" justify="space-between" fullWidth>
+        <Text size="normal" weight={600}>
+          Cast
+        </Text>
+        {!readOnly && (
+          <EditorButton
+            size="small"
+            variant="outlined"
+            startIcon={<PersonAddIcon fontSize="small" />}
+            onClick={onAdd}
+          >
+            Add
+          </EditorButton>
+        )}
+      </FlexRow>
+      <Divider />
+      {cast.length === 0 ? (
+        <EmptyState
+          title="No speakers"
+          description="Add a speaker and assign a voice to start voicing lines."
+        />
+      ) : (
+        cast.map((speaker) => (
+          <SpeakerRow
+            key={speaker.id}
+            scriptId={scriptId}
+            speaker={speaker}
+            readOnly={readOnly}
+          />
+        ))
+      )}
+    </FlexColumn>
+  );
+};
+
+export default ScriptCastPanel;

--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -1,0 +1,222 @@
+/** @jsxImportSource @emotion/react */
+import { useCallback, useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import StopIcon from "@mui/icons-material/Stop";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  TextInput,
+  EditorButton,
+  ToolbarIconButton,
+  Divider,
+  EmptyState,
+  LoadingSpinner,
+  SPACING
+} from "../ui_primitives";
+import {
+  useScript,
+  useScriptStore,
+  type ScriptSection
+} from "../../stores/script/ScriptStore";
+import { voiceAll } from "../../stores/script/scriptVoicing";
+import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
+import ScriptLineRow from "./ScriptLineRow";
+
+interface ScriptDocumentPaneProps {
+  scriptId: string;
+  readOnly: boolean;
+}
+
+const SectionBlock = ({
+  scriptId,
+  section,
+  currentLineId,
+  readOnly
+}: {
+  scriptId: string;
+  section: ScriptSection;
+  currentLineId: string | null;
+  readOnly: boolean;
+}) => {
+  const cast = useScript(scriptId).cast;
+  const setSectionTitle = useScriptStore((s) => s.setSectionTitle);
+  const addLine = useScriptStore((s) => s.addLine);
+  const removeSection = useScriptStore((s) => s.removeSection);
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      <FlexRow align="center" gap={SPACING.sm} fullWidth>
+        <TextInput
+          value={section.title ?? ""}
+          onChange={(e) =>
+            setSectionTitle(scriptId, section.id, e.target.value)
+          }
+          placeholder="Section title (optional)…"
+          hideLabel
+          label="Section title"
+          compact
+          fullWidth
+          disabled={readOnly}
+        />
+        {!readOnly && (
+          <ToolbarIconButton
+            tooltip="Remove section"
+            onClick={() => removeSection(scriptId, section.id)}
+            icon={<Text size="smaller">✕</Text>}
+          />
+        )}
+      </FlexRow>
+      <Divider />
+      {section.lines.map((line) => (
+        <ScriptLineRow
+          key={line.id}
+          scriptId={scriptId}
+          line={line}
+          cast={cast}
+          highlighted={line.id === currentLineId}
+          readOnly={readOnly}
+        />
+      ))}
+      {!readOnly && (
+        <FlexRow>
+          <EditorButton
+            size="small"
+            variant="text"
+            startIcon={<AddIcon fontSize="small" />}
+            onClick={() => addLine(scriptId, section.id)}
+          >
+            Add line
+          </EditorButton>
+        </FlexRow>
+      )}
+    </FlexColumn>
+  );
+};
+
+const ScriptDocumentPane = ({
+  scriptId,
+  readOnly
+}: ScriptDocumentPaneProps) => {
+  const { sections } = useScript(scriptId);
+  const addLine = useScriptStore((s) => s.addLine);
+  const addSection = useScriptStore((s) => s.addSection);
+  const { playing, currentLineId, play, stop } =
+    useScriptPlaythrough(scriptId);
+  const [voicingAll, setVoicingAll] = useState(false);
+
+  const onVoiceAll = useCallback(async () => {
+    setVoicingAll(true);
+    try {
+      await voiceAll(scriptId);
+    } finally {
+      setVoicingAll(false);
+    }
+  }, [scriptId]);
+
+  const isEmpty = sections.every((s) => s.lines.length === 0);
+
+  return (
+    <FlexColumn
+      gap={SPACING.md}
+      sx={{ flex: 1, minWidth: 0, height: "100%", overflowY: "auto" }}
+    >
+      <FlexRow
+        align="center"
+        gap={SPACING.sm}
+        sx={{
+          padding: SPACING.sm,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          position: "sticky",
+          top: 0,
+          backgroundColor: "background.paper",
+          zIndex: 1
+        }}
+      >
+        {!readOnly &&
+          (voicingAll ? (
+            <FlexRow align="center" gap={SPACING.xs}>
+              <LoadingSpinner size={18} />
+              <Text size="smaller">Voicing…</Text>
+            </FlexRow>
+          ) : (
+            <EditorButton
+              size="small"
+              variant="outlined"
+              startIcon={<GraphicEqIcon fontSize="small" />}
+              onClick={() => void onVoiceAll()}
+            >
+              Voice all
+            </EditorButton>
+          ))}
+        {playing ? (
+          <EditorButton
+            size="small"
+            variant="outlined"
+            startIcon={<StopIcon fontSize="small" />}
+            onClick={stop}
+          >
+            Stop
+          </EditorButton>
+        ) : (
+          <EditorButton
+            size="small"
+            variant="outlined"
+            startIcon={<PlayArrowIcon fontSize="small" />}
+            onClick={play}
+          >
+            Play through
+          </EditorButton>
+        )}
+      </FlexRow>
+
+      <FlexColumn
+        gap={SPACING.lg}
+        sx={{ padding: SPACING.md, maxWidth: 860, width: "100%" }}
+      >
+        {isEmpty && (
+          <EmptyState
+            title="Empty script"
+            description="Add a line to start writing. Assign speakers and voices in the Cast panel, then voice each line into a take."
+            actionText={readOnly ? undefined : "Add first line"}
+            onAction={readOnly ? undefined : () => addLine(scriptId)}
+          />
+        )}
+        {sections.map((section) => (
+          <SectionBlock
+            key={section.id}
+            scriptId={scriptId}
+            section={section}
+            currentLineId={currentLineId}
+            readOnly={readOnly}
+          />
+        ))}
+        {!readOnly && !isEmpty && (
+          <FlexRow gap={SPACING.sm}>
+            <EditorButton
+              size="small"
+              variant="text"
+              startIcon={<AddIcon fontSize="small" />}
+              onClick={() => addLine(scriptId)}
+            >
+              Add line
+            </EditorButton>
+            <EditorButton
+              size="small"
+              variant="text"
+              startIcon={<AddIcon fontSize="small" />}
+              onClick={() => addSection(scriptId)}
+            >
+              Add section
+            </EditorButton>
+          </FlexRow>
+        )}
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+export default ScriptDocumentPane;

--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -14,7 +14,8 @@ import {
   Divider,
   EmptyState,
   LoadingSpinner,
-  SPACING
+  SPACING,
+  Z_INDEX
 } from "../ui_primitives";
 import {
   useScript,
@@ -133,7 +134,7 @@ const ScriptDocumentPane = ({
           position: "sticky",
           top: 0,
           backgroundColor: "background.paper",
-          zIndex: 1
+          zIndex: Z_INDEX.sticky
         }}
       >
         {!readOnly &&

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -15,7 +15,9 @@ import {
   ToolbarIconButton,
   LoadingSpinner,
   Popover,
-  SPACING
+  SPACING,
+  BORDER_RADIUS,
+  MOTION
 } from "../ui_primitives";
 import {
   useScriptStore,
@@ -118,9 +120,9 @@ const ScriptLineRow = ({
       fullWidth
       sx={{
         padding: SPACING.sm,
-        borderRadius: 1,
+        borderRadius: BORDER_RADIUS.sm,
         backgroundColor: highlighted ? "action.selected" : "transparent",
-        transition: "background-color 120ms ease"
+        transition: MOTION.background
       }}
     >
       <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -1,0 +1,241 @@
+/** @jsxImportSource @emotion/react */
+import { useCallback, useState } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
+import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import HistoryIcon from "@mui/icons-material/History";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  TextInput,
+  Chip,
+  Tooltip,
+  ToolbarIconButton,
+  LoadingSpinner,
+  Popover,
+  SPACING
+} from "../ui_primitives";
+import {
+  useScriptStore,
+  useLineVoicing,
+  lineStatus,
+  effectiveVoice,
+  type ScriptLine,
+  type ScriptSpeaker
+} from "../../stores/script/ScriptStore";
+import { voiceLine } from "../../stores/script/scriptVoicing";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+import ScriptTakeGallery from "./ScriptTakeGallery";
+
+interface ScriptLineRowProps {
+  scriptId: string;
+  line: ScriptLine;
+  cast: ScriptSpeaker[];
+  highlighted: boolean;
+  readOnly: boolean;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft",
+  voiced: "Voiced",
+  stale: "Stale"
+};
+
+const STATUS_COLOR: Record<string, "default" | "success" | "warning"> = {
+  draft: "default",
+  voiced: "success",
+  stale: "warning"
+};
+
+const ScriptLineRow = ({
+  scriptId,
+  line,
+  cast,
+  highlighted,
+  readOnly
+}: ScriptLineRowProps) => {
+  const patchLine = useScriptStore((s) => s.patchLine);
+  const removeLine = useScriptStore((s) => s.removeLine);
+  const voicing = useLineVoicing(line.id);
+  const [galleryAnchor, setGalleryAnchor] = useState<HTMLElement | null>(null);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+
+  const voice = effectiveVoice(line, cast);
+  const status = lineStatus(line, voice);
+  const speaker = cast.find((s) => s.id === line.speakerId) ?? null;
+
+  const onTextChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      patchLine(scriptId, line.id, { text: e.target.value }),
+    [patchLine, scriptId, line.id]
+  );
+
+  const onDirectionChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      patchLine(scriptId, line.id, { direction: e.target.value }),
+    [patchLine, scriptId, line.id]
+  );
+
+  const cycleSpeaker = useCallback(() => {
+    if (cast.length === 0) return;
+    const idx = cast.findIndex((s) => s.id === line.speakerId);
+    // Cycle: none → first → … → last → none.
+    const next = idx < 0 ? cast[0] : (cast[idx + 1] ?? null);
+    patchLine(scriptId, line.id, { speakerId: next?.id ?? null });
+  }, [cast, line.speakerId, patchLine, scriptId, line.id]);
+
+  const onVoice = useCallback(async () => {
+    setVoiceError(null);
+    try {
+      await voiceLine(scriptId, line.id);
+    } catch (error) {
+      setVoiceError((error as Error).message ?? "Voicing failed");
+    }
+  }, [scriptId, line.id]);
+
+  const playCurrent = useCallback(async () => {
+    if (typeof Audio === "undefined") return;
+    const take = line.takes.find((t) => t.id === line.currentTakeId);
+    if (!take) return;
+    try {
+      const asset = await useAssetStore.getState().get(take.assetId);
+      const url = getAssetUrl(asset);
+      if (url) void new Audio(url).play().catch(() => undefined);
+    } catch {
+      // Asset unavailable.
+    }
+  }, [line.takes, line.currentTakeId]);
+
+  const hasCurrentTake = !!line.takes.find((t) => t.id === line.currentTakeId);
+
+  return (
+    <FlexRow
+      align="flex-start"
+      gap={SPACING.sm}
+      fullWidth
+      sx={{
+        padding: SPACING.sm,
+        borderRadius: 1,
+        backgroundColor: highlighted ? "action.selected" : "transparent",
+        transition: "background-color 120ms ease"
+      }}
+    >
+      <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
+        <span>
+          <Chip
+            label={speaker?.name ?? "No speaker"}
+            size="small"
+            onClick={readOnly ? undefined : cycleSpeaker}
+            sx={{
+              minWidth: 84,
+              cursor: readOnly || !cast.length ? "default" : "pointer",
+              backgroundColor: speaker?.color ?? undefined
+            }}
+          />
+        </span>
+      </Tooltip>
+
+      <FlexColumn gap={SPACING.micro} style={{ flex: 1, minWidth: 0 }}>
+        <TextInput
+          value={line.text}
+          onChange={onTextChange}
+          placeholder="Write a line…"
+          multiline
+          hideLabel
+          label="Line text"
+          compact
+          fullWidth
+          disabled={readOnly}
+        />
+        <TextInput
+          value={line.direction ?? ""}
+          onChange={onDirectionChange}
+          placeholder="Direction (e.g. whispering, tired)…"
+          hideLabel
+          label="Direction"
+          compact
+          fullWidth
+          disabled={readOnly}
+        />
+        {voiceError && (
+          <Text size="smaller" color="error">
+            {voiceError}
+          </Text>
+        )}
+      </FlexColumn>
+
+      <FlexColumn align="center" gap={SPACING.micro}>
+        <Chip
+          label={STATUS_LABEL[status]}
+          size="small"
+          color={STATUS_COLOR[status]}
+          compact
+        />
+        <FlexRow gap={SPACING.none} align="center">
+          {voicing ? (
+            <LoadingSpinner size={20} />
+          ) : (
+            <Tooltip
+              title={
+                voice
+                  ? status === "stale"
+                    ? "Re-voice line"
+                    : "Voice line"
+                  : "Assign a voice to this speaker first"
+              }
+            >
+              <span>
+                <ToolbarIconButton
+                  tooltip=""
+                  disabled={readOnly || !voice}
+                  onClick={() => void onVoice()}
+                  icon={<GraphicEqIcon fontSize="small" />}
+                />
+              </span>
+            </Tooltip>
+          )}
+          <ToolbarIconButton
+            tooltip="Play current take"
+            disabled={!hasCurrentTake}
+            onClick={() => void playCurrent()}
+            icon={<PlayArrowIcon fontSize="small" />}
+          />
+          <ToolbarIconButton
+            tooltip={`Takes (${line.takes.length})`}
+            onClick={(e: MouseEvent<HTMLElement>) =>
+              setGalleryAnchor(e.currentTarget)
+            }
+            icon={<HistoryIcon fontSize="small" />}
+          />
+          {!readOnly && (
+            <ToolbarIconButton
+              tooltip="Delete line"
+              onClick={() => removeLine(scriptId, line.id)}
+              icon={<DeleteOutlineIcon fontSize="small" />}
+            />
+          )}
+        </FlexRow>
+      </FlexColumn>
+
+      <Popover
+        open={!!galleryAnchor}
+        anchorEl={galleryAnchor}
+        onClose={() => setGalleryAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        <ScriptTakeGallery
+          scriptId={scriptId}
+          lineId={line.id}
+          takes={line.takes}
+          currentTakeId={line.currentTakeId ?? null}
+        />
+      </Popover>
+    </FlexRow>
+  );
+};
+
+export default ScriptLineRow;

--- a/web/src/components/script/ScriptTakeGallery.tsx
+++ b/web/src/components/script/ScriptTakeGallery.tsx
@@ -1,0 +1,154 @@
+/** @jsxImportSource @emotion/react */
+import { useCallback } from "react";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  Divider,
+  ToolbarIconButton,
+  EmptyState,
+  SPACING
+} from "../ui_primitives";
+import {
+  useScriptStore,
+  type ScriptTake
+} from "../../stores/script/ScriptStore";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+
+interface ScriptTakeGalleryProps {
+  scriptId: string;
+  lineId: string;
+  takes: ScriptTake[];
+  currentTakeId: string | null;
+}
+
+const formatDuration = (ms: number): string => {
+  const s = ms / 1000;
+  return `${s.toFixed(1)}s`;
+};
+
+const TakeRow = ({
+  scriptId,
+  lineId,
+  take,
+  isCurrent
+}: {
+  scriptId: string;
+  lineId: string;
+  take: ScriptTake;
+  isCurrent: boolean;
+}) => {
+  const setCurrentTake = useScriptStore((s) => s.setCurrentTake);
+  const toggleFavorite = useScriptStore((s) => s.toggleTakeFavorite);
+  const removeTake = useScriptStore((s) => s.removeTake);
+
+  const play = useCallback(async () => {
+    if (typeof Audio === "undefined") return;
+    try {
+      const asset = await useAssetStore.getState().get(take.assetId);
+      const url = getAssetUrl(asset);
+      if (url) void new Audio(url).play().catch(() => undefined);
+    } catch {
+      // Asset unavailable — nothing to play.
+    }
+  }, [take.assetId]);
+
+  return (
+    <FlexRow align="center" gap={SPACING.sm} fullWidth>
+      <ToolbarIconButton
+        tooltip={isCurrent ? "Current take" : "Use this take"}
+        onClick={() => setCurrentTake(scriptId, lineId, take.id)}
+        icon={
+          <CheckCircleIcon
+            fontSize="small"
+            color={isCurrent ? "primary" : "disabled"}
+          />
+        }
+      />
+      <FlexColumn gap={SPACING.none} style={{ flex: 1, minWidth: 0 }}>
+        <Text
+          size="small"
+          truncate
+          title={take.textSnapshot}
+          sx={{ fontStyle: "italic" }}
+        >
+          {take.textSnapshot || "(empty)"}
+        </Text>
+        <Text size="smaller" color="secondary">
+          {formatDuration(take.durationMs)}
+          {take.voiceSnapshot ? ` · ${take.voiceSnapshot.voice}` : ""}
+          {typeof take.costCredits === "number"
+            ? ` · ${take.costCredits} cr`
+            : ""}
+        </Text>
+      </FlexColumn>
+      <ToolbarIconButton
+        tooltip="Play take"
+        onClick={() => void play()}
+        icon={<span aria-hidden>▶</span>}
+      />
+      <ToolbarIconButton
+        tooltip={take.favorite ? "Unfavorite" : "Favorite"}
+        onClick={() => toggleFavorite(scriptId, lineId, take.id)}
+        icon={
+          take.favorite ? (
+            <StarIcon fontSize="small" color="warning" />
+          ) : (
+            <StarBorderIcon fontSize="small" />
+          )
+        }
+      />
+      <ToolbarIconButton
+        tooltip="Delete take"
+        onClick={() => removeTake(scriptId, lineId, take.id)}
+        icon={<DeleteOutlineIcon fontSize="small" />}
+      />
+    </FlexRow>
+  );
+};
+
+/** Popover body: the ordered take history for one line. */
+const ScriptTakeGallery = ({
+  scriptId,
+  lineId,
+  takes,
+  currentTakeId
+}: ScriptTakeGalleryProps) => {
+  if (takes.length === 0) {
+    return (
+      <div style={{ minWidth: 260, padding: 8 }}>
+        <EmptyState
+          title="No takes yet"
+          description="Voice this line to create the first take."
+        />
+      </div>
+    );
+  }
+  return (
+    <FlexColumn gap={SPACING.xs} style={{ minWidth: 320, padding: 8 }}>
+      <Text size="smaller" color="secondary">
+        {takes.length} take{takes.length === 1 ? "" : "s"}
+      </Text>
+      <Divider />
+      {takes
+        .slice()
+        .reverse()
+        .map((take) => (
+          <TakeRow
+            key={take.id}
+            scriptId={scriptId}
+            lineId={lineId}
+            take={take}
+            isCurrent={take.id === currentTakeId}
+          />
+        ))}
+    </FlexColumn>
+  );
+};
+
+export default ScriptTakeGallery;

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -7,6 +7,7 @@ import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
 import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
 import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
+import RecordVoiceOverOutlinedIcon from "@mui/icons-material/RecordVoiceOverOutlined";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 
 import {
@@ -22,6 +23,7 @@ import { trpcClient } from "../../trpc/client";
 import { useAssetSearch } from "../../serverState/useAssetSearch";
 import { useCreateTimeline } from "../../hooks/useTimelineSequence";
 import { useCreateStoryboard } from "../../hooks/storyboard/useStoryboards";
+import { useCreateScript } from "../../hooks/script/useScripts";
 import { useAssetStore } from "../../stores/AssetStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
@@ -148,6 +150,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const createAsset = useAssetStore((state) => state.createAsset);
   const createTimeline = useCreateTimeline();
   const createStoryboard = useCreateStoryboard();
+  const createScript = useCreateScript();
   const { searchAssets } = useAssetSearch();
 
   const close = useCallback(() => {
@@ -241,6 +244,24 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       console.error("Failed to create storyboard", error);
     }
   }, [createStoryboard, openTab, close]);
+
+  const handleNewScript = useCallback(async () => {
+    try {
+      const created = await createScript.mutateAsync({
+        name: "Untitled script",
+        projectId: "default"
+      });
+      openTab({
+        type: "script",
+        ref: created.id,
+        mode: "edit",
+        title: created.name
+      });
+      close();
+    } catch (error) {
+      console.error("Failed to create script", error);
+    }
+  }, [createScript, openTab, close]);
 
   const handleNewChat = useCallback(async () => {
     try {
@@ -398,6 +419,11 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               label="New storyboard"
               icon={<DashboardOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewStoryboard()}
+            />
+            <MenuItemPrimitive
+              label="New script"
+              icon={<RecordVoiceOverOutlinedIcon fontSize="small" />}
+              onClick={() => void handleNewScript()}
             />
             <MenuItemPrimitive
               label="New 3D model"

--- a/web/src/components/workspace/ScriptSurface.tsx
+++ b/web/src/components/workspace/ScriptSurface.tsx
@@ -1,0 +1,57 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect } from "react";
+import {
+  useWorkspaceTabsStore,
+  type WorkspaceTabMode
+} from "../../stores/WorkspaceTabsStore";
+import { useScriptStore, useScript } from "../../stores/script/ScriptStore";
+import { useScriptServerSync } from "../../hooks/script/useScriptServerSync";
+import ScriptDocumentPane from "../script/ScriptDocumentPane";
+import ScriptCastPanel from "../script/ScriptCastPanel";
+
+interface ScriptSurfaceProps {
+  refId: string;
+  mode: WorkspaceTabMode;
+  active: boolean;
+}
+
+/**
+ * Workspace surface for a script tab. `refId` is the script id. Ensures the
+ * script exists in the singleton store, mounts the server-sync/autosave hook,
+ * keeps the tab label in sync with the title, and lays out the document pane
+ * beside the cast panel (ElevenLabs-Studio style).
+ */
+const ScriptSurface = ({ refId, mode }: ScriptSurfaceProps) => {
+  const ensureScript = useScriptStore((state) => state.ensureScript);
+  const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
+  const { title, cast } = useScript(refId);
+  const readOnly = mode === "view";
+
+  useEffect(() => {
+    ensureScript(refId);
+  }, [ensureScript, refId]);
+
+  useScriptServerSync(refId);
+
+  useEffect(() => {
+    setTabTitle(refId, "script", title || "Untitled script");
+  }, [setTabTitle, refId, title]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "100%",
+        minHeight: 0,
+        position: "relative"
+      }}
+    >
+      <ScriptDocumentPane scriptId={refId} readOnly={readOnly} />
+      {!readOnly && (
+        <ScriptCastPanel scriptId={refId} cast={cast} readOnly={readOnly} />
+      )}
+    </div>
+  );
+};
+
+export default ScriptSurface;

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -8,6 +8,7 @@ import Model3DSurface from "./Model3DSurface";
 import AudioSurface from "./AudioSurface";
 import TimelineSurface from "./TimelineSurface";
 import StoryboardSurface from "./StoryboardSurface";
+import ScriptSurface from "./ScriptSurface";
 import ChatSurface from "./ChatSurface";
 import PageSurface from "./PageSurface";
 import { isPageTabKey } from "./pageTabs";
@@ -47,6 +48,8 @@ const TabContent = ({ tab, active }: TabContentProps) => {
       return (
         <StoryboardSurface refId={tab.ref} mode={tab.mode} active={active} />
       );
+    case "script":
+      return <ScriptSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "chat":
       return <ChatSurface refId={tab.ref} active={active} />;
     case "page":

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -35,6 +35,7 @@ const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
   sketch: false,
   timeline: true,
   storyboard: false,
+  script: false,
   model3d: true,
   text: true,
   audio: true,
@@ -48,6 +49,7 @@ const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
   "sketch",
   "timeline",
   "storyboard",
+  "script",
   "model3d",
   "chat"
 ]);
@@ -58,6 +60,7 @@ const TYPE_GLYPH: Record<WorkspaceTabType, string> = {
   sketch: "✎",
   timeline: "▤",
   storyboard: "▥",
+  script: "🎙",
   model3d: "◈",
   audio: "♪",
   text: "¶",
@@ -72,6 +75,7 @@ const TYPE_COLOR: Record<WorkspaceTabType, string> = {
   sketch: colorForType("image"),
   timeline: colorForType("video"),
   storyboard: colorForType("video"),
+  script: colorForType("audio"),
   model3d: colorForType("model_3d"),
   audio: colorForType("audio"),
   text: colorForType("text"),

--- a/web/src/hooks/script/useScriptPlaythrough.ts
+++ b/web/src/hooks/script/useScriptPlaythrough.ts
@@ -1,0 +1,99 @@
+/**
+ * useScriptPlaythrough — sequential playback of a script's current takes.
+ *
+ * A plain Audio-element chain (no compositor): play each voiced line's current
+ * take in document order, honoring `pauseAfterMs` between lines. Unvoiced lines
+ * are skipped. `currentLineId` drives the document-pane highlight.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useScriptStore } from "../../stores/script/ScriptStore";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+
+interface Playthrough {
+  playing: boolean;
+  currentLineId: string | null;
+  play: () => void;
+  stop: () => void;
+}
+
+export const useScriptPlaythrough = (scriptId: string): Playthrough => {
+  const [playing, setPlaying] = useState(false);
+  const [currentLineId, setCurrentLineId] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const cancelledRef = useRef(false);
+
+  const stop = useCallback(() => {
+    cancelledRef.current = true;
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = "";
+      audioRef.current = null;
+    }
+    setPlaying(false);
+    setCurrentLineId(null);
+  }, []);
+
+  useEffect(() => stop, [stop, scriptId]);
+
+  const play = useCallback(() => {
+    if (typeof Audio === "undefined") return;
+    const script = useScriptStore.getState().scripts[scriptId];
+    if (!script) return;
+
+    cancelledRef.current = false;
+    setPlaying(true);
+
+    const lines = script.sections
+      .flatMap((s) => s.lines)
+      .map((line) => ({
+        line,
+        take: line.takes.find((t) => t.id === line.currentTakeId)
+      }))
+      .filter((entry): entry is { line: typeof entry.line; take: NonNullable<typeof entry.take> } =>
+        !!entry.take
+      );
+
+    const wait = (ms: number): Promise<void> =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+
+    const playOne = (url: string): Promise<void> =>
+      new Promise((resolve) => {
+        const audio = new Audio(url);
+        audioRef.current = audio;
+        audio.onended = () => resolve();
+        audio.onerror = () => resolve();
+        void audio.play().catch(() => resolve());
+      });
+
+    const run = async (): Promise<void> => {
+      for (const { line, take } of lines) {
+        if (cancelledRef.current) break;
+        setCurrentLineId(line.id);
+        let url: string | null = null;
+        try {
+          const asset = await useAssetStore.getState().get(take.assetId);
+          url = getAssetUrl(asset);
+        } catch {
+          url = null;
+        }
+        if (cancelledRef.current) break;
+        if (url) await playOne(url);
+        if (cancelledRef.current) break;
+        if (line.pauseAfterMs && line.pauseAfterMs > 0)
+          await wait(line.pauseAfterMs);
+      }
+      if (!cancelledRef.current) {
+        setPlaying(false);
+        setCurrentLineId(null);
+      }
+    };
+
+    void run();
+  }, [scriptId]);
+
+  return { playing, currentLineId, play, stop };
+};
+
+export default useScriptPlaythrough;

--- a/web/src/hooks/script/useScriptServerSync.ts
+++ b/web/src/hooks/script/useScriptServerSync.ts
@@ -1,0 +1,152 @@
+/**
+ * useScriptServerSync
+ *
+ * Server persistence for one script tab. On mount: load the script's server
+ * document into the store (or upsert-create it when the tab refs a script the
+ * server doesn't know — new tabs). After load: watch the store and autosave
+ * with a debounce, using the server's `updatedAt` as a CAS token
+ * (`baseUpdatedAt`). On a conflict the server copy wins and is reloaded.
+ *
+ * Copied from useStoryboardServerSync — same machinery, script payload.
+ */
+
+import { useEffect, useRef } from "react";
+import { trpc, trpcClient } from "../../trpc/client";
+import { useScriptStore, type ScriptDraft } from "../../stores/script/ScriptStore";
+
+const AUTOSAVE_DEBOUNCE_MS = 750;
+const RETRY_DELAY_MS = 5_000;
+
+type ScriptResponse = Awaited<ReturnType<typeof trpcClient.scripts.get.query>>;
+type ScriptWireDocument = ScriptResponse["document"];
+
+/** The saved payload: the script minus identity and transient UI state. */
+const scriptToDocument = (script: ScriptDraft): ScriptWireDocument =>
+  ({
+    cast: script.cast,
+    sections: script.sections
+  }) as unknown as ScriptWireDocument;
+
+const responseToScript = (
+  res: ScriptResponse
+): Omit<ScriptDraft, "id" | "updatedAt"> => {
+  const doc = res.document;
+  return {
+    title: res.name === "Untitled script" ? "" : res.name,
+    cast: doc.cast as unknown as ScriptDraft["cast"],
+    sections: doc.sections as unknown as ScriptDraft["sections"],
+    timelineId: res.timelineId ?? null
+  };
+};
+
+const isNotFound = (error: unknown): boolean =>
+  !!error &&
+  typeof error === "object" &&
+  /not found/i.test((error as Error).message ?? "");
+
+export const useScriptServerSync = (scriptId: string): void => {
+  const utils = trpc.useUtils();
+  const syncedRef = useRef<ScriptDraft | null>(null);
+  const inFlightRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const utilsRef = useRef(utils);
+  utilsRef.current = utils;
+
+  useEffect(() => {
+    let disposed = false;
+    const store = useScriptStore;
+
+    const applyResponse = (res: ScriptResponse): void => {
+      if (disposed) return;
+      store.getState().loadScript(scriptId, responseToScript(res));
+      store.getState().setServerRevision(scriptId, res.updatedAt);
+      syncedRef.current = store.getState().scripts[scriptId] ?? null;
+    };
+
+    const load = async (): Promise<void> => {
+      try {
+        applyResponse(await trpcClient.scripts.get.query({ id: scriptId }));
+      } catch (error) {
+        if (!isNotFound(error)) {
+          console.error("Failed to load script", error);
+          return;
+        }
+        // Unknown to the server: upsert-create carrying any local content.
+        const local = store.getState().scripts[scriptId];
+        try {
+          const created = await trpcClient.scripts.create.mutate({
+            id: scriptId,
+            name: local?.title || "Untitled script",
+            document: local ? scriptToDocument(local) : undefined
+          });
+          if (disposed) return;
+          store.getState().setServerRevision(scriptId, created.updatedAt);
+          syncedRef.current = store.getState().scripts[scriptId] ?? null;
+          void utilsRef.current.scripts.list.invalidate();
+        } catch (createError) {
+          console.error("Failed to create script", createError);
+        }
+      }
+    };
+
+    const save = async (): Promise<void> => {
+      if (disposed || inFlightRef.current) return;
+      const script = store.getState().scripts[scriptId];
+      const revision = store.getState().serverRevisions[scriptId];
+      if (!script || !revision || script === syncedRef.current) return;
+
+      inFlightRef.current = true;
+      try {
+        const updated = await trpcClient.scripts.update.mutate({
+          id: scriptId,
+          baseUpdatedAt: revision,
+          name: script.title || "Untitled script",
+          document: scriptToDocument(script),
+          timelineId: script.timelineId
+        });
+        if (disposed) return;
+        store.getState().setServerRevision(scriptId, updated.updatedAt);
+        syncedRef.current = script;
+        void utilsRef.current.scripts.list.invalidate();
+        // Edits landed while the save was in flight — go again.
+        if (store.getState().scripts[scriptId] !== syncedRef.current) {
+          schedule();
+        }
+      } catch (error) {
+        if (disposed) return;
+        console.error("Script autosave failed", error);
+        if (/modified since last read/i.test((error as Error).message ?? "")) {
+          await load();
+        } else {
+          schedule(RETRY_DELAY_MS);
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    const schedule = (delayMs: number = AUTOSAVE_DEBOUNCE_MS): void => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        void save();
+      }, delayMs);
+    };
+
+    const unsubscribe = store.subscribe((state, prev) => {
+      if (state.scripts[scriptId] === prev.scripts[scriptId]) return;
+      if (state.scripts[scriptId] === syncedRef.current) return;
+      if (!state.serverRevisions[scriptId]) return;
+      schedule();
+    });
+
+    void load();
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [scriptId]);
+};
+
+export default useScriptServerSync;

--- a/web/src/hooks/script/useScripts.ts
+++ b/web/src/hooks/script/useScripts.ts
@@ -1,0 +1,34 @@
+/**
+ * tRPC hooks for server-persisted scripts. Mirrors useStoryboards:
+ * list/get queries plus create/delete mutations that keep the caches fresh.
+ */
+
+import { trpc } from "../../trpc/client";
+
+export const useScripts = () =>
+  trpc.scripts.list.useQuery({}, { staleTime: 30_000 });
+
+export const useScript = (id: string | null | undefined) =>
+  trpc.scripts.get.useQuery(
+    { id: id ?? "" },
+    { enabled: !!id, staleTime: 30_000 }
+  );
+
+export const useCreateScript = () => {
+  const utils = trpc.useUtils();
+  return trpc.scripts.create.useMutation({
+    onSuccess: (created) => {
+      void utils.scripts.list.invalidate();
+      utils.scripts.get.setData({ id: created.id }, created);
+    }
+  });
+};
+
+export const useDeleteScript = () => {
+  const utils = trpc.useUtils();
+  return trpc.scripts.delete.useMutation({
+    onSuccess: () => {
+      void utils.scripts.list.invalidate();
+    }
+  });
+};

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -20,6 +20,7 @@ export type WorkspaceTabType =
   | "sketch"
   | "timeline"
   | "storyboard"
+  | "script"
   | "model3d"
   | "audio"
   | "text"

--- a/web/src/stores/script/ScriptStore.ts
+++ b/web/src/stores/script/ScriptStore.ts
@@ -1,0 +1,522 @@
+/**
+ * ScriptStore
+ *
+ * Singleton Zustand store for the Script workspace surface. Like the
+ * storyboard (and unlike the timeline's per-editor document store), every open
+ * script lives in one `scripts` map keyed by ref id, so a script's cast + lines
+ * survive tab switches without a provider wrapper.
+ *
+ * A script inverts the timeline transcript's ownership: text is the source of
+ * truth, audio is derived. Each line is voiced into one or more takes (audio
+ * assets with word timings); the current take is what "send to timeline" and
+ * play-through use.
+ *
+ * Usage:
+ *   const script = useScript(scriptId);            // reactive script view
+ *   useScriptStore.getState().addLine(scriptId);   // mutate
+ */
+
+import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface VoiceBinding {
+  provider: string;
+  model: string;
+  voice: string;
+  settings?: Record<string, unknown>;
+}
+
+export interface ScriptCaptionWord {
+  word: string;
+  startMs: number;
+  endMs: number;
+}
+
+export interface ScriptTake {
+  id: string;
+  assetId: string;
+  durationMs: number;
+  words: ScriptCaptionWord[];
+  textSnapshot: string;
+  voiceSnapshot: VoiceBinding | null;
+  createdAt: string;
+  favorite?: boolean;
+  costCredits?: number;
+}
+
+export interface ScriptLine {
+  id: string;
+  speakerId?: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  voiceOverride?: VoiceBinding | null;
+  takes: ScriptTake[];
+  currentTakeId?: string | null;
+}
+
+export interface ScriptSection {
+  id: string;
+  title?: string;
+  lines: ScriptLine[];
+}
+
+export interface ScriptSpeaker {
+  id: string;
+  name: string;
+  color?: string;
+  voice?: VoiceBinding | null;
+}
+
+export interface ScriptDraft {
+  id: string;
+  title: string;
+  cast: ScriptSpeaker[];
+  sections: ScriptSection[];
+  /** Persisted timeline sequence this script was assembled into, if any. */
+  timelineId: string | null;
+  /** Epoch ms of the last mutation; drives the sidebar's recency sort. */
+  updatedAt: number;
+}
+
+interface ScriptStoreState {
+  scripts: Record<string, ScriptDraft>;
+  /** Server `updated_at` token per script — the CAS base for the next save. */
+  serverRevisions: Record<string, string>;
+  /** Line ids currently generating a take — transient, not persisted. */
+  voicingLineIds: Record<string, true>;
+
+  setServerRevision: (scriptId: string, revision: string | null) => void;
+  ensureScript: (id: string) => void;
+  loadScript: (
+    id: string,
+    script: Omit<ScriptDraft, "id" | "updatedAt">
+  ) => void;
+  removeScript: (id: string) => void;
+  getScript: (id: string) => ScriptDraft | undefined;
+
+  setTitle: (scriptId: string, title: string) => void;
+  setTimelineLink: (scriptId: string, timelineId: string | null) => void;
+
+  // Cast
+  addSpeaker: (scriptId: string, speaker: ScriptSpeaker) => void;
+  updateSpeaker: (
+    scriptId: string,
+    speakerId: string,
+    patch: Partial<Omit<ScriptSpeaker, "id">>
+  ) => void;
+  removeSpeaker: (scriptId: string, speakerId: string) => void;
+
+  // Sections
+  addSection: (scriptId: string, section?: Partial<ScriptSection>) => string;
+  setSectionTitle: (
+    scriptId: string,
+    sectionId: string,
+    title: string
+  ) => void;
+  removeSection: (scriptId: string, sectionId: string) => void;
+
+  // Lines
+  addLine: (scriptId: string, sectionId?: string) => string;
+  patchLine: (
+    scriptId: string,
+    lineId: string,
+    patch: Partial<Omit<ScriptLine, "id" | "takes">>
+  ) => void;
+  removeLine: (scriptId: string, lineId: string) => void;
+  reorderLines: (
+    scriptId: string,
+    sectionId: string,
+    orderedLineIds: string[]
+  ) => void;
+
+  // Takes
+  appendTake: (scriptId: string, lineId: string, take: ScriptTake) => void;
+  setCurrentTake: (
+    scriptId: string,
+    lineId: string,
+    takeId: string | null
+  ) => void;
+  toggleTakeFavorite: (
+    scriptId: string,
+    lineId: string,
+    takeId: string
+  ) => void;
+  removeTake: (scriptId: string, lineId: string, takeId: string) => void;
+
+  // Transient voicing status
+  setVoicing: (lineId: string, voicing: boolean) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let counter = 0;
+const uid = (prefix: string): string =>
+  `${prefix}_${Date.now().toString(36)}_${(counter++).toString(36)}`;
+
+export const emptyScript = (id: string): ScriptDraft => ({
+  id,
+  title: "",
+  cast: [],
+  sections: [],
+  timelineId: null,
+  updatedAt: Date.now()
+});
+
+/**
+ * Apply `mutate` to the script with `scriptId`. Returns the SAME state when the
+ * script is absent or `mutate` returns `null`, so no-op edits don't churn
+ * subscribers. Stamps `updatedAt` on every real mutation.
+ */
+const withScript = (
+  state: ScriptStoreState,
+  scriptId: string,
+  mutate: (script: ScriptDraft) => ScriptDraft | null
+): Partial<ScriptStoreState> | ScriptStoreState => {
+  const script = state.scripts[scriptId];
+  if (!script) return state;
+  const next = mutate(script);
+  if (!next || next === script) return state;
+  return {
+    scripts: {
+      ...state.scripts,
+      [scriptId]: { ...next, updatedAt: Date.now() }
+    }
+  };
+};
+
+/** Map every line in the script, returning the same script on a no-op. */
+const mapLine = (
+  script: ScriptDraft,
+  lineId: string,
+  fn: (line: ScriptLine) => ScriptLine
+): ScriptDraft => {
+  let changed = false;
+  const sections = script.sections.map((section) => {
+    let sectionChanged = false;
+    const lines = section.lines.map((line) => {
+      if (line.id !== lineId) return line;
+      const next = fn(line);
+      if (next !== line) sectionChanged = true;
+      return next;
+    });
+    if (!sectionChanged) return section;
+    changed = true;
+    return { ...section, lines };
+  });
+  return changed ? { ...script, sections } : script;
+};
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+export const useScriptStore = create<ScriptStoreState>((set, get) => ({
+  scripts: {},
+  serverRevisions: {},
+  voicingLineIds: {},
+
+  setServerRevision: (scriptId, revision) =>
+    set((state) => {
+      const serverRevisions = { ...state.serverRevisions };
+      if (revision === null) delete serverRevisions[scriptId];
+      else serverRevisions[scriptId] = revision;
+      return { serverRevisions };
+    }),
+
+  ensureScript: (id) =>
+    set((state) =>
+      state.scripts[id]
+        ? state
+        : { scripts: { ...state.scripts, [id]: emptyScript(id) } }
+    ),
+
+  loadScript: (id, script) =>
+    set((state) => ({
+      scripts: {
+        ...state.scripts,
+        [id]: { ...emptyScript(id), ...script, id, updatedAt: Date.now() }
+      }
+    })),
+
+  removeScript: (id) =>
+    set((state) => {
+      if (!state.scripts[id]) return state;
+      const scripts = { ...state.scripts };
+      delete scripts[id];
+      return { scripts };
+    }),
+
+  getScript: (id) => get().scripts[id],
+
+  setTitle: (scriptId, title) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        s.title === title ? s : { ...s, title }
+      )
+    ),
+
+  setTimelineLink: (scriptId, timelineId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        s.timelineId === timelineId ? s : { ...s, timelineId }
+      )
+    ),
+
+  addSpeaker: (scriptId, speaker) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => ({
+        ...s,
+        cast: [...s.cast, speaker]
+      }))
+    ),
+
+  updateSpeaker: (scriptId, speakerId, patch) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        const cast = s.cast.map((sp) =>
+          sp.id === speakerId ? { ...sp, ...patch } : sp
+        );
+        return { ...s, cast };
+      })
+    ),
+
+  removeSpeaker: (scriptId, speakerId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        const cast = s.cast.filter((sp) => sp.id !== speakerId);
+        if (cast.length === s.cast.length) return s;
+        // Unassign the removed speaker from every line.
+        const sections = s.sections.map((section) => ({
+          ...section,
+          lines: section.lines.map((line) =>
+            line.speakerId === speakerId
+              ? { ...line, speakerId: null }
+              : line
+          )
+        }));
+        return { ...s, cast, sections };
+      })
+    ),
+
+  addSection: (scriptId, section) => {
+    const id = section?.id ?? uid("sec");
+    set((state) =>
+      withScript(state, scriptId, (s) => ({
+        ...s,
+        sections: [
+          ...s.sections,
+          { id, title: section?.title, lines: section?.lines ?? [] }
+        ]
+      }))
+    );
+    return id;
+  },
+
+  setSectionTitle: (scriptId, sectionId, title) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => ({
+        ...s,
+        sections: s.sections.map((section) =>
+          section.id === sectionId ? { ...section, title } : section
+        )
+      }))
+    ),
+
+  removeSection: (scriptId, sectionId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        const sections = s.sections.filter((sec) => sec.id !== sectionId);
+        return sections.length === s.sections.length
+          ? s
+          : { ...s, sections };
+      })
+    ),
+
+  addLine: (scriptId, sectionId) => {
+    const lineId = uid("line");
+    const newLine: ScriptLine = { id: lineId, text: "", takes: [] };
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        // No target section (or none exist yet): append to the last section,
+        // creating one when the script is empty.
+        let sections = s.sections;
+        if (sections.length === 0) {
+          sections = [{ id: uid("sec"), lines: [newLine] }];
+          return { ...s, sections };
+        }
+        const targetId = sectionId ?? sections[sections.length - 1].id;
+        return {
+          ...s,
+          sections: sections.map((section) =>
+            section.id === targetId
+              ? { ...section, lines: [...section.lines, newLine] }
+              : section
+          )
+        };
+      })
+    );
+    return lineId;
+  },
+
+  patchLine: (scriptId, lineId, patch) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        mapLine(s, lineId, (line) => {
+          const keys = Object.keys(patch) as Array<keyof typeof patch>;
+          const unchanged = keys.every((k) => Object.is(line[k], patch[k]));
+          return unchanged ? line : { ...line, ...patch };
+        })
+      )
+    ),
+
+  removeLine: (scriptId, lineId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        let changed = false;
+        const sections = s.sections.map((section) => {
+          const lines = section.lines.filter((l) => l.id !== lineId);
+          if (lines.length !== section.lines.length) changed = true;
+          return lines.length === section.lines.length
+            ? section
+            : { ...section, lines };
+        });
+        return changed ? { ...s, sections } : s;
+      })
+    ),
+
+  reorderLines: (scriptId, sectionId, orderedLineIds) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => ({
+        ...s,
+        sections: s.sections.map((section) => {
+          if (section.id !== sectionId) return section;
+          const byId = new Map(section.lines.map((l) => [l.id, l]));
+          const lines = orderedLineIds
+            .map((id) => byId.get(id))
+            .filter((l): l is ScriptLine => !!l);
+          // Keep any lines the order list forgot (defensive).
+          for (const line of section.lines)
+            if (!orderedLineIds.includes(line.id)) lines.push(line);
+          return { ...section, lines };
+        })
+      }))
+    ),
+
+  appendTake: (scriptId, lineId, take) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        mapLine(s, lineId, (line) => ({
+          ...line,
+          takes: [...line.takes, take],
+          currentTakeId: take.id
+        }))
+      )
+    ),
+
+  setCurrentTake: (scriptId, lineId, takeId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        mapLine(s, lineId, (line) =>
+          line.currentTakeId === takeId
+            ? line
+            : { ...line, currentTakeId: takeId }
+        )
+      )
+    ),
+
+  toggleTakeFavorite: (scriptId, lineId, takeId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        mapLine(s, lineId, (line) => ({
+          ...line,
+          takes: line.takes.map((t) =>
+            t.id === takeId ? { ...t, favorite: !t.favorite } : t
+          )
+        }))
+      )
+    ),
+
+  removeTake: (scriptId, lineId, takeId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) =>
+        mapLine(s, lineId, (line) => {
+          const takes = line.takes.filter((t) => t.id !== takeId);
+          if (takes.length === line.takes.length) return line;
+          const currentTakeId =
+            line.currentTakeId === takeId
+              ? (takes[takes.length - 1]?.id ?? null)
+              : line.currentTakeId;
+          return { ...line, takes, currentTakeId };
+        })
+      )
+    ),
+
+  setVoicing: (lineId, voicing) =>
+    set((state) => {
+      const voicingLineIds = { ...state.voicingLineIds };
+      if (voicing) voicingLineIds[lineId] = true;
+      else delete voicingLineIds[lineId];
+      return { voicingLineIds };
+    })
+}));
+
+// ── Selector hooks ───────────────────────────────────────────────────────────
+
+const EMPTY_CAST: ScriptSpeaker[] = [];
+const EMPTY_SECTIONS: ScriptSection[] = [];
+
+/** Reactive multi-value view of a script (shallow-compared). */
+export const useScript = (
+  id: string
+): {
+  title: string;
+  cast: ScriptSpeaker[];
+  sections: ScriptSection[];
+  timelineId: string | null;
+} =>
+  useScriptStore(
+    useShallow((state) => {
+      const s = state.scripts[id];
+      return {
+        title: s?.title ?? "",
+        cast: s?.cast ?? EMPTY_CAST,
+        sections: s?.sections ?? EMPTY_SECTIONS,
+        timelineId: s?.timelineId ?? null
+      };
+    })
+  );
+
+/** Reactive transient voicing flag for a line. */
+export const useLineVoicing = (lineId: string): boolean =>
+  useScriptStore((state) => !!state.voicingLineIds[lineId]);
+
+/**
+ * Line status derived from its current take vs. the current text/voice.
+ * `draft` — no takes; `voiced` — current take matches; `stale` — text or voice
+ * changed since the take was made.
+ */
+export type LineStatus = "draft" | "voiced" | "stale";
+
+export const lineStatus = (
+  line: ScriptLine,
+  effectiveVoice: VoiceBinding | null
+): LineStatus => {
+  const take = line.takes.find((t) => t.id === line.currentTakeId);
+  if (!take) return "draft";
+  const textMatches = take.textSnapshot === line.text;
+  const voiceMatches =
+    JSON.stringify(take.voiceSnapshot) === JSON.stringify(effectiveVoice);
+  return textMatches && voiceMatches ? "voiced" : "stale";
+};
+
+/** The voice a line will be sung with: its override, else its speaker's. */
+export const effectiveVoice = (
+  line: ScriptLine,
+  cast: ScriptSpeaker[]
+): VoiceBinding | null => {
+  if (line.voiceOverride !== undefined && line.voiceOverride !== null)
+    return line.voiceOverride;
+  const speaker = cast.find((s) => s.id === line.speakerId);
+  return speaker?.voice ?? null;
+};

--- a/web/src/stores/script/__tests__/ScriptStore.test.ts
+++ b/web/src/stores/script/__tests__/ScriptStore.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment node
+ *
+ * Script store mutations and derived helpers: lines and takes accumulate,
+ * the current take switches without dropping history, removing a speaker
+ * unassigns its lines, and line status is derived from the current take's
+ * text/voice snapshot vs. the live line.
+ */
+
+import {
+  useScriptStore,
+  lineStatus,
+  effectiveVoice,
+  type ScriptTake,
+  type VoiceBinding
+} from "../ScriptStore";
+
+const SCRIPT = "script-1";
+
+const voice = (name: string): VoiceBinding => ({
+  provider: "openai",
+  model: "tts-1",
+  voice: name
+});
+
+const take = (over: Partial<ScriptTake>): ScriptTake => ({
+  id: "take-x",
+  assetId: "asset-x",
+  durationMs: 1000,
+  words: [],
+  textSnapshot: "hello",
+  voiceSnapshot: voice("alloy"),
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...over
+});
+
+const firstLineId = (): string => {
+  const s = useScriptStore.getState().scripts[SCRIPT];
+  return s.sections[0].lines[0].id;
+};
+
+afterEach(() => {
+  useScriptStore.getState().removeScript(SCRIPT);
+});
+
+describe("addLine", () => {
+  it("creates a section when the script is empty", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    const lineId = store.addLine(SCRIPT);
+    const s = useScriptStore.getState().scripts[SCRIPT];
+    expect(s.sections).toHaveLength(1);
+    expect(s.sections[0].lines[0].id).toBe(lineId);
+  });
+
+  it("appends to the last section when one exists", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    store.addLine(SCRIPT);
+    const s = useScriptStore.getState().scripts[SCRIPT];
+    expect(s.sections).toHaveLength(1);
+    expect(s.sections[0].lines).toHaveLength(2);
+  });
+});
+
+describe("takes", () => {
+  it("appendTake accumulates and sets current", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.appendTake(SCRIPT, lineId, take({ id: "t1" }));
+    store.appendTake(SCRIPT, lineId, take({ id: "t2" }));
+    const line = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines[0];
+    expect(line.takes.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(line.currentTakeId).toBe("t2");
+  });
+
+  it("removeTake falls back to the last remaining take", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.appendTake(SCRIPT, lineId, take({ id: "t1" }));
+    store.appendTake(SCRIPT, lineId, take({ id: "t2" }));
+    store.removeTake(SCRIPT, lineId, "t2");
+    const line = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines[0];
+    expect(line.takes.map((t) => t.id)).toEqual(["t1"]);
+    expect(line.currentTakeId).toBe("t1");
+  });
+});
+
+describe("removeSpeaker", () => {
+  it("unassigns the removed speaker from every line", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addSpeaker(SCRIPT, { id: "spk1", name: "A", voice: voice("alloy") });
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.patchLine(SCRIPT, lineId, { speakerId: "spk1" });
+    store.removeSpeaker(SCRIPT, "spk1");
+    const s = useScriptStore.getState().scripts[SCRIPT];
+    expect(s.cast).toHaveLength(0);
+    expect(s.sections[0].lines[0].speakerId).toBeNull();
+  });
+});
+
+describe("lineStatus", () => {
+  it("is draft with no takes, voiced when matching, stale when text drifts", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addSpeaker(SCRIPT, { id: "spk1", name: "A", voice: voice("alloy") });
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.patchLine(SCRIPT, lineId, { speakerId: "spk1", text: "hello" });
+
+    const draftLine = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines[0];
+    const eff = effectiveVoice(draftLine, useScriptStore.getState().scripts[SCRIPT].cast);
+    expect(lineStatus(draftLine, eff)).toBe("draft");
+
+    store.appendTake(SCRIPT, lineId, take({ id: "t1", textSnapshot: "hello", voiceSnapshot: voice("alloy") }));
+    const voicedLine = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines[0];
+    expect(lineStatus(voicedLine, eff)).toBe("voiced");
+
+    store.patchLine(SCRIPT, lineId, { text: "hello there" });
+    const staleLine = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines[0];
+    expect(lineStatus(staleLine, eff)).toBe("stale");
+  });
+});
+
+describe("effectiveVoice", () => {
+  it("prefers a line override over the speaker voice", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addSpeaker(SCRIPT, { id: "spk1", name: "A", voice: voice("alloy") });
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.patchLine(SCRIPT, lineId, {
+      speakerId: "spk1",
+      voiceOverride: voice("echo")
+    });
+    const s = useScriptStore.getState().scripts[SCRIPT];
+    const eff = effectiveVoice(s.sections[0].lines[0], s.cast);
+    expect(eff?.voice).toBe("echo");
+  });
+});

--- a/web/src/stores/script/scriptVoicing.ts
+++ b/web/src/stores/script/scriptVoicing.ts
@@ -1,0 +1,260 @@
+/**
+ * scriptVoicing — the per-line voicing pipeline.
+ *
+ * Identical to TimelineTranscriptStore.generateBeat, minus the timeline
+ * coupling: text is the source of truth, a voiced take is derived.
+ *
+ *   line text → generate_media (TTS) → probe duration →
+ *   transcribe_audio (word timings, best-effort) → append take
+ *
+ * Reuses the unified WebSocket runner's `generate_media` / `transcribe_audio`
+ * RPCs — no inline graphs, no bespoke engine.
+ */
+
+import {
+  globalWebSocketManager,
+  type WebSocketMessage
+} from "../../lib/websocket/GlobalWebSocketManager";
+import { useAssetStore } from "../AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+import {
+  useScriptStore,
+  effectiveVoice,
+  type ScriptCaptionWord,
+  type ScriptTake,
+  type VoiceBinding
+} from "./ScriptStore";
+
+/** Speech-to-text default for word-level take timing (best-effort). */
+export interface AsrConfig {
+  provider: string;
+  model: string;
+}
+
+export const DEFAULT_ASR_CONFIG: AsrConfig = {
+  provider: "openai",
+  model: "whisper-1"
+};
+
+// ── RPC helpers (mirror TimelineTranscriptStore's request/response pattern) ──
+
+interface RpcResponse extends WebSocketMessage {
+  type: "rpc_response";
+  request_id: string;
+  result?: Record<string, unknown>;
+  error?: { code?: string; message?: string };
+}
+
+function randomRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function rpcRequest(
+  command: string,
+  data: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  await globalWebSocketManager.ensureConnection();
+  const requestId = randomRequestId();
+  return new Promise((resolve, reject) => {
+    const unsubscribe = globalWebSocketManager.subscribe(requestId, (msg) => {
+      if (msg.type !== "rpc_response") return;
+      const response = msg as RpcResponse;
+      if (response.request_id !== requestId) return;
+      unsubscribe();
+      if (response.error) {
+        reject(new Error(response.error.message ?? "RPC failed"));
+        return;
+      }
+      resolve(response.result ?? {});
+    });
+    globalWebSocketManager
+      .send({ command, request_id: requestId, data })
+      .catch((err) => {
+        unsubscribe();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+  });
+}
+
+async function probeAudioDurationMs(url: string): Promise<number | null> {
+  if (typeof Audio === "undefined") return null;
+  return new Promise((resolve) => {
+    const audio = new Audio();
+    audio.preload = "metadata";
+    audio.onloadedmetadata = () => {
+      resolve(
+        Number.isFinite(audio.duration) && audio.duration > 0
+          ? Math.round(audio.duration * 1000)
+          : null
+      );
+    };
+    audio.onerror = () => resolve(null);
+    audio.src = url;
+  });
+}
+
+async function resolveAssetUrl(assetId: string): Promise<string | null> {
+  try {
+    const asset = await useAssetStore.getState().get(assetId);
+    return getAssetUrl(asset);
+  } catch {
+    return null;
+  }
+}
+
+function parseCaptionWords(
+  result: Record<string, unknown>
+): ScriptCaptionWord[] {
+  const raw = Array.isArray(result.words) ? result.words : [];
+  const words: ScriptCaptionWord[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const w = entry as Record<string, unknown>;
+    if (
+      typeof w.word === "string" &&
+      typeof w.startMs === "number" &&
+      typeof w.endMs === "number"
+    ) {
+      words.push({ word: w.word, startMs: w.startMs, endMs: w.endMs });
+    }
+  }
+  return words;
+}
+
+function takeId(): string {
+  return `take_${randomRequestId()}`;
+}
+
+/**
+ * Voice one line into a new take and set it current. Resolves to the appended
+ * take, or throws when the line has no voice or no text. Word timings are
+ * best-effort: a failed transcription still yields a playable take.
+ */
+export async function voiceLine(
+  scriptId: string,
+  lineId: string,
+  asr: AsrConfig = DEFAULT_ASR_CONFIG
+): Promise<ScriptTake> {
+  const store = useScriptStore;
+  const script = store.getState().scripts[scriptId];
+  if (!script) throw new Error("Script not found");
+  const line = script.sections
+    .flatMap((s) => s.lines)
+    .find((l) => l.id === lineId);
+  if (!line) throw new Error("Line not found");
+
+  const text = line.text.trim();
+  if (!text) throw new Error("Line has no text to voice");
+
+  const voice: VoiceBinding | null = effectiveVoice(line, script.cast);
+  if (!voice) {
+    throw new Error(
+      "Line has no voice — assign the speaker a voice or set a per-line override"
+    );
+  }
+
+  store.getState().setVoicing(lineId, true);
+  try {
+    const ttsResult = await rpcRequest("generate_media", {
+      mode: "audio",
+      provider: voice.provider,
+      model: voice.model,
+      voice: voice.voice,
+      prompt: text
+    });
+    const assetIds = Array.isArray(ttsResult.asset_ids)
+      ? (ttsResult.asset_ids as unknown[]).filter(
+          (id): id is string => typeof id === "string"
+        )
+      : [];
+    const audioAssetId = assetIds[0];
+    if (!audioAssetId) throw new Error("TTS returned no audio asset");
+
+    const url = await resolveAssetUrl(audioAssetId);
+    const durationMs = url ? ((await probeAudioDurationMs(url)) ?? 0) : 0;
+
+    let words: ScriptCaptionWord[] = [];
+    try {
+      const asrResult = await rpcRequest("transcribe_audio", {
+        provider: asr.provider,
+        model: asr.model,
+        asset_id: audioAssetId
+      });
+      words = parseCaptionWords(asrResult);
+    } catch (error) {
+      console.warn("Take transcription failed; take stays playable", error);
+    }
+
+    const take: ScriptTake = {
+      id: takeId(),
+      assetId: audioAssetId,
+      durationMs,
+      words,
+      textSnapshot: line.text,
+      voiceSnapshot: voice,
+      createdAt: new Date().toISOString(),
+      costCredits:
+        typeof ttsResult.cost_credits === "number"
+          ? ttsResult.cost_credits
+          : undefined
+    };
+    store.getState().appendTake(scriptId, lineId, take);
+    return take;
+  } finally {
+    store.getState().setVoicing(lineId, false);
+  }
+}
+
+/**
+ * Voice every draft/stale line in the script, bounded concurrency, respecting
+ * each line's effective voice. Lines already voiced (current take matches) and
+ * lines with no text or no voice are skipped. Returns the count voiced.
+ */
+export async function voiceAll(
+  scriptId: string,
+  asr: AsrConfig = DEFAULT_ASR_CONFIG,
+  concurrency = 3
+): Promise<number> {
+  const store = useScriptStore;
+  const script = store.getState().scripts[scriptId];
+  if (!script) return 0;
+
+  const targets = script.sections
+    .flatMap((s) => s.lines)
+    .filter((line) => {
+      if (!line.text.trim()) return false;
+      if (!effectiveVoice(line, script.cast)) return false;
+      const take = line.takes.find((t) => t.id === line.currentTakeId);
+      // Re-voice drafts and stale lines; skip up-to-date ones.
+      return (
+        !take ||
+        take.textSnapshot !== line.text ||
+        JSON.stringify(take.voiceSnapshot) !==
+          JSON.stringify(effectiveVoice(line, script.cast))
+      );
+    })
+    .map((line) => line.id);
+
+  let voiced = 0;
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < targets.length) {
+      const lineId = targets[cursor++];
+      try {
+        await voiceLine(scriptId, lineId, asr);
+        voiced += 1;
+      } catch (error) {
+        console.error("voiceAll: failed to voice line", lineId, error);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, targets.length) }, () =>
+      worker()
+    )
+  );
+  return voiced;
+}


### PR DESCRIPTION
Implements **Phase 1** of the [Script editor concept](docs/script-editor-concept.md): a script as a first-class resource where **text is the source of truth and audio is derived**. You can write a script, cast speakers to TTS voices, voice each line into takes (audio + word timings), audition takes, and play the script through — the ElevenLabs-Studio use case, standalone, before any timeline integration.

The implementation mirrors the existing **Storyboard** resource byte-for-byte where it can (table shape, tRPC CRUD with compare-and-swap, singleton store + debounced autosave, workspace-tab surface), and reuses the timeline transcript's voicing pipeline (`generate_media` / `transcribe_audio` RPCs).

## Backend
- **protocol** — `api-schemas/scripts.ts`: `scriptDocument` (cast/speakers, sections, lines, takes reusing `captionWord`) plus response/list/create/patch inputs.
- **models** — `Script` model with `emptyScriptDocument`/`countScriptLines`, SQLite + Postgres schema, `create_scripts` migration, in-memory test-DB schema, index exports.
- **websocket** — `scripts` tRPC router (`list`/`get`/`create`/`update` with CAS on `updated_at`/`delete`), mounted in the app router.

## Frontend
- **ScriptStore** — singleton keyed by ref id, `withScript` mutation wrapper stamping `updatedAt`, cast/section/line/take mutations, plus derived helpers: `lineStatus` (`draft`/`voiced`/`stale`) and `effectiveVoice` (per-line override → speaker voice).
- **Sync** — `useScriptServerSync` (debounced autosave, CAS token, server-wins on conflict) and `useScripts` TanStack Query hooks.
- **Voicing** — `scriptVoicing.ts`: per-line `voiceLine` and bounded-concurrency `voiceAll`, reusing `generate_media` (TTS) → probe duration → `transcribe_audio` (best-effort word timings) → append take.
- **Surface** — `ScriptSurface` + a new `script` workspace tab type (wired through `TabContent`, `WorkspaceTabBar`, `WorkspaceTabsStore`): document pane (per-line editor with speaker chip, direction, status badge, per-line voice spinner and play, take-gallery popover), cast panel with the existing `TTSModelSelect` voice picker, "Voice all", and sequential play-through. "New script" added to the open menu.

## Scope notes
- The document pane is a plain per-line editor rather than the Lexical transcript editor; that reuse (and Phases 2–4: send-to-timeline, agent tools/graph nodes, dialogue-mode/SRT export) is deferred.

## Tests
- `packages/models/tests/script.test.ts` — model CRUD, line counting, CAS apply/reject; bumped the built-in migration count.
- `web/src/stores/script/__tests__/ScriptStore.test.ts` — line/section creation, take accumulation and fallback, speaker unassign, derived line status, voice override precedence.

## Verification
- `npm run typecheck` (web) — clean
- ESLint (new web files) and lint for protocol/models/websocket — clean
- Model + migration tests and ScriptStore tests — passing (rebuilt `better-sqlite3` native module to run the DB tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpPWDkDrzsyg1voa383b4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpPWDkDrzsyg1voa383b4N)_