### PR TITLE
feat(agents): headless tool-loop eval runner for frontend tool surfaces

### DIFF
--- a/packages/agents/src/evals/tool-loop-bridge.ts
+++ b/packages/agents/src/evals/tool-loop-bridge.ts
@@ -1,0 +1,418 @@
+/**
+ * Headless bridge for the frontend tool-loop eval.
+ *
+ * The real frontend tools (`web/src/lib/tools/builtin/*`) mutate live zustand
+ * stores and, for the editor surfaces, the DOM. None of that can run under
+ * Node. This bridge reimplements the *effects* of the graph-editor + discovery
+ * tools against a plain in-memory graph, so a model can drive the exact same
+ * tool surface headlessly.
+ *
+ * What it does NOT fork is the tool *contract*: names, descriptions, and Zod
+ * parameter schemas are imported verbatim from `@nodetool-ai/protocol`'s
+ * {@link uiToolSchemas} — the single source of truth the browser builtins also
+ * consume (each `builtin/*.ts` wraps the same `uiXParams` shapes). Validation
+ * goes through the same `parseWithTypeCoercion` path as
+ * `FrontendToolRegistry.call`, so args are coerced identically.
+ */
+
+import { z } from "zod";
+import { parseWithTypeCoercion } from "@nodetool-ai/runtime";
+import { uiToolSchemas, type NodeMetadata } from "@nodetool-ai/protocol";
+
+export interface HeadlessNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { properties: Record<string, unknown>; title?: string };
+}
+
+export interface HeadlessEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}
+
+/** The mutable graph the tools read and write. */
+export interface ToolLoopState {
+  nodeMetadata: Record<string, NodeMetadata>;
+  nodes: HeadlessNode[];
+  edges: HeadlessEdge[];
+  currentWorkflowId: string;
+}
+
+/** Case-supplied starting point for a run. */
+export interface ToolLoopInitialState {
+  /** Node types the model may discover/add, keyed by `node_type`. */
+  nodeMetadata: Record<string, NodeMetadata>;
+  /** Pre-existing nodes (defaults to empty). */
+  nodes?: HeadlessNode[];
+  /** Pre-existing edges (defaults to empty). */
+  edges?: HeadlessEdge[];
+  currentWorkflowId?: string;
+}
+
+/** Snapshot of the graph handed to final-state predicates. */
+export interface ToolLoopFinalState {
+  nodes: HeadlessNode[];
+  edges: HeadlessEdge[];
+}
+
+/** One executable tool: the real contract + a headless executor. */
+export interface HeadlessTool {
+  name: string;
+  description: string;
+  /** `z.object(...)` built from the shared `uiToolSchemas` parameter shape. */
+  parameters: z.ZodTypeAny;
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface HeadlessBridge {
+  state: ToolLoopState;
+  tools: HeadlessTool[];
+  finalState: () => ToolLoopFinalState;
+}
+
+/**
+ * Graph-editor + discovery tools that have a faithful headless implementation.
+ * Editor-surface tools (timeline/sketch/storyboard/…) and backend-backed ones
+ * (`ui_search_models`) are intentionally excluded — they need a browser or a
+ * live service.
+ */
+export const DEFAULT_TOOL_NAMES = [
+  "ui_search_nodes",
+  "ui_add_node",
+  "ui_connect_nodes",
+  "ui_update_node_data",
+  "ui_set_node_title",
+  "ui_move_node",
+  "ui_delete_node",
+  "ui_delete_edge",
+  "ui_get_graph"
+] as const;
+
+export type DefaultToolName = (typeof DEFAULT_TOOL_NAMES)[number];
+
+export interface CreateBridgeOptions {
+  /** Restrict the exposed tools (defaults to {@link DEFAULT_TOOL_NAMES}). */
+  toolNames?: readonly string[];
+}
+
+function cloneNode(n: HeadlessNode): HeadlessNode {
+  return {
+    id: n.id,
+    type: n.type,
+    position: { ...n.position },
+    data: {
+      properties: { ...(n.data?.properties ?? {}) },
+      ...(n.data?.title !== undefined ? { title: n.data.title } : {})
+    }
+  };
+}
+
+/** True if adding source→target to `edges` would introduce a cycle. */
+function wouldCreateCycle(
+  edges: HeadlessEdge[],
+  source: string,
+  target: string
+): boolean {
+  // Walk forward from `target`; if we can reach `source`, the new edge closes
+  // a loop.
+  const adjacency = new Map<string, string[]>();
+  for (const e of edges) {
+    const list = adjacency.get(e.source) ?? [];
+    list.push(e.target);
+    adjacency.set(e.source, list);
+  }
+  const seen = new Set<string>();
+  const stack = [target];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node === source) return true;
+    if (seen.has(node)) continue;
+    seen.add(node);
+    for (const next of adjacency.get(node) ?? []) stack.push(next);
+  }
+  return false;
+}
+
+/**
+ * Build an in-memory bridge whose tools share the frontend contract but run
+ * headlessly. Each `execute` validates args with the shared Zod schema first,
+ * exactly like `FrontendToolRegistry.call`.
+ */
+export function createToolLoopBridge(
+  initial: ToolLoopInitialState,
+  opts: CreateBridgeOptions = {}
+): HeadlessBridge {
+  const state: ToolLoopState = {
+    nodeMetadata: initial.nodeMetadata,
+    nodes: (initial.nodes ?? []).map(cloneNode),
+    edges: (initial.edges ?? []).map((e) => ({ ...e })),
+    currentWorkflowId: initial.currentWorkflowId ?? "wf_eval"
+  };
+
+  let edgeSeq = state.edges.length;
+  const generateEdgeId = () => `edge_${++edgeSeq}`;
+  const findNode = (id: string) => state.nodes.find((n) => n.id === id);
+  const meta = (type: string): NodeMetadata | undefined =>
+    state.nodeMetadata[type];
+
+  // Headless implementations keyed by tool name. Behaviour mirrors the browser
+  // builtins closely enough to make the same objectives solvable, and to
+  // surface the same failure modes (unknown type, missing handle, cycle).
+  const impls: Record<
+    string,
+    (args: Record<string, unknown>) => Promise<unknown>
+  > = {
+    async ui_search_nodes(args) {
+      const query = String(args.query ?? "").toLowerCase();
+      const limit = typeof args.limit === "number" ? args.limit : 10;
+      const results = Object.values(state.nodeMetadata)
+        .filter((m) => {
+          if (!query) return true;
+          return (
+            m.node_type.toLowerCase().includes(query) ||
+            (m.title ?? "").toLowerCase().includes(query) ||
+            (m.description ?? "").toLowerCase().includes(query)
+          );
+        })
+        .slice(0, limit)
+        .map((m) => ({
+          node_type: m.node_type,
+          title: m.title,
+          description: m.description,
+          properties: (m.properties ?? []).map((p) => ({
+            name: p.name,
+            type: p.type?.type,
+            required: p.required
+          })),
+          outputs: (m.outputs ?? []).map((o) => ({
+            name: o.name,
+            type: o.type?.type
+          }))
+        }));
+      return { ok: true, count: results.length, results };
+    },
+
+    async ui_add_node(args) {
+      const id = String(args.id);
+      const type = String(args.type);
+      const m = meta(type);
+      if (!m) {
+        throw new Error(
+          `Node type not found: ${type}. Use ui_search_nodes to find the correct type.`
+        );
+      }
+      if (findNode(id)) {
+        throw new Error(`A node with id "${id}" already exists.`);
+      }
+      const rawPos = args.position;
+      const position =
+        rawPos &&
+        typeof rawPos === "object" &&
+        "x" in rawPos &&
+        "y" in rawPos &&
+        typeof (rawPos as { x: unknown }).x === "number" &&
+        typeof (rawPos as { y: unknown }).y === "number"
+          ? { x: (rawPos as { x: number }).x, y: (rawPos as { y: number }).y }
+          : { x: 120 + state.nodes.length * 240, y: 120 };
+
+      const provided = (args.properties as Record<string, unknown>) ?? {};
+      const properties: Record<string, unknown> = {};
+      for (const prop of m.properties ?? []) {
+        properties[prop.name] =
+          prop.name in provided ? provided[prop.name] : prop.default;
+      }
+      // Preserve any extra provided keys the metadata doesn't declare.
+      for (const [k, v] of Object.entries(provided)) {
+        if (!(k in properties)) properties[k] = v;
+      }
+
+      state.nodes.push({ id, type, position, data: { properties } });
+
+      const warnings: string[] = [];
+      for (const prop of m.properties ?? []) {
+        if (!prop.required) continue;
+        if (prop.name in provided) continue;
+        const v = properties[prop.name];
+        if (v === null || v === undefined || v === "") {
+          warnings.push(
+            `Required property '${prop.name}' is not set. Use ui_update_node_data to set it.`
+          );
+        }
+      }
+      return warnings.length > 0 ? { ok: true, id, warnings } : { ok: true, id };
+    },
+
+    async ui_connect_nodes(args) {
+      const sourceId = String(args.source_node_id);
+      const targetId = String(args.target_node_id);
+      const sourceHandle = String(args.source_handle);
+      const targetHandle = String(args.target_handle);
+      const src = findNode(sourceId);
+      const tgt = findNode(targetId);
+      if (!src) throw new Error(`Source node not found: ${sourceId}`);
+      if (!tgt) throw new Error(`Target node not found: ${targetId}`);
+      const srcMeta = meta(src.type);
+      const tgtMeta = meta(tgt.type);
+      if (!srcMeta) throw new Error(`Source node has no metadata: ${src.type}`);
+      if (!tgtMeta) throw new Error(`Target node has no metadata: ${tgt.type}`);
+
+      const hasOutput = (srcMeta.outputs ?? []).some(
+        (o) => o.name === sourceHandle
+      );
+      if (!hasOutput) {
+        const avail = (srcMeta.outputs ?? []).map((o) => o.name).join(", ");
+        throw new Error(
+          `Source handle '${sourceHandle}' not found on ${src.type}. Available outputs: [${avail || "none"}]`
+        );
+      }
+      const hasInput = (tgtMeta.properties ?? []).some(
+        (p) => p.name === targetHandle
+      );
+      if (!hasInput) {
+        const avail = (tgtMeta.properties ?? []).map((p) => p.name).join(", ");
+        throw new Error(
+          `Target handle '${targetHandle}' not found on ${tgt.type}. Available inputs: [${avail || "none"}]`
+        );
+      }
+
+      const duplicate = state.edges.find(
+        (e) =>
+          e.source === sourceId &&
+          e.sourceHandle === sourceHandle &&
+          e.target === targetId &&
+          e.targetHandle === targetHandle
+      );
+      if (duplicate) {
+        return { ok: true, edge_id: duplicate.id, note: "edge already exists" };
+      }
+      if (wouldCreateCycle(state.edges, sourceId, targetId)) {
+        throw new Error(
+          `Connecting ${sourceId} → ${targetId} would create a cycle.`
+        );
+      }
+      const edgeId = generateEdgeId();
+      state.edges.push({
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        sourceHandle,
+        targetHandle
+      });
+      return { ok: true, edge_id: edgeId };
+    },
+
+    async ui_update_node_data(args) {
+      const node = findNode(String(args.node_id));
+      if (!node) throw new Error(`Node not found: ${String(args.node_id)}`);
+      const data = (args.data as Record<string, unknown>) ?? {};
+      if (data.properties && typeof data.properties === "object") {
+        node.data.properties = {
+          ...node.data.properties,
+          ...(data.properties as Record<string, unknown>)
+        };
+      }
+      if (typeof data.title === "string") node.data.title = data.title;
+      return { ok: true };
+    },
+
+    async ui_set_node_title(args) {
+      const node = findNode(String(args.node_id));
+      if (!node) throw new Error(`Node not found: ${String(args.node_id)}`);
+      node.data.title = String(args.title);
+      return { ok: true };
+    },
+
+    async ui_move_node(args) {
+      const node = findNode(String(args.node_id));
+      if (!node) throw new Error(`Node not found: ${String(args.node_id)}`);
+      const pos = args.position as { x: number; y: number };
+      node.position = { x: pos.x, y: pos.y };
+      return { ok: true };
+    },
+
+    async ui_delete_node(args) {
+      const id = String(args.node_id);
+      const before = state.nodes.length;
+      state.nodes = state.nodes.filter((n) => n.id !== id);
+      if (state.nodes.length === before) {
+        throw new Error(`Node not found: ${id}`);
+      }
+      // Drop dangling edges, matching the store's cascade.
+      state.edges = state.edges.filter(
+        (e) => e.source !== id && e.target !== id
+      );
+      return { ok: true };
+    },
+
+    async ui_delete_edge(args) {
+      const id = String(args.edge_id);
+      const before = state.edges.length;
+      state.edges = state.edges.filter((e) => e.id !== id);
+      if (state.edges.length === before) {
+        throw new Error(`Edge not found: ${id}`);
+      }
+      return { ok: true };
+    },
+
+    async ui_get_graph() {
+      return {
+        ok: true,
+        workflow_id: state.currentWorkflowId,
+        nodes: state.nodes.map((n) => ({
+          id: n.id,
+          type: n.type,
+          position: n.position,
+          data: n.data
+        })),
+        edges: state.edges.map((e) => ({
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          sourceHandle: e.sourceHandle,
+          targetHandle: e.targetHandle
+        }))
+      };
+    }
+  };
+
+  const names = opts.toolNames ?? DEFAULT_TOOL_NAMES;
+  const tools: HeadlessTool[] = [];
+  for (const name of names) {
+    const schema = uiToolSchemas[name];
+    const impl = impls[name];
+    if (!schema) {
+      throw new Error(`No shared schema in uiToolSchemas for tool "${name}"`);
+    }
+    if (!impl) {
+      throw new Error(`No headless implementation for tool "${name}"`);
+    }
+    const parameters = z.object(schema.parameters);
+    tools.push({
+      name,
+      description: schema.description,
+      parameters,
+      // Validate through the same coercion path the browser registry uses,
+      // then run the effect.
+      execute: (args) => {
+        const parsed = parseWithTypeCoercion(parameters, args ?? {}) as Record<
+          string,
+          unknown
+        >;
+        return impl(parsed);
+      }
+    });
+  }
+
+  return {
+    state,
+    tools,
+    finalState: () => ({
+      nodes: state.nodes.map(cloneNode),
+      edges: state.edges.map((e) => ({ ...e }))
+    })
+  };
+}

--- a/packages/agents/src/evals/tool-loop-cases.ts
+++ b/packages/agents/src/evals/tool-loop-cases.ts
@@ -1,0 +1,229 @@
+/**
+ * Built-in evaluation cases for the frontend tool-loop flow.
+ *
+ * Each case ships a small, self-contained node catalog (so runs are
+ * deterministic and need no live registry) plus structural expectations on the
+ * tool sequence and the resulting graph. Expectations are deliberately loose on
+ * ordering-of-equivalent-calls and strict on outcomes: many tool orderings
+ * build a valid graph, but all must add the right node families, wire them, and
+ * avoid errors.
+ */
+
+import type { NodeMetadata, Property, OutputSlot } from "@nodetool-ai/protocol";
+import type {
+  ToolLoopEvalCase,
+  ToolLoopStatePredicate
+} from "./tool-loop-eval.js";
+import type { ToolLoopFinalState } from "./tool-loop-bridge.js";
+
+/** Minimal Property with the fields the headless tools read. */
+function prop(
+  name: string,
+  type: string,
+  opts: { required?: boolean; default?: unknown } = {}
+): Property {
+  return {
+    name,
+    type: { type, optional: !opts.required, type_args: [] },
+    default: opts.default ?? null,
+    required: opts.required ?? false
+  };
+}
+
+/** Minimal OutputSlot. */
+function out(name: string, type: string): OutputSlot {
+  return { name, type: { type, optional: false, type_args: [] }, stream: false };
+}
+
+/** Build a NodeMetadata stub carrying only the fields the tools consult. */
+function defineNode(
+  node_type: string,
+  opts: {
+    title?: string;
+    description?: string;
+    properties?: Property[];
+    outputs?: OutputSlot[];
+  } = {}
+): NodeMetadata {
+  const segments = node_type.split(".");
+  return {
+    title: opts.title ?? segments[segments.length - 1],
+    description: opts.description ?? "",
+    namespace: segments.slice(0, -1).join("."),
+    node_type,
+    layout: "default",
+    properties: opts.properties ?? [],
+    outputs: opts.outputs ?? [out("output", "any")],
+    recommended_models: [],
+    required_settings: [],
+    supports_dynamic_inputs: false,
+    is_streaming_output: false,
+    supports_dynamic_outputs: false
+  } as NodeMetadata;
+}
+
+/**
+ * Shared catalog: a string input, a couple of text-processing steps, an LLM
+ * agent step, and an output node. Enough to express "take input → process →
+ * output" objectives via the tool surface.
+ */
+const CATALOG: Record<string, NodeMetadata> = Object.fromEntries(
+  [
+    defineNode("nodetool.input.StringInput", {
+      title: "String Input",
+      description: "A workflow input that supplies a string value by name.",
+      properties: [
+        prop("name", "str", { required: true }),
+        prop("value", "str")
+      ],
+      outputs: [out("output", "str")]
+    }),
+    defineNode("nodetool.text.Concat", {
+      title: "Concat",
+      description: "Concatenate two strings into one.",
+      properties: [prop("a", "str", { required: true }), prop("b", "str")],
+      outputs: [out("output", "str")]
+    }),
+    defineNode("nodetool.text.FormatText", {
+      title: "Format Text",
+      description: "Format a template string using named inputs.",
+      properties: [
+        prop("template", "str", { required: true }),
+        prop("text", "str")
+      ],
+      outputs: [out("output", "str")]
+    }),
+    defineNode("nodetool.agents.Agent", {
+      title: "Agent",
+      description: "An LLM step: runs a prompt over its input and returns text.",
+      properties: [
+        prop("prompt", "str", { required: true }),
+        prop("input", "str")
+      ],
+      outputs: [out("output", "str")]
+    }),
+    defineNode("nodetool.output.StringOutput", {
+      title: "String Output",
+      description: "Surfaces a string as a named workflow output.",
+      properties: [
+        prop("name", "str", { required: true }),
+        prop("value", "str")
+      ],
+      outputs: []
+    })
+  ].map((m) => [m.node_type, m])
+);
+
+/** Count nodes in the final graph whose type starts with `prefix`. */
+function countByPrefix(state: ToolLoopFinalState, prefix: string): number {
+  return state.nodes.filter((n) => n.type.startsWith(prefix)).length;
+}
+
+/** Every non-input node has an incoming edge; every non-output an outgoing one. */
+const connectedPredicate: ToolLoopStatePredicate = {
+  name: "connected",
+  detail: "some node is unwired",
+  test: (state) => {
+    const hasIn = new Set(state.edges.map((e) => e.target));
+    const hasOut = new Set(state.edges.map((e) => e.source));
+    return state.nodes.every((n) => {
+      const isInput = n.type.startsWith("nodetool.input.");
+      const isOutput = n.type.startsWith("nodetool.output.");
+      if (!isInput && !hasIn.has(n.id)) return false;
+      if (!isOutput && !hasOut.has(n.id)) return false;
+      return true;
+    });
+  }
+};
+
+export const TOOL_LOOP_EVAL_CASES: readonly ToolLoopEvalCase[] = [
+  {
+    id: "summarize",
+    description: "Wire a StringInput → Agent → StringOutput chain via tools",
+    objective:
+      "Build a workflow that takes a string input named 'text', summarizes it with an LLM agent step, and exposes the summary as a string output named 'summary'. Search for node types, add the nodes, and connect them.",
+    initialState: { nodeMetadata: CATALOG },
+    expect: {
+      requiredTools: ["ui_add_node", "ui_connect_nodes"],
+      forbiddenTools: ["ui_delete_node"],
+      ordering: [["ui_add_node", "ui_connect_nodes"]],
+      noErrorResults: true,
+      minToolCalls: 3,
+      maxToolCalls: 20,
+      finalState: [
+        {
+          name: "hasInput",
+          detail: "no nodetool.input.* node",
+          test: (s) => countByPrefix(s, "nodetool.input.") >= 1
+        },
+        {
+          name: "hasAgent",
+          detail: "no nodetool.agents.* node",
+          test: (s) => countByPrefix(s, "nodetool.agents.") >= 1
+        },
+        {
+          name: "hasOutput",
+          detail: "no nodetool.output.* node",
+          test: (s) => countByPrefix(s, "nodetool.output.") >= 1
+        },
+        {
+          name: "minEdges",
+          detail: "fewer than 2 edges",
+          test: (s) => s.edges.length >= 2
+        },
+        connectedPredicate
+      ]
+    }
+  },
+  {
+    id: "extend-existing",
+    description: "Add an output to a pre-seeded input→agent graph",
+    objective:
+      "The workflow already has a StringInput ('text', id=in1) feeding an Agent (id=agent1). Add a StringOutput node named 'result' and connect the agent's output to it so the result is surfaced.",
+    initialState: {
+      nodeMetadata: CATALOG,
+      nodes: [
+        {
+          id: "in1",
+          type: "nodetool.input.StringInput",
+          position: { x: 100, y: 100 },
+          data: { properties: { name: "text", value: "" } }
+        },
+        {
+          id: "agent1",
+          type: "nodetool.agents.Agent",
+          position: { x: 360, y: 100 },
+          data: { properties: { prompt: "summarize", input: "" } }
+        }
+      ],
+      edges: [
+        {
+          id: "edge_1",
+          source: "in1",
+          target: "agent1",
+          sourceHandle: "output",
+          targetHandle: "input"
+        }
+      ]
+    },
+    expect: {
+      requiredTools: ["ui_add_node", "ui_connect_nodes"],
+      ordering: [["ui_add_node", "ui_connect_nodes"]],
+      noErrorResults: true,
+      minToolCalls: 2,
+      maxToolCalls: 12,
+      finalState: [
+        {
+          name: "hasOutput",
+          detail: "no nodetool.output.* node added",
+          test: (s) => countByPrefix(s, "nodetool.output.") >= 1
+        },
+        {
+          name: "agentWired",
+          detail: "agent1 output not connected onward",
+          test: (s) => s.edges.some((e) => e.source === "agent1")
+        }
+      ]
+    }
+  }
+];

--- a/packages/agents/src/evals/tool-loop-eval.ts
+++ b/packages/agents/src/evals/tool-loop-eval.ts
@@ -1,0 +1,453 @@
+/**
+ * Tool-loop evaluation harness — provider-agnostic.
+ *
+ * Drives a multi-turn tool-calling loop over the *frontend* tool surface: the
+ * model is handed the real `ui_*` tool contract (names/descriptions/Zod schemas
+ * from `@nodetool-ai/protocol`) and an objective, each requested tool runs
+ * against a {@link createToolLoopBridge headless bridge}, and the result is fed
+ * back — repeating until the model stops calling tools or a turn cap is hit.
+ *
+ * Where {@link runGraphPlannerEval} evaluates one-shot DSL authoring, this
+ * evaluates the incremental add-node/connect-node tool flow the browser UI and
+ * the agent WebSocket bridge actually expose. It records the same efficiency
+ * metrics and emits the same result/summary shapes so providers/models can be
+ * compared on one report.
+ *
+ * Scoring is structural (see {@link checkToolLoopExpectations}): required /
+ * forbidden tool names, ordering constraints, final-state predicates, tool-call
+ * budgets, and a no-error-results check — never an exact transcript match, so
+ * many valid tool orderings pass.
+ */
+
+import type { BaseProvider, Message } from "@nodetool-ai/runtime";
+import { zodToJsonSchema } from "@nodetool-ai/runtime";
+import type { EvalCheck } from "./graph-planner-eval.js";
+import {
+  createToolLoopBridge,
+  type ToolLoopInitialState,
+  type ToolLoopFinalState
+} from "./tool-loop-bridge.js";
+import { TOOL_LOOP_EVAL_CASES } from "./tool-loop-cases.js";
+
+/** One tool call the model made, with its result and whether it errored. */
+export interface ToolCallRecord {
+  name: string;
+  args: Record<string, unknown>;
+  result: unknown;
+  isError: boolean;
+}
+
+/** A named boolean assertion over the final graph state. */
+export interface ToolLoopStatePredicate {
+  name: string;
+  test: (state: ToolLoopFinalState) => boolean;
+  /** Optional detail shown when the predicate fails. */
+  detail?: string;
+}
+
+export interface ToolLoopEvalExpectations {
+  /** Tool names that must each be called at least once. */
+  requiredTools?: string[];
+  /** Tool names that must never be called. */
+  forbiddenTools?: string[];
+  /**
+   * Ordering constraints `[a, b]`: the first call of `a` must precede the first
+   * call of `b`. Both tools must be called for the check to pass.
+   */
+  ordering?: Array<[string, string]>;
+  /** Predicates on the final graph state (all must hold). */
+  finalState?: ToolLoopStatePredicate[];
+  /** Minimum total tool calls across the run. */
+  minToolCalls?: number;
+  /** Maximum total tool calls across the run (efficiency ceiling). */
+  maxToolCalls?: number;
+  /** When true, no tool call may have returned an error result. */
+  noErrorResults?: boolean;
+}
+
+export interface ToolLoopEvalCase {
+  id: string;
+  description: string;
+  objective: string;
+  /** Node catalog + starting graph the tools operate on. */
+  initialState: ToolLoopInitialState;
+  /**
+   * Case needs configured model providers to be solvable — skipped when the
+   * harness runs without any (mirrors the graph-planner suite).
+   */
+  needsModelProviders?: boolean;
+  expect: ToolLoopEvalExpectations;
+}
+
+/** Everything the pure checker needs — no provider, no I/O. */
+export interface ToolLoopObservation {
+  toolCalls: ToolCallRecord[];
+  finalState: ToolLoopFinalState;
+}
+
+export interface ToolLoopCaseResult {
+  caseId: string;
+  description: string;
+  skipped: boolean;
+  /** The loop ran to a natural stop / cap without a fatal provider error. */
+  accepted: boolean;
+  /** Fraction of checks passed (0 when the loop did not run). */
+  score: number;
+  checks: EvalCheck[];
+  /** Tool calls made, by tool name. */
+  toolCalls: Record<string, number>;
+  /** Total tool calls across all names. */
+  totalToolCalls: number;
+  durationMs: number;
+  costUsd: number;
+  error?: string;
+}
+
+export interface ToolLoopEvalReport {
+  provider: string;
+  model: string;
+  startedAt: string;
+  cases: ToolLoopCaseResult[];
+  summary: {
+    total: number;
+    skipped: number;
+    accepted: number;
+    /** accepted / (total - skipped) */
+    successRate: number;
+    /** Mean expectation score over non-skipped cases. */
+    meanScore: number;
+    avgToolCalls: number;
+    totalCostUsd: number;
+  };
+}
+
+export interface RunToolLoopEvalOptions {
+  provider: BaseProvider;
+  model: string;
+  /** Configured providers; enables model-dependent cases (else they skip). */
+  providers?: Record<string, BaseProvider>;
+  /** Cases to run; defaults to the built-in suite. */
+  cases?: readonly ToolLoopEvalCase[];
+  /** Turn cap — max tool-calling rounds before the loop stops. Defaults to 12. */
+  maxIterations?: number;
+  /** Override the system prompt handed to the model. */
+  systemPrompt?: string;
+  signal?: AbortSignal;
+  /** Progress callback (one line per event, for CLI display). */
+  onEvent?: (line: string) => void;
+}
+
+const DEFAULT_MAX_ITERATIONS = 12;
+
+const DEFAULT_SYSTEM_PROMPT = `You are a workflow-graph building assistant operating a node-based editor through UI tools.
+
+Build the workflow the user asks for by calling the ui_* tools:
+- Discover node types with ui_search_nodes before adding them — never guess a type.
+- Add nodes with ui_add_node (choose a stable, unique id per node and a {x, y} position).
+- Wire nodes together with ui_connect_nodes using the exact output/input handle names from ui_search_nodes.
+- Inspect your work with ui_get_graph when unsure.
+
+Call one tool at a time and use the result before the next call. When the objective is fully satisfied, STOP calling tools and give a one-line summary.`;
+
+function totalToolCalls(byName: Record<string, number>): number {
+  return Object.values(byName).reduce((a, b) => a + b, 0);
+}
+
+function buildUserPrompt(evalCase: ToolLoopEvalCase): string {
+  const existing =
+    (evalCase.initialState.nodes?.length ?? 0) > 0
+      ? `\n\nThe workflow already contains ${evalCase.initialState.nodes!.length} node(s); build on top of them.`
+      : "";
+  return `Objective: ${evalCase.objective}${existing}`;
+}
+
+/**
+ * Score a completed run against a case's structural expectations. Pure and
+ * fully unit-testable: it takes an {@link ToolLoopObservation} and never calls
+ * a provider.
+ */
+export function checkToolLoopExpectations(
+  observation: ToolLoopObservation,
+  expect: ToolLoopEvalExpectations
+): EvalCheck[] {
+  const checks: EvalCheck[] = [];
+  const sequence = observation.toolCalls.map((c) => c.name);
+  const called = new Set(sequence);
+
+  for (const name of expect.requiredTools ?? []) {
+    const pass = called.has(name);
+    checks.push({
+      name: `tool:${name}`,
+      pass,
+      detail: pass ? undefined : `never called ${name}`
+    });
+  }
+
+  for (const name of expect.forbiddenTools ?? []) {
+    const hit = called.has(name);
+    checks.push({
+      name: `not-tool:${name}`,
+      pass: !hit,
+      detail: hit ? `called forbidden tool ${name}` : undefined
+    });
+  }
+
+  for (const [a, b] of expect.ordering ?? []) {
+    const ia = sequence.indexOf(a);
+    const ib = sequence.indexOf(b);
+    const pass = ia !== -1 && ib !== -1 && ia < ib;
+    checks.push({
+      name: `order:${a}<${b}`,
+      pass,
+      detail: pass
+        ? undefined
+        : `${a} first@${ia}, ${b} first@${ib} (need ${a} before ${b})`
+    });
+  }
+
+  for (const predicate of expect.finalState ?? []) {
+    let pass = false;
+    let detail = predicate.detail;
+    try {
+      pass = predicate.test(observation.finalState);
+    } catch (e) {
+      detail = e instanceof Error ? e.message : String(e);
+    }
+    checks.push({
+      name: `state:${predicate.name}`,
+      pass,
+      detail: pass ? undefined : (detail ?? `predicate ${predicate.name} failed`)
+    });
+  }
+
+  if (expect.minToolCalls !== undefined) {
+    checks.push({
+      name: `toolCalls>=${expect.minToolCalls}`,
+      pass: sequence.length >= expect.minToolCalls,
+      detail: `made ${sequence.length}`
+    });
+  }
+  if (expect.maxToolCalls !== undefined) {
+    checks.push({
+      name: `toolCalls<=${expect.maxToolCalls}`,
+      pass: sequence.length <= expect.maxToolCalls,
+      detail: `made ${sequence.length}`
+    });
+  }
+
+  if (expect.noErrorResults) {
+    const errored = observation.toolCalls.filter((c) => c.isError);
+    checks.push({
+      name: "no-error-results",
+      pass: errored.length === 0,
+      detail:
+        errored.length === 0
+          ? undefined
+          : `${errored.length} errored: ${errored.map((c) => c.name).join(", ")}`
+    });
+  }
+
+  return checks;
+}
+
+async function runCase(
+  evalCase: ToolLoopEvalCase,
+  opts: RunToolLoopEvalOptions
+): Promise<ToolLoopCaseResult> {
+  const bridge = createToolLoopBridge(evalCase.initialState);
+  const toolCalls: Record<string, number> = {};
+  const records: ToolCallRecord[] = [];
+  const costBefore = opts.provider.getTotalCost();
+  const startedAt = Date.now();
+
+  // Provider tools carry a self-contained `execute`, so `generateLoop`
+  // dispatches directly to the bridge and feeds the stringified result back to
+  // the model — exactly how the graph planner drives its tools.
+  const providerTools = bridge.tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: zodToJsonSchema(tool.parameters),
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      toolCalls[tool.name] = (toolCalls[tool.name] ?? 0) + 1;
+      let result: unknown;
+      let isError = false;
+      try {
+        result = await tool.execute(args ?? {});
+      } catch (e) {
+        isError = true;
+        result = { error: e instanceof Error ? e.message : String(e) };
+      }
+      records.push({ name: tool.name, args: args ?? {}, result, isError });
+      opts.onEvent?.(`    [tool] ${tool.name}${isError ? " (error)" : ""}`);
+      return typeof result === "string" ? result : JSON.stringify(result);
+    }
+  }));
+
+  const messages: Message[] = [
+    { role: "system", content: opts.systemPrompt ?? DEFAULT_SYSTEM_PROMPT },
+    { role: "user", content: buildUserPrompt(evalCase) }
+  ];
+
+  let error: string | undefined;
+  try {
+    const stream = opts.provider.generateLoop({
+      messages,
+      model: opts.model,
+      tools: providerTools,
+      // Tools mutate shared graph state and read it back, so calls must be
+      // serialized.
+      sequentialTools: true,
+      maxIterations: opts.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+      signal: opts.signal
+    });
+    // Drain the stream; side effects (tool execution, result feedback) happen
+    // inside `generateLoop`.
+    for await (const _item of stream) {
+      if (opts.signal?.aborted) break;
+    }
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const costUsd = opts.provider.getTotalCost() - costBefore;
+  const accepted = error === undefined;
+
+  const observation: ToolLoopObservation = {
+    toolCalls: records,
+    finalState: bridge.finalState()
+  };
+
+  const checks: EvalCheck[] = [
+    { name: "accepted", pass: accepted, detail: error }
+  ];
+  if (accepted) {
+    checks.push(...checkToolLoopExpectations(observation, evalCase.expect));
+  }
+  const score = accepted
+    ? checks.filter((c) => c.pass).length / checks.length
+    : 0;
+
+  return {
+    caseId: evalCase.id,
+    description: evalCase.description,
+    skipped: false,
+    accepted,
+    score,
+    checks,
+    toolCalls,
+    totalToolCalls: totalToolCalls(toolCalls),
+    durationMs,
+    costUsd,
+    error
+  };
+}
+
+export async function runToolLoopEval(
+  opts: RunToolLoopEvalOptions
+): Promise<ToolLoopEvalReport> {
+  const cases = opts.cases ?? TOOL_LOOP_EVAL_CASES;
+  const hasModelProviders =
+    !!opts.providers && Object.keys(opts.providers).length > 0;
+  const results: ToolLoopCaseResult[] = [];
+
+  for (const evalCase of cases) {
+    if (opts.signal?.aborted) break;
+    if (evalCase.needsModelProviders && !hasModelProviders) {
+      opts.onEvent?.(`- ${evalCase.id}: SKIPPED (no model providers)`);
+      results.push({
+        caseId: evalCase.id,
+        description: evalCase.description,
+        skipped: true,
+        accepted: false,
+        score: 0,
+        checks: [],
+        toolCalls: {},
+        totalToolCalls: 0,
+        durationMs: 0,
+        costUsd: 0
+      });
+      continue;
+    }
+
+    opts.onEvent?.(`- ${evalCase.id}: ${evalCase.description}`);
+    const result = await runCase(evalCase, opts);
+    const failed = result.checks.filter((c) => !c.pass);
+    opts.onEvent?.(
+      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+        `tools=${result.totalToolCalls} ${Math.round(result.durationMs / 1000)}s` +
+        (failed.length > 0
+          ? ` | failed: ${failed.map((c) => c.name).join(", ")}`
+          : "")
+    );
+    results.push(result);
+  }
+
+  const ran = results.filter((r) => !r.skipped);
+  const acceptedResults = ran.filter((r) => r.accepted);
+  const summary = {
+    total: results.length,
+    skipped: results.length - ran.length,
+    accepted: acceptedResults.length,
+    successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+    meanScore:
+      ran.length > 0 ? ran.reduce((a, r) => a + r.score, 0) / ran.length : 0,
+    avgToolCalls:
+      ran.length > 0
+        ? ran.reduce((a, r) => a + r.totalToolCalls, 0) / ran.length
+        : 0,
+    totalCostUsd: ran.reduce((a, r) => a + r.costUsd, 0)
+  };
+
+  return {
+    provider: opts.provider.provider,
+    model: opts.model,
+    startedAt: new Date().toISOString(),
+    cases: results,
+    summary
+  };
+}
+
+/** Text summary table for terminal output. */
+export function formatToolLoopReport(report: ToolLoopEvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `Tool-loop eval — provider=${report.provider} model=${report.model}`
+  );
+  lines.push("");
+  const header = [
+    "case".padEnd(24),
+    "result".padEnd(7),
+    "score".padEnd(6),
+    "tools".padEnd(6),
+    "time".padEnd(7),
+    "cost"
+  ].join("");
+  lines.push(header);
+  lines.push("-".repeat(header.length));
+  for (const r of report.cases) {
+    lines.push(
+      [
+        r.caseId.padEnd(24),
+        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
+        String(r.totalToolCalls).padEnd(6),
+        `${Math.round(r.durationMs / 1000)}s`.padEnd(7),
+        r.costUsd > 0 ? `$${r.costUsd.toFixed(4)}` : "-"
+      ].join("")
+    );
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      lines.push(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  const s = report.summary;
+  lines.push("");
+  lines.push(
+    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  mean score ${s.meanScore.toFixed(2)}` +
+      `  avg tools ${s.avgToolCalls.toFixed(1)}` +
+      (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +
+      (s.skipped > 0 ? `  (${s.skipped} skipped)` : "")
+  );
+  return lines.join("\n");
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -372,6 +372,37 @@ export type {
 } from "./evals/graph-planner-eval.js";
 export { GRAPH_PLANNER_EVAL_CASES } from "./evals/graph-planner-cases.js";
 
+// Tool-loop evaluation harness (frontend ui_* tool surface)
+export {
+  runToolLoopEval,
+  formatToolLoopReport,
+  checkToolLoopExpectations
+} from "./evals/tool-loop-eval.js";
+export type {
+  ToolLoopEvalCase,
+  ToolLoopEvalExpectations,
+  ToolLoopStatePredicate,
+  ToolLoopObservation,
+  ToolCallRecord,
+  ToolLoopCaseResult,
+  ToolLoopEvalReport,
+  RunToolLoopEvalOptions
+} from "./evals/tool-loop-eval.js";
+export {
+  createToolLoopBridge,
+  DEFAULT_TOOL_NAMES
+} from "./evals/tool-loop-bridge.js";
+export type {
+  ToolLoopInitialState,
+  ToolLoopFinalState,
+  ToolLoopState,
+  HeadlessTool,
+  HeadlessBridge,
+  HeadlessNode,
+  HeadlessEdge
+} from "./evals/tool-loop-bridge.js";
+export { TOOL_LOOP_EVAL_CASES } from "./evals/tool-loop-cases.js";
+
 // Graph-native planning & execution
 export { evaluateGraphDsl } from "./graph-dsl.js";
 export type { GraphDslResult, EvaluateGraphDslOptions } from "./graph-dsl.js";

--- a/packages/agents/tests/tool-loop-eval.ollama.test.ts
+++ b/packages/agents/tests/tool-loop-eval.ollama.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Live tool-loop eval against a local Ollama model.
+ *
+ * This is the real end-to-end check the harness is built for: a local model
+ * drives the ui_* tool loop headlessly and builds a graph. It runs only when an
+ * Ollama daemon is reachable (default http://localhost:11434, override with
+ * OLLAMA_API_URL); otherwise it skips so the suite stays green everywhere.
+ *
+ *   OLLAMA_API_URL=http://localhost:11434 \
+ *   TOOL_LOOP_OLLAMA_MODEL=qwen2.5:7b \
+ *   npx vitest run tests/tool-loop-eval.ollama.test.ts
+ *
+ * Equivalent CLI run:
+ *   nodetool eval tool-loop --provider ollama --model qwen2.5:7b --min-success 1
+ */
+import { describe, it, expect } from "vitest";
+import { OllamaProvider } from "@nodetool-ai/runtime";
+import { runToolLoopEval, TOOL_LOOP_EVAL_CASES } from "../src/index.js";
+
+const OLLAMA_URL = process.env.OLLAMA_API_URL || "http://localhost:11434";
+const MODEL = process.env.TOOL_LOOP_OLLAMA_MODEL || "qwen2.5:7b";
+
+async function ollamaReachable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${OLLAMA_URL}/api/tags`, {
+      signal: AbortSignal.timeout(1500)
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("runToolLoopEval against local Ollama", () => {
+  it(
+    "drives the ui_* tool loop and builds a connected graph",
+    async (ctx) => {
+      if (!(await ollamaReachable())) {
+        ctx.skip();
+        return;
+      }
+
+      const provider = new OllamaProvider({ OLLAMA_API_URL: OLLAMA_URL });
+      const report = await runToolLoopEval({
+        provider,
+        model: MODEL,
+        cases: TOOL_LOOP_EVAL_CASES.filter((c) => c.id === "summarize"),
+        maxIterations: 16
+      });
+
+      const result = report.cases[0];
+      // The loop must have run to completion and made real progress.
+      expect(result.accepted).toBe(true);
+      expect(result.totalToolCalls).toBeGreaterThan(0);
+      // A capable local model should satisfy most structural checks.
+      expect(result.score).toBeGreaterThan(0.5);
+    },
+    120_000
+  );
+});

--- a/packages/agents/tests/tool-loop-eval.test.ts
+++ b/packages/agents/tests/tool-loop-eval.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Unit tests for the tool-loop eval harness (`src/evals/tool-loop-*`):
+ *   - `checkToolLoopExpectations`: pure structural scoring, no provider.
+ *   - `createToolLoopBridge`: headless execution of the real ui_* tool contract.
+ *   - `runToolLoopEval`: metrics collection + scoring driven by a scripted
+ *     provider that emulates a model's native tool loop — no network.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runToolLoopEval,
+  formatToolLoopReport,
+  checkToolLoopExpectations,
+  createToolLoopBridge,
+  type ToolLoopEvalCase,
+  type ToolLoopObservation
+} from "../src/index.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ProviderTool
+} from "@nodetool-ai/runtime";
+import type { NodeMetadata, Property, OutputSlot } from "@nodetool-ai/protocol";
+
+// --- catalog helpers ---------------------------------------------------------
+
+function prop(name: string, required = false): Property {
+  return {
+    name,
+    type: { type: "str", optional: !required, type_args: [] },
+    default: null,
+    required
+  };
+}
+function out(name: string): OutputSlot {
+  return { name, type: { type: "str", optional: false, type_args: [] }, stream: false };
+}
+function node(node_type: string, properties: Property[], outputs: OutputSlot[]): NodeMetadata {
+  return {
+    title: node_type,
+    description: "",
+    namespace: "",
+    node_type,
+    layout: "default",
+    properties,
+    outputs,
+    recommended_models: [],
+    required_settings: [],
+    supports_dynamic_inputs: false,
+    is_streaming_output: false,
+    supports_dynamic_outputs: false
+  } as NodeMetadata;
+}
+
+const CATALOG: Record<string, NodeMetadata> = {
+  "nodetool.input.StringInput": node(
+    "nodetool.input.StringInput",
+    [prop("name", true), prop("value")],
+    [out("output")]
+  ),
+  "nodetool.agents.Agent": node(
+    "nodetool.agents.Agent",
+    [prop("prompt", true), prop("input")],
+    [out("output")]
+  ),
+  "nodetool.output.StringOutput": node(
+    "nodetool.output.StringOutput",
+    [prop("name", true), prop("value")],
+    []
+  )
+};
+
+// --- scripted provider -------------------------------------------------------
+
+interface ScriptedCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Provider that replays one scripted list of tool calls through the tool
+ * `execute` closures (mirroring how a real provider's `generateLoop` dispatches
+ * self-executing tools), then ends the turn.
+ */
+function createScriptedProvider(script: ScriptedCall[]): BaseProvider {
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: ProviderTool[];
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      let seq = 0;
+      for (const call of script) {
+        if (args.signal?.aborted) break;
+        const id = `call_${++seq}`;
+        yield { id, name: call.name, args: call.args } as ProviderStreamItem;
+        await toolMap.get(call.name)?.execute?.(call.args, id);
+      }
+      yield { type: "chunk", content: "", done: true } as ProviderStreamItem;
+    }
+  } as unknown as BaseProvider;
+}
+
+// The happy-path transcript: search, add three nodes, wire two edges.
+const GOOD_SCRIPT: ScriptedCall[] = [
+  { name: "ui_search_nodes", args: { query: "input" } },
+  {
+    name: "ui_add_node",
+    args: {
+      id: "in1",
+      type: "nodetool.input.StringInput",
+      position: { x: 0, y: 0 },
+      properties: { name: "text" }
+    }
+  },
+  {
+    name: "ui_add_node",
+    args: {
+      id: "agent1",
+      type: "nodetool.agents.Agent",
+      position: { x: 240, y: 0 },
+      properties: { prompt: "summarize" }
+    }
+  },
+  {
+    name: "ui_add_node",
+    args: {
+      id: "out1",
+      type: "nodetool.output.StringOutput",
+      position: { x: 480, y: 0 },
+      properties: { name: "summary" }
+    }
+  },
+  {
+    name: "ui_connect_nodes",
+    args: {
+      source_node_id: "in1",
+      source_handle: "output",
+      target_node_id: "agent1",
+      target_handle: "input"
+    }
+  },
+  {
+    name: "ui_connect_nodes",
+    args: {
+      source_node_id: "agent1",
+      source_handle: "output",
+      target_node_id: "out1",
+      target_handle: "value"
+    }
+  }
+];
+
+const GOOD_CASE: ToolLoopEvalCase = {
+  id: "good",
+  description: "builds a full chain",
+  objective: "Take input text, summarize, output it.",
+  initialState: { nodeMetadata: CATALOG },
+  expect: {
+    requiredTools: ["ui_add_node", "ui_connect_nodes"],
+    forbiddenTools: ["ui_delete_node"],
+    ordering: [["ui_add_node", "ui_connect_nodes"]],
+    noErrorResults: true,
+    minToolCalls: 3,
+    maxToolCalls: 20,
+    finalState: [
+      {
+        name: "threeNodes",
+        test: (s) => s.nodes.length === 3
+      },
+      {
+        name: "twoEdges",
+        test: (s) => s.edges.length === 2
+      }
+    ]
+  }
+};
+
+const NEEDS_MODELS_CASE: ToolLoopEvalCase = {
+  id: "needs-models",
+  description: "skipped without providers",
+  objective: "Pick a model.",
+  needsModelProviders: true,
+  initialState: { nodeMetadata: CATALOG },
+  expect: {}
+};
+
+// --- runToolLoopEval ---------------------------------------------------------
+
+describe("runToolLoopEval", () => {
+  it("collects metrics, scores expectations, and skips model-dependent cases", async () => {
+    const provider = createScriptedProvider(GOOD_SCRIPT);
+    const report = await runToolLoopEval({
+      provider,
+      model: "test-model",
+      cases: [GOOD_CASE, NEEDS_MODELS_CASE]
+    });
+
+    expect(report.provider).toBe("scripted");
+    expect(report.cases).toHaveLength(2);
+
+    const good = report.cases[0];
+    expect(good.accepted).toBe(true);
+    expect(good.score).toBe(1);
+    expect(good.checks.every((c) => c.pass)).toBe(true);
+    expect(good.toolCalls["ui_add_node"]).toBe(3);
+    expect(good.toolCalls["ui_connect_nodes"]).toBe(2);
+    expect(good.totalToolCalls).toBe(6);
+
+    const skipped = report.cases[1];
+    expect(skipped.skipped).toBe(true);
+
+    expect(report.summary.total).toBe(2);
+    expect(report.summary.skipped).toBe(1);
+    expect(report.summary.accepted).toBe(1);
+    expect(report.summary.successRate).toBe(1);
+    expect(report.summary.avgToolCalls).toBe(6);
+    expect(report.summary.totalCostUsd).toBe(0);
+  });
+
+  it("penalizes error results and violated expectations", async () => {
+    // Adds a node with an unknown type (errors) and never connects anything.
+    const badScript: ScriptedCall[] = [
+      {
+        name: "ui_add_node",
+        args: { id: "x", type: "does.not.Exist", position: { x: 0, y: 0 } }
+      }
+    ];
+    const provider = createScriptedProvider(badScript);
+    const report = await runToolLoopEval({
+      provider,
+      model: "test-model",
+      cases: [GOOD_CASE]
+    });
+    const r = report.cases[0];
+    // The loop still ran to completion, so it is "accepted"...
+    expect(r.accepted).toBe(true);
+    // ...but many checks fail: no connect, error result, too few calls.
+    expect(r.score).toBeLessThan(1);
+    const byName = Object.fromEntries(r.checks.map((c) => [c.name, c.pass]));
+    expect(byName["no-error-results"]).toBe(false);
+    expect(byName["tool:ui_connect_nodes"]).toBe(false);
+  });
+
+  it("formats a readable report", async () => {
+    const provider = createScriptedProvider(GOOD_SCRIPT);
+    const report = await runToolLoopEval({
+      provider,
+      model: "test-model",
+      cases: [GOOD_CASE]
+    });
+    const text = formatToolLoopReport(report);
+    expect(text).toContain("provider=scripted model=test-model");
+    expect(text).toContain("good");
+    expect(text).toContain("success 1/1 (100%)");
+  });
+});
+
+// --- createToolLoopBridge ----------------------------------------------------
+
+describe("createToolLoopBridge", () => {
+  it("executes the real tool contract headlessly and mutates the graph", async () => {
+    const bridge = createToolLoopBridge({ nodeMetadata: CATALOG });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    await byName["ui_add_node"].execute({
+      id: "in1",
+      type: "nodetool.input.StringInput",
+      position: { x: 0, y: 0 },
+      properties: { name: "text" }
+    });
+    await byName["ui_add_node"].execute({
+      id: "agent1",
+      type: "nodetool.agents.Agent",
+      position: { x: 240, y: 0 },
+      properties: { prompt: "hi" }
+    });
+    const connectResult = (await byName["ui_connect_nodes"].execute({
+      source_node_id: "in1",
+      source_handle: "output",
+      target_node_id: "agent1",
+      target_handle: "input"
+    })) as { ok: boolean; edge_id: string };
+
+    expect(connectResult.ok).toBe(true);
+    const final = bridge.finalState();
+    expect(final.nodes).toHaveLength(2);
+    expect(final.edges).toHaveLength(1);
+    expect(final.edges[0].source).toBe("in1");
+  });
+
+  it("rejects unknown node types and invalid handles", async () => {
+    const bridge = createToolLoopBridge({ nodeMetadata: CATALOG });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    await expect(
+      byName["ui_add_node"].execute({
+        id: "x",
+        type: "no.such.Node",
+        position: { x: 0, y: 0 }
+      })
+    ).rejects.toThrow(/Node type not found/);
+
+    await byName["ui_add_node"].execute({
+      id: "in1",
+      type: "nodetool.input.StringInput",
+      position: { x: 0, y: 0 },
+      properties: { name: "t" }
+    });
+    await byName["ui_add_node"].execute({
+      id: "agent1",
+      type: "nodetool.agents.Agent",
+      position: { x: 1, y: 0 },
+      properties: { prompt: "p" }
+    });
+    await expect(
+      byName["ui_connect_nodes"].execute({
+        source_node_id: "in1",
+        source_handle: "not_a_handle",
+        target_node_id: "agent1",
+        target_handle: "input"
+      })
+    ).rejects.toThrow(/Source handle .* not found/);
+  });
+
+  it("prevents cycles", async () => {
+    const bridge = createToolLoopBridge({
+      nodeMetadata: CATALOG,
+      nodes: [
+        {
+          id: "a",
+          type: "nodetool.agents.Agent",
+          position: { x: 0, y: 0 },
+          data: { properties: {} }
+        },
+        {
+          id: "b",
+          type: "nodetool.agents.Agent",
+          position: { x: 1, y: 0 },
+          data: { properties: {} }
+        }
+      ],
+      edges: [
+        {
+          id: "edge_1",
+          source: "a",
+          target: "b",
+          sourceHandle: "output",
+          targetHandle: "input"
+        }
+      ]
+    });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    await expect(
+      byName["ui_connect_nodes"].execute({
+        source_node_id: "b",
+        source_handle: "output",
+        target_node_id: "a",
+        target_handle: "input"
+      })
+    ).rejects.toThrow(/cycle/);
+  });
+});
+
+// --- checkToolLoopExpectations (pure) ---------------------------------------
+
+function observation(
+  names: string[],
+  opts: {
+    errors?: string[];
+    nodes?: number;
+    edges?: number;
+  } = {}
+): ToolLoopObservation {
+  const errorSet = new Set(opts.errors ?? []);
+  return {
+    toolCalls: names.map((name) => ({
+      name,
+      args: {},
+      result: {},
+      isError: errorSet.has(name)
+    })),
+    finalState: {
+      nodes: Array.from({ length: opts.nodes ?? 0 }, (_, i) => ({
+        id: `n${i}`,
+        type: "nodetool.agents.Agent",
+        position: { x: 0, y: 0 },
+        data: { properties: {} }
+      })),
+      edges: Array.from({ length: opts.edges ?? 0 }, (_, i) => ({
+        id: `e${i}`,
+        source: "a",
+        target: "b",
+        sourceHandle: "output",
+        targetHandle: "input"
+      }))
+    }
+  };
+}
+
+describe("checkToolLoopExpectations", () => {
+  it("passes required/forbidden/ordering/budget/state/no-error when satisfied", () => {
+    const checks = checkToolLoopExpectations(
+      observation(["ui_add_node", "ui_add_node", "ui_connect_nodes"], {
+        nodes: 2,
+        edges: 1
+      }),
+      {
+        requiredTools: ["ui_add_node", "ui_connect_nodes"],
+        forbiddenTools: ["ui_delete_node"],
+        ordering: [["ui_add_node", "ui_connect_nodes"]],
+        minToolCalls: 2,
+        maxToolCalls: 5,
+        noErrorResults: true,
+        finalState: [{ name: "wired", test: (s) => s.edges.length === 1 }]
+      }
+    );
+    expect(checks.every((c) => c.pass)).toBe(true);
+    expect(checks.map((c) => c.name)).toEqual([
+      "tool:ui_add_node",
+      "tool:ui_connect_nodes",
+      "not-tool:ui_delete_node",
+      "order:ui_add_node<ui_connect_nodes",
+      "state:wired",
+      "toolCalls>=2",
+      "toolCalls<=5",
+      "no-error-results"
+    ]);
+  });
+
+  it("flags missing required tools, forbidden calls, bad ordering, and errors", () => {
+    const checks = checkToolLoopExpectations(
+      observation(["ui_connect_nodes", "ui_delete_node", "ui_add_node"], {
+        errors: ["ui_connect_nodes"]
+      }),
+      {
+        requiredTools: ["ui_search_nodes"],
+        forbiddenTools: ["ui_delete_node"],
+        ordering: [["ui_add_node", "ui_connect_nodes"]],
+        maxToolCalls: 2,
+        noErrorResults: true
+      }
+    );
+    const byName = Object.fromEntries(checks.map((c) => [c.name, c.pass]));
+    expect(byName["tool:ui_search_nodes"]).toBe(false);
+    expect(byName["not-tool:ui_delete_node"]).toBe(false);
+    // add_node came AFTER connect_nodes, so ordering fails.
+    expect(byName["order:ui_add_node<ui_connect_nodes"]).toBe(false);
+    expect(byName["toolCalls<=2"]).toBe(false);
+    expect(byName["no-error-results"]).toBe(false);
+  });
+
+  it("fails a final-state predicate that throws, surfacing the error", () => {
+    const checks = checkToolLoopExpectations(observation([]), {
+      finalState: [
+        {
+          name: "boom",
+          test: () => {
+            throw new Error("kaboom");
+          }
+        }
+      ]
+    });
+    expect(checks[0].pass).toBe(false);
+    expect(checks[0].detail).toContain("kaboom");
+  });
+
+  it("returns no checks for empty expectations", () => {
+    expect(checkToolLoopExpectations(observation([]), {})).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -151,4 +151,110 @@ export function registerEvalCommand(program: Command): void {
         process.exitCode = 1;
       }
     });
+
+  evalCmd
+    .command("tool-loop")
+    .description(
+      "Run the frontend tool-loop eval suite (ui_* tools) against a provider/model and report metrics"
+    )
+    .option(
+      "-p, --provider <id>",
+      "Provider id (ollama, anthropic, openai, ...)"
+    )
+    .option("-m, --model <id>", "Model id for the provider")
+    .option(
+      "--cases <ids>",
+      "Comma-separated case ids to run (default: all; see --list)"
+    )
+    .option("--list", "List available cases and exit")
+    .option("--json", "Print the full report as JSON")
+    .option("--out <path>", "Write the JSON report to a file")
+    .option("--max-iterations <n>", "Turn cap per case (default 12)")
+    .option(
+      "--min-success <rate>",
+      "Exit non-zero when the success rate is below this threshold (0..1)"
+    )
+    .action(async (opts: EvalCliOptions & { maxIterations?: string }) => {
+      const {
+        TOOL_LOOP_EVAL_CASES,
+        runToolLoopEval,
+        formatToolLoopReport
+      } = await import("@nodetool-ai/agents");
+
+      if (opts.list) {
+        for (const c of TOOL_LOOP_EVAL_CASES) {
+          console.log(
+            `${c.id.padEnd(24)} ${c.description}` +
+              (c.needsModelProviders ? " (needs model providers)" : "")
+          );
+        }
+        return;
+      }
+
+      if (!opts.provider || !opts.model) {
+        console.error("--provider and --model are required (or use --list)");
+        process.exitCode = 1;
+        return;
+      }
+
+      let cases = TOOL_LOOP_EVAL_CASES;
+      if (opts.cases) {
+        const wanted = new Set(opts.cases.split(",").map((s) => s.trim()));
+        cases = TOOL_LOOP_EVAL_CASES.filter((c) => wanted.has(c.id));
+        const missing = [...wanted].filter(
+          (id) => !cases.some((c) => c.id === id)
+        );
+        if (missing.length > 0) {
+          console.error(`Unknown case ids: ${missing.join(", ")} (see --list)`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      try {
+        const { createProviderStrict } = await import("../providers.js");
+        const provider = await createProviderStrict(opts.provider);
+
+        console.log(
+          `Running ${cases.length} tool-loop case(s) with ${opts.provider}/${opts.model}`
+        );
+
+        const report = await runToolLoopEval({
+          provider,
+          model: opts.model,
+          cases,
+          maxIterations: opts.maxIterations
+            ? Number(opts.maxIterations)
+            : undefined,
+          onEvent: (line) => {
+            if (!opts.json) console.log(line);
+          }
+        });
+
+        if (opts.out) {
+          const { writeFile } = await import("node:fs/promises");
+          await writeFile(opts.out, JSON.stringify(report, null, 2), "utf-8");
+          console.log(`Report written to ${opts.out}`);
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          console.log("\n" + formatToolLoopReport(report));
+        }
+
+        if (opts.minSuccess !== undefined) {
+          const threshold = Number(opts.minSuccess);
+          if (report.summary.successRate < threshold) {
+            console.error(
+              `Success rate ${report.summary.successRate.toFixed(2)} below threshold ${threshold}`
+            );
+            process.exitCode = 1;
+          }
+        }
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
 }


### PR DESCRIPTION
Implements task **T-20260720-0002** — a headless, multi-turn tool-calling eval runner for the frontend `ui_*` tool surface.

## What it does
Hands a model an objective plus the real frontend tool contract, executes each requested tool against an in-memory **headless bridge**, feeds the result back, and repeats until the model stops calling tools or a turn cap is hit. This evaluates the incremental add-node/connect-node flow the browser UI and the agent WebSocket bridge actually expose — complementing the one-shot `graph-planner-eval` suite it's modeled on.

## Key pieces
- **`packages/agents/src/evals/tool-loop-eval.ts`** — `ToolLoopEvalCase` (`id`, `description`, `objective`, `initialState`, optional `needsModelProviders`, `expect`), the runner, and a **pure, unit-testable `checkToolLoopExpectations()`** in the spirit of `checkExpectations()`: required/forbidden tool names, ordering constraints, final-state predicates, min/max total tool calls, and a no-error-results check. Emits the **same result/summary metric shapes** as `graph-planner-eval.ts` (per-case `accepted`/`score`/`checks`/`toolCalls`/`durationMs`/`costUsd`; summary `successRate`/`meanScore`/`avgToolCalls`/`totalCostUsd`).
- **`tool-loop-bridge.ts`** — in-memory bridge implementing the graph-editor + discovery tool effects headlessly. **Tool names, descriptions, and Zod parameter schemas are reused verbatim from `@nodetool-ai/protocol`'s `uiToolSchemas`** — the single source of truth the `web/src/lib/tools/builtin/*` files also consume (each wraps the same `uiXParams` shapes). **The schemas are not forked.** The dependency direction is already correct (`agents → protocol`), so no extraction to a new package was needed; args are validated through the same `parseWithTypeCoercion` path as `FrontendToolRegistry.call`.
- **`tool-loop-cases.ts`** — built-in suite with a self-contained node catalog (deterministic, no live registry).
- **`packages/cli`** — `nodetool eval tool-loop --provider ollama --model <m>` to run against a local Ollama model.

## Tests
- Pure `checkToolLoopExpectations` tests, headless-bridge execution tests, and a **scripted-provider integration test** that drives the exact `generateLoop` self-executing tool-dispatch path a real model uses (no network).
- A **gated live test** (`tool-loop-eval.ollama.test.ts`) that runs against a local Ollama daemon when reachable and skips otherwise.

`npx vitest run` in `packages/agents` is green (1498 passed, 1 skipped = the live Ollama test); `tsc --noEmit` is clean.

## Note on the live Ollama run
The harness is fully Ollama-wired (real `OllamaProvider`, CLI command, gated live test). The sandbox this ran in has no Ollama daemon and blocks the Ollama binary CDN, so the live daemon path is exercised via the gated test where a daemon exists:
```
nodetool eval tool-loop --provider ollama --model qwen2.5:7b --min-success 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)