### PR TITLE
Publish nodetool-bin to the AUR on release

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,72 @@
+name: Publish AUR package
+
+# Publishes the `nodetool-bin` package to the Arch User Repository (AUR) from
+# the Linux AppImage attached to each stable GitHub Release. Runs automatically
+# when a release is published, and can be dispatched manually to (re)publish a
+# specific version.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (without leading v), e.g. 0.7.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-aur:
+    name: Publish nodetool-bin to AUR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve version
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${{ github.event.release.tag_name }}"
+          fi
+          version="${version#v}"
+          # Only publish plain stable releases (X.Y.Z). Skip nightlies and
+          # pre-releases (e.g. rc, beta) — the AUR package tracks stable.
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version '${version}' is not a stable X.Y.Z release; skipping AUR publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Publishing nodetool-bin ${version} to AUR."
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Render PKGBUILD
+        if: steps.meta.outputs.publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p aur-pkg
+          sed "s|@PKGVER@|${VERSION}|g" packaging/aur/PKGBUILD > aur-pkg/PKGBUILD
+          echo "----- rendered PKGBUILD -----"
+          cat aur-pkg/PKGBUILD
+
+      - name: Publish to AUR
+        if: steps.meta.outputs.publish == 'true'
+        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
+        with:
+          pkgname: nodetool-bin
+          pkgbuild: aur-pkg/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ steps.meta.outputs.version }}"
+          updpkgsums: true
+          ssh_keyscan_types: rsa,ecdsa,ed25519

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Nodetool <hello@nodetool.ai>
+# This PKGBUILD is generated from packaging/aur/PKGBUILD by the
+# "Publish AUR package" GitHub workflow, which substitutes @PKGVER@ with the
+# release version and runs updpkgsums to fill in the checksum. Keep the
+# @PKGVER@ placeholder intact so the workflow can render it.
+pkgname=nodetool-bin
+pkgver=@PKGVER@
+pkgrel=1
+pkgdesc="Visual Builder for AI Workflows and Agents"
+arch=('x86_64')
+url="https://nodetool.ai"
+license=('AGPL-3.0-only')
+depends=('gtk3' 'nss' 'alsa-lib' 'hicolor-icon-theme')
+optdepends=('libnotify: desktop notifications')
+provides=('nodetool')
+conflicts=('nodetool')
+options=('!strip')
+_releasetag="v${pkgver}"
+source=("nodetool-${pkgver}.AppImage::https://github.com/nodetool-ai/nodetool/releases/download/${_releasetag}/Nodetool-${pkgver}-x86_64.AppImage")
+sha256sums=('SKIP')
+
+prepare() {
+  chmod +x "nodetool-${pkgver}.AppImage"
+  "./nodetool-${pkgver}.AppImage" --appimage-extract >/dev/null
+}
+
+package() {
+  # Install the extracted AppImage tree under /opt.
+  install -dm755 "${pkgdir}/opt/${pkgname}"
+  cp -a squashfs-root/. "${pkgdir}/opt/${pkgname}/"
+
+  # The Electron sandbox helper must be setuid root.
+  if [[ -f "${pkgdir}/opt/${pkgname}/chrome-sandbox" ]]; then
+    chmod 4755 "${pkgdir}/opt/${pkgname}/chrome-sandbox"
+  fi
+
+  # Launcher: AppRun sets APPDIR and execs the bundled Electron binary.
+  install -dm755 "${pkgdir}/usr/bin"
+  ln -s "/opt/${pkgname}/AppRun" "${pkgdir}/usr/bin/nodetool"
+
+  # Desktop entry: reuse the bundled .desktop, pointing Exec at the launcher.
+  # Leave Icon untouched so it matches the icon names shipped in the AppImage.
+  local desktop
+  desktop="$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -n1)"
+  if [[ -n "${desktop}" ]]; then
+    install -dm755 "${pkgdir}/usr/share/applications"
+    sed 's|^Exec=.*|Exec=nodetool %U|' "${desktop}" \
+      > "${pkgdir}/usr/share/applications/${pkgname}.desktop"
+  fi
+
+  # Hicolor icons for desktop integration.
+  if [[ -d squashfs-root/usr/share/icons ]]; then
+    install -dm755 "${pkgdir}/usr/share/icons"
+    cp -a squashfs-root/usr/share/icons/. "${pkgdir}/usr/share/icons/"
+  fi
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,45 @@
+# AUR packaging
+
+`nodetool-bin` is the Arch User Repository package for the NodeTool desktop app.
+It installs the Linux AppImage attached to each stable GitHub Release, so users
+on Arch-based distros can `paru -S nodetool-bin` / `yay -S nodetool-bin` instead
+of downloading the AppImage by hand.
+
+## How it works
+
+- [`PKGBUILD`](PKGBUILD) is the maintained package definition. It downloads
+  `Nodetool-<version>-x86_64.AppImage` from the release, extracts it into
+  `/opt/nodetool-bin`, symlinks the `nodetool` launcher into `/usr/bin`, and
+  installs the desktop entry and icons. The `@PKGVER@` placeholder is filled in
+  at publish time.
+- [`../../.github/workflows/aur-publish.yml`](../../.github/workflows/aur-publish.yml)
+  runs when a GitHub Release is published (or via manual dispatch). For stable
+  `X.Y.Z` versions it renders the `PKGBUILD`, computes the AppImage checksum
+  with `updpkgsums`, regenerates `.SRCINFO`, and pushes to
+  `ssh://aur@aur.archlinux.org/nodetool-bin.git` using
+  [`KSXGitHub/github-actions-deploy-aur`](https://github.com/marketplace/actions/publish-aur-package).
+  Pre-releases (rc/beta) and nightlies are skipped.
+
+## Required repository secrets
+
+The workflow needs three secrets, set under **Settings → Secrets and variables →
+Actions**:
+
+| Secret | Value |
+| --- | --- |
+| `AUR_SSH_PRIVATE_KEY` | Private SSH key whose public half is registered on the AUR account that maintains `nodetool-bin`. |
+| `AUR_USERNAME` | Git commit author name (e.g. the AUR maintainer name). |
+| `AUR_EMAIL` | Git commit author email. |
+
+The AUR account must own (or be a co-maintainer of) `nodetool-bin`. If the
+package does not exist yet, the first push from an account whose SSH key is
+registered creates it.
+
+## Testing the PKGBUILD locally
+
+On an Arch system:
+
+```bash
+sed 's/@PKGVER@/0.7.0/g' PKGBUILD > /tmp/PKGBUILD
+cd /tmp && updpkgsums && makepkg -si
+```


### PR DESCRIPTION
## What

Adds an AUR (Arch User Repository) packaging pipeline so Arch users can install NodeTool with `paru -S nodetool-bin` / `yay -S nodetool-bin`. The package ships the existing Linux AppImage that's already attached to each release — no new build artifacts.

## Changes

- **`packaging/aur/PKGBUILD`** — `nodetool-bin` binary package. Downloads `Nodetool-<version>-x86_64.AppImage` from the GitHub Release, extracts it into `/opt/nodetool-bin`, symlinks the `nodetool` launcher into `/usr/bin`, and installs the bundled `.desktop` entry and hicolor icons. Sets the Electron `chrome-sandbox` helper setuid root. The `@PKGVER@` placeholder is filled in at publish time.
- **`.github/workflows/aur-publish.yml`** — runs on `release: published` (and manual `workflow_dispatch` with a version input). For stable `X.Y.Z` versions it renders the PKGBUILD, then uses [`KSXGitHub/github-actions-deploy-aur@v4.2.0`](https://github.com/marketplace/actions/publish-aur-package) to compute checksums (`updpkgsums`), regenerate `.SRCINFO`, and push to `ssh://aur@aur.archlinux.org/nodetool-bin.git`. Pre-releases (rc/beta) and nightlies are skipped.
- **`packaging/aur/README.md`** — how it works and the required repository secrets.

## Required setup (repo secrets)

The workflow needs three Actions secrets before it can publish:

| Secret | Value |
| --- | --- |
| `AUR_SSH_PRIVATE_KEY` | Private SSH key whose public half is registered on the AUR maintainer account. |
| `AUR_USERNAME` | Git commit author name. |
| `AUR_EMAIL` | Git commit author email. |

The AUR account must own or co-maintain `nodetool-bin`; the first push from a registered key creates the package if it doesn't exist yet.

## Notes

- The source URL and asset name were verified against the current release (`Nodetool-0.7.0-rc.32-x86_64.AppImage`), so a stable `0.7.0` resolves to `Nodetool-0.7.0-x86_64.AppImage`.
- Extracting the AppImage (rather than running it via FUSE) means no `fuse2` runtime dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaVYS4GhDZ82oRfrKc4bwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaVYS4GhDZ82oRfrKc4bwA)_