### PR TITLE
fix(gemini): strip propertyNames from tool schemas

### DIFF
--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -144,6 +144,7 @@ const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "$ref",
   "definitions",
   "patternProperties",
+  "propertyNames",
   "unevaluatedProperties",
   "dependentSchemas",
   "dependentRequired",

--- a/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
@@ -324,6 +324,11 @@ describe("GeminiProvider – formatTools deduplication", () => {
               minimum: 0,
               exclusiveMinimum: 0,
               exclusiveMaximum: 100
+            },
+            labels: {
+              type: "object",
+              propertyNames: { pattern: "^[a-z]+$" },
+              additionalProperties: { type: "string" }
             }
           }
         }
@@ -334,6 +339,8 @@ describe("GeminiProvider – formatTools deduplication", () => {
     expect(params.additionalProperties).toBeUndefined();
     expect(params.properties.count.exclusiveMinimum).toBeUndefined();
     expect(params.properties.count.exclusiveMaximum).toBeUndefined();
+    expect(params.properties.labels.propertyNames).toBeUndefined();
+    expect(params.properties.labels.additionalProperties).toBeUndefined();
     // Supported constraints survive.
     expect(params.properties.count.minimum).toBe(0);
     expect(params.properties.count.type).toBe("integer");


### PR DESCRIPTION
## Problem

Calling the Gemini API with tools whose parameter schema contains `propertyNames` (used by dict/map-style JSON Schemas) fails with a 400 that aborts the whole tool batch:

```
Gemini API error 400: Invalid JSON payload received. Unknown name "propertyNames"
at 'tools[0].function_declarations[14].parameters.properties[1].value': Cannot find field.
```

Gemini's function-declaration schema is a strict subset of OpenAPI 3.0 and rejects JSON-Schema-only keywords. `sanitizeGeminiSchema` already strips `additionalProperties`, `patternProperties`, `$ref`, etc., but `propertyNames` was missing from the list.

## Fix

Add `propertyNames` to `GEMINI_UNSUPPORTED_SCHEMA_KEYS` in `packages/runtime/src/providers/gemini-provider.ts` so it's recursively stripped before the request is sent.

## Testing

Extended the existing "strips JSON-Schema-only keys Gemini rejects" coverage test with a dict/map property carrying `propertyNames` + `additionalProperties`, asserting both are removed. All 64 gemini provider tests pass; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179GKae8h73ByfcPMqQPRgR

---
_Generated by [Claude Code](https://claude.ai/code/session_0179GKae8h73ByfcPMqQPRgR)_