### PR TITLE
fix(chat): render referenced images as thumbnails in user messages

### DIFF
--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -102,6 +102,15 @@ export const createStyles = (theme: Theme) => ({
       padding: ".5em 1em"
     },
 
+    // A user's own referenced/attached image renders as a thumbnail, not a
+    // full-width preview. ImageView fills its container (width: 100%), so a
+    // max cap on the `.image-output` root is what constrains it — the inline
+    // width leaves maxWidth/maxHeight free for the stylesheet to set.
+    ".chat-message.user .message-content .image-output": {
+      maxWidth: "220px",
+      maxHeight: "220px"
+    },
+
     ".assistant": {
       alignItems: "flex-start",
       background: "transparent"


### PR DESCRIPTION
## Problem

An image referenced or attached in a user's **own** chat message rendered at full bubble width instead of thumbnail size.

## Cause

Inline images in chat messages render through `MessageContentRenderer` → `ImageView`. `ImageView`'s container and `<img>` are styled `width: 100%` / `height: 100%` with no `max-width`/`max-height`, so the image expands to fill whatever the message bubble allows. In the full-page (meta) layout the user bubble can span the full column, making the image very large. There was no size cap anywhere for inline chat images.

## Fix

Add a `maxWidth`/`maxHeight` cap (220px) on the `.image-output` root, scoped to `.chat-message.user .message-content`, in `ChatThreadView.styles.ts`. `ImageView` sets `width` inline but not `maxWidth`/`maxHeight`, so the stylesheet cap takes effect and constrains the image to thumbnail size while preserving aspect ratio (`object-fit: contain`). Assistant messages and media-generation outputs are unaffected.

## Testing

- `eslint` passes on the changed file.
- `tsc` reports no errors in the changed file (the pre-existing `browserRunnerCore.ts` module-resolution errors come from backend packages not built in this sandbox and are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gTbM2caw3NGhVnkBVxiLj

---
_Generated by [Claude Code](https://claude.ai/code/session_011gTbM2caw3NGhVnkBVxiLj)_