### PR TITLE
Add Script editor Phase 2: to-timeline bridge

### DIFF
--- a/docs/script-editor-concept.md
+++ b/docs/script-editor-concept.md
@@ -207,8 +207,13 @@ existing editor is a rewrite, not a feature.
    (`scriptVoicing`, reusing `generate_media` / `transcribe_audio`), take
    gallery, play-through. The document pane is a plain per-line editor rather
    than the Lexical transcript editor — that reuse is deferred to a later pass.
-2. **To timeline** — assemble with linkage keys, staleness, per-line
-   back-sync, re-assemble on structural drift, extract-as-script.
+2. **To timeline** *(implemented)* — assemble the current takes into a
+   voiceover sequence with `scriptId`/`scriptLineId` linkage keys
+   (`assembleScriptTimeline`, `useAssembleScriptTimeline`, "Send to timeline"),
+   per-line back-sync on re-voice / take switch (`stores/script/timelineSync`),
+   re-assemble in place on structural drift (preserving foreign tracks), and
+   extract-as-script from a timeline transcript (`extractScript`,
+   `useExtractScript`, the transcript panel's "Extract as script").
 3. **Automation** — `ui_script_*` agent tools + assistant panel, `ScriptRef` +
    graph nodes.
 4. **Depth** — dialogue-mode rendering, provider-native timestamps, SRT/VTT

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -280,6 +280,11 @@ export const timelineClip = z
      * strips them on every PATCH, breaking shot→clip revision round-trips. */
     storyboardBoardId: z.string().optional(),
     storyboardShotId: z.string().optional(),
+    /** Script provenance (script→timeline assemble bridge). Without these
+     * fields Zod strips them on every PATCH, breaking line→clip re-voice
+     * round-trips. */
+    scriptId: z.string().optional(),
+    scriptLineId: z.string().optional(),
     status: z.enum([
       "draft",
       "queued",

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -355,6 +355,14 @@ export interface TimelineClip {
    */
   storyboardBoardId?: string;
   storyboardShotId?: string;
+  /**
+   * Script provenance: the script/line this voiceover clip was assembled from.
+   * Lets a re-voiced line round-trip its new take into the assembled sequence
+   * (the take asset replaces this clip's currentAssetId, duration, caption).
+   * Both fields must also exist on the protocol zod schema or PATCH strips them.
+   */
+  scriptId?: string;
+  scriptLineId?: string;
   status: ClipStatus;
   locked: boolean;
   muted?: boolean;

--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -4,6 +4,7 @@ import AddIcon from "@mui/icons-material/Add";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
+import MovieIcon from "@mui/icons-material/Movie";
 import {
   FlexColumn,
   FlexRow,
@@ -24,6 +25,7 @@ import {
 } from "../../stores/script/ScriptStore";
 import { voiceAll } from "../../stores/script/scriptVoicing";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
+import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
 import ScriptLineRow from "./ScriptLineRow";
 
 interface ScriptDocumentPaneProps {
@@ -101,12 +103,13 @@ const ScriptDocumentPane = ({
   scriptId,
   readOnly
 }: ScriptDocumentPaneProps) => {
-  const { sections } = useScript(scriptId);
+  const { sections, timelineId } = useScript(scriptId);
   const addLine = useScriptStore((s) => s.addLine);
   const addSection = useScriptStore((s) => s.addSection);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
   const [voicingAll, setVoicingAll] = useState(false);
+  const { assemble, assembling } = useAssembleScriptTimeline();
 
   const onVoiceAll = useCallback(async () => {
     setVoicingAll(true);
@@ -117,7 +120,18 @@ const ScriptDocumentPane = ({
     }
   }, [scriptId]);
 
+  const onSendToTimeline = useCallback(() => {
+    void assemble(scriptId).catch(() => {
+      // Errors surface via the hook's `error`; swallow to keep the click quiet.
+    });
+  }, [assemble, scriptId]);
+
   const isEmpty = sections.every((s) => s.lines.length === 0);
+  const hasVoicedLine = sections.some((section) =>
+    section.lines.some((line) =>
+      line.takes.some((t) => t.id === line.currentTakeId)
+    )
+  );
 
   return (
     <FlexColumn
@@ -170,6 +184,26 @@ const ScriptDocumentPane = ({
             onClick={play}
           >
             Play through
+          </EditorButton>
+        )}
+        {!readOnly && (
+          <EditorButton
+            size="small"
+            variant="outlined"
+            startIcon={<MovieIcon fontSize="small" />}
+            onClick={onSendToTimeline}
+            disabled={assembling || !hasVoicedLine}
+            title={
+              hasVoicedLine
+                ? undefined
+                : "Voice at least one line to send it to a timeline"
+            }
+          >
+            {assembling
+              ? "Assembling…"
+              : timelineId
+                ? "Update timeline"
+                : "Send to timeline"}
           </EditorButton>
         )}
       </FlexRow>

--- a/web/src/components/script/ScriptTakeGallery.tsx
+++ b/web/src/components/script/ScriptTakeGallery.tsx
@@ -17,6 +17,7 @@ import {
   useScriptStore,
   type ScriptTake
 } from "../../stores/script/ScriptStore";
+import { syncLineClipToTimeline } from "../../stores/script/timelineSync";
 import { useAssetStore } from "../../stores/AssetStore";
 import { getAssetUrl } from "../../utils/assetHelpers";
 
@@ -47,6 +48,12 @@ const TakeRow = ({
   const toggleFavorite = useScriptStore((s) => s.toggleTakeFavorite);
   const removeTake = useScriptStore((s) => s.removeTake);
 
+  const useTake = useCallback(() => {
+    setCurrentTake(scriptId, lineId, take.id);
+    // Round-trip the newly-selected take into the assembled timeline, if any.
+    void syncLineClipToTimeline(scriptId, lineId, take);
+  }, [setCurrentTake, scriptId, lineId, take]);
+
   const play = useCallback(async () => {
     if (typeof Audio === "undefined") return;
     try {
@@ -62,7 +69,7 @@ const TakeRow = ({
     <FlexRow align="center" gap={SPACING.sm} fullWidth>
       <ToolbarIconButton
         tooltip={isCurrent ? "Current take" : "Use this take"}
-        onClick={() => setCurrentTake(scriptId, lineId, take.id)}
+        onClick={useTake}
         icon={
           <CheckCircleIcon
             fontSize="small"

--- a/web/src/components/script/__tests__/assembleScriptTimeline.test.ts
+++ b/web/src/components/script/__tests__/assembleScriptTimeline.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment node
+ */
+import type {
+  ScriptDraft,
+  ScriptLine,
+  ScriptTake
+} from "../../../stores/script/ScriptStore";
+import {
+  buildScriptTimelineDocument,
+  isAssemblableLine,
+  currentTake
+} from "../assembleScriptTimeline";
+
+const take = (overrides: Partial<ScriptTake> = {}): ScriptTake => ({
+  id: "take-0",
+  assetId: "asset-0",
+  durationMs: 2000,
+  words: [{ word: "hello", startMs: 0, endMs: 500 }],
+  textSnapshot: "Hello",
+  voiceSnapshot: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...overrides
+});
+
+const line = (overrides: Partial<ScriptLine> = {}): ScriptLine => ({
+  id: "line-0",
+  text: "Hello",
+  takes: [],
+  ...overrides
+});
+
+const voicedLine = (
+  id: string,
+  overrides: Partial<ScriptLine> = {},
+  takeOverrides: Partial<ScriptTake> = {}
+): ScriptLine => {
+  const t = take({ id: `${id}-take`, assetId: `asset-${id}`, ...takeOverrides });
+  return line({ id, takes: [t], currentTakeId: t.id, ...overrides });
+};
+
+const script = (overrides: Partial<ScriptDraft> = {}): ScriptDraft => ({
+  id: "script-1",
+  title: "My script",
+  cast: [],
+  sections: [],
+  timelineId: null,
+  updatedAt: 0,
+  ...overrides
+});
+
+describe("isAssemblableLine", () => {
+  it("requires a current take with a persisted asset", () => {
+    expect(isAssemblableLine(voicedLine("a"))).toBe(true);
+    expect(isAssemblableLine(line({ text: "draft" }))).toBe(false);
+    // A take exists but is not the current one.
+    expect(
+      isAssemblableLine(line({ takes: [take()], currentTakeId: null }))
+    ).toBe(false);
+  });
+});
+
+describe("currentTake", () => {
+  it("returns the take matching currentTakeId, else undefined", () => {
+    const l = voicedLine("a");
+    expect(currentTake(l)?.id).toBe("a-take");
+    expect(currentTake(line())).toBeUndefined();
+  });
+});
+
+describe("buildScriptTimelineDocument", () => {
+  it("lays voiced lines end to end in reading order with script links", () => {
+    const doc = buildScriptTimelineDocument(
+      script({
+        sections: [
+          { id: "s1", lines: [voicedLine("a"), voicedLine("b")] }
+        ]
+      })
+    );
+    expect(doc.tracks).toHaveLength(1);
+    expect(doc.tracks[0].type).toBe("audio");
+    expect(doc.clips).toHaveLength(2);
+    expect(doc.clips[0].startMs).toBe(0);
+    expect(doc.clips[1].startMs).toBe(2000);
+    expect(doc.durationMs).toBe(4000);
+    for (const clip of doc.clips) {
+      expect(clip.scriptId).toBe("script-1");
+      expect(clip.bindingKind).toBe("text-to-audio");
+      expect(clip.mediaType).toBe("audio");
+      expect(clip.trackId).toBe(doc.tracks[0].id);
+    }
+    expect(doc.clips[0].scriptLineId).toBe("a");
+    expect(doc.clips[0].currentAssetId).toBe("asset-a");
+    expect(doc.clips[0].caption?.words).toEqual([
+      { word: "hello", startMs: 0, endMs: 500 }
+    ]);
+  });
+
+  it("inserts each line's pauseAfterMs as a gap in the cursor", () => {
+    const doc = buildScriptTimelineDocument(
+      script({
+        sections: [
+          {
+            id: "s1",
+            lines: [voicedLine("a", { pauseAfterMs: 500 }), voicedLine("b")]
+          }
+        ]
+      })
+    );
+    expect(doc.clips[0].startMs).toBe(0);
+    expect(doc.clips[1].startMs).toBe(2500);
+  });
+
+  it("skips unvoiced lines and reports them", () => {
+    const doc = buildScriptTimelineDocument(
+      script({
+        sections: [
+          { id: "s1", lines: [line({ id: "draft" }), voicedLine("b")] }
+        ]
+      })
+    );
+    expect(doc.clips).toHaveLength(1);
+    expect(doc.clips[0].scriptLineId).toBe("b");
+    expect(doc.skippedLineIds).toEqual(["draft"]);
+  });
+
+  it("stamps the speaker label from the cast", () => {
+    const doc = buildScriptTimelineDocument(
+      script({
+        cast: [{ id: "spk1", name: "Narrator", voice: null }],
+        sections: [
+          { id: "s1", lines: [voicedLine("a", { speakerId: "spk1" })] }
+        ]
+      })
+    );
+    expect(doc.clips[0].speaker).toBe("Narrator");
+  });
+
+  it("falls back to a placeholder duration for an unprobed take", () => {
+    const doc = buildScriptTimelineDocument(
+      script({
+        sections: [
+          { id: "s1", lines: [voicedLine("a", {}, { durationMs: 0 })] }
+        ]
+      })
+    );
+    expect(doc.clips[0].durationMs).toBe(3000);
+  });
+});

--- a/web/src/components/script/__tests__/extractScript.test.ts
+++ b/web/src/components/script/__tests__/extractScript.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { buildScriptFromTimeline } from "../extractScript";
+
+const track = makeTrack({ type: "audio", name: "VO", index: 0 });
+
+const captionClip = (overrides: Partial<TimelineClip>): TimelineClip =>
+  makeClip({
+    trackId: track.id,
+    mediaType: "audio",
+    sourceType: "imported",
+    status: "generated",
+    ...overrides
+  });
+
+describe("buildScriptFromTimeline", () => {
+  it("returns an empty single section when there is no transcript", () => {
+    const result = buildScriptFromTimeline([]);
+    expect(result.cast).toEqual([]);
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].lines).toEqual([]);
+  });
+
+  it("projects captioned clips into lines with joined word text", () => {
+    const result = buildScriptFromTimeline([
+      captionClip({
+        id: "c1",
+        startMs: 0,
+        durationMs: 1000,
+        currentAssetId: "asset-1",
+        caption: {
+          words: [
+            { word: "Hello", startMs: 0, endMs: 400 },
+            { word: "world", startMs: 400, endMs: 900 }
+          ]
+        }
+      })
+    ]);
+    expect(result.sections[0].lines).toHaveLength(1);
+    const [lineRow] = result.sections[0].lines;
+    expect(lineRow.text).toBe("Hello world");
+    // The single-clip recording is carried across as the first take.
+    expect(lineRow.takes).toHaveLength(1);
+    expect(lineRow.takes[0].assetId).toBe("asset-1");
+    expect(lineRow.currentTakeId).toBe(lineRow.takes[0].id);
+    expect(lineRow.takes[0].words).toEqual([
+      { word: "Hello", startMs: 0, endMs: 400 },
+      { word: "world", startMs: 400, endMs: 900 }
+    ]);
+  });
+
+  it("builds a cast from distinct speaker labels and links lines to it", () => {
+    const result = buildScriptFromTimeline([
+      captionClip({
+        id: "c1",
+        startMs: 0,
+        durationMs: 1000,
+        speaker: "Alice",
+        currentAssetId: "asset-1",
+        caption: { words: [{ word: "Hi", startMs: 0, endMs: 300 }] }
+      }),
+      captionClip({
+        id: "c2",
+        startMs: 1000,
+        durationMs: 1000,
+        speaker: "Bob",
+        currentAssetId: "asset-2",
+        caption: { words: [{ word: "Hey", startMs: 0, endMs: 300 }] }
+      }),
+      captionClip({
+        id: "c3",
+        startMs: 2000,
+        durationMs: 1000,
+        speaker: "Alice",
+        currentAssetId: "asset-3",
+        caption: { words: [{ word: "Bye", startMs: 0, endMs: 300 }] }
+      })
+    ]);
+    expect(result.cast.map((s) => s.name)).toEqual(["Alice", "Bob"]);
+    const alice = result.cast.find((s) => s.name === "Alice")!;
+    const lines = result.sections[0].lines;
+    expect(lines[0].speakerId).toBe(alice.id);
+    expect(lines[2].speakerId).toBe(alice.id);
+    expect(result.cast.every((s) => s.voice === null)).toBe(true);
+  });
+});

--- a/web/src/components/script/assembleScriptTimeline.ts
+++ b/web/src/components/script/assembleScriptTimeline.ts
@@ -1,0 +1,102 @@
+/**
+ * assembleScriptTimeline — pure mapping from a script to a timeline document.
+ *
+ * The script owns its text; audio is derived. "Send to timeline" projects the
+ * current takes into a voiceover track: one asset-backed audio clip per voiced
+ * line, laid end to end in reading order with each line's `pauseAfterMs` gap.
+ * Every clip carries its take's word timings (`caption`), the speaker label,
+ * and two linkage keys (`scriptId` + `scriptLineId`) so a later re-voice can
+ * round-trip its new take into the assembled sequence — the script mirror of
+ * the storyboard's `storyboardBoardId`/`storyboardShotId` bridge.
+ *
+ * Lines without a voiced current take are skipped (reported as
+ * `skippedLineIds`) rather than laid as placeholders.
+ */
+
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type {
+  CaptionWord,
+  TimelineClip,
+  TimelineTrack
+} from "@nodetool-ai/timeline";
+import {
+  effectiveVoice,
+  type ScriptDraft,
+  type ScriptLine,
+  type ScriptTake
+} from "../../stores/script/ScriptStore";
+
+/** Fallback clip length for a take whose duration was never probed. */
+const PLACEHOLDER_LINE_MS = 3000;
+
+export interface AssembledScriptDocument {
+  tracks: TimelineTrack[];
+  clips: TimelineClip[];
+  /** Total length of the voiceover track in ms (last clip end). */
+  durationMs: number;
+  /** Lines skipped because they have no voiced current take. */
+  skippedLineIds: string[];
+}
+
+/** The current take of a line, if one is selected and present. */
+export const currentTake = (line: ScriptLine): ScriptTake | undefined =>
+  line.takes.find((t) => t.id === line.currentTakeId);
+
+/** A line is assemblable when its current take landed as an audio asset. */
+export const isAssemblableLine = (line: ScriptLine): boolean => {
+  const take = currentTake(line);
+  return !!take && typeof take.assetId === "string" && take.assetId.length > 0;
+};
+
+/** Copy a take's word timings into the timeline's `CaptionWord` shape. */
+export const takeCaptionWords = (take: ScriptTake): CaptionWord[] =>
+  take.words.map((w) => ({ word: w.word, startMs: w.startMs, endMs: w.endMs }));
+
+export function buildScriptTimelineDocument(
+  script: ScriptDraft
+): AssembledScriptDocument {
+  const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
+  const tracks: TimelineTrack[] = [track];
+  const clips: TimelineClip[] = [];
+  const skippedLineIds: string[] = [];
+
+  const speakerName = (speakerId?: string | null): string | undefined =>
+    speakerId
+      ? script.cast.find((s) => s.id === speakerId)?.name
+      : undefined;
+
+  let cursorMs = 0;
+  for (const line of script.sections.flatMap((s) => s.lines)) {
+    const take = currentTake(line);
+    if (!take || !take.assetId) {
+      skippedLineIds.push(line.id);
+      continue;
+    }
+    const durationMs =
+      take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS;
+    const words = takeCaptionWords(take);
+    clips.push(
+      makeClip({
+        trackId: track.id,
+        name: line.text.slice(0, 40) || "Line",
+        startMs: cursorMs,
+        durationMs,
+        mediaType: "audio",
+        sourceType: "imported",
+        bindingKind: "text-to-audio",
+        status: "generated",
+        currentAssetId: take.assetId,
+        prompt: line.text,
+        voice: effectiveVoice(line, script.cast)?.voice,
+        speaker: speakerName(line.speakerId),
+        caption: words.length ? { words } : undefined,
+        scriptId: script.id,
+        scriptLineId: line.id,
+        versions: []
+      })
+    );
+    cursorMs += durationMs + Math.max(0, line.pauseAfterMs ?? 0);
+  }
+
+  return { tracks, clips, durationMs: cursorMs, skippedLineIds };
+}

--- a/web/src/components/script/extractScript.ts
+++ b/web/src/components/script/extractScript.ts
@@ -1,0 +1,91 @@
+/**
+ * extractScript — the reverse of assemble: project a timeline's transcript into
+ * a script document.
+ *
+ * This closes the loop for recorded/imported media: transcribe a recording in
+ * the timeline, extract it as a script, then re-voice it with a cast. Each
+ * transcript paragraph becomes a line; distinct speaker labels become the cast
+ * (voiceless — the user assigns voices afterward). When a paragraph is backed
+ * by a single asset-bearing clip, its recording is carried across as the line's
+ * first take so the extracted script is immediately playable.
+ */
+
+import { buildTranscriptDoc } from "../../stores/timeline/transcriptOps";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import type {
+  ScriptCaptionWord,
+  ScriptLine,
+  ScriptSection,
+  ScriptSpeaker,
+  ScriptTake
+} from "../../stores/script/ScriptStore";
+
+export interface ExtractedScript {
+  cast: ScriptSpeaker[];
+  sections: ScriptSection[];
+}
+
+let counter = 0;
+const uid = (prefix: string): string =>
+  `${prefix}_${Date.now().toString(36)}_${(counter++).toString(36)}`;
+
+export function buildScriptFromTimeline(
+  clips: TimelineClip[]
+): ExtractedScript {
+  const doc = buildTranscriptDoc(clips);
+  const clipsById = new Map(clips.map((c) => [c.id, c]));
+
+  // Distinct speaker labels → cast, in first-seen order.
+  const speakerIdByName = new Map<string, string>();
+  const cast: ScriptSpeaker[] = [];
+  for (const segment of doc.segments) {
+    const name = segment.speaker?.trim();
+    if (!name || speakerIdByName.has(name)) continue;
+    const id = uid("spk");
+    speakerIdByName.set(name, id);
+    cast.push({ id, name, voice: null });
+  }
+
+  const lines: ScriptLine[] = doc.segments.map((segment) => {
+    const text = segment.isDraft
+      ? segment.draftText
+      : segment.tokens.map((t) => t.text).join(" ");
+    const speakerName = segment.speaker?.trim();
+    const speakerId = speakerName
+      ? (speakerIdByName.get(speakerName) ?? null)
+      : null;
+
+    const takes: ScriptTake[] = [];
+    let currentTakeId: string | null = null;
+    // Carry a single-clip recording across as the line's first take.
+    if (segment.clipIds.length === 1) {
+      const clip = clipsById.get(segment.clipIds[0]);
+      if (clip?.currentAssetId) {
+        const words: ScriptCaptionWord[] = (clip.caption?.words ?? []).map(
+          (w) => ({ word: w.word, startMs: w.startMs, endMs: w.endMs })
+        );
+        const take: ScriptTake = {
+          id: uid("take"),
+          assetId: clip.currentAssetId,
+          durationMs: clip.durationMs,
+          words,
+          textSnapshot: text,
+          voiceSnapshot: null,
+          createdAt: new Date().toISOString()
+        };
+        takes.push(take);
+        currentTakeId = take.id;
+      }
+    }
+
+    return {
+      id: uid("line"),
+      speakerId,
+      text,
+      takes,
+      currentTakeId
+    };
+  });
+
+  return { cast, sections: [{ id: uid("sec"), lines }] };
+}

--- a/web/src/components/timeline/TranscriptPanel.tsx
+++ b/web/src/components/timeline/TranscriptPanel.tsx
@@ -15,6 +15,7 @@ import React, { memo, useCallback, useMemo, useRef, useState } from "react";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import CleaningServicesIcon from "@mui/icons-material/CleaningServices";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
+import EditNoteIcon from "@mui/icons-material/EditNote";
 import { useShallow } from "zustand/react/shallow";
 
 import {
@@ -34,6 +35,7 @@ import { useTimelineTranscriptStore } from "../../stores/timeline/TimelineTransc
 import { buildTranscriptDoc, isTranscriptClip } from "../../stores/timeline/transcriptOps";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useAssetStore } from "../../stores/AssetStore";
+import { useExtractScript } from "../../hooks/script/useExtractScript";
 import { TranscriptEditor } from "./transcript/TranscriptEditor";
 
 export const TranscriptPanel: React.FC = memo(() => {
@@ -45,8 +47,10 @@ export const TranscriptPanel: React.FC = memo(() => {
 
   const removeFillers = useTimelineTranscriptStore((s) => s.removeFillers);
   const importMedia = useTimelineTranscriptStore((s) => s.importMedia);
+  const sequenceId = useTimelineStore((s) => s.sequenceId);
   const createAsset = useAssetStore((s) => s.createAsset);
   const addNotification = useNotificationStore((s) => s.addNotification);
+  const { extract, extracting } = useExtractScript();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importing, setImporting] = useState(false);
@@ -80,6 +84,21 @@ export const TranscriptPanel: React.FC = memo(() => {
     },
     [createAsset, importMedia, addNotification]
   );
+
+  const onExtractScript = useCallback(async () => {
+    if (!sequenceId) return;
+    try {
+      await extract(sequenceId);
+    } catch (err) {
+      addNotification({
+        content: `Extract as script failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        type: "error",
+        alert: true
+      });
+    }
+  }, [extract, sequenceId, addNotification]);
 
   return (
     <Panel
@@ -145,6 +164,21 @@ export const TranscriptPanel: React.FC = memo(() => {
               disabled={importing}
               onClick={() => fileInputRef.current?.click()}
             />
+            {sequenceId && segments.length > 0 ? (
+              <ToolbarIconButton
+                icon={
+                  extracting ? (
+                    <LoadingSpinner size={14} />
+                  ) : (
+                    <EditNoteIcon fontSize="small" />
+                  )
+                }
+                tooltip="Extract this transcript as an editable script"
+                aria-label="Extract as script"
+                disabled={extracting}
+                onClick={() => void onExtractScript()}
+              />
+            ) : null}
           </FlexRow>
         </FlexRow>
 

--- a/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
+++ b/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
@@ -1,0 +1,143 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { useAssembleScriptTimeline } from "../useAssembleScriptTimeline";
+import { useScriptStore, type ScriptTake } from "../../../stores/script/ScriptStore";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import { trpcClient } from "../../../trpc/client";
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    timeline: {
+      get: { query: jest.fn() },
+      create: { mutate: jest.fn() },
+      update: { mutate: jest.fn() }
+    }
+  }
+}));
+
+const getQuery = trpcClient.timeline.get.query as jest.Mock;
+const createMutate = trpcClient.timeline.create.mutate as jest.Mock;
+const updateMutate = trpcClient.timeline.update.mutate as jest.Mock;
+
+const take = (assetId: string): ScriptTake => ({
+  id: `${assetId}-take`,
+  assetId,
+  durationMs: 1000,
+  words: [],
+  textSnapshot: "hi",
+  voiceSnapshot: null,
+  createdAt: "2026-01-01T00:00:00.000Z"
+});
+
+const seedVoicedScript = (id: string, timelineId: string | null): void => {
+  const t = take("asset-a");
+  useScriptStore.getState().loadScript(id, {
+    title: "My script",
+    cast: [],
+    sections: [
+      { id: "s1", lines: [{ id: "line-a", text: "hi", takes: [t], currentTakeId: t.id }] }
+    ],
+    timelineId
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useScriptStore.setState({ scripts: {}, serverRevisions: {}, voicingLineIds: {} });
+  jest.spyOn(useWorkspaceTabsStore.getState(), "openTab").mockImplementation(
+    () => undefined as never
+  );
+});
+
+describe("useAssembleScriptTimeline", () => {
+  it("creates a sequence, links the script, and opens the tab", async () => {
+    seedVoicedScript("script-1", null);
+    createMutate.mockResolvedValue({ id: "tl-new" });
+    updateMutate.mockResolvedValue({});
+
+    const { result } = renderHook(() => useAssembleScriptTimeline());
+    let out: Awaited<ReturnType<typeof result.current.assemble>>;
+    await act(async () => {
+      out = await result.current.assemble("script-1");
+    });
+
+    expect(out!.sequenceId).toBe("tl-new");
+    expect(out!.clipCount).toBe(1);
+    expect(out!.reassembled).toBe(false);
+    expect(useScriptStore.getState().getScript("script-1")?.timelineId).toBe(
+      "tl-new"
+    );
+    expect(getQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws when no line is voiced", async () => {
+    useScriptStore.getState().loadScript("script-2", {
+      title: "Empty",
+      cast: [],
+      sections: [{ id: "s1", lines: [{ id: "l", text: "hi", takes: [] }] }],
+      timelineId: null
+    });
+    const { result } = renderHook(() => useAssembleScriptTimeline());
+    await act(async () => {
+      await expect(result.current.assemble("script-2")).rejects.toThrow(
+        /No voiced lines/
+      );
+    });
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("re-assembles in place, dropping the old voiceover track but keeping foreign tracks", async () => {
+    seedVoicedScript("script-1", "tl-1");
+    const oldVoTrack = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
+    const musicTrack = makeTrack({ type: "audio", name: "Music", index: 1 });
+    const oldVoClip: TimelineClip = makeClip({
+      trackId: oldVoTrack.id,
+      scriptId: "script-1",
+      scriptLineId: "line-a",
+      currentAssetId: "asset-old"
+    });
+    const musicClip: TimelineClip = makeClip({
+      trackId: musicTrack.id,
+      mediaType: "audio",
+      currentAssetId: "music-1"
+    });
+    getQuery.mockResolvedValue({
+      id: "tl-1",
+      updatedAt: "rev-1",
+      tracks: [oldVoTrack, musicTrack],
+      clips: [oldVoClip, musicClip],
+      markers: []
+    });
+    updateMutate.mockResolvedValue({});
+
+    const { result } = renderHook(() => useAssembleScriptTimeline());
+    let out: Awaited<ReturnType<typeof result.current.assemble>>;
+    await act(async () => {
+      out = await result.current.assemble("script-1");
+    });
+
+    expect(out!.reassembled).toBe(true);
+    expect(out!.sequenceId).toBe("tl-1");
+    expect(createMutate).not.toHaveBeenCalled();
+    const doc = updateMutate.mock.calls[0][0].document;
+    // Old voiceover track/clip dropped, music track/clip kept, new VO added.
+    expect(doc.tracks.map((t: { name: string }) => t.name)).toEqual([
+      "Voiceover",
+      "Music"
+    ]);
+    expect(doc.tracks.some((t: { id: string }) => t.id === oldVoTrack.id)).toBe(
+      false
+    );
+    expect(doc.clips.some((c: TimelineClip) => c.currentAssetId === "music-1")).toBe(
+      true
+    );
+    expect(doc.clips.some((c: TimelineClip) => c.currentAssetId === "asset-old")).toBe(
+      false
+    );
+    expect(doc.clips.some((c: TimelineClip) => c.currentAssetId === "asset-a")).toBe(
+      true
+    );
+  });
+});

--- a/web/src/hooks/script/useAssembleScriptTimeline.ts
+++ b/web/src/hooks/script/useAssembleScriptTimeline.ts
@@ -1,0 +1,137 @@
+/**
+ * useAssembleScriptTimeline
+ *
+ * The script → timeline handoff: projects the current takes into a persisted
+ * voiceover sequence, links the script to it, and opens the timeline tab. When
+ * the script is already linked (re-assemble after structural drift), it rewrites
+ * the linked sequence's voiceover track in place instead of creating a new one,
+ * preserving any other tracks the editor added. The pure document mapping lives
+ * in {@link buildScriptTimelineDocument}.
+ */
+
+import { useCallback, useState } from "react";
+import { trpcClient } from "../../trpc/client";
+import { useScriptStore } from "../../stores/script/ScriptStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { buildScriptTimelineDocument } from "../../components/script/assembleScriptTimeline";
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+
+export interface AssembleScriptResult {
+  sequenceId: string;
+  clipCount: number;
+  skippedLineIds: string[];
+  /** True when an existing linked sequence was rewritten rather than created. */
+  reassembled: boolean;
+}
+
+export interface UseAssembleScriptTimelineResult {
+  assemble: (scriptId: string) => Promise<AssembleScriptResult>;
+  assembling: boolean;
+  error: string | null;
+}
+
+export const useAssembleScriptTimeline =
+  (): UseAssembleScriptTimelineResult => {
+    const [assembling, setAssembling] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const assemble = useCallback(
+      async (scriptId: string): Promise<AssembleScriptResult> => {
+        const script = useScriptStore.getState().getScript(scriptId);
+        if (!script) {
+          throw new Error(`No script "${scriptId}".`);
+        }
+        const doc = buildScriptTimelineDocument(script);
+        if (doc.clips.length === 0) {
+          const message =
+            "No voiced lines to assemble — voice at least one line first.";
+          setError(message);
+          throw new Error(message);
+        }
+
+        setError(null);
+        setAssembling(true);
+        try {
+          const name = script.title.trim() || "Script voiceover";
+          const existingId = script.timelineId;
+
+          if (existingId) {
+            // Re-assemble: replace the script's voiceover track/clips, keep any
+            // other tracks and clips the editor added.
+            const sequence = await trpcClient.timeline.get.query({
+              id: existingId
+            });
+            const existingClips = sequence.clips as TimelineClip[];
+            const foreignClips = existingClips.filter(
+              (c) => c.scriptId !== scriptId
+            );
+            // Drop only the previous voiceover track(s) — tracks that carried
+            // this script's clips and hold no foreign clip. Empty tracks and
+            // tracks the editor added stay.
+            const thisScriptTrackIds = new Set(
+              existingClips
+                .filter((c) => c.scriptId === scriptId)
+                .map((c) => c.trackId)
+            );
+            const foreignTrackIds = new Set(foreignClips.map((c) => c.trackId));
+            const foreignTracks = (sequence.tracks as TimelineTrack[]).filter(
+              (t) => foreignTrackIds.has(t.id) || !thisScriptTrackIds.has(t.id)
+            );
+            await trpcClient.timeline.update.mutate({
+              id: existingId,
+              baseUpdatedAt: sequence.updatedAt,
+              document: {
+                tracks: [...doc.tracks, ...foreignTracks],
+                clips: [...doc.clips, ...foreignClips],
+                markers: sequence.markers ?? []
+              }
+            });
+            useWorkspaceTabsStore.getState().openTab({
+              type: "timeline",
+              ref: existingId,
+              mode: "edit",
+              title: name
+            });
+            return {
+              sequenceId: existingId,
+              clipCount: doc.clips.length,
+              skippedLineIds: doc.skippedLineIds,
+              reassembled: true
+            };
+          }
+
+          const sequence = await trpcClient.timeline.create.mutate({
+            name,
+            projectId: "default"
+          });
+          await trpcClient.timeline.update.mutate({
+            id: sequence.id,
+            document: { tracks: doc.tracks, clips: doc.clips, markers: [] }
+          });
+          useScriptStore.getState().setTimelineLink(scriptId, sequence.id);
+          useWorkspaceTabsStore.getState().openTab({
+            type: "timeline",
+            ref: sequence.id,
+            mode: "edit",
+            title: name
+          });
+          return {
+            sequenceId: sequence.id,
+            clipCount: doc.clips.length,
+            skippedLineIds: doc.skippedLineIds,
+            reassembled: false
+          };
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err));
+          throw err;
+        } finally {
+          setAssembling(false);
+        }
+      },
+      []
+    );
+
+    return { assemble, assembling, error };
+  };
+
+export default useAssembleScriptTimeline;

--- a/web/src/hooks/script/useExtractScript.ts
+++ b/web/src/hooks/script/useExtractScript.ts
@@ -1,0 +1,94 @@
+/**
+ * useExtractScript
+ *
+ * The timeline → script handoff: projects a sequence's transcript into a new
+ * script resource, seeds the store, and opens the script tab. The pure mapping
+ * lives in {@link buildScriptFromTimeline}.
+ */
+
+import { useCallback, useState } from "react";
+import { trpcClient } from "../../trpc/client";
+import { useScriptStore } from "../../stores/script/ScriptStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { buildScriptFromTimeline } from "../../components/script/extractScript";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+export interface ExtractScriptResult {
+  scriptId: string;
+  lineCount: number;
+}
+
+export interface UseExtractScriptResult {
+  extract: (timelineId: string) => Promise<ExtractScriptResult>;
+  extracting: boolean;
+  error: string | null;
+}
+
+export const useExtractScript = (): UseExtractScriptResult => {
+  const [extracting, setExtracting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const extract = useCallback(
+    async (timelineId: string): Promise<ExtractScriptResult> => {
+      setError(null);
+      setExtracting(true);
+      try {
+        const sequence = await trpcClient.timeline.get.query({
+          id: timelineId
+        });
+        const extracted = buildScriptFromTimeline(
+          sequence.clips as TimelineClip[]
+        );
+        const lineCount = extracted.sections.reduce(
+          (n, s) => n + s.lines.length,
+          0
+        );
+        if (lineCount === 0) {
+          const message =
+            "This timeline has no transcript to extract — add captioned or voiced clips first.";
+          setError(message);
+          throw new Error(message);
+        }
+
+        const name = `${sequence.name || "Timeline"} script`;
+        const created = await trpcClient.scripts.create.mutate({
+          name,
+          projectId: sequence.projectId,
+          // Persist the extracted content at creation so the tab's server-sync
+          // reload (which happens on mount) reads it back instead of clobbering
+          // the seeded store with an empty server document.
+          document: {
+            cast: extracted.cast,
+            sections: extracted.sections
+          } as Parameters<
+            typeof trpcClient.scripts.create.mutate
+          >[0]["document"]
+        });
+        useScriptStore.getState().loadScript(created.id, {
+          title: name,
+          cast: extracted.cast,
+          sections: extracted.sections,
+          timelineId: null
+        });
+        useScriptStore.getState().setServerRevision(created.id, created.updatedAt);
+        useWorkspaceTabsStore.getState().openTab({
+          type: "script",
+          ref: created.id,
+          mode: "edit",
+          title: name
+        });
+        return { scriptId: created.id, lineCount };
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        throw err;
+      } finally {
+        setExtracting(false);
+      }
+    },
+    []
+  );
+
+  return { extract, extracting, error };
+};
+
+export default useExtractScript;

--- a/web/src/stores/script/__tests__/timelineSync.test.ts
+++ b/web/src/stores/script/__tests__/timelineSync.test.ts
@@ -1,0 +1,122 @@
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { useScriptStore, type ScriptTake } from "../ScriptStore";
+import { syncLineClipToTimeline } from "../timelineSync";
+import { trpcClient } from "../../../trpc/client";
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    timeline: {
+      get: { query: jest.fn() },
+      update: { mutate: jest.fn() }
+    }
+  }
+}));
+
+const getQuery = trpcClient.timeline.get.query as jest.Mock;
+const updateMutate = trpcClient.timeline.update.mutate as jest.Mock;
+
+const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
+
+const linkedClip = (overrides: Partial<TimelineClip> = {}): TimelineClip =>
+  makeClip({
+    trackId: track.id,
+    mediaType: "audio",
+    sourceType: "imported",
+    status: "generated",
+    scriptId: "script-1",
+    scriptLineId: "line-1",
+    currentAssetId: "old-asset",
+    durationMs: 1000,
+    ...overrides
+  });
+
+const take = (overrides: Partial<ScriptTake> = {}): ScriptTake => ({
+  id: "take-2",
+  assetId: "new-asset",
+  durationMs: 2500,
+  words: [{ word: "hi", startMs: 0, endMs: 300 }],
+  textSnapshot: "hi",
+  voiceSnapshot: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...overrides
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useScriptStore.setState({ scripts: {}, serverRevisions: {}, voicingLineIds: {} });
+});
+
+const seedScript = (timelineId: string | null): void => {
+  useScriptStore.getState().loadScript("script-1", {
+    title: "S",
+    cast: [],
+    sections: [],
+    timelineId
+  });
+};
+
+describe("syncLineClipToTimeline", () => {
+  it("no-ops when the script has no linked timeline", async () => {
+    seedScript(null);
+    const result = await syncLineClipToTimeline("script-1", "line-1", take());
+    expect(result).toBe(false);
+    expect(getQuery).not.toHaveBeenCalled();
+  });
+
+  it("patches the linked clip's asset, duration, and caption via CAS update", async () => {
+    seedScript("tl-1");
+    getQuery.mockResolvedValue({
+      id: "tl-1",
+      updatedAt: "rev-1",
+      tracks: [track],
+      clips: [linkedClip(), linkedClip({ id: "other", scriptLineId: "line-2" })],
+      markers: []
+    });
+    updateMutate.mockResolvedValue({});
+
+    const result = await syncLineClipToTimeline("script-1", "line-1", take());
+
+    expect(result).toBe(true);
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const arg = updateMutate.mock.calls[0][0];
+    expect(arg.id).toBe("tl-1");
+    expect(arg.baseUpdatedAt).toBe("rev-1");
+    const patched = arg.document.clips.find(
+      (c: TimelineClip) => c.scriptLineId === "line-1"
+    );
+    expect(patched.currentAssetId).toBe("new-asset");
+    expect(patched.durationMs).toBe(2500);
+    expect(patched.caption.words).toEqual([{ word: "hi", startMs: 0, endMs: 300 }]);
+    // Unrelated clip untouched.
+    const untouched = arg.document.clips.find(
+      (c: TimelineClip) => c.scriptLineId === "line-2"
+    );
+    expect(untouched.currentAssetId).toBe("old-asset");
+  });
+
+  it("skips the update when the linked clip already has the take", async () => {
+    seedScript("tl-1");
+    getQuery.mockResolvedValue({
+      id: "tl-1",
+      updatedAt: "rev-1",
+      tracks: [track],
+      clips: [linkedClip({ currentAssetId: "new-asset", durationMs: 2500 })],
+      markers: []
+    });
+
+    const result = await syncLineClipToTimeline("script-1", "line-1", take());
+
+    expect(result).toBe(false);
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors and returns false", async () => {
+    seedScript("tl-1");
+    getQuery.mockRejectedValue(new Error("boom"));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await syncLineClipToTimeline("script-1", "line-1", take());
+    expect(result).toBe(false);
+    warn.mockRestore();
+  });
+});

--- a/web/src/stores/script/scriptVoicing.ts
+++ b/web/src/stores/script/scriptVoicing.ts
@@ -24,6 +24,7 @@ import {
   type ScriptTake,
   type VoiceBinding
 } from "./ScriptStore";
+import { syncLineClipToTimeline } from "./timelineSync";
 
 /** Speech-to-text default for word-level take timing (best-effort). */
 export interface AsrConfig {
@@ -202,6 +203,10 @@ export async function voiceLine(
           : undefined
     };
     store.getState().appendTake(scriptId, lineId, take);
+    // If this script was already assembled into a timeline, round-trip the new
+    // take into the linked clip. Fire-and-forget; a sync miss never fails the
+    // take (the sync logs and returns false).
+    void syncLineClipToTimeline(scriptId, lineId, take);
     return take;
   } finally {
     store.getState().setVoicing(lineId, false);

--- a/web/src/stores/script/timelineSync.ts
+++ b/web/src/stores/script/timelineSync.ts
@@ -1,0 +1,77 @@
+/**
+ * timelineSync — round-trips a re-voiced script line into its assembled
+ * timeline.
+ *
+ * When a script has been assembled (`script.timelineId` set) and a line gets a
+ * new current take, the linked voiceover clip (matched by `scriptLineId`) picks
+ * up the new take's asset, duration, and word timings. Uses a get→CAS-update
+ * cycle against the persisted document; an editor with the sequence open reads
+ * the change on next load. Failures are logged, never thrown — a sync miss must
+ * not fail the take.
+ *
+ * This mirrors the storyboard's `syncShotClipToTimeline`. Structural drift
+ * (adding/removing/reordering lines) is out of scope here — it prompts a
+ * re-assemble instead.
+ */
+
+import { trpcClient } from "../../trpc/client";
+import { useScriptStore, type ScriptTake } from "./ScriptStore";
+import { takeCaptionWords } from "../../components/script/assembleScriptTimeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+export async function syncLineClipToTimeline(
+  scriptId: string,
+  lineId: string,
+  take: ScriptTake
+): Promise<boolean> {
+  const timelineId = useScriptStore.getState().getScript(scriptId)?.timelineId;
+  if (!timelineId) {
+    return false;
+  }
+  try {
+    const sequence = await trpcClient.timeline.get.query({ id: timelineId });
+    const clips = sequence.clips as TimelineClip[];
+    const words = takeCaptionWords(take);
+    const durationMs = take.durationMs > 0 ? take.durationMs : undefined;
+    let changed = false;
+    const next = clips.map((clip) => {
+      if (clip.scriptLineId !== lineId || clip.scriptId !== scriptId) {
+        return clip;
+      }
+      const nextDuration = durationMs ?? clip.durationMs;
+      if (
+        clip.currentAssetId === take.assetId &&
+        clip.durationMs === nextDuration
+      ) {
+        return clip;
+      }
+      changed = true;
+      return {
+        ...clip,
+        currentAssetId: take.assetId,
+        durationMs: nextDuration,
+        caption: words.length ? { words } : clip.caption,
+        status: "generated" as const
+      };
+    });
+    if (!changed) {
+      return false;
+    }
+    await trpcClient.timeline.update.mutate({
+      id: timelineId,
+      baseUpdatedAt: sequence.updatedAt,
+      document: {
+        tracks: sequence.tracks,
+        clips: next,
+        markers: sequence.markers ?? []
+      }
+    });
+    return true;
+  } catch (err) {
+    console.warn(
+      `script→timeline sync failed for line ${lineId}:`,
+      err instanceof Error ? err.message : err
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [Script editor](../blob/main/docs/script-editor-concept.md) — the **to-timeline** bridge. Wires a script into the timeline, mirroring the storyboard's assemble/back-sync pattern (`storyboardBoardId`/`storyboardShotId` → `scriptId`/`scriptLineId`).

## What's included

- **Assemble** — `buildScriptTimelineDocument` projects the current takes into a voiceover track: one asset-backed audio clip per voiced line, laid end to end in reading order with each line's `pauseAfterMs` gap. Every clip carries the take's word timings (`caption`), the speaker label, and `scriptId`/`scriptLineId` linkage keys. `useAssembleScriptTimeline` creates + links the sequence and opens the timeline tab; a **Send to timeline** button in the document pane drives it. Unvoiced lines are skipped and reported.
- **Re-assemble on drift** — when the script is already linked, the voiceover track is rewritten in place: the old projection (this script's track + clips) is dropped, foreign tracks/clips the editor added are preserved, and the new projection is added.
- **Per-line back-sync** — `syncLineClipToTimeline` round-trips a re-voiced or newly selected take into the linked clip (asset, duration, caption) via a get→CAS-update cycle. Log-and-continue on failure — a sync miss never fails the take. Fired from `voiceLine` and the take gallery's "use this take".
- **Extract-as-script** — `buildScriptFromTimeline` projects a timeline transcript back into a new script resource (paragraphs → lines, distinct speaker labels → cast, single-clip recordings carried across as the first take). `useExtractScript` persists the content at creation and opens the tab; an **Extract as script** action lives in the transcript panel toolbar.
- **Linkage keys** — `scriptId`/`scriptLineId` added to the `TimelineClip` type and its protocol zod schema so they survive PATCH round-trips (the same fix the storyboard/caption fields needed).

## Testing

- `web`: typecheck ✅, lint ✅, new suites for `assembleScriptTimeline`, `extractScript`, `timelineSync`, and `useAssembleScriptTimeline` (create / re-assemble / guard paths) ✅
- `packages/protocol` (607) and `packages/timeline` (91) tests ✅

Docs: `docs/script-editor-concept.md` phasing updated to mark Phase 2 implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmMiUpyxCYCpATq6d9SS9W

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmMiUpyxCYCpATq6d9SS9W)_