### PR TITLE
fix(compositor): reverse compositing order so top input handle is top image

### DIFF
--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -2355,10 +2355,10 @@ function compositorLayerState(raw: unknown): CompositorLayerState {
 /**
  * Compositor — stacks multiple image layers with per-layer opacity and
  * blend mode. Dynamic image inputs are named `image_0`, `image_1`, ...;
- * the lowest-index input is the base (canvas), subsequent layers are
- * composited on top in index order at (0, 0). Per-layer state lives in
- * the `layers` list, indexed positionally against the sorted image
- * inputs. Hidden / zero-opacity layers are skipped.
+ * the lowest-index input is the top (frontmost) layer, subsequent layers
+ * are composited behind it. Per-layer state lives in the `layers` list,
+ * indexed positionally against the sorted image inputs. Hidden /
+ * zero-opacity layers are skipped.
  *
  * Compositing runs on the GPU through the shared WebGPULayerCompositor (the
  * same engine the sketch editor and timeline preview use), via Node.js Dawn —
@@ -2485,7 +2485,7 @@ export class CompositorNode extends BaseNode {
       };
     }
 
-    // Canvas size: explicit props win; otherwise the first layer's size.
+    // Canvas size: explicit props win; otherwise the top (first) layer's size.
     const canvasWidth =
       Number(this.canvas_width) > 0
         ? Math.floor(Number(this.canvas_width))
@@ -2494,6 +2494,9 @@ export class CompositorNode extends BaseNode {
       Number(this.canvas_height) > 0
         ? Math.floor(Number(this.canvas_height))
         : decoded[0].height;
+
+    // Reverse so that image_0 (top input handle) is composited last (on top).
+    decoded.reverse();
 
     // Composite on the GPU through the shared headless layer compositor (the
     // same engine the sketch editor and timeline preview use). Node uses the

--- a/packages/image-nodes/tests/regression-compositor.test.ts
+++ b/packages/image-nodes/tests/regression-compositor.test.ts
@@ -104,34 +104,34 @@ describe.skipIf(!hasGpu)("CompositorNode", () => {
   it("composites two layers using 'over' blend with positional layer state", async () => {
     const W = 8;
     const H = 8;
-    const red = await solidPng(W, H, { r: 255, g: 0, b: 0 });
     const blue = await solidPng(W, H, { r: 0, g: 0, b: 255 }, 128); // semi-transparent
+    const red = await solidPng(W, H, { r: 255, g: 0, b: 0 });
     const node = new CompositorNode();
+    // image_0 is the top (frontmost) layer; image_1 is the background.
     node.assign({
       layers: [
-        { opacity: 1, blend_mode: "over", visible: true },
-        { opacity: 0.5, blend_mode: "over", visible: true }
+        { opacity: 0.5, blend_mode: "over", visible: true },
+        { opacity: 1, blend_mode: "over", visible: true }
       ],
-      image_0: asImageRef(red, W, H),
-      image_1: asImageRef(blue, W, H)
+      image_0: asImageRef(blue, W, H),
+      image_1: asImageRef(red, W, H)
     });
     const result = await node.process();
     const out = result.output as Record<string, unknown>;
     expect(out.width).toBe(W);
     expect(out.height).toBe(H);
 
-    // The composite should mix the red base with the half-opacity blue
-    // layer — middle pixel should be neither pure red nor pure blue.
+    // The composite should mix the semi-transparent blue top layer with
+    // the red background — middle pixel should be neither pure red nor pure blue.
     const data = rgbaBytes(out);
-    // Sample centre pixel (RGBA stride = 4 over width W).
     const cx = Math.floor(W / 2);
     const cy = Math.floor(H / 2);
     const off = (cy * W + cx) * 4;
     const r = data[off];
     const g = data[off + 1];
     const b = data[off + 2];
-    expect(r).toBeGreaterThan(0); // red persisted
-    expect(b).toBeGreaterThan(0); // blue mixed in
+    expect(r).toBeGreaterThan(0); // red from background
+    expect(b).toBeGreaterThan(0); // blue from top layer
     expect(g).toBeLessThan(50); // no green in either input
   });
 
@@ -163,24 +163,24 @@ describe.skipIf(!hasGpu)("CompositorNode", () => {
   it("orders layers by numeric suffix, not insertion order", async () => {
     const W = 4;
     const H = 4;
-    const top = await solidPng(W, H, { r: 0, g: 0, b: 255 });
-    const base = await solidPng(W, H, { r: 255, g: 0, b: 0 });
+    const foreground = await solidPng(W, H, { r: 255, g: 0, b: 0 });
+    const background = await solidPng(W, H, { r: 0, g: 0, b: 255 });
     const node = new CompositorNode();
-    // Assign image_10 first, image_2 second — image_2 should be the base.
+    // Assign image_10 first, image_2 second — image_2 (lower index) is on top.
     node.assign({
       layers: [
         { opacity: 1, blend_mode: "over", visible: true },
         { opacity: 1, blend_mode: "over", visible: true }
       ],
-      image_10: asImageRef(top, W, H),
-      image_2: asImageRef(base, W, H)
+      image_10: asImageRef(background, W, H),
+      image_2: asImageRef(foreground, W, H)
     });
     const result = await node.process();
     const out = result.output as Record<string, unknown>;
     const data = rgbaBytes(out);
-    // With image_10 fully opaque blue on top, expect blue dominance.
-    expect(data[2]).toBeGreaterThan(200);
-    expect(data[0]).toBeLessThan(50);
+    // image_2 (lower index) is the foreground — expect red dominance.
+    expect(data[0]).toBeGreaterThan(200);
+    expect(data[2]).toBeLessThan(50);
   });
 
   it("outputs raw RGBA in-flight format", async () => {
@@ -242,16 +242,17 @@ describe.skipIf(!hasGpu)("CompositorNode", () => {
   it("supports 'multiply' blend mode", async () => {
     const W = 4;
     const H = 4;
-    const white = await solidPng(W, H, { r: 255, g: 255, b: 255 });
     const red = await solidPng(W, H, { r: 255, g: 0, b: 0 });
+    const white = await solidPng(W, H, { r: 255, g: 255, b: 255 });
     const node = new CompositorNode();
+    // image_0 (top) uses multiply; image_1 (bottom) is the white base.
     node.assign({
       layers: [
-        { opacity: 1, blend_mode: "over", visible: true },
-        { opacity: 1, blend_mode: "multiply", visible: true }
+        { opacity: 1, blend_mode: "multiply", visible: true },
+        { opacity: 1, blend_mode: "over", visible: true }
       ],
-      image_0: asImageRef(white, W, H),
-      image_1: asImageRef(red, W, H)
+      image_0: asImageRef(red, W, H),
+      image_1: asImageRef(white, W, H)
     });
     const result = await node.process();
     const out = result.output as Record<string, unknown>;
@@ -266,23 +267,24 @@ describe.skipIf(!hasGpu)("CompositorNode", () => {
   it("supports 'add' blend mode", async () => {
     const W = 4;
     const H = 4;
-    const halfRed = await solidPng(W, H, { r: 128, g: 0, b: 0 });
     const halfGreen = await solidPng(W, H, { r: 0, g: 128, b: 0 });
+    const halfRed = await solidPng(W, H, { r: 128, g: 0, b: 0 });
     const node = new CompositorNode();
+    // image_0 (top) uses add; image_1 (bottom) is the red base.
     node.assign({
       layers: [
-        { opacity: 1, blend_mode: "over", visible: true },
-        { opacity: 1, blend_mode: "add", visible: true }
+        { opacity: 1, blend_mode: "add", visible: true },
+        { opacity: 1, blend_mode: "over", visible: true }
       ],
-      image_0: asImageRef(halfRed, W, H),
-      image_1: asImageRef(halfGreen, W, H)
+      image_0: asImageRef(halfGreen, W, H),
+      image_1: asImageRef(halfRed, W, H)
     });
     const result = await node.process();
     const out = result.output as Record<string, unknown>;
     const data = rgbaBytes(out);
     const off = (Math.floor(H / 2) * W + Math.floor(W / 2)) * 4;
-    expect(data[off]).toBeGreaterThan(120); // R preserved
-    expect(data[off + 1]).toBeGreaterThan(120); // G added
+    expect(data[off]).toBeGreaterThan(120); // R from base
+    expect(data[off + 1]).toBeGreaterThan(120); // G added from top
     expect(data[off + 2]).toBeLessThan(10); // B stays 0
   });
 });

--- a/web/src/components/compositor/CompositorEditor.tsx
+++ b/web/src/components/compositor/CompositorEditor.tsx
@@ -165,7 +165,7 @@ const CompositorEditorInner: React.FC<CompositorEditorProps> = ({
 
   const canvasLayers = useMemo<CanvasLayer[]>(
     () =>
-      layers.map((l) => ({
+      [...layers].reverse().map((l) => ({
         id: l.id,
         opacity: l.opacity,
         blendModeId: blendModeGpuId(l.blendMode),
@@ -232,9 +232,9 @@ const CompositorEditorInner: React.FC<CompositorEditorProps> = ({
     canvasHeight
   ]);
 
-  // Render the stack top-first (highest index on top of the composite).
+  // Render the stack top-first (lowest index on top of the composite).
   const stack = useMemo(
-    () => layers.map((l, i) => ({ layer: l, index: i })).reverse(),
+    () => layers.map((l, i) => ({ layer: l, index: i })),
     [layers]
   );
 

--- a/web/src/components/node_types/editing/CompositorBody.tsx
+++ b/web/src/components/node_types/editing/CompositorBody.tsx
@@ -266,10 +266,10 @@ const CompositorBodyInner: React.FC<CompositorBodyProps> = ({
     []
   );
 
-  // Handles render top-to-bottom; highest image_N is the top (frontmost) layer.
+  // Handles render top-to-bottom; lowest image_N is the top (frontmost) layer.
   const handleProperties = useMemo<Property[]>(
     () =>
-      [...imageKeys].reverse().map((key) => ({
+      imageKeys.map((key) => ({
         name: key,
         type: imageType,
         required: false
@@ -412,24 +412,20 @@ const CompositorBodyInner: React.FC<CompositorBodyProps> = ({
         {imageKeys.length === 0 ? (
           <div className="empty-state">No layers yet - add one below.</div>
         ) : (
-          imageKeys.map((_, reverseIndex) => {
-            const idx = imageKeys.length - 1 - reverseIndex;
-            const key = imageKeys[idx];
-            return (
-              <LayerRow
-                key={key}
-                index={idx}
-                propertyKey={key}
-                state={layers[idx] ?? DEFAULT_LAYER_STATE}
-                image={upstreamForKey(key)}
-                onOpacityChange={onOpacityChange}
-                onOpacityComplete={onOpacityComplete}
-                onBlendChange={onBlendChange}
-                onToggleVisible={onToggleVisible}
-                onDelete={onDeleteLayer}
-              />
-            );
-          })
+          imageKeys.map((key, idx) => (
+            <LayerRow
+              key={key}
+              index={idx}
+              propertyKey={key}
+              state={layers[idx] ?? DEFAULT_LAYER_STATE}
+              image={upstreamForKey(key)}
+              onOpacityChange={onOpacityChange}
+              onOpacityComplete={onOpacityComplete}
+              onBlendChange={onBlendChange}
+              onToggleVisible={onToggleVisible}
+              onDelete={onDeleteLayer}
+            />
+          ))
         )}
       </FlexColumn>
 


### PR DESCRIPTION
Fixes #3539 — the compositor node now draws image_0 (lowest index, top handle) as the frontmost layer.

Generated with [Claude Code](https://claude.ai/code)