### PR TITLE
Add agentic assistant panel to the image editor

### DIFF
--- a/web/src/components/sketch/SketchAgentPanel.tsx
+++ b/web/src/components/sketch/SketchAgentPanel.tsx
@@ -1,0 +1,171 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, useEffect, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { useShallow } from "zustand/react/shallow";
+
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+
+import { FlexColumn, Text, SPACING, getSpacingPx } from "../ui_primitives";
+import ChatView from "../chat/containers/ChatView";
+import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
+
+const styles = (_theme: Theme) =>
+  css({
+    "&": {
+      height: "100%",
+      minHeight: 0,
+      display: "flex",
+      flexDirection: "column"
+    },
+    // ChatView is tuned for the full-page global chat (large left/bottom
+    // padding, centered max-width). Tighten it for this narrow side panel.
+    "& .chat-view": {
+      padding: `0 ${getSpacingPx(SPACING.xs)} ${getSpacingPx(
+        SPACING.xs
+      )} ${getSpacingPx(SPACING.xs)}`
+    },
+    "& .chat-input-section": {
+      width: "100%",
+      maxWidth: "100%"
+    },
+    "& .chat-thread-container": {
+      maxWidth: "100%",
+      paddingBottom: getSpacingPx(SPACING.md)
+    }
+  });
+
+/**
+ * Chat surface for the image / sketch editor. Reuses {@link ChatView} wired to
+ * the shared {@link useGlobalChatStore}, so the assistant can call the
+ * `ui_sketch_*` frontend tools the editor registers on the sketch agent
+ * bridge — adding layers, generating imagery, and reshaping the canvas like a
+ * real editor.
+ */
+const SketchAgentPanel = () => {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  // Bind the open document as the chat's `workflow_id`. The server only
+  // forwards client `ui_*` tools to the model when a turn carries a
+  // workflow_id (unified-websocket-runner gates on it), so without this the
+  // assistant never sees the editor's ui_sketch_* tools. The id is editor
+  // context, not a routing signal — we don't set `workflow_target`, so the turn
+  // stays a normal chat turn and the document is never run as a workflow.
+  const documentId = useSketchSessionStore((s) => s.documentId);
+
+  const { status, statusMessage, progress } = useGlobalChatStore(
+    useShallow((state) => ({
+      status: state.status,
+      statusMessage: state.statusMessage,
+      progress: state.progress
+    }))
+  );
+
+  const { selectedModel, setSelectedModel } = useGlobalChatStore(
+    useShallow((state) => ({
+      selectedModel: state.selectedModel,
+      setSelectedModel: state.setSelectedModel
+    }))
+  );
+
+  const { sendMessage, stopGeneration, connect, createNewThread, switchThread } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        sendMessage: state.sendMessage,
+        stopGeneration: state.stopGeneration,
+        connect: state.connect,
+        createNewThread: state.createNewThread,
+        switchThread: state.switchThread
+      }))
+    );
+
+  // Subscribe to the cache + current thread so the panel re-renders as the
+  // active conversation streams in; the messages themselves are read synchronously.
+  const { currentThreadId, messageCache, getCurrentMessagesSync } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        currentThreadId: state.currentThreadId,
+        messageCache: state.messageCache,
+        getCurrentMessagesSync: state.getCurrentMessagesSync
+      }))
+    );
+  const messages = useMemo(
+    () => getCurrentMessagesSync(),
+    [getCurrentMessagesSync, currentThreadId, messageCache]
+  );
+
+  // Establish the chat connection (and send the frontend-tool manifest, which
+  // now includes the editor's ui_sketch_* tools) when the panel mounts.
+  useEffect(() => {
+    connect().catch((err) => {
+      console.error("Failed to connect image editor chat:", err);
+    });
+  }, [connect]);
+
+  const chatStatus = useMemo(
+    () => (status === "stopping" ? "loading" : status),
+    [status]
+  );
+
+  const handleNewChat = useCallback(async () => {
+    try {
+      const id = await createNewThread();
+      switchThread(id);
+    } catch (err) {
+      console.error("Failed to start new image editor chat:", err);
+    }
+  }, [createNewThread, switchThread]);
+
+  const welcomePlaceholder = useMemo(
+    () => (
+      <FlexColumn
+        align="center"
+        justify="center"
+        fullHeight
+        padding={3}
+        sx={{ textAlign: "center" }}
+      >
+        <AutoAwesomeIcon sx={{ fontSize: 40, mb: 1.5, opacity: 0.5 }} />
+        <Text size="normal" weight={600} sx={{ mb: 1 }}>
+          Editor Assistant
+        </Text>
+        <Text size="small" color="secondary" sx={{ maxWidth: 280 }}>
+          Ask me to edit the image — e.g. &quot;generate a mountain landscape on
+          a new layer&quot;, &quot;add a blank layer filled with black&quot;, or
+          &quot;set the background layer to 50% opacity&quot;.
+        </Text>
+      </FlexColumn>
+    ),
+    []
+  );
+
+  return (
+    <div css={cssStyles}>
+      <ChatPanelHeader onNewChat={handleNewChat} />
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <ChatView
+          status={chatStatus}
+          messages={messages}
+          workflowId={documentId}
+          sendMessage={sendMessage}
+          progress={progress.current}
+          total={progress.total}
+          progressMessage={statusMessage}
+          model={selectedModel}
+          onModelChange={setSelectedModel}
+          onStop={stopGeneration}
+          onNewChat={handleNewChat}
+          requireToolSupport
+          hideModePicker
+          noMessagesPlaceholder={welcomePlaceholder}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default memo(SketchAgentPanel);

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -69,6 +69,8 @@ import {
   SketchCanvasPane
 } from "./editor-shell";
 import { ConnectedGeneratedLayerSection } from "./Inspector";
+import SketchAgentPanel from "./SketchAgentPanel";
+import { useSketchAgentBridge } from "../../hooks/sketch/useSketchAgentBridge";
 import { useSketchCanvasRefStore } from "../../stores/sketch/SketchCanvasRefStore";
 import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
 import { useSketchWorkflowFreshnessCheck } from "../../hooks/sketch/useSketchWorkflowFreshnessCheck";
@@ -182,6 +184,12 @@ export interface SketchEditorProps {
   /** Document-level actions rendered at the trailing edge of the top mode bar
    * (e.g. Save/Done when embedded in an asset tab). */
   headerActions?: React.ReactNode;
+  /**
+   * Whether this editor is the focused/visible surface. Drives whether this
+   * instance registers the agent bridge so the `ui_sketch_*` tools target the
+   * focused document. Defaults to `true`.
+   */
+  active?: boolean;
 }
 
 const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
@@ -194,7 +202,8 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
       onExportImage,
       onExportMask,
       suspendKeyboardShortcuts,
-      headerActions
+      headerActions,
+      active = true
     },
     ref
   ) {
@@ -205,6 +214,11 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     // every child so the column's reserved width also collapses, letting
     // the canvas grow into the freed space.
     const panelsHidden = useSketchStore((s) => s.panelsHidden);
+    const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
+
+    // Register the agent bridge for this instance while it is the focused
+    // surface so the `ui_sketch_*` tools drive this document.
+    useSketchAgentBridge(active);
 
     // ─── Session layer (all transient editor-session state) ─────────────
     const session = useEditorSession({
@@ -246,6 +260,10 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
         getMaskDataUrl: () => canvasRef.current?.getMaskDataUrl() ?? null,
         setLayerData: (layerId, data) =>
           canvasRef.current?.setLayerData(layerId, data),
+        getLayerData: (layerId) =>
+          canvasRef.current?.getLayerData(layerId) ?? null,
+        fillLayerWithColor: (layerId, color) =>
+          canvasRef.current?.fillLayerWithColor(layerId, color),
         clearActiveLayer: () => session.canvasActions.handleClearLayer()
       });
       return () => {
@@ -529,6 +547,28 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
               </CollapsibleSection>
 
               <ConnectedGeneratedLayerSection />
+            </FlexColumn>
+          )}
+
+          {/* AI assistant chat column — a toggleable right-most panel that
+          drives the editor through the ui_sketch_* agent tools. Gated on the
+          same panelsHidden chrome toggle so Tab collapses it too. */}
+          {!panelsHidden && assistantPanelOpen && (
+            <FlexColumn
+              className="sketch-editor__assistant-panel"
+              sx={{
+                width: SKETCH_SIZE.assistantPanelWidth,
+                minWidth: SKETCH_SIZE.assistantPanelWidth,
+                maxWidth: SKETCH_SIZE.assistantPanelWidth,
+                minHeight: 0,
+                flexShrink: 0,
+                backgroundColor: theme.vars.palette.background.paper,
+                borderLeft: `1px solid ${theme.vars.palette.divider}`,
+                overflow: "hidden"
+              }}
+              gap={0}
+            >
+              <SketchAgentPanel />
             </FlexColumn>
           )}
         </FlexRow>

--- a/web/src/components/sketch/StandaloneSketchEditor.tsx
+++ b/web/src/components/sketch/StandaloneSketchEditor.tsx
@@ -68,10 +68,8 @@ interface StandaloneSketchEditorProps {
   active?: boolean;
 }
 
-const StandaloneSketchEditorBody: React.FC<
-  Omit<StandaloneSketchEditorProps, "active">
-> = memo(
-  function StandaloneSketchEditorBody({ documentId, headerActions }) {
+const StandaloneSketchEditorBody: React.FC<StandaloneSketchEditorProps> = memo(
+  function StandaloneSketchEditorBody({ documentId, headerActions, active }) {
     const theme = useTheme();
     const styles = useMemo(() => containerStyles(theme), [theme]);
     const editorRef = useRef<SketchEditorHandle | null>(null);
@@ -213,6 +211,7 @@ const StandaloneSketchEditorBody: React.FC<
         <SketchEditor
           ref={editorRef}
           documentId={documentId}
+          active={active}
           initialDocument={seed.document}
           initialEditorState={initialEditorState ?? undefined}
           headerActions={
@@ -250,7 +249,7 @@ const StandaloneSketchEditor: React.FC<StandaloneSketchEditorProps> = ({
   ...bodyProps
 }) => (
   <SketchProvider active={active}>
-    <StandaloneSketchEditorBody {...bodyProps} />
+    <StandaloneSketchEditorBody active={active} {...bodyProps} />
   </SketchProvider>
 );
 

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -83,6 +83,8 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   const theme = useTheme();
 
   const panelsHidden = useSketchStore((s) => s.panelsHidden);
+  const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
+  const toggleAssistantPanel = useSketchStore((s) => s.toggleAssistantPanel);
   const docW = useSketchStore((s) => s.document.canvas.width);
   const docH = useSketchStore((s) => s.document.canvas.height);
 
@@ -355,6 +357,20 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
           sx={{ flexShrink: 0, height: 34 }}
         >
           Generate
+        </EditorButton>
+
+        {/* Assistant toggle — opens the right-side AI chat panel that drives
+            the editor through the ui_sketch_* agent tools. */}
+        <EditorButton
+          variant={assistantPanelOpen ? "contained" : "outlined"}
+          size="small"
+          onClick={toggleAssistantPanel}
+          startIcon={<AutoAwesomeIcon fontSize="small" />}
+          aria-pressed={assistantPanelOpen}
+          data-testid="sketch-assistant-toggle"
+          sx={{ flexShrink: 0, height: 34 }}
+        >
+          Assistant
         </EditorButton>
 
         {trailingActions}

--- a/web/src/components/sketch/sketchAgentBridge.ts
+++ b/web/src/components/sketch/sketchAgentBridge.ts
@@ -137,6 +137,18 @@ export interface SketchLayerImageResult {
   dataUrl: string;
 }
 
+export interface SketchRenderedAssetResult {
+  /** Uploaded (temporary) asset id. */
+  assetId: string;
+  /** Best-effort resolvable URL (falls back to asset://). */
+  url: string;
+  width: number;
+  height: number;
+  /** null for the composite; otherwise the rendered layer id. */
+  layerId: string | null;
+  layerName: string | null;
+}
+
 /**
  * Operations the live {@link SketchEditor} exposes to the agent tooling layer.
  * Layers are addressed by id, by (case-insensitive) name, or the literal
@@ -164,6 +176,15 @@ export interface SketchAgentHandler {
   setSelection: (op: SketchSelectionOp) => { hasSelection: boolean };
   /** Read pixels: the flattened composite (target null) or a single layer. */
   getLayerImage: (target: string | null) => Promise<SketchLayerImageResult>;
+  /**
+   * Render the composite (target null) or a single layer to a PNG and upload it
+   * as a temporary asset, returning its id + URL so it can be fed to other
+   * tools/workflows.
+   */
+  renderLayerToAsset: (
+    target: string | null,
+    name?: string
+  ) => Promise<SketchRenderedAssetResult>;
 }
 
 let handler: SketchAgentHandler | null = null;

--- a/web/src/components/sketch/sketchAgentBridge.ts
+++ b/web/src/components/sketch/sketchAgentBridge.ts
@@ -1,0 +1,192 @@
+/**
+ * sketchAgentBridge
+ *
+ * Bridge between the agent tooling layer (the `ui_sketch_*` frontend tools) and
+ * the live image / sketch editor, mirroring `timelineAgentBridge` for the video
+ * editor.
+ *
+ * The open {@link SketchEditor} registers a {@link SketchAgentHandler} while it
+ * is the active surface (and clears it on blur / unmount). The handler closes
+ * over the editor's per-instance stores (document, session bindings, canvas
+ * refs) plus the direct-generation job runner, so the tools always operate on
+ * the focused document — or fail cleanly when no editor is open.
+ *
+ * Everything crossing the bridge is a plain serializable value: the agent reads
+ * {@link SketchSnapshot} / {@link SketchLayerNode} objects and never touches
+ * Zustand store handles directly.
+ */
+
+import type { BlendMode } from "@nodetool-ai/gpu";
+
+/** The tools an agent can pick for a layer / canvas op. */
+export type SketchToolName =
+  | "move"
+  | "transform"
+  | "select"
+  | "brush"
+  | "pencil"
+  | "eraser"
+  | "eyedropper"
+  | "fill"
+  | "shape"
+  | "blur"
+  | "gradient"
+  | "crop"
+  | "clone_stamp"
+  | "adjust"
+  | "segment";
+
+/** Direct-generation kinds the agent can spawn on a new layer. */
+export type SketchGenerateKind = "text-to-image" | "image-to-image";
+
+/** Serializable view of a single layer (agent-friendly). */
+export interface SketchLayerNode {
+  id: string;
+  name: string;
+  type: "raster" | "mask" | "group";
+  visible: boolean;
+  /** 0..1 layer opacity. */
+  opacity: number;
+  blendMode: BlendMode;
+  locked: boolean;
+  alphaLock: boolean;
+  /** Id of the parent group layer, when nested. */
+  parentId: string | null;
+  /** 0-based stacking index in the flat layer array (higher = visually above). */
+  index: number;
+  /** True when this layer carries a generation binding. */
+  hasBinding: boolean;
+  /** Generation binding summary, when the layer has one. */
+  bindingKind?: string;
+  prompt?: string;
+  provider?: string;
+  model?: string;
+  bindingStatus?: string;
+}
+
+/** Full snapshot of the open document the agent reads to plan edits. */
+export interface SketchSnapshot {
+  documentId: string | null;
+  name: string;
+  /** Canvas (artboard) size in pixels. */
+  width: number;
+  height: number;
+  activeLayerId: string | null;
+  /** Active foreground color (hex). */
+  foregroundColor: string;
+  backgroundColor: string;
+  /** Currently-selected tool. */
+  activeTool: SketchToolName;
+  /** True when a pixel selection is active (mask present). */
+  hasSelection: boolean;
+  /** Layers from bottom to top. */
+  layers: SketchLayerNode[];
+}
+
+export interface SketchGenerateOptions {
+  kind: SketchGenerateKind;
+  prompt: string;
+  /** New layer name; defaults to a sensible name for the kind. */
+  name?: string;
+  provider?: string;
+  model?: string;
+  /** For image-to-image: the source layer id/name to transform. */
+  sourceLayer?: string;
+  width?: number;
+  height?: number;
+  aspectRatio?: string;
+  resolution?: string;
+  /** Kick off generation immediately (default true). */
+  autoGenerate?: boolean;
+}
+
+export interface SketchGenerateResult {
+  layer: SketchLayerNode;
+  /** True when a generation job was dispatched for the new layer. */
+  generationStarted: boolean;
+  /** Why generation did not start, when applicable. */
+  note?: string;
+}
+
+/** Layer props the agent can patch. Omit a field to leave it unchanged. */
+export interface SketchLayerPropsPatch {
+  name?: string;
+  visible?: boolean;
+  opacity?: number;
+  blendMode?: BlendMode;
+  locked?: boolean;
+  alphaLock?: boolean;
+}
+
+export interface SketchAddLayerOptions {
+  name?: string;
+  type?: "raster" | "mask";
+  /** Fill the new layer with this color (hex). */
+  fillColor?: string;
+}
+
+/** How {@link SketchAgentHandler.setSelection} shapes the pixel selection. */
+export type SketchSelectionOp = "all" | "clear" | "invert";
+
+export interface SketchLayerImageResult {
+  /** null target → the flattened composite; otherwise the addressed layer. */
+  layerId: string | null;
+  layerName: string | null;
+  width: number;
+  height: number;
+  dataUrl: string;
+}
+
+/**
+ * Operations the live {@link SketchEditor} exposes to the agent tooling layer.
+ * Layers are addressed by id, by (case-insensitive) name, or the literal
+ * `"active"` for the active layer. Each mutator returns the affected node so the
+ * agent gets immediate feedback.
+ */
+export interface SketchAgentHandler {
+  getSnapshot: () => SketchSnapshot;
+  addLayer: (opts: SketchAddLayerOptions) => SketchLayerNode;
+  removeLayer: (target: string) => SketchLayerNode;
+  duplicateLayer: (target: string) => SketchLayerNode;
+  selectLayer: (target: string) => SketchLayerNode;
+  setLayerProps: (
+    target: string,
+    patch: SketchLayerPropsPatch
+  ) => SketchLayerNode;
+  reorderLayer: (target: string, direction: "up" | "down") => SketchLayerNode;
+  mergeLayerDown: (target: string) => SketchLayerNode | null;
+  flattenVisible: () => SketchLayerNode;
+  generate: (opts: SketchGenerateOptions) => Promise<SketchGenerateResult>;
+  setForegroundColor: (color: string) => string;
+  setBackgroundColor: (color: string) => string;
+  setActiveTool: (tool: SketchToolName) => SketchToolName;
+  resizeCanvas: (width: number, height: number) => { width: number; height: number };
+  setSelection: (op: SketchSelectionOp) => { hasSelection: boolean };
+  /** Read pixels: the flattened composite (target null) or a single layer. */
+  getLayerImage: (target: string | null) => Promise<SketchLayerImageResult>;
+}
+
+let handler: SketchAgentHandler | null = null;
+
+/**
+ * Register (or clear, with null) the handler for the currently-focused editor.
+ * The editor calls this when it becomes active and clears it on unmount / blur
+ * so the ui_sketch_* tools always operate on the live document — or fail
+ * cleanly when no editor is open.
+ */
+export function setSketchAgentHandler(next: SketchAgentHandler | null): void {
+  handler = next;
+}
+
+export function hasSketchAgentHandler(): boolean {
+  return handler !== null;
+}
+
+export function getSketchAgentHandler(): SketchAgentHandler {
+  if (!handler) {
+    throw new Error(
+      "No image editor is open. Open an image document in the editor to use image-editor tools."
+    );
+  }
+  return handler;
+}

--- a/web/src/components/sketch/sketchAgentBridge.ts
+++ b/web/src/components/sketch/sketchAgentBridge.ts
@@ -185,6 +185,16 @@ export interface SketchAgentHandler {
     target: string | null,
     name?: string
   ) => Promise<SketchRenderedAssetResult>;
+  /**
+   * Render several layers to temporary assets. With `merge` false (default)
+   * each layer becomes its own asset; with `merge` true the named layers are
+   * composited (bottom-to-top, honoring opacity/blend) into a single asset.
+   * Returns one result per asset produced.
+   */
+  renderLayersToAssets: (
+    targets: string[],
+    opts?: { merge?: boolean; name?: string }
+  ) => Promise<SketchRenderedAssetResult[]>;
 }
 
 let handler: SketchAgentHandler | null = null;

--- a/web/src/components/sketch/sketchStyles.ts
+++ b/web/src/components/sketch/sketchStyles.ts
@@ -59,6 +59,7 @@ export const SKETCH_SIZE = {
   layerItemHeight: "39.2px",
   layerThumbnail: "39.2px",
   panelWidth: "260px",
+  assistantPanelWidth: "340px",
   iconButtonPad: "3px",
   borderRadius: BORDER_RADIUS.sm
 } as const;

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -17,6 +17,11 @@ export interface UiSlice {
   panelsHidden: boolean;
   togglePanelsHidden: () => void;
 
+  /** Whether the AI assistant chat panel is open (right side of the editor). */
+  assistantPanelOpen: boolean;
+  toggleAssistantPanel: () => void;
+  setAssistantPanelOpen: (open: boolean) => void;
+
   /** Cleared whenever a single layer is chosen exclusively (normal click). */
   selectedLayerIds: string[];
   /**
@@ -64,6 +69,11 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
   panelsHidden: false,
   togglePanelsHidden: () =>
     set((state) => ({ panelsHidden: !state.panelsHidden })),
+
+  assistantPanelOpen: false,
+  toggleAssistantPanel: () =>
+    set((state) => ({ assistantPanelOpen: !state.assistantPanelOpen })),
+  setAssistantPanelOpen: (open: boolean) => set({ assistantPanelOpen: open }),
 
   selectedLayerIds: [] as string[],
   layerShiftRangeAnchorId: null as string | null,

--- a/web/src/hooks/sketch/useSketchAgentBridge.ts
+++ b/web/src/hooks/sketch/useSketchAgentBridge.ts
@@ -16,7 +16,10 @@ import { coerceBlendMode } from "@nodetool-ai/gpu";
 
 import { useSketchInstance } from "../../stores/sketch/SketchInstance";
 import { useDirectGenJob } from "./useDirectGenJob";
-import { renderLayerToAsset } from "../../lib/sketch/renderLayerToAsset";
+import {
+  renderLayerToAsset,
+  renderLayersMerged
+} from "../../lib/sketch/renderLayerToAsset";
 import { getRememberedModel } from "../../stores/lastModelStore";
 import type {
   Layer,
@@ -29,6 +32,7 @@ import {
   setSketchAgentHandler,
   type SketchAgentHandler,
   type SketchLayerNode,
+  type SketchRenderedAssetResult,
   type SketchSnapshot,
   type SketchToolName
 } from "../../components/sketch/sketchAgentBridge";
@@ -402,6 +406,29 @@ export const useSketchAgentBridge = (active: boolean): void => {
           flattenToDataUrl: canvasRef.getState().flattenToDataUrl,
           name
         });
+      },
+
+      async renderLayersToAssets(targets, opts) {
+        if (targets.length === 0) {
+          throw new Error("Provide at least one layer to render.");
+        }
+        // Resolve every target up front so a bad id fails before uploading.
+        const layerIds = targets.map((t) => requireLayer(t).id);
+        if (opts?.merge) {
+          const merged = await renderLayersMerged({
+            doc: doc(),
+            layerIds,
+            name: opts?.name
+          });
+          return [merged];
+        }
+        const results: SketchRenderedAssetResult[] = [];
+        for (const layerId of layerIds) {
+          results.push(
+            await renderLayerToAsset({ doc: doc(), layerId, name: opts?.name })
+          );
+        }
+        return results;
       }
     };
   }, [instance, startDirectGen]);

--- a/web/src/hooks/sketch/useSketchAgentBridge.ts
+++ b/web/src/hooks/sketch/useSketchAgentBridge.ts
@@ -16,6 +16,7 @@ import { coerceBlendMode } from "@nodetool-ai/gpu";
 
 import { useSketchInstance } from "../../stores/sketch/SketchInstance";
 import { useDirectGenJob } from "./useDirectGenJob";
+import { renderLayerToAsset } from "../../lib/sketch/renderLayerToAsset";
 import { getRememberedModel } from "../../stores/lastModelStore";
 import type {
   Layer,
@@ -391,6 +392,16 @@ export const useSketchAgentBridge = (active: boolean): void => {
           height: d.canvas.height,
           dataUrl
         };
+      },
+
+      async renderLayerToAsset(target, name) {
+        const layerId = target === null ? null : requireLayer(target).id;
+        return renderLayerToAsset({
+          doc: doc(),
+          layerId,
+          flattenToDataUrl: canvasRef.getState().flattenToDataUrl,
+          name
+        });
       }
     };
   }, [instance, startDirectGen]);

--- a/web/src/hooks/sketch/useSketchAgentBridge.ts
+++ b/web/src/hooks/sketch/useSketchAgentBridge.ts
@@ -1,0 +1,409 @@
+/**
+ * useSketchAgentBridge
+ *
+ * Registers a {@link SketchAgentHandler} for the surrounding image / sketch
+ * editor instance while it is the active surface, so the `ui_sketch_*` agent
+ * tools operate on this document. Mirrors {@link useTimelineAgentBridge} but
+ * built against the sketch editor's per-instance stores (editor, session
+ * bindings, canvas refs) plus the direct-generation job runner.
+ *
+ * Only the active editor registers, so with several sketch tabs open the tools
+ * always target the focused one. The handler is cleared on blur / unmount.
+ */
+
+import { useEffect, useMemo } from "react";
+import { coerceBlendMode } from "@nodetool-ai/gpu";
+
+import { useSketchInstance } from "../../stores/sketch/SketchInstance";
+import { useDirectGenJob } from "./useDirectGenJob";
+import { getRememberedModel } from "../../stores/lastModelStore";
+import type {
+  Layer,
+  SketchDocument
+} from "../../components/sketch/types";
+import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
+import {
+  getSketchAgentHandler,
+  hasSketchAgentHandler,
+  setSketchAgentHandler,
+  type SketchAgentHandler,
+  type SketchLayerNode,
+  type SketchSnapshot,
+  type SketchToolName
+} from "../../components/sketch/sketchAgentBridge";
+
+const SKETCH_TOOLS: readonly SketchToolName[] = [
+  "move",
+  "transform",
+  "select",
+  "brush",
+  "pencil",
+  "eraser",
+  "eyedropper",
+  "fill",
+  "shape",
+  "blur",
+  "gradient",
+  "crop",
+  "clone_stamp",
+  "adjust",
+  "segment"
+];
+
+/** Serialize a layer to the agent-facing shape. */
+function toLayerNode(
+  layer: Layer,
+  index: number,
+  binding: LayerWorkflowBinding | undefined
+): SketchLayerNode {
+  return {
+    id: layer.id,
+    name: layer.name,
+    type: layer.type,
+    visible: layer.visible,
+    opacity: layer.opacity,
+    blendMode: layer.blendMode,
+    locked: layer.locked,
+    alphaLock: layer.alphaLock,
+    parentId: layer.parentId ?? null,
+    index,
+    hasBinding: !!binding,
+    bindingKind: binding?.kind,
+    prompt: binding?.prompt,
+    provider: binding?.provider,
+    model: binding?.model,
+    bindingStatus: binding?.status
+  };
+}
+
+export const useSketchAgentBridge = (active: boolean): void => {
+  const instance = useSketchInstance();
+  const { start: startDirectGen } = useDirectGenJob();
+
+  const handler = useMemo<SketchAgentHandler>(() => {
+    const { editor, session, canvasRef } = instance;
+
+    const doc = (): SketchDocument => editor.getState().document;
+
+    /** Resolve a layer by id, case-insensitive name, or the "active" keyword. */
+    const requireLayer = (target: string): Layer => {
+      const layers = doc().layers;
+      if (target === "active") {
+        const id = doc().activeLayerId;
+        const layer = layers.find((l) => l.id === id);
+        if (!layer) throw new Error("There is no active layer.");
+        return layer;
+      }
+      const byId = layers.find((l) => l.id === target);
+      if (byId) return byId;
+      const lower = target.toLowerCase();
+      const byName = layers.find((l) => l.name.toLowerCase() === lower);
+      if (byName) return byName;
+      throw new Error(`Layer not found in the document: ${target}`);
+    };
+
+    const bindingFor = (layerId: string): LayerWorkflowBinding | undefined =>
+      session.getState().bindings[layerId];
+
+    const layerNode = (layer: Layer): SketchLayerNode => {
+      const index = doc().layers.findIndex((l) => l.id === layer.id);
+      return toLayerNode(layer, index, bindingFor(layer.id));
+    };
+
+    const reReadLayer = (id: string): Layer => {
+      const layer = doc().layers.find((l) => l.id === id);
+      if (!layer) throw new Error(`Layer ${id} disappeared after the edit.`);
+      return layer;
+    };
+
+    /** Unique layer name within the current document. */
+    const uniqueLayerName = (base: string): string => {
+      const existing = new Set(doc().layers.map((l) => l.name));
+      if (!existing.has(base)) return base;
+      let n = 2;
+      while (existing.has(`${base} ${n}`)) n++;
+      return `${base} ${n}`;
+    };
+
+    return {
+      getSnapshot(): SketchSnapshot {
+        const state = editor.getState();
+        const d = state.document;
+        return {
+          documentId: session.getState().documentId,
+          name: session.getState().name,
+          width: d.canvas.width,
+          height: d.canvas.height,
+          activeLayerId: d.activeLayerId,
+          foregroundColor: state.foregroundColor || "#ffffff",
+          backgroundColor: state.backgroundColor || "#000000",
+          activeTool: state.activeTool as SketchToolName,
+          hasSelection: state.hasActiveSelection,
+          layers: d.layers.map((l, i) => toLayerNode(l, i, bindingFor(l.id)))
+        };
+      },
+
+      addLayer(opts) {
+        const state = editor.getState();
+        const id = state.addLayer(
+          uniqueLayerName(opts.name ?? "Layer"),
+          opts.type ?? "raster"
+        );
+        if (opts.fillColor) {
+          // The canvas creates the layer on its next render; fill once it
+          // exists, then persist the pixels and record a history entry —
+          // mirroring the layers panel's fill-on-add behavior.
+          requestAnimationFrame(() => {
+            const refs = canvasRef.getState();
+            refs.fillLayerWithColor?.(id, opts.fillColor as string);
+            const data = refs.getLayerData?.(id);
+            if (data) editor.getState().updateLayerData(id, data);
+            editor.getState().pushHistory("add layer");
+          });
+        } else {
+          state.pushHistory("add layer");
+        }
+        return layerNode(reReadLayer(id));
+      },
+
+      removeLayer(target) {
+        const layer = requireLayer(target);
+        const node = layerNode(layer);
+        editor.getState().removeLayer(layer.id);
+        editor.getState().pushHistory("remove layer");
+        return node;
+      },
+
+      duplicateLayer(target) {
+        const layer = requireLayer(target);
+        const before = new Set(doc().layers.map((l) => l.id));
+        editor.getState().duplicateLayer(layer.id);
+        editor.getState().pushHistory("duplicate layer");
+        const created = doc().layers.find((l) => !before.has(l.id));
+        return layerNode(created ?? reReadLayer(layer.id));
+      },
+
+      selectLayer(target) {
+        const layer = requireLayer(target);
+        editor.getState().setActiveLayer(layer.id);
+        return layerNode(reReadLayer(layer.id));
+      },
+
+      setLayerProps(target, patch) {
+        const layer = requireLayer(target);
+        const state = editor.getState();
+        if (patch.name !== undefined) state.renameLayer(layer.id, patch.name);
+        if (patch.opacity !== undefined) {
+          state.setLayerOpacity(layer.id, Math.max(0, Math.min(1, patch.opacity)));
+        }
+        if (patch.blendMode !== undefined) {
+          state.setLayerBlendMode(layer.id, coerceBlendMode(patch.blendMode));
+        }
+        if (patch.visible !== undefined && patch.visible !== layer.visible) {
+          state.toggleLayerVisibility(layer.id);
+        }
+        if (patch.alphaLock !== undefined && patch.alphaLock !== layer.alphaLock) {
+          state.toggleAlphaLock(layer.id);
+        }
+        editor.getState().pushHistory("edit layer");
+        return layerNode(reReadLayer(layer.id));
+      },
+
+      reorderLayer(target, direction) {
+        const layer = requireLayer(target);
+        const layers = doc().layers;
+        const from = layers.findIndex((l) => l.id === layer.id);
+        // Higher flat-array index = visually higher. "up" moves the layer
+        // toward the top of the stack (higher index).
+        const to = direction === "up" ? from + 1 : from - 1;
+        if (to < 0 || to >= layers.length) {
+          throw new Error(
+            `Cannot move layer "${layer.name}" ${direction}; it is already at the ${
+              direction === "up" ? "top" : "bottom"
+            }.`
+          );
+        }
+        editor.getState().reorderLayers(from, to);
+        editor.getState().pushHistory("reorder layers");
+        return layerNode(reReadLayer(layer.id));
+      },
+
+      mergeLayerDown(target) {
+        const layer = requireLayer(target);
+        editor.getState().mergeLayerDown(layer.id);
+        editor.getState().pushHistory("merge down");
+        const survivor = doc().layers.find((l) => l.id === layer.id);
+        return survivor ? layerNode(survivor) : null;
+      },
+
+      flattenVisible() {
+        editor.getState().flattenVisible();
+        editor.getState().pushHistory("flatten visible");
+        const id = doc().activeLayerId;
+        return layerNode(reReadLayer(id));
+      },
+
+      async generate(opts) {
+        const documentId = session.getState().documentId;
+        if (!documentId) {
+          throw new Error("No image document is open.");
+        }
+        const kind = opts.kind;
+        const modelKind = getRememberedModel("image");
+        const provider = opts.provider ?? modelKind?.provider;
+        const model = opts.model ?? modelKind?.model;
+
+        let sourceLayerId: string | null = null;
+        if (kind === "image-to-image") {
+          if (!opts.sourceLayer) {
+            throw new Error(
+              "image-to-image requires `sourceLayer` — the layer to transform."
+            );
+          }
+          sourceLayerId = requireLayer(opts.sourceLayer).id;
+        }
+
+        const d = doc();
+        const width = opts.width ?? d.canvas.width;
+        const height = opts.height ?? d.canvas.height;
+
+        const layerId = editor
+          .getState()
+          .addLayer(
+            uniqueLayerName(
+              opts.name ??
+                (kind === "text-to-image" ? "Text-to-Image" : "Image-to-Image")
+            )
+          );
+        session.getState().upsertBinding({
+          layerId,
+          kind,
+          prompt: opts.prompt.trim(),
+          provider,
+          model,
+          width,
+          height,
+          aspectRatio: opts.aspectRatio,
+          resolution: opts.resolution,
+          sourceLayerId,
+          status: "draft",
+          versions: []
+        });
+        editor.getState().setActiveLayer(layerId);
+
+        const canGenerate =
+          !!provider && !!model && opts.prompt.trim().length > 0;
+        let generationStarted = false;
+        let note: string | undefined;
+        if (opts.autoGenerate === false) {
+          note = "Layer created as a draft (autoGenerate was false).";
+        } else if (!canGenerate) {
+          note =
+            "Layer created as a draft — no model resolved. Provide provider + model, then regenerate.";
+        } else {
+          await startDirectGen(layerId);
+          generationStarted =
+            session.getState().bindings[layerId]?.status !== "failed";
+          if (!generationStarted) {
+            note = "Generation could not be started; the layer is a draft.";
+          }
+        }
+
+        return {
+          layer: layerNode(reReadLayer(layerId)),
+          generationStarted,
+          note
+        };
+      },
+
+      setForegroundColor(color) {
+        editor.getState().setForegroundColor(color);
+        return editor.getState().foregroundColor;
+      },
+
+      setBackgroundColor(color) {
+        editor.getState().setBackgroundColor(color);
+        return editor.getState().backgroundColor;
+      },
+
+      setActiveTool(tool) {
+        if (!SKETCH_TOOLS.includes(tool)) {
+          throw new Error(
+            `Unknown tool "${tool}". Valid tools: ${SKETCH_TOOLS.join(", ")}.`
+          );
+        }
+        editor.getState().setActiveTool(tool);
+        return tool;
+      },
+
+      resizeCanvas(width, height) {
+        const w = Math.max(1, Math.round(width));
+        const h = Math.max(1, Math.round(height));
+        editor.getState().resizeCanvas(w, h);
+        editor.getState().pushHistory("resize canvas");
+        return { width: w, height: h };
+      },
+
+      setSelection(op) {
+        const state = editor.getState();
+        switch (op) {
+          case "all":
+            state.selectAll();
+            break;
+          case "clear":
+            state.setSelection(null);
+            break;
+          case "invert":
+            state.invertSelection();
+            break;
+        }
+        state.pushHistory("selection", undefined, { selectionOnly: true });
+        return { hasSelection: editor.getState().hasActiveSelection };
+      },
+
+      async getLayerImage(target) {
+        const refs = canvasRef.getState();
+        const d = doc();
+        if (target === null) {
+          const flatten = refs.flattenToDataUrl;
+          if (!flatten) throw new Error("Canvas is not ready yet.");
+          const dataUrl = flatten();
+          if (!dataUrl) throw new Error("Could not flatten the canvas.");
+          return {
+            layerId: null,
+            layerName: null,
+            width: d.canvas.width,
+            height: d.canvas.height,
+            dataUrl
+          };
+        }
+        const layer = requireLayer(target);
+        const read = refs.getLayerData;
+        if (!read) throw new Error("Canvas is not ready yet.");
+        const dataUrl = read(layer.id);
+        if (!dataUrl) {
+          throw new Error(`Layer "${layer.name}" has no pixel data.`);
+        }
+        return {
+          layerId: layer.id,
+          layerName: layer.name,
+          width: d.canvas.width,
+          height: d.canvas.height,
+          dataUrl
+        };
+      }
+    };
+  }, [instance, startDirectGen]);
+
+  useEffect(() => {
+    if (!active) return;
+    setSketchAgentHandler(handler);
+    return () => {
+      // Only clear if we're still the registered handler — a newly-focused
+      // editor may have already replaced us.
+      if (hasSketchAgentHandler() && getSketchAgentHandler() === handler) {
+        setSketchAgentHandler(null);
+      }
+    };
+  }, [active, handler]);
+};

--- a/web/src/lib/sketch/renderLayerToAsset.ts
+++ b/web/src/lib/sketch/renderLayerToAsset.ts
@@ -116,6 +116,70 @@ export async function renderLayerToAsset(
   };
 }
 
+export interface RenderLayersMergedParams {
+  doc: SketchDocument;
+  /** Layer ids to composite together, in any order. */
+  layerIds: string[];
+  /** Optional override for the uploaded asset's file base name. */
+  name?: string;
+}
+
+/**
+ * Composite a subset of layers into a single PNG and upload it as a temporary
+ * asset. The named layers are drawn bottom-to-top in their original document
+ * order, honoring each layer's opacity and blend mode; their group nesting is
+ * flattened away (parents ignored) so the result is exactly those layers over
+ * transparency. Throws when a layer is missing or none of them have pixels.
+ */
+export async function renderLayersMerged(
+  params: RenderLayersMergedParams
+): Promise<RenderedLayerAsset> {
+  const { doc, layerIds, name } = params;
+  if (layerIds.length === 0) {
+    throw new Error("renderLayersMerged requires at least one layer id.");
+  }
+
+  const idSet = new Set(layerIds);
+  for (const id of layerIds) {
+    if (!doc.layers.some((l) => l.id === id)) {
+      throw new Error(`Layer not found in the document: ${id}`);
+    }
+  }
+
+  // Keep original document order (bottom → top) and render each selected layer
+  // at root level so its own opacity/blend apply without ancestor-group state.
+  const selected = doc.layers
+    .filter((l) => idSet.has(l.id))
+    .map((l) => ({ ...l, parentId: null, visible: true }));
+  if (!selected.some((l) => l.data)) {
+    throw new Error("None of the selected layers have pixel data to render.");
+  }
+
+  const filteredDoc: SketchDocument = {
+    ...doc,
+    maskLayerId: null,
+    layers: selected
+  };
+  const canvas = await flattenDocument(filteredDoc);
+  const blob = await canvasToBlob(canvas);
+
+  const file = new File([blob], `${safeBase(name ?? "layers")}.png`, {
+    type: blob.type || "image/png"
+  });
+  const asset = await useAssetStore
+    .getState()
+    .createAsset(file, undefined, undefined, undefined, "file");
+
+  return {
+    assetId: asset.id,
+    url: getAssetUrl(asset) ?? `asset://${asset.id}.png`,
+    width: doc.canvas.width,
+    height: doc.canvas.height,
+    layerId: null,
+    layerName: null
+  };
+}
+
 /** Best-effort delete of a temporary render asset. Never throws. */
 export async function deleteRenderedAsset(assetId: string): Promise<void> {
   try {

--- a/web/src/lib/sketch/renderLayerToAsset.ts
+++ b/web/src/lib/sketch/renderLayerToAsset.ts
@@ -1,0 +1,126 @@
+/**
+ * renderLayerToAsset
+ *
+ * Render a sketch layer — or the flattened composite of all visible layers — to
+ * a PNG and upload it as a throwaway ("temporary") asset, returning its id and
+ * URL.
+ *
+ * These uploads are ordinary assets (there is no server-side TTL); "temporary"
+ * means the caller owns their lifetime and should delete them once consumed,
+ * mirroring the inpaint / direct-gen source-image uploads. Use
+ * {@link deleteRenderedAsset} for best-effort cleanup.
+ *
+ * The composite prefers the live canvas (`flattenToDataUrl`, so unsaved strokes
+ * are included) and falls back to re-flattening the serialized document. A
+ * single layer is rendered from its committed raster data via `exportLayer`.
+ */
+
+import {
+  canvasToBlob,
+  exportLayer,
+  flattenDocument
+} from "../../components/sketch/serialization";
+import type { SketchDocument } from "../../components/sketch/types";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+
+export interface RenderedLayerAsset {
+  /** Uploaded asset id. */
+  assetId: string;
+  /** Best-effort resolvable URL for the asset (falls back to asset://). */
+  url: string;
+  /** Rendered image width (canvas width). */
+  width: number;
+  /** Rendered image height (canvas height). */
+  height: number;
+  /** null for the composite; otherwise the rendered layer id. */
+  layerId: string | null;
+  /** null for the composite; otherwise the rendered layer name. */
+  layerName: string | null;
+}
+
+async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
+  const res = await fetch(dataUrl);
+  return res.blob();
+}
+
+/** Sanitize a layer name into a safe file base. */
+function safeBase(name: string): string {
+  const trimmed = name.trim().replace(/[^a-z0-9-_]+/gi, "-").replace(/^-+|-+$/g, "");
+  return trimmed || "layer";
+}
+
+export interface RenderLayerToAssetParams {
+  doc: SketchDocument;
+  /** Layer id to render, or null for the flattened composite. */
+  layerId: string | null;
+  /** Live-canvas flatten getter, preferred for the composite when available. */
+  flattenToDataUrl?: (() => string | null) | null;
+  /** Optional override for the uploaded asset's file base name. */
+  name?: string;
+}
+
+/**
+ * Render the target and upload it as a temporary asset. Throws when the layer
+ * is missing/empty or the canvas cannot be rendered.
+ */
+export async function renderLayerToAsset(
+  params: RenderLayerToAssetParams
+): Promise<RenderedLayerAsset> {
+  const { doc, layerId, flattenToDataUrl, name } = params;
+  const width = doc.canvas.width;
+  const height = doc.canvas.height;
+
+  let blob: Blob;
+  let layerName: string | null = null;
+  let fileBase: string;
+
+  if (layerId === null) {
+    // Composite: prefer the live canvas so in-flight strokes are captured.
+    const liveDataUrl = flattenToDataUrl?.() ?? null;
+    if (liveDataUrl) {
+      blob = await dataUrlToBlob(liveDataUrl);
+    } else {
+      const canvas = await flattenDocument(doc);
+      blob = await canvasToBlob(canvas);
+    }
+    fileBase = safeBase(name ?? "composite");
+  } else {
+    const layer = doc.layers.find((l) => l.id === layerId);
+    if (!layer) {
+      throw new Error(`Layer not found in the document: ${layerId}`);
+    }
+    layerName = layer.name;
+    const canvas = await exportLayer(doc, layerId);
+    if (!canvas) {
+      throw new Error(`Layer "${layer.name}" has no pixel data to render.`);
+    }
+    blob = await canvasToBlob(canvas);
+    fileBase = safeBase(name ?? layer.name);
+  }
+
+  const file = new File([blob], `${fileBase}.png`, {
+    type: blob.type || "image/png"
+  });
+  const asset = await useAssetStore
+    .getState()
+    .createAsset(file, undefined, undefined, undefined, "file");
+
+  return {
+    assetId: asset.id,
+    url: getAssetUrl(asset) ?? `asset://${asset.id}.png`,
+    width,
+    height,
+    layerId,
+    layerName
+  };
+}
+
+/** Best-effort delete of a temporary render asset. Never throws. */
+export async function deleteRenderedAsset(assetId: string): Promise<void> {
+  try {
+    await useAssetStore.getState().delete(assetId);
+  } catch {
+    // Ignore — cleanup is best-effort.
+  }
+}

--- a/web/src/lib/tools/__tests__/sketchTools.test.ts
+++ b/web/src/lib/tools/__tests__/sketchTools.test.ts
@@ -58,7 +58,8 @@ const createMockHandler = (): jest.Mocked<SketchAgentHandler> => ({
   resizeCanvas: jest.fn(),
   setSelection: jest.fn(),
   getLayerImage: jest.fn(),
-  renderLayerToAsset: jest.fn()
+  renderLayerToAsset: jest.fn(),
+  renderLayersToAssets: jest.fn()
 });
 
 // The sketch tools never touch the workflow state, so a bare stub satisfies ctx.
@@ -295,11 +296,77 @@ describe("ui_sketch_* tools", () => {
       {},
       "sk-12",
       ctx
-    )) as { ok: boolean; assetId: string; url: string };
+    )) as { ok: boolean; assets: Array<{ assetId: string; url: string }> };
 
     expect(handler.renderLayerToAsset).toHaveBeenCalledWith(null, undefined);
-    expect(result.assetId).toBe("asset-9");
-    expect(result.url).toBe("asset://asset-9.png");
+    expect(result.assets[0].assetId).toBe("asset-9");
+    expect(result.assets[0].url).toBe("asset://asset-9.png");
+  });
+
+  it("renders multiple layers, each to its own asset", async () => {
+    const handler = createMockHandler();
+    handler.renderLayersToAssets.mockResolvedValue([
+      {
+        assetId: "asset-a",
+        url: "asset://asset-a.png",
+        width: 1024,
+        height: 1024,
+        layerId: "layer-1",
+        layerName: "Sky"
+      },
+      {
+        assetId: "asset-b",
+        url: "asset://asset-b.png",
+        width: 1024,
+        height: 1024,
+        layerId: "layer-2",
+        layerName: "Hills"
+      }
+    ]);
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_render_to_asset",
+      { targets: ["Sky", "Hills"] },
+      "sk-multi",
+      ctx
+    )) as { ok: boolean; assets: Array<{ assetId: string }> };
+
+    expect(handler.renderLayersToAssets).toHaveBeenCalledWith(["Sky", "Hills"], {
+      merge: undefined,
+      name: undefined
+    });
+    expect(handler.renderLayerToAsset).not.toHaveBeenCalled();
+    expect(result.assets.map((a) => a.assetId)).toEqual(["asset-a", "asset-b"]);
+  });
+
+  it("merges multiple layers into a single asset", async () => {
+    const handler = createMockHandler();
+    handler.renderLayersToAssets.mockResolvedValue([
+      {
+        assetId: "asset-merged",
+        url: "asset://asset-merged.png",
+        width: 1024,
+        height: 1024,
+        layerId: null,
+        layerName: null
+      }
+    ]);
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_render_to_asset",
+      { targets: ["Sky", "Hills"], merge: true, name: "scene" },
+      "sk-merge",
+      ctx
+    )) as { ok: boolean; assets: Array<{ assetId: string }> };
+
+    expect(handler.renderLayersToAssets).toHaveBeenCalledWith(["Sky", "Hills"], {
+      merge: true,
+      name: "scene"
+    });
+    expect(result.assets).toHaveLength(1);
+    expect(result.assets[0].assetId).toBe("asset-merged");
   });
 
   it("renders a named layer to a temporary asset", async () => {
@@ -314,14 +381,15 @@ describe("ui_sketch_* tools", () => {
     });
     setSketchAgentHandler(handler);
 
-    await FrontendToolRegistry.call(
+    const result = (await FrontendToolRegistry.call(
       "ui_sketch_render_to_asset",
       { target: "Sky", name: "sky-export" },
       "sk-13",
       ctx
-    );
+    )) as { ok: boolean; assets: Array<{ assetId: string }> };
 
     expect(handler.renderLayerToAsset).toHaveBeenCalledWith("Sky", "sky-export");
+    expect(result.assets[0].assetId).toBe("asset-10");
   });
 
   it("resizes the canvas through the handler", async () => {

--- a/web/src/lib/tools/__tests__/sketchTools.test.ts
+++ b/web/src/lib/tools/__tests__/sketchTools.test.ts
@@ -57,7 +57,8 @@ const createMockHandler = (): jest.Mocked<SketchAgentHandler> => ({
   setActiveTool: jest.fn(),
   resizeCanvas: jest.fn(),
   setSelection: jest.fn(),
-  getLayerImage: jest.fn()
+  getLayerImage: jest.fn(),
+  renderLayerToAsset: jest.fn()
 });
 
 // The sketch tools never touch the workflow state, so a bare stub satisfies ctx.
@@ -86,7 +87,8 @@ describe("ui_sketch_* tools", () => {
         "ui_sketch_set_tool",
         "ui_sketch_resize_canvas",
         "ui_sketch_selection",
-        "ui_sketch_get_layer_image"
+        "ui_sketch_get_layer_image",
+        "ui_sketch_render_to_asset"
       ])
     );
   });
@@ -274,6 +276,52 @@ describe("ui_sketch_* tools", () => {
 
     expect(handler.getLayerImage).toHaveBeenCalledWith(null);
     expect(result.dataUrl).toBe("data:image/png;base64,abc");
+  });
+
+  it("renders the composite to a temporary asset", async () => {
+    const handler = createMockHandler();
+    handler.renderLayerToAsset.mockResolvedValue({
+      assetId: "asset-9",
+      url: "asset://asset-9.png",
+      width: 1024,
+      height: 1024,
+      layerId: null,
+      layerName: null
+    });
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_render_to_asset",
+      {},
+      "sk-12",
+      ctx
+    )) as { ok: boolean; assetId: string; url: string };
+
+    expect(handler.renderLayerToAsset).toHaveBeenCalledWith(null, undefined);
+    expect(result.assetId).toBe("asset-9");
+    expect(result.url).toBe("asset://asset-9.png");
+  });
+
+  it("renders a named layer to a temporary asset", async () => {
+    const handler = createMockHandler();
+    handler.renderLayerToAsset.mockResolvedValue({
+      assetId: "asset-10",
+      url: "asset://asset-10.png",
+      width: 1024,
+      height: 1024,
+      layerId: "layer-1",
+      layerName: "Sky"
+    });
+    setSketchAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_sketch_render_to_asset",
+      { target: "Sky", name: "sky-export" },
+      "sk-13",
+      ctx
+    );
+
+    expect(handler.renderLayerToAsset).toHaveBeenCalledWith("Sky", "sky-export");
   });
 
   it("resizes the canvas through the handler", async () => {

--- a/web/src/lib/tools/__tests__/sketchTools.test.ts
+++ b/web/src/lib/tools/__tests__/sketchTools.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @jest-environment node
+ */
+import { FrontendToolRegistry } from "../frontendTools";
+import type { FrontendToolState } from "../frontendTools";
+import {
+  setSketchAgentHandler,
+  type SketchAgentHandler,
+  type SketchLayerNode,
+  type SketchSnapshot
+} from "../../../components/sketch/sketchAgentBridge";
+import "../builtin/sketch";
+
+const layerNode = (
+  overrides: Partial<SketchLayerNode> = {}
+): SketchLayerNode => ({
+  id: "layer-1",
+  name: "Layer 1",
+  type: "raster",
+  visible: true,
+  opacity: 1,
+  blendMode: "normal",
+  locked: false,
+  alphaLock: false,
+  parentId: null,
+  index: 0,
+  hasBinding: false,
+  ...overrides
+});
+
+const snapshot = (): SketchSnapshot => ({
+  documentId: "doc-1",
+  name: "Untitled",
+  width: 1024,
+  height: 1024,
+  activeLayerId: "layer-1",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#000000",
+  activeTool: "brush",
+  hasSelection: false,
+  layers: [layerNode()]
+});
+
+const createMockHandler = (): jest.Mocked<SketchAgentHandler> => ({
+  getSnapshot: jest.fn(),
+  addLayer: jest.fn(),
+  removeLayer: jest.fn(),
+  duplicateLayer: jest.fn(),
+  selectLayer: jest.fn(),
+  setLayerProps: jest.fn(),
+  reorderLayer: jest.fn(),
+  mergeLayerDown: jest.fn(),
+  flattenVisible: jest.fn(),
+  generate: jest.fn(),
+  setForegroundColor: jest.fn(),
+  setBackgroundColor: jest.fn(),
+  setActiveTool: jest.fn(),
+  resizeCanvas: jest.fn(),
+  setSelection: jest.fn(),
+  getLayerImage: jest.fn()
+});
+
+// The sketch tools never touch the workflow state, so a bare stub satisfies ctx.
+const ctx = { getState: () => ({}) as FrontendToolState };
+
+afterEach(() => {
+  setSketchAgentHandler(null);
+});
+
+describe("ui_sketch_* tools", () => {
+  it("registers all sketch tools in the manifest", () => {
+    const names = FrontendToolRegistry.getManifest().map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "ui_sketch_get_state",
+        "ui_sketch_add_layer",
+        "ui_sketch_remove_layer",
+        "ui_sketch_duplicate_layer",
+        "ui_sketch_select_layer",
+        "ui_sketch_set_layer_props",
+        "ui_sketch_reorder_layer",
+        "ui_sketch_merge_down",
+        "ui_sketch_flatten_visible",
+        "ui_sketch_generate",
+        "ui_sketch_set_color",
+        "ui_sketch_set_tool",
+        "ui_sketch_resize_canvas",
+        "ui_sketch_selection",
+        "ui_sketch_get_layer_image"
+      ])
+    );
+  });
+
+  it("exposes set_layer_props schema with target required", () => {
+    const tool = FrontendToolRegistry.getManifest().find(
+      (t) => t.name === "ui_sketch_set_layer_props"
+    );
+    expect(tool).toBeDefined();
+    const schema = tool?.parameters as {
+      type?: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toHaveProperty("target");
+    expect(schema.required).toContain("target");
+  });
+
+  it("rejects with a descriptive error when no editor is open", async () => {
+    await expect(
+      FrontendToolRegistry.call("ui_sketch_get_state", {}, "sk-1", ctx)
+    ).rejects.toThrow("No image editor is open");
+  });
+
+  it("returns the document snapshot through the handler", async () => {
+    const handler = createMockHandler();
+    handler.getSnapshot.mockReturnValue(snapshot());
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_get_state",
+      {},
+      "sk-2",
+      ctx
+    )) as { ok: boolean } & SketchSnapshot;
+
+    expect(handler.getSnapshot).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.layers).toHaveLength(1);
+    expect(result.width).toBe(1024);
+  });
+
+  it("adds a layer with a fill color", async () => {
+    const handler = createMockHandler();
+    handler.addLayer.mockReturnValue(layerNode({ name: "Sky" }));
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_add_layer",
+      { name: "Sky", fillColor: "#001133" },
+      "sk-3",
+      ctx
+    )) as { ok: boolean; layer: SketchLayerNode };
+
+    expect(handler.addLayer).toHaveBeenCalledWith({
+      name: "Sky",
+      fillColor: "#001133",
+      type: undefined
+    });
+    expect(result.layer.name).toBe("Sky");
+  });
+
+  it("generates imagery via the handler", async () => {
+    const handler = createMockHandler();
+    handler.generate.mockResolvedValue({
+      layer: layerNode({ name: "Text-to-Image", hasBinding: true }),
+      generationStarted: true
+    });
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_generate",
+      {
+        kind: "text-to-image",
+        prompt: "a mountain landscape",
+        provider: "fal",
+        model: "some-image-model"
+      },
+      "sk-4",
+      ctx
+    )) as { ok: boolean; layer: SketchLayerNode; generationStarted: boolean };
+
+    expect(handler.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "text-to-image",
+        prompt: "a mountain landscape",
+        provider: "fal",
+        model: "some-image-model"
+      })
+    );
+    expect(result.generationStarted).toBe(true);
+  });
+
+  it("rejects an unknown generation kind during validation", async () => {
+    setSketchAgentHandler(createMockHandler());
+    await expect(
+      FrontendToolRegistry.call(
+        "ui_sketch_generate",
+        { kind: "text-to-hologram", prompt: "x" },
+        "sk-5",
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+
+  it("forwards layer prop patches to the handler", async () => {
+    const handler = createMockHandler();
+    handler.setLayerProps.mockReturnValue(layerNode({ opacity: 0.5 }));
+    setSketchAgentHandler(handler);
+
+    await FrontendToolRegistry.call(
+      "ui_sketch_set_layer_props",
+      { target: "active", opacity: 0.5, blendMode: "multiply" },
+      "sk-6",
+      ctx
+    );
+
+    expect(handler.setLayerProps).toHaveBeenCalledWith("active", {
+      opacity: 0.5,
+      blendMode: "multiply"
+    });
+  });
+
+  it("rejects an out-of-range opacity during validation", async () => {
+    setSketchAgentHandler(createMockHandler());
+    await expect(
+      FrontendToolRegistry.call(
+        "ui_sketch_set_layer_props",
+        { target: "active", opacity: 5 },
+        "sk-7",
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+
+  it("sets foreground and background color through the handler", async () => {
+    const handler = createMockHandler();
+    handler.setForegroundColor.mockReturnValue("#ff0000");
+    handler.setBackgroundColor.mockReturnValue("#0000ff");
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_set_color",
+      { foreground: "#ff0000", background: "#0000ff" },
+      "sk-8",
+      ctx
+    )) as { ok: boolean; foreground: string; background: string };
+
+    expect(handler.setForegroundColor).toHaveBeenCalledWith("#ff0000");
+    expect(handler.setBackgroundColor).toHaveBeenCalledWith("#0000ff");
+    expect(result.foreground).toBe("#ff0000");
+    expect(result.background).toBe("#0000ff");
+  });
+
+  it("rejects an unknown tool during validation", async () => {
+    setSketchAgentHandler(createMockHandler());
+    await expect(
+      FrontendToolRegistry.call(
+        "ui_sketch_set_tool",
+        { tool: "teleport" },
+        "sk-9",
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+
+  it("reads the composite image when no target is given", async () => {
+    const handler = createMockHandler();
+    handler.getLayerImage.mockResolvedValue({
+      layerId: null,
+      layerName: null,
+      width: 1024,
+      height: 1024,
+      dataUrl: "data:image/png;base64,abc"
+    });
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_get_layer_image",
+      {},
+      "sk-10",
+      ctx
+    )) as { ok: boolean; dataUrl: string };
+
+    expect(handler.getLayerImage).toHaveBeenCalledWith(null);
+    expect(result.dataUrl).toBe("data:image/png;base64,abc");
+  });
+
+  it("resizes the canvas through the handler", async () => {
+    const handler = createMockHandler();
+    handler.resizeCanvas.mockReturnValue({ width: 512, height: 768 });
+    setSketchAgentHandler(handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_resize_canvas",
+      { width: 512, height: 768 },
+      "sk-11",
+      ctx
+    )) as { ok: boolean; width: number; height: number };
+
+    expect(handler.resizeCanvas).toHaveBeenCalledWith(512, 768);
+    expect(result.width).toBe(512);
+    expect(result.height).toBe(768);
+  });
+});

--- a/web/src/lib/tools/builtin/sketch.ts
+++ b/web/src/lib/tools/builtin/sketch.ts
@@ -1,0 +1,272 @@
+import { z } from "zod";
+import { FrontendToolRegistry } from "../frontendTools";
+import { getSketchAgentHandler } from "../../../components/sketch/sketchAgentBridge";
+
+/**
+ * Frontend tools that let the agent drive the live image / sketch editor —
+ * adding and arranging layers, generating imagery, recoloring, and reshaping the
+ * canvas like a real editor.
+ *
+ * They delegate to the handler the open {@link SketchEditor} registers on the
+ * {@link sketchAgentBridge}. When no editor is open, `getSketchAgentHandler`
+ * throws a descriptive error which the tool layer surfaces back to the agent.
+ *
+ * Conventions:
+ *   - Layers are addressed by id, by (case-insensitive) name, or the literal
+ *     `"active"` for the active layer.
+ *   - Call `ui_sketch_get_state` first to discover the ids/names other tools
+ *     need.
+ */
+
+const targetParam = z
+  .string()
+  .describe(
+    'Layer id, layer name (case-insensitive), or the literal "active" for the active layer.'
+  );
+
+const blendModeEnum = z.enum([
+  "normal",
+  "multiply",
+  "screen",
+  "overlay",
+  "darken",
+  "lighten",
+  "color-dodge",
+  "color-burn",
+  "hard-light",
+  "soft-light",
+  "difference",
+  "exclusion",
+  "add"
+]);
+
+const toolEnum = z.enum([
+  "move",
+  "transform",
+  "select",
+  "brush",
+  "pencil",
+  "eraser",
+  "eyedropper",
+  "fill",
+  "shape",
+  "blur",
+  "gradient",
+  "crop",
+  "clone_stamp",
+  "adjust",
+  "segment"
+]);
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_get_state",
+  description:
+    "Read the open image editor: document name, canvas size, the active layer, foreground/background color, the active tool, whether a pixel selection is active, and every layer (id, name, type, visibility, opacity, blend mode, lock state, and any generation binding prompt/provider/model/status). Call this first to discover what's on the canvas and to get the ids/names other image-editor tools need.",
+  parameters: z.object({}),
+  async execute() {
+    const snapshot = getSketchAgentHandler().getSnapshot();
+    return { ok: true, ...snapshot };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_add_layer",
+  description:
+    "Add a new layer above the active one. `type` is raster (default) or mask. Optionally give it a `name` and a `fillColor` (hex) to fill it with a solid color.",
+  parameters: z.object({
+    name: z.string().optional(),
+    type: z.enum(["raster", "mask"]).optional(),
+    fillColor: z
+      .string()
+      .optional()
+      .describe("Hex color to fill the new layer with, e.g. #ff0000.")
+  }),
+  async execute({ name, type, fillColor }) {
+    const layer = getSketchAgentHandler().addLayer({ name, type, fillColor });
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_remove_layer",
+  description: "Delete a layer from the document.",
+  parameters: z.object({ target: targetParam }),
+  async execute({ target }) {
+    const layer = getSketchAgentHandler().removeLayer(target);
+    return { ok: true, deleted: layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_duplicate_layer",
+  description:
+    "Duplicate a layer. The copy is inserted directly above the source.",
+  parameters: z.object({ target: targetParam }),
+  async execute({ target }) {
+    const layer = getSketchAgentHandler().duplicateLayer(target);
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_select_layer",
+  description: "Make a layer the active layer (subsequent edits target it).",
+  parameters: z.object({ target: targetParam }),
+  async execute({ target }) {
+    const layer = getSketchAgentHandler().selectLayer(target);
+    return { ok: true, active: layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_set_layer_props",
+  description:
+    "Change a layer's properties: `name`, `visible`, `opacity` (0..1), `blendMode`, `locked`, or `alphaLock` (lock transparency). Omit a field to leave it unchanged.",
+  parameters: z.object({
+    target: targetParam,
+    name: z.string().optional(),
+    visible: z.boolean().optional(),
+    opacity: z.number().min(0).max(1).optional(),
+    blendMode: blendModeEnum.optional(),
+    locked: z.boolean().optional(),
+    alphaLock: z.boolean().optional()
+  }),
+  async execute({ target, ...patch }) {
+    const layer = getSketchAgentHandler().setLayerProps(target, patch);
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_reorder_layer",
+  description:
+    "Move a layer up or down in the stack. `up` moves it toward the top (composited above its neighbors); `down` moves it toward the bottom.",
+  parameters: z.object({
+    target: targetParam,
+    direction: z.enum(["up", "down"])
+  }),
+  async execute({ target, direction }) {
+    const layer = getSketchAgentHandler().reorderLayer(target, direction);
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_merge_down",
+  description:
+    "Merge a layer into the layer directly below it, replacing the two with a single flattened raster layer.",
+  parameters: z.object({ target: targetParam }),
+  async execute({ target }) {
+    const layer = getSketchAgentHandler().mergeLayerDown(target);
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_flatten_visible",
+  description:
+    "Flatten all visible layers into a single raster layer. Returns the resulting layer.",
+  parameters: z.object({}),
+  async execute() {
+    const layer = getSketchAgentHandler().flattenVisible();
+    return { ok: true, layer };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_generate",
+  description:
+    'Generate imagery onto a new layer. `kind` is text-to-image (from a prompt) or image-to-image (transform an existing layer — pass `sourceLayer`). Provide `provider` and `model` (discover valid ones with the model-search tool); when omitted the last-used image model is reused. Optional `width`/`height` (default the canvas size), `aspectRatio` (e.g. "16:9"), and `resolution` (e.g. "1K") shape the output for models that use size enums. Generation starts immediately unless `autoGenerate` is false. Poll ui_sketch_get_state for the layer\'s binding status.',
+  parameters: z.object({
+    kind: z.enum(["text-to-image", "image-to-image"]),
+    prompt: z.string(),
+    name: z.string().optional(),
+    sourceLayer: targetParam
+      .optional()
+      .describe("For image-to-image: the layer to transform."),
+    provider: z.string().optional(),
+    model: z.string().optional(),
+    width: z.number().optional(),
+    height: z.number().optional(),
+    aspectRatio: z.string().optional(),
+    resolution: z.string().optional(),
+    autoGenerate: z.boolean().optional()
+  }),
+  async execute(args) {
+    const result = await getSketchAgentHandler().generate(args);
+    return { ok: true, ...result };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_set_color",
+  description:
+    "Set the editor's foreground and/or background color (hex). The foreground color is used by the brush, fill, and shape tools.",
+  parameters: z.object({
+    foreground: z.string().optional(),
+    background: z.string().optional()
+  }),
+  async execute({ foreground, background }) {
+    const handler = getSketchAgentHandler();
+    const result: { foreground?: string; background?: string } = {};
+    if (foreground !== undefined) {
+      result.foreground = handler.setForegroundColor(foreground);
+    }
+    if (background !== undefined) {
+      result.background = handler.setBackgroundColor(background);
+    }
+    return { ok: true, ...result };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_set_tool",
+  description:
+    "Select the active editor tool (e.g. brush, eraser, fill, select, move, transform, crop). Drives which tool the editor's pointer uses.",
+  parameters: z.object({ tool: toolEnum }),
+  async execute({ tool }) {
+    const active = getSketchAgentHandler().setActiveTool(tool);
+    return { ok: true, activeTool: active };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_resize_canvas",
+  description:
+    "Resize the canvas (artboard) to `width` x `height` pixels. Existing layers keep their pixels; content outside the new bounds is clipped.",
+  parameters: z.object({
+    width: z.number().min(1),
+    height: z.number().min(1)
+  }),
+  async execute({ width, height }) {
+    const size = getSketchAgentHandler().resizeCanvas(width, height);
+    return { ok: true, ...size };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_selection",
+  description:
+    "Shape the pixel selection: `all` selects the whole canvas, `invert` inverts the current selection, `clear` deselects. Inpainting and selection-scoped edits act within this selection.",
+  parameters: z.object({ op: z.enum(["all", "clear", "invert"]) }),
+  async execute({ op }) {
+    const result = getSketchAgentHandler().setSelection(op);
+    return { ok: true, ...result };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_get_layer_image",
+  description:
+    "Inspect the canvas as an image. Omit `target` (or pass null) for the flattened composite of all visible layers; pass a layer id/name to read that single layer's pixels. Returns a PNG data URL plus dimensions so you can see the current artwork before editing it.",
+  parameters: z.object({
+    target: targetParam
+      .nullable()
+      .optional()
+      .describe("Layer to read; omit or null for the flattened composite.")
+  }),
+  async execute({ target }) {
+    const result = await getSketchAgentHandler().getLayerImage(target ?? null);
+    return { ok: true, ...result };
+  }
+});

--- a/web/src/lib/tools/builtin/sketch.ts
+++ b/web/src/lib/tools/builtin/sketch.ts
@@ -270,3 +270,26 @@ FrontendToolRegistry.register({
     return { ok: true, ...result };
   }
 });
+
+FrontendToolRegistry.register({
+  name: "ui_sketch_render_to_asset",
+  description:
+    "Render the canvas to a PNG and save it as a temporary asset, returning its asset id and URL. Omit `target` (or pass null) for the flattened composite of all visible layers; pass a layer id/name to render that single layer. Use this to hand the current artwork (or one layer) to another tool or workflow that needs an asset id rather than raw pixels. The asset is a throwaway upload — delete it when you're done with it.",
+  parameters: z.object({
+    target: targetParam
+      .nullable()
+      .optional()
+      .describe("Layer to render; omit or null for the flattened composite."),
+    name: z
+      .string()
+      .optional()
+      .describe("Optional base name for the uploaded asset file.")
+  }),
+  async execute({ target, name }) {
+    const result = await getSketchAgentHandler().renderLayerToAsset(
+      target ?? null,
+      name
+    );
+    return { ok: true, ...result };
+  }
+});

--- a/web/src/lib/tools/builtin/sketch.ts
+++ b/web/src/lib/tools/builtin/sketch.ts
@@ -274,22 +274,39 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_sketch_render_to_asset",
   description:
-    "Render the canvas to a PNG and save it as a temporary asset, returning its asset id and URL. Omit `target` (or pass null) for the flattened composite of all visible layers; pass a layer id/name to render that single layer. Use this to hand the current artwork (or one layer) to another tool or workflow that needs an asset id rather than raw pixels. The asset is a throwaway upload — delete it when you're done with it.",
+    "Render the canvas to a PNG (or PNGs) and save it as a temporary asset, returning asset ids and URLs. Provide one of: nothing (or `target` null) → the flattened composite of all visible layers as one asset; a single `target` (id/name) → that one layer; or `targets` (a list of ids/names) → each layer as its own asset, unless `merge` is true, in which case the listed layers are composited (bottom-to-top, honoring opacity/blend) into a single asset. Use this to hand the artwork to another tool or workflow that needs an asset id rather than raw pixels. Assets are throwaway uploads — delete them when done. Returns `assets` (an array of {assetId, url, width, height, layerId, layerName}).",
   parameters: z.object({
     target: targetParam
       .nullable()
       .optional()
-      .describe("Layer to render; omit or null for the flattened composite."),
+      .describe(
+        "Single layer to render; omit (with no `targets`) for the flattened composite."
+      ),
+    targets: z
+      .array(targetParam)
+      .optional()
+      .describe("Multiple layers to render (ids/names)."),
+    merge: z
+      .boolean()
+      .optional()
+      .describe(
+        "When `targets` is given: composite them into one asset instead of one asset per layer."
+      ),
     name: z
       .string()
       .optional()
-      .describe("Optional base name for the uploaded asset file.")
+      .describe("Optional base name for the uploaded asset file(s).")
   }),
-  async execute({ target, name }) {
-    const result = await getSketchAgentHandler().renderLayerToAsset(
-      target ?? null,
-      name
-    );
-    return { ok: true, ...result };
+  async execute({ target, targets, merge, name }) {
+    const handler = getSketchAgentHandler();
+    if (targets && targets.length > 0) {
+      const assets = await handler.renderLayersToAssets(targets, {
+        merge,
+        name
+      });
+      return { ok: true, assets };
+    }
+    const result = await handler.renderLayerToAsset(target ?? null, name);
+    return { ok: true, assets: [result] };
   }
 });

--- a/web/src/lib/tools/frontendToolsIpc.ts
+++ b/web/src/lib/tools/frontendToolsIpc.ts
@@ -27,6 +27,7 @@ import "./builtin/uiActions";
 import "./builtin/model3d";
 import "./builtin/timeline";
 import "./builtin/storyboard";
+import "./builtin/sketch";
 import "./builtin/script";
 import "./builtin/puck";
 import "./builtin/entities";

--- a/web/src/stores/sketch/SketchCanvasRefStore.ts
+++ b/web/src/stores/sketch/SketchCanvasRefStore.ts
@@ -9,6 +9,10 @@ export interface SketchCanvasRefState {
   getMaskDataUrl: (() => string | null) | null;
   /** Writes pixel data (PNG data URL) into the given raster layer. */
   setLayerData: ((layerId: string, data: string | null) => void) | null;
+  /** Reads a layer's pixels as a serialized raster payload / PNG data URL. */
+  getLayerData: ((layerId: string) => string | null) | null;
+  /** Fills the given raster layer with a solid color (respecting alpha lock). */
+  fillLayerWithColor: ((layerId: string, color: string) => void) | null;
   /**
    * Clears the active layer — within the active selection if one exists,
    * otherwise the whole layer. Pushes its own history entry.
@@ -19,6 +23,8 @@ export interface SketchCanvasRefState {
     flattenToDataUrl: () => string;
     getMaskDataUrl: () => string | null;
     setLayerData: (layerId: string, data: string | null) => void;
+    getLayerData?: (layerId: string) => string | null;
+    fillLayerWithColor?: (layerId: string, color: string) => void;
     clearActiveLayer: () => void;
   }) => void;
   clearGetters: () => void;
@@ -34,6 +40,8 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
     flattenToDataUrl: null,
     getMaskDataUrl: null,
     setLayerData: null,
+    getLayerData: null,
+    fillLayerWithColor: null,
     clearActiveLayer: null,
 
     setGetters: (getters) =>
@@ -41,6 +49,8 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
         flattenToDataUrl: getters.flattenToDataUrl,
         getMaskDataUrl: getters.getMaskDataUrl,
         setLayerData: getters.setLayerData,
+        getLayerData: getters.getLayerData ?? null,
+        fillLayerWithColor: getters.fillLayerWithColor ?? null,
         clearActiveLayer: getters.clearActiveLayer
       }),
 
@@ -49,6 +59,8 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
         flattenToDataUrl: null,
         getMaskDataUrl: null,
         setLayerData: null,
+        getLayerData: null,
+        fillLayerWithColor: null,
         clearActiveLayer: null
       })
   }));


### PR DESCRIPTION
## What

Brings the timeline/storyboard editors' agent-chat pattern to the **image (sketch) editor**: a toggleable right-side **Assistant** panel whose LLM can drive the canvas through a new set of `ui_sketch_*` frontend tools. No backend changes — the unified `/ws` chat loop already forwards any registered `ui_*` tool whose manifest it received, as long as the turn carries a `workflow_id`.

Until now the editor's only AI surfaces were single-shot: the full-frame prompt bar and the selection inpaint/edit bar. This adds a conversational agent that can plan and execute multi-step edits (add layers, generate, recolor, reorder, resize, inspect) like a real editor.

## How

- **`components/sketch/sketchAgentBridge.ts`** — serializable `SketchAgentHandler` interface + snapshot/node types, with `get/set/hasSketchAgentHandler` (mirrors `timelineAgentBridge`). Nothing but plain JSON crosses the bridge.
- **`hooks/sketch/useSketchAgentBridge.ts`** — builds the handler from the editor's per-instance stores (editor, session bindings, canvas refs) plus `useDirectGenJob`, and registers it while the editor is the focused surface (cleared on blur/unmount). Layers are addressed by id, case-insensitive name, or the literal `"active"`.
- **`lib/tools/builtin/sketch.ts`** — registers the `ui_sketch_*` tools: `get_state`, `add_layer`, `remove_layer`, `duplicate_layer`, `select_layer`, `set_layer_props`, `reorder_layer`, `merge_down`, `flatten_visible`, `generate` (text-to-image / image-to-image), `set_color`, `set_tool`, `resize_canvas`, `selection`, and `get_layer_image` (returns a PNG data URL so the agent can *see* the artwork). Registered in `frontendToolsIpc.ts`.
- **`components/sketch/SketchAgentPanel.tsx`** — reuses `ChatView` + `GlobalChatStore`, passing the open document id as `workflow_id` (context only — no `workflow_target`, so the document is never run as a workflow).
- **`SketchEditor.tsx`** — mounts the panel as a toggleable right-most column, calls `useSketchAgentBridge(active)`, and threads an `active` prop from `StandaloneSketchEditor`. An **Assistant** toggle button was added to the prompt bar; the `assistantPanelOpen` flag lives in the UI slice.
- **`SketchCanvasRefStore.ts`** — extended with `getLayerData` / `fillLayerWithColor` getters (kept optional for existing callers) so the bridge can read and fill layers, reusing the canvas's real fill logic.

## Testing

- `npm run typecheck` (web): 0 errors.
- `npm run lint` (web): passes (exit 0); the panel's `useMemo` dep warning matches the existing `TimelineAgentPanel`/`StoryboardAgentPanel` siblings.
- New `src/lib/tools/__tests__/sketchTools.test.ts` (13 tests) covers manifest registration, schema shape, the no-editor error path, handler delegation, and Zod validation rejections — all pass. Existing `SketchCanvasRefStore`/`SelectionActionBar` suites still pass. (The unrelated canvas-rendering suites fail only because the native `canvas` dep is skipped in this sandbox; verified identical failures without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyF6AfWZPdihy1TLKLi9ca

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyF6AfWZPdihy1TLKLi9ca)_