### PR TITLE
fix(openai): snap gpt-image-2 sizes instead of dropping them

### DIFF
--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -510,6 +510,63 @@ export class OpenAIProvider extends BaseProvider {
     ];
   }
 
+  /**
+   * gpt-image-2 accepts arbitrary sizes within limits: both edges a multiple of
+   * 16, long edge <= 3840, aspect ratio <= 3:1, and total area between 0.64MP
+   * and 8.3MP. Requested sizes rarely land on that grid (16:9 at 1K is
+   * 1820x1024), so snap to the nearest valid size preserving the aspect ratio
+   * rather than dropping `size` and letting the API default to a square.
+   */
+  static snapToGptImage2Size(width: number, height: number): string | null {
+    const MIN_AREA = 655_360;
+    const MAX_AREA = 8_294_400;
+    const MAX_EDGE = 3840;
+    const MAX_RATIO = 3;
+
+    if (!(width > 0) || !(height > 0)) return null;
+
+    const landscape = width >= height;
+    const ratio = Math.min(
+      MAX_RATIO,
+      landscape ? width / height : height / width
+    );
+
+    // Derive edges from the clamped ratio at the requested area, then pull the
+    // area into range.
+    const area = Math.min(MAX_AREA, Math.max(MIN_AREA, width * height));
+    let long = Math.sqrt(area * ratio);
+    let short = long / ratio;
+    if (long > MAX_EDGE) {
+      short *= MAX_EDGE / long;
+      long = MAX_EDGE;
+    }
+
+    const snap = (v: number): number =>
+      Math.min(MAX_EDGE, Math.max(16, Math.round(v / 16) * 16));
+    let longPx = snap(long);
+    let shortPx = snap(short);
+
+    // Snapping can nudge the area out of range; step it back in.
+    while (longPx * shortPx < MIN_AREA && longPx + 16 <= MAX_EDGE) {
+      longPx += 16;
+      shortPx = snap(longPx / ratio);
+    }
+    while (longPx * shortPx > MAX_AREA && longPx - 16 >= 16) {
+      longPx -= 16;
+      shortPx = snap(longPx / ratio);
+    }
+    // Rounding the short edge down can tip the ratio back over the limit, so
+    // round up here.
+    if (longPx / shortPx > MAX_RATIO) {
+      shortPx = Math.min(longPx, Math.ceil(longPx / MAX_RATIO / 16) * 16);
+    }
+
+    const areaPx = longPx * shortPx;
+    if (areaPx < MIN_AREA || areaPx > MAX_AREA) return null;
+
+    return landscape ? `${longPx}x${shortPx}` : `${shortPx}x${longPx}`;
+  }
+
   resolveImageSize(
     width?: number | null,
     height?: number | null,
@@ -520,21 +577,7 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     if (model === "gpt-image-2" || model?.startsWith("gpt-image-2-") === true) {
-      const area = width * height;
-      const longEdge = Math.max(width, height);
-      const shortEdge = Math.min(width, height);
-      const isValid =
-        Number.isInteger(width) &&
-        Number.isInteger(height) &&
-        width > 0 &&
-        height > 0 &&
-        longEdge <= 3840 &&
-        width % 16 === 0 &&
-        height % 16 === 0 &&
-        longEdge / shortEdge <= 3 &&
-        area >= 655_360 &&
-        area <= 8_294_400;
-      return isValid ? `${width}x${height}` : null;
+      return OpenAIProvider.snapToGptImage2Size(width, height);
     }
 
     const supported: Array<[number, number]> = [

--- a/packages/runtime/tests/providers/openai-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/openai-provider-coverage.test.ts
@@ -83,13 +83,62 @@ describe("OpenAIProvider – resolveImageSize", () => {
     ).toBe("2160x3840");
   });
 
-  it("uses the API default for invalid GPT Image 2 dimensions", () => {
+  it("returns null for non-positive GPT Image 2 dimensions", () => {
     expect(provider.resolveImageSize(-1024, -1024, "gpt-image-2")).toBeNull();
-    expect(provider.resolveImageSize(2049, 1152, "gpt-image-2")).toBeNull();
-    expect(provider.resolveImageSize(3856, 1152, "gpt-image-2")).toBeNull();
-    expect(provider.resolveImageSize(2400, 784, "gpt-image-2")).toBeNull();
-    expect(provider.resolveImageSize(800, 800, "gpt-image-2")).toBeNull();
-    expect(provider.resolveImageSize(3840, 2176, "gpt-image-2")).toBeNull();
+  });
+
+  it("snaps off-grid GPT Image 2 dimensions to the 16px grid", () => {
+    expect(provider.resolveImageSize(2049, 1152, "gpt-image-2")).toBe(
+      "2048x1152"
+    );
+    // 16:9 at 1K — the size the TextToImage node actually requests.
+    expect(provider.resolveImageSize(1820, 1024, "gpt-image-2")).toBe(
+      "1824x1024"
+    );
+  });
+
+  it("scales GPT Image 2 dimensions back inside the API limits", () => {
+    // Long edge over 3840 (and over 3:1, so the short edge grows too).
+    expect(provider.resolveImageSize(3856, 1152, "gpt-image-2")).toBe(
+      "3648x1216"
+    );
+    // Area over 8.3MP.
+    expect(provider.resolveImageSize(3840, 2176, "gpt-image-2")).toBe(
+      "3824x2160"
+    );
+    // Area under 0.64MP.
+    expect(provider.resolveImageSize(800, 800, "gpt-image-2")).toBe("816x816");
+  });
+
+  it("clamps GPT Image 2 aspect ratios beyond 3:1", () => {
+    // 6:1 clamps to 3:1, keeping the requested pixel budget.
+    expect(provider.resolveImageSize(2400, 400, "gpt-image-2")).toBe(
+      "1696x576"
+    );
+  });
+
+  it("keeps every TextToImage aspect ratio non-square for GPT Image 2", () => {
+    const ratios: Array<[number, number]> = [
+      [16, 9],
+      [4, 3],
+      [21, 9],
+      [9, 16],
+      [3, 4],
+      [4, 5]
+    ];
+    for (const [aw, ah] of ratios) {
+      const [w, h] =
+        aw >= ah ? [Math.round((1024 * aw) / ah), 1024] : [1024, Math.round((1024 * ah) / aw)];
+      const size = provider.resolveImageSize(w, h, "gpt-image-2");
+      expect(size).not.toBeNull();
+      const [ow, oh] = size!.split("x").map(Number);
+      expect(ow % 16).toBe(0);
+      expect(oh % 16).toBe(0);
+      expect(ow * oh).toBeGreaterThanOrEqual(655_360);
+      expect(ow * oh).toBeLessThanOrEqual(8_294_400);
+      // Ratio preserved within 1%.
+      expect(Math.abs(ow / oh / (w / h) - 1)).toBeLessThan(0.01);
+    }
   });
 });
 


### PR DESCRIPTION
## The bug

`nodetool.image.TextToImage` exposes **aspect ratio + resolution**, not width/height. `packages/image-nodes/src/nodes/image.ts:213` converts them to pixels — 16:9 @ 1K → **1820×1024**.

`resolveImageSize` then validated those dims against `gpt-image-2`'s constraints and returned `null` on any mismatch. That drops `size` from the request entirely, so the API falls back to its **1024×1024 default**.

Since `1820 % 16 ≠ 0`, nearly every non-square ratio failed the 16px-grid check: 4:3→1365, 16:9→1820, 21:9→2389, and every 4K long edge exceeds the 3840 cap. Of the 30 ratio×resolution combinations the node can produce, only **2** (1:1 and 3:2) survived — everything else silently rendered square.

## The fix

Replaced the validate-or-discard check with `snapToGptImage2Size`, which preserves the requested aspect ratio and pixel budget while snapping onto the 16px grid, clamping the long edge to 3840, the ratio to 3:1, and the area into [0.64MP, 8.3MP].

`imageToImage` shares the same helper, so it's fixed too.

## Verification

- All 30 node-producible ratio×resolution combinations now yield valid non-square sizes, ratio drift under 0.4%.
- 300k-input fuzz against every API constraint: **zero invalid, zero nulls**. Worst-case drift 2%, only on extreme inputs that must be scaled up to reach the minimum area.
- Fuzzing caught a real bug in the first attempt — clamping a 6:1 ratio rounded the short edge *down*, leaving the result at 3.03:1, still out of spec.
- Full runtime provider suite passes (1619 tests); `tsc` clean; no new lint errors.

## Not covered

`gpt-image-1`, `gpt-image-1.5` and `gpt-image-1-mini` only accept `1024x1024`, `1024x1536`, `1536x1024`. On those a 16:9 request resolves to `1536x1024` (3:2), the closest available — an API limitation, not something this code can work around. The real fix there is UI-side: constrain the aspect-ratio choices per model so the picker doesn't promise 16:9 it can't deliver.