### PR TITLE
feat(model3d): toggleable right-side assistant panel

### DIFF
--- a/web/src/components/model_editor/Model3DEditor.tsx
+++ b/web/src/components/model_editor/Model3DEditor.tsx
@@ -23,6 +23,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import GridOnIcon from "@mui/icons-material/GridOn";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
 import {
   FlexColumn,
@@ -36,9 +37,7 @@ import {
   EditorButton,
   CloseButton,
   DownloadButton,
-  TabGroup,
   BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
-import type { TabItem } from "../ui_primitives";
 import SceneOutliner from "./SceneOutliner";
 import PropertiesPanel from "./PropertiesPanel";
 import Model3DChatPanel from "./Model3DChatPanel";
@@ -58,16 +57,22 @@ import {
 } from "./model3DToolBridge";
 
 type GizmoMode = "translate" | "rotate" | "scale";
-type LeftTab = "scene" | "chat";
 
 const PANEL_WIDTH = 240;
-// The left panel hosts both the scene tree and the chat, so it gets more room.
-const LEFT_PANEL_WIDTH = 320;
+// The assistant hosts a chat conversation, so it gets more room than the
+// scene/properties panels.
+const ASSISTANT_PANEL_WIDTH = 320;
 
-const LEFT_TABS: TabItem[] = [
-  { value: "scene", label: "Scene" },
-  { value: "chat", label: "Chat" }
-];
+// Remembers whether the assistant panel was left open across editor sessions.
+const ASSISTANT_OPEN_KEY = "model3d.assistantOpen";
+
+const readAssistantOpen = (): boolean => {
+  try {
+    return localStorage.getItem(ASSISTANT_OPEN_KEY) === "true";
+  } catch {
+    return false;
+  }
+};
 
 const styles = (theme: Theme) =>
   css({
@@ -103,31 +108,22 @@ const styles = (theme: Theme) =>
       backgroundColor: theme.vars.palette.background.paper,
       borderRight: `1px solid ${theme.vars.palette.divider}`
     },
-    ".side-panel.left": {
-      width: `${LEFT_PANEL_WIDTH}px`
-    },
     ".side-panel.right": {
       borderRight: "none",
       borderLeft: `1px solid ${theme.vars.palette.divider}`
+    },
+    ".side-panel.assistant": {
+      width: `${ASSISTANT_PANEL_WIDTH}px`
     },
     ".panel-header": {
       padding: theme.spacing(2, 3),
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
       flexShrink: 0
     },
-    ".panel-tabs": {
-      flexShrink: 0,
-      borderBottom: `1px solid ${theme.vars.palette.divider}`
-    },
-    ".left-panel-body": {
+    ".panel-body": {
       flex: 1,
       minHeight: 0,
-      display: "flex"
-    },
-    ".left-panel-pane": {
-      width: "100%",
-      minWidth: 0,
-      minHeight: 0,
+      display: "flex",
       flexDirection: "column"
     },
     ".canvas-wrap": {
@@ -341,7 +337,19 @@ const Model3DEditor = ({ url, name, onSave, onClose }: Model3DEditorProps) => {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [fitTrigger, setFitTrigger] = useState(0);
-  const [leftTab, setLeftTab] = useState<LeftTab>("scene");
+  const [showAssistant, setShowAssistant] = useState<boolean>(readAssistantOpen);
+
+  const toggleAssistant = useCallback(() => {
+    setShowAssistant((open) => {
+      const next = !open;
+      try {
+        localStorage.setItem(ASSISTANT_OPEN_KEY, String(next));
+      } catch {
+        // Persistence is best-effort; ignore storage failures.
+      }
+      return next;
+    });
+  }, []);
 
   const bump = useCallback(() => setTick((t) => t + 1), []);
 
@@ -747,6 +755,13 @@ const Model3DEditor = ({ url, name, onSave, onClose }: Model3DEditorProps) => {
           size="small"
         />
         <FlexRow style={{ marginLeft: "auto" }} gap={1} align="center">
+          <ToolbarIconButton
+            icon={<AutoAwesomeIcon fontSize="small" />}
+            tooltip={showAssistant ? "Hide assistant" : "Show assistant"}
+            onClick={toggleAssistant}
+            active={showAssistant}
+            size="small"
+          />
           <DownloadButton onClick={handleSave} tooltip="Save to asset" />
           <CloseButton onClick={onClose} tooltip="Close editor" />
         </FlexRow>
@@ -754,34 +769,18 @@ const Model3DEditor = ({ url, name, onSave, onClose }: Model3DEditorProps) => {
 
       <FlexRow className="editor-body" fullWidth>
         <FlexColumn className="side-panel left" fullHeight>
-          <TabGroup
-            className="panel-tabs"
-            size="small"
-            fullWidth
-            tabs={LEFT_TABS}
-            value={leftTab}
-            onChange={(value) => setLeftTab(value as LeftTab)}
-          />
-          <div className="left-panel-body">
-            {/* Both panes stay mounted (toggled via display) so the chat
-                connection and scroll state survive tab switches. */}
-            <div
-              className="left-panel-pane"
-              style={{ display: leftTab === "scene" ? "flex" : "none" }}
-            >
-              <SceneOutliner
-                nodes={treeNodes}
-                selectedUuid={selectedUuid}
-                onSelect={setSelectedUuid}
-                onToggleVisible={handleToggleVisible}
-              />
-            </div>
-            <div
-              className="left-panel-pane"
-              style={{ display: leftTab === "chat" ? "flex" : "none" }}
-            >
-              <Model3DChatPanel />
-            </div>
+          <FlexRow className="panel-header">
+            <Text size="small" weight={600}>
+              Scene
+            </Text>
+          </FlexRow>
+          <div className="panel-body">
+            <SceneOutliner
+              nodes={treeNodes}
+              selectedUuid={selectedUuid}
+              onSelect={setSelectedUuid}
+              onToggleVisible={handleToggleVisible}
+            />
           </div>
         </FlexColumn>
 
@@ -837,6 +836,30 @@ const Model3DEditor = ({ url, name, onSave, onClose }: Model3DEditorProps) => {
             </Text>
           </FlexRow>
           <PropertiesPanel object={selectedObject} tick={tick} onChanged={bump} />
+        </FlexColumn>
+
+        {/* Kept mounted (toggled via display) so the chat connection and
+            scroll state survive hiding the panel. */}
+        <FlexColumn
+          className="side-panel right assistant"
+          fullHeight
+          style={{ display: showAssistant ? "flex" : "none" }}
+        >
+          <FlexRow className="panel-header" justify="space-between" align="center">
+            <FlexRow gap={1} align="center">
+              <AutoAwesomeIcon fontSize="small" />
+              <Text size="small" weight={600}>
+                Assistant
+              </Text>
+            </FlexRow>
+            <CloseButton
+              onClick={() => toggleAssistant()}
+              tooltip="Hide assistant"
+            />
+          </FlexRow>
+          <div className="panel-body">
+            <Model3DChatPanel />
+          </div>
         </FlexColumn>
       </FlexRow>
 


### PR DESCRIPTION
## Summary

Promotes the 3D editor's AI assistant from a buried left-panel **Chat** tab into a dedicated, **toggleable panel on the right side** of the editor.

Before, the assistant (`Model3DChatPanel`) shared the left panel with the scene outliner via a `TabGroup`, so you had to switch away from the scene tree to talk to it. Now:

- The **left panel** holds only the scene outliner (with a plain "Scene" header instead of tabs).
- The **assistant** lives in its own right-side panel next to Properties, with an `AutoAwesome` welcome/header icon and a close button.
- An `AutoAwesome` **toolbar toggle** (and the panel's close button) show/hide the assistant. The button reflects open/closed state via its `active` styling.
- The open/closed choice **persists across editor sessions** via `localStorage` (`model3d.assistantOpen`, best-effort with try/catch).
- The panel stays **mounted while hidden** (`display` toggle), so the chat connection and scroll position survive being closed — same technique the old tab used.

No changes to the chat wiring itself — `Model3DChatPanel` is reused as-is, still driving the scene through the existing `ui_3d_*` tool bridge.

## Changes

- `web/src/components/model_editor/Model3DEditor.tsx`
  - Removed the left `TabGroup` / `leftTab` state and the `Chat` tab; left panel is now scene-only.
  - Added `showAssistant` state with `localStorage` persistence and a `toggleAssistant` handler.
  - Added a toolbar toggle button and a right-side assistant panel hosting `Model3DChatPanel`.
  - Renamed panel CSS helpers (`.panel-body`, `.side-panel.assistant`) and dropped now-unused tab styles/constants.

## Testing

- `npm run typecheck` — no errors in the touched file (pre-existing failures are unbuilt `@nodetool-ai/*-nodes` packages, unrelated).
- `eslint` on the edited file — clean.
- `jest src/components/model_editor` — 26 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dg9ztX8EBtTysH39JgHzW

---
_Generated by [Claude Code](https://claude.ai/code/session_013dg9ztX8EBtTysH39JgHzW)_