### PR TITLE
Add Script editor Phase 4: SRT/VTT subtitle export

### DIFF
--- a/docs/script-editor-concept.md
+++ b/docs/script-editor-concept.md
@@ -223,8 +223,15 @@ existing editor is a rewrite, not a feature.
    property editor, and a graph node family (`ConstantScript`, `LoadScript`,
    `VoiceScript` — batch TTS over a cast, `ScriptToTimeline`) reading/writing
    scripts through new `ProcessingContext` script methods.
-4. **Depth** — dialogue-mode rendering, provider-native timestamps, SRT/VTT
-   export, bundle support.
+4. **Depth** — SRT/VTT export *(implemented)*: a shared, framework-agnostic
+   subtitle codec (`@nodetool-ai/timeline` `assembleSubtitleCues` / `cuesToSrt` /
+   `cuesToVtt`) that lays each line's current take end to end with the authored
+   pauses and renders line- or word-granularity cues from the take word timings,
+   surfaced as a graph node (`ScriptToSubtitles`), an agent tool
+   (`ui_script_export_subtitles`), and an "Export SRT" button on the script
+   surface (`exportScriptSubtitles`). Still open: dialogue-mode rendering,
+   provider-native timestamps, audio-only mixdown, and `.nodetool` bundle
+   support.
 
 Phase 1 is deliberately shippable alone: a script you can write, cast, voice,
 and listen to is already the ElevenLabs-Studio use case, before any timeline

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -11,6 +11,7 @@ export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./snap.js";
 export * from "./staleSet.js";
+export * from "./subtitles.js";
 export * from "./placement/index.js";
 export * from "./snapping/index.js";
 export * from "./animation/index.js";

--- a/packages/timeline/src/subtitles.ts
+++ b/packages/timeline/src/subtitles.ts
@@ -1,0 +1,143 @@
+/**
+ * Subtitle export — turn timed caption words into SRT or WebVTT.
+ *
+ * Captions in this codebase are word-level (`CaptionWord`: word + start/end in
+ * ms), timed relative to the clip/take they belong to. A subtitle file is a flat
+ * list of cues laid on an absolute timeline, so exporting is two steps:
+ *
+ *   1. assemble cues — walk a sequence of voiced entries (script lines, timeline
+ *      clips), offsetting each entry's local word timings by a running cursor and
+ *      the authored pauses between them (`assembleSubtitleCues`);
+ *   2. format — render the cues as `.srt` or `.vtt` text (`cuesToSrt`/`cuesToVtt`).
+ *
+ * The module is pure and framework-agnostic (no protocol/model imports) so both
+ * the script graph nodes and the web editor can share one source of truth.
+ */
+
+/** A word timed relative to the entry (line/take/clip) it belongs to. */
+export interface SubtitleWord {
+  word: string;
+  startMs: number;
+  endMs: number;
+}
+
+/** One rendered subtitle cue on the absolute output timeline. */
+export interface SubtitleCue {
+  startMs: number;
+  endMs: number;
+  text: string;
+}
+
+/** A voiced entry to lay onto the subtitle timeline, in playback order. */
+export interface SubtitleEntry {
+  /** The full spoken text of the entry (used for line-granularity cues). */
+  text: string;
+  /** Duration of the entry's audio in ms; the cue span when words are absent. */
+  durationMs: number;
+  /** Entry-local word timings, when available (drives word granularity). */
+  words?: SubtitleWord[];
+  /** Authored silence after this entry before the next one starts. */
+  pauseAfterMs?: number;
+}
+
+export type SubtitleGranularity = "line" | "word";
+export type SubtitleFormat = "srt" | "vtt";
+
+export interface AssembleSubtitleOptions {
+  /**
+   * `"line"` (default) emits one cue per entry spanning its whole duration;
+   * `"word"` emits one cue per timed word, falling back to a line cue for
+   * entries that carry no word timings.
+   */
+  granularity?: SubtitleGranularity;
+}
+
+/** Minimum cue length so a zero/negative span still renders as a visible cue. */
+const MIN_CUE_MS = 1;
+
+/**
+ * Lay a sequence of voiced entries onto an absolute timeline, producing subtitle
+ * cues. Entries run end to end, separated by their `pauseAfterMs`. Empty-text
+ * entries and entries with a non-positive duration are skipped.
+ */
+export function assembleSubtitleCues(
+  entries: SubtitleEntry[],
+  options: AssembleSubtitleOptions = {}
+): SubtitleCue[] {
+  const granularity = options.granularity ?? "line";
+  const cues: SubtitleCue[] = [];
+  let cursorMs = 0;
+
+  for (const entry of entries) {
+    const text = entry.text.trim();
+    const durationMs = entry.durationMs;
+    if (!text || durationMs <= 0) continue;
+
+    if (granularity === "word" && entry.words && entry.words.length > 0) {
+      for (const word of entry.words) {
+        const label = word.word.trim();
+        if (!label) continue;
+        const startMs = cursorMs + Math.max(0, word.startMs);
+        const endMs = cursorMs + Math.max(word.startMs, word.endMs);
+        cues.push({
+          startMs,
+          endMs: Math.max(startMs + MIN_CUE_MS, endMs),
+          text: label
+        });
+      }
+    } else {
+      cues.push({
+        startMs: cursorMs,
+        endMs: cursorMs + Math.max(MIN_CUE_MS, durationMs),
+        text
+      });
+    }
+
+    cursorMs += durationMs + Math.max(0, entry.pauseAfterMs ?? 0);
+  }
+
+  return cues;
+}
+
+/** `HH:MM:SS<sep>mmm` — SRT uses a comma separator, WebVTT a period. */
+function formatTimestamp(totalMs: number, sep: "," | "."): string {
+  const ms = Math.max(0, Math.round(totalMs));
+  const hours = Math.floor(ms / 3_600_000);
+  const minutes = Math.floor((ms % 3_600_000) / 60_000);
+  const seconds = Math.floor((ms % 60_000) / 1000);
+  const millis = ms % 1000;
+  const pad = (n: number, width = 2): string => String(n).padStart(width, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}${sep}${pad(millis, 3)}`;
+}
+
+/** Render cues as SubRip (`.srt`): numbered blocks, comma-decimal timestamps. */
+export function cuesToSrt(cues: SubtitleCue[]): string {
+  return (
+    cues
+      .map((cue, index) => {
+        const start = formatTimestamp(cue.startMs, ",");
+        const end = formatTimestamp(cue.endMs, ",");
+        return `${index + 1}\n${start} --> ${end}\n${cue.text}`;
+      })
+      .join("\n\n") + (cues.length > 0 ? "\n" : "")
+  );
+}
+
+/** Render cues as WebVTT (`.vtt`): `WEBVTT` header, period-decimal timestamps. */
+export function cuesToVtt(cues: SubtitleCue[]): string {
+  if (cues.length === 0) return "WEBVTT\n";
+  const blocks = cues.map((cue) => {
+    const start = formatTimestamp(cue.startMs, ".");
+    const end = formatTimestamp(cue.endMs, ".");
+    return `${start} --> ${end}\n${cue.text}`;
+  });
+  return `WEBVTT\n\n${blocks.join("\n\n")}\n`;
+}
+
+/** Render cues in the requested format. */
+export function formatSubtitles(
+  cues: SubtitleCue[],
+  format: SubtitleFormat
+): string {
+  return format === "vtt" ? cuesToVtt(cues) : cuesToSrt(cues);
+}

--- a/packages/timeline/tests/subtitles.test.ts
+++ b/packages/timeline/tests/subtitles.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  assembleSubtitleCues,
+  cuesToSrt,
+  cuesToVtt,
+  formatSubtitles,
+  type SubtitleEntry
+} from "../src/subtitles.js";
+
+describe("assembleSubtitleCues", () => {
+  it("lays line cues end to end, offsetting by durations and pauses", () => {
+    const entries: SubtitleEntry[] = [
+      { text: "Hello there.", durationMs: 1500, pauseAfterMs: 500 },
+      { text: "Welcome.", durationMs: 1000 }
+    ];
+    const cues = assembleSubtitleCues(entries);
+    expect(cues).toEqual([
+      { startMs: 0, endMs: 1500, text: "Hello there." },
+      { startMs: 2000, endMs: 3000, text: "Welcome." }
+    ]);
+  });
+
+  it("skips empty-text and non-positive-duration entries", () => {
+    const cues = assembleSubtitleCues([
+      { text: "   ", durationMs: 1000 },
+      { text: "Kept.", durationMs: 0 },
+      { text: "Real.", durationMs: 800 }
+    ]);
+    expect(cues).toEqual([{ startMs: 0, endMs: 800, text: "Real." }]);
+  });
+
+  it("emits per-word cues in word granularity, offset by the cursor", () => {
+    const entries: SubtitleEntry[] = [
+      {
+        text: "Hi you",
+        durationMs: 1000,
+        words: [
+          { word: "Hi", startMs: 0, endMs: 400 },
+          { word: "you", startMs: 500, endMs: 900 }
+        ],
+        pauseAfterMs: 200
+      },
+      {
+        text: "Bye",
+        durationMs: 500,
+        words: [{ word: "Bye", startMs: 100, endMs: 450 }]
+      }
+    ];
+    const cues = assembleSubtitleCues(entries, { granularity: "word" });
+    expect(cues).toEqual([
+      { startMs: 0, endMs: 400, text: "Hi" },
+      { startMs: 500, endMs: 900, text: "you" },
+      // Second entry starts at 1000 + 200 pause = 1200.
+      { startMs: 1300, endMs: 1650, text: "Bye" }
+    ]);
+  });
+
+  it("falls back to a line cue when word granularity finds no words", () => {
+    const cues = assembleSubtitleCues(
+      [{ text: "No timings", durationMs: 900 }],
+      { granularity: "word" }
+    );
+    expect(cues).toEqual([{ startMs: 0, endMs: 900, text: "No timings" }]);
+  });
+
+  it("guarantees a minimum visible span for zero-length words", () => {
+    const cues = assembleSubtitleCues(
+      [
+        {
+          text: "x",
+          durationMs: 100,
+          words: [{ word: "x", startMs: 50, endMs: 50 }]
+        }
+      ],
+      { granularity: "word" }
+    );
+    expect(cues[0].endMs).toBeGreaterThan(cues[0].startMs);
+  });
+});
+
+describe("cuesToSrt", () => {
+  it("numbers blocks and uses comma-decimal timestamps", () => {
+    const srt = cuesToSrt([
+      { startMs: 0, endMs: 1500, text: "Hello there." },
+      { startMs: 2000, endMs: 3000, text: "Welcome." }
+    ]);
+    expect(srt).toBe(
+      "1\n00:00:00,000 --> 00:00:01,500\nHello there.\n\n" +
+        "2\n00:00:02,000 --> 00:00:03,000\nWelcome.\n"
+    );
+  });
+
+  it("formats hours and minutes past a minute", () => {
+    const srt = cuesToSrt([
+      { startMs: 3_661_234, endMs: 3_662_000, text: "Late." }
+    ]);
+    expect(srt).toContain("01:01:01,234 --> 01:01:02,000");
+  });
+
+  it("renders empty for no cues", () => {
+    expect(cuesToSrt([])).toBe("");
+  });
+});
+
+describe("cuesToVtt", () => {
+  it("prepends the WEBVTT header and uses period-decimal timestamps", () => {
+    const vtt = cuesToVtt([
+      { startMs: 0, endMs: 1500, text: "Hello there." }
+    ]);
+    expect(vtt).toBe(
+      "WEBVTT\n\n00:00:00.000 --> 00:00:01.500\nHello there.\n"
+    );
+  });
+
+  it("emits just the header for no cues", () => {
+    expect(cuesToVtt([])).toBe("WEBVTT\n");
+  });
+});
+
+describe("formatSubtitles", () => {
+  it("dispatches on format", () => {
+    const cues = [{ startMs: 0, endMs: 1000, text: "Hi." }];
+    expect(formatSubtitles(cues, "srt")).toBe(cuesToSrt(cues));
+    expect(formatSubtitles(cues, "vtt")).toBe(cuesToVtt(cues));
+  });
+});

--- a/packages/video-nodes/src/nodes/script.ts
+++ b/packages/video-nodes/src/nodes/script.ts
@@ -10,14 +10,19 @@
  */
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import type { ScriptRef, TimelineRef } from "@nodetool-ai/protocol";
+import type { ScriptRef } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { concatBytes, encodePcm16Wav } from "@nodetool-ai/audio-nodes";
 import {
+  assembleSubtitleCues,
+  formatSubtitles,
   makeClip,
   makeSequence,
   makeTrack,
   type CaptionWord,
+  type SubtitleEntry,
+  type SubtitleFormat,
+  type SubtitleGranularity,
   type TimelineClip,
   type TimelineSequence,
   type TimelineTrack
@@ -416,6 +421,81 @@ export class ScriptToTimelineNode extends BaseNode {
   }
 }
 
+export class ScriptToSubtitlesNode extends BaseNode {
+  static readonly nodeType = "nodetool.script.ScriptToSubtitles";
+  static readonly title = "Script To Subtitles";
+  static readonly description =
+    "Export a voiced script as SRT or WebVTT subtitles, straight from each current take's word timings — one cue per line (or per word), laid out end to end with the authored pauses. Voice the script first; unvoiced lines are skipped.\n    script, subtitles, srt, vtt, captions, export\n\n    Use cases:\n    - Produce a subtitle sidecar for a voiced narration\n    - Generate word-timed captions from take timings\n    - Feed subtitles into a burn-in or upload step";
+  static readonly metadataOutputTypes = {
+    subtitles: "str",
+    cue_count: "int"
+  };
+  static readonly inlineFields = ["script", "format", "granularity"];
+  static readonly inputFields = ["script"];
+
+  @prop({
+    type: "script",
+    default: scriptRefDefault,
+    title: "Script",
+    description: "The voiced script to export subtitles from."
+  })
+  declare script: ScriptRef;
+
+  @prop({
+    type: "enum",
+    default: "srt",
+    title: "Format",
+    description: "Subtitle format: SubRip (.srt) or WebVTT (.vtt).",
+    values: ["srt", "vtt"]
+  })
+  declare format: SubtitleFormat;
+
+  @prop({
+    type: "enum",
+    default: "line",
+    title: "Granularity",
+    description:
+      "One cue per line (whole line text) or per word (using take word timings).",
+    values: ["line", "word"]
+  })
+  declare granularity: SubtitleGranularity;
+
+  async process(
+    context?: ProcessingContext
+  ): Promise<Record<string, unknown>> {
+    const script = await loadScript(this.script, context);
+    const doc = script.document;
+
+    const entries: SubtitleEntry[] = [];
+    for (const line of allLines(doc)) {
+      const take = currentTake(line);
+      if (!take || !take.assetId) continue;
+      const text = line.text.trim();
+      if (!text) continue;
+      entries.push({
+        text: line.text,
+        durationMs: take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS,
+        words: take.words,
+        pauseAfterMs: line.pauseAfterMs
+      });
+    }
+
+    if (entries.length === 0) {
+      throw new Error(
+        "ScriptToSubtitles: no voiced lines to export — voice the script first"
+      );
+    }
+
+    const cues = assembleSubtitleCues(entries, {
+      granularity: this.granularity
+    });
+    return {
+      subtitles: formatSubtitles(cues, this.format),
+      cue_count: cues.length
+    };
+  }
+}
+
 // ── TTS helpers (mirror audio TextToSpeechNode's provider routing) ──
 
 interface SynthResult {
@@ -498,5 +578,6 @@ async function probeDurationMs(
 export const SCRIPT_NODES = tagAsNode([
   LoadScriptNode,
   VoiceScriptNode,
-  ScriptToTimelineNode
+  ScriptToTimelineNode,
+  ScriptToSubtitlesNode
 ]);

--- a/packages/video-nodes/tests/script-nodes.test.ts
+++ b/packages/video-nodes/tests/script-nodes.test.ts
@@ -39,9 +39,12 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...original, execFile: mockExecFile };
 });
 
-const { LoadScriptNode, VoiceScriptNode, ScriptToTimelineNode } = await import(
-  "../src/nodes/script.js"
-);
+const {
+  LoadScriptNode,
+  VoiceScriptNode,
+  ScriptToTimelineNode,
+  ScriptToSubtitlesNode
+} = await import("../src/nodes/script.js");
 
 const VOICE = { provider: "openai", model: "tts-1", voice: "alloy" };
 
@@ -248,6 +251,85 @@ describe("ScriptToTimelineNode", () => {
   it("throws when no lines are voiced", async () => {
     const context = stubContext(baseScript());
     const node = new ScriptToTimelineNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    await expect(node.process(context as never)).rejects.toThrow(
+      /no voiced lines/
+    );
+  });
+});
+
+describe("ScriptToSubtitlesNode", () => {
+  function voicedScript() {
+    const script = baseScript();
+    const lines = script.document.sections[0].lines;
+    lines[0].takes = [
+      {
+        id: "take-1",
+        assetId: "asset-1",
+        durationMs: 1500,
+        words: [
+          { word: "Hello", startMs: 0, endMs: 700 },
+          { word: "there.", startMs: 800, endMs: 1400 }
+        ],
+        textSnapshot: lines[0].text,
+        voiceSnapshot: VOICE,
+        createdAt: "2026-01-01T00:00:00.000Z"
+      }
+    ];
+    lines[0].currentTakeId = "take-1";
+    lines[0].pauseAfterMs = 500;
+    lines[1].takes = [
+      {
+        id: "take-2",
+        assetId: "asset-2",
+        durationMs: 1000,
+        words: [],
+        textSnapshot: lines[1].text,
+        voiceSnapshot: VOICE,
+        createdAt: "2026-01-01T00:00:00.000Z"
+      }
+    ];
+    lines[1].currentTakeId = "take-2";
+    return script;
+  }
+
+  it("exports SRT line cues offset by durations and pauses", async () => {
+    const context = stubContext(voicedScript());
+    const node = new ScriptToSubtitlesNode();
+    node.assign({ script: { type: "script", id: "script-1" } });
+    const result = (await node.process(context as never)) as {
+      subtitles: string;
+      cue_count: number;
+    };
+    expect(result.cue_count).toBe(2);
+    expect(result.subtitles).toBe(
+      "1\n00:00:00,000 --> 00:00:01,500\nHello there.\n\n" +
+        "2\n00:00:02,000 --> 00:00:03,000\nWelcome.\n"
+    );
+  });
+
+  it("exports WebVTT word cues from take word timings", async () => {
+    const context = stubContext(voicedScript());
+    const node = new ScriptToSubtitlesNode();
+    node.assign({
+      script: { type: "script", id: "script-1" },
+      format: "vtt",
+      granularity: "word"
+    });
+    const result = (await node.process(context as never)) as {
+      subtitles: string;
+      cue_count: number;
+    };
+    // Two timed words on line 1, line 2 falls back to one line cue.
+    expect(result.cue_count).toBe(3);
+    expect(result.subtitles.startsWith("WEBVTT")).toBe(true);
+    expect(result.subtitles).toContain("00:00:00.000 --> 00:00:00.700\nHello");
+    expect(result.subtitles).toContain("00:00:00.800 --> 00:00:01.400\nthere.");
+  });
+
+  it("throws when no lines are voiced", async () => {
+    const context = stubContext(baseScript());
+    const node = new ScriptToSubtitlesNode();
     node.assign({ script: { type: "script", id: "script-1" } });
     await expect(node.process(context as never)).rejects.toThrow(
       /no voiced lines/

--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -5,6 +5,7 @@ import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import MovieIcon from "@mui/icons-material/Movie";
+import SubtitlesIcon from "@mui/icons-material/Subtitles";
 import {
   FlexColumn,
   FlexRow,
@@ -24,6 +25,7 @@ import {
   type ScriptSection
 } from "../../stores/script/ScriptStore";
 import { voiceAll } from "../../stores/script/scriptVoicing";
+import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
 import ScriptLineRow from "./ScriptLineRow";
@@ -126,6 +128,25 @@ const ScriptDocumentPane = ({
     });
   }, [assemble, scriptId]);
 
+  const onExportSubtitles = useCallback(() => {
+    const script = useScriptStore.getState().getScript(scriptId);
+    if (!script) return;
+    const result = exportScriptSubtitles(script, { format: "srt" });
+    if (!result) return;
+    const base =
+      script.title.trim().replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+/, "") ||
+      "script";
+    const blob = new Blob([result.text], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${base}.${result.format}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [scriptId]);
+
   const isEmpty = sections.every((s) => s.lines.length === 0);
   const hasVoicedLine = sections.some((section) =>
     section.lines.some((line) =>
@@ -204,6 +225,22 @@ const ScriptDocumentPane = ({
               : timelineId
                 ? "Update timeline"
                 : "Send to timeline"}
+          </EditorButton>
+        )}
+        {!readOnly && (
+          <EditorButton
+            size="small"
+            variant="outlined"
+            startIcon={<SubtitlesIcon fontSize="small" />}
+            onClick={onExportSubtitles}
+            disabled={!hasVoicedLine}
+            title={
+              hasVoicedLine
+                ? "Download SRT subtitles from the voiced takes"
+                : "Voice at least one line to export subtitles"
+            }
+          >
+            Export SRT
           </EditorButton>
         )}
       </FlexRow>

--- a/web/src/components/script/__tests__/scriptAgentBridge.test.ts
+++ b/web/src/components/script/__tests__/scriptAgentBridge.test.ts
@@ -14,7 +14,8 @@ const makeMockHandler = (): ScriptAgentHandler => ({
   setLineSpeaker: jest.fn(),
   voiceLine: jest.fn(),
   voiceAll: jest.fn(),
-  sendToTimeline: jest.fn()
+  sendToTimeline: jest.fn(),
+  exportSubtitles: jest.fn()
 });
 
 describe("scriptAgentBridge", () => {

--- a/web/src/components/script/scriptAgentBridge.ts
+++ b/web/src/components/script/scriptAgentBridge.ts
@@ -15,6 +15,10 @@
  */
 
 import type { VoiceBinding } from "../../stores/script/ScriptStore";
+import type {
+  SubtitleFormat,
+  SubtitleGranularity
+} from "@nodetool-ai/timeline";
 
 /** A voiced take's line status, derived from the current take vs. the line. */
 export type ScriptLineStatus = "draft" | "voiced" | "stale";
@@ -97,6 +101,14 @@ export interface ScriptAgentHandler {
     skippedLineIds: string[];
     reassembled: boolean;
   }>;
+  /**
+   * Render the script's current takes as SRT or WebVTT subtitles (from the take
+   * word timings) and trigger a download. Throws when no line is voiced.
+   */
+  exportSubtitles: (options?: {
+    format?: SubtitleFormat;
+    granularity?: SubtitleGranularity;
+  }) => { text: string; format: SubtitleFormat; cueCount: number };
 }
 
 let handler: ScriptAgentHandler | null = null;

--- a/web/src/hooks/script/useScriptAgentBridge.ts
+++ b/web/src/hooks/script/useScriptAgentBridge.ts
@@ -19,6 +19,7 @@ import {
   type VoiceBinding
 } from "../../stores/script/ScriptStore";
 import { voiceLine, voiceAll } from "../../stores/script/scriptVoicing";
+import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useAssembleScriptTimeline } from "./useAssembleScriptTimeline";
 import {
   getScriptAgentHandler,
@@ -221,6 +222,21 @@ export const useScriptAgentBridge = (
           clipCount: result.clipCount,
           skippedLineIds: result.skippedLineIds,
           reassembled: result.reassembled
+        };
+      },
+
+      exportSubtitles(options) {
+        const script = requireScript();
+        const result = exportScriptSubtitles(script, options);
+        if (!result) {
+          throw new Error(
+            "No voiced lines to export — voice at least one line first."
+          );
+        }
+        return {
+          text: result.text,
+          format: result.format,
+          cueCount: result.cueCount
         };
       }
     };

--- a/web/src/lib/tools/__tests__/scriptTools.test.ts
+++ b/web/src/lib/tools/__tests__/scriptTools.test.ts
@@ -52,7 +52,8 @@ const createMockHandler = (): jest.Mocked<ScriptAgentHandler> => ({
   setLineSpeaker: jest.fn(),
   voiceLine: jest.fn(),
   voiceAll: jest.fn(),
-  sendToTimeline: jest.fn()
+  sendToTimeline: jest.fn(),
+  exportSubtitles: jest.fn()
 });
 
 // The script tools never touch the workflow state, so a bare stub satisfies ctx.
@@ -75,7 +76,8 @@ describe("ui_script_* tools", () => {
         "ui_script_set_speaker",
         "ui_script_voice_line",
         "ui_script_voice_all",
-        "ui_script_send_to_timeline"
+        "ui_script_send_to_timeline",
+        "ui_script_export_subtitles"
       ])
     );
   });
@@ -228,6 +230,31 @@ describe("ui_script_* tools", () => {
     expect(result.sequenceId).toBe("seq-1");
     expect(result.clipCount).toBe(3);
     expect(result.skippedLineIds).toEqual(["line-9"]);
+  });
+
+  it("exports subtitles through the handler", async () => {
+    const handler = createMockHandler();
+    handler.exportSubtitles.mockReturnValue({
+      text: "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHi.\n",
+      format: "vtt",
+      cueCount: 1
+    });
+    setScriptAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_script_export_subtitles",
+      { format: "vtt", granularity: "word" },
+      "tc-subs",
+      ctx
+    )) as { ok: boolean; text: string; format: string; cueCount: number };
+
+    expect(handler.exportSubtitles).toHaveBeenCalledWith({
+      format: "vtt",
+      granularity: "word"
+    });
+    expect(result.ok).toBe(true);
+    expect(result.format).toBe("vtt");
+    expect(result.cueCount).toBe(1);
   });
 
   it("clears a line's speaker with null through the handler", async () => {

--- a/web/src/lib/tools/builtin/script.ts
+++ b/web/src/lib/tools/builtin/script.ts
@@ -142,6 +142,31 @@ FrontendToolRegistry.register({
 });
 
 FrontendToolRegistry.register({
+  name: "ui_script_export_subtitles",
+  description:
+    "Export the script's current takes as SRT or WebVTT subtitles, straight from the take word timings — one cue per line (default) or per word, laid out end to end with the authored pauses. Unvoiced lines are skipped; voice at least one line first. Returns the subtitle file text and cue count.",
+  parameters: z.object({
+    format: z
+      .enum(["srt", "vtt"])
+      .optional()
+      .describe("Subtitle format: SubRip (srt, default) or WebVTT (vtt)."),
+    granularity: z
+      .enum(["line", "word"])
+      .optional()
+      .describe(
+        "One cue per line (default) or per word (using take word timings)."
+      )
+  }),
+  async execute({ format, granularity }) {
+    const result = getScriptAgentHandler().exportSubtitles({
+      format,
+      granularity
+    });
+    return { ok: true, ...result };
+  }
+});
+
+FrontendToolRegistry.register({
   name: "ui_script_send_to_timeline",
   description:
     "Assemble the script's current takes into a persisted timeline sequence and open it in the timeline editor — one voiceover clip per voiced line, laid end to end with the authored pauses. Lines without a current take are skipped (returned in skippedLineIds). If the script is already linked to a timeline, its voiceover track is rewritten in place (reassembled). Voice at least one line first.",

--- a/web/src/stores/script/__tests__/scriptSubtitles.test.ts
+++ b/web/src/stores/script/__tests__/scriptSubtitles.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment node
+ *
+ * Subtitle export from a script's current takes: line and word granularity,
+ * pause/duration layout, unvoiced-line skipping, and the empty-script guard.
+ */
+
+import {
+  exportScriptSubtitles,
+  scriptSubtitleEntries
+} from "../scriptSubtitles";
+import type {
+  ScriptDraft,
+  ScriptLine,
+  ScriptTake,
+  VoiceBinding
+} from "../ScriptStore";
+
+const VOICE: VoiceBinding = {
+  provider: "openai",
+  model: "tts-1",
+  voice: "alloy"
+};
+
+const take = (over: Partial<ScriptTake>): ScriptTake => ({
+  id: "take-x",
+  assetId: "asset-x",
+  durationMs: 1000,
+  words: [],
+  textSnapshot: "hello",
+  voiceSnapshot: VOICE,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...over
+});
+
+const line = (over: Partial<ScriptLine>): ScriptLine => ({
+  id: "line-x",
+  text: "",
+  takes: [],
+  ...over
+});
+
+const draft = (lines: ScriptLine[]): ScriptDraft => ({
+  id: "script-1",
+  title: "My Script",
+  cast: [],
+  sections: [{ id: "sec-1", lines }],
+  timelineId: null,
+  updatedAt: 0
+});
+
+describe("scriptSubtitleEntries", () => {
+  it("keeps only voiced lines with text, in document order", () => {
+    const script = draft([
+      line({
+        id: "l1",
+        text: "Voiced.",
+        currentTakeId: "t1",
+        takes: [take({ id: "t1", durationMs: 1200 })]
+      }),
+      line({ id: "l2", text: "Draft, no take." }),
+      line({
+        id: "l3",
+        text: "   ",
+        currentTakeId: "t3",
+        takes: [take({ id: "t3" })]
+      })
+    ]);
+    const entries = scriptSubtitleEntries(script);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ text: "Voiced.", durationMs: 1200 });
+  });
+});
+
+describe("exportScriptSubtitles", () => {
+  const voiced = (): ScriptDraft =>
+    draft([
+      line({
+        id: "l1",
+        text: "Hello there.",
+        pauseAfterMs: 500,
+        currentTakeId: "t1",
+        takes: [
+          take({
+            id: "t1",
+            durationMs: 1500,
+            words: [
+              { word: "Hello", startMs: 0, endMs: 700 },
+              { word: "there.", startMs: 800, endMs: 1400 }
+            ]
+          })
+        ]
+      }),
+      line({
+        id: "l2",
+        text: "Welcome.",
+        currentTakeId: "t2",
+        takes: [take({ id: "t2", durationMs: 1000, words: [] })]
+      })
+    ]);
+
+  it("renders SRT line cues offset by durations and pauses", () => {
+    const result = exportScriptSubtitles(voiced(), { format: "srt" });
+    expect(result).not.toBeNull();
+    expect(result?.cueCount).toBe(2);
+    expect(result?.text).toBe(
+      "1\n00:00:00,000 --> 00:00:01,500\nHello there.\n\n" +
+        "2\n00:00:02,000 --> 00:00:03,000\nWelcome.\n"
+    );
+  });
+
+  it("renders WebVTT word cues from take word timings", () => {
+    const result = exportScriptSubtitles(voiced(), {
+      format: "vtt",
+      granularity: "word"
+    });
+    expect(result?.format).toBe("vtt");
+    expect(result?.cueCount).toBe(3);
+    expect(result?.text.startsWith("WEBVTT")).toBe(true);
+    expect(result?.text).toContain("00:00:00.000 --> 00:00:00.700\nHello");
+  });
+
+  it("returns null when nothing is voiced", () => {
+    expect(exportScriptSubtitles(draft([line({ text: "Draft." })]))).toBeNull();
+  });
+});

--- a/web/src/stores/script/scriptSubtitles.ts
+++ b/web/src/stores/script/scriptSubtitles.ts
@@ -1,0 +1,71 @@
+/**
+ * scriptSubtitles — export a script's current takes as SRT or WebVTT.
+ *
+ * Text is the source of truth, audio (and its word timings) is derived: this
+ * walks the script's lines in document order, takes each line's *current* take,
+ * and lays the takes end to end with the authored `pauseAfterMs` gaps — the same
+ * layout `assembleScriptTimeline` uses — then renders subtitle cues via the
+ * shared `@nodetool-ai/timeline` formatter. Unvoiced lines (no current take) are
+ * skipped.
+ */
+
+import {
+  assembleSubtitleCues,
+  formatSubtitles,
+  type SubtitleEntry,
+  type SubtitleFormat,
+  type SubtitleGranularity
+} from "@nodetool-ai/timeline";
+
+import type { ScriptDraft } from "./ScriptStore";
+
+/** Fallback cue length for a current take whose duration is unknown. */
+const PLACEHOLDER_LINE_MS = 3000;
+
+export interface ScriptSubtitleOptions {
+  format?: SubtitleFormat;
+  granularity?: SubtitleGranularity;
+}
+
+export interface ScriptSubtitleResult {
+  /** The rendered subtitle file content. */
+  text: string;
+  format: SubtitleFormat;
+  cueCount: number;
+}
+
+/** Build the voiced entries a subtitle export lays onto its timeline. */
+export const scriptSubtitleEntries = (script: ScriptDraft): SubtitleEntry[] => {
+  const entries: SubtitleEntry[] = [];
+  for (const section of script.sections) {
+    for (const line of section.lines) {
+      const take = line.takes.find((t) => t.id === line.currentTakeId);
+      if (!take || !take.assetId) continue;
+      if (!line.text.trim()) continue;
+      entries.push({
+        text: line.text,
+        durationMs: take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS,
+        words: take.words,
+        pauseAfterMs: line.pauseAfterMs
+      });
+    }
+  }
+  return entries;
+};
+
+/**
+ * Render a script's current takes as subtitles. Returns `null` when the script
+ * has no voiced lines to export.
+ */
+export const exportScriptSubtitles = (
+  script: ScriptDraft,
+  options: ScriptSubtitleOptions = {}
+): ScriptSubtitleResult | null => {
+  const format = options.format ?? "srt";
+  const entries = scriptSubtitleEntries(script);
+  if (entries.length === 0) return null;
+  const cues = assembleSubtitleCues(entries, {
+    granularity: options.granularity ?? "line"
+  });
+  return { text: formatSubtitles(cues, format), format, cueCount: cues.length };
+};


### PR DESCRIPTION
Phase 4 ("Depth") of the [Script editor](../blob/main/docs/script-editor-concept.md) starts with **subtitle export**: turn a voiced script's current takes into an SRT or WebVTT file, straight from the take word timings.

A script keeps text as the source of truth and audio (with its word timings) derived. This export walks the script's lines in document order, takes each line's *current* take, and lays the takes end to end with the authored `pauseAfterMs` gaps — the same layout "send to timeline" uses — then renders subtitle cues.

## What's included

- **Shared codec** — `packages/timeline/src/subtitles.ts`: `assembleSubtitleCues` lays voiced entries onto an absolute timeline into cues (`line` granularity → one cue per line, `word` → one cue per timed word, falling back to a line cue when a take has no words); `cuesToSrt` / `cuesToVtt` / `formatSubtitles` render them. Pure and framework-agnostic (no protocol/model imports) so the graph node and the web editor share one source of truth.
- **Graph node** — `nodetool.script.ScriptToSubtitles` (`format` + `granularity` props) for headless pipelines: LLM writes → voice → export subtitles.
- **Agent tool** — `ui_script_export_subtitles`, plus an `exportSubtitles` method on the script agent bridge.
- **UI** — an "Export SRT" button on the script surface that downloads the file (enabled once a line is voiced).
- **Doc** — the concept doc's phasing marks SRT/VTT export as implemented and lists what remains in Phase 4 (dialogue-mode rendering, provider-native timestamps, audio-only mixdown, `.nodetool` bundle support).

## Testing

- `packages/timeline/tests/subtitles.test.ts` — cue assembly (line/word, pause/duration layout, skip rules, min-span) and SRT/VTT formatting.
- `packages/video-nodes/tests/script-nodes.test.ts` — `ScriptToSubtitles` SRT line export, VTT word export, and the empty-script guard.
- `web/src/stores/script/__tests__/scriptSubtitles.test.ts` — the web export helper.
- `web/src/lib/tools/__tests__/scriptTools.test.ts` — the `ui_script_export_subtitles` tool wiring.

`npm run typecheck` (web + video-nodes), root `oxlint`, and web `lint:design` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGTVsg5vGpT1N1bNVPhGzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGTVsg5vGpT1N1bNVPhGzZ)_