### PR TITLE
Motion design phase 1: clip animation engine + preview/export + agent tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53479,6 +53479,7 @@
         "@gltf-transform/core": "^4.3.0",
         "@gltf-transform/functions": "^4.3.0",
         "@nodetool-ai/audio-nodes": "*",
+        "@nodetool-ai/config": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -240,6 +240,28 @@ export const clipBindingKind = z.enum([
 ]);
 export type ClipBindingKind = z.infer<typeof clipBindingKind>;
 
+// ── Motion-design animations ─────────────────────────────────────────────────
+
+/**
+ * One motion-design animation attached to a clip. `preset` and `easing` are
+ * plain strings on the wire by design (forward compat): a document saved by a
+ * newer client may carry ids this build doesn't know — they parse fine and are
+ * skipped at compile time. Validation of preset/role is the engine's job, not
+ * the schema's. Without this field on the clip schema Zod would strip
+ * `animations` on every PATCH, silently losing motion on save.
+ */
+export const clipAnimation = z.object({
+  id: z.string(),
+  role: z.enum(["in", "out", "emphasis", "loop"]),
+  preset: z.string(),
+  durationMs: z.number(),
+  delayMs: z.number().optional(),
+  easing: z.string().optional(),
+  enabled: z.boolean().optional(),
+  params: z.record(z.string(), z.union([z.number(), z.string(), z.boolean()])).optional()
+});
+export type ClipAnimation = z.infer<typeof clipAnimation>;
+
 export const timelineClip = z
   .object({
     id: z.string(),
@@ -313,7 +335,10 @@ export const timelineClip = z
     speaker: z.string().optional(),
     /** Paragraph grouping id for transcript clips. Without this field Zod strips
      * it on every PATCH, so autosave silently breaks paragraph grouping. */
-    paragraphId: z.string().optional()
+    paragraphId: z.string().optional(),
+    /** Motion-design animations. Without this field Zod strips it on every
+     * PATCH, so autosave erases animations. */
+    animations: z.array(clipAnimation).optional()
   });
 export type TimelineClip = z.infer<typeof timelineClip>;
 

--- a/packages/protocol/tests/timeline.test.ts
+++ b/packages/protocol/tests/timeline.test.ts
@@ -79,4 +79,54 @@ describe("timelineClip schema", () => {
     };
     expect(timelineClip.safeParse(clip).success).toBe(false);
   });
+
+  it("preserves clip animations through a parse round-trip", () => {
+    const clip = {
+      ...baseClip,
+      animations: [
+        {
+          id: "anim-1",
+          role: "in" as const,
+          preset: "slide",
+          durationMs: 500,
+          delayMs: 200,
+          easing: "easeOut",
+          enabled: true,
+          params: { direction: "left", distance: 0.3 }
+        },
+        {
+          id: "anim-2",
+          role: "loop" as const,
+          preset: "kenBurns",
+          durationMs: 3000
+        }
+      ]
+    };
+    const parsed = timelineClip.parse(clip);
+    expect(parsed.animations).toEqual(clip.animations);
+  });
+
+  it("parses a clip with no animations field", () => {
+    const parsed = timelineClip.parse(baseClip);
+    expect(parsed.animations).toBeUndefined();
+  });
+
+  it("accepts an unknown preset string (validation is the engine's job)", () => {
+    const clip = {
+      ...baseClip,
+      animations: [
+        { id: "a", role: "in" as const, preset: "future-preset-99", durationMs: 400 }
+      ]
+    };
+    const result = timelineClip.safeParse(clip);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an animation with an unknown role", () => {
+    const clip = {
+      ...baseClip,
+      animations: [{ id: "a", role: "bogus", preset: "fade", durationMs: 400 }]
+    };
+    expect(timelineClip.safeParse(clip).success).toBe(false);
+  });
 });

--- a/packages/timeline/src/animation/compile.ts
+++ b/packages/timeline/src/animation/compile.ts
@@ -1,0 +1,204 @@
+/**
+ * Preset → curve compiler. Presets never render directly; `compileClipAnimations`
+ * resolves each `ClipAnimation` into a `CompiledAnimation` — a window on the
+ * clip-local clock plus keyframe curves with easing baked onto each segment.
+ * The sampler (`sample.ts`) then needs no preset or role knowledge.
+ *
+ * Pure: no DOM, GPU, or store access.
+ */
+
+import type { AnimationRole, ClipAnimation, EasingId } from "./types.js";
+import {
+  getAnimationPreset,
+  resolvePresetParams,
+  type Canvas
+} from "./presets.js";
+
+export type AnimatedProperty =
+  | "offsetX" // canvas px, added to transform.position.x
+  | "offsetY" // canvas px, added to transform.position.y
+  | "scale" // uniform multiplier on ClipTransform.scale
+  | "rotation" // radians, added to ClipTransform.rotation
+  | "opacity"; // multiplier on the layer's resolved opacity
+
+export interface Keyframe {
+  /** Normalized 0..1 within the animation window. */
+  t: number;
+  value: number;
+  /** Easing of the segment ending at this keyframe. Undefined → linear. */
+  easing?: EasingId;
+}
+
+export interface PropertyCurve {
+  property: AnimatedProperty;
+  /** Sorted by `t`; first `t === 0`, last `t === 1`. */
+  keyframes: Keyframe[];
+}
+
+export interface CompiledAnimation {
+  role: AnimationRole;
+  /** Clip-local ms, resolved from role + delay + duration. */
+  windowStartMs: number;
+  windowEndMs: number;
+  /**
+   * Repeat the window until clip end. Set by the preset's role handling, not
+   * derived from role alone: most `"loop"` presets compile `loop: true`, but
+   * `kenBurns` compiles `loop: false` (one-shot over the whole clip).
+   */
+  loop: boolean;
+  /** Cycle length in ms when `loop` is true; the window runs to clip end. */
+  periodMs?: number;
+  /** Hold the `t=0` values before the window (true for `"in"`). */
+  holdBefore: boolean;
+  /** Hold the `t=1` values after the window (true for `"out"`). */
+  holdAfter: boolean;
+  curves: PropertyCurve[];
+}
+
+/** Default segment easing when neither the animation nor the preset pins one. */
+function roleDefaultEasing(role: AnimationRole): EasingId {
+  switch (role) {
+    case "in":
+      return "easeOut";
+    case "out":
+      return "easeIn";
+    case "emphasis":
+      return "easeInOut";
+    case "loop":
+      return "linear";
+  }
+}
+
+/** Reverse a curve in time: an "in" curve run backwards is the "out" curve. */
+function reverseCurve(curve: PropertyCurve): PropertyCurve {
+  const n = curve.keyframes.length;
+  const keyframes: Keyframe[] = curve.keyframes.map((_, i) => {
+    const src = curve.keyframes[n - 1 - i];
+    return { t: 1 - src.t, value: src.value, easing: src.easing };
+  });
+  return { property: curve.property, keyframes };
+}
+
+/** Bake the effective easing onto each keyframe's incoming segment. */
+function applyEasing(
+  curves: PropertyCurve[],
+  animation: ClipAnimation,
+  role: AnimationRole,
+  presetEasing: EasingId | undefined
+): PropertyCurve[] {
+  const override = animation.easing; // overrides every segment when set
+  const base = presetEasing ?? roleDefaultEasing(role);
+  return curves.map((curve) => ({
+    property: curve.property,
+    keyframes: curve.keyframes.map((kf) => ({
+      t: kf.t,
+      value: kf.value,
+      easing: override ?? kf.easing ?? base
+    }))
+  }));
+}
+
+/**
+ * Compile a clip's animations into windowed curves.
+ *
+ * - `canvas` resolves normalized preset distances to px.
+ * - `clipDurationMs` sets window math; windows are clamped to it and windows
+ *   that start at or after clip end are dropped.
+ * - Unknown presets and roles the preset does not allow are skipped (with a
+ *   console warning) — forward compatibility with newer documents.
+ */
+export function compileClipAnimations(
+  animations: ClipAnimation[] | undefined,
+  clipDurationMs: number,
+  canvas: Canvas
+): CompiledAnimation[] {
+  if (!animations || animations.length === 0) return [];
+  const out: CompiledAnimation[] = [];
+
+  for (const animation of animations) {
+    if (animation.enabled === false) continue;
+    const preset = getAnimationPreset(animation.preset);
+    if (!preset) {
+      console.warn(
+        `[timeline] unknown animation preset "${animation.preset}" — skipped`
+      );
+      continue;
+    }
+    if (!preset.roles.includes(animation.role)) {
+      console.warn(
+        `[timeline] preset "${animation.preset}" does not support role "${animation.role}" — skipped`
+      );
+      continue;
+    }
+
+    const params = resolvePresetParams(preset, animation.params);
+    let curves = preset.curves(params, canvas, animation.role);
+    if (animation.role === "out") {
+      curves = curves.map(reverseCurve);
+    }
+    curves = applyEasing(curves, animation, animation.role, preset.defaultEasing);
+
+    const delayMs = Math.max(0, animation.delayMs ?? 0);
+    const durationMs = Math.max(1, animation.durationMs);
+
+    if (preset.fullClip) {
+      // kenBurns: one-shot over the whole clip; duration/delay ignored.
+      out.push({
+        role: animation.role,
+        windowStartMs: 0,
+        windowEndMs: clipDurationMs,
+        loop: false,
+        holdBefore: false,
+        holdAfter: true,
+        curves
+      });
+      continue;
+    }
+
+    if (animation.role === "loop") {
+      // The window runs from the delay to clip end, cycling at `durationMs`.
+      const windowStartMs = Math.max(0, delayMs);
+      if (windowStartMs >= clipDurationMs) continue;
+      out.push({
+        role: "loop",
+        windowStartMs,
+        windowEndMs: clipDurationMs,
+        loop: true,
+        periodMs: durationMs,
+        holdBefore: false,
+        holdAfter: false,
+        curves
+      });
+      continue;
+    }
+
+    let windowStartMs: number;
+    let windowEndMs: number;
+    if (animation.role === "out") {
+      windowEndMs = clipDurationMs - delayMs;
+      windowStartMs = windowEndMs - durationMs;
+    } else {
+      windowStartMs = delayMs;
+      windowEndMs = delayMs + durationMs;
+    }
+
+    // Clamp to the clip and drop degenerate windows.
+    windowEndMs = Math.min(windowEndMs, clipDurationMs);
+    windowStartMs = Math.max(0, windowStartMs);
+    if (windowStartMs >= clipDurationMs || windowEndMs <= windowStartMs) {
+      continue;
+    }
+
+    out.push({
+      role: animation.role,
+      windowStartMs,
+      windowEndMs,
+      loop: false,
+      holdBefore: animation.role === "in",
+      holdAfter: animation.role === "out",
+      curves
+    });
+  }
+
+  return out;
+}

--- a/packages/timeline/src/animation/easing.ts
+++ b/packages/timeline/src/animation/easing.ts
@@ -1,0 +1,81 @@
+/**
+ * Easing functions. Each maps `t ∈ [0,1]` to a progress value; most land in
+ * `[0,1]` but the overshoot easings (`easeOutBack`, `easeOutElastic`) can leave
+ * that range on purpose. Callers clamp at the *composition* site (opacity to
+ * [0,1], scale to ≥ 0), never here — the overshoot is the point.
+ *
+ * Pure; no allocation.
+ */
+
+import type { EasingId } from "./types.js";
+
+const BACK_C1 = 1.70158;
+const BACK_C3 = BACK_C1 + 1;
+
+const ELASTIC_C4 = (2 * Math.PI) / 3;
+
+function easeIn(t: number): number {
+  return t * t * t;
+}
+
+function easeOut(t: number): number {
+  const u = 1 - t;
+  return 1 - u * u * u;
+}
+
+function easeInOut(t: number): number {
+  return t < 0.5
+    ? 4 * t * t * t
+    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+function easeOutBack(t: number): number {
+  const u = t - 1;
+  return 1 + BACK_C3 * u * u * u + BACK_C1 * u * u;
+}
+
+function easeOutElastic(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * ELASTIC_C4) + 1;
+}
+
+function easeOutBounce(t: number): number {
+  const n1 = 7.5625;
+  const d1 = 2.75;
+  if (t < 1 / d1) {
+    return n1 * t * t;
+  }
+  if (t < 2 / d1) {
+    const u = t - 1.5 / d1;
+    return n1 * u * u + 0.75;
+  }
+  if (t < 2.5 / d1) {
+    const u = t - 2.25 / d1;
+    return n1 * u * u + 0.9375;
+  }
+  const u = t - 2.625 / d1;
+  return n1 * u * u + 0.984375;
+}
+
+/** Evaluate easing `id` at `t`. `t` is not clamped; endpoints are exact. */
+export function ease(id: EasingId, t: number): number {
+  switch (id) {
+    case "linear":
+      return t;
+    case "easeIn":
+      return easeIn(t);
+    case "easeOut":
+      return easeOut(t);
+    case "easeInOut":
+      return easeInOut(t);
+    case "easeOutBack":
+      return easeOutBack(t);
+    case "easeOutElastic":
+      return easeOutElastic(t);
+    case "easeOutBounce":
+      return easeOutBounce(t);
+    default:
+      return t;
+  }
+}

--- a/packages/timeline/src/animation/index.ts
+++ b/packages/timeline/src/animation/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @nodetool-ai/timeline – animation (motion-design) public API.
+ *
+ * Pure engine: preset → curve compiler and sampler. No DOM, GPU, or store.
+ */
+
+export * from "./types.js";
+export * from "./easing.js";
+export * from "./presets.js";
+export * from "./compile.js";
+export * from "./sample.js";

--- a/packages/timeline/src/animation/presets.ts
+++ b/packages/timeline/src/animation/presets.ts
@@ -1,0 +1,314 @@
+/**
+ * Preset catalog v1. Each preset declares its allowed roles, default
+ * duration/easing, params (with defaults and ranges), and a curve generator.
+ * Curve generators author the *forward* ("in") motion; `compileClipAnimations`
+ * reverses it in time for the `"out"` role, so a preset never special-cases in
+ * vs out.
+ *
+ * Position params are normalized (fraction of canvas width/height); generators
+ * resolve them to px against the passed `canvas`, keeping the sampler and GPU
+ * unit-free.
+ *
+ * Pure: no DOM, GPU, or store access.
+ */
+
+import type { AnimationPresetId, AnimationRole, EasingId } from "./types.js";
+import type { AnimatedProperty, Keyframe, PropertyCurve } from "./compile.js";
+import { ease } from "./easing.js";
+
+export interface Canvas {
+  width: number;
+  height: number;
+}
+
+export type PresetParamValue = number | string | boolean;
+export type ResolvedParams = Record<string, PresetParamValue>;
+
+export interface PresetParamSpec {
+  name: string;
+  default: PresetParamValue;
+  /** Numeric range hints for UI sliders. */
+  min?: number;
+  max?: number;
+  /** Allowed values for string (option) params. */
+  options?: string[];
+}
+
+export interface AnimationPreset {
+  id: AnimationPresetId;
+  roles: AnimationRole[];
+  defaultDurationMs: number;
+  /** When set, overrides the per-role default segment easing. */
+  defaultEasing?: EasingId;
+  params: PresetParamSpec[];
+  describe: string;
+  /**
+   * When true the preset runs once over the whole clip (window = full clip,
+   * `holdAfter`), ignoring duration/delay. Only `kenBurns` sets this.
+   */
+  fullClip?: boolean;
+  curves(params: ResolvedParams, canvas: Canvas, role: AnimationRole): PropertyCurve[];
+}
+
+// ── param helpers ─────────────────────────────────────────────────────────
+
+function num(params: ResolvedParams, name: string, fallback: number): number {
+  const v = params[name];
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+function str(params: ResolvedParams, name: string, fallback: string): string {
+  const v = params[name];
+  return typeof v === "string" ? v : fallback;
+}
+
+/** Sample `fn` at `count` evenly-spaced points t ∈ [0,1] into a curve. */
+function sampleCurve(
+  property: AnimatedProperty,
+  count: number,
+  fn: (t: number) => number
+): PropertyCurve {
+  const keyframes: Keyframe[] = [];
+  for (let i = 0; i < count; i++) {
+    const t = i / (count - 1);
+    keyframes.push({ t, value: fn(t) });
+  }
+  return { property, keyframes };
+}
+
+const TWO_PI = Math.PI * 2;
+
+// ── catalog ────────────────────────────────────────────────────────────────
+
+const PRESETS: AnimationPreset[] = [
+  {
+    id: "fade",
+    roles: ["in", "out"],
+    defaultDurationMs: 500,
+    params: [],
+    describe: "Fade opacity between 0 and 1.",
+    curves: () => [{ property: "opacity", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }]
+  },
+  {
+    id: "slide",
+    roles: ["in", "out"],
+    defaultDurationMs: 500,
+    params: [
+      { name: "direction", default: "left", options: ["left", "right", "up", "down"] },
+      { name: "distance", default: 0.3, min: 0, max: 1 }
+    ],
+    describe: "Slide in from a direction (opacity fades in with it).",
+    curves: (params, canvas) => {
+      const direction = str(params, "direction", "left");
+      const distance = num(params, "distance", 0.3);
+      const dx = distance * canvas.width;
+      const dy = distance * canvas.height;
+      const curves: PropertyCurve[] = [
+        { property: "opacity", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+      ];
+      switch (direction) {
+        case "right":
+          curves.push({ property: "offsetX", keyframes: [{ t: 0, value: dx }, { t: 1, value: 0 }] });
+          break;
+        case "up":
+          curves.push({ property: "offsetY", keyframes: [{ t: 0, value: -dy }, { t: 1, value: 0 }] });
+          break;
+        case "down":
+          curves.push({ property: "offsetY", keyframes: [{ t: 0, value: dy }, { t: 1, value: 0 }] });
+          break;
+        case "left":
+        default:
+          curves.push({ property: "offsetX", keyframes: [{ t: 0, value: -dx }, { t: 1, value: 0 }] });
+          break;
+      }
+      return curves;
+    }
+  },
+  {
+    id: "pop",
+    roles: ["in", "out"],
+    defaultDurationMs: 500,
+    defaultEasing: "easeOut",
+    params: [{ name: "overshoot", default: 1.08, min: 1, max: 1.5 }],
+    describe: "Scale up past 1 then settle, with a fade in.",
+    curves: (params) => {
+      const overshoot = num(params, "overshoot", 1.08);
+      return [
+        {
+          property: "scale",
+          keyframes: [
+            { t: 0, value: 0.6 },
+            { t: 0.6, value: overshoot },
+            { t: 1, value: 1 }
+          ]
+        },
+        {
+          property: "opacity",
+          keyframes: [
+            { t: 0, value: 0 },
+            { t: 0.6, value: 1 },
+            { t: 1, value: 1 }
+          ]
+        }
+      ];
+    }
+  },
+  {
+    id: "spin",
+    roles: ["in", "out"],
+    defaultDurationMs: 500,
+    params: [{ name: "turns", default: 0.25, min: 0, max: 2 }],
+    describe: "Rotate into place while fading in.",
+    curves: (params) => {
+      const turns = num(params, "turns", 0.25);
+      return [
+        { property: "rotation", keyframes: [{ t: 0, value: -turns * TWO_PI }, { t: 1, value: 0 }] },
+        { property: "opacity", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+      ];
+    }
+  },
+  {
+    id: "pulse",
+    roles: ["emphasis"],
+    defaultDurationMs: 600,
+    defaultEasing: "easeInOut",
+    params: [{ name: "intensity", default: 0.06, min: 0, max: 0.5 }],
+    describe: "Scale up and back for a soft heartbeat.",
+    curves: (params) => {
+      const intensity = num(params, "intensity", 0.06);
+      return [
+        {
+          property: "scale",
+          keyframes: [
+            { t: 0, value: 1 },
+            { t: 0.5, value: 1 + intensity },
+            { t: 1, value: 1 }
+          ]
+        }
+      ];
+    }
+  },
+  {
+    id: "shake",
+    roles: ["emphasis"],
+    defaultDurationMs: 600,
+    defaultEasing: "linear",
+    params: [
+      { name: "intensity", default: 0.02, min: 0, max: 0.2 },
+      { name: "cycles", default: 4, min: 1, max: 12 }
+    ],
+    describe: "Horizontal zig-zag; starts and ends at rest.",
+    curves: (params, canvas) => {
+      const intensity = num(params, "intensity", 0.02);
+      const cycles = Math.max(1, Math.round(num(params, "cycles", 4)));
+      const amp = intensity * canvas.width;
+      const count = cycles * 4 + 1;
+      return [sampleCurve("offsetX", count, (t) => amp * Math.sin(TWO_PI * cycles * t))];
+    }
+  },
+  {
+    id: "bounce",
+    roles: ["emphasis"],
+    defaultDurationMs: 600,
+    defaultEasing: "linear",
+    params: [{ name: "height", default: 0.05, min: 0, max: 0.3 }],
+    describe: "Hop up and land with a bounce.",
+    curves: (params, canvas) => {
+      const height = num(params, "height", 0.05) * canvas.height;
+      // Rise on [0,0.5] (easeOut), fall back to rest on [0.5,1] (easeOutBounce).
+      const profile = (t: number): number => {
+        if (t < 0.5) return ease("easeOut", t / 0.5);
+        return 1 - ease("easeOutBounce", (t - 0.5) / 0.5);
+      };
+      // Negative offsetY = up on the canvas.
+      return [sampleCurve("offsetY", 24, (t) => -height * profile(t))];
+    }
+  },
+  {
+    id: "kenBurns",
+    roles: ["loop"],
+    defaultDurationMs: 3000,
+    defaultEasing: "easeInOut",
+    fullClip: true,
+    params: [
+      { name: "zoom", default: 0.12, min: 0, max: 1 },
+      { name: "direction", default: "in", options: ["in", "out"] },
+      { name: "driftX", default: 0.02, min: -0.2, max: 0.2 },
+      { name: "driftY", default: 0.02, min: -0.2, max: 0.2 }
+    ],
+    describe: "Slow zoom and drift across the whole clip (one shot).",
+    curves: (params, canvas) => {
+      const zoom = num(params, "zoom", 0.12);
+      const direction = str(params, "direction", "in");
+      const driftX = num(params, "driftX", 0.02) * canvas.width;
+      const driftY = num(params, "driftY", 0.02) * canvas.height;
+      const from = direction === "out" ? 1 + zoom : 1;
+      const to = direction === "out" ? 1 : 1 + zoom;
+      return [
+        { property: "scale", keyframes: [{ t: 0, value: from }, { t: 1, value: to }] },
+        { property: "offsetX", keyframes: [{ t: 0, value: 0 }, { t: 1, value: driftX }] },
+        { property: "offsetY", keyframes: [{ t: 0, value: 0 }, { t: 1, value: driftY }] }
+      ];
+    }
+  },
+  {
+    id: "float",
+    roles: ["loop"],
+    defaultDurationMs: 3000,
+    defaultEasing: "linear",
+    params: [{ name: "amplitude", default: 0.015, min: 0, max: 0.2 }],
+    describe: "Gentle vertical bob (loops seamlessly).",
+    curves: (params, canvas) => {
+      const amp = num(params, "amplitude", 0.015) * canvas.height;
+      return [sampleCurve("offsetY", 16, (t) => -amp * Math.sin(TWO_PI * t))];
+    }
+  },
+  {
+    id: "breathe",
+    roles: ["loop"],
+    defaultDurationMs: 3000,
+    defaultEasing: "linear",
+    params: [{ name: "intensity", default: 0.03, min: 0, max: 0.3 }],
+    describe: "Slow scale in and out (loops seamlessly).",
+    curves: (params) => {
+      const intensity = num(params, "intensity", 0.03);
+      return [
+        sampleCurve("scale", 16, (t) => 1 + intensity * (0.5 - 0.5 * Math.cos(TWO_PI * t)))
+      ];
+    }
+  },
+  {
+    id: "rotate",
+    roles: ["loop"],
+    defaultDurationMs: 3000,
+    defaultEasing: "linear",
+    params: [{ name: "direction", default: "cw", options: ["cw", "ccw"] }],
+    describe: "Continuous rotation, one turn per cycle.",
+    curves: (params) => {
+      const sign = str(params, "direction", "cw") === "ccw" ? -1 : 1;
+      return [{ property: "rotation", keyframes: [{ t: 0, value: 0 }, { t: 1, value: sign * TWO_PI }] }];
+    }
+  }
+];
+
+export const ANIMATION_PRESETS: readonly AnimationPreset[] = PRESETS;
+
+const PRESET_BY_ID = new Map<string, AnimationPreset>(PRESETS.map((p) => [p.id, p]));
+
+/** Look up a preset by id, or `undefined` for an unknown (newer-client) id. */
+export function getAnimationPreset(id: string): AnimationPreset | undefined {
+  return PRESET_BY_ID.get(id);
+}
+
+/** Fill in preset param defaults for any keys the caller omitted. */
+export function resolvePresetParams(
+  preset: AnimationPreset,
+  raw: ResolvedParams | undefined
+): ResolvedParams {
+  const resolved: ResolvedParams = {};
+  for (const spec of preset.params) {
+    const provided = raw?.[spec.name];
+    resolved[spec.name] = provided === undefined ? spec.default : provided;
+  }
+  return resolved;
+}

--- a/packages/timeline/src/animation/sample.ts
+++ b/packages/timeline/src/animation/sample.ts
@@ -1,0 +1,142 @@
+/**
+ * Sampler. Folds a clip's `CompiledAnimation[]` into a single `AnimationSample`
+ * at a clip-local time. Offsets and rotation add; scale and opacity multiply.
+ * Order-independent across animations (the fold is commutative).
+ *
+ * Pure; supports an optional scratch `out` object so the render loop allocates
+ * nothing in the steady state.
+ */
+
+import { ease } from "./easing.js";
+import type { CompiledAnimation, Keyframe, PropertyCurve } from "./compile.js";
+
+export interface AnimationSample {
+  /** px, add to transform.position.x */
+  offsetX: number;
+  /** px, add to transform.position.y */
+  offsetY: number;
+  /** multiply transform.scale.x and .y */
+  scale: number;
+  /** radians, add to transform.rotation */
+  rotation: number;
+  /** 0..1, multiply layer opacity */
+  opacity: number;
+}
+
+export const IDENTITY_SAMPLE: Readonly<AnimationSample> = Object.freeze({
+  offsetX: 0,
+  offsetY: 0,
+  scale: 1,
+  rotation: 0,
+  opacity: 1
+});
+
+function resetIdentity(s: AnimationSample): AnimationSample {
+  s.offsetX = 0;
+  s.offsetY = 0;
+  s.scale = 1;
+  s.rotation = 0;
+  s.opacity = 1;
+  return s;
+}
+
+/** Evaluate a curve at normalized `t` (keyframes sorted, first t=0, last t=1). */
+function evalCurve(curve: PropertyCurve, t: number): number {
+  const kfs = curve.keyframes;
+  if (kfs.length === 0) return 0;
+  if (t <= kfs[0].t) return kfs[0].value;
+  const last = kfs[kfs.length - 1];
+  if (t >= last.t) return last.value;
+  for (let i = 1; i < kfs.length; i++) {
+    const b: Keyframe = kfs[i];
+    if (t <= b.t) {
+      const a = kfs[i - 1];
+      const span = b.t - a.t;
+      const segT = span > 0 ? (t - a.t) / span : 0;
+      const eased = ease(b.easing ?? "linear", segT);
+      return a.value + (b.value - a.value) * eased;
+    }
+  }
+  return last.value;
+}
+
+/**
+ * Resolve the normalized `t` for one animation at `localMs`, or `null` when the
+ * animation contributes identity (outside its window with no hold).
+ */
+function windowT(anim: CompiledAnimation, localMs: number): number | null {
+  if (anim.loop) {
+    const period = anim.periodMs ?? anim.windowEndMs - anim.windowStartMs;
+    if (period <= 0) return null;
+    if (localMs < anim.windowStartMs || localMs >= anim.windowEndMs) return null;
+    return ((localMs - anim.windowStartMs) % period) / period;
+  }
+  if (localMs < anim.windowStartMs) {
+    return anim.holdBefore ? 0 : null;
+  }
+  if (localMs > anim.windowEndMs) {
+    return anim.holdAfter ? 1 : null;
+  }
+  const span = anim.windowEndMs - anim.windowStartMs;
+  return span > 0 ? (localMs - anim.windowStartMs) / span : 0;
+}
+
+function foldAnimation(anim: CompiledAnimation, t: number, acc: AnimationSample): void {
+  for (const curve of anim.curves) {
+    const value = evalCurve(curve, t);
+    switch (curve.property) {
+      case "offsetX":
+        acc.offsetX += value;
+        break;
+      case "offsetY":
+        acc.offsetY += value;
+        break;
+      case "rotation":
+        acc.rotation += value;
+        break;
+      case "scale":
+        acc.scale *= value;
+        break;
+      case "opacity":
+        acc.opacity *= value;
+        break;
+    }
+  }
+}
+
+/**
+ * Fold all compiled animations at `localMs` into one sample. Pass `out` to
+ * reuse a scratch object (it is reset before writing).
+ */
+export function sampleAnimations(
+  compiled: CompiledAnimation[],
+  localMs: number,
+  out?: AnimationSample
+): AnimationSample {
+  const acc = resetIdentity(out ?? { offsetX: 0, offsetY: 0, scale: 1, rotation: 0, opacity: 1 });
+  for (const anim of compiled) {
+    const t = windowT(anim, localMs);
+    if (t === null) continue;
+    foldAnimation(anim, t, acc);
+  }
+  // Overshoot easings can push these past their natural range.
+  if (acc.opacity < 0) acc.opacity = 0;
+  else if (acc.opacity > 1) acc.opacity = 1;
+  if (acc.scale < 0) acc.scale = 0;
+  return acc;
+}
+
+/** True when any compiled animation is inside an actively-animating window. */
+export function hasActiveAnimationWindow(
+  compiled: CompiledAnimation[],
+  localMs: number
+): boolean {
+  for (const anim of compiled) {
+    if (anim.loop) {
+      if (localMs >= anim.windowStartMs && localMs < anim.windowEndMs) return true;
+    } else if (localMs >= anim.windowStartMs && localMs <= anim.windowEndMs) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/timeline/src/animation/types.ts
+++ b/packages/timeline/src/animation/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Motion-design animation types (pure, no DOM/GPU/store access).
+ *
+ * A `ClipAnimation` is a named preset attached to a clip. Presets never render
+ * directly; they compile to keyframe curves (see `compile.ts`) sampled by one
+ * sampler (`sample.ts`). This keeps the authoring surface small (preset + a few
+ * params) while leaving room for a curve editor later without a schema break.
+ */
+
+/** What phase of the clip an animation drives. */
+export type AnimationRole = "in" | "out" | "emphasis" | "loop";
+
+export type EasingId =
+  | "linear"
+  | "easeIn"
+  | "easeOut"
+  | "easeInOut" // cubic
+  | "easeOutBack" // overshoot (pop)
+  | "easeOutElastic"
+  | "easeOutBounce";
+
+export interface ClipAnimation {
+  /** `crypto.randomUUID()` at creation. */
+  id: string;
+  role: AnimationRole;
+  /**
+   * An {@link AnimationPresetId}. Typed `string` on purpose: documents saved by
+   * a newer client may carry ids this build doesn't know — they parse fine and
+   * are skipped at compile time (forward compat). Tool inputs and the UI
+   * constrain to the catalog union.
+   */
+  preset: string;
+  /** Animation length in ms. For `"loop"`, the period of one cycle. */
+  durationMs: number;
+  /**
+   * `"in" | "emphasis" | "loop"`: offset from clip start to window start.
+   * `"out"`: offset from clip END back to window end (0 = ends exactly at clip
+   * end). Default 0.
+   */
+  delayMs?: number;
+  /** Overrides the preset default and every per-segment easing when set. */
+  easing?: EasingId;
+  /** Default true. Disabled animations are kept but not evaluated. */
+  enabled?: boolean;
+  /** Preset-specific knobs; unknown keys ignored. See the preset catalog. */
+  params?: Record<string, number | string | boolean>;
+}
+
+/**
+ * Union of every preset id in the v1 catalog. Kept in sync with
+ * `ANIMATION_PRESETS` in `presets.ts`.
+ */
+export type AnimationPresetId =
+  | "fade"
+  | "slide"
+  | "pop"
+  | "spin"
+  | "pulse"
+  | "shake"
+  | "bounce"
+  | "kenBurns"
+  | "float"
+  | "breathe"
+  | "rotate";

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -13,3 +13,4 @@ export * from "./snap.js";
 export * from "./staleSet.js";
 export * from "./placement/index.js";
 export * from "./snapping/index.js";
+export * from "./animation/index.js";

--- a/packages/timeline/src/splitClip.ts
+++ b/packages/timeline/src/splitClip.ts
@@ -1,6 +1,32 @@
 import { createTimeOrderedUuid } from "./defaults.js";
 import { sourceRate } from "./sourceRate.js";
+import type { ClipAnimation } from "./animation/types.js";
 import type { CaptionWord, TimelineClip } from "./types.js";
+
+/**
+ * Partition a clip's animations across a split. `"in"` animations stay on the
+ * left half (they play at the clip's original start); `"out"` on the right (they
+ * play at the original end); `"emphasis"` and `"loop"` are copied to both halves
+ * — their windows re-derive from each half's own duration at compile time.
+ * Right-half animations get fresh ids so the two clips edit independently.
+ */
+function splitAnimations(
+  animations: ReadonlyArray<ClipAnimation>
+): { left: ClipAnimation[]; right: ClipAnimation[] } {
+  const left: ClipAnimation[] = [];
+  const right: ClipAnimation[] = [];
+  for (const anim of animations) {
+    if (anim.role === "in") {
+      left.push({ ...anim });
+    } else if (anim.role === "out") {
+      right.push({ ...anim, id: createTimeOrderedUuid() });
+    } else {
+      left.push({ ...anim });
+      right.push({ ...anim, id: createTimeOrderedUuid() });
+    }
+  }
+  return { left, right };
+}
 
 /**
  * Partition clip-local caption words at `splitMs` — the split point measured in
@@ -57,6 +83,8 @@ export function splitClip(clip: TimelineClip, atMs: number): [TimelineClip, Time
     ? splitCaptionWords(clip.caption.words, leftDurationMs, rightDurationMs)
     : null;
 
+  const animations = clip.animations ? splitAnimations(clip.animations) : null;
+
   const leftClip: TimelineClip = {
     ...clip,
     id: createTimeOrderedUuid(),
@@ -69,6 +97,9 @@ export function splitClip(clip: TimelineClip, atMs: number): [TimelineClip, Time
   delete leftClip.fadeOutMs;
   if (captions) {
     leftClip.caption = { words: captions.left };
+  }
+  if (animations) {
+    leftClip.animations = animations.left;
   }
 
   const rightClip: TimelineClip = {
@@ -86,6 +117,9 @@ export function splitClip(clip: TimelineClip, atMs: number): [TimelineClip, Time
   delete rightClip.transitionIn;
   if (captions) {
     rightClip.caption = { words: captions.right };
+  }
+  if (animations) {
+    rightClip.animations = animations.right;
   }
 
   return [leftClip, rightClip];

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -20,6 +20,11 @@ export type ClipStatus =
 import type { BlendMode } from "@nodetool-ai/gpu";
 export type { BlendMode };
 
+// Motion-design animations attached to a clip (pure engine in ./animation).
+// Re-exported from the package root via ./animation/index.js, so only imported
+// here (not re-exported) to avoid a duplicate star-export.
+import type { ClipAnimation } from "./animation/types.js";
+
 export interface TimelineSequence {
   id: string;
   projectId: string;
@@ -393,6 +398,13 @@ export interface TimelineClip {
    * `durationMs` for the transition to be visible.
    */
   transitionIn?: ClipTransition;
+  /**
+   * Motion-design animations evaluated at render time (see
+   * `animation/`). Evaluation is order-independent (the fold is commutative —
+   * see `animation/sample.ts`); array order is presentation order in the UI
+   * only. Must also exist on the protocol zod schema or PATCH would strip it.
+   */
+  animations?: ClipAnimation[];
 }
 
 /**

--- a/packages/timeline/tests/animation.compile.test.ts
+++ b/packages/timeline/tests/animation.compile.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import { compileClipAnimations } from "../src/animation/compile.js";
+import type { ClipAnimation } from "../src/animation/types.js";
+
+const CANVAS = { width: 1920, height: 1080 };
+
+function anim(overrides: Partial<ClipAnimation>): ClipAnimation {
+  return {
+    id: "a1",
+    role: "in",
+    preset: "fade",
+    durationMs: 500,
+    ...overrides
+  };
+}
+
+describe("compileClipAnimations", () => {
+  it("returns [] for undefined / empty", () => {
+    expect(compileClipAnimations(undefined, 3000, CANVAS)).toEqual([]);
+    expect(compileClipAnimations([], 3000, CANVAS)).toEqual([]);
+  });
+
+  it("places an 'in' window at [delay, delay+duration] with holdBefore", () => {
+    const [c] = compileClipAnimations([anim({ delayMs: 200, durationMs: 500 })], 3000, CANVAS);
+    expect(c.windowStartMs).toBe(200);
+    expect(c.windowEndMs).toBe(700);
+    expect(c.holdBefore).toBe(true);
+    expect(c.holdAfter).toBe(false);
+    expect(c.loop).toBe(false);
+  });
+
+  it("measures an 'out' window from the clip end with holdAfter", () => {
+    const [c] = compileClipAnimations(
+      [anim({ role: "out", preset: "fade", delayMs: 0, durationMs: 500 })],
+      3000,
+      CANVAS
+    );
+    expect(c.windowEndMs).toBe(3000);
+    expect(c.windowStartMs).toBe(2500);
+    expect(c.holdAfter).toBe(true);
+    expect(c.holdBefore).toBe(false);
+  });
+
+  it("clamps a window longer than the clip", () => {
+    const [c] = compileClipAnimations([anim({ durationMs: 5000 })], 1000, CANVAS);
+    expect(c.windowStartMs).toBe(0);
+    expect(c.windowEndMs).toBe(1000);
+  });
+
+  it("drops a window that starts at or after clip end", () => {
+    expect(compileClipAnimations([anim({ delayMs: 4000 })], 3000, CANVAS)).toEqual([]);
+  });
+
+  it("skips disabled animations", () => {
+    expect(compileClipAnimations([anim({ enabled: false })], 3000, CANVAS)).toEqual([]);
+  });
+
+  it("skips unknown presets with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(compileClipAnimations([anim({ preset: "does-not-exist" })], 3000, CANVAS)).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("skips a role the preset does not allow", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // fade only allows in/out
+    expect(compileClipAnimations([anim({ role: "loop", preset: "fade" })], 3000, CANVAS)).toEqual(
+      []
+    );
+    warn.mockRestore();
+  });
+
+  it("compiles a loop over the whole clip with a period", () => {
+    const [c] = compileClipAnimations(
+      [anim({ role: "loop", preset: "float", durationMs: 1000 })],
+      5000,
+      CANVAS
+    );
+    expect(c.loop).toBe(true);
+    expect(c.periodMs).toBe(1000);
+    expect(c.windowStartMs).toBe(0);
+    expect(c.windowEndMs).toBe(5000);
+  });
+
+  it("compiles kenBurns as a full-clip one-shot ignoring duration/delay", () => {
+    const [c] = compileClipAnimations(
+      [anim({ role: "loop", preset: "kenBurns", durationMs: 500, delayMs: 999 })],
+      4000,
+      CANVAS
+    );
+    expect(c.loop).toBe(false);
+    expect(c.windowStartMs).toBe(0);
+    expect(c.windowEndMs).toBe(4000);
+    expect(c.holdAfter).toBe(true);
+  });
+
+  it("resolves slide distance to px against the canvas", () => {
+    const [c] = compileClipAnimations(
+      [anim({ preset: "slide", params: { direction: "left", distance: 0.5 } })],
+      3000,
+      CANVAS
+    );
+    const offsetX = c.curves.find((cu) => cu.property === "offsetX");
+    expect(offsetX?.keyframes[0].value).toBeCloseTo(-960, 3); // -0.5 * 1920
+  });
+
+  it("reverses the curve for the 'out' role", () => {
+    const [inC] = compileClipAnimations([anim({ role: "in", preset: "fade" })], 3000, CANVAS);
+    const [outC] = compileClipAnimations([anim({ role: "out", preset: "fade" })], 3000, CANVAS);
+    const inOp = inC.curves[0].keyframes;
+    const outOp = outC.curves[0].keyframes;
+    expect(inOp[0].value).toBe(0);
+    expect(inOp[inOp.length - 1].value).toBe(1);
+    expect(outOp[0].value).toBe(1);
+    expect(outOp[outOp.length - 1].value).toBe(0);
+  });
+
+  it("is deterministic — same inputs give deeply equal output", () => {
+    const input = [anim({ preset: "pop", role: "in" }), anim({ role: "loop", preset: "breathe" })];
+    const a = compileClipAnimations(input, 3000, CANVAS);
+    const b = compileClipAnimations(input, 3000, CANVAS);
+    expect(a).toEqual(b);
+  });
+
+  it("applies the animation easing override to every segment", () => {
+    const [c] = compileClipAnimations(
+      [anim({ preset: "pop", role: "in", easing: "linear" })],
+      3000,
+      CANVAS
+    );
+    for (const curve of c.curves) {
+      for (const kf of curve.keyframes) {
+        expect(kf.easing).toBe("linear");
+      }
+    }
+  });
+});

--- a/packages/timeline/tests/animation.easing.test.ts
+++ b/packages/timeline/tests/animation.easing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { ease } from "../src/animation/easing.js";
+import type { EasingId } from "../src/animation/types.js";
+
+const ALL: EasingId[] = [
+  "linear",
+  "easeIn",
+  "easeOut",
+  "easeInOut",
+  "easeOutBack",
+  "easeOutElastic",
+  "easeOutBounce"
+];
+
+describe("ease", () => {
+  it("maps endpoints exactly for every easing", () => {
+    for (const id of ALL) {
+      expect(ease(id, 0)).toBeCloseTo(0, 6);
+      expect(ease(id, 1)).toBeCloseTo(1, 6);
+    }
+  });
+
+  it("easeOut is monotonic increasing", () => {
+    let prev = -Infinity;
+    for (let i = 0; i <= 20; i++) {
+      const v = ease("easeOut", i / 20);
+      expect(v).toBeGreaterThanOrEqual(prev);
+      prev = v;
+    }
+  });
+
+  it("easeOutBack overshoots past 1", () => {
+    let maxV = 0;
+    for (let i = 0; i <= 100; i++) maxV = Math.max(maxV, ease("easeOutBack", i / 100));
+    expect(maxV).toBeGreaterThan(1);
+  });
+
+  it("linear is the identity", () => {
+    expect(ease("linear", 0.37)).toBeCloseTo(0.37, 6);
+  });
+});

--- a/packages/timeline/tests/animation.sample.test.ts
+++ b/packages/timeline/tests/animation.sample.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { compileClipAnimations } from "../src/animation/compile.js";
+import {
+  IDENTITY_SAMPLE,
+  hasActiveAnimationWindow,
+  sampleAnimations
+} from "../src/animation/sample.js";
+import { ANIMATION_PRESETS } from "../src/animation/presets.js";
+import type { ClipAnimation } from "../src/animation/types.js";
+
+const CANVAS = { width: 1000, height: 1000 };
+
+function compile(animations: ClipAnimation[], clipMs: number) {
+  return compileClipAnimations(animations, clipMs, CANVAS);
+}
+
+describe("sampleAnimations", () => {
+  it("is identity with no animations", () => {
+    expect(sampleAnimations([], 100)).toEqual({ ...IDENTITY_SAMPLE });
+  });
+
+  it("holds opacity 0 during an 'in' delay, animates in the window", () => {
+    const c = compile(
+      [{ id: "a", role: "in", preset: "fade", durationMs: 500, delayMs: 300 }],
+      3000
+    );
+    expect(sampleAnimations(c, 0).opacity).toBe(0); // held before window
+    expect(sampleAnimations(c, 150).opacity).toBe(0); // still in delay
+    const mid = sampleAnimations(c, 550).opacity; // 250ms into a 500ms window
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(1);
+    expect(sampleAnimations(c, 900).opacity).toBeCloseTo(1, 6); // after window: identity ×1
+  });
+
+  it("identity outside an emphasis window", () => {
+    const c = compile(
+      [{ id: "a", role: "emphasis", preset: "pulse", durationMs: 600, delayMs: 1000 }],
+      3000
+    );
+    expect(sampleAnimations(c, 500).scale).toBe(1);
+    expect(sampleAnimations(c, 1300).scale).toBeGreaterThan(1); // peak region
+    expect(sampleAnimations(c, 2000).scale).toBe(1);
+  });
+
+  it("folds concurrent in + loop", () => {
+    const c = compile(
+      [
+        { id: "a", role: "in", preset: "fade", durationMs: 500 },
+        { id: "b", role: "loop", preset: "breathe", durationMs: 1000 }
+      ],
+      3000
+    );
+    const s = sampleAnimations(c, 250);
+    expect(s.opacity).toBeGreaterThan(0);
+    expect(s.opacity).toBeLessThan(1); // fade still running
+    expect(s.scale).not.toBe(1); // breathe active
+  });
+
+  it("loop wraps continuously (value at t and t+period match)", () => {
+    const c = compile(
+      [{ id: "a", role: "loop", preset: "float", durationMs: 1000 }],
+      5000
+    );
+    const s1 = sampleAnimations(c, 250);
+    const s2 = sampleAnimations(c, 1250);
+    expect(s2.offsetY).toBeCloseTo(s1.offsetY, 6);
+  });
+
+  it("clamps folded opacity to [0,1] under overshoot easing", () => {
+    // Two pop-ins overlapping can push opacity above 1 before clamping.
+    const c = compile(
+      [
+        { id: "a", role: "in", preset: "pop", durationMs: 500 },
+        { id: "b", role: "in", preset: "fade", durationMs: 500 }
+      ],
+      3000
+    );
+    for (let ms = 0; ms <= 600; ms += 25) {
+      const o = sampleAnimations(c, ms).opacity;
+      expect(o).toBeGreaterThanOrEqual(0);
+      expect(o).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("writes into a provided scratch object", () => {
+    const c = compile([{ id: "a", role: "in", preset: "fade", durationMs: 500 }], 3000);
+    const scratch = { offsetX: 9, offsetY: 9, scale: 9, rotation: 9, opacity: 9 };
+    const out = sampleAnimations(c, 250, scratch);
+    expect(out).toBe(scratch);
+    expect(out.offsetX).toBe(0); // reset before writing
+  });
+});
+
+describe("loop start==end invariant", () => {
+  const loopPresets = ANIMATION_PRESETS.filter(
+    (p) => p.roles.includes("loop") && !p.fullClip
+  );
+
+  it("every repeating loop preset returns to its start value", () => {
+    for (const preset of loopPresets) {
+      const c = compile(
+        [{ id: "x", role: "loop", preset: preset.id, durationMs: 1000 }],
+        4000
+      );
+      for (const anim of c) {
+        for (const curve of anim.curves) {
+          // rotation is modular (0 and 2π are visually identical) — exempt.
+          if (curve.property === "rotation") continue;
+          const first = curve.keyframes[0].value;
+          const last = curve.keyframes[curve.keyframes.length - 1].value;
+          expect(last).toBeCloseTo(first, 6);
+        }
+      }
+    }
+  });
+});
+
+describe("hasActiveAnimationWindow", () => {
+  it("is true inside the window and false outside (non-hold)", () => {
+    const c = compile(
+      [{ id: "a", role: "emphasis", preset: "pulse", durationMs: 600, delayMs: 500 }],
+      3000
+    );
+    expect(hasActiveAnimationWindow(c, 100)).toBe(false);
+    expect(hasActiveAnimationWindow(c, 700)).toBe(true);
+    expect(hasActiveAnimationWindow(c, 2000)).toBe(false);
+  });
+
+  it("is true throughout a loop", () => {
+    const c = compile([{ id: "a", role: "loop", preset: "rotate", durationMs: 1000 }], 3000);
+    expect(hasActiveAnimationWindow(c, 0)).toBe(true);
+    expect(hasActiveAnimationWindow(c, 2999)).toBe(true);
+  });
+});

--- a/packages/timeline/tests/animation.split.test.ts
+++ b/packages/timeline/tests/animation.split.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { splitClip } from "../src/splitClip.js";
+import type { TimelineClip } from "../src/types.js";
+import type { ClipAnimation } from "../src/animation/types.js";
+
+function makeClipWithAnimations(animations: ClipAnimation[]): TimelineClip {
+  return {
+    id: "clip-1",
+    trackId: "track-1",
+    name: "clip",
+    startMs: 100,
+    durationMs: 400,
+    mediaType: "video",
+    sourceType: "generated",
+    status: "generated",
+    locked: false,
+    versions: [],
+    animations
+  };
+}
+
+describe("splitClip with animations", () => {
+  it("keeps 'in' left, 'out' right, copies emphasis/loop to both", () => {
+    const clip = makeClipWithAnimations([
+      { id: "in-1", role: "in", preset: "fade", durationMs: 300 },
+      { id: "out-1", role: "out", preset: "fade", durationMs: 300 },
+      { id: "emph-1", role: "emphasis", preset: "pulse", durationMs: 400 },
+      { id: "loop-1", role: "loop", preset: "float", durationMs: 1000 }
+    ]);
+    const [left, right] = splitClip(clip, 300);
+
+    const leftRoles = (left.animations ?? []).map((a) => a.role).sort();
+    const rightRoles = (right.animations ?? []).map((a) => a.role).sort();
+    expect(leftRoles).toEqual(["emphasis", "in", "loop"]);
+    expect(rightRoles).toEqual(["emphasis", "loop", "out"]);
+  });
+
+  it("regenerates ids on the right half", () => {
+    const clip = makeClipWithAnimations([
+      { id: "loop-1", role: "loop", preset: "float", durationMs: 1000 }
+    ]);
+    const [left, right] = splitClip(clip, 300);
+    expect(left.animations?.[0].id).toBe("loop-1");
+    expect(right.animations?.[0].id).not.toBe("loop-1");
+    expect(right.animations?.[0].preset).toBe("float");
+  });
+
+  it("leaves clips without animations untouched", () => {
+    const clip = makeClipWithAnimations([]);
+    delete clip.animations;
+    const [left, right] = splitClip(clip, 300);
+    expect(left.animations).toBeUndefined();
+    expect(right.animations).toBeUndefined();
+  });
+});

--- a/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
+++ b/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
@@ -16,6 +16,8 @@ const makeMockHandler = (): TimelineAgentHandler => ({
   duplicateClip: jest.fn(),
   setClipParams: jest.fn(),
   setClipBinding: jest.fn(),
+  setClipAnimations: jest.fn(),
+  clearClipAnimations: jest.fn(),
   getClipFrames: jest.fn(),
   selectClip: jest.fn(),
   seek: jest.fn()

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -40,13 +40,16 @@ import {
   clipSourceTimeSec,
   computeActiveLayers,
   computeActiveLayersWithHorizon,
+  createAnimationCompileCache,
   effectiveAssetId,
+  hasActiveAnimation,
   isClipActive,
+  resolveAnimatedLayerProps,
   trackZ,
   PREVIEW_OVERLAY_Z,
   MAX_VIDEO_LAYERS
 } from "./sceneModel";
-import type { ResolvedCaption } from "./sceneModel";
+import type { ActiveLayer, ResolvedCaption } from "./sceneModel";
 import { CaptionRasterizer } from "./captionRender";
 
 interface PlaceholderLayer {
@@ -420,6 +423,21 @@ export const PreviewCompositor: React.FC = memo(() => {
     [clips]
   );
 
+  // Memoized preset→curve compilation for motion-design animations, so the
+  // rAF loop only samples (never compiles). Invalidated internally when a
+  // clip's animations / duration / canvas size change.
+  const animCacheRef = useRef(createAnimationCompileCache());
+  // Latest sequence resolution, read by the rAF loop (whose closure only
+  // rebinds on [gpuReady, isPlaying]) to resolve animation offsets in px.
+  const canvasSizeRef = useRef({ width: sequenceWidth, height: sequenceHeight });
+  canvasSizeRef.current = { width: sequenceWidth, height: sequenceHeight };
+  // Active layers from the last scene computation, valid until the next
+  // clip/word boundary — used per tick to test for in-flight animation.
+  const lastLayersRef = useRef<ActiveLayer[]>([]);
+  // Latest React scene time, read by the paused one-shot render path.
+  const currentTimeMsRef = useRef(currentTimeMs);
+  currentTimeMsRef.current = currentTimeMs;
+
   // Signature of the visible scene at a given time: the ordered active layer
   // ids plus, for captions, which word is currently spoken (so a highlight
   // change inside one clip still bumps the scene during playback). Used to
@@ -427,7 +445,9 @@ export const PreviewCompositor: React.FC = memo(() => {
   // returns the change horizon so the loop can skip recomputing this while
   // the query time stays inside the current clip/word boundaries.
   const sceneSignature = useCallback(
-    (timeMs: number): { signature: string; nextChangeMs: number } => {
+    (
+      timeMs: number
+    ): { signature: string; nextChangeMs: number; layers: ActiveLayer[] } => {
       const { layers, nextChangeMs } = computeActiveLayersWithHorizon(
         tracks,
         clips,
@@ -442,7 +462,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         }
         sig += "|";
       }
-      return { signature: sig, nextChangeMs };
+      return { signature: sig, nextChangeMs, layers };
     },
     [tracks, clips]
   );
@@ -764,81 +784,115 @@ export const PreviewCompositor: React.FC = memo(() => {
     []
   );
 
-  // Build the GPU layer list from active slots and image layers.
-  const buildLayers = useCallback((): CompositeLayer[] => {
-    const out: CompositeLayer[] = [];
-    const pool = videoRefs.current;
+  // Build the GPU layer list from active slots and image layers, resolving
+  // each layer's motion-design animation at `atMs` (the frame being drawn).
+  const buildLayers = useCallback(
+    (atMs: number): CompositeLayer[] => {
+      const out: CompositeLayer[] = [];
+      const pool = videoRefs.current;
+      const canvas = { width: sequenceWidth, height: sequenceHeight };
+      const cache = animCacheRef.current;
 
-    activeVideoSlots.forEach((slot) => {
-      const slotIndex = clipSlotMap.current.get(slot.clipId);
-      if (slotIndex === undefined) return;
-      const el = pool[slotIndex];
-      // Keep the layer in the list even if the video momentarily drops below
-      // HAVE_CURRENT_DATA (e.g. during a scrub seek). The compositor reuses
-      // the previously uploaded texture so we don't flash to black.
-      if (!el || el.videoWidth === 0) return;
-      out.push({
-        id: `v:${slot.clipId}`,
-        source: el,
-        opacity: slot.opacity,
-        blendMode: slot.blendMode,
-        zIndex: trackZ(slot.trackIndex),
-        transform: slot.transform,
-        borderRadius: slot.borderRadius,
-        effects: slot.effects,
-        trackEffects: slot.trackEffects
+      activeVideoSlots.forEach((slot) => {
+        const slotIndex = clipSlotMap.current.get(slot.clipId);
+        if (slotIndex === undefined) return;
+        const el = pool[slotIndex];
+        // Keep the layer in the list even if the video momentarily drops below
+        // HAVE_CURRENT_DATA (e.g. during a scrub seek). The compositor reuses
+        // the previously uploaded texture so we don't flash to black.
+        if (!el || el.videoWidth === 0) return;
+        const clip = clipById.get(slot.clipId);
+        const anim = clip
+          ? resolveAnimatedLayerProps(
+              { clip, transform: slot.transform, opacity: slot.opacity },
+              atMs,
+              canvas,
+              cache
+            )
+          : { transform: slot.transform, opacity: slot.opacity };
+        out.push({
+          id: `v:${slot.clipId}`,
+          source: el,
+          opacity: anim.opacity,
+          blendMode: slot.blendMode,
+          zIndex: trackZ(slot.trackIndex),
+          transform: anim.transform,
+          borderRadius: slot.borderRadius,
+          effects: slot.effects,
+          trackEffects: slot.trackEffects
+        });
       });
-    });
 
-    for (const layer of activeImageLayers) {
-      if (!layer.assetUrl) continue;
-      const img = ensureImageElement(layer.assetUrl);
-      if (!img) continue;
-      out.push({
-        id: `i:${layer.clipId}`,
-        source: img,
-        opacity: layer.opacity,
-        blendMode: layer.blendMode,
-        zIndex: trackZ(layer.trackIndex),
-        transform: layer.transform,
-        borderRadius: layer.borderRadius,
-        effects: layer.effects,
-        trackEffects: layer.trackEffects
-      });
-    }
+      for (const layer of activeImageLayers) {
+        if (!layer.assetUrl) continue;
+        const img = ensureImageElement(layer.assetUrl);
+        if (!img) continue;
+        const clip = clipById.get(layer.clipId);
+        const anim = clip
+          ? resolveAnimatedLayerProps(
+              { clip, transform: layer.transform, opacity: layer.opacity },
+              atMs,
+              canvas,
+              cache
+            )
+          : { transform: layer.transform, opacity: layer.opacity };
+        out.push({
+          id: `i:${layer.clipId}`,
+          source: img,
+          opacity: anim.opacity,
+          blendMode: layer.blendMode,
+          zIndex: trackZ(layer.trackIndex),
+          transform: anim.transform,
+          borderRadius: layer.borderRadius,
+          effects: layer.effects,
+          trackEffects: layer.trackEffects
+        });
+      }
 
-    for (const layer of activeCaptionLayers) {
-      const bitmap = captionRasterizerRef.current.rasterize(
-        layer.caption,
-        sequenceWidth,
-        sequenceHeight
-      );
-      if (!bitmap) continue;
-      out.push({
-        id: `c:${layer.clipId}`,
-        source: bitmap,
-        opacity: layer.opacity,
-        blendMode: layer.blendMode,
-        zIndex: trackZ(layer.trackIndex),
-        transform: layer.transform
-      });
-    }
+      for (const layer of activeCaptionLayers) {
+        const bitmap = captionRasterizerRef.current.rasterize(
+          layer.caption,
+          sequenceWidth,
+          sequenceHeight
+        );
+        if (!bitmap) continue;
+        const clip = clipById.get(layer.clipId);
+        const anim = clip
+          ? resolveAnimatedLayerProps(
+              { clip, transform: layer.transform, opacity: layer.opacity },
+              atMs,
+              canvas,
+              cache
+            )
+          : { transform: layer.transform, opacity: layer.opacity };
+        out.push({
+          id: `c:${layer.clipId}`,
+          source: bitmap,
+          opacity: anim.opacity,
+          blendMode: layer.blendMode,
+          zIndex: trackZ(layer.trackIndex),
+          transform: anim.transform
+        });
+      }
 
-    return out;
-  }, [
-    activeVideoSlots,
-    activeImageLayers,
-    activeCaptionLayers,
-    ensureImageElement,
-    sequenceWidth,
-    sequenceHeight
-  ]);
+      return out;
+    },
+    [
+      activeVideoSlots,
+      activeImageLayers,
+      activeCaptionLayers,
+      clipById,
+      ensureImageElement,
+      sequenceWidth,
+      sequenceHeight
+    ]
+  );
 
   const renderFrame = useCallback(() => {
     if (!gpuReady) return;
     const compositor = compositorRef.current;
     if (!compositor) return;
-    compositor.setLayers(buildLayersRef.current());
+    compositor.setLayers(buildLayersRef.current(currentTimeMsRef.current));
     compositor.render();
   }, [gpuReady]);
 
@@ -925,6 +979,7 @@ export const PreviewCompositor: React.FC = memo(() => {
     let lastSignature = seed.signature;
     lastLiveMsRef.current = seedMs;
     lastNextChangeMsRef.current = seed.nextChangeMs;
+    lastLayersRef.current = seed.layers;
     lastComputeTracksRef.current = latestTracksRef.current;
     lastComputeClipsRef.current = latestClipsRef.current;
     // Force a composite on the very first frame after play starts so any
@@ -949,6 +1004,7 @@ export const PreviewCompositor: React.FC = memo(() => {
         setChanged = result.signature !== lastSignature;
         lastSignature = result.signature;
         lastNextChangeMsRef.current = result.nextChangeMs;
+        lastLayersRef.current = result.layers;
         lastComputeTracksRef.current = latestTracksRef.current;
         lastComputeClipsRef.current = latestClipsRef.current;
         if (setChanged) {
@@ -960,7 +1016,8 @@ export const PreviewCompositor: React.FC = memo(() => {
       // A frame needs re-compositing when the active set just changed, or when
       // any active video is decoding new pixels (i.e. actually playing). Pure
       // image/caption scenes are static between boundary changes, so skip the
-      // redundant clear+blit.
+      // redundant clear+blit — UNLESS a motion-design animation is in flight,
+      // which changes transform/opacity every tick even with a cached layer set.
       let dirty = setChanged || forceRender;
       forceRender = false;
       if (!dirty) {
@@ -973,9 +1030,20 @@ export const PreviewCompositor: React.FC = memo(() => {
           }
         }
       }
+      if (
+        !dirty &&
+        hasActiveAnimation(
+          lastLayersRef.current,
+          liveMs,
+          canvasSizeRef.current,
+          animCacheRef.current
+        )
+      ) {
+        dirty = true;
+      }
 
       if (dirty) {
-        compositor.setLayers(buildLayersRef.current());
+        compositor.setLayers(buildLayersRef.current(liveMs));
         compositor.render();
       }
       raf = requestAnimationFrame(tick);

--- a/web/src/components/timeline/preview/__tests__/animationResolve.test.ts
+++ b/web/src/components/timeline/preview/__tests__/animationResolve.test.ts
@@ -1,0 +1,148 @@
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type {
+  ClipAnimation,
+  TimelineClip,
+  TimelineTrack
+} from "@nodetool-ai/timeline";
+
+import {
+  computeActiveLayers,
+  computeActiveLayersWithHorizon,
+  createAnimationCompileCache,
+  hasActiveAnimation,
+  resolveAnimatedLayerProps
+} from "../sceneModel";
+import type { ActiveLayer } from "../sceneModel";
+
+const CANVAS = { width: 1000, height: 1000 };
+
+const animatedClip = (animations: ClipAnimation[]): TimelineClip =>
+  makeClip({
+    id: "clip-1",
+    status: "generated",
+    currentAssetId: "asset-1",
+    mediaType: "image",
+    startMs: 0,
+    durationMs: 2000,
+    animations
+  });
+
+const layerFor = (clip: TimelineClip): ActiveLayer => ({
+  kind: "image",
+  clip,
+  clipId: clip.id,
+  trackIndex: 0,
+  blendMode: "normal",
+  opacity: clip.opacity ?? 1,
+  assetId: clip.currentAssetId,
+  transform: clip.transform
+});
+
+describe("resolveAnimatedLayerProps", () => {
+  it("returns the layer's own values when there are no animations", () => {
+    const clip = makeClip({ mediaType: "image", opacity: 0.5 });
+    const layer = layerFor(clip);
+    const out = resolveAnimatedLayerProps(layer, 100, CANVAS);
+    expect(out.opacity).toBe(0.5);
+    expect(out.transform).toBe(layer.transform);
+  });
+
+  it("composes a static transform with a slide-in at the window midpoint", () => {
+    const clip = animatedClip([
+      {
+        id: "a",
+        role: "in",
+        preset: "slide",
+        durationMs: 500,
+        easing: "linear",
+        params: { direction: "left", distance: 0.3 }
+      }
+    ]);
+    clip.transform = {
+      position: { x: 100, y: 0 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+      anchor: { x: 0.5, y: 0.5 }
+    };
+    const layer = layerFor(clip);
+    // Window [0,500]; midpoint t=0.5 with linear easing.
+    const out = resolveAnimatedLayerProps(layer, 250, CANVAS);
+    // slide left starts at -0.3*1000 = -300, linear to 0 → -150 at t=0.5.
+    expect(out.transform?.position.x).toBeCloseTo(100 - 150, 3);
+    expect(out.opacity).toBeCloseTo(0.5, 6); // opacity 0→1 linear at t=0.5
+  });
+
+  it("holds opacity 0 before a delayed fade-in", () => {
+    const clip = animatedClip([
+      { id: "a", role: "in", preset: "fade", durationMs: 500, delayMs: 400 }
+    ]);
+    const out = resolveAnimatedLayerProps(layerFor(clip), 100, CANVAS);
+    expect(out.opacity).toBe(0);
+  });
+});
+
+describe("preview / export parity", () => {
+  it("resolves identically at window start, mid, end, and past-end", () => {
+    const clip = animatedClip([
+      { id: "a", role: "in", preset: "pop", durationMs: 600 },
+      { id: "b", role: "loop", preset: "float", durationMs: 1000 }
+    ]);
+    const previewCache = createAnimationCompileCache();
+    const exportCache = createAnimationCompileCache();
+    const layer = layerFor(clip);
+    for (const t of [0, 300, 600, 1200]) {
+      const preview = resolveAnimatedLayerProps(layer, t, CANVAS, previewCache);
+      const exported = resolveAnimatedLayerProps(layer, t, CANVAS, exportCache);
+      expect(exported).toEqual(preview);
+      // And cache vs no-cache agree too.
+      expect(resolveAnimatedLayerProps(layer, t, CANVAS)).toEqual(preview);
+    }
+  });
+});
+
+describe("change horizon is unaffected by animations", () => {
+  const track: TimelineTrack = makeTrack({ type: "video", visible: true });
+  const base = (animations?: ClipAnimation[]): TimelineClip =>
+    makeClip({
+      trackId: track.id,
+      status: "generated",
+      currentAssetId: "asset-1",
+      mediaType: "image",
+      startMs: 0,
+      durationMs: 1000,
+      animations
+    });
+
+  it("nextChangeMs matches with and without animations", () => {
+    const without = computeActiveLayersWithHorizon([track], [base()], 200);
+    const withAnim = computeActiveLayersWithHorizon(
+      [track],
+      [base([{ id: "a", role: "loop", preset: "float", durationMs: 300 }])],
+      200
+    );
+    expect(withAnim.nextChangeMs).toBe(without.nextChangeMs);
+  });
+});
+
+describe("hasActiveAnimation", () => {
+  const clip = animatedClip([
+    { id: "a", role: "in", preset: "fade", durationMs: 400, delayMs: 200 }
+  ]);
+  const layers = computeActiveLayers(
+    [makeTrack({ id: clip.trackId, type: "video", visible: true })],
+    [clip],
+    300
+  );
+
+  it("is true inside the animating window", () => {
+    expect(hasActiveAnimation(layers, 300, CANVAS)).toBe(true);
+  });
+
+  it("is false during the pre-window hold", () => {
+    expect(hasActiveAnimation(layers, 100, CANVAS)).toBe(false);
+  });
+
+  it("is false after the window ends", () => {
+    expect(hasActiveAnimation(layers, 900, CANVAS)).toBe(false);
+  });
+});

--- a/web/src/components/timeline/preview/sceneModel.ts
+++ b/web/src/components/timeline/preview/sceneModel.ts
@@ -11,11 +11,18 @@
  */
 
 import type {
+  ClipAnimation,
   ClipEffect,
   ClipTransform,
+  CompiledAnimation,
   TimelineClip,
   TimelineTrack,
   TrackEffect
+} from "@nodetool-ai/timeline";
+import {
+  compileClipAnimations,
+  hasActiveAnimationWindow,
+  sampleAnimations
 } from "@nodetool-ai/timeline";
 import type { CompositorBlendMode } from "./gpu/types";
 
@@ -394,4 +401,138 @@ export function computeActiveLayers(
 ): ActiveLayer[] {
   return computeActiveLayersWithHorizon(tracks, clips, currentTimeMs, options)
     .layers;
+}
+
+// ── Motion-design animation resolution ───────────────────────────────────────
+
+/**
+ * The animated transform/opacity a layer should render with at a point in time.
+ * Composed from the layer's static `transform`/`opacity` and its animation
+ * sample. Identical fields to the layer when it has no active animation.
+ */
+export interface AnimatedLayerProps {
+  transform?: ClipTransform;
+  opacity: number;
+}
+
+interface CompileCacheEntry {
+  /** The `animations` array reference this entry was compiled from. */
+  animationsRef: ClipAnimation[];
+  /** Recompile when the clip is trimmed (window math depends on duration). */
+  durationMs: number;
+  canvasW: number;
+  canvasH: number;
+  compiled: CompiledAnimation[];
+}
+
+/**
+ * Per-clip memoized compilation so the rAF loop never compiles. Invalidated
+ * when the clip's `animations` array reference, its duration, or the canvas
+ * size changes. Keyed by clip id.
+ */
+export type AnimationCompileCache = Map<string, CompileCacheEntry>;
+
+export function createAnimationCompileCache(): AnimationCompileCache {
+  return new Map();
+}
+
+function compiledFor(
+  clip: TimelineClip,
+  canvas: { width: number; height: number },
+  cache?: AnimationCompileCache
+): CompiledAnimation[] {
+  const animations = clip.animations;
+  if (!animations || animations.length === 0) return [];
+  if (cache) {
+    const hit = cache.get(clip.id);
+    if (
+      hit &&
+      hit.animationsRef === animations &&
+      hit.durationMs === clip.durationMs &&
+      hit.canvasW === canvas.width &&
+      hit.canvasH === canvas.height
+    ) {
+      return hit.compiled;
+    }
+    const compiled = compileClipAnimations(animations, clip.durationMs, canvas);
+    cache.set(clip.id, {
+      animationsRef: animations,
+      durationMs: clip.durationMs,
+      canvasW: canvas.width,
+      canvasH: canvas.height,
+      compiled
+    });
+    return compiled;
+  }
+  return compileClipAnimations(animations, clip.durationMs, canvas);
+}
+
+const IDENTITY_TRANSFORM: ClipTransform = {
+  position: { x: 0, y: 0 },
+  scale: { x: 1, y: 1 },
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 }
+};
+
+/**
+ * Compose a layer's static transform/opacity with its animation sample at
+ * `currentTimeMs`. Returns the layer's existing values (no allocation) when the
+ * clip has no enabled animations or the sample is identity at this time.
+ *
+ * `sample.opacity` multiplies the already-resolved layer opacity (base ×
+ * crossfade), so animations compose with `transitionIn` rather than fight it.
+ */
+export function resolveAnimatedLayerProps(
+  layer: { clip: TimelineClip; transform?: ClipTransform; opacity: number },
+  currentTimeMs: number,
+  canvas: { width: number; height: number },
+  cache?: AnimationCompileCache
+): AnimatedLayerProps {
+  const clip = layer.clip;
+  const compiled = compiledFor(clip, canvas, cache);
+  if (compiled.length === 0) {
+    return { transform: layer.transform, opacity: layer.opacity };
+  }
+
+  const s = sampleAnimations(compiled, currentTimeMs - clip.startMs);
+  if (
+    s.offsetX === 0 &&
+    s.offsetY === 0 &&
+    s.scale === 1 &&
+    s.rotation === 0 &&
+    s.opacity === 1
+  ) {
+    return { transform: layer.transform, opacity: layer.opacity };
+  }
+
+  const base = layer.transform ?? IDENTITY_TRANSFORM;
+  const transform: ClipTransform = {
+    position: { x: base.position.x + s.offsetX, y: base.position.y + s.offsetY },
+    scale: { x: base.scale.x * s.scale, y: base.scale.y * s.scale },
+    rotation: base.rotation + s.rotation,
+    anchor: base.anchor
+  };
+  return { transform, opacity: layer.opacity * s.opacity };
+}
+
+/**
+ * True when any active layer has an animation whose window covers
+ * `currentTimeMs`. The live preview uses this to keep redrawing every rAF tick
+ * while motion is in flight, even though the cached layer *set* is unchanged.
+ */
+export function hasActiveAnimation(
+  layers: ActiveLayer[],
+  currentTimeMs: number,
+  canvas: { width: number; height: number },
+  cache?: AnimationCompileCache
+): boolean {
+  for (const layer of layers) {
+    const clip = layer.clip;
+    if (!clip.animations || clip.animations.length === 0) continue;
+    const compiled = compiledFor(clip, canvas, cache);
+    if (hasActiveAnimationWindow(compiled, currentTimeMs - clip.startMs)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -26,6 +26,8 @@ import type { CompositeLayer } from "../preview/gpu/types";
 import {
   clipSourceTimeSec,
   computeActiveLayers,
+  createAnimationCompileCache,
+  resolveAnimatedLayerProps,
   trackZ
 } from "../preview/sceneModel";
 import { CaptionRasterizer } from "../preview/captionRender";
@@ -230,6 +232,11 @@ export async function renderTimeline(
       );
     let releasePastIndex = 0;
 
+    // Motion-design animations resolve against the sequence resolution (px),
+    // matching the live preview. The compile cache lives for the whole render.
+    const animCanvas = { width: opts.width, height: opts.height };
+    const animCache = createAnimationCompileCache();
+
     const frameDurationSec = 1 / fps;
     for (let frame = 0; frame < totalFrames; frame++) {
       throwIfAborted(signal);
@@ -254,6 +261,14 @@ export async function renderTimeline(
       // (bottom-to-top) layer order.
       const resolved = await Promise.all(
         layers.map(async (layer): Promise<CompositeLayer | null> => {
+          // Same per-frame animation resolution as the live compositor, so the
+          // exported motion is 1:1 with the preview.
+          const anim = resolveAnimatedLayerProps(
+            layer,
+            timeMs,
+            animCanvas,
+            animCache
+          );
           if (layer.kind === "caption" && layer.caption) {
             const bitmap = captionRasterizer.rasterize(
               layer.caption,
@@ -264,10 +279,10 @@ export async function renderTimeline(
             return {
               id: `c:${layer.clipId}`,
               source: bitmap,
-              opacity: layer.opacity,
+              opacity: anim.opacity,
               blendMode: layer.blendMode,
               zIndex: trackZ(layer.trackIndex),
-              transform: layer.transform
+              transform: anim.transform
             };
           }
 
@@ -286,10 +301,10 @@ export async function renderTimeline(
             return {
               id: `v:${layer.clipId}`,
               source: el,
-              opacity: layer.opacity,
+              opacity: anim.opacity,
               blendMode: layer.blendMode,
               zIndex: trackZ(layer.trackIndex),
-              transform: layer.transform,
+              transform: anim.transform,
               borderRadius: layer.borderRadius,
               effects: layer.effects,
               trackEffects: layer.trackEffects
@@ -301,10 +316,10 @@ export async function renderTimeline(
           return {
             id: `i:${layer.clipId}`,
             source: img,
-            opacity: layer.opacity,
+            opacity: anim.opacity,
             blendMode: layer.blendMode,
             zIndex: trackZ(layer.trackIndex),
-            transform: layer.transform,
+            transform: anim.transform,
             borderRadius: layer.borderRadius,
             effects: layer.effects,
             trackEffects: layer.trackEffects

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -66,6 +66,20 @@ export interface TimelineClipNode {
   hidden: boolean;
   muted: boolean;
   locked: boolean;
+  /** Motion-design animations attached to the clip, when any. */
+  animations?: TimelineAnimationNode[];
+}
+
+/** Serializable view of one motion-design animation on a clip. */
+export interface TimelineAnimationNode {
+  id: string;
+  role: "in" | "out" | "emphasis" | "loop";
+  preset: string;
+  durationMs: number;
+  delayMs?: number;
+  easing?: string;
+  enabled?: boolean;
+  params?: Record<string, number | string | boolean>;
 }
 
 /** Full snapshot of the open sequence the agent reads to plan edits. */
@@ -192,6 +206,21 @@ export interface TimelineClipFramesResult {
   frames: TimelineClipFrameNode[];
 }
 
+/** One animation the agent asks to apply. Ids and defaults are filled in by
+ *  the handler from the preset catalog. */
+export interface ClipAnimationInput {
+  role: "in" | "out" | "emphasis" | "loop";
+  preset: string;
+  durationMs?: number;
+  delayMs?: number;
+  easing?: string;
+  enabled?: boolean;
+  params?: Record<string, number | string | boolean>;
+}
+
+/** How {@link TimelineAgentHandler.setClipAnimations} applies its inputs. */
+export type ClipAnimationMode = "add" | "replace";
+
 /**
  * Operations the live {@link TimelineEditor} exposes to the agent tooling
  * layer. Clips and tracks are addressed by id or by (case-insensitive) name;
@@ -221,6 +250,21 @@ export interface TimelineAgentHandler {
     target: string,
     patch: TimelineClipBindingPatch
   ) => Promise<TimelineClipNode>;
+  /**
+   * Apply motion-design animations to a clip. `replace` (default) swaps the
+   * clip's animations; `add` appends. Throws with the valid options when a
+   * preset is unknown or a role is not allowed for the preset.
+   */
+  setClipAnimations: (
+    target: string,
+    animations: ClipAnimationInput[],
+    mode: ClipAnimationMode
+  ) => TimelineClipNode;
+  /** Remove a clip's animations, optionally only those of one role. */
+  clearClipAnimations: (
+    target: string,
+    role?: ClipAnimationInput["role"]
+  ) => TimelineClipNode;
   getClipFrames: (
     target: string,
     opts: TimelineClipFramesOptions

--- a/web/src/hooks/timeline/__tests__/buildClipAnimation.test.ts
+++ b/web/src/hooks/timeline/__tests__/buildClipAnimation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+import { buildClipAnimation } from "../buildClipAnimation";
+
+describe("buildClipAnimation", () => {
+  it("fills the preset default duration and a fresh id", () => {
+    const anim = buildClipAnimation({ role: "in", preset: "fade" });
+    expect(anim.preset).toBe("fade");
+    expect(anim.role).toBe("in");
+    expect(anim.durationMs).toBe(500); // fade default
+    expect(anim.id).toBeTruthy();
+  });
+
+  it("keeps an explicit duration and passes params through", () => {
+    const anim = buildClipAnimation({
+      role: "in",
+      preset: "slide",
+      durationMs: 800,
+      params: { direction: "up", distance: 0.4 }
+    });
+    expect(anim.durationMs).toBe(800);
+    expect(anim.params).toEqual({ direction: "up", distance: 0.4 });
+  });
+
+  it("throws listing valid presets for an unknown preset", () => {
+    expect(() =>
+      buildClipAnimation({ role: "in", preset: "sparkle" })
+    ).toThrow(/Valid presets:.*fade.*kenBurns/s);
+  });
+
+  it("throws listing allowed roles when the role is not supported", () => {
+    // pulse is emphasis-only.
+    expect(() =>
+      buildClipAnimation({ role: "in", preset: "pulse" })
+    ).toThrow(/Allowed roles: emphasis/);
+  });
+
+  it("generates a distinct id per call", () => {
+    const a = buildClipAnimation({ role: "loop", preset: "float" });
+    const b = buildClipAnimation({ role: "loop", preset: "float" });
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/web/src/hooks/timeline/buildClipAnimation.ts
+++ b/web/src/hooks/timeline/buildClipAnimation.ts
@@ -1,0 +1,47 @@
+/**
+ * buildClipAnimation
+ *
+ * Validate an agent-requested animation against the preset catalog and fill in
+ * defaults (duration, a fresh id). Pure, so the agent handler and its tests
+ * share one code path. Throws with the valid options listed when the preset is
+ * unknown or the role is not allowed for it — the tool layer surfaces the throw
+ * to the agent.
+ */
+
+import {
+  ANIMATION_PRESETS,
+  getAnimationPreset,
+  type ClipAnimation
+} from "@nodetool-ai/timeline";
+import type { ClipAnimationInput } from "../../components/timeline/timelineAgentBridge";
+
+export function buildClipAnimation(input: ClipAnimationInput): ClipAnimation {
+  const preset = getAnimationPreset(input.preset);
+  if (!preset) {
+    const valid = ANIMATION_PRESETS.map((p) => p.id).join(", ");
+    throw new Error(
+      `Unknown animation preset "${input.preset}". Valid presets: ${valid}.`
+    );
+  }
+  if (!preset.roles.includes(input.role)) {
+    throw new Error(
+      `Preset "${preset.id}" does not support role "${input.role}". ` +
+        `Allowed roles: ${preset.roles.join(", ")}.`
+    );
+  }
+  const anim: ClipAnimation = {
+    id: crypto.randomUUID(),
+    role: input.role,
+    preset: input.preset,
+    durationMs: input.durationMs ?? preset.defaultDurationMs
+  };
+  if (input.delayMs !== undefined) anim.delayMs = input.delayMs;
+  // Easing is validated at sample time (unknown ids fall back to linear), so
+  // the wire value passes straight through.
+  if (input.easing !== undefined) {
+    anim.easing = input.easing as ClipAnimation["easing"];
+  }
+  if (input.enabled !== undefined) anim.enabled = input.enabled;
+  if (input.params !== undefined) anim.params = input.params;
+  return anim;
+}

--- a/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
+++ b/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
@@ -14,9 +14,18 @@ import {
 import { markTimelineLoadMigrated } from "./useTimelineAutosave";
 
 import type { TimelineSequence } from "@nodetool-ai/timeline";
+import type { RouterOutputs } from "../../trpc/client";
+
+/**
+ * The wire shape from `trpc.timeline.get` types animation `easing`/`preset` as
+ * plain strings (forward compat); the store's `TimelineSequence` narrows
+ * `easing` to `EasingId`. The compiler tolerates unknown ids at sample time, so
+ * the wire→store cast on load is safe.
+ */
+type WireSequence = RouterOutputs["timeline"]["get"];
 
 export function useLoadTimelineIntoStore(
-  sequence: TimelineSequence | undefined | null
+  sequence: WireSequence | undefined | null
 ): void {
   const store = useTimelineStoreApi();
 
@@ -35,7 +44,7 @@ export function useLoadTimelineIntoStore(
       // persist that migrated document once.
       markTimelineLoadMigrated(sequence.id);
     }
-    store.getState().loadSequence(sequence);
+    store.getState().loadSequence(sequence as TimelineSequence);
     // The load is a tracked `set`; clear history so the first Ctrl+Z can't
     // undo "past" the loaded sequence into the empty default state.
     timelineTemporalOf(store).clear();

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -12,7 +12,12 @@
  */
 
 import { useEffect, useMemo } from "react";
-import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import type {
+  ClipAnimation,
+  TimelineClip,
+  TimelineTrack
+} from "@nodetool-ai/timeline";
+import { buildClipAnimation } from "./buildClipAnimation";
 
 import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
 import { useTimelineUIStoreApi } from "../../stores/timeline/TimelineUIStore";
@@ -26,6 +31,7 @@ import {
   hasTimelineAgentHandler,
   setTimelineAgentHandler,
   type TimelineAgentHandler,
+  type TimelineAnimationNode,
   type TimelineClipNode,
   type TimelineClipFrameNode,
   type TimelineGenerateKind,
@@ -120,7 +126,21 @@ function toClipNode(
     fadeOutMs: clip.fadeOutMs,
     hidden: !!clip.hidden,
     muted: !!clip.muted,
-    locked: clip.locked
+    locked: clip.locked,
+    animations: clip.animations?.map(toAnimationNode)
+  };
+}
+
+function toAnimationNode(anim: ClipAnimation): TimelineAnimationNode {
+  return {
+    id: anim.id,
+    role: anim.role,
+    preset: anim.preset,
+    durationMs: anim.durationMs,
+    delayMs: anim.delayMs,
+    easing: anim.easing,
+    enabled: anim.enabled,
+    params: anim.params
   };
 }
 
@@ -445,6 +465,25 @@ export const useTimelineAgentBridge = (active: boolean): void => {
         if (patch.regenerate) {
           await startDirectGen(clip.id);
         }
+        return clipNode(reReadClip(clip.id));
+      },
+
+      setClipAnimations(target, animations, mode) {
+        const clip = requireClip(target);
+        const built = animations.map(buildClipAnimation);
+        const next =
+          mode === "add" ? [...(clip.animations ?? []), ...built] : built;
+        doc.getState().setClipAnimations(clip.id, next);
+        return clipNode(reReadClip(clip.id));
+      },
+
+      clearClipAnimations(target, role) {
+        const clip = requireClip(target);
+        const current = clip.animations ?? [];
+        const next = role
+          ? current.filter((a) => a.role !== role)
+          : [];
+        doc.getState().setClipAnimations(clip.id, next);
         return clipNode(reReadClip(clip.id));
       },
 

--- a/web/src/lib/tools/__tests__/timelineTools.test.ts
+++ b/web/src/lib/tools/__tests__/timelineTools.test.ts
@@ -72,6 +72,8 @@ const createMockHandler = (): jest.Mocked<TimelineAgentHandler> => ({
   duplicateClip: jest.fn(),
   setClipParams: jest.fn(),
   setClipBinding: jest.fn(),
+  setClipAnimations: jest.fn(),
+  clearClipAnimations: jest.fn(),
   getClipFrames: jest.fn(),
   selectClip: jest.fn(),
   seek: jest.fn()
@@ -99,6 +101,9 @@ describe("ui_timeline_* tools", () => {
         "ui_timeline_duplicate_clip",
         "ui_timeline_set_clip_params",
         "ui_timeline_set_clip_binding",
+        "ui_timeline_animate_clip",
+        "ui_timeline_clear_animations",
+        "ui_timeline_list_animation_presets",
         "ui_timeline_get_clip_frames",
         "ui_timeline_select_clip",
         "ui_timeline_seek"
@@ -297,5 +302,97 @@ describe("ui_timeline_* tools", () => {
 
     expect(handler.seek).toHaveBeenCalledWith(1500);
     expect(result.playheadMs).toBe(1500);
+  });
+
+  it("animates a clip, defaulting mode to replace", async () => {
+    const handler = createMockHandler();
+    handler.setClipAnimations.mockReturnValue(clipNode());
+    setTimelineAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_timeline_animate_clip",
+      {
+        target: "selected",
+        animations: [{ role: "in", preset: "pop", durationMs: 400 }]
+      },
+      "tc-anim",
+      ctx
+    );
+
+    expect(handler.setClipAnimations).toHaveBeenCalledWith(
+      "selected",
+      [{ role: "in", preset: "pop", durationMs: 400 }],
+      "replace"
+    );
+  });
+
+  it("passes mode add through to the handler", async () => {
+    const handler = createMockHandler();
+    handler.setClipAnimations.mockReturnValue(clipNode());
+    setTimelineAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_timeline_animate_clip",
+      {
+        target: "clip-1",
+        mode: "add",
+        animations: [{ role: "loop", preset: "float" }]
+      },
+      "tc-anim-add",
+      ctx
+    );
+
+    expect(handler.setClipAnimations).toHaveBeenCalledWith(
+      "clip-1",
+      [{ role: "loop", preset: "float" }],
+      "add"
+    );
+  });
+
+  it("rejects an animation with an unknown role during validation", async () => {
+    setTimelineAgentHandler(createMockHandler());
+    await expect(
+      FrontendToolRegistry.call(
+        "ui_timeline_animate_clip",
+        { target: "clip-1", animations: [{ role: "wiggle", preset: "pop" }] },
+        "tc-anim-bad",
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+
+  it("clears animations, forwarding an optional role filter", async () => {
+    const handler = createMockHandler();
+    handler.clearClipAnimations.mockReturnValue(clipNode());
+    setTimelineAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_timeline_clear_animations",
+      { target: "clip-1", role: "out" },
+      "tc-clear",
+      ctx
+    );
+
+    expect(handler.clearClipAnimations).toHaveBeenCalledWith("clip-1", "out");
+  });
+
+  it("lists the animation preset catalog without needing an editor", async () => {
+    const result = (await FrontendToolRegistry.call(
+      "ui_timeline_list_animation_presets",
+      {},
+      "tc-presets",
+      ctx
+    )) as {
+      ok: boolean;
+      presets: Array<{ id: string; roles: string[]; describe: string }>;
+    };
+
+    expect(result.ok).toBe(true);
+    const ids = result.presets.map((p) => p.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["fade", "slide", "pop", "kenBurns", "float"])
+    );
+    const kenBurns = result.presets.find((p) => p.id === "kenBurns");
+    expect(kenBurns?.roles).toContain("loop");
   });
 });

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
+import { ANIMATION_PRESETS } from "@nodetool-ai/timeline";
 import { FrontendToolRegistry } from "../frontendTools";
 import { getTimelineAgentHandler } from "../../../components/timeline/timelineAgentBridge";
+
+const animationRole = z.enum(["in", "out", "emphasis", "loop"]);
 
 /**
  * Frontend tools that let the agent drive the live timeline / video editor —
@@ -196,6 +199,72 @@ FrontendToolRegistry.register({
   async execute({ target, ...patch }) {
     const clip = await getTimelineAgentHandler().setClipBinding(target, patch);
     return { ok: true, clip };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_timeline_animate_clip",
+  description:
+    "Attach motion-design animations to a clip — no keyframing, just named presets. Roles: `in` (entrance: fade, slide, pop, spin), `out` (exit: fade, slide, pop, spin), `emphasis` (mid-clip: pulse, shake, bounce), `loop` (continuous: kenBurns, float, breathe, rotate). Each animation: `role`, `preset`, optional `durationMs` (defaults per preset), `delayMs`, `easing`, and preset `params`. `mode` \"replace\" (default) swaps the clip's animations; \"add\" appends. Call ui_timeline_list_animation_presets for the full param list. Recommended loop: ui_timeline_get_state -> animate -> ui_timeline_get_clip_frames at the window boundaries -> adjust.",
+  parameters: z.object({
+    target: targetParam,
+    mode: z.enum(["add", "replace"]).optional(),
+    animations: z
+      .array(
+        z.object({
+          role: animationRole,
+          preset: z
+            .string()
+            .describe("Preset id, e.g. fade, slide, pop, kenBurns, float."),
+          durationMs: z.number().optional(),
+          delayMs: z.number().optional(),
+          easing: z.string().optional(),
+          params: z
+            .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
+            .optional()
+        })
+      )
+      .min(1)
+  }),
+  async execute({ target, mode, animations }) {
+    const clip = getTimelineAgentHandler().setClipAnimations(
+      target,
+      animations,
+      mode ?? "replace"
+    );
+    return { ok: true, clip };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_timeline_clear_animations",
+  description:
+    "Remove motion-design animations from a clip. Pass `role` to clear only that role (in/out/emphasis/loop); omit it to clear all.",
+  parameters: z.object({
+    target: targetParam,
+    role: animationRole.optional()
+  }),
+  async execute({ target, role }) {
+    const clip = getTimelineAgentHandler().clearClipAnimations(target, role);
+    return { ok: true, clip };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_timeline_list_animation_presets",
+  description:
+    "List the motion-design animation presets: id, allowed roles, params (with defaults and ranges), default duration/easing, and a one-line description. Use this to discover the exact preset names and params for ui_timeline_animate_clip.",
+  parameters: z.object({}),
+  async execute() {
+    const presets = ANIMATION_PRESETS.map((p) => ({
+      id: p.id,
+      roles: p.roles,
+      defaultDurationMs: p.defaultDurationMs,
+      defaultEasing: p.defaultEasing,
+      params: p.params,
+      describe: p.describe
+    }));
+    return { ok: true, presets };
   }
 });
 

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -1518,8 +1518,12 @@ export const createTimelineStore = (
             mediaTypeOverride: opts?.mediaTypeOverride
           });
 
+          // The wire schema types animation `easing`/`preset` as plain strings
+          // (forward compat); the store's TimelineClip narrows `easing` to
+          // EasingId. The compiler tolerates unknown ids at sample time, so the
+          // wire→store cast is safe here.
           set((state) => ({
-            clips: [...state.clips, newClip]
+            clips: [...state.clips, newClip as TimelineClip]
           }));
 
           return newClip.id;

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -44,6 +44,7 @@ import type {
   TimelineMarker,
   TrackEffect,
   ClipBindingKind,
+  ClipAnimation,
   TranscriptLine
 } from "@nodetool-ai/timeline";
 import type { Asset } from "../ApiTypes";
@@ -244,6 +245,10 @@ export interface TimelineStoreState {
 
   /** Update an arbitrary subset of fields on a clip. */
   patchClip: (clipId: string, patch: Partial<TimelineClip>) => void;
+
+  /** Replace a clip's motion-design animations. One patch per call so undo
+   *  granularity stays per-edit. */
+  setClipAnimations: (clipId: string, animations: ClipAnimation[]) => void;
 
   /** Restore a clip to a previously generated version (purely local; autosave persists on next save cycle). */
   restoreVersion: (clipId: string, versionId: string) => void;
@@ -1109,6 +1114,9 @@ export const createTimelineStore = (
             };
           }),
 
+        // Trims change only duration/in-out points. Animations need no rewrite:
+        // `compileClipAnimations` clamps windows to the clip's current duration
+        // and drops windows that fall off the end at sample time.
         trimClipStart: (clipId, deltaMs) =>
           set((state) => {
             const clip = state.clips.find((c) => c.id === clipId);
@@ -1338,6 +1346,12 @@ export const createTimelineStore = (
             };
           }),
 
+        // patchClip replaces the `animations` array wholesale (spread, no
+        // array merge) and flows through the temporal middleware, so this is
+        // just a typed, discoverable entry point for animation edits.
+        setClipAnimations: (clipId, animations) =>
+          get().patchClip(clipId, { animations }),
+
         restoreVersion: (clipId, versionId) =>
           set((state) => {
             const clip = state.clips.find((c) => c.id === clipId);
@@ -1392,6 +1406,12 @@ export const createTimelineStore = (
               lastGeneratedHash: undefined,
               // A lone duplicate is not linked to the source group.
               linkId: undefined,
+              // Copy animations with fresh ids so the two clips edit
+              // independently (trim/split re-derive windows per clip).
+              animations: currentSrc.animations?.map((a) => ({
+                ...a,
+                id: createTimeOrderedUuid()
+              })),
               versions: []
             });
             newClipId = newClip.id;

--- a/web/src/stores/timeline/__tests__/TimelineStore.animations.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.animations.test.ts
@@ -1,0 +1,99 @@
+/**
+ * TimelineStore animation actions: setClipAnimations (undo/redo), split role
+ * partitioning, and duplicate id regeneration.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { createTimelineStore, timelineTemporalOf } from "../TimelineStore";
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type { ClipAnimation } from "@nodetool-ai/timeline";
+
+function mkStore() {
+  return createTimelineStore();
+}
+
+function seedClip(store: ReturnType<typeof mkStore>, animations?: ClipAnimation[]) {
+  const track = makeTrack({ type: "video", name: "V1" });
+  const clip = makeClip({
+    trackId: track.id,
+    name: "clip-1",
+    startMs: 0,
+    durationMs: 3000,
+    animations
+  });
+  store.setState({ tracks: [track], clips: [clip] });
+  return clip;
+}
+
+const fadeIn: ClipAnimation = {
+  id: "in-1",
+  role: "in",
+  preset: "fade",
+  durationMs: 500
+};
+
+describe("setClipAnimations", () => {
+  it("sets animations and supports undo / redo", () => {
+    const store = mkStore();
+    const clip = seedClip(store);
+
+    store.getState().setClipAnimations(clip.id, [fadeIn]);
+    expect(store.getState().clips[0].animations).toEqual([fadeIn]);
+
+    timelineTemporalOf(store).undo();
+    expect(store.getState().clips[0].animations).toBeUndefined();
+
+    timelineTemporalOf(store).redo();
+    expect(store.getState().clips[0].animations).toEqual([fadeIn]);
+  });
+
+  it("records exactly one undo entry per change", () => {
+    const store = mkStore();
+    const clip = seedClip(store);
+    const before = timelineTemporalOf(store).pastStates.length;
+    store.getState().setClipAnimations(clip.id, [fadeIn]);
+    expect(timelineTemporalOf(store).pastStates.length).toBe(before + 1);
+  });
+});
+
+describe("splitClipAtTime with animations", () => {
+  it("keeps in on the left, out on the right, copies emphasis/loop to both", () => {
+    const store = mkStore();
+    const clip = seedClip(store, [
+      { id: "in-1", role: "in", preset: "fade", durationMs: 300 },
+      { id: "out-1", role: "out", preset: "fade", durationMs: 300 },
+      { id: "emph-1", role: "emphasis", preset: "pulse", durationMs: 400 },
+      { id: "loop-1", role: "loop", preset: "float", durationMs: 1000 }
+    ]);
+
+    store.getState().splitClipAtTime(clip.id, 1500);
+    const clips = store.getState().clips;
+    expect(clips).toHaveLength(2);
+    const [left, right] = [...clips].sort((a, b) => a.startMs - b.startMs);
+    expect((left.animations ?? []).map((a) => a.role).sort()).toEqual([
+      "emphasis",
+      "in",
+      "loop"
+    ]);
+    expect((right.animations ?? []).map((a) => a.role).sort()).toEqual([
+      "emphasis",
+      "loop",
+      "out"
+    ]);
+  });
+});
+
+describe("duplicateClip with animations", () => {
+  it("copies animations with fresh ids", async () => {
+    const store = mkStore();
+    const clip = seedClip(store, [
+      { id: "loop-1", role: "loop", preset: "float", durationMs: 1000 }
+    ]);
+
+    const newId = await store.getState().duplicateClip(clip.id);
+    const dup = store.getState().clips.find((c) => c.id === newId);
+    expect(dup?.animations).toHaveLength(1);
+    expect(dup?.animations?.[0].preset).toBe("float");
+    expect(dup?.animations?.[0].id).not.toBe("loop-1");
+  });
+});


### PR DESCRIPTION
Implements Milestone 1 of [docs/plans/motion-design.md](docs/plans/motion-design.md) — Jitter-style motion design on timeline clips via named animation presets, with no manual keyframing. The primary authoring surface is the agent; manual UI (inspector, clip chips) is Milestone 2 and not in this PR.

## What's here (T1–T5)

**T1 — Pure animation engine** (`packages/timeline/src/animation/`)
- `types.ts`: `ClipAnimation`, `AnimationRole`, `EasingId`, `AnimationPresetId`
- `easing.ts`: cubic + overshoot easings (back, elastic, bounce)
- `presets.ts`: v1 catalog — `fade`, `slide`, `pop`, `spin`, `pulse`, `shake`, `bounce`, `kenBurns`, `float`, `breathe`, `rotate`
- `compile.ts`: presets → windowed keyframe curves (per-role window math, clamping to clip duration, `out`-role time reversal, `kenBurns` full-clip one-shot, baked segment easing)
- `sample.ts`: order-independent fold (offsets/rotation add, scale/opacity multiply), hold/loop rules, opacity/scale clamping, `hasActiveAnimationWindow`
- `TimelineClip.animations` field; `splitClip` partitions animations by role (in→left, out→right, emphasis/loop→both with fresh right-half ids)

**T2 — Wire schema** (`packages/protocol`)
- `clipAnimation` zod schema on the clip; `preset`/`easing` are plain strings for forward compat (unknown ids parse and are skipped at compile time). Without the field PATCH would strip animations on autosave.

**T3 — Preview + export rendering** (`web/src/components/timeline/`)
- `resolveAnimatedLayerProps` / `hasActiveAnimation` / `AnimationCompileCache` in `sceneModel.ts` compose a layer's static transform+opacity with its animation sample per frame
- `PreviewCompositor` resolves at the frame's live time and redraws every rAF tick while an animation window is active (even with a cached layer set), so motion doesn't freeze mid-clip; paused frames draw once
- `TimelineRenderer` applies the same resolver per stepped frame — export is 1:1 with preview
- `computeActiveLayersWithHorizon` and its change-horizon contract are untouched

**T4 — Store + edit semantics** (`web/src/stores/timeline/TimelineStore.ts`)
- `setClipAnimations` action (undo/redo via the temporal middleware); `duplicateClip` copies animations with fresh ids; trim needs no data rewrite (compile-time clamping)

**T5 — Agent tools** (`web/src/lib/tools/builtin/timeline.ts`)
- `ui_timeline_animate_clip` (mode add|replace), `ui_timeline_clear_animations`, `ui_timeline_list_animation_presets`
- `TimelineAgentHandler` gains `setClipAnimations`/`clearClipAnimations`; `getSnapshot` includes each clip's animations; `buildClipAnimation` is a shared pure validator that throws listing valid presets/roles on bad input

## Testing

- `packages/timeline`: 122 tests green (easings, window math per role, sampler fold, loop wraparound + start==end invariant, split, determinism)
- `packages/protocol`: animation round-trip (present/absent/unknown-preset/bad-role)
- `web`: all 702 timeline tests green, including new `resolveAnimatedLayerProps` composition, preview/export parity, horizon-unchanged, store animation actions, agent tool forwarding, and `buildClipAnimation` validation
- `npm run typecheck` / `eslint` clean on all touched files

## Not in this PR

Milestone 2 (inspector "Animate" section, clip chips, e2e visual verification) and Milestone 3 (text clips) are separately mergeable follow-ups per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHF1jHnwqXtQ4KeGf7mLGZ)_