### PR TITLE
fix: resolve high-severity npm dependency vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,9 @@
     "msgpackr": "^1.11.9",
     "ts-node": "^10.9.2"
   },
+  "overrides": {
+    "unzipper": ">=0.12.3"
+  },
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },


### PR DESCRIPTION
## Summary

- Add npm `overrides` for `unzipper>=0.12.3` to fix HIGH severity path traversal vulnerability (CVE-2023-50551)
- Eliminates deprecated `fstream` and `rimraf@2` transitive dependency chains

## Before merging

Run `npm install` to regenerate `package-lock.json` with the new override.

Closes #2130

Generated with [Claude Code](https://claude.ai/code)