### PR TITLE
feat: offer node-llama-cpp in the Package Manager

### DIFF
--- a/electron/src/runtime/packages/definitions.ts
+++ b/electron/src/runtime/packages/definitions.ts
@@ -194,4 +194,19 @@ export const RUNTIME_PACKAGES: Record<RuntimePackageId, RuntimePackage> = {
       "@tensorflow-models/qna",
     ],
   }),
+
+  "node-llama-cpp": new NpmRuntimePackage({
+    id: "node-llama-cpp",
+    name: "llama.cpp (in-process)",
+    description:
+      "Runs GGUF models inside the NodeTool server — no separate llama.cpp server. Ships Metal on macOS; on Windows and Linux npm pulls the CPU, Vulkan and CUDA builds, which is why the download is large.",
+    category: "library",
+    versionRange: "3.x",
+    npmPackages: ["node-llama-cpp@3.19.1"],
+    packageNames: ["node-llama-cpp"],
+    // The prebuilt binaries dominate: ~50 MB on macOS (Metal only) versus
+    // ~640 MB on Windows / Linux, where npm installs every GPU-backend variant
+    // matching the platform (CPU, Vulkan, CUDA, CUDA-ext).
+    approxSizeMB: process.platform === "darwin" ? 50 : 640,
+  }),
 };

--- a/electron/src/types.d.ts
+++ b/electron/src/types.d.ts
@@ -1021,6 +1021,7 @@ export type RuntimePackageId =
   | "yt-dlp"
   | "transformers-js"
   | "tensorflow-js"
+  | "node-llama-cpp"
   | "tmux"
   | "claude"
   | "claude-agent-sdk";

--- a/packages/runtime/src/providers/node-llama-cpp-provider.ts
+++ b/packages/runtime/src/providers/node-llama-cpp-provider.ts
@@ -184,6 +184,69 @@ async function getDefaultModelsDir(): Promise<string> {
   return path.join(home, ".cache", "llama.cpp");
 }
 
+/** Default HuggingFace hub cache. Mirrors `@nodetool-ai/huggingface`'s
+ * `getDefaultHfCacheDir`; that package sits above runtime in the dependency
+ * order, so the resolution is duplicated rather than imported — same reason as
+ * {@link getDefaultModelsDir}. */
+async function getHfHubCacheDir(): Promise<string | null> {
+  const os = await importNodeBuiltin<typeof import("node:os")>("node:os");
+  const path = await importNodeBuiltin<typeof import("node:path")>("node:path");
+  if (!os || !path) return null;
+  const expand = (p: string) =>
+    p.startsWith("~") ? path.join(os.homedir(), p.slice(1)) : p;
+
+  const envCache = process.env.HF_HUB_CACHE;
+  if (envCache) return expand(envCache);
+  const hfHome = process.env.HF_HOME;
+  if (hfHome) return path.join(expand(hfHome), "hub");
+  return path.join(os.homedir(), ".cache", "huggingface", "hub");
+}
+
+/** A GGUF file discovered on disk. `id` is what gets loaded (a bare filename
+ * inside the models directory, or an absolute path elsewhere); `name` is what
+ * the model picker shows. */
+interface LocalGgufModel {
+  id: string;
+  name: string;
+}
+
+/** A directory entry that is a GGUF file. Symlinks count: the HuggingFace hub
+ * cache stores every snapshot file as a link into `blobs/`, so requiring a
+ * plain file hid those models entirely. */
+function isGgufEntry(entry: import("node:fs").Dirent): boolean {
+  return (
+    (entry.isFile() || entry.isSymbolicLink()) &&
+    entry.name.toLowerCase().endsWith(".gguf")
+  );
+}
+
+/** Absolute paths of every GGUF under `dir`. Sharded repos nest them a level
+ * or two deep, so recurse — bounded, since hub snapshots are shallow. */
+async function walkGgufFiles(
+  fsp: typeof import("node:fs/promises"),
+  path: typeof import("node:path"),
+  dir: string,
+  depth = 3
+): Promise<string[]> {
+  if (depth < 0) return [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (isGgufEntry(entry)) {
+      out.push(full);
+    } else if (entry.isDirectory()) {
+      out.push(...(await walkGgufFiles(fsp, path, full, depth - 1)));
+    }
+  }
+  return out;
+}
+
 function asText(content: Message["content"]): string {
   if (typeof content === "string") return content;
   if (!content) return "";
@@ -566,24 +629,39 @@ export class NodeLlamaCppProvider extends BaseProvider {
   }
 
   async getAvailableLanguageModels(): Promise<LanguageModel[]> {
-    const files = await this.scanGgufFiles();
-    return files.map((id) => ({ id, name: id, provider: "node_llama_cpp" }));
+    const models = await this.scanGgufFiles();
+    return models.map((m) => ({ ...m, provider: "node_llama_cpp" }));
   }
 
   async getAvailableEmbeddingModels(): Promise<EmbeddingModel[]> {
-    const files = await this.scanGgufFiles();
-    return files.map((id) => ({ id, name: id, provider: "node_llama_cpp" }));
+    const models = await this.scanGgufFiles();
+    return models.map((m) => ({ ...m, provider: "node_llama_cpp" }));
   }
 
-  /** List GGUF filenames (relative to the models directory) available locally. */
-  private async scanGgufFiles(): Promise<string[]> {
+  /**
+   * List the GGUF models available locally, from both places they land:
+   * the flat llama.cpp cache (or `NODE_LLAMA_CPP_MODELS_DIR`), and the
+   * HuggingFace hub cache that the app's model downloader writes to. Without
+   * the latter, a GGUF pulled from a HuggingFace repo was never selectable.
+   */
+  private async scanGgufFiles(): Promise<LocalGgufModel[]> {
+    const models = [
+      ...(await this.scanModelsDir()),
+      ...(await this.scanHfHubCache())
+    ];
+    // A models directory pointed at the hub cache would surface both views.
+    const seen = new Set<string>();
+    return models
+      .filter((m) => (seen.has(m.id) ? false : (seen.add(m.id), true)))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /** GGUFs sitting directly in the configured/default models directory. */
+  private async scanModelsDir(): Promise<LocalGgufModel[]> {
     const fsp = await importNodeBuiltin<typeof import("node:fs/promises")>(
       "node:fs/promises"
     );
-    const path = await importNodeBuiltin<typeof import("node:path")>(
-      "node:path"
-    );
-    if (!fsp || !path) return [];
+    if (!fsp) return [];
     const dir = await this.resolveModelsDir();
     let entries: import("node:fs").Dirent[];
     try {
@@ -592,11 +670,48 @@ export class NodeLlamaCppProvider extends BaseProvider {
       return [];
     }
     return entries
-      .filter(
-        (e) => e.isFile() && e.name.toLowerCase().endsWith(".gguf")
-      )
-      .map((e) => e.name)
-      .sort();
+      .filter((e) => isGgufEntry(e))
+      .map((e) => ({ id: e.name, name: e.name }));
+  }
+
+  /**
+   * GGUFs inside the HuggingFace hub cache, which stores them as
+   * `models--<org>--<repo>/snapshots/<sha>/<file>.gguf`. Those entries are
+   * symlinks into `blobs/`, so the walk must accept symlinks. Ids are absolute
+   * paths — {@link getOrLoadModel} loads those directly.
+   */
+  private async scanHfHubCache(): Promise<LocalGgufModel[]> {
+    const fsp = await importNodeBuiltin<typeof import("node:fs/promises")>(
+      "node:fs/promises"
+    );
+    const path = await importNodeBuiltin<typeof import("node:path")>(
+      "node:path"
+    );
+    if (!fsp || !path) return [];
+    const hubDir = await getHfHubCacheDir();
+    if (!hubDir) return [];
+
+    let repos: import("node:fs").Dirent[];
+    try {
+      repos = await fsp.readdir(hubDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const out: LocalGgufModel[] = [];
+    for (const repo of repos) {
+      if (!repo.isDirectory() || !repo.name.startsWith("models--")) continue;
+      // `models--org--repo` → `org/repo`; a repo with no org has one segment.
+      const label = repo.name.slice("models--".length).split("--").join("/");
+      const snapshots = path.join(hubDir, repo.name, "snapshots");
+      for (const file of await walkGgufFiles(fsp, path, snapshots)) {
+        out.push({
+          id: file,
+          name: `${path.basename(file)} (${label})`
+        });
+      }
+    }
+    return out;
   }
 
   isContextLengthError(error: unknown): boolean {

--- a/packages/runtime/tests/providers/node-llama-cpp-provider.test.ts
+++ b/packages/runtime/tests/providers/node-llama-cpp-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, rm, symlink, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -21,13 +21,24 @@ import { NodeLlamaCppProvider } from "../../src/providers/node-llama-cpp-provide
 
 describe("NodeLlamaCppProvider", () => {
   let modelsDir: string;
+  let hubDir: string;
+  let prevHubCache: string | undefined;
 
   beforeEach(async () => {
     modelsDir = await mkdtemp(join(tmpdir(), "nlc-models-"));
+    // Model discovery also reads the HuggingFace hub cache, so point it at an
+    // empty directory — otherwise these assertions pick up whatever GGUFs the
+    // developer happens to have downloaded.
+    hubDir = await mkdtemp(join(tmpdir(), "nlc-hub-empty-"));
+    prevHubCache = process.env.HF_HUB_CACHE;
+    process.env.HF_HUB_CACHE = hubDir;
   });
 
   afterEach(async () => {
+    if (prevHubCache === undefined) delete process.env.HF_HUB_CACHE;
+    else process.env.HF_HUB_CACHE = prevHubCache;
     await rm(modelsDir, { recursive: true, force: true });
+    await rm(hubDir, { recursive: true, force: true });
   });
 
   it("requires no secrets and reports its provider id", () => {
@@ -96,5 +107,107 @@ describe("NodeLlamaCppProvider", () => {
     expect(provider.isContextLengthError(new Error("network down"))).toBe(
       false
     );
+  });
+});
+
+/**
+ * GGUFs land in two places: the flat llama.cpp cache and the HuggingFace hub
+ * cache the app's downloader writes to. The hub layout nests them under
+ * `models--org--repo/snapshots/<sha>/` and stores each as a symlink into
+ * `blobs/`, so a scan that only read one flat directory and required
+ * `isFile()` found nothing — a downloaded model was never selectable.
+ */
+describe("NodeLlamaCppProvider – GGUF discovery", () => {
+  let hubDir: string;
+  let prevHubCache: string | undefined;
+
+  beforeEach(async () => {
+    hubDir = await mkdtemp(join(tmpdir(), "nlc-hub-"));
+    prevHubCache = process.env.HF_HUB_CACHE;
+    process.env.HF_HUB_CACHE = hubDir;
+  });
+
+  afterEach(async () => {
+    if (prevHubCache === undefined) delete process.env.HF_HUB_CACHE;
+    else process.env.HF_HUB_CACHE = prevHubCache;
+    await rm(hubDir, { recursive: true, force: true });
+  });
+
+  it("lists a symlinked GGUF in the models directory", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nlc-sym-"));
+    try {
+      await writeFile(join(dir, "real.bin"), "x");
+      await symlink(join(dir, "real.bin"), join(dir, "linked.gguf"));
+
+      const provider = new NodeLlamaCppProvider({
+        NODE_LLAMA_CPP_MODELS_DIR: dir
+      });
+      const models = await provider.getAvailableLanguageModels();
+      expect(models.map((m) => m.id)).toContain("linked.gguf");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers GGUFs in the HuggingFace hub cache with a readable name", async () => {
+    const snapshot = join(
+      hubDir,
+      "models--ggml-org--gemma-3-4b-it-GGUF",
+      "snapshots",
+      "abc123"
+    );
+    await mkdir(snapshot, { recursive: true });
+    const blob = join(hubDir, "blob-data");
+    await writeFile(blob, "x");
+    await symlink(blob, join(snapshot, "gemma-3-4b-it-Q4_K_M.gguf"));
+
+    const emptyDir = await mkdtemp(join(tmpdir(), "nlc-empty-"));
+    try {
+      const provider = new NodeLlamaCppProvider({
+        NODE_LLAMA_CPP_MODELS_DIR: emptyDir
+      });
+      const models = await provider.getAvailableLanguageModels();
+
+      expect(models).toHaveLength(1);
+      // Absolute id so the model loads from wherever the hub cache lives.
+      expect(models[0].id).toBe(join(snapshot, "gemma-3-4b-it-Q4_K_M.gguf"));
+      expect(models[0].name).toBe(
+        "gemma-3-4b-it-Q4_K_M.gguf (ggml-org/gemma-3-4b-it-GGUF)"
+      );
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps bare filenames for models in the models directory", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nlc-flat-"));
+    try {
+      await writeFile(join(dir, "local.gguf"), "x");
+      const provider = new NodeLlamaCppProvider({
+        NODE_LLAMA_CPP_MODELS_DIR: dir
+      });
+      const models = await provider.getAvailableLanguageModels();
+      // Relative ids keep already-saved workflow references working.
+      expect(models.map((m) => m.id)).toEqual(["local.gguf"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-GGUF files in the hub cache", async () => {
+    const snapshot = join(hubDir, "models--org--repo", "snapshots", "sha");
+    await mkdir(snapshot, { recursive: true });
+    await writeFile(join(snapshot, "config.json"), "{}");
+    await writeFile(join(snapshot, "README.md"), "hi");
+
+    const emptyDir = await mkdtemp(join(tmpdir(), "nlc-empty2-"));
+    try {
+      const provider = new NodeLlamaCppProvider({
+        NODE_LLAMA_CPP_MODELS_DIR: emptyDir
+      });
+      expect(await provider.getAvailableLanguageModels()).toEqual([]);
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
   });
 });

--- a/web/src/components/packages/usePackageManager.ts
+++ b/web/src/components/packages/usePackageManager.ts
@@ -34,6 +34,7 @@ const RUNTIME_GROUP: Record<string, "language" | "media" | "ai" | "agent"> = {
   "yt-dlp": "media",
   "transformers-js": "ai",
   "tensorflow-js": "ai",
+  "node-llama-cpp": "ai",
   tmux: "agent",
   claude: "agent"
 };


### PR DESCRIPTION
## Summary

Make the in-process llama.cpp backend installable on demand instead of shipping it in every desktop artifact.

`node-llama-cpp`'s prebuilt binaries are ~50 MB on macOS (Metal only) but ~640 MB on Windows/Linux, where npm pulls the CPU, Vulkan, CUDA and CUDA-ext variants. Baking that into the installer isn't worth it for a feature most users never touch.

## Changes

- `electron/src/runtime/packages/definitions.ts` — new `node-llama-cpp` `NpmRuntimePackage`, pinned to `3.19.1`, category `library`, platform-aware `approxSizeMB`.
- `electron/src/types.d.ts` — added the id to `RuntimePackageId`.
- `web/src/components/packages/usePackageManager.ts` — grouped under **AI runtimes** next to Transformers.js and TensorFlow.js.

The plumbing already existed: `NpmRuntimePackage` installs into `<userData>/optional-node`, Electron passes that root to the backend as `NODETOOL_OPTIONAL_NODE_MODULES`, and `importOptionalModule` falls back to it when the bare import misses. The provider's existing "install it from the Package Manager" error hint is now accurate.

Also carries a separate commit with the GGUF-discovery work that was already in the tree: scanning the HuggingFace hub cache alongside the llama.cpp models directory, following symlinks and recursing into sharded repos.

## Follow-ups (not in this PR)

- `packages/cli` declares `node-llama-cpp` as a hard `dependency`, so the published CLI pulls those binaries unconditionally. Making it an optional peer (matching `packages/runtime`) would fix that.
- `electron/electron-builder.json` still has inert `asarUnpack` globs for `node-llama-cpp` — the backend ships via `extraResources`, outside asar.

## Test plan

- [x] `npm run typecheck --workspace=electron`, web `tsc --noEmit`
- [x] `npm run lint --workspace=electron`
- [x] `definitions.test.ts`, `NpmRuntimePackage.test.ts`, `usePackageManager.test.ts`, `node-llama-cpp-provider.test.ts`
- [ ] Manual: install from Package Manager → AI runtimes, restart server, run a GGUF model

🤖 Generated with [Claude Code](https://claude.com/claude-code)