### PR TITLE
refactor(agents): GraphPlanner one-shots the workflow as a graph DSL program

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -222,7 +222,7 @@ Core business logic for workflows, nodes, agents, and persistence.
 **`agents`** — Multi-step LLM agent system with layered execution:
 - `Agent` — Entry point. Takes an objective (plus skills, tools, and optional `outputSchema`); orchestrates planning, execution, and final synthesis. With a pre-built `task` it skips planning and runs a single task. With `useGraphPlanner` it builds and runs a workflow DAG via `GraphPlanner` + `AgentWorkflowRunner`.
 - `TaskPlanner` — LLM-driven decomposition of an objective into a `TaskPlan` DAG of tasks and steps.
-- `GraphPlanner` + `GraphBuilder` — LLM iteratively builds a typed workflow graph using `search_nodes` / `add_node` / `add_edge` tools; produces `GraphData` ready for the kernel.
+- `GraphPlanner` + `GraphBuilder` — LLM discovers nodes with `search_nodes` / `get_node_info` / `find_model`, then submits the whole workflow as one sandboxed graph DSL program (`submit_graph`); validation errors round-trip until the graph is accepted. Produces `GraphData` ready for the kernel.
 - `ParallelTaskExecutor` → `TaskExecutor` → `StepExecutor` — Runs `TaskPlan` tasks concurrently, each task's steps sequentially (or in parallel when independent).
 - `CompilerAgent` — Final synthesis pass after `ParallelTaskExecutor` finishes; reads accumulated `context.memory` and produces the deliverable (schema-conformant JSON when `outputSchema` is set, otherwise prose).
 - `AgentWorkflowRunner` — Hands a `GraphData` graph to `WorkflowRunner` (kernel) with a custom resolver that maps `nodetool.agents.AgentStep` nodes to `AgentStepExecutor`.
@@ -375,8 +375,9 @@ Agent.execute(context)
   │                                                        │
   ├─── useGraphPlanner ───────────────────────────────────┤
   │    GraphPlanner                                        │
-  │      ├── LLM iteratively calls: search_nodes,         │
-  │      │   get_node_info, add_node, add_edge, finish_graph│
+  │      ├── LLM discovers nodes (search_nodes,           │
+  │      │   get_node_info, find_model), then one-shots   │
+  │      │   the whole graph as a DSL program (submit_graph)│
   │      └── GraphBuilder validates DAG, emits GraphData  │
   │    AgentWorkflowRunner                                 │
   │      └── WorkflowRunner (kernel) with custom resolver:│
@@ -713,7 +714,7 @@ REST endpoints follow standard conventions:
 4. Agent loads skills from filesystem (auto-matched to objective) and recalls long-term memory
 5. Path selection:
    pre-built task → TaskExecutor → StepExecutor: LLM ↔ tools until finish_step
-   useGraphPlanner → GraphPlanner: LLM builds node graph iteratively
+   useGraphPlanner → GraphPlanner: LLM one-shots the node graph as a DSL program
                     AgentWorkflowRunner → WorkflowRunner (kernel)
                       AgentStep nodes → AgentStepExecutor → StepExecutor
                       Other nodes    → NodeRegistry (deterministic)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,22 @@ npm run dev:nodetool -- generate fal-ai --list-models              # discover mo
 npm run dev:nodetool -- generate fal-ai flux-schnell "..." --json  # machine-readable
 ```
 
+### nodetool eval (Agent Evaluation Suites)
+
+Runs the GraphPlanner evaluation suite against any registered provider and
+reports metrics: success rate, expectation score, one-shot rate (graphs
+accepted on the first `submit_graph`), submit rounds, tool calls, duration,
+and cost. Cases and expectations live in
+`packages/agents/src/evals/`.
+
+```bash
+npm run dev:nodetool -- eval graph-planner --list                     # show cases
+npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval graph-planner -p ollama -m qwen-3.5:4b --cases summarize,branch-both-paths
+npm run dev:nodetool -- eval graph-planner -p openai -m gpt-5.4-mini --json --out report.json
+npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8   # non-zero exit below threshold
+```
+
 ### nodetool affected (Changed-File → Workspace Mapping)
 
 Maps changed files (or the git working tree) to the minimal set of workspaces to

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -338,6 +338,25 @@ into a fresh attempt when the model stops without an accepted graph.
 Tests: `tests/graph-dsl.test.ts`, `tests/graph-planner-coverage.test.ts`,
 `tests/graph-planner-loop.test.ts`.
 
+### Eval suite
+
+`src/evals/` carries a provider-agnostic evaluation harness for the planner:
+`GRAPH_PLANNER_EVAL_CASES` (objectives + structural expectations — input
+wiring, node-family patterns, branch handles, no provider-locked nodes) and
+`runGraphPlannerEval` (metrics per case: accepted, score, submit rounds,
+tool calls, attempts, duration, cost; aggregate: success rate, one-shot rate,
+averages). Run it against any registered provider:
+
+```bash
+npm run dev:nodetool -- eval graph-planner --list
+npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval graph-planner -p ollama -m qwen-3.5:4b --cases summarize
+npm run dev:nodetool -- eval graph-planner -p openai -m gpt-5.4-mini --json --out report.json
+npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8  # CI gate
+```
+
+Harness tests (scripted provider, no network): `tests/graph-planner-eval.test.ts`.
+
 ## Observing LLM Steps and Planning
 
 ### Execution Tree (CLI)

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -307,6 +307,37 @@ and the guest `agent()` re-throws.
 Tests: `tests/script-runner.test.ts`, `tests/script-planner.test.ts`,
 `tests/agent-script-mode.test.ts`.
 
+## Graph Mode (one-shot DSL planning)
+
+`GraphPlanner` builds a workflow graph by having the LLM write ONE graph DSL
+program instead of a tool call per node/edge. Discovery tools (`search_nodes`,
+`get_node_info`, `list_nodes`, `find_model`) stay; construction goes through a
+single `submit_graph(code)` tool. The program is plain JavaScript with the
+same wiring semantics as `@nodetool-ai/dsl` — `node(type, properties)` creates
+a node, passing `ref.output(slot?)` as a property value becomes an edge, and
+the program ends with `return graph();`:
+
+```js
+const prompt = node("nodetool.input.StringInput", { name: "prompt" });
+const image = node("nodetool.image.TextToImage", {
+  prompt: prompt.output(),
+  model: { provider: "fal_ai", id: "fal-ai/flux/schnell" }
+});
+node("nodetool.output.ImageOutput", { name: "image", value: image.output() });
+return graph();
+```
+
+The program runs in the QuickJS sandbox (`evaluateGraphDsl` in
+`src/graph-dsl.ts` — no host access), is loaded into a `GraphBuilder`, and
+validated structurally plus with node-sdk's `validateGraph`. Failures return
+as the `submit_graph` tool result, so the model fixes the program and
+resubmits over feedback rounds; an accepted submission ends the loop. The
+outer retry (`maxRetries`, default 3) carries the last program and its errors
+into a fresh attempt when the model stops without an accepted graph.
+
+Tests: `tests/graph-dsl.test.ts`, `tests/graph-planner-coverage.test.ts`,
+`tests/graph-planner-loop.test.ts`.
+
 ## Observing LLM Steps and Planning
 
 ### Execution Tree (CLI)

--- a/packages/agents/src/evals/graph-planner-cases.ts
+++ b/packages/agents/src/evals/graph-planner-cases.ts
@@ -1,0 +1,121 @@
+/**
+ * Built-in evaluation cases for the GraphPlanner one-shot DSL flow.
+ *
+ * Each case is an objective plus machine-checkable expectations on the
+ * accepted graph. Expectations are deliberately structural (node-type
+ * patterns, input wiring, handle usage) rather than exact-graph matches —
+ * many graphs are valid answers, but all of them must wire the inputs, use
+ * the right node families, and avoid provider-locked nodes.
+ */
+
+import type { GraphPlannerEvalCase } from "./graph-planner-eval.js";
+
+export const GRAPH_PLANNER_EVAL_CASES: readonly GraphPlannerEvalCase[] = [
+  {
+    id: "summarize",
+    description: "Single LLM step with one wired input and one output",
+    objective:
+      "Take the input text and produce a one-paragraph summary of it with an LLM step. Output the summary.",
+    inputs: { text: "NodeTool is a visual AI workflow platform..." },
+    expect: {
+      requiredInputNames: ["text"],
+      minAgentSteps: 1,
+      requireOutputNode: true,
+      minNodes: 3,
+      maxNodes: 6
+    }
+  },
+  {
+    id: "chain-multi-output",
+    description: "Two chained LLM steps, both results surfaced as outputs",
+    objective:
+      "Take the input text, summarize it in one paragraph with an LLM step, then translate that summary to German with a second LLM step. Output both the summary and the translation.",
+    inputs: { text: "NodeTool is a visual AI workflow platform..." },
+    expect: {
+      requiredInputNames: ["text"],
+      minAgentSteps: 2,
+      minOutputNodes: 2,
+      minNodes: 5,
+      maxNodes: 9
+    }
+  },
+  {
+    id: "parallel-fanout",
+    description: "Independent parallel branches, one LLM step per language",
+    objective:
+      "Write a haiku about the input topic in English, German, and French — one LLM step per language, running in parallel. Output all three haikus.",
+    inputs: { topic: "autumn rain" },
+    expect: {
+      requiredInputNames: ["topic"],
+      minAgentSteps: 3,
+      minOutputNodes: 3,
+      maxNodes: 12
+    }
+  },
+  {
+    id: "loop-authoring",
+    description: "Repetition the DSL should express as a JS loop, not copy-paste",
+    objective:
+      "Generate one short limerick for each of these five animals: cat, dog, fox, owl, bear — one LLM step per animal. Output every limerick.",
+    expect: {
+      minAgentSteps: 5,
+      minOutputNodes: 5,
+      maxNodes: 16
+    }
+  },
+  {
+    id: "branch-both-paths",
+    description: "Conditional with both If branches wired",
+    objective:
+      "If the input language is exactly the string \"de\", translate the input text to German with an LLM step; otherwise translate it to French with an LLM step. Output the translation from each branch.",
+    inputs: { language: "de", text: "Good morning!" },
+    expect: {
+      requiredInputNames: ["language", "text"],
+      requiredNodeTypePatterns: ["^nodetool\\.control\\.If$"],
+      requiredSourceHandles: ["if_true", "if_false"],
+      minAgentSteps: 2
+    }
+  },
+  {
+    id: "deterministic-over-llm",
+    description: "Pure string mechanics must not be solved with an LLM step",
+    objective:
+      "Concatenate the two input strings first and second, in that order, and output the result. This is pure string mechanics — no reasoning or generation involved.",
+    inputs: { first: "Hello, ", second: "world" },
+    expect: {
+      requiredInputNames: ["first", "second"],
+      requiredNodeTypePatterns: ["^nodetool\\.text\\."],
+      forbiddenNodeTypePatterns: ["^nodetool\\.agents\\.AgentStep$"],
+      requireOutputNode: true
+    }
+  },
+  {
+    id: "inputs-wiring",
+    description: "Every runtime parameter must reach the graph via an input node",
+    objective:
+      "Plan a day-by-day travel itinerary with an LLM step, using the input city and the input number of days. Output the itinerary.",
+    inputs: { city: "Lisbon", days: 3 },
+    expect: {
+      requiredInputNames: ["city", "days"],
+      minAgentSteps: 1,
+      requireOutputNode: true
+    }
+  },
+  {
+    id: "image-generation",
+    description:
+      "Generic AI image node with a real model picked via find_model, then a deterministic post-process",
+    objective:
+      "Generate an image from the input prompt, then posterize it down to 3 colors, and output the posterized image.",
+    inputs: { prompt: "a red fox in snow" },
+    needsModelProviders: true,
+    expect: {
+      requiredInputNames: ["prompt"],
+      requiredNodeTypePatterns: [
+        "^nodetool\\.image\\.TextToImage$",
+        "^lib\\.image\\."
+      ],
+      requireOutputNode: true
+    }
+  }
+];

--- a/packages/agents/src/evals/graph-planner-eval.ts
+++ b/packages/agents/src/evals/graph-planner-eval.ts
@@ -1,0 +1,439 @@
+/**
+ * GraphPlanner evaluation harness — provider-agnostic.
+ *
+ * Runs a set of {@link GraphPlannerEvalCase}s through `GraphPlanner.plan()`
+ * with any `BaseProvider`, records efficiency metrics from the message stream
+ * (tool calls, submit rounds, attempts, duration, cost), and scores each
+ * accepted graph against the case's structural expectations. The result is a
+ * machine-readable report plus a text summary, so different providers/models
+ * can be compared on the same suite.
+ */
+
+import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { GraphData } from "@nodetool-ai/protocol";
+import { GraphPlanner } from "../graph-planner.js";
+import { AGENT_STEP_NODE_TYPE } from "../graph-builder.js";
+import { PROVIDER_NAMESPACES } from "../prompts/graph-planner-prompt.js";
+import { GRAPH_PLANNER_EVAL_CASES } from "./graph-planner-cases.js";
+
+export interface GraphPlannerEvalExpectations {
+  /** Input-node `name` properties that must exist (one node per name). */
+  requiredInputNames?: string[];
+  /** Regex sources; each must match at least one node type in the graph. */
+  requiredNodeTypePatterns?: string[];
+  /** Regex sources; none may match any node type in the graph. */
+  forbiddenNodeTypePatterns?: string[];
+  /** Edge sourceHandles that must each be used by at least one edge. */
+  requiredSourceHandles?: string[];
+  /** Minimum number of AgentStep nodes. */
+  minAgentSteps?: number;
+  /** Minimum number of `nodetool.output.*` nodes. */
+  minOutputNodes?: number;
+  /** At least one `nodetool.output.*` node. */
+  requireOutputNode?: boolean;
+  minNodes?: number;
+  maxNodes?: number;
+}
+
+export interface GraphPlannerEvalCase {
+  id: string;
+  description: string;
+  objective: string;
+  inputs?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  /**
+   * Case needs configured model providers (`find_model`) to be solvable —
+   * skipped when the harness runs without any.
+   */
+  needsModelProviders?: boolean;
+  expect: GraphPlannerEvalExpectations;
+}
+
+export interface EvalCheck {
+  name: string;
+  pass: boolean;
+  detail?: string;
+}
+
+export interface GraphPlannerCaseResult {
+  caseId: string;
+  description: string;
+  skipped: boolean;
+  /** Planner returned an accepted graph. */
+  accepted: boolean;
+  /** Fraction of checks passed (0 when no graph was produced). */
+  score: number;
+  checks: EvalCheck[];
+  /** Total tool calls the planner made, by tool name. */
+  toolCalls: Record<string, number>;
+  /** submit_graph calls — 1 means the model one-shotted the graph. */
+  submitRounds: number;
+  /** Outer planning attempts consumed (1 = no retry). */
+  attempts: number;
+  durationMs: number;
+  costUsd: number;
+  nodes: number;
+  edges: number;
+  error?: string;
+}
+
+export interface GraphPlannerEvalReport {
+  provider: string;
+  model: string;
+  startedAt: string;
+  cases: GraphPlannerCaseResult[];
+  summary: {
+    total: number;
+    skipped: number;
+    accepted: number;
+    /** accepted / (total - skipped) */
+    successRate: number;
+    /** Mean expectation score over non-skipped cases. */
+    meanScore: number;
+    /** Fraction of accepted graphs that needed exactly one submit_graph call. */
+    oneShotRate: number;
+    avgSubmitRounds: number;
+    avgToolCalls: number;
+    avgDurationMs: number;
+    totalCostUsd: number;
+  };
+}
+
+export interface RunGraphPlannerEvalOptions {
+  provider: BaseProvider;
+  model: string;
+  registry: NodeRegistry;
+  /** Configured providers for `find_model`; enables model-dependent cases. */
+  providers?: Record<string, BaseProvider>;
+  /** Cases to run; defaults to the built-in suite. */
+  cases?: readonly GraphPlannerEvalCase[];
+  maxRetries?: number;
+  signal?: AbortSignal;
+  /** Progress callback (one line per event, for CLI display). */
+  onEvent?: (line: string) => void;
+}
+
+function totalToolCalls(byName: Record<string, number>): number {
+  return Object.values(byName).reduce((a, b) => a + b, 0);
+}
+
+/** Score an accepted graph against the case expectations. */
+export function checkExpectations(
+  graph: GraphData,
+  expect: GraphPlannerEvalExpectations
+): EvalCheck[] {
+  const checks: EvalCheck[] = [];
+  const types = graph.nodes.map((n) => n.type);
+
+  for (const name of expect.requiredInputNames ?? []) {
+    const found = graph.nodes.some(
+      (n) =>
+        n.type.startsWith("nodetool.input.") && n.properties?.["name"] === name
+    );
+    checks.push({
+      name: `input:${name}`,
+      pass: found,
+      detail: found ? undefined : `no nodetool.input.* node with name "${name}"`
+    });
+  }
+
+  for (const pattern of expect.requiredNodeTypePatterns ?? []) {
+    const re = new RegExp(pattern);
+    const found = types.some((t) => re.test(t));
+    checks.push({
+      name: `has:${pattern}`,
+      pass: found,
+      detail: found ? undefined : `no node type matches /${pattern}/`
+    });
+  }
+
+  for (const pattern of expect.forbiddenNodeTypePatterns ?? []) {
+    const re = new RegExp(pattern);
+    const offender = types.find((t) => re.test(t));
+    checks.push({
+      name: `not:${pattern}`,
+      pass: !offender,
+      detail: offender ? `forbidden node type ${offender}` : undefined
+    });
+  }
+
+  for (const handle of expect.requiredSourceHandles ?? []) {
+    const found = graph.edges.some((e) => e.sourceHandle === handle);
+    checks.push({
+      name: `handle:${handle}`,
+      pass: found,
+      detail: found ? undefined : `no edge uses sourceHandle "${handle}"`
+    });
+  }
+
+  if (expect.minAgentSteps !== undefined) {
+    const count = types.filter((t) => t === AGENT_STEP_NODE_TYPE).length;
+    checks.push({
+      name: `agentSteps>=${expect.minAgentSteps}`,
+      pass: count >= expect.minAgentSteps,
+      detail: `found ${count}`
+    });
+  }
+
+  const outputCount = types.filter((t) =>
+    t.startsWith("nodetool.output.")
+  ).length;
+  if (expect.minOutputNodes !== undefined) {
+    checks.push({
+      name: `outputs>=${expect.minOutputNodes}`,
+      pass: outputCount >= expect.minOutputNodes,
+      detail: `found ${outputCount}`
+    });
+  }
+  if (expect.requireOutputNode) {
+    checks.push({
+      name: "outputs>=1",
+      pass: outputCount >= 1,
+      detail: `found ${outputCount}`
+    });
+  }
+
+  if (expect.minNodes !== undefined) {
+    checks.push({
+      name: `nodes>=${expect.minNodes}`,
+      pass: graph.nodes.length >= expect.minNodes,
+      detail: `found ${graph.nodes.length}`
+    });
+  }
+  if (expect.maxNodes !== undefined) {
+    checks.push({
+      name: `nodes<=${expect.maxNodes}`,
+      pass: graph.nodes.length <= expect.maxNodes,
+      detail: `found ${graph.nodes.length}`
+    });
+  }
+
+  // Universal check: provider-locked nodes are forbidden unless the case
+  // explicitly requires one (none of the built-in cases do).
+  const providerNode = types.find((t) =>
+    PROVIDER_NAMESPACES.some((ns) => t.startsWith(`${ns}.`))
+  );
+  checks.push({
+    name: "no-provider-nodes",
+    pass: !providerNode,
+    detail: providerNode ? `provider-locked node ${providerNode}` : undefined
+  });
+
+  return checks;
+}
+
+async function runCase(
+  evalCase: GraphPlannerEvalCase,
+  opts: RunGraphPlannerEvalOptions
+): Promise<GraphPlannerCaseResult> {
+  const toolCalls: Record<string, number> = {};
+  let attempts = 0;
+  const costBefore = opts.provider.getTotalCost();
+  const startedAt = Date.now();
+
+  const planner = new GraphPlanner({
+    provider: opts.provider,
+    model: opts.model,
+    registry: opts.registry,
+    providers: opts.providers,
+    inputs: evalCase.inputs,
+    outputSchema: evalCase.outputSchema,
+    maxRetries: opts.maxRetries,
+    signal: opts.signal
+  });
+
+  let graph: GraphData | null = null;
+  let error: string | undefined;
+  try {
+    const gen = planner.plan(
+      evalCase.objective,
+      {} as ProcessingContext
+    );
+    let res = await gen.next();
+    while (!res.done) {
+      const m = res.value as { type?: string } & Record<string, unknown>;
+      if (m.type === "tool_call_update") {
+        const name = String(m.name ?? "unknown");
+        toolCalls[name] = (toolCalls[name] ?? 0) + 1;
+        opts.onEvent?.(`    [tool] ${name}`);
+      } else if (
+        m.type === "planning_update" &&
+        m.phase === "generation" &&
+        m.status === "running"
+      ) {
+        attempts++;
+      }
+      res = await gen.next();
+    }
+    graph = res.value;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const costUsd = opts.provider.getTotalCost() - costBefore;
+  const submitRounds = toolCalls["submit_graph"] ?? 0;
+
+  const checks: EvalCheck[] = [
+    { name: "accepted", pass: graph !== null, detail: error }
+  ];
+  if (graph) {
+    checks.push(...checkExpectations(graph, evalCase.expect));
+  }
+  const score = graph
+    ? checks.filter((c) => c.pass).length / checks.length
+    : 0;
+
+  return {
+    caseId: evalCase.id,
+    description: evalCase.description,
+    skipped: false,
+    accepted: graph !== null,
+    score,
+    checks,
+    toolCalls,
+    submitRounds,
+    attempts: Math.max(attempts, 1),
+    durationMs,
+    costUsd,
+    nodes: graph?.nodes.length ?? 0,
+    edges: graph?.edges.length ?? 0,
+    error
+  };
+}
+
+export async function runGraphPlannerEval(
+  opts: RunGraphPlannerEvalOptions
+): Promise<GraphPlannerEvalReport> {
+  const cases = opts.cases ?? GRAPH_PLANNER_EVAL_CASES;
+  const hasModelProviders =
+    !!opts.providers && Object.keys(opts.providers).length > 0;
+  const results: GraphPlannerCaseResult[] = [];
+
+  for (const evalCase of cases) {
+    if (opts.signal?.aborted) break;
+    if (evalCase.needsModelProviders && !hasModelProviders) {
+      opts.onEvent?.(`- ${evalCase.id}: SKIPPED (no model providers)`);
+      results.push({
+        caseId: evalCase.id,
+        description: evalCase.description,
+        skipped: true,
+        accepted: false,
+        score: 0,
+        checks: [],
+        toolCalls: {},
+        submitRounds: 0,
+        attempts: 0,
+        durationMs: 0,
+        costUsd: 0,
+        nodes: 0,
+        edges: 0
+      });
+      continue;
+    }
+
+    opts.onEvent?.(`- ${evalCase.id}: ${evalCase.description}`);
+    const result = await runCase(evalCase, opts);
+    const failed = result.checks.filter((c) => !c.pass);
+    opts.onEvent?.(
+      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+        `submits=${result.submitRounds} tools=${totalToolCalls(result.toolCalls)} ` +
+        `nodes=${result.nodes} edges=${result.edges} ${Math.round(result.durationMs / 1000)}s` +
+        (failed.length > 0
+          ? ` | failed: ${failed.map((c) => c.name).join(", ")}`
+          : "")
+    );
+    results.push(result);
+  }
+
+  const ran = results.filter((r) => !r.skipped);
+  const acceptedResults = ran.filter((r) => r.accepted);
+  const summary = {
+    total: results.length,
+    skipped: results.length - ran.length,
+    accepted: acceptedResults.length,
+    successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+    meanScore:
+      ran.length > 0
+        ? ran.reduce((a, r) => a + r.score, 0) / ran.length
+        : 0,
+    oneShotRate:
+      acceptedResults.length > 0
+        ? acceptedResults.filter((r) => r.submitRounds === 1).length /
+          acceptedResults.length
+        : 0,
+    avgSubmitRounds:
+      ran.length > 0
+        ? ran.reduce((a, r) => a + r.submitRounds, 0) / ran.length
+        : 0,
+    avgToolCalls:
+      ran.length > 0
+        ? ran.reduce((a, r) => a + totalToolCalls(r.toolCalls), 0) / ran.length
+        : 0,
+    avgDurationMs:
+      ran.length > 0
+        ? ran.reduce((a, r) => a + r.durationMs, 0) / ran.length
+        : 0,
+    totalCostUsd: ran.reduce((a, r) => a + r.costUsd, 0)
+  };
+
+  return {
+    provider: opts.provider.provider,
+    model: opts.model,
+    startedAt: new Date().toISOString(),
+    cases: results,
+    summary
+  };
+}
+
+/** Text summary table for terminal output. */
+export function formatEvalReport(report: GraphPlannerEvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `GraphPlanner eval — provider=${report.provider} model=${report.model}`
+  );
+  lines.push("");
+  const header = [
+    "case".padEnd(22),
+    "result".padEnd(7),
+    "score".padEnd(6),
+    "submits".padEnd(8),
+    "tools".padEnd(6),
+    "nodes".padEnd(6),
+    "time".padEnd(7),
+    "cost"
+  ].join("");
+  lines.push(header);
+  lines.push("-".repeat(header.length));
+  for (const r of report.cases) {
+    lines.push(
+      [
+        r.caseId.padEnd(22),
+        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
+        String(r.submitRounds).padEnd(8),
+        String(totalToolCalls(r.toolCalls)).padEnd(6),
+        String(r.nodes).padEnd(6),
+        `${Math.round(r.durationMs / 1000)}s`.padEnd(7),
+        r.costUsd > 0 ? `$${r.costUsd.toFixed(4)}` : "-"
+      ].join("")
+    );
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      lines.push(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  const s = report.summary;
+  lines.push("");
+  lines.push(
+    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  mean score ${s.meanScore.toFixed(2)}` +
+      `  one-shot ${(s.oneShotRate * 100).toFixed(0)}%` +
+      `  avg submits ${s.avgSubmitRounds.toFixed(1)}` +
+      `  avg tools ${s.avgToolCalls.toFixed(1)}` +
+      `  avg time ${(s.avgDurationMs / 1000).toFixed(1)}s` +
+      (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +
+      (s.skipped > 0 ? `  (${s.skipped} skipped)` : "")
+  );
+  return lines.join("\n");
+}

--- a/packages/agents/src/graph-dsl.ts
+++ b/packages/agents/src/graph-dsl.ts
@@ -1,0 +1,174 @@
+/**
+ * Graph DSL — evaluate an LLM-authored workflow program into GraphData.
+ *
+ * The planner LLM writes ONE plain-JavaScript program using the same
+ * handle-wiring semantics as `@nodetool-ai/dsl` (`createNode` / `workflow`):
+ * `node(type, properties)` creates a node, passing `ref.output(slot?)` as a
+ * property value becomes an edge, and `return graph()` collects everything.
+ * The program runs in the QuickJS WebAssembly sandbox — no host access beyond
+ * the two predefined functions — so a malformed or malicious program cannot
+ * touch the host.
+ */
+
+import type { GraphData, NodeDescriptor, Edge } from "@nodetool-ai/protocol";
+import { runInSandbox } from "./js-sandbox.js";
+
+/** Wall-clock budget for a graph program. Pure graph building is fast. */
+export const GRAPH_DSL_TIMEOUT_MS = 10_000;
+
+/**
+ * Guest-side prelude defining the DSL surface. `node()` registers a node and
+ * returns a ref whose `.output(slot?)` produces a wiring handle; `graph()`
+ * turns handle-valued top-level properties into edges (mirroring how
+ * `workflow()` in @nodetool-ai/dsl derives edges from OutputHandle inputs).
+ * All created nodes are included — an orphan node is a validation finding for
+ * the planner to fix, not something to silently prune.
+ */
+const GRAPH_DSL_PRELUDE = `const __nodes = [];
+const __ids = Object.create(null);
+function __autoId(type) {
+  const last = String(type).split(".").pop() || "node";
+  const snake = last.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  const n = (__ids[snake] = (__ids[snake] || 0) + 1);
+  return n === 1 ? snake : snake + "_" + n;
+}
+function node(type, properties, id) {
+  if (typeof type !== "string" || type.length === 0) {
+    throw new Error("node(type, properties): type must be a non-empty string");
+  }
+  if (properties !== undefined && (properties === null || typeof properties !== "object" || Array.isArray(properties))) {
+    throw new Error("node(type, properties): properties must be an object");
+  }
+  const nodeId = typeof id === "string" && id.length > 0 ? id : __autoId(type);
+  __nodes.push({ id: nodeId, type: type, properties: properties || {} });
+  return {
+    id: nodeId,
+    output: function (slot) {
+      if (slot !== undefined && (typeof slot !== "string" || slot.length === 0)) {
+        throw new Error("output(slot): slot must be a non-empty string");
+      }
+      return { __handle: true, source: nodeId, sourceHandle: slot || "output" };
+    }
+  };
+}
+function graph() {
+  const nodes = [];
+  const edges = [];
+  for (const n of __nodes) {
+    const data = {};
+    for (const key in n.properties) {
+      const v = n.properties[key];
+      if (v && typeof v === "object" && v.__handle === true) {
+        edges.push({ source: v.source, sourceHandle: v.sourceHandle, target: n.id, targetHandle: key });
+      } else {
+        data[key] = v;
+      }
+    }
+    nodes.push({ id: n.id, type: n.type, properties: data });
+  }
+  return { __graph: true, nodes: nodes, edges: edges };
+}
+`;
+
+export interface EvaluateGraphDslOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface GraphDslResult {
+  graph?: GraphData;
+  error?: string;
+  logs?: string[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Convert the sandbox return value into GraphData, or explain why it isn't
+ * one. The prelude guarantees the shape for programs that end in
+ * `return graph()`; anything else (returning a node ref, a string, nothing)
+ * gets an actionable message instead of a crash downstream.
+ */
+function toGraphData(result: unknown): { graph?: GraphData; error?: string } {
+  const record = asRecord(result);
+  if (
+    !record ||
+    record.__graph !== true ||
+    !Array.isArray(record.nodes) ||
+    !Array.isArray(record.edges)
+  ) {
+    return {
+      error:
+        "The program must end with `return graph();` — it returned something else."
+    };
+  }
+
+  const nodes: NodeDescriptor[] = [];
+  for (const raw of record.nodes) {
+    const n = asRecord(raw);
+    if (!n || typeof n.id !== "string" || typeof n.type !== "string") {
+      return { error: "Malformed node in graph() result." };
+    }
+    nodes.push({
+      id: n.id,
+      type: n.type,
+      name: n.id,
+      properties: asRecord(n.properties) ?? {}
+    });
+  }
+
+  const edges: Edge[] = [];
+  for (const raw of record.edges) {
+    const e = asRecord(raw);
+    if (
+      !e ||
+      typeof e.source !== "string" ||
+      typeof e.sourceHandle !== "string" ||
+      typeof e.target !== "string" ||
+      typeof e.targetHandle !== "string"
+    ) {
+      return { error: "Malformed edge in graph() result." };
+    }
+    edges.push({
+      source: e.source,
+      sourceHandle: e.sourceHandle,
+      target: e.target,
+      targetHandle: e.targetHandle
+    });
+  }
+
+  return { graph: { nodes, edges } };
+}
+
+/**
+ * Run a graph DSL program in the sandbox and return the graph it builds.
+ * Errors (syntax, runtime, wrong return shape) come back as `error` text the
+ * planner can feed to the model for the next round.
+ */
+export async function evaluateGraphDsl(
+  code: string,
+  options: EvaluateGraphDslOptions = {}
+): Promise<GraphDslResult> {
+  if (!code.trim()) {
+    return { error: "Program is empty." };
+  }
+
+  const run = await runInSandbox({
+    code: `${GRAPH_DSL_PRELUDE}\n${code}`,
+    timeoutMs: options.timeoutMs ?? GRAPH_DSL_TIMEOUT_MS,
+    signal: options.signal
+  });
+
+  if (!run.success) {
+    return {
+      error: run.error ?? "Program execution failed.",
+      logs: run.logs
+    };
+  }
+
+  return { ...toGraphData(run.result), logs: run.logs };
+}

--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -1,9 +1,12 @@
 /**
- * GraphPlanner -- builds a workflow graph directly via LLM tool calling.
+ * GraphPlanner -- builds a workflow graph from one LLM-authored DSL program.
  *
- * Instead of producing a TaskPlan with prose steps, this planner gives the LLM
- * tools to search for nodes, inspect their metadata, and build a DAG node-by-node.
- * The result is a GraphData that goes straight to WorkflowRunner.
+ * The LLM discovers nodes with a few read-only tools (search_nodes,
+ * get_node_info, list_nodes, find_model), then one-shots the ENTIRE workflow
+ * as a graph DSL program submitted through `submit_graph`. Validation errors
+ * round-trip as tool results so the model fixes the program over feedback
+ * rounds instead of mutating the graph one add_node/add_edge call at a time.
+ * The accepted program's graph goes straight to WorkflowRunner.
  */
 
 import type {
@@ -25,12 +28,7 @@ import type {
 } from "@nodetool-ai/protocol";
 
 import { Tool } from "./tools/base-tool.js";
-import { GraphBuilder } from "./graph-builder.js";
-import { AddNodeTool } from "./tools/add-node-tool.js";
-import { AddEdgeTool } from "./tools/add-edge-tool.js";
-import { RemoveNodeTool } from "./tools/remove-node-tool.js";
-import { RemoveEdgeTool } from "./tools/remove-edge-tool.js";
-import { FinishGraphTool } from "./tools/finish-graph-tool.js";
+import { SubmitGraphTool } from "./tools/submit-graph-tool.js";
 import { LocalSearchNodesTool } from "./tools/local-search-nodes-tool.js";
 import { LocalGetNodeInfoTool } from "./tools/local-get-node-info-tool.js";
 import { LocalListNodesTool } from "./tools/local-list-nodes-tool.js";
@@ -43,7 +41,12 @@ import {
 const log = createLogger("nodetool.agents.graph-planner");
 
 const MAX_RETRIES = 3;
-const MAX_TOOL_CALLS_PER_TURN = 50;
+/**
+ * Per-attempt tool-call budget: discovery lookups plus a handful of
+ * submit_graph feedback rounds. Far below the old per-node budget because the
+ * graph arrives as one program, not one call per node/edge.
+ */
+const MAX_TOOL_CALLS_PER_TURN = 20;
 
 const GRAPH_CREATION_PROMPT_TEMPLATE = `Build a workflow graph to achieve this objective.
 
@@ -135,7 +138,7 @@ export class GraphPlanner {
   }
 
   /**
-   * Build a workflow graph from an objective using LLM tool calling.
+   * Build a workflow graph from an objective via one-shot DSL authoring.
    * Returns null on repeated failure.
    */
   async *plan(
@@ -195,11 +198,6 @@ export class GraphPlanner {
       executionToolsCount: this.tools.length
     });
 
-    // One builder for the whole plan: retries continue from the graph built so
-    // far (the retry message carries a snapshot of it) instead of silently
-    // starting over while telling the model to "fix the issues".
-    const builder = new GraphBuilder();
-
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       log.info("GraphPlanner attempt", {
         objective: objective.slice(0, 60),
@@ -214,10 +212,10 @@ export class GraphPlanner {
         content:
           attempt > 0
             ? `Retry attempt ${attempt + 1}/${this.maxRetries}...`
-            : "Building workflow graph..."
+            : "Writing workflow graph program..."
       } satisfies PlanningUpdate;
 
-      const result = yield* this.runToolLoop(messages, builder);
+      const result = yield* this.runDslLoop(messages);
 
       if (result.graph) {
         log.info("Graph built", {
@@ -236,7 +234,7 @@ export class GraphPlanner {
       }
 
       const errorMsg =
-        result.error ?? `Graph was not finalized on attempt ${attempt + 1}`;
+        result.error ?? `Graph was not accepted on attempt ${attempt + 1}`;
 
       log.warn("Graph building retry", {
         attempt: attempt + 1,
@@ -251,16 +249,12 @@ export class GraphPlanner {
       } satisfies PlanningUpdate;
 
       // The provider loop copies the message array, so the model has no
-      // memory of its previous attempt — include the preserved builder state
-      // so "fix and finish" is actionable rather than a restart from nothing.
+      // memory of its previous attempt — carry the last submitted program and
+      // its errors forward so "fix and resubmit" is actionable rather than a
+      // restart from nothing.
       messages.push({
         role: "user",
-        content: `Error: ${errorMsg}
-
-The graph you built so far is preserved:
-${builder.describe()}
-
-Fix the issues (use remove_node / remove_edge to correct mistakes) and call finish_graph again.`
+        content: this.buildRetryMessage(errorMsg, result)
       });
     }
 
@@ -282,32 +276,56 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
     return null;
   }
 
+  private buildRetryMessage(
+    errorMsg: string,
+    result: { lastCode?: string; lastErrors?: string[] }
+  ): string {
+    const parts = [`Error: ${errorMsg}`];
+    if (result.lastCode) {
+      parts.push(
+        `Your last submitted program:\n\`\`\`js\n${result.lastCode}\n\`\`\``
+      );
+    }
+    if (result.lastErrors && result.lastErrors.length > 0) {
+      parts.push(
+        `Validation errors:\n${result.lastErrors.map((e) => `- ${e}`).join("\n")}`
+      );
+    }
+    parts.push(
+      "Fix the issues and call submit_graph with the FULL corrected program."
+    );
+    return parts.join("\n\n");
+  }
+
   /**
-   * Run the multi-turn tool-calling loop.
-   * The LLM can call search/inspect/add tools multiple times before finish_graph.
+   * Run one planning attempt: discovery tool calls plus submit_graph feedback
+   * rounds, until a submission is accepted or the budget is spent.
    */
-  private async *runToolLoop(
-    messages: Message[],
-    builder: GraphBuilder
-  ): AsyncGenerator<ProcessingMessage, { graph?: GraphData; error?: string }> {
-    const addNodeTool = new AddNodeTool(builder, this.registry);
-    const addEdgeTool = new AddEdgeTool(builder, this.registry);
-    const removeNodeTool = new RemoveNodeTool(builder);
-    const removeEdgeTool = new RemoveEdgeTool(builder);
-    const finishGraphTool = new FinishGraphTool(builder, this.registry);
-    const searchNodesTool = new LocalSearchNodesTool(this.registry);
-    const getNodeInfoTool = new LocalGetNodeInfoTool(this.registry);
-    const listNodesTool = new LocalListNodesTool(this.registry);
+  private async *runDslLoop(
+    messages: Message[]
+  ): AsyncGenerator<
+    ProcessingMessage,
+    { graph?: GraphData; error?: string; lastCode?: string; lastErrors?: string[] }
+  > {
+    // `submit_graph` is only *conditionally* terminal: an accepted graph ends
+    // the loop; a failed submission returns its errors as the tool result and
+    // does NOT abort, so the model fixes the program within the budget. The
+    // static `terminal` flag can't express that, so the AbortController stops
+    // the loop on acceptance. It also short-circuits when the per-turn
+    // tool-call budget is spent.
+    const abort = new AbortController();
+    const unlinkAbort = linkAbort(abort, this.signal);
+    let exhausted = false;
+
+    const submitGraphTool = new SubmitGraphTool(this.registry, {
+      signal: abort.signal
+    });
 
     const allTools: Tool[] = [
-      searchNodesTool,
-      getNodeInfoTool,
-      listNodesTool,
-      addNodeTool,
-      addEdgeTool,
-      removeNodeTool,
-      removeEdgeTool,
-      finishGraphTool
+      new LocalSearchNodesTool(this.registry),
+      new LocalGetNodeInfoTool(this.registry),
+      new LocalListNodesTool(this.registry),
+      submitGraphTool
     ];
 
     if (this.hasFindModel && this.providers) {
@@ -317,20 +335,8 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
     let totalToolCalls = 0;
 
     // The provider drives the tool loop, so backends that run their own agent
-    // loop (e.g. the Claude Agent SDK) work. Each graph tool carries its own
-    // `execute` closure that mutates the shared builder.
-    //
-    // `finish_graph` is only *conditionally* terminal: on a valid graph it
-    // finalizes and aborts the loop; on a validation failure it returns the
-    // errors as the tool result and does NOT abort, so the model iterates and
-    // fixes the graph within the tool-call budget. The static `terminal` flag
-    // can't express that, so the AbortController stops the loop on a successful
-    // finish. It also short-circuits when the per-turn tool-call budget is
-    // spent (an early-stop that is not a terminal tool).
-    const abort = new AbortController();
-    const unlinkAbort = linkAbort(abort, this.signal);
-    let exhausted = false;
-
+    // loop (e.g. the Claude Agent SDK) work. Each tool carries its own
+    // `execute` closure.
     const makeExecute =
       (tool: Tool) =>
       async (args: Record<string, unknown>): Promise<string> => {
@@ -338,7 +344,10 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
         log.info("GraphPlanner tool call", {
           totalToolCalls,
           name: tool.name,
-          args
+          args:
+            tool.name === submitGraphTool.name
+              ? { codeChars: String((args?.code as string) ?? "").length }
+              : args
         });
 
         const toolStartedAt = Date.now();
@@ -354,19 +363,17 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
           name: tool.name,
           durationMs: Date.now() - toolStartedAt,
           resultLength: resultStr.length,
-          resultPreview: resultStr.slice(0, 240),
-          nodesBuilt: builder.nodeCount,
-          edgesBuilt: builder.edgeCount
+          resultPreview: resultStr.slice(0, 240)
         });
 
-        if (tool.name === "finish_graph" && finishGraphTool.graph) {
-          log.info("GraphPlanner finish_graph succeeded", {
-            nodes: finishGraphTool.graph.nodes.length,
-            edges: finishGraphTool.graph.edges.length
+        if (tool.name === submitGraphTool.name && submitGraphTool.graph) {
+          log.info("GraphPlanner submit_graph accepted", {
+            nodes: submitGraphTool.graph.nodes.length,
+            edges: submitGraphTool.graph.edges.length
           });
-          // Valid graph captured — end the loop promptly. A failed finish_graph
-          // returns its errors as the tool result (no abort) so the model can
-          // fix and call finish_graph again within the budget.
+          // Accepted graph captured — end the loop promptly. A failed
+          // submission returns its errors as the tool result (no abort) so
+          // the model can fix the program and resubmit within the budget.
           abort.abort();
         } else if (totalToolCalls >= MAX_TOOL_CALLS_PER_TURN) {
           exhausted = true;
@@ -428,29 +435,39 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
       unlinkAbort();
     }
 
-    if (finishGraphTool.graph) {
-      return { graph: finishGraphTool.graph };
+    if (submitGraphTool.graph) {
+      return { graph: submitGraphTool.graph };
     }
+
+    const carry = {
+      lastCode: submitGraphTool.lastCode ?? undefined,
+      lastErrors:
+        submitGraphTool.lastErrors.length > 0
+          ? submitGraphTool.lastErrors
+          : undefined
+    };
 
     if (exhausted) {
       log.warn("GraphPlanner hit MAX_TOOL_CALLS_PER_TURN", {
         totalToolCalls,
-        max: MAX_TOOL_CALLS_PER_TURN,
-        nodesBuilt: builder.nodeCount,
-        edgesBuilt: builder.edgeCount
+        max: MAX_TOOL_CALLS_PER_TURN
       });
       return {
-        error: `Exceeded maximum tool calls (${MAX_TOOL_CALLS_PER_TURN})`
+        error: `Exceeded maximum tool calls (${MAX_TOOL_CALLS_PER_TURN})`,
+        ...carry
       };
     }
 
-    log.warn("GraphPlanner stopped without finish_graph", {
-      nodesBuilt: builder.nodeCount,
-      edgesBuilt: builder.edgeCount
+    log.warn("GraphPlanner stopped without an accepted submit_graph", {
+      totalToolCalls,
+      submitted: submitGraphTool.lastCode != null
     });
     return {
       error:
-        "LLM stopped without calling finish_graph. Please build the graph and call finish_graph."
+        submitGraphTool.lastCode != null
+          ? "The last submitted program did not pass validation."
+          : "LLM stopped without calling submit_graph. Write the graph program and submit it via submit_graph.",
+      ...carry
     };
   }
 
@@ -467,16 +484,8 @@ Fix the issues (use remove_node / remove_edge to correct mistakes) and call fini
         return `Listing nodes in ${String(args.namespace ?? "all")}`;
       case "find_model":
         return `Finding model for ${String(args.task ?? args.capability ?? "task")}`;
-      case "add_node":
-        return `Adding node ${String(args.node_type ?? "")}${args.id ? ` (${String(args.id)})` : ""}`;
-      case "add_edge":
-        return `Connecting ${String(args.source ?? "")} → ${String(args.target ?? "")}`;
-      case "remove_node":
-        return `Removing node ${String(args.id ?? "")}`;
-      case "remove_edge":
-        return `Disconnecting ${String(args.source ?? "")} → ${String(args.target ?? "")}`;
-      case "finish_graph":
-        return "Finalizing graph";
+      case "submit_graph":
+        return "Submitting workflow graph";
       default:
         return `Calling ${name}`;
     }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -264,6 +264,7 @@ export {
 } from "./tools/plan-builder-tools.js";
 
 // Graph-native planner tools
+export { SubmitGraphTool } from "./tools/submit-graph-tool.js";
 export { AddNodeTool } from "./tools/add-node-tool.js";
 export { AddEdgeTool } from "./tools/add-edge-tool.js";
 export { RemoveNodeTool } from "./tools/remove-node-tool.js";
@@ -356,6 +357,8 @@ export {
 export type { ScriptRunnerOptions } from "./script-runner.js";
 
 // Graph-native planning & execution
+export { evaluateGraphDsl } from "./graph-dsl.js";
+export type { GraphDslResult, EvaluateGraphDslOptions } from "./graph-dsl.js";
 export { GraphBuilder, AGENT_STEP_NODE_TYPE } from "./graph-builder.js";
 export { GraphPlanner } from "./graph-planner.js";
 export type { GraphPlannerOptions } from "./graph-planner.js";

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -356,6 +356,22 @@ export {
 } from "./script-runner.js";
 export type { ScriptRunnerOptions } from "./script-runner.js";
 
+// GraphPlanner evaluation harness
+export {
+  runGraphPlannerEval,
+  formatEvalReport,
+  checkExpectations
+} from "./evals/graph-planner-eval.js";
+export type {
+  GraphPlannerEvalCase,
+  GraphPlannerEvalExpectations,
+  GraphPlannerCaseResult,
+  GraphPlannerEvalReport,
+  RunGraphPlannerEvalOptions,
+  EvalCheck
+} from "./evals/graph-planner-eval.js";
+export { GRAPH_PLANNER_EVAL_CASES } from "./evals/graph-planner-cases.js";
+
 // Graph-native planning & execution
 export { evaluateGraphDsl } from "./graph-dsl.js";
 export type { GraphDslResult, EvaluateGraphDslOptions } from "./graph-dsl.js";

--- a/packages/agents/src/prompts/graph-planner-prompt.ts
+++ b/packages/agents/src/prompts/graph-planner-prompt.ts
@@ -19,7 +19,7 @@ export type GenericNodeCapability =
   | "generate_message";
 
 export interface GenericAINode {
-  /** Fully-qualified node_type to pass to add_node. */
+  /** Fully-qualified node_type to use in the graph program. */
   type: string;
   /** Provider capability used to look up models via `find_model`. */
   capability: GenericNodeCapability;
@@ -219,17 +219,17 @@ export function buildGraphPlannerSystemPrompt(
 
   const tools = [
     hasFindModel
-      ? "- `find_model(capability, [task], [provider_hint], [prefer_local])` — REQUIRED before adding any generic AI node. Returns ranked `{provider, model_id, name, downloaded, recommended}` filtered to providers the user has actually configured. Use the first result unless the user named a specific provider."
+      ? "- `find_model(capability, [task], [provider_hint], [prefer_local])` — REQUIRED before using any generic AI node. Returns ranked `{provider, model_id, name, downloaded, recommended}` filtered to providers the user has actually configured. Use the first result unless the user named a specific provider."
       : null,
     "- `search_nodes(query, [namespace], [include_provider_nodes])` — deterministic core nodes only by default. Provider-specific nodes are HIDDEN unless `include_provider_nodes: true`. Optional `namespace` restricts results to a single core namespace.",
-    "- `get_node_info(node_type)` — fetch full property/output schema. REQUIRED before `add_node` for non-generic nodes.",
+    "- `get_node_info(node_type)` — fetch full property/output schema. REQUIRED before using a non-generic node in the program.",
     "- `list_nodes([namespace])` — browse a baseline namespace.",
-    "- `add_node`, `add_edge`, `remove_node`, `remove_edge`, `finish_graph` — graph mutation. `remove_node` / `remove_edge` correct mistakes in place; do not leave orphan nodes behind."
+    "- `submit_graph(code)` — submit the COMPLETE graph program. Returns validation errors to fix, or accepts the graph."
   ]
     .filter((line): line is string => line !== null)
     .join("\n");
 
-  return `You are a WorkflowArchitect. Build a workflow graph (DAG of NodeTool nodes connected by typed edges) that achieves the user's objective.
+  return `You are a WorkflowArchitect. Write ONE program that builds a workflow graph (DAG of NodeTool nodes connected by typed edges) achieving the user's objective, and submit it via \`submit_graph\`.
 
 # Node-selection policy (READ FIRST)
 
@@ -255,44 +255,66 @@ ${hasFindModel ? "use `find_model` to pick a real model+provider." : "AgentStep 
 
 ${CORE_BASELINE_NAMESPACES.join(", ")}, plus any \`lib.*\` library namespace.
 
+# Graph DSL (how to write the program)
+
+Plain JavaScript — no imports, no TypeScript annotations. Two functions are
+predefined:
+
+- \`node(type, properties)\` — create a node. Returns a ref with
+  \`.output(slot?)\` (slot defaults to \`"output"\`). Pass a ref's output as a
+  property value to wire an edge into that input. Optional third argument sets
+  an explicit snake_case id (ids are auto-derived from the type otherwise).
+- \`graph()\` — collect every created node and all wired edges. The program
+  MUST end with \`return graph();\`.
+
+Example — image generation from a runtime prompt, post-processed:
+
+\`\`\`js
+const prompt = node("nodetool.input.StringInput", { name: "prompt" });
+const image = node("nodetool.image.TextToImage", {
+  prompt: prompt.output(),
+  model: { provider: "fal_ai", id: "fal-ai/flux/schnell" }
+});
+const poster = node("lib.image.filter.Posterize", {
+  image: image.output(),
+  colors: 3
+});
+node("nodetool.output.ImageOutput", { name: "image", value: poster.output() });
+return graph();
+\`\`\`
+
+Multi-output nodes use named slots: \`ifNode.output("if_true")\`,
+\`ifNode.output("if_false")\`. Plain JS is available for repetition — loops,
+arrays, template strings — use it instead of copy-pasting near-identical nodes.
+
 # Execution Sequence (follow in order)
 
-1. **SEARCH** — call \`search_nodes\` with broad category terms (\`"image
-   generation"\`, \`"color filter"\`, not narrow guesses). Stop searching as
-   soon as a viable node appears in results. Do not enumerate alternatives.
-2. **INSPECT** — call \`get_node_info\` ONCE per non-generic node before
-   adding, to verify property names and handles. Generic AI nodes from the
-   table above don't need inspection.
-${hasFindModel ? "3. **PICK MODEL** — for each generic AI node (except AgentStep), call `find_model` once with the node's capability and use the first ranked result.\n" : "3. **(no model lookup — providers not configured; prefer AgentStep for AI work)**\n"}4. **PLACE** — call \`add_node\` once per node with a unique snake_case
-   \`id\` and required \`properties\`.
-5. **CONNECT** — call \`add_edge\` once per edge using exact handle names
-   from the inspect step. Verify source output type matches target input.
-6. **FINALIZE** — call \`finish_graph\`. If validation fails, fix the
-   reported issues and call \`finish_graph\` again — do not restart search.
-
-# Search Strategy
-
-- Use broad category terms with \`n_results: 20\` to see all options at once.
-- If a query returns 0 results, broaden it or pass a \`namespace\` filter
-  (\`nodetool.image\`, \`nodetool.text\`, \`lib.image\`, etc.).
-- Pick the first reasonable match from the results — there is no "perfect"
-  node to hunt for.
-- Avoid exploratory or repeated tool calls that are unlikely to change
-  the outcome.
+1. **DISCOVER** — for non-generic nodes, call \`search_nodes\` with broad
+   category terms (\`"image generation"\`, \`"color filter"\`, not narrow
+   guesses) and \`get_node_info\` ONCE per node type you will use, to verify
+   property names and handles. Generic AI nodes from the table above don't
+   need inspection. Batch independent lookups; skip discovery entirely when
+   the graph only uses generic AI nodes and input/output nodes.
+${hasFindModel ? "2. **PICK MODEL** — for each generic AI node (except AgentStep), call `find_model` once with the node's capability and use the first ranked result.\n" : "2. **(no model lookup — providers not configured; prefer AgentStep for AI work)**\n"}3. **WRITE & SUBMIT** — write the COMPLETE program in one shot and call
+   \`submit_graph\` with it. Do not build incrementally; the whole workflow
+   goes in a single submission.
+4. **FIX** — if \`submit_graph\` returns errors, correct the program and
+   resubmit the FULL program (each submission replaces the previous one).
+   Do not restart discovery for errors that name the fix.
 
 # Error Recovery
 
-Read the error message before reacting. Adjust parameters; do NOT retry
-the same failing call.
+Read the error message before reacting; fix the program, don't rewrite it
+from scratch.
 
 | Error | Fix |
 |---|---|
-| \`Duplicate node id: 'X'\` | Node already exists. Use \`add_edge\` to wire data into it, or pick a different id for a separate node. |
-| \`Unknown node type: 'X'\` | Re-run \`search_nodes\` with a broader query or different namespace. |
-| \`Source/Target node 'X' does not exist\` | Add the missing node before the edge. |
+| \`code_error\` (syntax / runtime) | Fix the JavaScript. The program must be plain JS ending in \`return graph();\`. |
+| \`Unknown node type: 'X'\` | Re-run \`search_nodes\` with a broader query or different namespace, then resubmit. |
+| \`Duplicate node id: 'X'\` | Two nodes got the same explicit id — rename one. |
 | Wrong handle name | Re-run \`get_node_info\` for exact input/output handle names. |
-| Wrong node or wrong wiring | \`remove_node\` / \`remove_edge\` the mistake, then add the correct one. |
-| Validation errors from \`finish_graph\` | Fix the specific issue (missing required property → re-add the node with it set, or wire an edge into that input) and call \`finish_graph\` again. Do not rebuild from scratch. |
+| Missing required property | Set it in the node's properties or wire an edge into that input. |
+| Cycle errors | The dataflow must be a DAG — remove the back edge. |
 
 # Workflow Patterns (named templates — match user intent to one)
 
@@ -325,7 +347,7 @@ both paths.
 permutation. Connect generic AI nodes of different modalities, optionally
 through an AgentStep for transformation logic.
 
-# Required Properties (set on add_node)
+# Required Properties (set in node() properties)
 
 | Node family | Required properties |
 |---|---|
@@ -338,7 +360,7 @@ through an AgentStep for transformation logic.
 | \`nodetool.constant.String\` / \`Integer\` / \`Float\` / \`Boolean\` | \`value\` |
 | Other nodes | Whatever \`get_node_info\` lists as required. |
 
-Set required properties at \`add_node\` time. Leave the rest at defaults —
+Set required properties when creating the node. Leave the rest at defaults —
 they get overridden by edges or are fine as-is.
 
 # Workflow Inputs
@@ -373,9 +395,8 @@ ${tools}
   workflow. Required: \`instructions\` (string). Optional: \`tools\` (string
   array), \`output_schema\` (JSON schema string). Input handle: \`input\`.
   Output handle: \`output\`.
-- Do NOT use \`nodetool.agents.Agent\` (the standalone agent node) — it
-  requires a complex \`model\` property that cannot be set reliably via
-  \`add_node\`. Use \`AgentStep\` instead.
+- Do NOT use \`nodetool.agents.Agent\` (the standalone agent node) — use
+  \`AgentStep\` instead.
 
 # Persistence
 

--- a/packages/agents/src/tools/finish-graph-tool.ts
+++ b/packages/agents/src/tools/finish-graph-tool.ts
@@ -31,7 +31,7 @@ const FINISH_GRAPH_INPUT_SCHEMA = {
  * accepts — also count as known, mirroring the add-time check. Everything else
  * passes through.
  */
-function agentStepAwareRegistry(
+export function agentStepAwareRegistry(
   registry: GraphValidationRegistry
 ): GraphValidationRegistry {
   return {
@@ -51,7 +51,7 @@ function agentStepAwareRegistry(
 }
 
 /** True when the registry implements the full validation surface (stubs and mocks often don't). */
-function supportsDeepValidation(
+export function supportsDeepValidation(
   registry: unknown
 ): registry is GraphValidationRegistry {
   const r = registry as Partial<GraphValidationRegistry> | null | undefined;

--- a/packages/agents/src/tools/submit-graph-tool.ts
+++ b/packages/agents/src/tools/submit-graph-tool.ts
@@ -1,0 +1,173 @@
+/**
+ * SubmitGraphTool -- planner tool that accepts the whole workflow as one
+ * graph DSL program.
+ *
+ * The LLM one-shots the graph as code instead of issuing an add_node /
+ * add_edge tool call per element. The program is evaluated in the QuickJS
+ * sandbox, loaded into a GraphBuilder, and validated (structural checks plus
+ * the node-sdk's static `validateGraph` when the registry supports it).
+ * Failures come back as the tool result so the model fixes the program and
+ * resubmits — feedback rounds instead of incremental mutation.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { validateGraph } from "@nodetool-ai/node-sdk";
+import type { GraphData } from "@nodetool-ai/protocol";
+import { Tool } from "./base-tool.js";
+import { GraphBuilder, AGENT_STEP_NODE_TYPE } from "../graph-builder.js";
+import { evaluateGraphDsl } from "../graph-dsl.js";
+import {
+  agentStepAwareRegistry,
+  supportsDeepValidation
+} from "./finish-graph-tool.js";
+
+const SUBMIT_GRAPH_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    code: {
+      type: "string" as const,
+      description:
+        "The complete graph program: plain JavaScript using node(type, properties) " +
+        "and ref.output(slot?) for wiring, ending with `return graph();`. " +
+        "Always submit the FULL program — each submission replaces the previous one."
+    }
+  },
+  required: ["code"] as string[],
+  additionalProperties: false as const
+};
+
+export interface SubmitGraphToolOptions {
+  signal?: AbortSignal;
+}
+
+export class SubmitGraphTool extends Tool {
+  readonly name = "submit_graph";
+  readonly description =
+    "Submit the complete workflow graph as one DSL program. Returns validation " +
+    "errors to fix (resubmit the full corrected program), or accepts the graph.";
+  readonly jsonSchema: Record<string, unknown> = SUBMIT_GRAPH_INPUT_SCHEMA;
+
+  /** The finalized graph, available after a successful submission. */
+  private _graph: GraphData | null = null;
+  /** Last submitted program — surfaced in the planner's retry prompt. */
+  lastCode: string | null = null;
+  /** Errors from the last failed submission. */
+  lastErrors: string[] = [];
+
+  get graph(): GraphData | null {
+    return this._graph;
+  }
+
+  constructor(
+    private readonly registry: NodeRegistry,
+    private readonly options: SubmitGraphToolOptions = {}
+  ) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const code = typeof params["code"] === "string" ? params["code"] : "";
+    this.lastCode = code;
+    this.lastErrors = [];
+
+    const evaluated = await evaluateGraphDsl(code, {
+      signal: this.options.signal
+    });
+    if (!evaluated.graph) {
+      const error = evaluated.error ?? "Program produced no graph.";
+      this.lastErrors = [error];
+      return {
+        status: "code_error",
+        error,
+        ...(evaluated.logs && evaluated.logs.length > 0
+          ? { logs: evaluated.logs }
+          : {})
+      };
+    }
+
+    const errors: string[] = [];
+    const builder = new GraphBuilder();
+
+    for (const node of evaluated.graph.nodes) {
+      const isAgentStep = node.type === AGENT_STEP_NODE_TYPE;
+      if (
+        !isAgentStep &&
+        !this.registry.has(node.type) &&
+        !this.registry.getMetadata(node.type)
+      ) {
+        errors.push(
+          `Unknown node type: '${node.type}' (node '${node.id}'). Use search_nodes to find available types.`
+        );
+        continue;
+      }
+      if (isAgentStep) {
+        const instructions = node.properties?.["instructions"];
+        if (!instructions || typeof instructions !== "string") {
+          errors.push(
+            `AgentStep node '${node.id}' requires an "instructions" property (non-empty string).`
+          );
+          continue;
+        }
+      }
+      for (const e of builder.addNode(
+        node.id,
+        node.type,
+        node.properties,
+        node.name
+      )) {
+        errors.push(e);
+      }
+    }
+
+    for (const edge of evaluated.graph.edges) {
+      for (const e of builder.addEdge(
+        edge.source,
+        edge.sourceHandle,
+        edge.target,
+        edge.targetHandle
+      )) {
+        errors.push(e);
+      }
+    }
+
+    const warnings: string[] = [];
+    if (errors.length === 0) {
+      errors.push(...builder.validate());
+    }
+    if (errors.length === 0 && supportsDeepValidation(this.registry)) {
+      const report = validateGraph(
+        builder.snapshot(),
+        agentStepAwareRegistry(this.registry)
+      );
+      for (const issue of report.issues) {
+        if (issue.severity === "error") errors.push(issue.message);
+        else warnings.push(issue.message);
+      }
+    }
+
+    if (errors.length > 0) {
+      this.lastErrors = errors;
+      return {
+        status: "validation_failed",
+        errors,
+        ...(warnings.length > 0 ? { warnings } : {})
+      };
+    }
+
+    this._graph = builder.build();
+    return {
+      status: "graph_accepted",
+      nodes: this._graph.nodes.length,
+      edges: this._graph.edges.length,
+      ...(warnings.length > 0 ? { warnings } : {})
+    };
+  }
+
+  userMessage(_params: Record<string, unknown>): string {
+    return "Submitting workflow graph";
+  }
+}

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -109,6 +109,7 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   finish_task: "read",
   finish_step: "read",
   finish_graph: "read",
+  submit_graph: "read",
   add_node: "read",
   add_edge: "read",
   // run_subtask spawns a child loop whose own tools are gated; the call

--- a/packages/agents/tests/graph-dsl.test.ts
+++ b/packages/agents/tests/graph-dsl.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the graph DSL evaluator (`src/graph-dsl.ts`): the sandboxed
+ * node()/graph() prelude, handle→edge wiring, auto ids, and error surfaces.
+ */
+import { describe, it, expect } from "vitest";
+import { evaluateGraphDsl } from "../src/graph-dsl.js";
+
+describe("evaluateGraphDsl", () => {
+  it("builds nodes and derives edges from output handles", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      const input = node("nodetool.input.StringInput", { name: "prompt" });
+      const step = node("nodetool.agents.AgentStep", {
+        instructions: "Summarize",
+        input: input.output()
+      });
+      node("nodetool.output.StringOutput", { name: "result", value: step.output() });
+      return graph();
+    `);
+
+    expect(error).toBeUndefined();
+    expect(graph).toBeDefined();
+    expect(graph!.nodes).toHaveLength(3);
+    expect(graph!.edges).toEqual([
+      {
+        source: "string_input",
+        sourceHandle: "output",
+        target: "agent_step",
+        targetHandle: "input"
+      },
+      {
+        source: "agent_step",
+        sourceHandle: "output",
+        target: "string_output",
+        targetHandle: "value"
+      }
+    ]);
+    // Handle values are stripped from properties; plain values stay.
+    const step = graph!.nodes.find((n) => n.id === "agent_step")!;
+    expect(step.properties).toEqual({ instructions: "Summarize" });
+  });
+
+  it("derives unique snake_case ids and honors explicit ids", async () => {
+    const { graph } = await evaluateGraphDsl(`
+      node("nodetool.image.TextToImage", { prompt: "a" });
+      node("nodetool.image.TextToImage", { prompt: "b" });
+      node("nodetool.image.TextToImage", { prompt: "c" }, "hero_image");
+      return graph();
+    `);
+
+    expect(graph!.nodes.map((n) => n.id)).toEqual([
+      "text_to_image",
+      "text_to_image_2",
+      "hero_image"
+    ]);
+  });
+
+  it("supports named output slots", async () => {
+    const { graph } = await evaluateGraphDsl(`
+      const cond = node("nodetool.control.If", { condition: true });
+      node("nodetool.output.StringOutput", { name: "yes", value: cond.output("if_true") });
+      node("nodetool.output.StringOutput", { name: "no", value: cond.output("if_false") });
+      return graph();
+    `);
+
+    expect(graph!.edges.map((e) => e.sourceHandle).sort()).toEqual([
+      "if_false",
+      "if_true"
+    ]);
+  });
+
+  it("supports plain JS for repetition", async () => {
+    const { graph } = await evaluateGraphDsl(`
+      const prompts = ["fox", "owl", "bear"];
+      for (const p of prompts) {
+        node("nodetool.image.TextToImage", { prompt: "a " + p });
+      }
+      return graph();
+    `);
+    expect(graph!.nodes).toHaveLength(3);
+  });
+
+  it("reports syntax errors as error text", async () => {
+    const { graph, error } = await evaluateGraphDsl(`const x = ;`);
+    expect(graph).toBeUndefined();
+    expect(error).toMatch(/SyntaxError|unexpected/i);
+  });
+
+  it("reports runtime errors from the program", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      node(42, {});
+      return graph();
+    `);
+    expect(graph).toBeUndefined();
+    expect(error).toContain("type must be a non-empty string");
+  });
+
+  it("rejects a program that does not return graph()", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      node("nodetool.agents.AgentStep", { instructions: "x" });
+      return "done";
+    `);
+    expect(graph).toBeUndefined();
+    expect(error).toContain("return graph();");
+  });
+
+  it("rejects an empty program", async () => {
+    const { error } = await evaluateGraphDsl("   ");
+    expect(error).toBe("Program is empty.");
+  });
+});

--- a/packages/agents/tests/graph-planner-coverage.test.ts
+++ b/packages/agents/tests/graph-planner-coverage.test.ts
@@ -2,14 +2,15 @@
  * Coverage tests for GraphPlanner (`src/graph-planner.ts`).
  *
  * Drives the planner with a scripted provider whose `generateLoop` replays a
- * per-attempt list of tool calls (executing each graph tool's `execute`
- * closure, exactly like a real provider), so we can exercise:
- *   - successful build, chunk streaming, and every formatToolCallMessage branch
+ * per-attempt list of tool calls (executing each tool's `execute` closure,
+ * exactly like a real provider), so we can exercise:
+ *   - one-shot DSL submission, chunk streaming, and tool-call messages
  *   - the find_model registration path (providers supplied)
- *   - retry after a failed attempt, then success
+ *   - submit_graph feedback rounds within one attempt (invalid → fixed)
+ *   - retry after a failed attempt (with the last program in the retry prompt)
  *   - all-attempts-fail -> null
- *   - the per-turn tool-call budget (MAX_TOOL_CALLS_PER_TURN) exhaustion
- *   - "stopped without finish_graph"
+ *   - the per-turn tool-call budget exhaustion
+ *   - "stopped without submit_graph"
  *   - custom systemPrompt / outputSchema / execution-tools formatting
  */
 import { describe, it, expect } from "vitest";
@@ -33,6 +34,9 @@ const stubRegistry = {
   listMetadata: () => []
 } as unknown as NodeRegistry;
 
+const VALID_PROGRAM = `const step = node("${AGENT_STEP_NODE_TYPE}", { instructions: "do it" }, "step1");
+return graph();`;
+
 interface LoopArgs {
   messages: Array<{ role: string; content: string }>;
   tools?: Array<{
@@ -44,6 +48,7 @@ interface LoopArgs {
 
 interface ProviderCapture {
   lastArgs?: LoopArgs;
+  toolResults?: string[];
 }
 
 /**
@@ -80,7 +85,8 @@ function createScriptedProvider(
         yield tc as unknown as ProviderStreamItem;
         const tool = toolMap.get(tc.name);
         if (tool?.execute) {
-          await tool.execute(tc.args as Record<string, unknown>);
+          const result = await tool.execute(tc.args as Record<string, unknown>);
+          opts.capture?.toolResults?.push(String(result));
         }
         if (args.signal?.aborted) break;
       }
@@ -144,7 +150,7 @@ class BareTool extends Tool {
 }
 
 describe("GraphPlanner — coverage", () => {
-  it("builds a graph, streams chunks, and formats every tool-call message", async () => {
+  it("builds a graph from one submission, streams chunks, and formats tool-call messages", async () => {
     const script: ToolCall[] = [
       { id: "t1", name: "search_nodes", args: { query: "text" } },
       {
@@ -157,64 +163,13 @@ describe("GraphPlanner — coverage", () => {
       { id: "t5", name: "unknown_tool", args: {} },
       {
         id: "t6",
-        name: "add_node",
+        name: "submit_graph",
         args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          node_type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "a" }
+          code: `const a = node("${AGENT_STEP_NODE_TYPE}", { instructions: "a" }, "n1");
+node("${AGENT_STEP_NODE_TYPE}", { instructions: "c", input: a.output() }, "n3");
+return graph();`
         }
-      },
-      {
-        id: "t7",
-        name: "add_node",
-        args: {
-          id: "n2",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "b" }
-        }
-      },
-      {
-        id: "t8",
-        name: "add_edge",
-        args: {
-          source: "n1",
-          source_handle: "output",
-          target: "n2",
-          target_handle: "input"
-        }
-      },
-      {
-        id: "t9",
-        name: "remove_edge",
-        args: {
-          source: "n1",
-          source_handle: "output",
-          target: "n2",
-          target_handle: "input"
-        }
-      },
-      { id: "t10", name: "remove_node", args: { id: "n2" } },
-      {
-        id: "t11",
-        name: "add_node",
-        args: {
-          id: "n3",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "c" }
-        }
-      },
-      {
-        id: "t12",
-        name: "add_edge",
-        args: {
-          source: "n1",
-          source_handle: "output",
-          target: "n3",
-          target_handle: "input"
-        }
-      },
-      { id: "t13", name: "finish_graph", args: { title: "G" } }
+      }
     ];
 
     const provider = createScriptedProvider([script], {
@@ -234,6 +189,12 @@ describe("GraphPlanner — coverage", () => {
     expect(value).not.toBeNull();
     expect(value!.nodes).toHaveLength(2);
     expect(value!.edges).toHaveLength(1);
+    expect(value!.edges[0]).toEqual({
+      source: "n1",
+      sourceHandle: "output",
+      target: "n3",
+      targetHandle: "input"
+    });
 
     const tm = toolMessages(messages);
     expect(tm).toContain('Searching nodes for "text"');
@@ -241,11 +202,7 @@ describe("GraphPlanner — coverage", () => {
     expect(tm).toContain("Listing nodes in nodetool.text");
     expect(tm).toContain("Finding model for text_to_image");
     expect(tm).toContain("Calling unknown_tool");
-    expect(tm).toContain(`Adding node ${AGENT_STEP_NODE_TYPE} (n1)`);
-    expect(tm).toContain("Connecting n1 → n2");
-    expect(tm).toContain("Disconnecting n1 → n2");
-    expect(tm).toContain("Removing node n2");
-    expect(tm).toContain("Finalizing graph");
+    expect(tm).toContain("Submitting workflow graph");
 
     // The streamed non-final chunk is forwarded.
     const chunkContents = messages
@@ -254,24 +211,18 @@ describe("GraphPlanner — coverage", () => {
     expect(chunkContents).toContain("thinking...");
 
     // Success planning update.
-    expect(planningContents(messages).some((c) => /Graph built: 2 nodes/.test(c))).toBe(
-      true
-    );
+    expect(
+      planningContents(messages).some((c) => /Graph built: 2 nodes/.test(c))
+    ).toBe(true);
   });
 
   it("prefers the LLM-authored _message over the formatted fallback", async () => {
     const script: ToolCall[] = [
       {
         id: "t1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "a" },
-          _message: "Custom status line"
-        }
-      },
-      { id: "t2", name: "finish_graph", args: {} }
+        name: "submit_graph",
+        args: { code: VALID_PROGRAM, _message: "Custom status line" }
+      }
     ];
     const planner = new GraphPlanner({
       provider: createScriptedProvider([script]),
@@ -285,26 +236,100 @@ describe("GraphPlanner — coverage", () => {
     expect(toolMessages(messages)).toContain("Custom status line");
   });
 
-  it("retries after a failed attempt, then succeeds", async () => {
-    // Attempt 0: finish_graph on an empty builder -> validation_failed, graph
-    // stays null. Attempt 1: add a node then finish -> success.
-    const attempt0: ToolCall[] = [
-      { id: "f0", name: "finish_graph", args: {} }
-    ];
-    const attempt1: ToolCall[] = [
-      {
-        id: "a1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      },
-      { id: "f1", name: "finish_graph", args: {} }
+  it("round-trips validation errors within one attempt (feedback rounds)", async () => {
+    const capture: ProviderCapture = { toolResults: [] };
+    // First submission: empty graph -> validation_failed as the tool result.
+    // Second submission in the SAME attempt: fixed program -> accepted.
+    const script: ToolCall[] = [
+      { id: "s1", name: "submit_graph", args: { code: "return graph();" } },
+      { id: "s2", name: "submit_graph", args: { code: VALID_PROGRAM } }
     ];
     const planner = new GraphPlanner({
-      provider: createScriptedProvider([attempt0, attempt1]),
+      provider: createScriptedProvider([script], { capture }),
+      model: "opus",
+      registry: stubRegistry,
+      maxRetries: 1
+    });
+    const { value } = await collect(
+      planner.plan("obj", createMockContext() as ProcessingContext)
+    );
+    expect(value).not.toBeNull();
+    expect(value!.nodes).toHaveLength(1);
+
+    // The failed round returned its errors to the model as the tool result.
+    expect(capture.toolResults![0]).toContain("validation_failed");
+    expect(capture.toolResults![0]).toContain("at least one node");
+    expect(capture.toolResults![1]).toContain("graph_accepted");
+  });
+
+  it("returns code errors for a broken program as the tool result", async () => {
+    const capture: ProviderCapture = { toolResults: [] };
+    const script: ToolCall[] = [
+      { id: "s1", name: "submit_graph", args: { code: "const x = ;" } },
+      { id: "s2", name: "submit_graph", args: { code: VALID_PROGRAM } }
+    ];
+    const planner = new GraphPlanner({
+      provider: createScriptedProvider([script], { capture }),
+      model: "opus",
+      registry: stubRegistry,
+      maxRetries: 1
+    });
+    const { value } = await collect(
+      planner.plan("obj", createMockContext() as ProcessingContext)
+    );
+    expect(value).not.toBeNull();
+    expect(capture.toolResults![0]).toContain("code_error");
+  });
+
+  it("rejects unknown node types and AgentStep without instructions", async () => {
+    const capture: ProviderCapture = { toolResults: [] };
+    const script: ToolCall[] = [
+      {
+        id: "s1",
+        name: "submit_graph",
+        args: {
+          code: `node("nodetool.made.Up", {});
+node("${AGENT_STEP_NODE_TYPE}", {});
+return graph();`
+        }
+      }
+    ];
+    const planner = new GraphPlanner({
+      provider: createScriptedProvider([script]),
+      model: "opus",
+      registry: stubRegistry,
+      maxRetries: 1
+    });
+    const { value } = await collect(
+      planner.plan("obj", createMockContext() as ProcessingContext)
+    );
+    expect(value).toBeNull();
+
+    const planner2 = new GraphPlanner({
+      provider: createScriptedProvider([script], { capture }),
+      model: "opus",
+      registry: stubRegistry,
+      maxRetries: 1
+    });
+    await collect(planner2.plan("obj", createMockContext() as ProcessingContext));
+    expect(capture.toolResults![0]).toContain("Unknown node type: 'nodetool.made.Up'");
+    expect(capture.toolResults![0]).toContain(
+      'requires an \\"instructions\\" property'
+    );
+  });
+
+  it("retries after a failed attempt and carries the last program into the retry prompt", async () => {
+    const capture: ProviderCapture = {};
+    // Attempt 0: one invalid submission, then the model stops.
+    // Attempt 1: fixed submission -> success.
+    const attempt0: ToolCall[] = [
+      { id: "s0", name: "submit_graph", args: { code: "return graph();" } }
+    ];
+    const attempt1: ToolCall[] = [
+      { id: "s1", name: "submit_graph", args: { code: VALID_PROGRAM } }
+    ];
+    const planner = new GraphPlanner({
+      provider: createScriptedProvider([attempt0, attempt1], { capture }),
       model: "opus",
       registry: stubRegistry
     });
@@ -316,57 +341,20 @@ describe("GraphPlanner — coverage", () => {
     expect(
       planningContents(messages).some((c) => c.includes("Retry attempt 2/3"))
     ).toBe(true);
-  });
 
-  it("preserves the built graph across retry attempts and snapshots it in the retry message", async () => {
-    const capture: ProviderCapture = {};
-    // Attempt 0: adds a node but never finishes. Attempt 1: only finish_graph —
-    // this can only succeed if the builder survived the retry.
-    const attempt0: ToolCall[] = [
-      {
-        id: "a0",
-        name: "add_node",
-        args: {
-          id: "kept",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      }
-    ];
-    const attempt1: ToolCall[] = [{ id: "f1", name: "finish_graph", args: {} }];
-    const planner = new GraphPlanner({
-      provider: createScriptedProvider([attempt0, attempt1], { capture }),
-      model: "opus",
-      registry: stubRegistry
-    });
-    const { value } = await collect(
-      planner.plan("obj", createMockContext() as ProcessingContext)
-    );
-    expect(value).not.toBeNull();
-    expect(value!.nodes).toHaveLength(1);
-    expect(value!.nodes[0].id).toBe("kept");
-
-    // The retry turn told the model what it already built.
+    // The retry turn showed the model its previous program and the errors.
     const msgs = capture.lastArgs!.messages;
     const retryMsg = msgs[msgs.length - 1];
     expect(retryMsg.role).toBe("user");
-    expect(retryMsg.content).toContain("preserved");
-    expect(retryMsg.content).toContain("node kept");
+    expect(retryMsg.content).toContain("return graph();");
+    expect(retryMsg.content).toContain("at least one node");
+    expect(retryMsg.content).toContain("FULL corrected program");
   });
 
   it("renders caller inputs into the planning prompt", async () => {
     const capture: ProviderCapture = {};
     const script: ToolCall[] = [
-      {
-        id: "a1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      },
-      { id: "f1", name: "finish_graph", args: {} }
+      { id: "s1", name: "submit_graph", args: { code: VALID_PROGRAM } }
     ];
     const planner = new GraphPlanner({
       provider: createScriptedProvider([script], { capture }),
@@ -382,7 +370,7 @@ describe("GraphPlanner — coverage", () => {
     expect(userPrompt).toContain("nodetool.input.");
   });
 
-  it("returns null after all attempts fail (no finish_graph)", async () => {
+  it("returns null after all attempts fail (no submit_graph)", async () => {
     // Every attempt yields no tool calls at all.
     const planner = new GraphPlanner({
       provider: createScriptedProvider([[], []]),
@@ -410,18 +398,10 @@ describe("GraphPlanner — coverage", () => {
     ).toBe(true);
   });
 
-  it("reports the stopped-without-finish error", async () => {
+  it("reports the stopped-without-submit error", async () => {
     const attempt: ToolCall[] = [
-      {
-        id: "a1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      }
-      // no finish_graph
+      { id: "t1", name: "search_nodes", args: { query: "text" } }
+      // no submit_graph
     ];
     const planner = new GraphPlanner({
       provider: createScriptedProvider([attempt]),
@@ -435,21 +415,17 @@ describe("GraphPlanner — coverage", () => {
     expect(value).toBeNull();
     expect(
       planningContents(messages).some((c) =>
-        c.includes("LLM stopped without calling finish_graph")
+        c.includes("LLM stopped without calling submit_graph")
       )
     ).toBe(true);
   });
 
   it("reports exhaustion when the per-turn tool-call budget is spent", async () => {
-    // 50 add_node calls with no finish -> hits MAX_TOOL_CALLS_PER_TURN.
-    const attempt: ToolCall[] = Array.from({ length: 50 }, (_, i) => ({
-      id: `a${i}`,
-      name: "add_node",
-      args: {
-        id: `n${i}`,
-        type: AGENT_STEP_NODE_TYPE,
-        properties: { instructions: `s${i}` }
-      }
+    // 20 discovery calls with no submission -> hits the budget.
+    const attempt: ToolCall[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `t${i}`,
+      name: "search_nodes",
+      args: { query: `q${i}` }
     }));
     const planner = new GraphPlanner({
       provider: createScriptedProvider([attempt]),
@@ -463,7 +439,7 @@ describe("GraphPlanner — coverage", () => {
     expect(value).toBeNull();
     expect(
       planningContents(messages).some((c) =>
-        c.includes("Exceeded maximum tool calls (50)")
+        c.includes("Exceeded maximum tool calls (20)")
       )
     ).toBe(true);
   });
@@ -471,23 +447,17 @@ describe("GraphPlanner — coverage", () => {
   it("uses a custom systemPrompt and renders outputSchema + execution tools", async () => {
     const capture: ProviderCapture = {};
     const script: ToolCall[] = [
-      {
-        id: "a1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      },
-      { id: "f1", name: "finish_graph", args: {} }
+      { id: "s1", name: "submit_graph", args: { code: VALID_PROGRAM } }
     ];
     const planner = new GraphPlanner({
       provider: createScriptedProvider([script], { capture }),
       model: "opus",
       registry: stubRegistry,
       systemPrompt: "CUSTOM SYSTEM PROMPT",
-      outputSchema: { type: "object", properties: { summary: { type: "string" } } },
+      outputSchema: {
+        type: "object",
+        properties: { summary: { type: "string" } }
+      },
       tools: [new SchemaTool(), new BareTool()]
     });
 
@@ -514,16 +484,7 @@ describe("GraphPlanner — coverage", () => {
   it('renders "None specified" when no outputSchema is given', async () => {
     const capture: ProviderCapture = {};
     const script: ToolCall[] = [
-      {
-        id: "a1",
-        name: "add_node",
-        args: {
-          id: "n1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "x" }
-        }
-      },
-      { id: "f1", name: "finish_graph", args: {} }
+      { id: "s1", name: "submit_graph", args: { code: VALID_PROGRAM } }
     ];
     const planner = new GraphPlanner({
       provider: createScriptedProvider([script], { capture }),

--- a/packages/agents/tests/graph-planner-eval.test.ts
+++ b/packages/agents/tests/graph-planner-eval.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the GraphPlanner eval harness (`src/evals/`): metrics
+ * collection from the message stream, expectation scoring, skip logic, and
+ * report formatting — all with a scripted provider, no network.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runGraphPlannerEval,
+  formatEvalReport,
+  checkExpectations,
+  type GraphPlannerEvalCase
+} from "../src/index.js";
+import { AGENT_STEP_NODE_TYPE } from "../src/graph-builder.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+
+// Accepts every node type; no validateNode → deep validation is skipped.
+const stubRegistry = {
+  has: () => true,
+  getMetadata: () => undefined,
+  listMetadata: () => []
+} as unknown as NodeRegistry;
+
+/** Provider replaying one scripted tool-call list per generateLoop call. */
+function createScriptedProvider(attempts: ToolCall[][]): BaseProvider {
+  let attemptIndex = 0;
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const script = attempts[attemptIndex] ?? [];
+      attemptIndex++;
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const tc of script) {
+        if (args.signal?.aborted) break;
+        yield tc as unknown as ProviderStreamItem;
+        await toolMap.get(tc.name)?.execute?.(tc.args as Record<string, unknown>);
+        if (args.signal?.aborted) break;
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+const GOOD_PROGRAM = `const t = node("nodetool.input.StringInput", { name: "text" });
+const s = node("${AGENT_STEP_NODE_TYPE}", { instructions: "summarize", input: t.output() });
+node("nodetool.output.Output", { name: "summary", value: s.output() });
+return graph();`;
+
+const CASES: GraphPlannerEvalCase[] = [
+  {
+    id: "good",
+    description: "passes all checks",
+    objective: "Summarize the input text.",
+    inputs: { text: "hello" },
+    expect: {
+      requiredInputNames: ["text"],
+      minAgentSteps: 1,
+      requireOutputNode: true,
+      minNodes: 3
+    }
+  },
+  {
+    id: "needs-models",
+    description: "skipped without providers",
+    objective: "Generate an image.",
+    needsModelProviders: true,
+    expect: {}
+  }
+];
+
+describe("runGraphPlannerEval", () => {
+  it("collects metrics, scores expectations, and skips model-dependent cases", async () => {
+    // Case "good": one failed submission (feedback round) then success.
+    const provider = createScriptedProvider([
+      [
+        { id: "s1", name: "submit_graph", args: { code: "return graph();" } },
+        { id: "s2", name: "submit_graph", args: { code: GOOD_PROGRAM } }
+      ]
+    ]);
+
+    const report = await runGraphPlannerEval({
+      provider,
+      model: "test-model",
+      registry: stubRegistry,
+      cases: CASES
+    });
+
+    expect(report.provider).toBe("scripted");
+    expect(report.cases).toHaveLength(2);
+
+    const good = report.cases[0];
+    expect(good.accepted).toBe(true);
+    expect(good.score).toBe(1);
+    expect(good.submitRounds).toBe(2);
+    expect(good.toolCalls["submit_graph"]).toBe(2);
+    expect(good.nodes).toBe(3);
+    expect(good.edges).toBe(2);
+    expect(good.checks.every((c) => c.pass)).toBe(true);
+
+    const skipped = report.cases[1];
+    expect(skipped.skipped).toBe(true);
+
+    expect(report.summary.total).toBe(2);
+    expect(report.summary.skipped).toBe(1);
+    expect(report.summary.accepted).toBe(1);
+    expect(report.summary.successRate).toBe(1);
+    // 2 submits on the accepted case → not a one-shot.
+    expect(report.summary.oneShotRate).toBe(0);
+    expect(report.summary.avgSubmitRounds).toBe(2);
+  });
+
+  it("scores a failed case 0 and reports the error check", async () => {
+    // Model never submits anything, all attempts fail.
+    const provider = createScriptedProvider([[], [], []]);
+    const report = await runGraphPlannerEval({
+      provider,
+      model: "test-model",
+      registry: stubRegistry,
+      cases: [CASES[0]],
+      maxRetries: 2
+    });
+    const r = report.cases[0];
+    expect(r.accepted).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.attempts).toBe(2);
+    expect(report.summary.successRate).toBe(0);
+  });
+
+  it("formats a readable report", async () => {
+    const provider = createScriptedProvider([
+      [{ id: "s1", name: "submit_graph", args: { code: GOOD_PROGRAM } }]
+    ]);
+    const report = await runGraphPlannerEval({
+      provider,
+      model: "test-model",
+      registry: stubRegistry,
+      cases: [CASES[0]]
+    });
+    const text = formatEvalReport(report);
+    expect(text).toContain("provider=scripted model=test-model");
+    expect(text).toContain("good");
+    expect(text).toContain("success 1/1 (100%)");
+    expect(text).toContain("one-shot 100%");
+  });
+});
+
+describe("checkExpectations", () => {
+  it("flags missing inputs, forbidden types, and provider-locked nodes", () => {
+    const graph = {
+      nodes: [
+        {
+          id: "a",
+          type: "openai.image.CreateImage",
+          name: "a",
+          properties: {}
+        },
+        {
+          id: "b",
+          type: AGENT_STEP_NODE_TYPE,
+          name: "b",
+          properties: { instructions: "x" }
+        }
+      ],
+      edges: []
+    };
+    const checks = checkExpectations(graph, {
+      requiredInputNames: ["text"],
+      forbiddenNodeTypePatterns: ["^nodetool\\.agents\\.AgentStep$"],
+      requiredSourceHandles: ["if_true"]
+    });
+    const byName = Object.fromEntries(checks.map((c) => [c.name, c.pass]));
+    expect(byName["input:text"]).toBe(false);
+    expect(byName["not:^nodetool\\.agents\\.AgentStep$"]).toBe(false);
+    expect(byName["handle:if_true"]).toBe(false);
+    expect(byName["no-provider-nodes"]).toBe(false);
+  });
+});

--- a/packages/agents/tests/graph-planner-loop.test.ts
+++ b/packages/agents/tests/graph-planner-loop.test.ts
@@ -83,15 +83,13 @@ describe("GraphPlanner — provider-driven tool loop", () => {
   it("builds a graph when the provider runs its own tool loop (agent SDK)", async () => {
     const provider = createSdkLoopProvider([
       {
-        id: "tc_add",
-        name: "add_node",
+        id: "tc_submit",
+        name: "submit_graph",
         args: {
-          id: "step1",
-          type: AGENT_STEP_NODE_TYPE,
-          properties: { instructions: "Summarize the input" }
+          code: `node("${AGENT_STEP_NODE_TYPE}", { instructions: "Summarize the input" }, "step1");
+return graph();`
         }
-      },
-      { id: "tc_finish", name: "finish_graph", args: { title: "G" } }
+      }
     ]);
 
     const planner = new GraphPlanner({
@@ -106,6 +104,7 @@ describe("GraphPlanner — provider-driven tool loop", () => {
 
     expect(graph).not.toBeNull();
     expect(graph!.nodes).toHaveLength(1);
+    expect(graph!.nodes[0].id).toBe("step1");
     expect(graph!.nodes[0].type).toBe(AGENT_STEP_NODE_TYPE);
   });
 });

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -1,0 +1,154 @@
+/**
+ * `nodetool eval graph-planner` — run the GraphPlanner evaluation suite
+ * against any registered provider and print/save a metrics report.
+ *
+ * The suite lives in `@nodetool-ai/agents` (`GRAPH_PLANNER_EVAL_CASES`); this
+ * command wires up a provider from the runtime registry, the full TS node
+ * registry, and (when available) configured model providers for `find_model`.
+ * Heavy deps are imported lazily so command registration stays light.
+ */
+import type { Command } from "commander";
+
+interface EvalCliOptions {
+  provider?: string;
+  model?: string;
+  cases?: string;
+  list?: boolean;
+  json?: boolean;
+  out?: string;
+  maxRetries?: string;
+  minSuccess?: string;
+  /** commander negated flag: `--no-find-model` sets this to false. */
+  findModel?: boolean;
+}
+
+export function registerEvalCommand(program: Command): void {
+  const evalCmd = program
+    .command("eval")
+    .description("Evaluation suites for the agent system");
+
+  evalCmd
+    .command("graph-planner")
+    .description(
+      "Run the GraphPlanner (one-shot DSL) eval suite against a provider/model and report metrics"
+    )
+    .option(
+      "-p, --provider <id>",
+      "Provider id (anthropic, openai, claude_agent_sdk, ollama, ...)"
+    )
+    .option("-m, --model <id>", "Model id for the provider")
+    .option(
+      "--cases <ids>",
+      "Comma-separated case ids to run (default: all; see --list)"
+    )
+    .option("--list", "List available cases and exit")
+    .option("--json", "Print the full report as JSON")
+    .option("--out <path>", "Write the JSON report to a file")
+    .option("--max-retries <n>", "Planner attempts per case (default 3)")
+    .option(
+      "--min-success <rate>",
+      "Exit non-zero when the success rate is below this threshold (0..1)"
+    )
+    .option(
+      "--no-find-model",
+      "Run without configured model providers (skips model-dependent cases)"
+    )
+    .action(async (opts: EvalCliOptions) => {
+      const {
+        GRAPH_PLANNER_EVAL_CASES,
+        runGraphPlannerEval,
+        formatEvalReport
+      } = await import("@nodetool-ai/agents");
+
+      if (opts.list) {
+        for (const c of GRAPH_PLANNER_EVAL_CASES) {
+          console.log(
+            `${c.id.padEnd(24)} ${c.description}` +
+              (c.needsModelProviders ? " (needs model providers)" : "")
+          );
+        }
+        return;
+      }
+
+      if (!opts.provider || !opts.model) {
+        console.error("--provider and --model are required (or use --list)");
+        process.exitCode = 1;
+        return;
+      }
+
+      let cases = GRAPH_PLANNER_EVAL_CASES;
+      if (opts.cases) {
+        const wanted = new Set(opts.cases.split(",").map((s) => s.trim()));
+        cases = GRAPH_PLANNER_EVAL_CASES.filter((c) => wanted.has(c.id));
+        const missing = [...wanted].filter(
+          (id) => !cases.some((c) => c.id === id)
+        );
+        if (missing.length > 0) {
+          console.error(
+            `Unknown case ids: ${missing.join(", ")} (see --list)`
+          );
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      try {
+        const [{ createProviderStrict, buildConfiguredProviders }, registryMod] =
+          await Promise.all([
+            import("../providers.js"),
+            import("../node-registry.js")
+          ]);
+
+        const provider = await createProviderStrict(opts.provider);
+        const registry = registryMod.buildFullRegistry();
+        const providers =
+          opts.findModel === false
+            ? undefined
+            : await buildConfiguredProviders();
+
+        console.log(
+          `Running ${cases.length} case(s) with ${opts.provider}/${opts.model}` +
+            (providers && Object.keys(providers).length > 0
+              ? ` (find_model: ${Object.keys(providers).join(", ")})`
+              : " (no model providers — model-dependent cases skipped)")
+        );
+
+        const report = await runGraphPlannerEval({
+          provider,
+          model: opts.model,
+          registry,
+          providers,
+          cases,
+          maxRetries: opts.maxRetries ? Number(opts.maxRetries) : undefined,
+          onEvent: (line) => {
+            if (!opts.json) console.log(line);
+          }
+        });
+
+        if (opts.out) {
+          const { writeFile } = await import("node:fs/promises");
+          await writeFile(opts.out, JSON.stringify(report, null, 2), "utf-8");
+          console.log(`Report written to ${opts.out}`);
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          console.log("\n" + formatEvalReport(report));
+        }
+
+        if (opts.minSuccess !== undefined) {
+          const threshold = Number(opts.minSuccess);
+          if (report.summary.successRate < threshold) {
+            console.error(
+              `Success rate ${report.summary.successRate.toFixed(2)} below threshold ${threshold}`
+            );
+            process.exitCode = 1;
+          }
+        }
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -55,6 +55,7 @@ import { registerAppCommands } from "./commands/app.js";
 import { registerValidateCommand } from "./commands/validate.js";
 import { registerNodeCommands } from "./commands/node.js";
 import { registerGenerateCommand } from "./commands/generate.js";
+import { registerEvalCommand } from "./commands/eval.js";
 import { registerAffectedCommand } from "./commands/affected.js";
 import {
   listConfiguredProviderInfo,
@@ -1833,6 +1834,7 @@ registerAppCommands(program);
 registerValidateCommand(program);
 registerNodeCommands(program);
 registerGenerateCommand(program);
+registerEvalCommand(program);
 registerAffectedCommand(program);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

GraphPlanner operated the wrong way for agents: one tool call per node and edge (`add_node`, `add_edge`, `remove_node`, `remove_edge`, `finish_graph`), which means one LLM round-trip per graph element. That burns tokens and latency, and models are much better at one-shotting a whole program than incrementally mutating state through 30 tool calls.

## What

The planner LLM now writes the **entire workflow as one graph DSL program** and submits it through a single `submit_graph(code)` tool. Validation errors come back as the tool result, so refinement happens as **feedback rounds** over the whole program instead of per-element mutation. Discovery tools (`search_nodes`, `get_node_info`, `list_nodes`, `find_model`) are unchanged.

The DSL is plain JavaScript mirroring the semantics of the TypeScript DSL we already ship (`@nodetool-ai/dsl`): `node(type, properties)` creates a node, passing `ref.output(slot?)` as a property value becomes an edge, and `return graph()` collects everything. Plain JS (loops, template strings) replaces copy-pasted node calls, which further cuts tokens.

```js
const prompt = node("nodetool.input.StringInput", { name: "prompt" });
const image = node("nodetool.image.TextToImage", {
  prompt: prompt.output(),
  model: { provider: "fal_ai", id: "fal-ai/flux/schnell" }
});
node("nodetool.output.ImageOutput", { name: "image", value: image.output() });
return graph();
```

The program runs in the existing QuickJS WebAssembly sandbox (no host access, hard CPU/memory limits), then the result is loaded into `GraphBuilder` and validated structurally plus with node-sdk's static `validateGraph` — same checks as before, now in one pass per submission.

- **`packages/agents/src/graph-dsl.ts`** (new) — `evaluateGraphDsl`: sandboxed prelude + result shape checks → `GraphData`
- **`packages/agents/src/tools/submit-graph-tool.ts`** (new) — evaluate → build → validate → `graph_accepted` / `validation_failed` / `code_error`
- **`packages/agents/src/graph-planner.ts`** — discovery + submit loop; the outer retry prompt carries the last submitted program and its errors; per-attempt tool budget drops 50 → 20
- **`packages/agents/src/prompts/graph-planner-prompt.ts`** — DSL authoring guide with example replaces the add_node/add_edge execution sequence and error table
- The old graph-mutation tools stay exported (unchanged, still usable standalone); `GraphPlanner` no longer registers them

## Evaluation suite (second commit)

`packages/agents/src/evals/` adds a provider-agnostic eval harness, exposed as **`nodetool eval graph-planner`**:

- **8 cases** covering input wiring, chained/parallel/looped LLM steps, If-branch wiring (both handles), deterministic-over-LLM node choice, and `find_model` image generation — each scored against structural expectations, not exact-graph matches, plus a universal no-provider-locked-nodes check.
- **Metrics** per case: accepted, expectation score, submit rounds, tool calls by name, attempts, duration, cost. Aggregates: success rate, mean score, **one-shot rate**, averages, total cost.
- **Runner**: `nodetool eval graph-planner -p <provider> -m <model> [--cases ids] [--json] [--out report.json] [--min-success 0.8]` — works with any provider in the runtime registry; model-dependent cases skip when no providers are configured.

## Testing

- New `tests/graph-dsl.test.ts` (8 tests) and `tests/graph-planner-eval.test.ts` (4 tests, scripted provider, no network)
- Rewrote `tests/graph-planner-coverage.test.ts` and `tests/graph-planner-loop.test.ts` to drive `submit_graph`, including in-attempt feedback rounds, retry-with-last-program, budget exhaustion, and the Claude Agent SDK-style provider loop
- Full `packages/agents` suite: **1472 passed**; websocket consumer tests (`llm-agent-coverage`, `mcp-server`) pass
- **Live E2E with the real Claude Agent SDK provider** (`claude_agent_sdk`/`claude-sonnet-5`): planner one-shotted a 5-node summarize+translate workflow; a wrong output-node type came back as a validation error and was fixed in one feedback round. Eval run on 3 cases: 3/3 accepted, mean score 1.00, one case one-shotting an 8-node If-branch graph
- `npm run build:packages` (56 packages), agents+cli lint, web + electron typecheck all green (mobile typecheck fails only from missing Expo deps in the sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6vFbzSqeXAW4mPs18Sn6k