### PR TITLE
Script editor: drag lines to reorder, insert lines anywhere

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useState } from "react";
+import type { DragEvent } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
@@ -17,6 +18,7 @@ import {
   EmptyState,
   LoadingSpinner,
   SPACING,
+  BORDER_RADIUS,
   TYPOGRAPHY,
   MOTION,
   Z_INDEX
@@ -30,28 +32,141 @@ import { voiceAll } from "../../stores/script/scriptVoicing";
 import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
-import ScriptLineRow, { GUTTER } from "./ScriptLineRow";
+import ScriptLineRow, { TEXT_INSET } from "./ScriptLineRow";
 
 interface ScriptDocumentPaneProps {
   scriptId: string;
   readOnly: boolean;
 }
 
+/** A pending drop position: land the dragged line before `beforeLineId` (or at
+ * the end of `sectionId` when null). */
+interface DropTarget {
+  sectionId: string;
+  beforeLineId: string | null;
+}
+
+interface LineDnd {
+  draggingLineId: string | null;
+  dropTarget: DropTarget | null;
+  onLineDragStart: (lineId: string) => void;
+  onLineDragEnd: () => void;
+  setDropTarget: (target: DropTarget | null) => void;
+  onLineDrop: () => void;
+}
+
+/**
+ * A hover-revealed gap between lines: a hairline with a centered "+" that
+ * inserts a new line at this position. Also acts as a drop target so a line can
+ * be dropped precisely between two others.
+ */
+const InsertLineGap = ({
+  onInsert,
+  onDragOver,
+  onDrop,
+  active
+}: {
+  onInsert: () => void;
+  onDragOver: (e: DragEvent<HTMLElement>) => void;
+  onDrop: (e: DragEvent<HTMLElement>) => void;
+  active: boolean;
+}) => (
+  <Box
+    onDragOver={onDragOver}
+    onDrop={onDrop}
+    sx={{
+      marginLeft: `${TEXT_INSET}px`,
+      height: 12,
+      display: "flex",
+      alignItems: "center",
+      cursor: "pointer",
+      "& .insert-line-rule": {
+        opacity: active ? 1 : 0,
+        transition: MOTION.opacity
+      },
+      "&:hover .insert-line-rule": { opacity: 1 }
+    }}
+  >
+    <Box
+      component="button"
+      type="button"
+      onClick={onInsert}
+      aria-label="Insert line here"
+      className="insert-line-rule"
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: SPACING.xs,
+        width: "100%",
+        padding: SPACING.none,
+        border: "none",
+        background: "none",
+        cursor: "pointer",
+        color: "primary.main"
+      }}
+    >
+      <AddIcon sx={{ fontSize: 14 }} />
+      <Box
+        sx={{
+          flex: 1,
+          height: 2,
+          borderRadius: BORDER_RADIUS.sm,
+          backgroundColor: "primary.main"
+        }}
+      />
+    </Box>
+  </Box>
+);
+
 const SectionBlock = ({
   scriptId,
   section,
   currentLineId,
-  readOnly
+  readOnly,
+  dnd
 }: {
   scriptId: string;
   section: ScriptSection;
   currentLineId: string | null;
   readOnly: boolean;
+  dnd: LineDnd;
 }) => {
   const cast = useScript(scriptId).cast;
   const setSectionTitle = useScriptStore((s) => s.setSectionTitle);
   const addLine = useScriptStore((s) => s.addLine);
+  const insertLine = useScriptStore((s) => s.insertLine);
   const removeSection = useScriptStore((s) => s.removeSection);
+
+  const isTarget = (beforeLineId: string | null): boolean =>
+    dnd.dropTarget?.sectionId === section.id &&
+    dnd.dropTarget.beforeLineId === beforeLineId;
+
+  // Snap a drag hovering a row to the nearest gap (before this line, or before
+  // the next one), so the active gap's rule marks where the drop will land.
+  const onRowDragOver =
+    (lineId: string, nextLineId: string | null) =>
+    (e: DragEvent<HTMLElement>) => {
+      if (!dnd.draggingLineId) return;
+      e.preventDefault();
+      const rect = e.currentTarget.getBoundingClientRect();
+      const after = e.clientY - rect.top > rect.height / 2;
+      dnd.setDropTarget({
+        sectionId: section.id,
+        beforeLineId: after ? nextLineId : lineId
+      });
+    };
+
+  const onGapDragOver =
+    (beforeLineId: string | null) => (e: DragEvent<HTMLElement>) => {
+      if (!dnd.draggingLineId) return;
+      e.preventDefault();
+      dnd.setDropTarget({ sectionId: section.id, beforeLineId });
+    };
+
+  const onGapDrop = (e: DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    dnd.onLineDrop();
+  };
 
   return (
     <FlexColumn
@@ -106,18 +221,45 @@ const SectionBlock = ({
           </Box>
         )}
       </FlexRow>
-      {section.lines.map((line) => (
-        <ScriptLineRow
-          key={line.id}
-          scriptId={scriptId}
-          line={line}
-          cast={cast}
-          highlighted={line.id === currentLineId}
-          readOnly={readOnly}
-        />
-      ))}
+      {section.lines.map((line, index) => {
+        const nextLineId = section.lines[index + 1]?.id ?? null;
+        return (
+          <div key={line.id}>
+            {!readOnly && (
+              <InsertLineGap
+                onInsert={() => insertLine(scriptId, section.id, index)}
+                onDragOver={onGapDragOver(line.id)}
+                onDrop={onGapDrop}
+                active={isTarget(line.id)}
+              />
+            )}
+            <ScriptLineRow
+              scriptId={scriptId}
+              line={line}
+              cast={cast}
+              highlighted={line.id === currentLineId}
+              readOnly={readOnly}
+              isDragging={dnd.draggingLineId === line.id}
+              onDragStart={
+                readOnly ? undefined : () => dnd.onLineDragStart(line.id)
+              }
+              onDragEnd={readOnly ? undefined : dnd.onLineDragEnd}
+              onDragOver={onRowDragOver(line.id, nextLineId)}
+              onDrop={onGapDrop}
+            />
+          </div>
+        );
+      })}
       {!readOnly && (
-        <FlexRow sx={{ marginLeft: `${GUTTER + 8}px` }}>
+        <InsertLineGap
+          onInsert={() => insertLine(scriptId, section.id, section.lines.length)}
+          onDragOver={onGapDragOver(null)}
+          onDrop={onGapDrop}
+          active={isTarget(null)}
+        />
+      )}
+      {!readOnly && (
+        <FlexRow sx={{ marginLeft: `${TEXT_INSET}px` }}>
           <EditorButton
             size="small"
             variant="text"
@@ -139,10 +281,38 @@ const ScriptDocumentPane = ({
   const { sections, timelineId } = useScript(scriptId);
   const addLine = useScriptStore((s) => s.addLine);
   const addSection = useScriptStore((s) => s.addSection);
+  const moveLine = useScriptStore((s) => s.moveLine);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
   const [voicingAll, setVoicingAll] = useState(false);
   const { assemble, assembling } = useAssembleScriptTimeline();
+
+  const [draggingLineId, setDraggingLineId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+
+  // `dnd` is rebuilt every render, so these handlers see the current drag state
+  // directly — no memoization needed and no stale closures.
+  const dnd: LineDnd = {
+    draggingLineId,
+    dropTarget,
+    onLineDragStart: setDraggingLineId,
+    onLineDragEnd: () => {
+      setDraggingLineId(null);
+      setDropTarget(null);
+    },
+    setDropTarget,
+    onLineDrop: () => {
+      if (draggingLineId && dropTarget)
+        moveLine(
+          scriptId,
+          draggingLineId,
+          dropTarget.sectionId,
+          dropTarget.beforeLineId
+        );
+      setDraggingLineId(null);
+      setDropTarget(null);
+    }
+  };
 
   const onVoiceAll = useCallback(async () => {
     setVoicingAll(true);
@@ -298,10 +468,11 @@ const ScriptDocumentPane = ({
             section={section}
             currentLineId={currentLineId}
             readOnly={readOnly}
+            dnd={dnd}
           />
         ))}
         {!readOnly && !isEmpty && (
-          <FlexRow gap={SPACING.sm} sx={{ marginLeft: `${GUTTER + 8}px` }}>
+          <FlexRow gap={SPACING.sm} sx={{ marginLeft: `${TEXT_INSET}px` }}>
             <EditorButton
               size="small"
               variant="text"

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useState } from "react";
-import type { ChangeEvent, MouseEvent } from "react";
+import type { ChangeEvent, DragEvent, MouseEvent } from "react";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import HistoryIcon from "@mui/icons-material/History";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import TheaterComedyIcon from "@mui/icons-material/TheaterComedy";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import {
   FlexColumn,
   FlexRow,
@@ -40,10 +41,26 @@ interface ScriptLineRowProps {
   cast: ScriptSpeaker[];
   highlighted: boolean;
   readOnly: boolean;
+  /** True while this row is the one being dragged (dimmed as it lifts out). */
+  isDragging?: boolean;
+  onDragStart?: (e: DragEvent<HTMLElement>) => void;
+  onDragEnd?: (e: DragEvent<HTMLElement>) => void;
+  onDragOver?: (e: DragEvent<HTMLElement>) => void;
+  onDrop?: (e: DragEvent<HTMLElement>) => void;
 }
 
 /** Width of the screenplay speaker gutter. */
 export const GUTTER = 104;
+
+/** Width of the hover-revealed drag handle rail left of the gutter. */
+export const DRAG_RAIL = 20;
+
+/**
+ * Left offset (px) of the line's text column: drag rail + gutter and the two
+ * 16px flex gaps around them. Add-line buttons and insert affordances align to
+ * this so they sit under the dialogue, not the speaker names.
+ */
+export const TEXT_INSET = DRAG_RAIL + 16 + GUTTER + 16;
 
 /**
  * Borderless field styling: the script reads as a document, so the input
@@ -69,7 +86,12 @@ const ScriptLineRow = ({
   line,
   cast,
   highlighted,
-  readOnly
+  readOnly,
+  isDragging = false,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop
 }: ScriptLineRowProps) => {
   const patchLine = useScriptStore((s) => s.patchLine);
   const removeLine = useScriptStore((s) => s.removeLine);
@@ -140,16 +162,32 @@ const ScriptLineRow = ({
     });
   }, [hasDirection, patchLine, scriptId, line.id]);
 
+  const draggable = !readOnly && !!onDragStart;
+
+  const handleDragStart = useCallback(
+    (e: DragEvent<HTMLElement>) => {
+      // Some browsers only initiate a drag once dataTransfer carries a payload.
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", line.id);
+      onDragStart?.(e);
+    },
+    [onDragStart, line.id]
+  );
+
   return (
     <FlexRow
       align="flex-start"
       gap={SPACING.md}
       fullWidth
+      onDragOver={onDragOver}
+      onDrop={onDrop}
       sx={{
+        position: "relative",
         padding: SPACING.sm,
         paddingLeft: SPACING.none,
         borderRadius: BORDER_RADIUS.sm,
         backgroundColor: highlighted ? "action.selected" : "transparent",
+        opacity: isDragging ? 0.4 : 1,
         transition: MOTION.background,
         "&:hover": {
           backgroundColor: highlighted ? "action.selected" : "action.hover"
@@ -160,9 +198,42 @@ const ScriptLineRow = ({
         },
         "&:hover .script-line-actions, &:focus-within .script-line-actions": {
           opacity: 1
-        }
+        },
+        "& .script-line-drag": {
+          opacity: 0,
+          transition: MOTION.opacity
+        },
+        "&:hover .script-line-drag": { opacity: 1 }
       }}
     >
+      {draggable ? (
+        <Tooltip title="Drag to reorder">
+          <Box
+            className="script-line-drag"
+            draggable
+            onDragStart={handleDragStart}
+            onDragEnd={onDragEnd}
+            aria-label="Drag to reorder line"
+            sx={{
+              flexShrink: 0,
+              width: DRAG_RAIL,
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "flex-start",
+              marginTop: SPACING.sm,
+              color: "text.disabled",
+              cursor: "grab",
+              "&:active": { cursor: "grabbing" },
+              "&:hover": { color: "text.secondary" }
+            }}
+          >
+            <DragIndicatorIcon fontSize="small" />
+          </Box>
+        </Tooltip>
+      ) : (
+        <Box sx={{ flexShrink: 0, width: DRAG_RAIL }} />
+      )}
+
       <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
         <Box
           component="button"

--- a/web/src/stores/script/ScriptStore.ts
+++ b/web/src/stores/script/ScriptStore.ts
@@ -120,6 +120,7 @@ interface ScriptStoreState {
 
   // Lines
   addLine: (scriptId: string, sectionId?: string) => string;
+  insertLine: (scriptId: string, sectionId: string, index: number) => string;
   patchLine: (
     scriptId: string,
     lineId: string,
@@ -130,6 +131,18 @@ interface ScriptStoreState {
     scriptId: string,
     sectionId: string,
     orderedLineIds: string[]
+  ) => void;
+  /**
+   * Move `lineId` (from any section) so it lands directly before
+   * `beforeLineId` in `targetSectionId`; a null `beforeLineId` appends to the
+   * end. Positioning by neighbour id rather than a numeric index keeps the drop
+   * stable regardless of the shift caused by removing the line first.
+   */
+  moveLine: (
+    scriptId: string,
+    lineId: string,
+    targetSectionId: string,
+    beforeLineId: string | null
   ) => void;
 
   // Takes
@@ -359,6 +372,24 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
     return lineId;
   },
 
+  insertLine: (scriptId, sectionId, index) => {
+    const lineId = uid("line");
+    const newLine: ScriptLine = { id: lineId, text: "", takes: [] };
+    set((state) =>
+      withScript(state, scriptId, (s) => ({
+        ...s,
+        sections: s.sections.map((section) => {
+          if (section.id !== sectionId) return section;
+          const lines = [...section.lines];
+          const at = Math.max(0, Math.min(index, lines.length));
+          lines.splice(at, 0, newLine);
+          return { ...section, lines };
+        })
+      }))
+    );
+    return lineId;
+  },
+
   patchLine: (scriptId, lineId, patch) =>
     set((state) =>
       withScript(state, scriptId, (s) =>
@@ -401,6 +432,41 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
           return { ...section, lines };
         })
       }))
+    ),
+
+  moveLine: (scriptId, lineId, targetSectionId, beforeLineId) =>
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        if (lineId === beforeLineId) return s;
+        let moved: ScriptLine | undefined;
+        const stripped = s.sections.map((section) => {
+          const idx = section.lines.findIndex((l) => l.id === lineId);
+          if (idx < 0) return section;
+          moved = section.lines[idx];
+          return {
+            ...section,
+            lines: section.lines.filter((l) => l.id !== lineId)
+          };
+        });
+        if (!moved) return s;
+        const line = moved;
+        let inserted = false;
+        const sections = stripped.map((section) => {
+          if (section.id !== targetSectionId) return section;
+          const lines = [...section.lines];
+          const at =
+            beforeLineId == null
+              ? lines.length
+              : (() => {
+                  const i = lines.findIndex((l) => l.id === beforeLineId);
+                  return i < 0 ? lines.length : i;
+                })();
+          lines.splice(at, 0, line);
+          inserted = true;
+          return { ...section, lines };
+        });
+        return inserted ? { ...s, sections } : s;
+      })
     ),
 
   appendTake: (scriptId, lineId, take) =>

--- a/web/src/stores/script/__tests__/ScriptStore.test.ts
+++ b/web/src/stores/script/__tests__/ScriptStore.test.ts
@@ -64,6 +64,82 @@ describe("addLine", () => {
   });
 });
 
+describe("insertLine", () => {
+  const seed = (n: number): string => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    for (let i = 0; i < n; i++) store.addLine(SCRIPT);
+    return useScriptStore.getState().scripts[SCRIPT].sections[0].id;
+  };
+
+  it("inserts at the given index", () => {
+    const sectionId = seed(2);
+    const store = useScriptStore.getState();
+    const [a, b] = store.scripts[SCRIPT].sections[0].lines.map((l) => l.id);
+    const mid = store.insertLine(SCRIPT, sectionId, 1);
+    const ids = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines.map((l) => l.id);
+    expect(ids).toEqual([a, mid, b]);
+  });
+
+  it("clamps an out-of-range index to the end", () => {
+    const sectionId = seed(1);
+    const store = useScriptStore.getState();
+    const first = store.scripts[SCRIPT].sections[0].lines[0].id;
+    const last = store.insertLine(SCRIPT, sectionId, 99);
+    const ids = useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[0].lines.map((l) => l.id);
+    expect(ids).toEqual([first, last]);
+  });
+});
+
+describe("moveLine", () => {
+  const seed = (n: number): { sectionId: string; ids: string[] } => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    for (let i = 0; i < n; i++) store.addLine(SCRIPT);
+    const section = useScriptStore.getState().scripts[SCRIPT].sections[0];
+    return { sectionId: section.id, ids: section.lines.map((l) => l.id) };
+  };
+  const currentIds = (sectionIdx = 0): string[] =>
+    useScriptStore
+      .getState()
+      .scripts[SCRIPT].sections[sectionIdx].lines.map((l) => l.id);
+
+  it("moves a line before another within a section", () => {
+    const { sectionId, ids } = seed(3); // [a, b, c]
+    useScriptStore.getState().moveLine(SCRIPT, ids[2], sectionId, ids[0]);
+    expect(currentIds()).toEqual([ids[2], ids[0], ids[1]]);
+  });
+
+  it("appends to the end when beforeLineId is null", () => {
+    const { sectionId, ids } = seed(3); // [a, b, c]
+    useScriptStore.getState().moveLine(SCRIPT, ids[0], sectionId, null);
+    expect(currentIds()).toEqual([ids[1], ids[2], ids[0]]);
+  });
+
+  it("is a no-op when dropped on itself", () => {
+    const { sectionId, ids } = seed(3);
+    useScriptStore.getState().moveLine(SCRIPT, ids[1], sectionId, ids[1]);
+    expect(currentIds()).toEqual(ids);
+  });
+
+  it("moves a line across sections", () => {
+    const { sectionId: secA, ids } = seed(2); // section A: [a, b]
+    const store = useScriptStore.getState();
+    const secB = store.addSection(SCRIPT);
+    store.addLine(SCRIPT, secB); // section B: [c]
+    const cId = useScriptStore.getState().scripts[SCRIPT].sections[1].lines[0]
+      .id;
+    store.moveLine(SCRIPT, ids[0], secB, cId);
+    expect(currentIds(0)).toEqual([ids[1]]);
+    expect(currentIds(1)).toEqual([ids[0], cId]);
+    void secA;
+  });
+});
+
 describe("takes", () => {
   it("appendTake accumulates and sets current", () => {
     const store = useScriptStore.getState();


### PR DESCRIPTION
## What

The script document pane (`ScriptDocumentPane`) previously only supported **appending** lines to the end of a section. This PR makes lines directly manipulable:

- **Drag to reorder** — each line has a hover-revealed drag handle (native HTML5 drag-and-drop, matching the rest of the app). Drag a line up or down within its section, or across sections.
- **Insert anywhere** — a hover-revealed `+` gap between every line (and at the section end) inserts a new empty line at that exact position.

## How

**Store (`ScriptStore.ts`)**
- `insertLine(scriptId, sectionId, index)` — insert an empty line at a clamped index.
- `moveLine(scriptId, lineId, targetSectionId, beforeLineId)` — move a line so it lands directly before `beforeLineId` (or at the end when `null`). Positioning by neighbour id rather than a numeric index keeps the drop stable regardless of the shift caused by removing the line first, and handles cross-section moves.

**UI**
- `ScriptLineRow` gains a drag handle rail (left of the speaker gutter) plus `onDragStart/End/Over/Drop` props; the dragged row dims while it lifts out. `dataTransfer` is seeded so Firefox initiates the drag.
- `ScriptDocumentPane` owns the drag state. Rows and the gaps between them are drop targets; a row hover snaps the drop to the nearest gap, whose rule marks where the line will land. A new `InsertLineGap` renders both the click-to-insert affordance and the drop indicator.
- Add/insert affordances align to the text column via a shared `TEXT_INSET` (the drag rail now sits left of the gutter).

## Testing

- `ScriptStore.test.ts` — new `insertLine` (index + clamp) and `moveLine` (within-section reorder, append, no-op on self, cross-section) coverage.
- `npm run typecheck`, `npx eslint` on changed files, and the script test/component suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VzzXX3pEkNEBA8ZJ1Nie

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VzzXX3pEkNEBA8ZJ1Nie)_