### PR TITLE
Keep chat prompt anchored at top after a turn settles

### DIFF
--- a/web/src/components/chat/thread/ChatThreadView.test.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.test.tsx
@@ -252,6 +252,92 @@ describe("ChatThreadView", () => {
     rafSpy.mockRestore();
   });
 
+  it("keeps the new turn anchored at the top after the response settles", () => {
+    const rafSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 1;
+      });
+    const { container, rerender } = renderWithTheme(
+      <ChatThreadView {...defaultProps} />
+    );
+    const scrollHost = container.querySelector(
+      ".scrollable-message-wrapper"
+    ) as HTMLDivElement;
+    const realContent = container.querySelector(
+      ".chat-messages-real-content"
+    ) as HTMLDivElement;
+    Object.defineProperty(scrollHost, "clientHeight", {
+      configurable: true,
+      value: 600
+    });
+    scrollHost.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
+    realContent.getBoundingClientRect = () => ({ bottom: 500 }) as DOMRect;
+
+    const nextMessages: Message[] = [
+      ...mockMessages,
+      {
+        type: "message",
+        id: "3",
+        role: "user",
+        content: "A follow-up",
+        created_at: new Date().toISOString()
+      }
+    ];
+    // New user turn arrives while the request is in flight → anchoring mode.
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <ChatThreadView
+          {...defaultProps}
+          messages={nextMessages}
+          status="loading"
+        />
+      </ThemeProvider>
+    );
+    expect(scrollHost).toHaveAttribute(
+      "data-scroll-mode",
+      "anchoring-new-turn"
+    );
+
+    // The prompt has landed near the top of the viewport.
+    scrollHost.scrollTop = 400;
+
+    // Response settles: stay anchored, do NOT snap the view to the bottom.
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <ChatThreadView
+          {...defaultProps}
+          messages={[
+            ...nextMessages,
+            {
+              type: "message",
+              id: "4",
+              role: "assistant",
+              content: "Answer",
+              created_at: new Date().toISOString()
+            }
+          ]}
+          status="connected"
+        />
+      </ThemeProvider>
+    );
+
+    // Regression: previously this switched to "following-end" and bottom-aligned
+    // the content, pulling the prompt off the top. It must stay anchored.
+    expect(scrollHost).toHaveAttribute(
+      "data-scroll-mode",
+      "anchoring-new-turn"
+    );
+    expect(scrollHost.scrollTop).toBe(400);
+    // Tail trimmed to just what holds the anchor: scrollTop(400) +
+    // clientHeight(600) - realContentBottom(scrollTop 400 + rect.bottom 500) = 100.
+    expect(container.querySelector(".chat-anchor-tail")).toHaveStyle({
+      height: "100px"
+    });
+    rafSpy.mockRestore();
+  });
+
   it("lands on the latest message when a thread is first shown", () => {
     const rafSpy = jest
       .spyOn(window, "requestAnimationFrame")

--- a/web/src/components/chat/thread/ChatThreadView.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.tsx
@@ -807,8 +807,14 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
     };
   }, [applyScrollPolicy, scrollHost]);
 
-  // Once the turn settles, remove its reserved tail and return to normal end
-  // following. Free-scrolling mode is never overridden by a status change.
+  // Once the turn settles, keep the just-sent prompt anchored where it landed
+  // instead of snapping the view to the conversation bottom (which for a short
+  // response would pull earlier messages down and push the prompt off the top).
+  // Trim the reserved tail to the minimum that holds the current scroll offset
+  // so no large empty gap lingers below the response. A long response that
+  // already followed to the bottom keeps ~zero tail and stays put. The anchor is
+  // released only when the user scrolls (→ free-scrolling) or sends the next
+  // turn. Free-scrolling mode is never overridden by a status change.
   useEffect(() => {
     if (status === "loading" || status === "streaming") {
       if (scrollModeRef.current === "anchoring-new-turn") {
@@ -818,14 +824,19 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
     }
     if (scrollModeRef.current !== "anchoring-new-turn") return;
     if (!anchorSawBusyRef.current) return;
-    setScrollMode("following-end");
-    positionedAnchorIdRef.current = null;
     anchorSawBusyRef.current = false;
-    setActiveAnchor(null);
-    setAnchorTailHeight(0);
-    const frame = requestAnimationFrame(applyScrollPolicy);
-    return () => cancelAnimationFrame(frame);
-  }, [applyScrollPolicy, setScrollMode, status]);
+    const el = scrollRef.current;
+    const realContentBottom = getRealContentBottom();
+    if (!el || realContentBottom == null) {
+      setAnchorTailHeight(0);
+      return;
+    }
+    const requiredTail = Math.max(
+      0,
+      el.scrollTop + el.clientHeight - realContentBottom
+    );
+    setAnchorTailHeight(requiredTail);
+  }, [getRealContentBottom, status]);
 
   const isThoughtExpanded = useCallback(
     (key: string) => expandedThoughtsRef.current[key] ?? false,


### PR DESCRIPTION
## Problem

When you send a chat message, the view anchors your new prompt near the top of the viewport while the response streams — which is correct. But once the turn completes, the prompt snaps back down and the view returns to the bottom of the conversation.

## Cause

The turn-completion effect in `ChatThreadView` switched the scroll mode from `anchoring-new-turn` to `following-end`, dropped the reserved tail, and called `applyScrollPolicy`, whose `following-end` branch **bottom-aligns** the content. For a response shorter than the viewport, bottom-aligning pulls earlier messages back into view and pushes the just-sent prompt off the top — the "moves back to bottom" symptom.

## Fix

On settle, stay in `anchoring-new-turn` mode and trim the reserved tail to the minimum needed to hold the current scroll offset, instead of snapping to the conversation bottom:

- **Short response**: the prompt stays pinned near the top, with the tail trimmed so there's no large empty gap below the answer.
- **Long response** (already followed to the bottom while streaming): keeps ~zero tail and stays put — no change from before.

The anchor releases only when the user scrolls (→ `free-scrolling`) or sends the next turn, matching the existing behavior for those paths.

## Testing

- Added a test that a settled turn stays in `anchoring-new-turn` mode, keeps its scroll offset (no bottom-snap), and trims the tail to the holding height.
- All 11 tests in `ChatThreadView.test.tsx` pass.
- Lint clean on the changed files (no new warnings); no new type errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkHPprQSJFyixSKMUKkB6z)_