### PR TITLE
refactor(cli): generic eval suite registry for `nodetool eval`

### DIFF
--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -1,13 +1,21 @@
 /**
- * `nodetool eval graph-planner` — run the GraphPlanner evaluation suite
- * against any registered provider and print/save a metrics report.
+ * `nodetool eval <suite>` — run a registered evaluation suite against any
+ * provider and print/save a metrics report.
  *
- * The suite lives in `@nodetool-ai/agents` (`GRAPH_PLANNER_EVAL_CASES`); this
- * command wires up a provider from the runtime registry, the full TS node
- * registry, and (when available) configured model providers for `find_model`.
- * Heavy deps are imported lazily so command registration stays light.
+ * Suites are data, not code: each entry in `EVAL_SUITES` describes one suite
+ * (its subcommand name, how to list its cases, and how to run it). The shared
+ * runner wires up a provider from the runtime registry, the full TS node
+ * registry, and (when available) configured model providers for `find_model`,
+ * then hands them to the suite. Adding a suite means pushing an `EvalSuite`
+ * entry — not another hand-wired command block.
+ *
+ * The GraphPlanner suite lives in `@nodetool-ai/agents`
+ * (`GRAPH_PLANNER_EVAL_CASES`). Heavy deps are imported lazily so command
+ * registration stays light.
  */
 import type { Command } from "commander";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 
 interface EvalCliOptions {
   provider?: string;
@@ -22,133 +30,227 @@ interface EvalCliOptions {
   findModel?: boolean;
 }
 
+/** Metadata for one eval case, shown by `--list`. */
+interface EvalCaseMeta {
+  id: string;
+  description: string;
+  /** Case needs configured model providers (`find_model`) to be solvable. */
+  needsModelProviders?: boolean;
+}
+
+/** Runtime deps handed to a suite's `run`, built once by the shared runner. */
+interface EvalRunDeps {
+  /** Provider constructed from `--provider`. */
+  provider: BaseProvider;
+  /** The raw `--provider` id (for display). */
+  providerId: string;
+  model: string;
+  registry: NodeRegistry;
+  /** Configured providers for `find_model`; undefined when `--no-find-model`. */
+  providers?: Record<string, BaseProvider>;
+  /** Case ids to run; undefined runs the whole suite. */
+  caseIds?: string[];
+  maxRetries?: number;
+  /** Progress callback (one line per event, for CLI display). */
+  onEvent: (line: string) => void;
+}
+
+/** Outcome of a suite run, consumed by the shared runner. */
+interface EvalRunResult {
+  /** Opaque report object; written verbatim when `--out`/`--json` are set. */
+  report: unknown;
+  /** Human-readable report for the default (non-JSON) output. */
+  formatted: string;
+  /** Overall success rate (0..1) for the `--min-success` gate. */
+  successRate: number;
+}
+
+/**
+ * A registered evaluation suite. Adding a suite is data — push an entry to
+ * `EVAL_SUITES` — not another hand-wired command block.
+ */
+interface EvalSuite {
+  /** Subcommand name, e.g. `graph-planner` (`nodetool eval graph-planner`). */
+  id: string;
+  description: string;
+  /** Case metadata for `--list`. */
+  listCases(): Promise<EvalCaseMeta[]>;
+  /** Run the suite against the built deps. */
+  run(deps: EvalRunDeps): Promise<EvalRunResult>;
+}
+
+/** GraphPlanner one-shot DSL suite (`@nodetool-ai/agents`). */
+const graphPlannerSuite: EvalSuite = {
+  id: "graph-planner",
+  description:
+    "Run the GraphPlanner (one-shot DSL) eval suite against a provider/model and report metrics",
+  async listCases() {
+    const { GRAPH_PLANNER_EVAL_CASES } = await import("@nodetool-ai/agents");
+    return GRAPH_PLANNER_EVAL_CASES.map((c) => ({
+      id: c.id,
+      description: c.description,
+      needsModelProviders: c.needsModelProviders
+    }));
+  },
+  async run(deps) {
+    const { GRAPH_PLANNER_EVAL_CASES, runGraphPlannerEval, formatEvalReport } =
+      await import("@nodetool-ai/agents");
+
+    let cases = GRAPH_PLANNER_EVAL_CASES;
+    if (deps.caseIds) {
+      const wanted = new Set(deps.caseIds);
+      cases = GRAPH_PLANNER_EVAL_CASES.filter((c) => wanted.has(c.id));
+      const missing = [...wanted].filter(
+        (id) => !cases.some((c) => c.id === id)
+      );
+      if (missing.length > 0) {
+        throw new Error(`Unknown case ids: ${missing.join(", ")} (see --list)`);
+      }
+    }
+
+    console.log(
+      `Running ${cases.length} case(s) with ${deps.providerId}/${deps.model}` +
+        (deps.providers && Object.keys(deps.providers).length > 0
+          ? ` (find_model: ${Object.keys(deps.providers).join(", ")})`
+          : " (no model providers — model-dependent cases skipped)")
+    );
+
+    const report = await runGraphPlannerEval({
+      provider: deps.provider,
+      model: deps.model,
+      registry: deps.registry,
+      providers: deps.providers,
+      cases,
+      maxRetries: deps.maxRetries,
+      onEvent: deps.onEvent
+    });
+
+    return {
+      report,
+      formatted: formatEvalReport(report),
+      successRate: report.summary.successRate
+    };
+  }
+};
+
+/** All evaluation suites exposed under `nodetool eval <suite>`. */
+export const EVAL_SUITES: readonly EvalSuite[] = [graphPlannerSuite];
+
+/**
+ * Shared runner for every suite: handles `--list`, builds the provider/
+ * registry/find-model deps, runs the suite, and applies the common
+ * `--out`/`--json`/`--min-success` handling.
+ */
+async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
+  if (opts.list) {
+    for (const c of await suite.listCases()) {
+      console.log(
+        `${c.id.padEnd(24)} ${c.description}` +
+          (c.needsModelProviders ? " (needs model providers)" : "")
+      );
+    }
+    return;
+  }
+
+  if (!opts.provider || !opts.model) {
+    console.error("--provider and --model are required (or use --list)");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const [{ createProviderStrict, buildConfiguredProviders }, registryMod] =
+      await Promise.all([
+        import("../providers.js"),
+        import("../node-registry.js")
+      ]);
+
+    const provider = await createProviderStrict(opts.provider);
+    const registry = registryMod.buildFullRegistry();
+    const providers =
+      opts.findModel === false ? undefined : await buildConfiguredProviders();
+
+    const caseIds = opts.cases
+      ? opts.cases
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
+
+    const result = await suite.run({
+      provider,
+      providerId: opts.provider,
+      model: opts.model,
+      registry,
+      providers,
+      caseIds,
+      maxRetries: opts.maxRetries ? Number(opts.maxRetries) : undefined,
+      onEvent: (line) => {
+        if (!opts.json) console.log(line);
+      }
+    });
+
+    if (opts.out) {
+      const { writeFile } = await import("node:fs/promises");
+      await writeFile(
+        opts.out,
+        JSON.stringify(result.report, null, 2),
+        "utf-8"
+      );
+      console.log(`Report written to ${opts.out}`);
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(result.report, null, 2));
+    } else {
+      console.log("\n" + result.formatted);
+    }
+
+    if (opts.minSuccess !== undefined) {
+      const threshold = Number(opts.minSuccess);
+      if (result.successRate < threshold) {
+        console.error(
+          `Success rate ${result.successRate.toFixed(2)} below threshold ${threshold}`
+        );
+        process.exitCode = 1;
+      }
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  }
+}
+
 export function registerEvalCommand(program: Command): void {
   const evalCmd = program
     .command("eval")
     .description("Evaluation suites for the agent system");
 
-  evalCmd
-    .command("graph-planner")
-    .description(
-      "Run the GraphPlanner (one-shot DSL) eval suite against a provider/model and report metrics"
-    )
-    .option(
-      "-p, --provider <id>",
-      "Provider id (anthropic, openai, claude_agent_sdk, ollama, ...)"
-    )
-    .option("-m, --model <id>", "Model id for the provider")
-    .option(
-      "--cases <ids>",
-      "Comma-separated case ids to run (default: all; see --list)"
-    )
-    .option("--list", "List available cases and exit")
-    .option("--json", "Print the full report as JSON")
-    .option("--out <path>", "Write the JSON report to a file")
-    .option("--max-retries <n>", "Planner attempts per case (default 3)")
-    .option(
-      "--min-success <rate>",
-      "Exit non-zero when the success rate is below this threshold (0..1)"
-    )
-    .option(
-      "--no-find-model",
-      "Run without configured model providers (skips model-dependent cases)"
-    )
-    .action(async (opts: EvalCliOptions) => {
-      const {
-        GRAPH_PLANNER_EVAL_CASES,
-        runGraphPlannerEval,
-        formatEvalReport
-      } = await import("@nodetool-ai/agents");
-
-      if (opts.list) {
-        for (const c of GRAPH_PLANNER_EVAL_CASES) {
-          console.log(
-            `${c.id.padEnd(24)} ${c.description}` +
-              (c.needsModelProviders ? " (needs model providers)" : "")
-          );
-        }
-        return;
-      }
-
-      if (!opts.provider || !opts.model) {
-        console.error("--provider and --model are required (or use --list)");
-        process.exitCode = 1;
-        return;
-      }
-
-      let cases = GRAPH_PLANNER_EVAL_CASES;
-      if (opts.cases) {
-        const wanted = new Set(opts.cases.split(",").map((s) => s.trim()));
-        cases = GRAPH_PLANNER_EVAL_CASES.filter((c) => wanted.has(c.id));
-        const missing = [...wanted].filter(
-          (id) => !cases.some((c) => c.id === id)
-        );
-        if (missing.length > 0) {
-          console.error(
-            `Unknown case ids: ${missing.join(", ")} (see --list)`
-          );
-          process.exitCode = 1;
-          return;
-        }
-      }
-
-      try {
-        const [{ createProviderStrict, buildConfiguredProviders }, registryMod] =
-          await Promise.all([
-            import("../providers.js"),
-            import("../node-registry.js")
-          ]);
-
-        const provider = await createProviderStrict(opts.provider);
-        const registry = registryMod.buildFullRegistry();
-        const providers =
-          opts.findModel === false
-            ? undefined
-            : await buildConfiguredProviders();
-
-        console.log(
-          `Running ${cases.length} case(s) with ${opts.provider}/${opts.model}` +
-            (providers && Object.keys(providers).length > 0
-              ? ` (find_model: ${Object.keys(providers).join(", ")})`
-              : " (no model providers — model-dependent cases skipped)")
-        );
-
-        const report = await runGraphPlannerEval({
-          provider,
-          model: opts.model,
-          registry,
-          providers,
-          cases,
-          maxRetries: opts.maxRetries ? Number(opts.maxRetries) : undefined,
-          onEvent: (line) => {
-            if (!opts.json) console.log(line);
-          }
-        });
-
-        if (opts.out) {
-          const { writeFile } = await import("node:fs/promises");
-          await writeFile(opts.out, JSON.stringify(report, null, 2), "utf-8");
-          console.log(`Report written to ${opts.out}`);
-        }
-
-        if (opts.json) {
-          console.log(JSON.stringify(report, null, 2));
-        } else {
-          console.log("\n" + formatEvalReport(report));
-        }
-
-        if (opts.minSuccess !== undefined) {
-          const threshold = Number(opts.minSuccess);
-          if (report.summary.successRate < threshold) {
-            console.error(
-              `Success rate ${report.summary.successRate.toFixed(2)} below threshold ${threshold}`
-            );
-            process.exitCode = 1;
-          }
-        }
-      } catch (err) {
-        console.error(err instanceof Error ? err.message : String(err));
-        process.exitCode = 1;
-      }
-    });
+  for (const suite of EVAL_SUITES) {
+    evalCmd
+      .command(suite.id)
+      .description(suite.description)
+      .option(
+        "-p, --provider <id>",
+        "Provider id (anthropic, openai, claude_agent_sdk, ollama, ...)"
+      )
+      .option("-m, --model <id>", "Model id for the provider")
+      .option(
+        "--cases <ids>",
+        "Comma-separated case ids to run (default: all; see --list)"
+      )
+      .option("--list", "List available cases and exit")
+      .option("--json", "Print the full report as JSON")
+      .option("--out <path>", "Write the JSON report to a file")
+      .option("--max-retries <n>", "Planner attempts per case (default 3)")
+      .option(
+        "--min-success <rate>",
+        "Exit non-zero when the success rate is below this threshold (0..1)"
+      )
+      .option(
+        "--no-find-model",
+        "Run without configured model providers (skips model-dependent cases)"
+      )
+      .action((opts: EvalCliOptions) => runSuite(suite, opts));
+  }
 }

--- a/packages/cli/tests/eval-command.test.ts
+++ b/packages/cli/tests/eval-command.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the `nodetool eval` command registration (src/commands/eval.ts).
+ *
+ * The command is now data-driven: one subcommand is generated per entry in
+ * `EVAL_SUITES`. These tests verify the registry drives registration and that
+ * each suite exposes the full option surface. Heavy deps are imported lazily
+ * inside the action, so registration is testable without them.
+ */
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { registerEvalCommand, EVAL_SUITES } from "../src/commands/eval.js";
+
+function evalCommand() {
+  const program = new Command();
+  registerEvalCommand(program);
+  const cmd = program.commands.find((c) => c.name() === "eval");
+  if (!cmd) throw new Error("eval command not registered");
+  return cmd;
+}
+
+describe("registerEvalCommand", () => {
+  it("registers the eval command", () => {
+    expect(evalCommand().description()).toMatch(/evaluation suites/i);
+  });
+
+  it("generates one subcommand per registered suite", () => {
+    const subNames = evalCommand()
+      .commands.map((c) => c.name())
+      .sort();
+    const suiteIds = EVAL_SUITES.map((s) => s.id).sort();
+    expect(subNames).toEqual(suiteIds);
+  });
+
+  it("exposes graph-planner as a registered suite", () => {
+    expect(EVAL_SUITES.some((s) => s.id === "graph-planner")).toBe(true);
+  });
+
+  it("gives every suite the full option surface", () => {
+    for (const sub of evalCommand().commands) {
+      const flags = sub.options.map((o) => o.long).filter(Boolean);
+      expect(flags).toEqual(
+        expect.arrayContaining([
+          "--provider",
+          "--model",
+          "--cases",
+          "--list",
+          "--json",
+          "--out",
+          "--max-retries",
+          "--min-success",
+          "--no-find-model"
+        ])
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Refactors `packages/cli/src/commands/eval.ts` from a single hand-wired `eval graph-planner` command into a **data-driven `EVAL_SUITES` registry**. Adding a new evaluation suite is now data (one `EvalSuite` entry) rather than another duplicated command block.

## What changed
- Introduced an `EvalSuite` interface (`id`, `description`, `listCases()`, `run(deps)`) and an exported `EVAL_SUITES` array; the GraphPlanner suite is the first entry.
- A shared `runSuite` runner builds the provider, full TS node registry, and (optionally) configured `find_model` providers once, then hands typed `EvalRunDeps` to the suite. It also owns the common `--list` / `--out` / `--json` / `--min-success` handling.
- `registerEvalCommand` now generates one subcommand per registered suite in a loop — every suite gets the identical option surface (`--provider`, `--model`, `--cases`, `--list`, `--json`, `--out`, `--max-retries`, `--min-success`, `--no-find-model`).
- Heavy deps stay lazily imported inside the action, so command registration remains light.

Behavior for `nodetool eval graph-planner` is unchanged — same flags, output, and exit codes.

## Tests
- New `packages/cli/tests/eval-command.test.ts` verifies the registry drives registration (one subcommand per `EVAL_SUITES` entry, graph-planner present) and that each generated subcommand exposes the full option surface.

## Verification
- `tsc --noEmit` (package `lint`/typecheck) passes via turbo (deps built).
- `oxlint packages/cli/src` clean (no findings in the changed files).
- New test suite passes (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)