### PR TITLE
Price generic model nodes in the cost estimator

### DIFF
--- a/packages/node-sdk/src/cost-estimate.ts
+++ b/packages/node-sdk/src/cost-estimate.ts
@@ -7,6 +7,11 @@
  * price are still reported (cost 0, confidence "unknown") and counted, never
  * hidden — the plan-before-spend view must surface uncertainty.
  *
+ * Generic nodes (e.g. `nodetool.image.TextToImage`) carry no fixed node-type
+ * price — the model is chosen at runtime through a provider-model property such
+ * as `model`. For those, the estimator reads the selected model id from node
+ * data and prices it through the caller-supplied `getModelPrice` lookup.
+ *
  * No I/O: callers supply a `getMetadata` lookup so this stays hermetic and
  * usable from web, agents, and the CLI alike.
  */
@@ -33,16 +38,58 @@ export interface KieUnitPricingLike extends UnitPricing {
   source?: "live" | "bundle";
 }
 
+/** A single node property as exposed by `NodeMetadata` — only the shape read here. */
+export interface NodePropertyLike {
+  name?: string;
+  type?: { type?: string } | null;
+}
+
 /** Minimal slice of `NodeMetadata` this estimator reads. */
 export interface NodeMetadataLike {
   fal_unit_pricing?: FalUnitPricingLike | null;
   kie_unit_pricing?: KieUnitPricingLike | null;
+  /** Properties, used to find a provider-model selection on generic nodes. */
+  properties?: Array<NodePropertyLike | null> | null;
 }
+
+/** Price for a dynamically-selected model, as returned by `getModelPrice`. */
+export interface ModelUnitPricingLike extends UnitPricing {
+  source?: "live" | "bundle";
+}
+
+/** A model chosen on a node via a provider-model property (e.g. `model`). */
+export interface SelectedModel {
+  id: string;
+  provider: string | null;
+}
+
+/**
+ * Property `type.type` values whose value is a provider-backed model selection
+ * carrying a provider + model id. Kept in sync with the web `PROVIDER_MODEL_TYPES`
+ * list. Local model types (`llama_model`, `hf.*`) are excluded — they aren't
+ * priced through a provider catalog.
+ */
+const PROVIDER_MODEL_TYPES = new Set([
+  "language_model",
+  "image_model",
+  "embedding_model",
+  "tts_model",
+  "asr_model",
+  "video_model"
+]);
 
 export interface CostEstimateInput {
   nodes: Array<{ id: string; type: string; data?: Record<string, unknown> }>;
   /** Look up metadata (which may carry fal_unit_pricing / kie_unit_pricing) for a node type. */
   getMetadata: (nodeType: string) => NodeMetadataLike | undefined;
+  /**
+   * Optional lookup of unit pricing for a model selected on a generic node's
+   * provider-model property. Returns `null`/`undefined` when the model is
+   * unknown. Without it, generic nodes stay "unknown".
+   */
+  getModelPrice?: (
+    model: SelectedModel
+  ) => ModelUnitPricingLike | null | undefined;
   /** Optional per-node expected run count (fan-out). Defaults to 1. */
   quantities?: Record<string, number>;
   currency?: string;
@@ -68,8 +115,51 @@ interface ResolvedPrice {
   confidence: CostConfidence;
 }
 
-/** Resolve a node's unit price from metadata: FAL first, then kie, else none. */
-function resolvePrice(metadata: NodeMetadataLike | undefined): ResolvedPrice | null {
+/**
+ * The model selected on a generic node, read from the value of its first
+ * provider-model property (e.g. `model` on TextToImage). Returns null when the
+ * node exposes no such property or nothing is selected.
+ */
+function selectedModel(
+  metadata: NodeMetadataLike | undefined,
+  data: Record<string, unknown> | undefined
+): SelectedModel | null {
+  if (!data) return null;
+  const properties = metadata?.properties;
+  if (!properties) return null;
+
+  for (const property of properties) {
+    const propType = property?.type?.type;
+    const name = property?.name;
+    if (!name || !propType || !PROVIDER_MODEL_TYPES.has(propType)) {
+      continue;
+    }
+    const value = data[name];
+    if (value && typeof value === "object") {
+      const id = (value as { id?: unknown }).id;
+      if (typeof id === "string" && id.trim() !== "") {
+        const provider = (value as { provider?: unknown }).provider;
+        return {
+          id,
+          provider: typeof provider === "string" ? provider : null
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a node's unit price. Node-type metadata pricing wins (FAL, then kie);
+ * for generic nodes that carry none, fall back to the model chosen on a
+ * provider-model property, priced through `getModelPrice`.
+ */
+function resolvePrice(
+  metadata: NodeMetadataLike | undefined,
+  data: Record<string, unknown> | undefined,
+  getModelPrice: CostEstimateInput["getModelPrice"]
+): ResolvedPrice | null {
   const fal = metadata?.fal_unit_pricing;
   if (fal && Number.isFinite(fal.unit_price)) {
     return {
@@ -98,6 +188,22 @@ function resolvePrice(metadata: NodeMetadataLike | undefined): ResolvedPrice | n
     }
   }
 
+  if (getModelPrice) {
+    const model = selectedModel(metadata, data);
+    if (model) {
+      const price = getModelPrice(model);
+      if (price && Number.isFinite(price.unit_price)) {
+        return {
+          provider: model.provider ?? "model",
+          model: model.id,
+          unitPrice: price.unit_price,
+          billingUnit: price.billing_unit,
+          confidence: confidenceFromSource(price.source)
+        };
+      }
+    }
+  }
+
   return null;
 }
 
@@ -111,7 +217,11 @@ export function estimateWorkflowCost(input: CostEstimateInput): WorkflowCostEsti
 
   for (const node of input.nodes) {
     const quantity = positiveQuantity(quantities[node.id]);
-    const price = resolvePrice(input.getMetadata(node.type));
+    const price = resolvePrice(
+      input.getMetadata(node.type),
+      node.data,
+      input.getModelPrice
+    );
 
     if (!price) {
       items.push({

--- a/packages/node-sdk/tests/cost-estimate.test.ts
+++ b/packages/node-sdk/tests/cost-estimate.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   estimateWorkflowCost,
+  type CostEstimateInput,
   type NodeMetadataLike
 } from "../src/cost-estimate.js";
 
 const FAL_TYPE = "fal.image.FluxSchnell";
 const KIE_TYPE = "kie.video.Veo";
 const LLM_TYPE = "nodetool.agents.Agent";
+const GENERIC_TYPE = "nodetool.image.TextToImage";
 
 const metadataByType: Record<string, NodeMetadataLike> = {
   [FAL_TYPE]: {
@@ -27,11 +29,28 @@ const metadataByType: Record<string, NodeMetadataLike> = {
       usd_price: 2.5,
       source: "live"
     }
+  },
+  // A generic node has no fixed node-type price — it exposes a provider-model
+  // property whose value carries the selected model.
+  [GENERIC_TYPE]: {
+    properties: [{ name: "model", type: { type: "image_model" } }]
   }
 };
 
 const getMetadata = (type: string): NodeMetadataLike | undefined =>
   metadataByType[type];
+
+const modelPrices: Record<string, { unit_price: number; billing_unit: string }> =
+  {
+    "fal-ai/flux/dev": { unit_price: 0.025, billing_unit: "images" }
+  };
+
+const getModelPrice: CostEstimateInput["getModelPrice"] = (model) => {
+  const price = modelPrices[model.id];
+  return price
+    ? { ...price, currency: "USD", source: "bundle" as const }
+    : null;
+};
 
 describe("estimateWorkflowCost", () => {
   it("prices a fal node as unit_price * quantity with fan-out", () => {
@@ -90,6 +109,68 @@ describe("estimateWorkflowCost", () => {
     expect(unknown?.provider).toBeNull();
     expect(unknown?.model).toBeNull();
     expect(unknown?.quantity).toBe(1);
+  });
+
+  it("prices a generic node from its selected model field", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [
+        {
+          id: "g1",
+          type: GENERIC_TYPE,
+          data: {
+            model: {
+              type: "image_model",
+              provider: "fal_ai",
+              id: "fal-ai/flux/dev"
+            }
+          }
+        }
+      ],
+      getMetadata,
+      getModelPrice,
+      quantities: { g1: 2 }
+    });
+
+    const item = estimate.items[0];
+    expect(item.provider).toBe("fal_ai");
+    expect(item.model).toBe("fal-ai/flux/dev");
+    expect(item.unit_price).toBe(0.025);
+    expect(item.quantity).toBe(2);
+    expect(item.confidence).toBe("estimate");
+    expect(item.estimated_cost).toBeCloseTo(0.05, 10);
+    expect(estimate.unknown_count).toBe(0);
+    expect(estimate.total).toBeCloseTo(0.05, 10);
+  });
+
+  it("reports a generic node as unknown when its model has no price", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [
+        {
+          id: "g1",
+          type: GENERIC_TYPE,
+          data: {
+            model: { type: "image_model", id: "fal-ai/unpriced" }
+          }
+        }
+      ],
+      getMetadata,
+      getModelPrice
+    });
+
+    expect(estimate.unknown_count).toBe(1);
+    expect(estimate.total).toBe(0);
+    expect(estimate.items[0].confidence).toBe("unknown");
+  });
+
+  it("reports a generic node as unknown when no model is selected", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [{ id: "g1", type: GENERIC_TYPE, data: {} }],
+      getMetadata,
+      getModelPrice
+    });
+
+    expect(estimate.unknown_count).toBe(1);
+    expect(estimate.items[0].confidence).toBe("unknown");
   });
 
   it("defaults quantity to 1 for non-positive or missing entries", () => {

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -54,10 +54,25 @@ const mockMetadata: Record<string, unknown> = {
   "nodetool.llm.Agent": {
     properties: [{ name: "model", type: { type: "language_model" } }]
   },
+  "nodetool.image.TextToImage": {
+    properties: [{ name: "model", type: { type: "image_model" } }]
+  },
   "nodetool.text.Concat": {
     properties: [{ name: "a", type: { type: "str" } }]
   }
 };
+
+jest.mock("../../utils/modelUnitPricing", () => ({
+  getModelUnitPrice: (model: { id: string }) =>
+    model.id === "fal-ai/flux/schnell"
+      ? {
+          unit_price: 0.003,
+          billing_unit: "images",
+          currency: "USD",
+          source: "bundle"
+        }
+      : null
+}));
 
 jest.mock("../../stores/MetadataStore", () => ({
   __esModule: true,
@@ -93,6 +108,33 @@ describe("useWorkflowCostEstimate", () => {
       (i) => i.node_type === "nodetool.llm.Agent"
     );
     expect(unknown?.confidence).toBe("unknown");
+  });
+
+  it("prices a generic node from its selected model field", () => {
+    mockNodes = [
+      {
+        id: "t2i",
+        type: "nodetool.image.TextToImage",
+        data: {
+          model: {
+            type: "image_model",
+            provider: "huggingface_fal_ai",
+            id: "fal-ai/flux/schnell"
+          },
+          num_images: 2
+        }
+      }
+    ];
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    const item = result.current!.items.find((i) => i.node_id === "t2i");
+    expect(item?.model).toBe("fal-ai/flux/schnell");
+    expect(item?.provider).toBe("huggingface_fal_ai");
+    expect(item?.quantity).toBe(2);
+    expect(item?.estimated_cost).toBeCloseTo(0.006, 5);
+    expect(item?.confidence).toBe("estimate");
+    expect(result.current!.unknown_count).toBe(0);
   });
 
   it("multiplies a node's cost by its fan-out output count", () => {

--- a/web/src/hooks/useWorkflowCostEstimate.ts
+++ b/web/src/hooks/useWorkflowCostEstimate.ts
@@ -4,8 +4,9 @@
  * Reads the open workflow's nodes (from its NodeStore) and the node-type
  * metadata (which carries `fal_unit_pricing` / `kie_unit_pricing`), keeps only
  * the nodes that use an AI model, then runs the pure {@link estimateWorkflowCost}
- * estimator. Re-computes when the graph or metadata changes. Returns `null`
- * when the graph isn't available yet.
+ * estimator. Generic nodes (e.g. TextToImage) are priced from their selected
+ * `model` field via the FAL/kie pricing catalogs. Re-computes when the graph or
+ * metadata changes. Returns `null` when the graph isn't available yet.
  */
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
@@ -19,6 +20,7 @@ import {
   nodeExpectedQuantity,
   nodeMetadataUsesAiModel
 } from "../utils/aiModelNodes";
+import { getModelUnitPrice } from "../utils/modelUnitPricing";
 
 const EMPTY_NODES: Node<NodeData>[] = [];
 
@@ -63,6 +65,7 @@ export function useWorkflowCostEstimate(
         data: node.data as Record<string, unknown> | undefined
       })),
       getMetadata: (nodeType) => getMetadata(nodeType),
+      getModelPrice: getModelUnitPrice,
       quantities,
       currency: "USD"
     });

--- a/web/src/utils/modelUnitPricing.ts
+++ b/web/src/utils/modelUnitPricing.ts
@@ -1,0 +1,64 @@
+/**
+ * Look up a unit price for a model chosen on a generic node's provider-model
+ * property (e.g. `model` on `nodetool.image.TextToImage`). The model id matches
+ * the endpoint/model key in the codegen pricing catalogs: FAL is keyed by
+ * `endpoint_id` (e.g. `fal-ai/flux/schnell`), kie by `model_id`. Returns a
+ * bundle-sourced price, or null when the model isn't in either catalog.
+ */
+
+import type {
+  ModelUnitPricingLike,
+  SelectedModel
+} from "@nodetool-ai/node-sdk/cost-estimate";
+import falUnitPricingCatalog from "@nodetool/fal-unit-pricing-catalog";
+import kieUnitPricingCatalog from "@nodetool/kie-unit-pricing-catalog";
+
+interface CatalogPrice {
+  unit_price?: unknown;
+  billing_unit?: unknown;
+  currency?: unknown;
+  usd_price?: unknown;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function falPrice(modelId: string): ModelUnitPricingLike | null {
+  const prices = falUnitPricingCatalog.prices;
+  const entry = prices?.[modelId] as CatalogPrice | undefined;
+  if (!entry) return null;
+  const unitPrice = readNumber(entry.unit_price);
+  if (unitPrice === undefined) return null;
+  return {
+    unit_price: unitPrice,
+    billing_unit: typeof entry.billing_unit === "string" ? entry.billing_unit : "",
+    currency: typeof entry.currency === "string" ? entry.currency : "USD",
+    source: "bundle"
+  };
+}
+
+function kiePrice(modelId: string): ModelUnitPricingLike | null {
+  const entry = kieUnitPricingCatalog.prices?.[modelId] as
+    | CatalogPrice
+    | undefined;
+  if (!entry) return null;
+  // Only the USD conversion is a real price; a raw credit figure has no fixed
+  // USD value, so skip the model when it's absent.
+  const usd = readNumber(entry.usd_price);
+  if (usd === undefined) return null;
+  return {
+    unit_price: usd,
+    billing_unit: typeof entry.billing_unit === "string" ? entry.billing_unit : "",
+    currency: "USD",
+    source: "bundle"
+  };
+}
+
+export function getModelUnitPrice(
+  model: SelectedModel
+): ModelUnitPricingLike | null {
+  return falPrice(model.id) ?? kiePrice(model.id);
+}
+
+export default getModelUnitPrice;


### PR DESCRIPTION
## Problem

Generic nodes like `nodetool.image.TextToImage` carry no fixed node-type price — the model is chosen at runtime through a provider-model property (`image_model`, `language_model`, `video_model`, …). The cost estimator only knew about `fal_unit_pricing` / `kie_unit_pricing` attached per **node type**, so these generic nodes always showed up as **"unknown"** in the plan-before-spend view even when the selected model has a known price.

## Change

- **`packages/node-sdk/src/cost-estimate.ts`** — the pure estimator now accepts an optional `getModelPrice` lookup. When a node has no node-type price (FAL/kie), it reads the model selected on the node's first provider-model property (`{ id, provider }` from node data) and prices it through `getModelPrice`. Node-type pricing still takes precedence; unpriced/unselected models stay "unknown" as before.
- **`web/src/utils/modelUnitPricing.ts`** (new) — resolves a selected model id against the codegen FAL (`endpoint_id`) and kie (`model_id`) pricing catalogs, returning a bundle-sourced unit price.
- **`web/src/hooks/useWorkflowCostEstimate.ts`** — wires `getModelPrice` into the estimator so the cost panel prices generic nodes from their selected `model` field.

## Tests

- `packages/node-sdk/tests/cost-estimate.test.ts` — prices a generic node from its selected model (with fan-out), and keeps it "unknown" when the model has no price or none is selected.
- `web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx` — end-to-end: a TextToImage node with a selected FAL model is priced via the catalog lookup.

Typecheck, lint, and the affected test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzZ2fQ2ymgQk2HxxANM4fP)_