### PR TITLE
Add VLM-judge creative critique tools

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -210,6 +210,14 @@ export {
 } from "./tools/media-tools.js";
 export { ImageGenerationTool } from "./tools/image-generation-tool.js";
 export {
+  CritiqueImageTool,
+  CompareImagesTool,
+  ScoreImageAdherenceTool,
+  RecordStylePreferenceTool,
+  GetStyleProfileTool,
+  CREATIVE_CRITIQUE_TOOL_NAMES
+} from "./tools/creative-critique-tools.js";
+export {
   persistOutput,
   workspaceDir as workspaceDirFromContext,
   inferImageMime,

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -77,6 +77,13 @@ import {
 } from "./edit-search-tools.js";
 import { TodoWriteTool } from "./todo-tools.js";
 import { ViewImageTool, ListImagesTool } from "./view-image-tool.js";
+import {
+  CritiqueImageTool,
+  CompareImagesTool,
+  ScoreImageAdherenceTool,
+  RecordStylePreferenceTool,
+  GetStyleProfileTool
+} from "./creative-critique-tools.js";
 
 export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   // Filesystem (workspace-relative)
@@ -103,6 +110,13 @@ export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   DataForSEOSearchTool,
   DataForSEONewsTool,
   DataForSEOImagesTool,
+
+  // Creative critique (VLM judging + taste memory)
+  CritiqueImageTool,
+  CompareImagesTool,
+  ScoreImageAdherenceTool,
+  RecordStylePreferenceTool,
+  GetStyleProfileTool,
 
   // Generation
   ImageGenerationTool,

--- a/packages/agents/src/tools/creative-critique-tools.ts
+++ b/packages/agents/src/tools/creative-critique-tools.ts
@@ -1,0 +1,725 @@
+/**
+ * Creative critique tools — the judging half of a generate → look → critique →
+ * revise loop, built entirely on VLM chat calls (`generate_message` capability).
+ * No dedicated scorer models: the same vision-capable chat models the agent
+ * already uses do the judging, shaped around what VLMs are measurably good at:
+ *
+ * - `compare_images` uses pairwise comparison, never absolute scores. VLM
+ *   judges agree with humans far more when picking between two images than
+ *   when scoring one, and verdicts flip with presentation order — so every
+ *   match runs twice with the order swapped, and a tiebreak call settles
+ *   disagreements.
+ * - `critique_image` asks for *directional* defects (what's wrong, where, and
+ *   the concrete fix) rather than a score. It explicitly forbids "add more
+ *   detail" advice — iteration loops driven by vague critique polish details
+ *   while freezing a bad composition.
+ * - `score_image_adherence` decomposes the brief into binary yes/no checks and
+ *   has the VLM answer each one — an explainable adherence score, instead of
+ *   one opaque number a judge can't calibrate.
+ *
+ * The taste half: `record_style_preference` / `get_style_profile` persist the
+ * user's aesthetic preferences through {@link LongTermMemory} so briefs and
+ * judge rubrics can carry a durable style profile across sessions.
+ *
+ * All judging tools take `provider` + `model` params (pair with `find_model`,
+ * capability `generate_message` on a vision-capable model) and run through
+ * `ProcessingContext.runProviderPrediction`, so asset:// image URIs resolve
+ * exactly like they do everywhere else.
+ */
+
+import type { Message, MessageContent } from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+import { extractJSON } from "../utils/json-parser.js";
+import { LongTermMemory } from "../long-term-memory.js";
+import { getLongTermMemory } from "./ltm-tools.js";
+
+const MAX_COMPARE_IMAGES = 8;
+const MAX_ADHERENCE_QUESTIONS = 12;
+const JUDGE_MAX_TOKENS = 1500;
+
+interface ModelArgs {
+  provider: string;
+  model: string;
+}
+
+function parseModelArgs(
+  params: Record<string, unknown>
+): ModelArgs | { error: string } {
+  const provider = params["provider"];
+  const model = params["model"];
+  if (typeof provider !== "string" || !provider) {
+    return {
+      error:
+        "provider must be a non-empty string (use find_model with a vision-capable chat model)"
+    };
+  }
+  if (typeof model !== "string" || !model) {
+    return {
+      error:
+        "model must be a non-empty string (use find_model with a vision-capable chat model)"
+    };
+  }
+  return { provider, model };
+}
+
+/** Normalize an image source so the context media resolver can inline it. */
+function normalizeImageSource(source: string): string {
+  const trimmed = source.trim();
+  if (
+    trimmed.startsWith("data:") ||
+    trimmed.startsWith("asset://") ||
+    /^https?:\/\//i.test(trimmed)
+  ) {
+    return trimmed;
+  }
+  // Bare asset ids (what list_images and generate_image return) become
+  // asset:// URIs, which resolveMessageMediaUris inlines as data URIs.
+  return `asset://${trimmed}`;
+}
+
+function imagePart(source: string): MessageContent {
+  return {
+    type: "image_url",
+    image: { type: "image", uri: normalizeImageSource(source) }
+  };
+}
+
+function textPart(text: string): MessageContent {
+  return { type: "text", text };
+}
+
+/** Pull the text out of a provider response message. */
+function messageText(message: Message): string {
+  const content = message.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+async function judgeCall(
+  context: ProcessingContext,
+  m: ModelArgs,
+  content: MessageContent[]
+): Promise<string> {
+  const result = (await context.runProviderPrediction({
+    provider: m.provider,
+    capability: "generate_message",
+    model: m.model,
+    params: {
+      messages: [{ role: "user", content }] satisfies Message[],
+      max_tokens: JUDGE_MAX_TOKENS,
+      temperature: 0
+    }
+  })) as Message;
+  return messageText(result);
+}
+
+function tasteBlock(params: Record<string, unknown>): string {
+  const profile = params["taste_profile"];
+  if (typeof profile !== "string" || !profile.trim()) return "";
+  return `\n\nThe user's known aesthetic preferences (weigh these alongside the brief):\n${profile.trim()}`;
+}
+
+// ---------------------------------------------------------------------------
+// critique_image
+// ---------------------------------------------------------------------------
+
+interface CritiqueDefect {
+  defect: string;
+  location: string;
+  fix: string;
+}
+
+interface CritiqueResult {
+  verdict: "pass" | "revise";
+  defects: CritiqueDefect[];
+  strengths: string[];
+}
+
+function parseCritique(text: string): CritiqueResult | null {
+  const parsed = extractJSON(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  const verdict = obj["verdict"] === "pass" ? "pass" : "revise";
+  const defects: CritiqueDefect[] = Array.isArray(obj["defects"])
+    ? (obj["defects"] as unknown[])
+        .filter((d): d is Record<string, unknown> =>
+          Boolean(d && typeof d === "object")
+        )
+        .map((d) => ({
+          defect: String(d["defect"] ?? ""),
+          location: String(d["location"] ?? ""),
+          fix: String(d["fix"] ?? "")
+        }))
+        .filter((d) => d.defect)
+    : [];
+  const strengths: string[] = Array.isArray(obj["strengths"])
+    ? (obj["strengths"] as unknown[]).map(String).filter(Boolean)
+    : [];
+  return { verdict, defects, strengths };
+}
+
+export class CritiqueImageTool extends Tool {
+  readonly name = "critique_image";
+  readonly description =
+    "Have a vision model critique a generated image against the brief and " +
+    "return directional feedback: concrete defects with locations and fixes, " +
+    "plus a pass/revise verdict. Use the fixes to revise the prompt and " +
+    "regenerate; if the critique names no specific defect, prefer generating " +
+    "fresh variations over further iteration.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      provider: {
+        type: "string" as const,
+        description: "Provider id of a vision-capable chat model (find_model)."
+      },
+      model: { type: "string" as const, description: "Model id." },
+      image: {
+        type: "string" as const,
+        description: "Image to critique: asset id, asset:// URI, URL, or data URI."
+      },
+      brief: {
+        type: "string" as const,
+        description:
+          "What the image is supposed to be — the original creative brief, " +
+          "including mood, constraints, and any must-have elements."
+      },
+      taste_profile: {
+        type: "string" as const,
+        description:
+          "Optional style profile from get_style_profile to judge against " +
+          "the user's aesthetic, not generic taste."
+      }
+    },
+    required: ["provider", "model", "image", "brief"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const m = parseModelArgs(params);
+    if ("error" in m) return m;
+    const image = params["image"];
+    const brief = params["brief"];
+    if (typeof image !== "string" || !image) return { error: "image is required" };
+    if (typeof brief !== "string" || !brief) return { error: "brief is required" };
+
+    const prompt =
+      `You are a demanding art director reviewing one image against a brief.` +
+      `\n\nBrief:\n${brief}${tasteBlock(params)}` +
+      `\n\nExamine the image and report only defects you can point at: things that are` +
+      ` wrong, missing relative to the brief, or technically broken (anatomy, geometry,` +
+      ` illegible text, composition, lighting inconsistencies). For each defect say` +
+      ` exactly where it is and the concrete change that fixes it.` +
+      `\n\nRules:` +
+      `\n- Never suggest adding embellishment or "more detail" — only fixes to named problems.` +
+      `\n- If the composition itself is wrong for the brief, say so explicitly; that means` +
+      ` regenerating, not patching.` +
+      `\n- Verdict "pass" only if the image fulfills the brief with no defect a client would notice.` +
+      `\n\nRespond with JSON only:` +
+      `\n{"verdict": "pass" | "revise", "defects": [{"defect": "...", "location": "...",` +
+      ` "fix": "..."}], "strengths": ["..."]}`;
+
+    try {
+      const text = await judgeCall(context, m, [
+        textPart(prompt),
+        imagePart(image)
+      ]);
+      const critique = parseCritique(text);
+      if (!critique) {
+        return { error: `Judge did not return parseable JSON: ${text.slice(0, 300)}` };
+      }
+      return { type: "critique", provider: m.provider, model: m.model, ...critique };
+    } catch (e) {
+      return {
+        error: `critique_image failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
+
+  userMessage(): string {
+    return "Critiquing image against the brief";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// compare_images
+// ---------------------------------------------------------------------------
+
+interface MatchRecord {
+  a: string;
+  b: string;
+  winner: string;
+  agreed: boolean;
+  reason: string;
+}
+
+function parsePairVerdict(text: string): { winner: 1 | 2; reason: string } | null {
+  const parsed = extractJSON(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+  const winner = Number(obj["winner"]);
+  if (winner !== 1 && winner !== 2) return null;
+  return { winner, reason: String(obj["reason"] ?? "") };
+}
+
+export class CompareImagesTool extends Tool {
+  readonly name = "compare_images";
+  readonly description =
+    "Pick the image that best fulfills a brief from 2-8 candidates using a " +
+    "vision model as a pairwise judge. Runs a knockout tournament; every " +
+    "match is judged twice with the presentation order swapped (VLM verdicts " +
+    "are order-sensitive) and a tiebreak call settles disagreements. Returns " +
+    "the winner plus every match verdict. All candidates remain available — " +
+    "treat the ranking as triage, not deletion.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      provider: {
+        type: "string" as const,
+        description: "Provider id of a vision-capable chat model (find_model)."
+      },
+      model: { type: "string" as const, description: "Model id." },
+      images: {
+        type: "array" as const,
+        items: { type: "string" as const },
+        minItems: 2,
+        maxItems: MAX_COMPARE_IMAGES,
+        description:
+          "2-8 candidate images: asset ids, asset:// URIs, URLs, or data URIs."
+      },
+      brief: {
+        type: "string" as const,
+        description: "The creative brief the images are judged against."
+      },
+      taste_profile: {
+        type: "string" as const,
+        description:
+          "Optional style profile from get_style_profile so the judge weighs " +
+          "the user's aesthetic."
+      }
+    },
+    required: ["provider", "model", "images", "brief"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const m = parseModelArgs(params);
+    if ("error" in m) return m;
+    const images = params["images"];
+    const brief = params["brief"];
+    if (
+      !Array.isArray(images) ||
+      images.length < 2 ||
+      images.some((i) => typeof i !== "string" || !i)
+    ) {
+      return { error: "images must be an array of 2-8 non-empty strings" };
+    }
+    if (images.length > MAX_COMPARE_IMAGES) {
+      return { error: `images must contain at most ${MAX_COMPARE_IMAGES} candidates` };
+    }
+    if (typeof brief !== "string" || !brief) return { error: "brief is required" };
+
+    const prompt =
+      `You are judging which of two images better fulfills a creative brief.` +
+      `\n\nBrief:\n${brief}${tasteBlock(params)}` +
+      `\n\nImage 1 is shown first, image 2 second. Judge fulfillment of the brief and` +
+      ` craft (composition, coherence, technical execution) — not which image is busier` +
+      ` or more embellished. You must pick exactly one winner.` +
+      `\n\nRespond with JSON only: {"winner": 1 | 2, "reason": "one sentence"}`;
+
+    const judgePair = async (
+      a: string,
+      b: string
+    ): Promise<{ winner: string; reason: string } | { error: string }> => {
+      const call = async (first: string, second: string) => {
+        const text = await judgeCall(context, m, [
+          textPart(prompt),
+          imagePart(first),
+          imagePart(second)
+        ]);
+        const verdict = parsePairVerdict(text);
+        if (!verdict) {
+          throw new Error(`Judge did not return parseable JSON: ${text.slice(0, 200)}`);
+        }
+        return {
+          winner: verdict.winner === 1 ? first : second,
+          reason: verdict.reason
+        };
+      };
+      try {
+        // Same pair, both presentation orders: an order-dependent preference
+        // cancels out; only a stable preference wins outright.
+        const [forward, reversed] = [await call(a, b), await call(b, a)];
+        if (forward.winner === reversed.winner) {
+          return { winner: forward.winner, reason: forward.reason };
+        }
+        const tiebreakFirst = Math.random() < 0.5;
+        const tiebreak = tiebreakFirst ? await call(a, b) : await call(b, a);
+        return {
+          winner: tiebreak.winner,
+          reason: `(order-sensitive verdict, tiebreak) ${tiebreak.reason}`
+        };
+      } catch (e) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    };
+
+    const matches: MatchRecord[] = [];
+    let round = images.map(String);
+    try {
+      while (round.length > 1) {
+        const next: string[] = [];
+        for (let i = 0; i + 1 < round.length; i += 2) {
+          const result = await judgePair(round[i], round[i + 1]);
+          if ("error" in result) return { error: `compare_images failed: ${result.error}` };
+          matches.push({
+            a: round[i],
+            b: round[i + 1],
+            winner: result.winner,
+            agreed: !result.reason.startsWith("(order-sensitive"),
+            reason: result.reason
+          });
+          next.push(result.winner);
+        }
+        if (round.length % 2 === 1) next.push(round[round.length - 1]);
+        round = next;
+      }
+    } catch (e) {
+      return {
+        error: `compare_images failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+
+    return {
+      type: "comparison",
+      provider: m.provider,
+      model: m.model,
+      winner: round[0],
+      matches,
+      note:
+        "Winner of a pairwise knockout. Other candidates were not deleted — " +
+        "surface them to the user if the pick looks wrong."
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const n = Array.isArray(params["images"]) ? params["images"].length : 0;
+    return n ? `Comparing ${n} images against the brief` : "Comparing images";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// score_image_adherence
+// ---------------------------------------------------------------------------
+
+interface AdherenceAnswer {
+  question: string;
+  answer: "yes" | "no";
+  note: string;
+}
+
+export class ScoreImageAdherenceTool extends Tool {
+  readonly name = "score_image_adherence";
+  readonly description =
+    "Score how faithfully an image matches a brief by decomposing the brief " +
+    "into binary yes/no checks and answering each one with a vision model. " +
+    "Returns the per-check answers and the fraction that passed — an " +
+    "explainable adherence score, not an opaque rating. Pass `questions` to " +
+    "skip decomposition and check exactly those.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      provider: {
+        type: "string" as const,
+        description: "Provider id of a vision-capable chat model (find_model)."
+      },
+      model: { type: "string" as const, description: "Model id." },
+      image: {
+        type: "string" as const,
+        description: "Image to score: asset id, asset:// URI, URL, or data URI."
+      },
+      brief: {
+        type: "string" as const,
+        description: "The creative brief the image must adhere to."
+      },
+      questions: {
+        type: "array" as const,
+        items: { type: "string" as const },
+        description:
+          "Optional explicit yes/no checks. When omitted, the brief is " +
+          "decomposed into up to 12 atomic checks automatically."
+      }
+    },
+    required: ["provider", "model", "image", "brief"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const m = parseModelArgs(params);
+    if ("error" in m) return m;
+    const image = params["image"];
+    const brief = params["brief"];
+    if (typeof image !== "string" || !image) return { error: "image is required" };
+    if (typeof brief !== "string" || !brief) return { error: "brief is required" };
+
+    try {
+      let questions = Array.isArray(params["questions"])
+        ? (params["questions"] as unknown[]).map(String).filter(Boolean)
+        : [];
+
+      if (questions.length === 0) {
+        const decomposeText = await judgeCall(context, m, [
+          textPart(
+            `Decompose this creative brief into at most ${MAX_ADHERENCE_QUESTIONS} atomic` +
+              ` yes/no questions, each verifiable by looking at a single image. Cover every` +
+              ` explicit requirement (subjects, counts, colors, text, style, composition,` +
+              ` mood). Phrase each so "yes" means the requirement is met. Skip anything not` +
+              ` visually checkable.` +
+              `\n\nBrief:\n${brief}` +
+              `\n\nRespond with JSON only: {"questions": ["..."]}`
+          )
+        ]);
+        const parsed = extractJSON(decomposeText);
+        const list =
+          parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)["questions"]
+            : parsed;
+        questions = Array.isArray(list) ? list.map(String).filter(Boolean) : [];
+        if (questions.length === 0) {
+          return {
+            error: `Could not decompose the brief into checks: ${decomposeText.slice(0, 300)}`
+          };
+        }
+      }
+      questions = questions.slice(0, MAX_ADHERENCE_QUESTIONS);
+
+      const answerText = await judgeCall(context, m, [
+        textPart(
+          `Answer each question about the image with a strict yes or no. "yes" only if` +
+            ` the image clearly satisfies it; when unsure, answer "no" and say why in the note.` +
+            `\n\nQuestions:\n${questions.map((q, i) => `${i + 1}. ${q}`).join("\n")}` +
+            `\n\nRespond with JSON only:` +
+            `\n{"answers": [{"question": "...", "answer": "yes" | "no", "note": "..."}]}`
+        ),
+        imagePart(image)
+      ]);
+      const parsed = extractJSON(answerText);
+      const rawAnswers =
+        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)["answers"]
+          : null;
+      if (!Array.isArray(rawAnswers) || rawAnswers.length === 0) {
+        return { error: `Judge did not return parseable answers: ${answerText.slice(0, 300)}` };
+      }
+      const answers: AdherenceAnswer[] = rawAnswers
+        .filter((a): a is Record<string, unknown> => Boolean(a && typeof a === "object"))
+        .map((a) => ({
+          question: String(a["question"] ?? ""),
+          answer: a["answer"] === "yes" ? "yes" : "no",
+          note: String(a["note"] ?? "")
+        }));
+      const passed = answers.filter((a) => a.answer === "yes").length;
+      return {
+        type: "adherence",
+        provider: m.provider,
+        model: m.model,
+        score: answers.length ? passed / answers.length : 0,
+        passed,
+        total: answers.length,
+        failed: answers.filter((a) => a.answer === "no"),
+        answers
+      };
+    } catch (e) {
+      return {
+        error: `score_image_adherence failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
+
+  userMessage(): string {
+    return "Scoring image adherence to the brief";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// record_style_preference / get_style_profile
+// ---------------------------------------------------------------------------
+
+function resolveMemory(
+  bound: LongTermMemory | null,
+  context: ProcessingContext
+): LongTermMemory | null {
+  return bound ?? getLongTermMemory(context.userId);
+}
+
+export class RecordStylePreferenceTool extends Tool {
+  readonly name = "record_style_preference";
+  readonly description =
+    "Persist one aesthetic preference learned from the user — which variant " +
+    "they chose, what they rejected, or a stated taste — as a durable memory. " +
+    "Call it whenever the user picks between candidates, corrects a style, or " +
+    "expresses what they like. These accumulate into the profile returned by " +
+    "get_style_profile.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      takeaway: {
+        type: "string" as const,
+        description:
+          "One self-contained sentence stating the preference (e.g. \"User " +
+          "prefers muted, desaturated palettes over vivid colors for poster " +
+          "work.\")."
+      },
+      chosen: {
+        type: "string" as const,
+        description: "Optional short description of what the user picked."
+      },
+      rejected: {
+        type: "string" as const,
+        description: "Optional short description of what they passed over."
+      },
+      brief: {
+        type: "string" as const,
+        description: "Optional context: the brief or task the choice was made in."
+      },
+      importance: {
+        type: "number" as const,
+        minimum: 0,
+        maximum: 1,
+        description:
+          "How broadly this preference applies (1 = always, 0.3 = niche). Default 0.6."
+      }
+    },
+    required: ["takeaway"]
+  };
+
+  constructor(private readonly bound: LongTermMemory | null = null) {
+    super();
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const memory = resolveMemory(this.bound, context);
+    if (!memory) {
+      return { stored: false, note: "Long-term memory is not configured." };
+    }
+    const takeaway = typeof params["takeaway"] === "string" ? params["takeaway"].trim() : "";
+    if (!takeaway) return { stored: false, note: "takeaway is required" };
+
+    const details: string[] = [];
+    if (typeof params["chosen"] === "string" && params["chosen"].trim())
+      details.push(`chose: ${params["chosen"].trim()}`);
+    if (typeof params["rejected"] === "string" && params["rejected"].trim())
+      details.push(`over: ${params["rejected"].trim()}`);
+    if (typeof params["brief"] === "string" && params["brief"].trim())
+      details.push(`brief: ${params["brief"].trim()}`);
+    const text = details.length ? `${takeaway} (${details.join("; ")})` : takeaway;
+
+    const stored = await memory.remember(text, {
+      kind: "preference",
+      importance:
+        typeof params["importance"] === "number" ? params["importance"] : 0.6,
+      source: "style_preference"
+    });
+    if (!stored) {
+      return { stored: false, note: "Skipped as duplicate of existing preference." };
+    }
+    return { stored: true, id: stored.id, text };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const t = typeof params["takeaway"] === "string" ? params["takeaway"] : "";
+    return t ? `Remembering preference: ${t.slice(0, 60)}` : "Recording style preference";
+  }
+}
+
+export class GetStyleProfileTool extends Tool {
+  readonly name = "get_style_profile";
+  readonly description =
+    "Retrieve the user's accumulated aesthetic preferences as a style profile " +
+    "block. Inject it into generation prompts and pass it as `taste_profile` " +
+    "to critique_image / compare_images so judging reflects the user's taste, " +
+    "not generic preference.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string" as const,
+        description:
+          "Optional focus (e.g. \"typography\", \"color palettes for posters\"). " +
+          "Defaults to a broad visual-style query."
+      },
+      k: {
+        type: "number" as const,
+        minimum: 1,
+        maximum: 20,
+        description: "Maximum preferences to include (default 10)."
+      }
+    },
+    required: []
+  };
+
+  constructor(private readonly bound: LongTermMemory | null = null) {
+    super();
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const memory = resolveMemory(this.bound, context);
+    if (!memory) {
+      return { profile: "", items: [], note: "Long-term memory is not configured." };
+    }
+    const query =
+      typeof params["query"] === "string" && params["query"].trim()
+        ? params["query"].trim()
+        : "visual style aesthetic preference taste";
+    const k =
+      typeof params["k"] === "number" && Number.isFinite(params["k"])
+        ? Math.max(1, Math.min(20, Math.trunc(params["k"])))
+        : 10;
+
+    const items = (await memory.recall(query, { k })).filter(
+      (item) => item.kind === "preference"
+    );
+    return {
+      profile: items.map((item) => `- ${item.text}`).join("\n"),
+      items: items.map((item) => ({
+        id: item.id,
+        text: item.text,
+        importance: item.importance
+      }))
+    };
+  }
+
+  userMessage(): string {
+    return "Loading the user's style profile";
+  }
+}
+
+/** Names of the creative critique tools. */
+export const CREATIVE_CRITIQUE_TOOL_NAMES = [
+  "critique_image",
+  "compare_images",
+  "score_image_adherence",
+  "record_style_preference",
+  "get_style_profile"
+] as const;

--- a/packages/agents/src/tools/creative-critique-tools.ts
+++ b/packages/agents/src/tools/creative-critique-tools.ts
@@ -27,6 +27,7 @@
  * exactly like they do everywhere else.
  */
 
+import { randomInt } from "node:crypto";
 import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { Tool } from "./base-tool.js";
@@ -366,8 +367,10 @@ export class CompareImagesTool extends Tool {
         if (forward.winner === reversed.winner) {
           return { winner: forward.winner, reason: forward.reason };
         }
-        const tiebreakFirst = Math.random() < 0.5;
-        const tiebreak = tiebreakFirst ? await call(a, b) : await call(b, a);
+        // crypto randomInt over Math.random: not security-sensitive (it only
+        // picks the tiebreak presentation order), but it keeps CodeQL's
+        // insecure-randomness rule quiet without an exception.
+        const tiebreak = randomInt(2) === 0 ? await call(a, b) : await call(b, a);
         return {
           winner: tiebreak.winner,
           reason: `(order-sensitive verdict, tiebreak) ${tiebreak.reason}`

--- a/packages/agents/tests/creative-critique-tools.test.ts
+++ b/packages/agents/tests/creative-critique-tools.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for the VLM-judge creative critique tools: critique_image,
+ * compare_images, score_image_adherence, record_style_preference,
+ * get_style_profile.
+ *
+ * All judging goes through `ProcessingContext.runProviderPrediction` with the
+ * `generate_message` capability; that surface is mocked here — no providers,
+ * network, or database. The taste tools are exercised against a stubbed
+ * LongTermMemory bound via the constructor.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Message, MessageContent } from "@nodetool-ai/protocol";
+import {
+  CritiqueImageTool,
+  CompareImagesTool,
+  ScoreImageAdherenceTool,
+  RecordStylePreferenceTool,
+  GetStyleProfileTool
+} from "../src/tools/creative-critique-tools.js";
+import type { LongTermMemory } from "../src/long-term-memory.js";
+
+function makeContext(runProviderPrediction?: ReturnType<typeof vi.fn>): any {
+  return { runProviderPrediction, userId: "user-1" };
+}
+
+function reply(json: unknown): Message {
+  return { role: "assistant", content: JSON.stringify(json) };
+}
+
+/** URIs of the image parts of the single user message in a judge call. */
+function imageUris(call: unknown[]): string[] {
+  const params = (call[0] as { params: { messages: Message[] } }).params;
+  const content = params.messages[0].content as MessageContent[];
+  return content
+    .filter((p): p is Extract<MessageContent, { type: "image_url" }> =>
+      p.type === "image_url"
+    )
+    .map((p) => p.image.uri ?? "");
+}
+
+function promptText(call: unknown[]): string {
+  const params = (call[0] as { params: { messages: Message[] } }).params;
+  const content = params.messages[0].content as MessageContent[];
+  return content
+    .map((p) => (p.type === "text" ? p.text : ""))
+    .join("\n");
+}
+
+/* ---------------- critique_image ---------------- */
+
+describe("CritiqueImageTool", () => {
+  it("validates provider/model/image/brief", async () => {
+    const tool = new CritiqueImageTool();
+    expect(
+      ((await tool.process(makeContext(), { model: "m", image: "i", brief: "b" })) as any)
+        .error
+    ).toContain("provider");
+    expect(
+      ((await tool.process(makeContext(), {
+        provider: "p",
+        model: "m",
+        brief: "b"
+      })) as any).error
+    ).toBe("image is required");
+    expect(
+      ((await tool.process(makeContext(), {
+        provider: "p",
+        model: "m",
+        image: "i"
+      })) as any).error
+    ).toBe("brief is required");
+  });
+
+  it("returns a parsed critique and normalizes bare asset ids", async () => {
+    const rpp = vi.fn().mockResolvedValue(
+      reply({
+        verdict: "revise",
+        defects: [
+          { defect: "text illegible", location: "bottom third", fix: "larger type" }
+        ],
+        strengths: ["strong palette"]
+      })
+    );
+    const tool = new CritiqueImageTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "openai",
+      model: "gpt-5",
+      image: "abc123",
+      brief: "A poster",
+      taste_profile: "- prefers muted palettes"
+    })) as any;
+
+    expect(r.verdict).toBe("revise");
+    expect(r.defects).toEqual([
+      { defect: "text illegible", location: "bottom third", fix: "larger type" }
+    ]);
+    expect(r.strengths).toEqual(["strong palette"]);
+    expect(rpp).toHaveBeenCalledTimes(1);
+    expect(imageUris(rpp.mock.calls[0])).toEqual(["asset://abc123"]);
+    expect(promptText(rpp.mock.calls[0])).toContain("prefers muted palettes");
+    // Judging runs deterministically.
+    expect((rpp.mock.calls[0][0] as any).params.temperature).toBe(0);
+  });
+
+  it("errors on unparseable judge output", async () => {
+    const rpp = vi.fn().mockResolvedValue({ role: "assistant", content: "nope" });
+    const tool = new CritiqueImageTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      image: "asset://x",
+      brief: "b"
+    })) as any;
+    expect(r.error).toContain("parseable JSON");
+  });
+});
+
+/* ---------------- compare_images ---------------- */
+
+describe("CompareImagesTool", () => {
+  it("rejects bad image lists", async () => {
+    const tool = new CompareImagesTool();
+    const one = (await tool.process(makeContext(), {
+      provider: "p",
+      model: "m",
+      images: ["only-one"],
+      brief: "b"
+    })) as any;
+    expect(one.error).toContain("2-8");
+    const nine = (await tool.process(makeContext(), {
+      provider: "p",
+      model: "m",
+      images: Array.from({ length: 9 }, (_, i) => `i${i}`),
+      brief: "b"
+    })) as any;
+    expect(nine.error).toContain("at most 8");
+  });
+
+  it("picks a stable winner from two order-swapped calls per match", async () => {
+    // The judge always prefers a.png regardless of presentation order.
+    const rpp = vi.fn().mockImplementation(async (req: any) => {
+      const uris = imageUris([req]);
+      const winner = uris.indexOf("asset://a.png") === 0 ? 1 : 2;
+      return reply({ winner, reason: "cleaner composition" });
+    });
+    const tool = new CompareImagesTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      images: ["a.png", "b.png"],
+      brief: "b"
+    })) as any;
+
+    // The winner is reported by the caller's original identifier.
+    expect(r.winner).toBe("a.png");
+    expect(r.matches).toHaveLength(1);
+    expect(r.matches[0].agreed).toBe(true);
+    expect(rpp).toHaveBeenCalledTimes(2);
+    // Second call presents the pair in reversed order.
+    expect(imageUris(rpp.mock.calls[0])).toEqual(["asset://a.png", "asset://b.png"]);
+    expect(imageUris(rpp.mock.calls[1])).toEqual(["asset://b.png", "asset://a.png"]);
+  });
+
+  it("runs a tiebreak call when the order-swapped verdicts disagree", async () => {
+    // Position-biased judge: always prefers whichever image is shown first.
+    const rpp = vi
+      .fn()
+      .mockImplementation(async () => reply({ winner: 1, reason: "first looks best" }));
+    const tool = new CompareImagesTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      images: ["a.png", "b.png"],
+      brief: "b"
+    })) as any;
+
+    expect(rpp).toHaveBeenCalledTimes(3);
+    expect(r.matches[0].agreed).toBe(false);
+    expect(r.matches[0].reason).toContain("order-sensitive");
+    expect(["a.png", "b.png"]).toContain(r.winner);
+  });
+
+  it("runs a knockout over more than two candidates with byes", async () => {
+    // Preference order c > a > b, stable across presentation order.
+    const rank: Record<string, number> = {
+      "asset://a.png": 1,
+      "asset://b.png": 2,
+      "asset://c.png": 0
+    };
+    const rpp = vi.fn().mockImplementation(async (req: any) => {
+      const uris = imageUris([req]);
+      const winner = rank[uris[0]] < rank[uris[1]] ? 1 : 2;
+      return reply({ winner, reason: "better" });
+    });
+    const tool = new CompareImagesTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      images: ["a.png", "b.png", "c.png"],
+      brief: "b"
+    })) as any;
+
+    // Round 1: a vs b (a wins), c gets a bye. Round 2: a vs c (c wins).
+    expect(r.winner).toBe("c.png");
+    expect(r.matches).toHaveLength(2);
+    expect(rpp).toHaveBeenCalledTimes(4);
+  });
+
+  it("surfaces judge failures as an error", async () => {
+    const rpp = vi.fn().mockRejectedValue(new Error("provider down"));
+    const tool = new CompareImagesTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      images: ["a.png", "b.png"],
+      brief: "b"
+    })) as any;
+    expect(r.error).toContain("provider down");
+  });
+});
+
+/* ---------------- score_image_adherence ---------------- */
+
+describe("ScoreImageAdherenceTool", () => {
+  it("decomposes the brief, answers each check, and scores", async () => {
+    const rpp = vi
+      .fn()
+      .mockResolvedValueOnce(
+        reply({ questions: ["Is there a fox?", "Is it snowing?", "Is the fox red?"] })
+      )
+      .mockResolvedValueOnce(
+        reply({
+          answers: [
+            { question: "Is there a fox?", answer: "yes", note: "" },
+            { question: "Is it snowing?", answer: "no", note: "clear sky" },
+            { question: "Is the fox red?", answer: "yes", note: "" }
+          ]
+        })
+      );
+    const tool = new ScoreImageAdherenceTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      image: "img1",
+      brief: "a red fox in snow"
+    })) as any;
+
+    expect(rpp).toHaveBeenCalledTimes(2);
+    // Decomposition call is text-only; the answer call carries the image.
+    expect(imageUris(rpp.mock.calls[0])).toEqual([]);
+    expect(imageUris(rpp.mock.calls[1])).toEqual(["asset://img1"]);
+    expect(r.score).toBeCloseTo(2 / 3);
+    expect(r.passed).toBe(2);
+    expect(r.total).toBe(3);
+    expect(r.failed).toEqual([
+      { question: "Is it snowing?", answer: "no", note: "clear sky" }
+    ]);
+  });
+
+  it("skips decomposition when questions are supplied", async () => {
+    const rpp = vi.fn().mockResolvedValue(
+      reply({ answers: [{ question: "Is it a logo?", answer: "yes", note: "" }] })
+    );
+    const tool = new ScoreImageAdherenceTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      image: "img1",
+      brief: "a logo",
+      questions: ["Is it a logo?"]
+    })) as any;
+
+    expect(rpp).toHaveBeenCalledTimes(1);
+    expect(r.score).toBe(1);
+  });
+
+  it("errors when decomposition yields no checks", async () => {
+    const rpp = vi.fn().mockResolvedValue({ role: "assistant", content: "??" });
+    const tool = new ScoreImageAdherenceTool();
+    const r = (await tool.process(makeContext(rpp), {
+      provider: "p",
+      model: "m",
+      image: "img1",
+      brief: "b"
+    })) as any;
+    expect(r.error).toContain("decompose");
+  });
+});
+
+/* ---------------- taste tools ---------------- */
+
+function makeMemory(overrides: Partial<Record<"remember" | "recall", any>> = {}) {
+  return {
+    remember:
+      overrides.remember ??
+      vi.fn().mockResolvedValue({ id: "mem-1", kind: "preference", importance: 0.6 }),
+    recall: overrides.recall ?? vi.fn().mockResolvedValue([])
+  } as unknown as LongTermMemory;
+}
+
+describe("RecordStylePreferenceTool", () => {
+  it("stores the takeaway with choice context appended", async () => {
+    const remember = vi
+      .fn()
+      .mockResolvedValue({ id: "mem-1", kind: "preference", importance: 0.6 });
+    const tool = new RecordStylePreferenceTool(makeMemory({ remember }));
+    const r = (await tool.process(makeContext(), {
+      takeaway: "User prefers muted palettes.",
+      chosen: "variant B",
+      rejected: "variant A",
+      brief: "poster"
+    })) as any;
+
+    expect(r.stored).toBe(true);
+    expect(r.text).toBe(
+      "User prefers muted palettes. (chose: variant B; over: variant A; brief: poster)"
+    );
+    expect(remember).toHaveBeenCalledWith(r.text, {
+      kind: "preference",
+      importance: 0.6,
+      source: "style_preference"
+    });
+  });
+
+  it("reports duplicates and missing configuration", async () => {
+    const dupTool = new RecordStylePreferenceTool(
+      makeMemory({ remember: vi.fn().mockResolvedValue(null) })
+    );
+    const dup = (await dupTool.process(makeContext(), { takeaway: "t" })) as any;
+    expect(dup.stored).toBe(false);
+    expect(dup.note).toContain("duplicate");
+
+    const unbound = new RecordStylePreferenceTool();
+    const r = (await unbound.process(makeContext(), { takeaway: "t" })) as any;
+    expect(r.stored).toBe(false);
+    expect(r.note).toContain("not configured");
+  });
+});
+
+describe("GetStyleProfileTool", () => {
+  it("returns only preference memories formatted as a profile block", async () => {
+    const recall = vi.fn().mockResolvedValue([
+      { id: "1", text: "Prefers muted palettes.", kind: "preference", importance: 0.8 },
+      { id: "2", text: "Works at a design studio.", kind: "fact", importance: 0.5 },
+      { id: "3", text: "Dislikes drop shadows.", kind: "preference", importance: 0.6 }
+    ]);
+    const tool = new GetStyleProfileTool(makeMemory({ recall }));
+    const r = (await tool.process(makeContext(), {})) as any;
+
+    expect(r.profile).toBe("- Prefers muted palettes.\n- Dislikes drop shadows.");
+    expect(r.items).toHaveLength(2);
+    expect(recall).toHaveBeenCalledWith(
+      "visual style aesthetic preference taste",
+      { k: 10 }
+    );
+  });
+
+  it("passes a custom query and k through to recall", async () => {
+    const recall = vi.fn().mockResolvedValue([]);
+    const tool = new GetStyleProfileTool(makeMemory({ recall }));
+    await tool.process(makeContext(), { query: "typography", k: 3 });
+    expect(recall).toHaveBeenCalledWith("typography", { k: 3 });
+  });
+});


### PR DESCRIPTION
## What

Five new agent tools in `packages/agents` that close the creative feedback loop — generate → look → critique → revise — built entirely on the vision-capable chat providers NodeTool already ships. No dedicated scorer models (PickScore/HPSv3-style weights) are introduced; all judging is VLM tool calls.

- **`critique_image`** — reviews one image against the brief and returns *directional* feedback: concrete defects with location and fix, plus a pass/revise verdict. The prompt forbids "add more detail" advice, since vague critique makes iteration loops polish details while freezing a bad composition.
- **`compare_images`** — picks the best of 2–8 candidates via a pairwise knockout tournament. VLM judges rank far better than they score and their verdicts are order-sensitive, so every match is judged twice with the presentation order swapped; disagreements go to a tiebreak call. Returns the winner plus every match verdict (triage, not deletion).
- **`score_image_adherence`** — decomposes the brief into up to 12 binary yes/no checks (or takes explicit ones) and has the VLM answer each, returning per-check answers and the pass fraction — an explainable adherence score instead of one opaque rating.
- **`record_style_preference` / `get_style_profile`** — persist aesthetic preferences (which variant the user chose, over what, in which brief) through `LongTermMemory` and return them as a profile block to inject into generation prompts and pass as `taste_profile` to the judging tools.

## How

Judging tools take `provider` + `model` params (pair with `find_model` on a vision-capable chat model) and call `ProcessingContext.runProviderPrediction` with the `generate_message` capability at temperature 0, so `asset://` image sources resolve to data URIs through the existing media resolver. Bare asset ids are normalized to `asset://` URIs. Taste tools follow the `ltm-tools` binding pattern (constructor-bound `LongTermMemory` or per-user registry fallback, degrading gracefully when LTM isn't configured). All five are registered in `BUILTIN_TOOL_CLASSES` and exported from the package index.

## Tests

15 new Vitest cases in `packages/agents/tests/creative-critique-tools.test.ts` covering param validation, JSON-parse failure paths, order-swap agreement and position-bias tiebreak behavior, knockout rounds with byes, adherence decompose/answer flow, and both taste tools. `npm run test --workspace=packages/agents` shows no new failures (71 pre-existing failures on this branch's base are environmental — sqlite-vec native module unavailable under `--ignore-scripts` install). Package `tsc --noEmit` and lint pass; web and electron typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGdnz8JAsc4p3SyUUY3sAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGdnz8JAsc4p3SyUUY3sAc)_