### PR TITLE
refactor(script): lay out the script editor as a document

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -9,14 +9,16 @@ import SubtitlesIcon from "@mui/icons-material/Subtitles";
 import {
   FlexColumn,
   FlexRow,
+  Box,
   Text,
   TextInput,
   EditorButton,
   ToolbarIconButton,
-  Divider,
   EmptyState,
   LoadingSpinner,
   SPACING,
+  TYPOGRAPHY,
+  MOTION,
   Z_INDEX
 } from "../ui_primitives";
 import {
@@ -28,7 +30,7 @@ import { voiceAll } from "../../stores/script/scriptVoicing";
 import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
-import ScriptLineRow from "./ScriptLineRow";
+import ScriptLineRow, { GUTTER } from "./ScriptLineRow";
 
 interface ScriptDocumentPaneProps {
   scriptId: string;
@@ -52,29 +54,58 @@ const SectionBlock = ({
   const removeSection = useScriptStore((s) => s.removeSection);
 
   return (
-    <FlexColumn gap={SPACING.xs} fullWidth>
-      <FlexRow align="center" gap={SPACING.sm} fullWidth>
+    <FlexColumn
+      gap={SPACING.xs}
+      fullWidth
+      sx={{
+        "& .section-remove": { opacity: 0, transition: MOTION.opacity },
+        "&:hover .section-remove, &:focus-within .section-remove": {
+          opacity: 1
+        }
+      }}
+    >
+      <FlexRow
+        align="center"
+        gap={SPACING.sm}
+        fullWidth
+        sx={{
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          paddingBottom: SPACING.xs,
+          marginBottom: SPACING.sm
+        }}
+      >
         <TextInput
           value={section.title ?? ""}
           onChange={(e) =>
             setSectionTitle(scriptId, section.id, e.target.value)
           }
-          placeholder="Section title (optional)…"
+          placeholder="Untitled section"
           hideLabel
           label="Section title"
           compact
           fullWidth
           disabled={readOnly}
+          sx={{
+            "& .MuiOutlinedInput-root": { backgroundColor: "transparent" },
+            "& .MuiOutlinedInput-notchedOutline": { border: "none" },
+            "& .MuiOutlinedInput-input": {
+              paddingLeft: SPACING.none,
+              ...TYPOGRAPHY.sans.title,
+              letterSpacing: "0.02em"
+            }
+          }}
         />
         {!readOnly && (
-          <ToolbarIconButton
-            tooltip="Remove section"
-            onClick={() => removeSection(scriptId, section.id)}
-            icon={<Text size="smaller">✕</Text>}
-          />
+          <Box className="section-remove">
+            <ToolbarIconButton
+              tooltip="Remove section"
+              onClick={() => removeSection(scriptId, section.id)}
+              icon={<Text size="smaller">✕</Text>}
+            />
+          </Box>
         )}
       </FlexRow>
-      <Divider />
       {section.lines.map((line) => (
         <ScriptLineRow
           key={line.id}
@@ -86,7 +117,7 @@ const SectionBlock = ({
         />
       ))}
       {!readOnly && (
-        <FlexRow>
+        <FlexRow sx={{ marginLeft: `${GUTTER + 8}px` }}>
           <EditorButton
             size="small"
             variant="text"
@@ -163,7 +194,8 @@ const ScriptDocumentPane = ({
         align="center"
         gap={SPACING.sm}
         sx={{
-          padding: SPACING.sm,
+          paddingY: SPACING.sm,
+          paddingX: SPACING.md,
           borderBottom: "1px solid",
           borderColor: "divider",
           position: "sticky",
@@ -181,7 +213,7 @@ const ScriptDocumentPane = ({
           ) : (
             <EditorButton
               size="small"
-              variant="outlined"
+              variant="contained"
               startIcon={<GraphicEqIcon fontSize="small" />}
               onClick={() => void onVoiceAll()}
             >
@@ -191,7 +223,7 @@ const ScriptDocumentPane = ({
         {playing ? (
           <EditorButton
             size="small"
-            variant="outlined"
+            variant="text"
             startIcon={<StopIcon fontSize="small" />}
             onClick={stop}
           >
@@ -200,17 +232,18 @@ const ScriptDocumentPane = ({
         ) : (
           <EditorButton
             size="small"
-            variant="outlined"
+            variant="text"
             startIcon={<PlayArrowIcon fontSize="small" />}
             onClick={play}
           >
             Play through
           </EditorButton>
         )}
+        <Box sx={{ flex: 1 }} />
         {!readOnly && (
           <EditorButton
             size="small"
-            variant="outlined"
+            variant="text"
             startIcon={<MovieIcon fontSize="small" />}
             onClick={onSendToTimeline}
             disabled={assembling || !hasVoicedLine}
@@ -230,7 +263,7 @@ const ScriptDocumentPane = ({
         {!readOnly && (
           <EditorButton
             size="small"
-            variant="outlined"
+            variant="text"
             startIcon={<SubtitlesIcon fontSize="small" />}
             onClick={onExportSubtitles}
             disabled={!hasVoicedLine}
@@ -246,8 +279,9 @@ const ScriptDocumentPane = ({
       </FlexRow>
 
       <FlexColumn
-        gap={SPACING.lg}
-        sx={{ padding: SPACING.md, maxWidth: 860, width: "100%" }}
+        gap={SPACING.xxl}
+        style={{ maxWidth: 780, width: "100%", margin: "0 auto" }}
+        sx={{ paddingX: SPACING.xl, paddingY: SPACING.xl }}
       >
         {isEmpty && (
           <EmptyState
@@ -267,15 +301,7 @@ const ScriptDocumentPane = ({
           />
         ))}
         {!readOnly && !isEmpty && (
-          <FlexRow gap={SPACING.sm}>
-            <EditorButton
-              size="small"
-              variant="text"
-              startIcon={<AddIcon fontSize="small" />}
-              onClick={() => addLine(scriptId)}
-            >
-              Add line
-            </EditorButton>
+          <FlexRow gap={SPACING.sm} sx={{ marginLeft: `${GUTTER + 8}px` }}>
             <EditorButton
               size="small"
               variant="text"

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -5,18 +5,20 @@ import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import HistoryIcon from "@mui/icons-material/History";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import TheaterComedyIcon from "@mui/icons-material/TheaterComedy";
 import {
   FlexColumn,
   FlexRow,
+  Box,
   Text,
   TextInput,
-  Chip,
   Tooltip,
   ToolbarIconButton,
   LoadingSpinner,
   Popover,
   SPACING,
   BORDER_RADIUS,
+  TYPOGRAPHY,
   MOTION
 } from "../ui_primitives";
 import {
@@ -40,17 +42,27 @@ interface ScriptLineRowProps {
   readOnly: boolean;
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  draft: "Draft",
-  voiced: "Voiced",
-  stale: "Stale"
-};
+/** Width of the screenplay speaker gutter. */
+export const GUTTER = 104;
 
-const STATUS_COLOR: Record<string, "default" | "success" | "warning"> = {
-  draft: "default",
-  voiced: "success",
-  stale: "warning"
-};
+/**
+ * Borderless field styling: the script reads as a document, so the input
+ * chrome only materializes on hover/focus.
+ */
+const quietField = {
+  "& .MuiOutlinedInput-root": {
+    backgroundColor: "transparent",
+    transition: MOTION.background,
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: "transparent",
+      transition: MOTION.border
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "divider" },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "primary.main"
+    }
+  }
+} as const;
 
 const ScriptLineRow = ({
   scriptId,
@@ -64,6 +76,7 @@ const ScriptLineRow = ({
   const voicing = useLineVoicing(line.id);
   const [galleryAnchor, setGalleryAnchor] = useState<HTMLElement | null>(null);
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [directionOpen, setDirectionOpen] = useState(false);
 
   const voice = effectiveVoice(line, cast);
   const status = lineStatus(line, voice);
@@ -112,35 +125,72 @@ const ScriptLineRow = ({
   }, [line.takes, line.currentTakeId]);
 
   const hasCurrentTake = !!line.takes.find((t) => t.id === line.currentTakeId);
+  // A direction is opt-in: an empty one stays out of the reading flow until
+  // the author asks for it, so untouched lines sit as tight as printed dialogue.
+  const hasDirection = !!line.direction?.trim();
+  const showDirection = hasDirection || directionOpen;
+
+  const toggleDirection = useCallback(() => {
+    setDirectionOpen((open) => {
+      if (open || hasDirection) {
+        patchLine(scriptId, line.id, { direction: "" });
+        return false;
+      }
+      return true;
+    });
+  }, [hasDirection, patchLine, scriptId, line.id]);
 
   return (
     <FlexRow
       align="flex-start"
-      gap={SPACING.sm}
+      gap={SPACING.md}
       fullWidth
       sx={{
         padding: SPACING.sm,
+        paddingLeft: SPACING.none,
         borderRadius: BORDER_RADIUS.sm,
         backgroundColor: highlighted ? "action.selected" : "transparent",
-        transition: MOTION.background
+        transition: MOTION.background,
+        "&:hover": {
+          backgroundColor: highlighted ? "action.selected" : "action.hover"
+        },
+        "& .script-line-actions": {
+          opacity: 0,
+          transition: MOTION.opacity
+        },
+        "&:hover .script-line-actions, &:focus-within .script-line-actions": {
+          opacity: 1
+        }
       }}
     >
       <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
-        <span>
-          <Chip
-            label={speaker?.name ?? "No speaker"}
-            size="small"
-            onClick={readOnly ? undefined : cycleSpeaker}
-            sx={{
-              minWidth: 84,
-              cursor: readOnly || !cast.length ? "default" : "pointer",
-              backgroundColor: speaker?.color ?? undefined
-            }}
-          />
-        </span>
+        <Box
+          component="button"
+          type="button"
+          disabled={readOnly || !cast.length}
+          onClick={readOnly ? undefined : cycleSpeaker}
+          sx={{
+            flexShrink: 0,
+            width: GUTTER,
+            marginTop: SPACING.sm,
+            padding: SPACING.none,
+            border: "none",
+            background: "none",
+            textAlign: "right",
+            cursor: readOnly || !cast.length ? "default" : "pointer",
+            ...TYPOGRAPHY.sans.label,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: speaker ? speaker.color ?? "text.primary" : "text.disabled",
+            transition: MOTION.fast,
+            "&:hover:not(:disabled)": { color: "primary.main" }
+          }}
+        >
+          {speaker?.name ?? "no speaker"}
+        </Box>
       </Tooltip>
 
-      <FlexColumn gap={SPACING.micro} style={{ flex: 1, minWidth: 0 }}>
+      <FlexColumn gap={SPACING.none} style={{ flex: 1, minWidth: 0 }}>
         <TextInput
           value={line.text}
           onChange={onTextChange}
@@ -151,32 +201,67 @@ const ScriptLineRow = ({
           compact
           fullWidth
           disabled={readOnly}
+          sx={{
+            ...quietField,
+            "& .MuiOutlinedInput-input": { ...TYPOGRAPHY.sans.body }
+          }}
         />
-        <TextInput
-          value={line.direction ?? ""}
-          onChange={onDirectionChange}
-          placeholder="Direction (e.g. whispering, tired)…"
-          hideLabel
-          label="Direction"
-          compact
-          fullWidth
-          disabled={readOnly}
-        />
+        {showDirection && (
+          <TextInput
+            autoFocus={!hasDirection}
+            value={line.direction ?? ""}
+            onChange={onDirectionChange}
+            placeholder="Direction (e.g. whispering, tired)…"
+            hideLabel
+            label="Direction"
+            compact
+            fullWidth
+            disabled={readOnly}
+            sx={{
+              ...quietField,
+              "& .MuiOutlinedInput-input": {
+                fontStyle: "italic",
+                color: "text.secondary"
+              }
+            }}
+          />
+        )}
         {voiceError && (
-          <Text size="smaller" color="error">
+          <Text size="smaller" color="error" sx={{ paddingLeft: SPACING.sm }}>
             {voiceError}
           </Text>
         )}
       </FlexColumn>
 
-      <FlexColumn align="center" gap={SPACING.micro}>
-        <Chip
-          label={STATUS_LABEL[status]}
-          size="small"
-          color={STATUS_COLOR[status]}
-          compact
-        />
-        <FlexRow gap={SPACING.none} align="center">
+      <FlexRow
+        align="center"
+        justify="flex-end"
+        gap={SPACING.xs}
+        sx={{ flexShrink: 0, marginTop: SPACING.xs }}
+      >
+        {status === "stale" ? (
+          <Text size="smaller" color="warning">
+            Stale
+          </Text>
+        ) : (
+          <Tooltip title={status === "voiced" ? "Voiced" : "Not voiced yet"}>
+            <Box
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                backgroundColor:
+                  status === "voiced" ? "success.main" : "action.disabled"
+              }}
+            />
+          </Tooltip>
+        )}
+        <FlexRow
+          className="script-line-actions"
+          gap={SPACING.none}
+          align="center"
+          sx={voicing ? { opacity: "1 !important" } : undefined}
+        >
           {voicing ? (
             <LoadingSpinner size={20} />
           ) : (
@@ -199,6 +284,14 @@ const ScriptLineRow = ({
               </span>
             </Tooltip>
           )}
+          {!readOnly && (
+            <ToolbarIconButton
+              tooltip={showDirection ? "Remove direction" : "Add direction"}
+              onClick={toggleDirection}
+              icon={<TheaterComedyIcon fontSize="small" />}
+              sx={showDirection ? { color: "primary.main" } : undefined}
+            />
+          )}
           <ToolbarIconButton
             tooltip="Play current take"
             disabled={!hasCurrentTake}
@@ -220,7 +313,7 @@ const ScriptLineRow = ({
             />
           )}
         </FlexRow>
-      </FlexColumn>
+      </FlexRow>
 
       <Popover
         open={!!galleryAnchor}


### PR DESCRIPTION
The script editor read as a stack of form fields: two bordered inputs per line, a status chip, and four always-visible icons, all stranded on the left of a wide pane. This reworks the document pane and line row into screenplay shape.

## Changes

- **Speaker** is a right-aligned gutter label tinted with its cast color, replacing the filled chip. Still click-to-cycle.
- **Line text and direction** lose their permanent outlines; input chrome appears on hover and focus.
- **Direction is opt-in** behind a per-line toggle instead of always occupying a row. Clicking it opens and focuses the field; clicking again clears and collapses it. Lines that already carry a direction always show it.
- **Status chip → dot** (success when voiced, muted when draft). Only "Stale" still needs a word.
- **Row actions** fade in on hover/focus-within, pinned right, no layout shift.
- **Section titles** render as headings over a hairline rule; the remove button appears on hover.
- **Content column** centers at 780px. The toolbar gets one primary action ("Voice all") and pushes the export actions right. The duplicate document-level "Add line" is gone.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint -c eslint.design.config.mjs` clean on both files
- `npx jest src/components/script` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)