### PR TITLE
Add Script editor Phase 3: automation (agent tools + graph nodes)

### DIFF
--- a/docs/script-editor-concept.md
+++ b/docs/script-editor-concept.md
@@ -214,8 +214,15 @@ existing editor is a rewrite, not a feature.
    re-assemble in place on structural drift (preserving foreign tracks), and
    extract-as-script from a timeline transcript (`extractScript`,
    `useExtractScript`, the transcript panel's "Extract as script").
-3. **Automation** — `ui_script_*` agent tools + assistant panel, `ScriptRef` +
-   graph nodes.
+3. **Automation** *(implemented)* — `ui_script_*` agent tools
+   (`scriptAgentBridge`, `useScriptAgentBridge`, `builtin/script`:
+   `get_state`, `add_speaker`, `set_speaker_voice`, `add_line`, `set_line_text`,
+   `set_speaker`, `voice_line`, `voice_all`, `send_to_timeline`) + an in-surface
+   assistant panel (`ScriptAgentPanel`, a Cast/Assistant dock toggle),
+   `ScriptRef` in the protocol type system with a `script` data type and
+   property editor, and a graph node family (`ConstantScript`, `LoadScript`,
+   `VoiceScript` — batch TTS over a cast, `ScriptToTimeline`) reading/writing
+   scripts through new `ProcessingContext` script methods.
 4. **Depth** — dialogue-mode rendering, provider-native timestamps, SRT/VTT
    export, bundle support.
 

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -368,6 +368,12 @@ export {
   TIMELINE_NODES
 } from "@nodetool-ai/video-nodes/nodes/timeline";
 export {
+  LoadScriptNode,
+  VoiceScriptNode,
+  ScriptToTimelineNode,
+  SCRIPT_NODES
+} from "@nodetool-ai/video-nodes/nodes/script";
+export {
   SummarizerNode,
   EnhancePromptNode,
   CreateThreadNode,
@@ -761,6 +767,7 @@ import { IMAGE_NODES } from "@nodetool-ai/image-nodes/nodes/image";
 import { SKETCH_NODES } from "@nodetool-ai/image-nodes/nodes/sketch";
 import { VIDEO_NODES } from "@nodetool-ai/video-nodes/nodes/video";
 import { TIMELINE_NODES } from "@nodetool-ai/video-nodes/nodes/timeline";
+import { SCRIPT_NODES } from "@nodetool-ai/video-nodes/nodes/script";
 import { AGENT_NODES } from "@nodetool-ai/llm-nodes/nodes/agents";
 import { GENERATOR_NODES } from "@nodetool-ai/llm-nodes/nodes/generators";
 import { DIRECTOR_NODES } from "@nodetool-ai/llm-nodes/nodes/director";
@@ -852,6 +859,7 @@ export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...SKETCH_NODES,
   ...VIDEO_NODES,
   ...TIMELINE_NODES,
+  ...SCRIPT_NODES,
   ...AGENT_NODES,
   ...GENERATOR_NODES,
   ...DIRECTOR_NODES,

--- a/packages/core-nodes/src/nodes/constant.ts
+++ b/packages/core-nodes/src/nodes/constant.ts
@@ -9,6 +9,7 @@ import type {
   ImageRef,
   LanguageModel,
   Model3DRef,
+  ScriptRef,
   SketchRef,
   TimelineRef,
   TTSModel,
@@ -23,6 +24,7 @@ import {
   imageRefDefault,
   jsonRefDefault,
   model3DRefDefault,
+  scriptRefDefault,
   sketchRefDefault,
   timelineRefDefault,
   videoRefDefault
@@ -363,6 +365,29 @@ export class ConstantTimelineNode extends BaseNode {
     title: "Value"
   })
   declare value: TimelineRef;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: this.value ?? {} };
+  }
+}
+
+export class ConstantScriptNode extends BaseNode {
+  static readonly nodeType = "nodetool.constant.Script";
+  static readonly title = "Script";
+  static readonly description =
+    "References a script in the workflow.\n    script, voiceover, narration, cast, tts\n\n    Use cases:\n    - Pass a script between nodes for voicing or timeline assembly\n    - Open and edit the referenced script in the script editor\n    - Provide a fixed script input for downstream nodes";
+  static readonly metadataOutputTypes = {
+    output: "script"
+  };
+  static readonly inlineFields = ["value"];
+  static readonly inputFields = [];
+
+  @prop({
+    type: "script",
+    default: scriptRefDefault,
+    title: "Value"
+  })
+  declare value: ScriptRef;
 
   async process(): Promise<Record<string, unknown>> {
     return { output: this.value ?? {} };
@@ -896,6 +921,7 @@ export const CONSTANT_NODES = tagAsUniversal([
   ConstantDocumentNode,
   ConstantSketchNode,
   ConstantTimelineNode,
+  ConstantScriptNode,
   ConstantJSONNode,
   ConstantModel3DNode,
   ConstantDataFrameNode,

--- a/packages/core-nodes/src/nodes/ref-defaults.ts
+++ b/packages/core-nodes/src/nodes/ref-defaults.ts
@@ -101,6 +101,12 @@ export const timelineRefDefault = {
   data: null
 };
 
+export const scriptRefDefault = {
+  type: "script",
+  id: null,
+  data: null
+};
+
 export const hfModelDefault = {
   type: "hf.model",
   repo_id: "",

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -249,6 +249,18 @@ export interface TimelineRef {
   data?: unknown;
 }
 
+/**
+ * Reference to a persisted script (text-owns-audio document), editable in the
+ * script editor and passable between workflow nodes.
+ */
+export interface ScriptRef {
+  type: "script";
+  /** Id of the persisted script. */
+  id?: string | null;
+  /** Optional inline script document payload. */
+  data?: unknown;
+}
+
 export interface WorkflowRef {
   type: "workflow_ref";
   id: string;

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -400,6 +400,25 @@ export interface ProcessingContextModelInterfaces {
     id: string;
     sequence: unknown;
   }) => Promise<unknown | null>;
+  /** Load a persisted script by id; null when missing or not owned. */
+  getScript?: (args: {
+    userId: string;
+    id: string;
+  }) => Promise<unknown | null>;
+  /** Create a persisted script from a name + document. */
+  createScript?: (args: {
+    userId: string;
+    name?: string;
+    projectId?: string;
+    document: unknown;
+  }) => Promise<unknown>;
+  /** Replace a persisted script's document (and optional timeline link); null when missing or not owned. */
+  updateScript?: (args: {
+    userId: string;
+    id: string;
+    document?: unknown;
+    timelineId?: string | null;
+  }) => Promise<unknown | null>;
 }
 
 function isWithinRoot(root: string, target: string): boolean {
@@ -1955,6 +1974,31 @@ export class ProcessingContext {
   ): Promise<unknown | null> {
     const fn = this.requireModelInterface("updateTimelineSequence");
     return fn({ userId: this.userId, id, sequence });
+  }
+
+  /** Load a persisted script owned by the current user. */
+  async getScript(id: string): Promise<unknown | null> {
+    const fn = this.requireModelInterface("getScript");
+    return fn({ userId: this.userId, id });
+  }
+
+  /** Create a persisted script owned by the current user. */
+  async createScript(args: {
+    name?: string;
+    projectId?: string;
+    document: unknown;
+  }): Promise<unknown> {
+    const fn = this.requireModelInterface("createScript");
+    return fn({ userId: this.userId, ...args });
+  }
+
+  /** Replace a persisted script's document (and optional timeline link). */
+  async updateScript(
+    id: string,
+    args: { document?: unknown; timelineId?: string | null }
+  ): Promise<unknown | null> {
+    const fn = this.requireModelInterface("updateScript");
+    return fn({ userId: this.userId, id, ...args });
   }
 
   /**

--- a/packages/video-nodes/src/index.ts
+++ b/packages/video-nodes/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./nodes/video.js";
 export * from "./nodes/timeline.js";
+export * from "./nodes/script.js";
 export * from "./nodes/lib-video-download.js";
 export * from "./nodes/model3d.js";
 

--- a/packages/video-nodes/src/nodes/script.ts
+++ b/packages/video-nodes/src/nodes/script.ts
@@ -1,0 +1,502 @@
+/**
+ * Script nodes — operate on persisted scripts (the script editor's documents)
+ * referenced by the `script` type. A script owns its text; audio is derived.
+ *
+ * - LoadScript reads a script's text and metadata for downstream LLM/text nodes.
+ * - VoiceScript batch-synthesizes every draft/stale line with its cast voice,
+ *   appending a take per line and persisting the script.
+ * - ScriptToTimeline assembles the current takes into a voiceover sequence,
+ *   the headless mirror of the editor's "Send to timeline".
+ */
+
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { ScriptRef, TimelineRef } from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { concatBytes, encodePcm16Wav } from "@nodetool-ai/audio-nodes";
+import {
+  makeClip,
+  makeSequence,
+  makeTrack,
+  type CaptionWord,
+  type TimelineClip,
+  type TimelineSequence,
+  type TimelineTrack
+} from "@nodetool-ai/timeline";
+import { tagAsNode } from "@nodetool-ai/nodes-utils";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { ffprobeDuration } from "./ffmpeg-helpers.js";
+
+const scriptRefDefault = { type: "script", id: null, data: null } as const;
+
+/** Fallback clip length for a take whose duration could not be determined. */
+const PLACEHOLDER_LINE_MS = 3000;
+
+// ── Script document shapes (structurally match @nodetool-ai/models Script) ──
+
+interface VoiceBindingLike {
+  provider: string;
+  model: string;
+  voice: string;
+  settings?: Record<string, unknown>;
+}
+
+interface ScriptTakeLike {
+  id: string;
+  assetId: string;
+  durationMs: number;
+  words: CaptionWord[];
+  textSnapshot: string;
+  voiceSnapshot: VoiceBindingLike | null;
+  createdAt: string;
+  favorite?: boolean;
+  costCredits?: number;
+}
+
+interface ScriptLineLike {
+  id: string;
+  speakerId?: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  voiceOverride?: VoiceBindingLike | null;
+  takes: ScriptTakeLike[];
+  currentTakeId?: string | null;
+}
+
+interface ScriptSpeakerLike {
+  id: string;
+  name: string;
+  color?: string;
+  voice?: VoiceBindingLike | null;
+}
+
+interface ScriptDocumentLike {
+  cast: ScriptSpeakerLike[];
+  sections: { id: string; title?: string; lines: ScriptLineLike[] }[];
+}
+
+interface ScriptResponseLike {
+  id: string;
+  projectId: string;
+  name: string;
+  document: ScriptDocumentLike;
+  timelineId?: string;
+  updatedAt: string;
+}
+
+interface ScriptRefLike {
+  type?: string;
+  id?: string | null;
+  data?: unknown;
+}
+
+async function loadScript(
+  ref: unknown,
+  context: ProcessingContext | undefined
+): Promise<ScriptResponseLike> {
+  const scriptRef = (ref ?? {}) as ScriptRefLike;
+  if (!scriptRef.id) {
+    throw new Error(
+      "Script input is empty — connect a Constant Script node and pick a script"
+    );
+  }
+  if (!context) {
+    throw new Error("Script nodes require a processing context");
+  }
+  const script = (await context.getScript(
+    scriptRef.id
+  )) as ScriptResponseLike | null;
+  if (!script) {
+    throw new Error(`Script not found: ${scriptRef.id}`);
+  }
+  return script;
+}
+
+const allLines = (doc: ScriptDocumentLike): ScriptLineLike[] =>
+  doc.sections.flatMap((s) => s.lines);
+
+const currentTake = (line: ScriptLineLike): ScriptTakeLike | undefined =>
+  line.takes.find((t) => t.id === line.currentTakeId);
+
+/** The voice a line will be voiced with: its override, else its speaker's. */
+const effectiveVoice = (
+  line: ScriptLineLike,
+  cast: ScriptSpeakerLike[]
+): VoiceBindingLike | null => {
+  if (line.voiceOverride) return line.voiceOverride;
+  const speaker = cast.find((s) => s.id === line.speakerId);
+  return speaker?.voice ?? null;
+};
+
+/** Whether a line needs (re-)voicing: no current take, or text/voice drifted. */
+const needsVoicing = (
+  line: ScriptLineLike,
+  voice: VoiceBindingLike | null
+): boolean => {
+  const take = currentTake(line);
+  if (!take) return true;
+  return (
+    take.textSnapshot !== line.text ||
+    JSON.stringify(take.voiceSnapshot) !== JSON.stringify(voice)
+  );
+};
+
+// ── Nodes ────────────────────────────────────────────────────────────────────
+
+export class LoadScriptNode extends BaseNode {
+  static readonly nodeType = "nodetool.script.LoadScript";
+  static readonly title = "Load Script";
+  static readonly description =
+    "Read a persisted script's text and metadata.\n    script, text, voiceover, narration, load\n\n    Use cases:\n    - Feed a script's text into an LLM or text node\n    - Inspect line count and cast before voicing\n    - Branch a workflow on a script's contents";
+  static readonly metadataOutputTypes = {
+    text: "str",
+    lines: "list[str]",
+    name: "str",
+    line_count: "int"
+  };
+  static readonly inlineFields = ["script"];
+  static readonly inputFields = ["script"];
+
+  @prop({
+    type: "script",
+    default: scriptRefDefault,
+    title: "Script",
+    description: "The script to read."
+  })
+  declare script: ScriptRef;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    const script = await loadScript(this.script, context);
+    const lines = allLines(script.document).map((line) => line.text);
+    return {
+      text: lines.join("\n"),
+      lines,
+      name: script.name,
+      line_count: lines.length
+    };
+  }
+}
+
+export class VoiceScriptNode extends BaseNode {
+  static readonly nodeType = "nodetool.script.VoiceScript";
+  static readonly title = "Voice Script";
+  static readonly description =
+    "Synthesize speech for every draft or stale line of a script, using each line's cast voice, and save the takes back onto the script. Lines already up to date, or with no text or no voice, are skipped.\n    script, voiceover, tts, narration, batch\n\n    Use cases:\n    - Voice an LLM-written script in one step\n    - Re-voice lines whose text or voice changed\n    - Produce narration assets for timeline assembly";
+  static readonly requiredRuntimes = ["ffmpeg"];
+  static readonly metadataOutputTypes = {
+    output: "script",
+    voiced_count: "int"
+  };
+  static readonly inlineFields = ["script"];
+  static readonly inputFields = ["script"];
+
+  @prop({
+    type: "script",
+    default: scriptRefDefault,
+    title: "Script",
+    description: "The script whose lines to voice."
+  })
+  declare script: ScriptRef;
+
+  @prop({
+    type: "float",
+    default: 1,
+    title: "Speed",
+    description: "Speech speed multiplier passed to the TTS provider.",
+    min: 0.25,
+    max: 4
+  })
+  declare speed: number;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    if (!context) {
+      throw new Error("VoiceScript requires a processing context");
+    }
+    const script = await loadScript(this.script, context);
+    const doc = script.document;
+    const cast = doc.cast ?? [];
+
+    const workDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "nodetool-voice-script-")
+    );
+    let voiced = 0;
+    try {
+      for (const line of allLines(doc)) {
+        const text = line.text.trim();
+        if (!text) continue;
+        const voice = effectiveVoice(line, cast);
+        if (!voice) continue;
+        if (!needsVoicing(line, voice)) continue;
+
+        const synth = await synthesizeLine(context, text, voice, this.speed);
+        if (!synth) continue;
+
+        const durationMs = await probeDurationMs(
+          synth.bytes,
+          workDir,
+          voiced
+        );
+        const asset = (await context.createAsset({
+          name: `${script.name || "script"}-line-${voiced + 1}`,
+          contentType: synth.contentType,
+          content: synth.bytes
+        })) as { id: string };
+
+        const take: ScriptTakeLike = {
+          id: `take_${randomUUID()}`,
+          assetId: asset.id,
+          durationMs,
+          words: [],
+          textSnapshot: line.text,
+          voiceSnapshot: voice,
+          createdAt: new Date().toISOString()
+        };
+        line.takes = [...line.takes, take];
+        line.currentTakeId = take.id;
+        voiced += 1;
+      }
+    } finally {
+      await fs.rm(workDir, { recursive: true, force: true });
+    }
+
+    if (voiced > 0) {
+      const saved = (await context.updateScript(script.id, {
+        document: doc
+      })) as { id: string } | null;
+      if (!saved) {
+        throw new Error(
+          "VoiceScript: failed to save the script (it was modified concurrently)"
+        );
+      }
+    }
+
+    return {
+      output: { type: "script", id: script.id },
+      voiced_count: voiced
+    };
+  }
+}
+
+export class ScriptToTimelineNode extends BaseNode {
+  static readonly nodeType = "nodetool.script.ScriptToTimeline";
+  static readonly title = "Script To Timeline";
+  static readonly description =
+    "Assemble a script's current takes into a voiceover timeline — one audio clip per voiced line, laid end to end with the authored pauses, each linked back to its script line. Updates the linked timeline in place when the script already has one. Voice the script first.\n    script, timeline, voiceover, assemble, sequence\n\n    Use cases:\n    - Turn a voiced script into an editable sequence\n    - Build a narration track for a video edit\n    - Round-trip re-voiced lines into an existing timeline";
+  static readonly metadataOutputTypes = {
+    output: "timeline"
+  };
+  static readonly inlineFields = ["script"];
+  static readonly inputFields = ["script"];
+
+  @prop({
+    type: "script",
+    default: scriptRefDefault,
+    title: "Script",
+    description: "The voiced script to assemble."
+  })
+  declare script: ScriptRef;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    if (!context) {
+      throw new Error("ScriptToTimeline requires a processing context");
+    }
+    const script = await loadScript(this.script, context);
+    const doc = script.document;
+    const cast = doc.cast ?? [];
+    const name = script.name?.trim() || "Script voiceover";
+
+    const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
+    const tracks: TimelineTrack[] = [track];
+    const clips: TimelineClip[] = [];
+
+    const speakerName = (speakerId?: string | null): string | undefined =>
+      speakerId ? cast.find((s) => s.id === speakerId)?.name : undefined;
+
+    let cursorMs = 0;
+    for (const line of allLines(doc)) {
+      const take = currentTake(line);
+      if (!take || !take.assetId) continue;
+      const durationMs =
+        take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS;
+      clips.push(
+        makeClip({
+          trackId: track.id,
+          name: line.text.slice(0, 40) || "Line",
+          startMs: cursorMs,
+          durationMs,
+          mediaType: "audio",
+          sourceType: "imported",
+          bindingKind: "text-to-audio",
+          status: "generated",
+          currentAssetId: take.assetId,
+          prompt: line.text,
+          voice: effectiveVoice(line, cast)?.voice,
+          speaker: speakerName(line.speakerId),
+          caption: take.words.length ? { words: take.words } : undefined,
+          scriptId: script.id,
+          scriptLineId: line.id,
+          versions: []
+        })
+      );
+      cursorMs += durationMs + Math.max(0, line.pauseAfterMs ?? 0);
+    }
+
+    if (clips.length === 0) {
+      throw new Error(
+        "ScriptToTimeline: no voiced lines to assemble — voice the script first"
+      );
+    }
+
+    const existingId = script.timelineId;
+    let seq: TimelineSequence;
+    if (existingId) {
+      // Re-assemble: replace this script's voiceover track/clips, keep any
+      // other tracks and clips the editor added.
+      const existing = (await context.getTimelineSequence(
+        existingId
+      )) as TimelineSequence | null;
+      if (!existing) {
+        throw new Error(`Linked timeline not found: ${existingId}`);
+      }
+      const foreignClips = existing.clips.filter(
+        (c) => c.scriptId !== script.id
+      );
+      const thisScriptTrackIds = new Set(
+        existing.clips
+          .filter((c) => c.scriptId === script.id)
+          .map((c) => c.trackId)
+      );
+      const foreignTrackIds = new Set(foreignClips.map((c) => c.trackId));
+      const foreignTracks = existing.tracks.filter(
+        (t) => foreignTrackIds.has(t.id) || !thisScriptTrackIds.has(t.id)
+      );
+      seq = {
+        ...existing,
+        tracks: [...tracks, ...foreignTracks],
+        clips: [...clips, ...foreignClips]
+      };
+      seq.durationMs = seq.clips.reduce(
+        (end, c) => Math.max(end, c.startMs + c.durationMs),
+        0
+      );
+      const saved = (await context.updateTimelineSequence(existingId, seq)) as {
+        id: string;
+      } | null;
+      if (!saved) {
+        throw new Error("ScriptToTimeline: failed to update the linked timeline");
+      }
+      return { output: { type: "timeline", id: saved.id } };
+    }
+
+    seq = makeSequence({ name, projectId: script.projectId, tracks, clips });
+    seq.durationMs = cursorMs;
+    const saved = (await context.createTimelineSequence(seq)) as {
+      id: string;
+    } | null;
+    if (!saved) {
+      throw new Error("ScriptToTimeline: failed to create the timeline");
+    }
+    // Link the script to the new sequence (best-effort — a CAS miss doesn't
+    // invalidate the timeline we just wrote).
+    try {
+      await context.updateScript(script.id, { timelineId: saved.id });
+    } catch (error) {
+      console.warn("ScriptToTimeline: failed to link script to timeline", error);
+    }
+    return { output: { type: "timeline", id: saved.id } };
+  }
+}
+
+// ── TTS helpers (mirror audio TextToSpeechNode's provider routing) ──
+
+interface SynthResult {
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+async function synthesizeLine(
+  context: ProcessingContext,
+  text: string,
+  voice: VoiceBindingLike,
+  speed: number
+): Promise<SynthResult | null> {
+  const provider = voice.provider;
+  const model = voice.model;
+  if (!provider || !model) return null;
+  const params = { text, voice: voice.voice, speed };
+
+  // Providers that stream raw PCM (OpenAI, ElevenLabs…) are wrapped into a WAV.
+  // Providers that return an encoded audio file (FAL, KIE) go through the
+  // encoded path.
+  if (await context.providerSupportsStreamingTTS(provider)) {
+    const chunks: Uint8Array[] = [];
+    let sampleRate = 24000;
+    for await (const item of context.streamProviderPrediction({
+      provider,
+      capability: "text_to_speech",
+      model,
+      params
+    })) {
+      const piece = item as { samples?: Int16Array; sampleRate?: number };
+      if (typeof piece.sampleRate === "number" && piece.sampleRate > 0) {
+        sampleRate = piece.sampleRate;
+      }
+      if (piece.samples instanceof Int16Array) {
+        chunks.push(
+          new Uint8Array(
+            piece.samples.buffer.slice(
+              piece.samples.byteOffset,
+              piece.samples.byteOffset + piece.samples.byteLength
+            )
+          )
+        );
+      }
+    }
+    const wav = encodePcm16Wav(concatBytes(chunks), sampleRate, 1);
+    if (wav.length === 0) return null;
+    return { bytes: wav, contentType: "audio/wav" };
+  }
+
+  const encoded = await context.textToSpeechEncoded({
+    provider,
+    capability: "text_to_speech",
+    model,
+    params
+  });
+  if (!encoded?.data || encoded.data.length === 0) return null;
+  return {
+    bytes: encoded.data,
+    contentType:
+      typeof encoded.mimeType === "string" ? encoded.mimeType : "audio/mpeg"
+  };
+}
+
+async function probeDurationMs(
+  bytes: Uint8Array,
+  workDir: string,
+  index: number
+): Promise<number> {
+  const probePath = path.join(workDir, `line_${index}`);
+  try {
+    await fs.writeFile(probePath, bytes);
+    const seconds = await ffprobeDuration(probePath);
+    return seconds > 0 ? Math.round(seconds * 1000) : PLACEHOLDER_LINE_MS;
+  } catch {
+    return PLACEHOLDER_LINE_MS;
+  }
+}
+
+export const SCRIPT_NODES = tagAsNode([
+  LoadScriptNode,
+  VoiceScriptNode,
+  ScriptToTimelineNode
+]);

--- a/packages/video-nodes/tests/script-nodes.test.ts
+++ b/packages/video-nodes/tests/script-nodes.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Behavior tests for the script node family (LoadScriptNode, VoiceScriptNode,
+ * ScriptToTimelineNode). child_process is mocked so ffprobe answers a fixed
+ * duration; the ProcessingContext is stubbed with in-memory script/timeline
+ * stores and a fake streaming-TTS provider.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function mockResponse(cmd: string): { stdout: string; stderr: string } {
+  if (cmd === "ffprobe") {
+    return { stdout: "1.5\n", stderr: "" };
+  }
+  return { stdout: "", stderr: "" };
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (
+    cmd: string,
+    _args: string[],
+    optionsOrCb: unknown,
+    maybeCb?: unknown
+  ) => {
+    const cb =
+      typeof optionsOrCb === "function"
+        ? (optionsOrCb as (e: Error | null, o: string, s: string) => void)
+        : typeof maybeCb === "function"
+          ? (maybeCb as (e: Error | null, o: string, s: string) => void)
+          : null;
+    if (cb) {
+      const resp = mockResponse(cmd);
+      cb(null, resp.stdout, resp.stderr);
+    }
+  };
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")] = (
+    cmd: string
+  ): Promise<{ stdout: string; stderr: string }> =>
+    Promise.resolve(mockResponse(cmd));
+  return { ...original, execFile: mockExecFile };
+});
+
+const { LoadScriptNode, VoiceScriptNode, ScriptToTimelineNode } = await import(
+  "../src/nodes/script.js"
+);
+
+const VOICE = { provider: "openai", model: "tts-1", voice: "alloy" };
+
+function baseScript() {
+  return {
+    id: "script-1",
+    projectId: "default",
+    name: "My script",
+    timelineId: undefined as string | undefined,
+    document: {
+      cast: [{ id: "spk-1", name: "Narrator", voice: VOICE }],
+      sections: [
+        {
+          id: "sec-1",
+          lines: [
+            {
+              id: "line-1",
+              speakerId: "spk-1",
+              text: "Hello there.",
+              takes: [] as any[],
+              currentTakeId: null as string | null
+            },
+            {
+              id: "line-2",
+              speakerId: "spk-1",
+              text: "Welcome.",
+              takes: [] as any[],
+              currentTakeId: null as string | null
+            }
+          ]
+        }
+      ]
+    }
+  };
+}
+
+function stubContext(script: ReturnType<typeof baseScript> | null) {
+  const timelines: Record<string, any> = {};
+  return {
+    _timelines: timelines,
+    getScript: vi.fn(async () => script),
+    updateScript: vi.fn(async (_id: string, patch: any) => {
+      if (script && patch.document) script.document = patch.document;
+      if (script && patch.timelineId !== undefined)
+        script.timelineId = patch.timelineId;
+      return script;
+    }),
+    createAsset: vi.fn(async () => ({ id: `asset-${Math.random()}` })),
+    providerSupportsStreamingTTS: vi.fn(async () => true),
+    streamProviderPrediction: vi.fn(async function* () {
+      yield { samples: new Int16Array([1, 2, 3, 4]), sampleRate: 24000 };
+    }),
+    textToSpeechEncoded: vi.fn(async () => null),
+    getTimelineSequence: vi.fn(async (id: string) => timelines[id] ?? null),
+    createTimelineSequence: vi.fn(async (seq: { id: string }) => {
+      timelines[seq.id] = seq;
+      return seq;
+    }),
+    updateTimelineSequence: vi.fn(async (id: string, seq: unknown) => {
+      timelines[id] = seq;
+      return { id };
+    })
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LoadScriptNode", () => {
+  it("joins line texts and reports the count", async () => {
+    const context = stubContext(baseScript());
+    const node = new LoadScriptNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    const result = (await node.process(context as never)) as {
+      text: string;
+      lines: string[];
+      name: string;
+      line_count: number;
+    };
+    expect(result.lines).toEqual(["Hello there.", "Welcome."]);
+    expect(result.text).toBe("Hello there.\nWelcome.");
+    expect(result.name).toBe("My script");
+    expect(result.line_count).toBe(2);
+  });
+
+  it("throws when the script input is empty", async () => {
+    const node = new LoadScriptNode();
+    node.assign({ script: { type: "script", id: null } });
+    await expect(
+      node.process(stubContext(null) as never)
+    ).rejects.toThrow(/Script input is empty/);
+  });
+});
+
+describe("VoiceScriptNode", () => {
+  it("voices every draft line and saves takes back to the script", async () => {
+    const script = baseScript();
+    const context = stubContext(script);
+    const node = new VoiceScriptNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+
+    const result = (await node.process(context as never)) as {
+      output: { type: string; id: string };
+      voiced_count: number;
+    };
+
+    expect(result.voiced_count).toBe(2);
+    expect(result.output).toMatchObject({ type: "script", id: "script-1" });
+    expect(context.createAsset).toHaveBeenCalledTimes(2);
+    expect(context.updateScript).toHaveBeenCalledTimes(1);
+    const lines = script.document.sections[0].lines;
+    expect(lines[0].takes).toHaveLength(1);
+    expect(lines[0].currentTakeId).toBe(lines[0].takes[0].id);
+    // Duration comes from the mocked ffprobe (1.5s).
+    expect(lines[0].takes[0].durationMs).toBe(1500);
+    expect(lines[0].takes[0].textSnapshot).toBe("Hello there.");
+  });
+
+  it("skips up-to-date lines on a second run", async () => {
+    const script = baseScript();
+    const context = stubContext(script);
+    const node = new VoiceScriptNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    await node.process(context as never);
+
+    vi.clearAllMocks();
+    const result = (await node.process(context as never)) as {
+      voiced_count: number;
+    };
+    expect(result.voiced_count).toBe(0);
+    expect(context.createAsset).not.toHaveBeenCalled();
+  });
+
+  it("skips lines with no voice", async () => {
+    const script = baseScript();
+    script.document.cast[0].voice = undefined as never;
+    const context = stubContext(script);
+    const node = new VoiceScriptNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    const result = (await node.process(context as never)) as {
+      voiced_count: number;
+    };
+    expect(result.voiced_count).toBe(0);
+  });
+});
+
+describe("ScriptToTimelineNode", () => {
+  it("assembles voiced takes into a new voiceover sequence", async () => {
+    const script = baseScript();
+    // Pre-voice both lines.
+    for (const line of script.document.sections[0].lines) {
+      const take = {
+        id: `take-${line.id}`,
+        assetId: `asset-${line.id}`,
+        durationMs: 2000,
+        words: [],
+        textSnapshot: line.text,
+        voiceSnapshot: VOICE,
+        createdAt: "2026-01-01T00:00:00.000Z"
+      };
+      line.takes = [take];
+      line.currentTakeId = take.id;
+    }
+    const context = stubContext(script);
+    const node = new ScriptToTimelineNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+
+    const result = (await node.process(context as never)) as {
+      output: { type: string; id: string };
+    };
+
+    expect(result.output.type).toBe("timeline");
+    expect(context.createTimelineSequence).toHaveBeenCalledTimes(1);
+    const saved = context.createTimelineSequence.mock.calls[0][0] as {
+      tracks: Array<{ type: string; name: string }>;
+      clips: Array<{
+        mediaType: string;
+        startMs: number;
+        durationMs: number;
+        scriptId: string;
+        scriptLineId: string;
+        currentAssetId: string;
+      }>;
+    };
+    expect(saved.tracks[0]).toMatchObject({ type: "audio", name: "Voiceover" });
+    expect(saved.clips).toHaveLength(2);
+    expect(saved.clips[0]).toMatchObject({
+      mediaType: "audio",
+      startMs: 0,
+      durationMs: 2000,
+      scriptId: "script-1",
+      scriptLineId: "line-1"
+    });
+    // Second clip laid after the first.
+    expect(saved.clips[1].startMs).toBe(2000);
+    // The script gets linked to the new sequence.
+    expect(context.updateScript).toHaveBeenCalledWith(
+      "script-1",
+      expect.objectContaining({ timelineId: expect.any(String) })
+    );
+  });
+
+  it("throws when no lines are voiced", async () => {
+    const context = stubContext(baseScript());
+    const node = new ScriptToTimelineNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    await expect(node.process(context as never)).rejects.toThrow(
+      /no voiced lines/
+    );
+  });
+});

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -39,6 +39,7 @@ import {
   ModelChangeEvent,
   ModelObserver,
   Prediction,
+  Script,
   Thread,
   TimelineSequence,
   Workflow,
@@ -1035,6 +1036,37 @@ function createRuntimeContext(opts: {
         }
       );
       return updated ? updated.toTimelineSequence() : null;
+    },
+    getScript: async ({ userId, id }) => {
+      const script = await Script.findById(id);
+      if (!script || script.user_id !== userId) return null;
+      return script.toResponse();
+    },
+    createScript: async ({ userId, name, projectId, document }) => {
+      const script = new Script({
+        user_id: userId,
+        name: name ?? "Untitled script",
+        project_id: projectId ?? "default",
+        document: JSON.stringify(document)
+      });
+      await script.save();
+      return script.toResponse();
+    },
+    updateScript: async ({ userId, id, document, timelineId }) => {
+      const existing = await Script.findById(id);
+      if (!existing || existing.user_id !== userId) return null;
+      const fields: Partial<{
+        document: string;
+        timeline_id: string | null;
+      }> = {};
+      if (document !== undefined) fields.document = JSON.stringify(document);
+      if (timelineId !== undefined) fields.timeline_id = timelineId;
+      const updated = await Script.updateFieldsIfUnchanged(
+        id,
+        existing.updated_at,
+        fields
+      );
+      return updated ? updated.toResponse() : null;
     }
   });
 

--- a/web/src/components/node/PropertyInput.resolver.tsx
+++ b/web/src/components/node/PropertyInput.resolver.tsx
@@ -31,6 +31,7 @@ import FontProperty from "../properties/FontProperty";
 import SelectProperty from "../properties/SelectProperty";
 import SketchProperty from "../properties/SketchProperty";
 import TimelineProperty from "../properties/TimelineProperty";
+import ScriptProperty from "../properties/ScriptProperty";
 import ImageSizeProperty from "../properties/ImageSizeProperty";
 import JSONProperty from "../properties/JSONProperty";
 import StringListProperty from "../properties/StringListProperty";
@@ -176,6 +177,8 @@ function componentForType(type: string): ComponentType<PropertyProps> {
       return SketchProperty;
     case "timeline":
       return TimelineProperty;
+    case "script":
+      return ScriptProperty;
     case "workflow":
       return WorkflowProperty;
     case "dataframe":

--- a/web/src/components/properties/ScriptProperty.tsx
+++ b/web/src/components/properties/ScriptProperty.tsx
@@ -1,0 +1,92 @@
+import { memo, useCallback } from "react";
+import isEqual from "../../utils/isEqual";
+import { useLocation, useNavigate } from "react-router-dom";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import type { SelectChangeEvent } from "../ui_primitives";
+
+import PropertyLabel from "../node/PropertyLabel";
+import type { PropertyProps } from "../node/PropertyInput.types";
+import { useScripts } from "../../hooks/script/useScripts";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { NodeSelect, NodeMenuItem } from "../editor_ui";
+import { FlexRow, ToolbarIconButton } from "../ui_primitives";
+
+/**
+ * Property editor for the `script` type: pick a persisted script and jump
+ * straight into the script editor to edit it.
+ */
+const ScriptProperty = (props: PropertyProps) => {
+  const { property, value, onChange } = props;
+  const id = `script-${property.name}-${props.propertyIndex}`;
+  const { data, error, isLoading } = useScripts();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const selectedId: string = value?.id || "";
+  const selected = data?.find((script) => script.id === selectedId);
+
+  const handleChange = useCallback(
+    (e: SelectChangeEvent<unknown>) => {
+      onChange({
+        type: "script",
+        id: String(e.target.value)
+      });
+    },
+    [onChange]
+  );
+
+  const handleOpenEditor = useCallback(() => {
+    if (!selectedId) {
+      return;
+    }
+    // Scripts live only in the workspace — open a tab there, navigating into
+    // the workspace first when we're elsewhere.
+    openTab({
+      type: "script",
+      ref: selectedId,
+      mode: "edit",
+      title: selected?.name || "Untitled script"
+    });
+    if (!location.pathname.startsWith("/workspace")) {
+      navigate("/workspace");
+    }
+  }, [selectedId, selected?.name, location.pathname, openTab, navigate]);
+
+  return (
+    <>
+      <PropertyLabel
+        name={property.name}
+        description={property.description}
+        id={id}
+      />
+      <FlexRow gap={0.5} align="center" fullWidth>
+        <NodeSelect
+          id={id}
+          labelId={id}
+          name=""
+          value={selectedId}
+          onChange={handleChange}
+        >
+          {isLoading && <NodeMenuItem disabled>Loading…</NodeMenuItem>}
+          {error && <NodeMenuItem disabled>Error: {error.message}</NodeMenuItem>}
+          {data?.map((script) => (
+            <NodeMenuItem key={script.id} value={script.id}>
+              {script.name || "Untitled script"}
+            </NodeMenuItem>
+          ))}
+        </NodeSelect>
+        <ToolbarIconButton
+          size="small"
+          ariaLabel="Open in script editor"
+          tooltip="Open in script editor"
+          disabled={!selectedId}
+          onClick={handleOpenEditor}
+          icon={<DescriptionOutlinedIcon fontSize="inherit" />}
+        />
+      </FlexRow>
+    </>
+  );
+};
+
+export default memo(ScriptProperty, isEqual);

--- a/web/src/components/script/ScriptAgentPanel.tsx
+++ b/web/src/components/script/ScriptAgentPanel.tsx
@@ -1,0 +1,174 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, useEffect, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { useShallow } from "zustand/react/shallow";
+
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+
+import { FlexColumn, Text, SPACING, getSpacingPx } from "../ui_primitives";
+import ChatView from "../chat/containers/ChatView";
+import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+
+const styles = (_theme: Theme) =>
+  css({
+    "&": {
+      height: "100%",
+      minHeight: 0,
+      display: "flex",
+      flexDirection: "column"
+    },
+    // ChatView is tuned for the full-page global chat (large left/bottom
+    // padding, centered max-width). Tighten it for this narrow side panel.
+    "& .chat-view": {
+      padding: `0 ${getSpacingPx(SPACING.xs)} ${getSpacingPx(
+        SPACING.xs
+      )} ${getSpacingPx(SPACING.xs)}`
+    },
+    "& .chat-input-section": {
+      width: "100%",
+      maxWidth: "100%"
+    },
+    "& .chat-thread-container": {
+      maxWidth: "100%",
+      paddingBottom: getSpacingPx(SPACING.md)
+    }
+  });
+
+interface ScriptAgentPanelProps {
+  scriptId: string;
+}
+
+/**
+ * Chat surface for the Script editor. Reuses {@link ChatView} wired to the
+ * shared {@link useGlobalChatStore}, so the assistant can call the
+ * `ui_script_*` frontend tools the surface registers on the script agent
+ * bridge — writing, casting, and voicing lines like a co-writer.
+ */
+const ScriptAgentPanel = ({ scriptId }: ScriptAgentPanelProps) => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  // Bind the open script id as the chat's `workflow_id`. The server only
+  // forwards client `ui_*` tools to the model when a turn carries a
+  // workflow_id, so without this the assistant never sees the ui_script_*
+  // tools. The id is editor context, not a routing signal — we don't set
+  // `workflow_target`, so the turn stays a normal chat turn and the script is
+  // never run as a workflow.
+  const { status, statusMessage, progress } = useGlobalChatStore(
+    useShallow((state) => ({
+      status: state.status,
+      statusMessage: state.statusMessage,
+      progress: state.progress
+    }))
+  );
+
+  const { selectedModel, setSelectedModel } = useGlobalChatStore(
+    useShallow((state) => ({
+      selectedModel: state.selectedModel,
+      setSelectedModel: state.setSelectedModel
+    }))
+  );
+
+  const {
+    sendMessage,
+    stopGeneration,
+    connect,
+    createNewThread,
+    switchThread
+  } = useGlobalChatStore(
+    useShallow((state) => ({
+      sendMessage: state.sendMessage,
+      stopGeneration: state.stopGeneration,
+      connect: state.connect,
+      createNewThread: state.createNewThread,
+      switchThread: state.switchThread
+    }))
+  );
+
+  const { currentThreadId, messageCache, getCurrentMessagesSync } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        currentThreadId: state.currentThreadId,
+        messageCache: state.messageCache,
+        getCurrentMessagesSync: state.getCurrentMessagesSync
+      }))
+    );
+  const messages = useMemo(
+    () => getCurrentMessagesSync(),
+    [getCurrentMessagesSync, currentThreadId, messageCache]
+  );
+
+  // Establish the chat connection (and send the frontend-tool manifest, which
+  // now includes the surface's ui_script_* tools) when the panel mounts.
+  useEffect(() => {
+    connect().catch((err) => {
+      console.error("Failed to connect script editor chat:", err);
+    });
+  }, [connect]);
+
+  const chatStatus = useMemo(
+    () => (status === "stopping" ? "loading" : status),
+    [status]
+  );
+
+  const handleNewChat = useCallback(async () => {
+    try {
+      const id = await createNewThread();
+      switchThread(id);
+    } catch (err) {
+      console.error("Failed to start new script editor chat:", err);
+    }
+  }, [createNewThread, switchThread]);
+
+  const welcomePlaceholder = useMemo(
+    () => (
+      <FlexColumn
+        align="center"
+        justify="center"
+        fullHeight
+        padding={3}
+        sx={{ textAlign: "center" }}
+      >
+        <AutoAwesomeIcon sx={{ fontSize: 40, mb: 1.5, opacity: 0.5 }} />
+        <Text size="normal" weight={600} sx={{ mb: 1 }}>
+          Script Assistant
+        </Text>
+        <Text size="small" color="secondary" sx={{ maxWidth: 280 }}>
+          Ask me to write and voice the script — e.g. &quot;draft a 30-second
+          intro for two hosts&quot;, &quot;add a line for Narrator&quot;, or
+          &quot;voice every line and send it to a timeline&quot;.
+        </Text>
+      </FlexColumn>
+    ),
+    []
+  );
+
+  return (
+    <div css={cssStyles}>
+      <ChatPanelHeader onNewChat={handleNewChat} />
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <ChatView
+          status={chatStatus}
+          messages={messages}
+          workflowId={scriptId}
+          sendMessage={sendMessage}
+          progress={progress.current}
+          total={progress.total}
+          progressMessage={statusMessage}
+          model={selectedModel}
+          onModelChange={setSelectedModel}
+          onStop={stopGeneration}
+          onNewChat={handleNewChat}
+          requireToolSupport
+          hideModePicker
+          noMessagesPlaceholder={welcomePlaceholder}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default memo(ScriptAgentPanel);

--- a/web/src/components/script/ScriptCastPanel.tsx
+++ b/web/src/components/script/ScriptCastPanel.tsx
@@ -143,10 +143,7 @@ const ScriptCastPanel = ({
     <FlexColumn
       gap={SPACING.md}
       sx={{
-        width: 300,
-        flexShrink: 0,
-        borderLeft: "1px solid",
-        borderColor: "divider",
+        width: "100%",
         padding: SPACING.md,
         height: "100%",
         overflowY: "auto"

--- a/web/src/components/script/__tests__/scriptAgentBridge.test.ts
+++ b/web/src/components/script/__tests__/scriptAgentBridge.test.ts
@@ -1,0 +1,61 @@
+import {
+  setScriptAgentHandler,
+  hasScriptAgentHandler,
+  getScriptAgentHandler
+} from "../scriptAgentBridge";
+import type { ScriptAgentHandler } from "../scriptAgentBridge";
+
+const makeMockHandler = (): ScriptAgentHandler => ({
+  getSnapshot: jest.fn(),
+  addSpeaker: jest.fn(),
+  setSpeakerVoice: jest.fn(),
+  addLine: jest.fn(),
+  setLineText: jest.fn(),
+  setLineSpeaker: jest.fn(),
+  voiceLine: jest.fn(),
+  voiceAll: jest.fn(),
+  sendToTimeline: jest.fn()
+});
+
+describe("scriptAgentBridge", () => {
+  afterEach(() => {
+    setScriptAgentHandler(null);
+  });
+
+  describe("hasScriptAgentHandler", () => {
+    it("returns false when no handler is registered", () => {
+      expect(hasScriptAgentHandler()).toBe(false);
+    });
+
+    it("returns true after a handler is registered", () => {
+      setScriptAgentHandler(makeMockHandler());
+      expect(hasScriptAgentHandler()).toBe(true);
+    });
+
+    it("returns false after handler is cleared", () => {
+      setScriptAgentHandler(makeMockHandler());
+      setScriptAgentHandler(null);
+      expect(hasScriptAgentHandler()).toBe(false);
+    });
+  });
+
+  describe("getScriptAgentHandler", () => {
+    it("throws when no handler is registered", () => {
+      expect(() => getScriptAgentHandler()).toThrow("No script is open.");
+    });
+
+    it("returns the registered handler", () => {
+      const handler = makeMockHandler();
+      setScriptAgentHandler(handler);
+      expect(getScriptAgentHandler()).toBe(handler);
+    });
+
+    it("returns the most recently registered handler", () => {
+      const first = makeMockHandler();
+      const second = makeMockHandler();
+      setScriptAgentHandler(first);
+      setScriptAgentHandler(second);
+      expect(getScriptAgentHandler()).toBe(second);
+    });
+  });
+});

--- a/web/src/components/script/scriptAgentBridge.ts
+++ b/web/src/components/script/scriptAgentBridge.ts
@@ -1,0 +1,122 @@
+/**
+ * scriptAgentBridge
+ *
+ * Bridge between the agent tooling layer (the `ui_script_*` frontend tools) and
+ * the live Script surface, mirroring {@link storyboardAgentBridge}.
+ *
+ * The open ScriptSurface registers a {@link ScriptAgentHandler} while it is the
+ * active surface and clears it on unmount, so the tools always operate on the
+ * focused script — or fail cleanly when no script is open.
+ *
+ * Everything crossing the bridge is a plain serializable value: the agent reads
+ * {@link ScriptSnapshot} / {@link ScriptLineNode} objects and never touches
+ * Zustand store handles directly. Lines and speakers are addressed by id, and
+ * lines also by 0-based document index or the literal `"selected"` keyword.
+ */
+
+import type { VoiceBinding } from "../../stores/script/ScriptStore";
+
+/** A voiced take's line status, derived from the current take vs. the line. */
+export type ScriptLineStatus = "draft" | "voiced" | "stale";
+
+/** Serializable view of a single line the agent reads and edits. */
+export interface ScriptLineNode {
+  id: string;
+  /** 0-based position of the line across the whole document (all sections). */
+  index: number;
+  sectionId: string;
+  speakerId: string | null;
+  speakerName: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  status: ScriptLineStatus;
+  /** Number of takes recorded on the line. */
+  takeCount: number;
+  /** Duration of the current take in ms, or null when the line is unvoiced. */
+  currentTakeDurationMs: number | null;
+}
+
+/** Serializable view of a cast member. */
+export interface ScriptSpeakerNode {
+  id: string;
+  name: string;
+  color?: string;
+  voice: VoiceBinding | null;
+}
+
+/** Full snapshot of the open script the agent reads to plan its edits. */
+export interface ScriptSnapshot {
+  scriptId: string;
+  title: string;
+  cast: ScriptSpeakerNode[];
+  lines: ScriptLineNode[];
+  /** True once the script has been assembled into a timeline sequence. */
+  hasTimeline: boolean;
+  timelineId: string | null;
+}
+
+/** Fields the agent can supply when adding a line. */
+export interface ScriptAddLineInput {
+  text: string;
+  /** Speaker id to assign; the line inherits that speaker's voice. */
+  speakerId?: string;
+  direction?: string;
+  /** 0-based insertion index across the document; appended when omitted. */
+  index?: number;
+}
+
+/**
+ * Operations the live ScriptSurface exposes to the agent tooling layer. Lines
+ * are addressed by id, 0-based document index, or the literal `"selected"`;
+ * speakers by id.
+ */
+export interface ScriptAgentHandler {
+  getSnapshot: () => ScriptSnapshot;
+  addSpeaker: (name: string, voice?: VoiceBinding) => ScriptSpeakerNode;
+  setSpeakerVoice: (
+    speakerId: string,
+    voice: VoiceBinding
+  ) => ScriptSpeakerNode;
+  addLine: (input: ScriptAddLineInput) => ScriptLineNode;
+  setLineText: (target: string, text: string) => ScriptLineNode;
+  setLineSpeaker: (
+    target: string,
+    speakerId: string | null
+  ) => ScriptLineNode;
+  voiceLine: (target: string) => Promise<ScriptLineNode>;
+  voiceAll: () => Promise<{ voiced: number }>;
+  /**
+   * Assemble the current takes into a persisted timeline sequence (or update the
+   * one already linked) and open its tab. Throws when no line has a current
+   * take to lay down.
+   */
+  sendToTimeline: () => Promise<{
+    sequenceId: string;
+    clipCount: number;
+    skippedLineIds: string[];
+    reassembled: boolean;
+  }>;
+}
+
+let handler: ScriptAgentHandler | null = null;
+
+/**
+ * Register (or clear, with null) the handler for the currently-focused script.
+ * The surface calls this when it becomes active and clears it on unmount so the
+ * ui_script_* tools always operate on the live script — or fail cleanly.
+ */
+export function setScriptAgentHandler(next: ScriptAgentHandler | null): void {
+  handler = next;
+}
+
+export function hasScriptAgentHandler(): boolean {
+  return handler !== null;
+}
+
+export function getScriptAgentHandler(): ScriptAgentHandler {
+  if (!handler) {
+    throw new Error("No script is open.");
+  }
+  return handler;
+}

--- a/web/src/components/workspace/ScriptSurface.tsx
+++ b/web/src/components/workspace/ScriptSurface.tsx
@@ -1,13 +1,19 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import GroupsIcon from "@mui/icons-material/Groups";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import {
   useWorkspaceTabsStore,
   type WorkspaceTabMode
 } from "../../stores/WorkspaceTabsStore";
 import { useScriptStore, useScript } from "../../stores/script/ScriptStore";
 import { useScriptServerSync } from "../../hooks/script/useScriptServerSync";
+import { useScriptAgentBridge } from "../../hooks/script/useScriptAgentBridge";
+import { FlexColumn, TabGroup } from "../ui_primitives";
 import ScriptDocumentPane from "../script/ScriptDocumentPane";
 import ScriptCastPanel from "../script/ScriptCastPanel";
+import ScriptAgentPanel from "../script/ScriptAgentPanel";
 
 interface ScriptSurfaceProps {
   refId: string;
@@ -15,27 +21,42 @@ interface ScriptSurfaceProps {
   active: boolean;
 }
 
+type DockTab = "cast" | "assistant";
+
 /**
  * Workspace surface for a script tab. `refId` is the script id. Ensures the
  * script exists in the singleton store, mounts the server-sync/autosave hook,
- * keeps the tab label in sync with the title, and lays out the document pane
- * beside the cast panel (ElevenLabs-Studio style).
+ * registers the agent bridge (so the active script drives the ui_script_*
+ * tools), keeps the tab label in sync with the title, and lays out the document
+ * pane beside a right dock that toggles between the cast panel and the
+ * assistant (ElevenLabs-Studio style).
  */
-const ScriptSurface = ({ refId, mode }: ScriptSurfaceProps) => {
+const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
+  const theme = useTheme();
   const ensureScript = useScriptStore((state) => state.ensureScript);
   const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
   const { title, cast } = useScript(refId);
   const readOnly = mode === "view";
+  const [dockTab, setDockTab] = useState<DockTab>("cast");
 
   useEffect(() => {
     ensureScript(refId);
   }, [ensureScript, refId]);
 
   useScriptServerSync(refId);
+  useScriptAgentBridge(refId, active);
 
   useEffect(() => {
     setTabTitle(refId, "script", title || "Untitled script");
   }, [setTabTitle, refId, title]);
+
+  const dockTabs = useMemo(
+    () => [
+      { value: "cast", label: "Cast", icon: <GroupsIcon /> },
+      { value: "assistant", label: "Assistant", icon: <AutoAwesomeIcon /> }
+    ],
+    []
+  );
 
   return (
     <div
@@ -48,7 +69,38 @@ const ScriptSurface = ({ refId, mode }: ScriptSurfaceProps) => {
     >
       <ScriptDocumentPane scriptId={refId} readOnly={readOnly} />
       {!readOnly && (
-        <ScriptCastPanel scriptId={refId} cast={cast} readOnly={readOnly} />
+        <FlexColumn
+          fullHeight
+          sx={{
+            width: 320,
+            flexShrink: 0,
+            minHeight: 0,
+            borderLeft: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          <TabGroup
+            tabs={dockTabs}
+            value={dockTab}
+            onChange={(value) => setDockTab(value as DockTab)}
+            size="small"
+            fullWidth
+            sx={{
+              flexShrink: 0,
+              borderBottom: `1px solid ${theme.vars.palette.divider}`
+            }}
+          />
+          <FlexColumn fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+            {dockTab === "cast" ? (
+              <ScriptCastPanel
+                scriptId={refId}
+                cast={cast}
+                readOnly={readOnly}
+              />
+            ) : (
+              <ScriptAgentPanel scriptId={refId} />
+            )}
+          </FlexColumn>
+        </FlexColumn>
       )}
     </div>
   );

--- a/web/src/config/data_types.ts
+++ b/web/src/config/data_types.ts
@@ -149,6 +149,18 @@ const NODETOOL_DATA_TYPES: DataType[] = [
     icon: "MovieFilter"
   },
   {
+    value: "script",
+    label: "Script",
+    description:
+      "Reference to a script. Can be opened and edited in the script editor and passed between nodes.",
+    color: colour("audio"),
+    textColor: "var(--palette-action-active)",
+    name: "",
+    slug: "",
+    namespace: "",
+    icon: "Description"
+  },
+  {
     value: "bool",
     label: "Boolean",
     description:

--- a/web/src/hooks/script/useScriptAgentBridge.ts
+++ b/web/src/hooks/script/useScriptAgentBridge.ts
@@ -1,0 +1,240 @@
+/**
+ * useScriptAgentBridge
+ *
+ * Registers a {@link ScriptAgentHandler} for the surrounding Script surface
+ * while it is active, so the `ui_script_*` agent tools operate on this script.
+ * Mirrors {@link useStoryboardAgentBridge}: only the active surface registers,
+ * and the handler is cleared on unmount unless already replaced.
+ */
+
+import { useEffect, useMemo } from "react";
+
+import {
+  useScriptStore,
+  effectiveVoice,
+  lineStatus,
+  type ScriptDraft,
+  type ScriptLine,
+  type ScriptSpeaker,
+  type VoiceBinding
+} from "../../stores/script/ScriptStore";
+import { voiceLine, voiceAll } from "../../stores/script/scriptVoicing";
+import { useAssembleScriptTimeline } from "./useAssembleScriptTimeline";
+import {
+  getScriptAgentHandler,
+  hasScriptAgentHandler,
+  setScriptAgentHandler,
+  type ScriptAgentHandler,
+  type ScriptLineNode,
+  type ScriptSnapshot,
+  type ScriptSpeakerNode
+} from "../../components/script/scriptAgentBridge";
+
+/** Flatten every line of the script with its section id and document index. */
+const flatLines = (
+  script: ScriptDraft
+): Array<{ line: ScriptLine; sectionId: string; index: number }> => {
+  const out: Array<{ line: ScriptLine; sectionId: string; index: number }> = [];
+  let index = 0;
+  for (const section of script.sections) {
+    for (const line of section.lines) {
+      out.push({ line, sectionId: section.id, index });
+      index += 1;
+    }
+  }
+  return out;
+};
+
+const toSpeakerNode = (speaker: ScriptSpeaker): ScriptSpeakerNode => ({
+  id: speaker.id,
+  name: speaker.name,
+  color: speaker.color,
+  voice: speaker.voice ?? null
+});
+
+export const useScriptAgentBridge = (
+  scriptId: string,
+  active: boolean
+): void => {
+  const { assemble } = useAssembleScriptTimeline();
+
+  const handler = useMemo<ScriptAgentHandler>(() => {
+    const store = () => useScriptStore.getState();
+
+    const requireScript = (): ScriptDraft => {
+      const script = store().getScript(scriptId);
+      if (!script) {
+        throw new Error("No script is open.");
+      }
+      return script;
+    };
+
+    /** Resolve a line by id or 0-based document index. */
+    const requireLine = (
+      target: string
+    ): { line: ScriptLine; sectionId: string } => {
+      const script = requireScript();
+      const flat = flatLines(script);
+      const byId = flat.find((f) => f.line.id === target);
+      if (byId) return byId;
+      const asIndex = Number(target);
+      if (Number.isInteger(asIndex)) {
+        const byIndex = flat.find((f) => f.index === asIndex);
+        if (byIndex) return byIndex;
+      }
+      throw new Error(`Line not found in the script: ${target}`);
+    };
+
+    const requireSpeaker = (speakerId: string): ScriptSpeaker => {
+      const speaker = requireScript().cast.find((s) => s.id === speakerId);
+      if (!speaker) {
+        throw new Error(`Speaker not found in the cast: ${speakerId}`);
+      }
+      return speaker;
+    };
+
+    const toLineNode = (
+      line: ScriptLine,
+      sectionId: string,
+      index: number,
+      cast: ScriptSpeaker[]
+    ): ScriptLineNode => {
+      const voice = effectiveVoice(line, cast);
+      const take = line.takes.find((t) => t.id === line.currentTakeId);
+      const speaker = cast.find((s) => s.id === line.speakerId);
+      return {
+        id: line.id,
+        index,
+        sectionId,
+        speakerId: line.speakerId ?? null,
+        speakerName: speaker?.name ?? null,
+        text: line.text,
+        direction: line.direction,
+        pauseAfterMs: line.pauseAfterMs,
+        status: lineStatus(line, voice),
+        takeCount: line.takes.length,
+        currentTakeDurationMs: take ? take.durationMs : null
+      };
+    };
+
+    const reReadLine = (lineId: string): ScriptLineNode => {
+      const script = requireScript();
+      const flat = flatLines(script);
+      const found = flat.find((f) => f.line.id === lineId);
+      if (!found) {
+        throw new Error(`Line ${lineId} disappeared after the edit.`);
+      }
+      return toLineNode(found.line, found.sectionId, found.index, script.cast);
+    };
+
+    const getSnapshot = (): ScriptSnapshot => {
+      const script = requireScript();
+      return {
+        scriptId,
+        title: script.title,
+        cast: script.cast.map(toSpeakerNode),
+        lines: flatLines(script).map((f) =>
+          toLineNode(f.line, f.sectionId, f.index, script.cast)
+        ),
+        hasTimeline: script.timelineId !== null,
+        timelineId: script.timelineId
+      };
+    };
+
+    return {
+      getSnapshot,
+
+      addSpeaker(name: string, voice?: VoiceBinding) {
+        requireScript();
+        const id = crypto.randomUUID();
+        const speaker: ScriptSpeaker = { id, name, voice: voice ?? null };
+        store().addSpeaker(scriptId, speaker);
+        const created = requireSpeaker(id);
+        return toSpeakerNode(created);
+      },
+
+      setSpeakerVoice(speakerId: string, voice: VoiceBinding) {
+        requireSpeaker(speakerId);
+        store().updateSpeaker(scriptId, speakerId, { voice });
+        return toSpeakerNode(requireSpeaker(speakerId));
+      },
+
+      addLine(input) {
+        const script = requireScript();
+        // Insert before the line currently at `index`; append when omitted or
+        // out of range. Anchor to that line's section so it lands nearby.
+        const flat = flatLines(script);
+        const anchor =
+          input.index !== undefined ? flat[input.index] : undefined;
+        const lineId = store().addLine(scriptId, anchor?.sectionId);
+        store().patchLine(scriptId, lineId, {
+          text: input.text,
+          speakerId: input.speakerId ?? null,
+          direction: input.direction
+        });
+        if (anchor) {
+          // The new line was appended to the anchor's section; move it to sit
+          // just before the anchor within that section.
+          const section = store()
+            .getScript(scriptId)
+            ?.sections.find((s) => s.id === anchor.sectionId);
+          if (section) {
+            const others = section.lines
+              .filter((l) => l.id !== lineId)
+              .map((l) => l.id);
+            const at = others.indexOf(anchor.line.id);
+            others.splice(at >= 0 ? at : others.length, 0, lineId);
+            store().reorderLines(scriptId, section.id, others);
+          }
+        }
+        return reReadLine(lineId);
+      },
+
+      setLineText(target, text) {
+        const { line } = requireLine(target);
+        store().patchLine(scriptId, line.id, { text });
+        return reReadLine(line.id);
+      },
+
+      setLineSpeaker(target, speakerId) {
+        const { line } = requireLine(target);
+        if (speakerId !== null) requireSpeaker(speakerId);
+        store().patchLine(scriptId, line.id, { speakerId });
+        return reReadLine(line.id);
+      },
+
+      async voiceLine(target) {
+        const { line } = requireLine(target);
+        await voiceLine(scriptId, line.id);
+        return reReadLine(line.id);
+      },
+
+      async voiceAll() {
+        const voiced = await voiceAll(scriptId);
+        return { voiced };
+      },
+
+      async sendToTimeline() {
+        const result = await assemble(scriptId);
+        return {
+          sequenceId: result.sequenceId,
+          clipCount: result.clipCount,
+          skippedLineIds: result.skippedLineIds,
+          reassembled: result.reassembled
+        };
+      }
+    };
+  }, [scriptId, assemble]);
+
+  useEffect(() => {
+    if (!active) return;
+    setScriptAgentHandler(handler);
+    return () => {
+      if (hasScriptAgentHandler() && getScriptAgentHandler() === handler) {
+        setScriptAgentHandler(null);
+      }
+    };
+  }, [active, handler]);
+};
+
+export default useScriptAgentBridge;

--- a/web/src/lib/tools/__tests__/scriptTools.test.ts
+++ b/web/src/lib/tools/__tests__/scriptTools.test.ts
@@ -1,0 +1,247 @@
+/**
+ * @jest-environment node
+ */
+import { FrontendToolRegistry } from "../frontendTools";
+import type { FrontendToolState } from "../frontendTools";
+import {
+  setScriptAgentHandler,
+  type ScriptAgentHandler,
+  type ScriptLineNode,
+  type ScriptSnapshot,
+  type ScriptSpeakerNode
+} from "../../../components/script/scriptAgentBridge";
+import "../builtin/script";
+
+const lineNode = (overrides: Partial<ScriptLineNode> = {}): ScriptLineNode => ({
+  id: "line-1",
+  index: 0,
+  sectionId: "sec-1",
+  speakerId: null,
+  speakerName: null,
+  text: "Hello there.",
+  status: "draft",
+  takeCount: 0,
+  currentTakeDurationMs: null,
+  ...overrides
+});
+
+const speakerNode = (
+  overrides: Partial<ScriptSpeakerNode> = {}
+): ScriptSpeakerNode => ({
+  id: "spk-1",
+  name: "Narrator",
+  voice: null,
+  ...overrides
+});
+
+const snapshot = (): ScriptSnapshot => ({
+  scriptId: "script-1",
+  title: "My script",
+  cast: [speakerNode()],
+  lines: [lineNode()],
+  hasTimeline: false,
+  timelineId: null
+});
+
+const createMockHandler = (): jest.Mocked<ScriptAgentHandler> => ({
+  getSnapshot: jest.fn(),
+  addSpeaker: jest.fn(),
+  setSpeakerVoice: jest.fn(),
+  addLine: jest.fn(),
+  setLineText: jest.fn(),
+  setLineSpeaker: jest.fn(),
+  voiceLine: jest.fn(),
+  voiceAll: jest.fn(),
+  sendToTimeline: jest.fn()
+});
+
+// The script tools never touch the workflow state, so a bare stub satisfies ctx.
+const ctx = { getState: () => ({}) as FrontendToolState };
+
+afterEach(() => {
+  setScriptAgentHandler(null);
+});
+
+describe("ui_script_* tools", () => {
+  it("registers all script tools in the manifest", () => {
+    const names = FrontendToolRegistry.getManifest().map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "ui_script_get_state",
+        "ui_script_add_speaker",
+        "ui_script_set_speaker_voice",
+        "ui_script_add_line",
+        "ui_script_set_line_text",
+        "ui_script_set_speaker",
+        "ui_script_voice_line",
+        "ui_script_voice_all",
+        "ui_script_send_to_timeline"
+      ])
+    );
+  });
+
+  it("exposes add_line's parameter schema with text required", () => {
+    const tool = FrontendToolRegistry.getManifest().find(
+      (t) => t.name === "ui_script_add_line"
+    );
+    expect(tool).toBeDefined();
+    const schema = tool?.parameters as {
+      type?: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toHaveProperty("text");
+    expect(schema.required).toContain("text");
+  });
+
+  it("rejects with a descriptive error when no script is open", async () => {
+    await expect(
+      FrontendToolRegistry.call("ui_script_get_state", {}, "tc-1", ctx)
+    ).rejects.toThrow("No script is open.");
+  });
+
+  it("returns the script snapshot through the handler", async () => {
+    const handler = createMockHandler();
+    handler.getSnapshot.mockReturnValue(snapshot());
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_get_state",
+      {},
+      "tc-2",
+      ctx
+    )) as { ok: boolean } & ScriptSnapshot;
+
+    expect(handler.getSnapshot).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0].text).toBe("Hello there.");
+  });
+
+  it("adds a line via the handler", async () => {
+    const handler = createMockHandler();
+    handler.addLine.mockReturnValue(lineNode({ text: "A new line." }));
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_add_line",
+      { text: "A new line.", speakerId: "spk-1" },
+      "tc-3",
+      ctx
+    )) as { ok: boolean; line: ScriptLineNode };
+
+    expect(handler.addLine).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "A new line.", speakerId: "spk-1" })
+    );
+    expect(result.ok).toBe(true);
+    expect(result.line.text).toBe("A new line.");
+  });
+
+  it("adds a speaker with a voice through the handler", async () => {
+    const handler = createMockHandler();
+    handler.addSpeaker.mockReturnValue(
+      speakerNode({
+        name: "Host",
+        voice: { provider: "elevenlabs", model: "eleven_v3", voice: "rachel" }
+      })
+    );
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_add_speaker",
+      {
+        name: "Host",
+        voice: { provider: "elevenlabs", model: "eleven_v3", voice: "rachel" }
+      },
+      "tc-spk",
+      ctx
+    )) as { ok: boolean; speaker: ScriptSpeakerNode };
+
+    expect(handler.addSpeaker).toHaveBeenCalledWith("Host", {
+      provider: "elevenlabs",
+      model: "eleven_v3",
+      voice: "rachel"
+    });
+    expect(result.speaker.name).toBe("Host");
+  });
+
+  it("voices a single line through the handler", async () => {
+    const handler = createMockHandler();
+    handler.voiceLine.mockResolvedValue(
+      lineNode({ status: "voiced", takeCount: 1, currentTakeDurationMs: 1200 })
+    );
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_voice_line",
+      { target: "0" },
+      "tc-4",
+      ctx
+    )) as { ok: boolean; line: ScriptLineNode };
+
+    expect(handler.voiceLine).toHaveBeenCalledWith("0");
+    expect(result.line.status).toBe("voiced");
+  });
+
+  it("voices all lines through the handler", async () => {
+    const handler = createMockHandler();
+    handler.voiceAll.mockResolvedValue({ voiced: 4 });
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_voice_all",
+      {},
+      "tc-all",
+      ctx
+    )) as { ok: boolean; voiced: number };
+
+    expect(handler.voiceAll).toHaveBeenCalled();
+    expect(result.voiced).toBe(4);
+  });
+
+  it("sends the script to a timeline through the handler", async () => {
+    const handler = createMockHandler();
+    handler.sendToTimeline.mockResolvedValue({
+      sequenceId: "seq-1",
+      clipCount: 3,
+      skippedLineIds: ["line-9"],
+      reassembled: false
+    });
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_send_to_timeline",
+      {},
+      "tc-send",
+      ctx
+    )) as {
+      ok: boolean;
+      sequenceId: string;
+      clipCount: number;
+      skippedLineIds: string[];
+      reassembled: boolean;
+    };
+
+    expect(handler.sendToTimeline).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.sequenceId).toBe("seq-1");
+    expect(result.clipCount).toBe(3);
+    expect(result.skippedLineIds).toEqual(["line-9"]);
+  });
+
+  it("clears a line's speaker with null through the handler", async () => {
+    const handler = createMockHandler();
+    handler.setLineSpeaker.mockReturnValue(lineNode({ speakerId: null }));
+    setScriptAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_script_set_speaker",
+      { target: "0", speakerId: null },
+      "tc-6",
+      ctx
+    );
+
+    expect(handler.setLineSpeaker).toHaveBeenCalledWith("0", null);
+  });
+});

--- a/web/src/lib/tools/builtin/script.ts
+++ b/web/src/lib/tools/builtin/script.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import { FrontendToolRegistry } from "../frontendTools";
+import { getScriptAgentHandler } from "../../../components/script/scriptAgentBridge";
+
+/**
+ * Frontend tools that let the agent write and voice the live Script surface —
+ * read its cast and lines, add cast members and lines, edit line text and
+ * speaker, voice lines into takes, and assemble the takes into a timeline. Each
+ * delegates to the handler the open ScriptSurface registers on the
+ * {@link scriptAgentBridge}; when no script is open the handler getter throws
+ * "No script is open." which the tool layer surfaces to the agent.
+ *
+ * Lines are addressed by id or 0-based document index; speakers by id. Call
+ * `ui_script_get_state` first to discover the ids the other tools need.
+ */
+
+const lineTargetParam = z
+  .string()
+  .describe(
+    "Line id or its 0-based index across the whole script (as a string)."
+  );
+
+const voiceParam = z
+  .object({
+    provider: z
+      .string()
+      .describe("TTS provider id, e.g. 'elevenlabs', 'openai'."),
+    model: z.string().describe("TTS model id for the provider."),
+    voice: z.string().describe("Voice id/name within the provider/model."),
+    settings: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe("Provider-specific synthesis knobs (stability, speed, …).")
+  })
+  .describe("A provider/model/voice selection the cast member speaks with.");
+
+FrontendToolRegistry.register({
+  name: "ui_script_get_state",
+  description:
+    "Read the open script: title, whether it has been assembled into a timeline, the cast (each speaker's id, name, and voice binding), and every line in document order with its id, index, section, speaker, text, direction, voicing status (draft/voiced/stale), take count, and current-take duration. Call this first to discover the line/speaker ids the other tools need.",
+  parameters: z.object({}),
+  async execute() {
+    const snapshot = getScriptAgentHandler().getSnapshot();
+    return { ok: true, ...snapshot };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_add_speaker",
+  description:
+    "Add a cast member (speaker). `name` is required; optionally bind a `voice` (provider/model/voice) the speaker is voiced with. Lines assigned to this speaker inherit its voice. Returns the created speaker with its id.",
+  parameters: z.object({
+    name: z.string(),
+    voice: voiceParam.optional()
+  }),
+  async execute({ name, voice }) {
+    const speaker = getScriptAgentHandler().addSpeaker(name, voice);
+    return { ok: true, speaker };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_set_speaker_voice",
+  description:
+    "Set (or replace) the TTS voice bound to a cast member, given its `speakerId` and a `voice` (provider/model/voice). Lines that use this speaker's voice become stale until re-voiced.",
+  parameters: z.object({
+    speakerId: z.string(),
+    voice: voiceParam
+  }),
+  async execute({ speakerId, voice }) {
+    const speaker = getScriptAgentHandler().setSpeakerVoice(speakerId, voice);
+    return { ok: true, speaker };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_add_line",
+  description:
+    "Add a line to the script. `text` is the spoken content (required). Optionally assign a `speakerId` (the line inherits that speaker's voice), a `direction` (a free-form performance note like 'whispering, tired'), and an `index` to insert at (0-based across the document; appended when omitted). The line starts unvoiced.",
+  parameters: z.object({
+    text: z.string(),
+    speakerId: z.string().optional(),
+    direction: z.string().optional(),
+    index: z.number().optional()
+  }),
+  async execute({ text, speakerId, direction, index }) {
+    const line = getScriptAgentHandler().addLine({
+      text,
+      speakerId,
+      direction,
+      index
+    });
+    return { ok: true, line };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_set_line_text",
+  description:
+    "Replace a line's spoken text. If the line was voiced, this makes its current take stale (re-voice it with ui_script_voice_line).",
+  parameters: z.object({ target: lineTargetParam, text: z.string() }),
+  async execute({ target, text }) {
+    const line = getScriptAgentHandler().setLineText(target, text);
+    return { ok: true, line };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_set_speaker",
+  description:
+    "Assign (or clear, with null) the speaker of a line. The line then inherits that speaker's voice. Pass null to unassign the speaker.",
+  parameters: z.object({
+    target: lineTargetParam,
+    speakerId: z.string().nullable()
+  }),
+  async execute({ target, speakerId }) {
+    const line = getScriptAgentHandler().setLineSpeaker(target, speakerId);
+    return { ok: true, line };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_voice_line",
+  description:
+    "Voice a single line into a new take (TTS with the line's effective voice), setting it as the current take. The line must have text and an effective voice (its own override or its speaker's). Returns the updated line; the take's word timings arrive best-effort.",
+  parameters: z.object({ target: lineTargetParam }),
+  async execute({ target }) {
+    const line = await getScriptAgentHandler().voiceLine(target);
+    return { ok: true, line };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_voice_all",
+  description:
+    "Voice every draft or stale line in the script (bounded concurrency), respecting each line's effective voice. Lines already up to date, or with no text or no voice, are skipped. Returns the number of lines voiced.",
+  parameters: z.object({}),
+  async execute() {
+    const result = await getScriptAgentHandler().voiceAll();
+    return { ok: true, ...result };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_script_send_to_timeline",
+  description:
+    "Assemble the script's current takes into a persisted timeline sequence and open it in the timeline editor — one voiceover clip per voiced line, laid end to end with the authored pauses. Lines without a current take are skipped (returned in skippedLineIds). If the script is already linked to a timeline, its voiceover track is rewritten in place (reassembled). Voice at least one line first.",
+  parameters: z.object({}),
+  async execute() {
+    const result = await getScriptAgentHandler().sendToTimeline();
+    return { ok: true, ...result };
+  }
+});

--- a/web/src/lib/tools/frontendToolsIpc.ts
+++ b/web/src/lib/tools/frontendToolsIpc.ts
@@ -27,6 +27,7 @@ import "./builtin/uiActions";
 import "./builtin/model3d";
 import "./builtin/timeline";
 import "./builtin/storyboard";
+import "./builtin/script";
 import "./builtin/puck";
 import "./builtin/entities";
 import { getAgentSocketClient } from "../agent/AgentSocketClient";


### PR DESCRIPTION
Phase 3 of the Script editor (see `docs/script-editor-concept.md`) makes a script drivable by the chat agent and usable inside workflow graphs. Phases 1 (author + voice, #4352) and 2 (to-timeline bridge, #4357) are already on `main`.

## Agent tools + assistant panel (web)

- **`scriptAgentBridge`** — a module-level handler singleton, mirroring `storyboardAgentBridge` / `timelineAgentBridge`. Everything crossing the bridge is plain serializable data (`ScriptSnapshot`, `ScriptLineNode`, `ScriptSpeakerNode`); lines are addressed by id or 0-based document index.
- **`useScriptAgentBridge(scriptId, active)`** — registers the handler for the active Script surface (built over `ScriptStore` + `scriptVoicing` + `useAssembleScriptTimeline`) and clears it on unmount.
- **`ui_script_*` tools** (`lib/tools/builtin/script.ts`, registered in `frontendToolsIpc.ts`): `get_state`, `add_speaker`, `set_speaker_voice`, `add_line`, `set_line_text`, `set_speaker`, `voice_line`, `voice_all`, `send_to_timeline`. This is what makes "paste a topic, get a voiced script" a chat interaction.
- **`ScriptAgentPanel`** — an in-surface assistant reusing `ChatView` + the global chat (same pattern as `TimelineAgentPanel`), behind a **Cast / Assistant** dock toggle added to `ScriptSurface`.

## Graph nodes (packages)

- **`ScriptRef`** protocol type (`{ type: "script", id?, data? }`), a `script` data type + `ScriptProperty` editor, and a **`ConstantScript`** node so a script can be pinned into a graph.
- **`LoadScript`** — read a script's text, lines, name, and line count.
- **`VoiceScript`** — batch TTS over the cast: synthesize every draft/stale line with its effective voice, probe duration, append a take, and persist the script. Reuses the audio TTS provider routing (streaming-PCM → WAV, else the encoded path).
- **`ScriptToTimeline`** — assemble the current takes into a voiceover sequence (one clip per voiced line with `scriptId`/`scriptLineId` linkage keys), creating a new timeline or updating a linked one in place. The headless mirror of the editor's "Send to timeline".
- **`ProcessingContext`** gains `getScript` / `createScript` / `updateScript`, wired to the `Script` model (with the owner check) in the unified websocket runner.

## Tests

- `scriptAgentBridge.test.ts` + `scriptTools.test.ts` (web) — handler register/clear + every tool through `FrontendToolRegistry.call`.
- `script-nodes.test.ts` (video-nodes) — LoadScript text/lines, VoiceScript voices drafts / skips up-to-date & voiceless lines / saves takes, ScriptToTimeline assembly + linkage + re-voice guard.

## Verification

- `npm run build:packages` — 56/56 packages build (backend lint is `tsc --noEmit`, covered).
- `web` typecheck + lint clean; new web tests pass; property/node/config suites pass.
- Backend tests pass for models (script), core-nodes, video-nodes, base-nodes. The only base-nodes failures are pre-existing environmental ones (missing `better-sqlite3` native binding / ffprobe / WebGPU) unrelated to this change — they pass after `npm run rebuild:native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUEZLqTaqiAwxmseF4oUJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUEZLqTaqiAwxmseF4oUJw)_