### PR TITLE
feat: add Flatpak to Linux release targets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -221,15 +221,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
 
-      - name: Install Flatpak SDK and runtime (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install -y flatpak flatpak-builder elfutils
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y flathub org.freedesktop.Platform//24.08
-          sudo flatpak install -y flathub org.freedesktop.Sdk//24.08
-          sudo flatpak install -y flathub org.electronjs.Electron2.BaseApp//24.08
-
       - name: Configure node-gyp Python path
         shell: bash
         run: |
@@ -733,7 +724,6 @@ jobs:
             electron/dist/*.dmg
             electron/dist/*.zip
             electron/dist/*.AppImage
-            electron/dist/*.flatpak
             electron/dist/*.exe
             electron/dist/*.blockmap
             electron/dist/*.yml
@@ -848,7 +838,6 @@ jobs:
             release-assets/*.zip
             release-assets/*.dmg
             release-assets/*.AppImage
-            release-assets/*.flatpak
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -221,6 +221,15 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
 
+      - name: Install Flatpak SDK and runtime (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y flatpak flatpak-builder elfutils
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install -y flathub org.freedesktop.Platform//24.08
+          sudo flatpak install -y flathub org.freedesktop.Sdk//24.08
+          sudo flatpak install -y flathub org.electronjs.Electron2.BaseApp//24.08
+
       - name: Configure node-gyp Python path
         shell: bash
         run: |
@@ -724,6 +733,7 @@ jobs:
             electron/dist/*.dmg
             electron/dist/*.zip
             electron/dist/*.AppImage
+            electron/dist/*.flatpak
             electron/dist/*.exe
             electron/dist/*.blockmap
             electron/dist/*.yml
@@ -838,6 +848,7 @@ jobs:
             release-assets/*.zip
             release-assets/*.dmg
             release-assets/*.AppImage
+            release-assets/*.flatpak
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml

--- a/electron/electron-builder.json
+++ b/electron/electron-builder.json
@@ -99,7 +99,8 @@
     },
     "linux": {
         "target": [
-            "AppImage"
+            "AppImage",
+            "flatpak"
         ],
         "category": "Development",
         "maintainer": "hello@nodetool.ai",

--- a/scripts/validate-release-assets.mjs
+++ b/scripts/validate-release-assets.mjs
@@ -43,6 +43,7 @@ const checks = [
     (f) => f.endsWith(".zip") && f.includes("Nodetool-") && !/win-unpacked/i.test(f),
   ],
   ["Linux AppImage", (f) => f.endsWith(".AppImage")],
+  ["Linux Flatpak", (f) => f.endsWith(".flatpak")],
   ["blockmap", (f) => f.endsWith(".blockmap")],
   ["web archive", (f) => /^nodetool-web-.+\.zip$/.test(f)],
   ["MCP bundle", (f) => f.endsWith(".mcpb")],


### PR DESCRIPTION
Add Flatpak as a Linux distribution format alongside AppImage.

- Add "flatpak" to linux.target in electron-builder.json
- Add Flatpak validation to release asset validation script
- Workflow changes provided as a diff (must be applied manually due to GitHub App permission restrictions)

Closes #183

Generated with [Claude Code](https://claude.ai/code)