### PR TITLE
fix: surface graph-planner activity in chat, make it cancellable, save editable graphs

### DIFF
--- a/packages/agents/src/graph-planner.ts
+++ b/packages/agents/src/graph-planner.ts
@@ -24,7 +24,8 @@ import type {
   ProcessingMessage,
   Chunk,
   PlanningUpdate,
-  ToolCallUpdate
+  ToolCallUpdate,
+  ToolResultUpdate
 } from "@nodetool-ai/protocol";
 
 import { Tool } from "./tools/base-tool.js";
@@ -333,13 +334,20 @@ export class GraphPlanner {
     }
 
     let totalToolCalls = 0;
+    // Tool results are produced inside the `execute` closures the provider
+    // drives, off the event stream. Park them here and drain into the stream
+    // so the UI can resolve each running tool-call card.
+    const pendingResults: ToolResultUpdate[] = [];
 
     // The provider drives the tool loop, so backends that run their own agent
     // loop (e.g. the Claude Agent SDK) work. Each tool carries its own
     // `execute` closure.
     const makeExecute =
       (tool: Tool) =>
-      async (args: Record<string, unknown>): Promise<string> => {
+      async (
+        args: Record<string, unknown>,
+        toolCallId?: string
+      ): Promise<string> => {
         totalToolCalls++;
         log.info("GraphPlanner tool call", {
           totalToolCalls,
@@ -365,6 +373,16 @@ export class GraphPlanner {
           resultLength: resultStr.length,
           resultPreview: resultStr.slice(0, 240)
         });
+
+        if (toolCallId) {
+          pendingResults.push({
+            type: "tool_result_update",
+            node_id: "graph_planner",
+            tool_call_id: toolCallId,
+            name: tool.name,
+            result: { result: resultStr }
+          });
+        }
 
         if (tool.name === submitGraphTool.name && submitGraphTool.graph) {
           log.info("GraphPlanner submit_graph accepted", {
@@ -400,6 +418,7 @@ export class GraphPlanner {
 
     try {
       for await (const item of stream) {
+        while (pendingResults.length > 0) yield pendingResults.shift()!;
         if ("id" in item && "name" in item && "args" in item) {
           const tc = item as ToolCall;
           const args = (tc.args as Record<string, unknown>) ?? {};
@@ -434,6 +453,9 @@ export class GraphPlanner {
     } finally {
       unlinkAbort();
     }
+    // The last tool's result lands after the stream ends (the accepted
+    // submit_graph aborts the loop from inside its own execute).
+    while (pendingResults.length > 0) yield pendingResults.shift()!;
 
     if (submitGraphTool.graph) {
       return { graph: submitGraphTool.graph };

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -491,6 +491,12 @@ export interface PlanWorkflowGraphToolOptions {
    * so the UI can nest them under this tool's call card.
    */
   forwardMessage?: (msg: ProcessingMessage) => Promise<void> | void;
+  /**
+   * Resolves the abort signal for the *current* chat turn. Read lazily on each
+   * call: the tool outlives a single turn, and each turn installs a fresh
+   * controller, so a captured signal would go stale after the first Stop.
+   */
+  signal?: () => AbortSignal | undefined;
 }
 
 export class PlanWorkflowGraphTool extends Tool {
@@ -540,18 +546,31 @@ export class PlanWorkflowGraphTool extends Tool {
         ? (params[TOOL_CALL_ID_FIELD] as string)
         : null;
 
+    const signal = this.opts.signal?.();
+    if (signal?.aborted) {
+      return { error: "Graph planning was cancelled." };
+    }
+
     const planner = new GraphPlanner({
       provider: this.opts.provider,
       model: this.opts.model,
       registry: this.opts.registry,
       tools: [],
       inputs: (params["inputs"] as Record<string, unknown>) ?? {},
-      providers: this.opts.providers
+      providers: this.opts.providers,
+      signal
     });
 
     const gen = planner.plan(objective, context);
     let next = await gen.next();
     while (!next.done) {
+      // The planner's own abort stops its LLM loop, but a tool call already
+      // in flight still resolves — stop driving the generator so a Stop ends
+      // the turn promptly instead of after the current round.
+      if (signal?.aborted) {
+        await gen.return(null);
+        return { error: "Graph planning was cancelled." };
+      }
       if (this.opts.forwardMessage) {
         const tagged = {
           ...(next.value as unknown as Record<string, unknown>),
@@ -565,6 +584,10 @@ export class PlanWorkflowGraphTool extends Tool {
         }
       }
       next = await gen.next();
+    }
+
+    if (signal?.aborted) {
+      return { error: "Graph planning was cancelled." };
     }
 
     const graph = next.value;

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -48,32 +48,67 @@ function getHeaders(context: ProcessingContext): Record<string, string> {
   return headers;
 }
 
+/**
+ * Normalize an agent-authored graph into the *stored* workflow shape.
+ *
+ * Two representations exist. The kernel (and `GraphPlanner`/`GraphBuilder`)
+ * puts a node's property bag under `properties`; the persisted/editor shape
+ * puts it flat under `data`, with layout under `ui_properties`. Saving kernel
+ * shape runs fine — `normalizeGraph` in the websocket runner maps `data` →
+ * `properties` on the way to the kernel and leaves an existing `properties`
+ * alone — but the editor reads `node.data`, so such a workflow opens with
+ * every node blank and stacked at the origin.
+ *
+ * This is the boundary where that conversion has to happen: `create_workflow`
+ * is the only tool that persists a graph.
+ */
 function normalizeWorkflowGraph(graph: unknown): unknown {
   if (!graph || typeof graph !== "object" || Array.isArray(graph)) return graph;
   const record = graph as Record<string, unknown>;
   const rawNodes = record["nodes"];
   const rawEdges = record["edges"];
 
-  const normalizeNode = (value: unknown, fallbackId?: string): unknown => {
+  const normalizeNode = (
+    value: unknown,
+    index: number,
+    fallbackId?: string
+  ): unknown => {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
       return value;
     }
     const node = value as Record<string, unknown>;
-    const { node_type, parameters, ...rest } = node;
-    const properties = node["properties"] ?? parameters;
+    // `properties` and `parameters` are dropped from the spread so the stored
+    // node carries the bag once, under `data`.
+    const { node_type, parameters, properties, ...rest } = node;
+    const data = properties ?? parameters ?? node["data"];
+    const uiProperties = node["ui_properties"];
     return {
       ...rest,
       id: node["id"] ?? fallbackId,
       type: node["type"] ?? node_type,
-      ...(properties === undefined ? {} : { properties })
+      ...(data === undefined ? {} : { data }),
+      // The planner emits no layout. Lay the nodes out on a grid so the
+      // workflow is readable when opened instead of one pile at the origin.
+      ui_properties:
+        uiProperties && typeof uiProperties === "object"
+          ? uiProperties
+          : {
+              position: {
+                x: (index % 4) * 280,
+                y: Math.floor(index / 4) * 200
+              },
+              zIndex: 0,
+              width: 280,
+              selectable: true
+            }
     };
   };
 
   const nodes = Array.isArray(rawNodes)
-    ? rawNodes.map((node) => normalizeNode(node))
+    ? rawNodes.map((node, index) => normalizeNode(node, index))
     : rawNodes && typeof rawNodes === "object"
-      ? Object.entries(rawNodes as Record<string, unknown>).map(([id, node]) =>
-          normalizeNode(node, id)
+      ? Object.entries(rawNodes as Record<string, unknown>).map(
+          ([id, node], index) => normalizeNode(node, index, id)
         )
       : rawNodes;
 

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -137,17 +137,31 @@ describe("CreateWorkflowTool", () => {
     });
 
     const body = JSON.parse(lastFetchOpts().body as string);
+    // Stored shape: the property bag lives flat under `data`, not
+    // `properties` — the editor reads `node.data`.
     expect(body.graph).toEqual({
       nodes: [
         {
           id: "search",
           type: "openai.text.WebSearch",
-          properties: { query: "current technology news" }
+          data: { query: "current technology news" },
+          ui_properties: {
+            position: { x: 0, y: 0 },
+            zIndex: 0,
+            width: 280,
+            selectable: true
+          }
         },
         {
           id: "summarize",
           type: "mistral.text.ChatComplete",
-          properties: { model: "mistral-large-latest" }
+          data: { model: "mistral-large-latest" },
+          ui_properties: {
+            position: { x: 280, y: 0 },
+            zIndex: 0,
+            width: 280,
+            selectable: true
+          }
         }
       ],
       edges: [
@@ -194,14 +208,73 @@ describe("CreateWorkflowTool", () => {
       {
         id: "search_node",
         type: "xai.text.WebSearch",
-        properties: { query: "latest news", search_mode: "on" }
+        data: { query: "latest news", search_mode: "on" },
+        ui_properties: {
+          position: { x: 0, y: 0 },
+          zIndex: 0,
+          width: 280,
+          selectable: true
+        }
       },
       {
         id: "summarizer_node",
         type: "nodetool.agents.Agent",
-        properties: { instructions: "Summarize the news" }
+        data: { instructions: "Summarize the news" },
+        ui_properties: {
+          position: { x: 280, y: 0 },
+          zIndex: 0,
+          width: 280,
+          selectable: true
+        }
       }
     ]);
+  });
+
+  it("keeps a graph that already uses the stored `data` shape", async () => {
+    await tool.process(ctx, {
+      name: "Already stored shape",
+      graph: {
+        nodes: [
+          {
+            id: "n1",
+            type: "nodetool.input.StringInput",
+            data: { name: "prompt" },
+            ui_properties: { position: { x: 42, y: 99 }, zIndex: 0 }
+          }
+        ],
+        edges: []
+      }
+    });
+
+    const body = JSON.parse(lastFetchOpts().body as string);
+    expect(body.graph.nodes).toEqual([
+      {
+        id: "n1",
+        type: "nodetool.input.StringInput",
+        data: { name: "prompt" },
+        ui_properties: { position: { x: 42, y: 99 }, zIndex: 0 }
+      }
+    ]);
+  });
+
+  it("never stores a node carrying both `properties` and `data`", async () => {
+    await tool.process(ctx, {
+      name: "Planner output",
+      graph: {
+        nodes: [
+          {
+            id: "n1",
+            type: "nodetool.input.StringInput",
+            properties: { name: "prompt" }
+          }
+        ],
+        edges: []
+      }
+    });
+
+    const node = JSON.parse(lastFetchOpts().body as string).graph.nodes[0];
+    expect(node.properties).toBeUndefined();
+    expect(node.data).toEqual({ name: "prompt" });
   });
 
   it("userMessage includes name", () => {

--- a/packages/agents/tests/plan-workflow-graph-tool.test.ts
+++ b/packages/agents/tests/plan-workflow-graph-tool.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `plan_workflow_graph` runs the GraphPlanner inside a chat turn, so a Stop
+ * must end it promptly instead of letting every remaining LLM call finish.
+ */
+import { describe, it, expect } from "vitest";
+import { PlanWorkflowGraphTool } from "../src/tools/mcp-tools.js";
+import { AGENT_NODE_TYPE } from "../src/graph-builder.js";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const stubRegistry = {
+  has: (type: string) => type === AGENT_NODE_TYPE,
+  getMetadata: () => undefined,
+  listMetadata: () => []
+} as unknown as NodeRegistry;
+
+const SUBMIT_CALL: ToolCall = {
+  id: "tc_submit",
+  name: "submit_graph",
+  args: {
+    code: `node("${AGENT_NODE_TYPE}", { prompt: "Summarize" }, "step1");
+return graph();`
+  }
+};
+
+/** Provider that drives the tool loop itself, one scripted call at a time. */
+function createProvider(
+  script: ToolCall[],
+  onLoop?: () => void
+): BaseProvider {
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+      yield { type: "chunk", content: "", done: true };
+    },
+    async *generateMessagesTraced(): AsyncGenerator<ProviderStreamItem> {
+      yield { type: "chunk", content: "", done: true };
+    },
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (
+          a: Record<string, unknown>,
+          id?: string
+        ) => Promise<string | unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      onLoop?.();
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const tc of script) {
+        if (args.signal?.aborted) break;
+        yield tc;
+        const content = (await toolMap.get(tc.name)?.execute?.(tc.args, tc.id)) ?? "";
+        yield {
+          type: "message",
+          message: {
+            role: "tool",
+            toolCallId: tc.id,
+            content:
+              typeof content === "string" ? content : JSON.stringify(content)
+          }
+        };
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+function createTool(opts: {
+  provider: BaseProvider;
+  signal?: () => AbortSignal | undefined;
+  forwardMessage?: (msg: ProcessingMessage) => void;
+}): PlanWorkflowGraphTool {
+  return new PlanWorkflowGraphTool({
+    provider: opts.provider,
+    model: "test-model",
+    registry: stubRegistry,
+    signal: opts.signal,
+    forwardMessage: opts.forwardMessage
+  });
+}
+
+describe("PlanWorkflowGraphTool cancellation", () => {
+  it("plans normally when the turn is not aborted", async () => {
+    const tool = createTool({ provider: createProvider([SUBMIT_CALL]) });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "Build a graph" }
+    )) as { graph?: { nodes: unknown[] }; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.graph!.nodes).toHaveLength(1);
+  });
+
+  it("returns cancelled without invoking the planner when already aborted", async () => {
+    let loopRan = false;
+    const controller = new AbortController();
+    controller.abort();
+    const tool = createTool({
+      provider: createProvider([SUBMIT_CALL], () => {
+        loopRan = true;
+      }),
+      signal: () => controller.signal
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "Build a graph" }
+    )) as { error?: string };
+
+    expect(result.error).toBe("Graph planning was cancelled.");
+    expect(loopRan).toBe(false);
+  });
+
+  it("stops driving the planner when the turn aborts mid-plan", async () => {
+    const controller = new AbortController();
+    const forwarded: string[] = [];
+    const tool = createTool({
+      provider: createProvider([SUBMIT_CALL]),
+      signal: () => controller.signal,
+      // Abort as soon as the planner emits its first progress event, the way a
+      // user hitting Stop mid-plan does.
+      forwardMessage: (msg) => {
+        forwarded.push(msg.type);
+        controller.abort();
+      }
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "Build a graph" }
+    )) as { graph?: unknown; error?: string };
+
+    expect(result.error).toBe("Graph planning was cancelled.");
+    expect(result.graph).toBeUndefined();
+    expect(forwarded.length).toBeGreaterThan(0);
+  });
+
+  it("reads the signal per call, so a later turn is not stuck on a stale abort", async () => {
+    const stale = new AbortController();
+    stale.abort();
+    let current = stale;
+    const tool = createTool({
+      provider: createProvider([SUBMIT_CALL]),
+      signal: () => current.signal
+    });
+    const ctx = createMockContext() as ProcessingContext;
+
+    const cancelled = (await tool.process(ctx, {
+      objective: "First"
+    })) as { error?: string };
+    expect(cancelled.error).toBe("Graph planning was cancelled.");
+
+    current = new AbortController();
+    const fresh = (await tool.process(ctx, { objective: "Second" })) as {
+      graph?: { nodes: unknown[] };
+      error?: string;
+    };
+    expect(fresh.error).toBeUndefined();
+    expect(fresh.graph!.nodes).toHaveLength(1);
+  });
+});

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -3737,6 +3737,7 @@ export class UnifiedWebSocketRunner {
           model,
           registry: this.nodeRegistry,
           providers: chatProviders,
+          signal: () => this.chatAbort?.signal,
           forwardMessage: async (msg) => {
             const enriched: Record<string, unknown> = {
               ...(msg as unknown as Record<string, unknown>)
@@ -3744,6 +3745,11 @@ export class UnifiedWebSocketRunner {
             if (enriched.thread_id == null) enriched.thread_id = threadId;
             if (enriched.workflow_id == null) enriched.workflow_id = workflowId;
             await this.sendMessage(enriched);
+            // The planner's discovery/submit tool calls arrive as transient
+            // tool_call_update events. Emit a persistent card so the chat UI
+            // shows what the planner is doing, nested under the parent
+            // plan_workflow_graph card.
+            await this.emitSyntheticToolCallCard(enriched);
           }
         })
       );

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -403,7 +403,6 @@ export const createStyles = (theme: Theme) => ({
 
     ".tool-call-card": {
       width: "100%",
-      border: `1px solid ${theme.vars.palette.divider}`,
       borderRadius: BORDER_RADIUS.md,
       background: theme.vars.palette.action.hover,
       overflow: "hidden",


### PR DESCRIPTION
Three related fixes to the GraphPlanner → chat path.

## 1. Surface planner tool calls in chat + drop the tool-call border
The GraphPlanner already yielded `tool_call_update`, but calls routed through `PlanWorkflowGraphTool` only reached the chat UI as transient "now running" state — the persistent `ToolCallCard` needs an assistant message with `tool_calls`. The forwarder now emits a synthetic card (matching the subtask forwarder), so the user watches the planner search nodes and submit the graph, nested under the parent `plan_workflow_graph` card.

Cards also need to *resolve*. The planner never emitted `tool_result_update` because results are produced inside the provider-driven `execute` closures, off the event stream. They're now parked in a queue and drained into the stream — including a tail drain, since an accepted `submit_graph` aborts the loop from inside its own `execute`, so its result lands after the stream ends.

Also removes the `1px` border from `.tool-call-card` (keeps radius + hover background).

## 2. Make PlanWorkflowGraphTool cancellable
The tool ran `GraphPlanner` without a signal, so a chat Stop couldn't interrupt it — planning ran every remaining LLM call to completion. The current turn's abort signal is threaded through as a thunk (the tool outlives one turn and each turn installs a fresh controller, so a captured signal would go stale after the first Stop), and checked before constructing the planner, in the drain loop (returning the generator so an in-flight tool call doesn't keep it going), and after the loop.

## 3. Save planner graphs in the stored `data` shape
`create_workflow`'s `normalizeWorkflowGraph` wrote each node's property bag under `properties` (kernel shape). The editor reads `node.data`, so a `plan_workflow_graph` → `create_workflow` workflow opened with every node blank and stacked at the origin. It still *ran*, because the runner's `normalizeGraph` only maps `data`→`properties` when `properties` is absent — which masked the bug. Now folds `properties`/`parameters`/existing `data` into a flat `data` bag (destructured out of the spread so a node never carries both keys), and gives nodes without `ui_properties` a 4-across grid layout, matching `workflowGraphToUiGraph`.

Note: this fixes graphs saved from now on. Any workflow already persisted with `properties` stays blank in the editor and would need a one-time migration.

## Testing
- Agents suite green (1487 tests). New coverage: `plan-workflow-graph-tool.test.ts` (4 cancellation cases incl. the stale-signal regression); `mcp-tools.test.ts` updated to the stored shape + already-stored passthrough + never-both-keys invariant.
- Lint + typecheck pass on agents, websocket, and web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)