### PR TITLE
feat: add KIE webhook callback support (#3216)

### DIFF
--- a/packages/kie-nodes/src/kie-base.ts
+++ b/packages/kie-nodes/src/kie-base.ts
@@ -3,11 +3,16 @@
  * Uses native fetch (Node 18+).
  */
 
-import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import { loadMediaRefBytes, registerWebhookWait } from "@nodetool-ai/runtime";
 import type { MediaRefValue, ProcessingContext } from "@nodetool-ai/runtime";
 
 const KIE_API_BASE = "https://api.kie.ai";
 const KIE_UPLOAD_URL = "https://kieai.redpandaai.co/api/file-stream-upload";
+
+function getWebhookBaseUrl(): string | undefined {
+  const url = process.env.KIE_WEBHOOK_URL;
+  return url && url.trim() ? url.replace(/\/+$/, "") : undefined;
+}
 
 function headers(apiKey: string): Record<string, string> {
   return {
@@ -89,6 +94,17 @@ async function pollStatus(
     await new Promise((r) => setTimeout(r, pollInterval));
   }
   throw pollTimeoutError(taskId, maxAttempts, pollInterval);
+}
+
+async function fetchRecordInfo(
+  apiKey: string,
+  taskId: string
+): Promise<Record<string, unknown>> {
+  const url = `${KIE_API_BASE}/api/v1/jobs/recordInfo?taskId=${taskId}`;
+  const res = await fetch(url, { headers: headers(apiKey) });
+  const data = (await res.json()) as Record<string, unknown>;
+  if (data.code !== undefined) checkStatus(data);
+  return data;
 }
 
 async function downloadResult(
@@ -473,9 +489,28 @@ export async function kieExecuteTask(
   pollEndpoint?: string,
   resultObjectKey?: string
 ): Promise<KieExecuteResult> {
+  const webhookBase = getWebhookBaseUrl();
+
   if (submitEndpoint) {
     // Custom submit/poll endpoints (Veo, Runway, etc.)
-    const taskId = await submitCustom(apiKey, submitEndpoint, { model, ...input });
+    const customInput = webhookBase
+      ? { model, ...input, callBackUrl: `${webhookBase}/api/kie/webhook` }
+      : { model, ...input };
+    const taskId = await submitCustom(apiKey, submitEndpoint, customInput);
+
+    if (webhookBase) {
+      const timeoutMs = pollInterval * maxAttempts;
+      await registerWebhookWait(taskId, timeoutMs);
+      // Fetch the final status after webhook fires
+      const url = `${KIE_API_BASE}${pollEndpoint ?? submitEndpoint}?taskId=${taskId}`;
+      const res = await fetch(url, { headers: headers(apiKey) });
+      const statusData = (await res.json()) as Record<string, unknown>;
+      const creditsConsumed = parseCreditsConsumed(statusData);
+      const resultBytes = await downloadCustomResult(statusData);
+      const b64 = resultBytes.toString("base64");
+      return { data: b64, items: [b64], taskId, creditsConsumed };
+    }
+
     const statusData = await pollCustom(
       apiKey,
       taskId,
@@ -488,8 +523,21 @@ export async function kieExecuteTask(
     const b64 = resultBytes.toString("base64");
     return { data: b64, items: [b64], taskId, creditsConsumed };
   }
-  const taskId = await submitTask(apiKey, model, input);
-  const statusData = await pollStatus(apiKey, taskId, pollInterval, maxAttempts);
+
+  const finalInput = webhookBase
+    ? { ...input, callBackUrl: `${webhookBase}/api/kie/webhook` }
+    : input;
+  const taskId = await submitTask(apiKey, model, finalInput);
+
+  let statusData: Record<string, unknown>;
+  if (webhookBase) {
+    const timeoutMs = pollInterval * maxAttempts;
+    await registerWebhookWait(taskId, timeoutMs);
+    statusData = await fetchRecordInfo(apiKey, taskId);
+  } else {
+    statusData = await pollStatus(apiKey, taskId, pollInterval, maxAttempts);
+  }
+
   const creditsConsumed = parseCreditsConsumed(statusData);
   if (resultObjectKey) {
     const text = await downloadTextResult(apiKey, taskId, resultObjectKey);
@@ -506,11 +554,15 @@ export async function kieSubmitSuno(
   input: Record<string, unknown>,
   endpoint = "/api/v1/generate"
 ): Promise<string> {
-  // callBackUrl is always required by the Suno API. Since we poll for results
-  // we don't actually use it, so inject a placeholder if not already set.
+  // callBackUrl is always required by the Suno API. When KIE_WEBHOOK_URL is
+  // set we use it; otherwise inject a placeholder (we poll instead).
+  const webhookBase = getWebhookBaseUrl();
+  const callBackUrl = webhookBase
+    ? `${webhookBase}/api/kie/webhook`
+    : "https://nodetool.ai/kie-callback";
   const body = input.callBackUrl
     ? input
-    : { ...input, callBackUrl: "https://nodetool.ai/kie-callback" };
+    : { ...input, callBackUrl };
   const res = await fetch(`${KIE_API_BASE}${endpoint}`, {
     method: "POST",
     headers: headers(apiKey),
@@ -560,9 +612,20 @@ export async function kieExecuteSunoTask(
   endpoint?: string
 ): Promise<KieExecuteResult> {
   const taskId = await kieSubmitSuno(apiKey, input, endpoint);
-  const pollResult = await kiePollSuno(apiKey, taskId, pollInterval, maxAttempts);
+  const webhookBase = getWebhookBaseUrl();
+
+  let pollResult: Record<string, unknown>;
+  if (webhookBase) {
+    const timeoutMs = pollInterval * maxAttempts;
+    await registerWebhookWait(taskId, timeoutMs);
+    const url = `${KIE_API_BASE}/api/v1/generate/record-info?taskId=${taskId}`;
+    const res = await fetch(url, { headers: headers(apiKey) });
+    pollResult = (await res.json()) as Record<string, unknown>;
+  } else {
+    pollResult = await kiePollSuno(apiKey, taskId, pollInterval, maxAttempts);
+  }
+
   const creditsConsumed = parseCreditsConsumed(pollResult);
-  // Polling response: data.response.sunoData[].audioUrl
   const sunoData = (
     (pollResult.data as Record<string, unknown>)?.response as Record<string, unknown>
   )?.sunoData as Array<Record<string, unknown>>;

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -78,6 +78,13 @@ export { PythonProvider };
 export { ReplicateProvider };
 export { FalProvider };
 export { KieProvider };
+export {
+  registerWebhookWait,
+  resolveWebhook,
+  rejectWebhook,
+  hasPendingWebhook,
+  pendingCount as kieWebhookPendingCount
+} from "./kie-webhook-registry.js";
 export { ElevenLabsProvider };
 export { TopazProvider };
 export { ReveProvider };

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -41,6 +41,7 @@ import {
   selectMaskImageInput,
   type ModelInputField
 } from "./manifest-models.js";
+import { registerWebhookWait } from "./kie-webhook-registry.js";
 import { sniffAudioMime } from "./audio-mime.js";
 import { OpenAIProvider } from "./openai-provider.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
@@ -59,9 +60,19 @@ const log = createLogger("nodetool.runtime.providers.kie");
 const KIE_API_BASE = "https://api.kie.ai";
 const KIE_UPLOAD_URL =
   "https://kieai.redpandaai.co/api/file-stream-upload";
-// The Suno API always requires a callBackUrl. We poll for results instead of
-// receiving callbacks, so a placeholder satisfies the requirement.
+// The Suno API always requires a callBackUrl. When KIE_WEBHOOK_URL is set we
+// use it; otherwise a placeholder satisfies the requirement (we poll instead).
 const KIE_SUNO_CALLBACK = "https://nodetool.ai/kie-callback";
+
+/**
+ * When set, KIE tasks are submitted with a real callBackUrl and the provider
+ * waits for the webhook instead of polling. Set to the public base URL of this
+ * server (e.g. `https://myserver.example.com`).
+ */
+function getWebhookBaseUrl(): string | undefined {
+  const url = process.env.KIE_WEBHOOK_URL;
+  return url && url.trim() ? url.replace(/\/+$/, "") : undefined;
+}
 
 type KieChatApi = "openai" | "anthropic" | "responses";
 
@@ -358,6 +369,25 @@ async function submitTask(
   return taskId;
 }
 
+/**
+ * Submit a task with an optional webhook callback URL. When webhook mode is
+ * enabled, the callBackUrl is injected into the input so KIE calls us back
+ * when the task completes. The generic `/api/kie/webhook` endpoint extracts
+ * the taskId from the callback body.
+ */
+async function submitTaskWithWebhook(
+  apiKey: string,
+  model: string,
+  input: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<string> {
+  const webhookBase = getWebhookBaseUrl();
+  const finalInput = webhookBase
+    ? { ...input, callBackUrl: `${webhookBase}/api/kie/webhook` }
+    : input;
+  return submitTask(apiKey, model, finalInput, signal);
+}
+
 async function pollUntilDone(
   apiKey: string,
   taskId: string,
@@ -405,6 +435,26 @@ async function pollUntilDone(
   );
 }
 
+/**
+ * Wait for a KIE task to complete: use webhook if KIE_WEBHOOK_URL is set,
+ * otherwise fall back to polling.
+ */
+async function waitForCompletion(
+  apiKey: string,
+  taskId: string,
+  pollInterval: number,
+  maxAttempts: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (getWebhookBaseUrl()) {
+    const timeoutMs = pollInterval * maxAttempts;
+    log.info("Waiting for KIE webhook callback", { taskId, timeoutMs });
+    await registerWebhookWait(taskId, timeoutMs, signal);
+    return;
+  }
+  await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+}
+
 async function downloadResultBytes(
   apiKey: string,
   taskId: string,
@@ -437,7 +487,10 @@ async function submitSuno(
   input: Record<string, unknown>,
   signal?: AbortSignal
 ): Promise<string> {
-  const body = { ...input, callBackUrl: KIE_SUNO_CALLBACK };
+  const callBackUrl = getWebhookBaseUrl()
+    ? `${getWebhookBaseUrl()}/api/kie/webhook`
+    : KIE_SUNO_CALLBACK;
+  const body = { ...input, callBackUrl };
   const res = await fetch(`${KIE_API_BASE}${endpoint}`, {
     method: "POST",
     headers: headers(apiKey),
@@ -759,6 +812,17 @@ export class KieProvider extends BaseProvider {
         meta.maxAttempts,
         params.timeoutSeconds
       );
+      if (getWebhookBaseUrl()) {
+        const timeoutMs = pollInterval * maxAttempts;
+        log.info("Waiting for KIE Suno webhook callback", { taskId, timeoutMs });
+        await registerWebhookWait(taskId, timeoutMs, signal);
+        // After webhook fires, fetch the record to download audio
+        const url = `${KIE_API_BASE}/api/v1/generate/record-info?taskId=${taskId}`;
+        const res = await fetch(url, { headers: headers(apiKey), signal });
+        const record = await parseKieJson(res, "record-info");
+        const bytes = await this.downloadSunoAudio(record, signal);
+        return { data: bytes, mimeType: sniffAudioMime(bytes) };
+      }
       const record = await pollSuno(
         apiKey,
         taskId,
@@ -780,8 +844,8 @@ export class KieProvider extends BaseProvider {
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input, signal);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input, signal);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts, signal);
     const bytes = await downloadResultBytes(apiKey, taskId, signal);
     return { data: bytes, mimeType: sniffAudioMime(bytes) };
   }
@@ -875,8 +939,8 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie textToSpeech", { model: args.model });
     const apiKey = this.requireApiKey();
     const { pollInterval, maxAttempts } = this.pollConfig(args.model);
-    const taskId = await submitTask(apiKey, args.model, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    const taskId = await submitTaskWithWebhook(apiKey, args.model, input);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     const bytes = await downloadResultBytes(apiKey, taskId);
     return { data: bytes, mimeType: sniffAudioMime(bytes) };
   }
@@ -897,8 +961,8 @@ export class KieProvider extends BaseProvider {
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input, signal);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input, signal);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts, signal);
     return downloadResultBytes(apiKey, taskId, signal);
   }
 
@@ -953,8 +1017,8 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie textToImage", { model: modelId });
     const apiKey = this.requireApiKey();
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 
@@ -1042,8 +1106,8 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie imageToImage", { model: modelId, images: imageUrls.length });
 
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 
@@ -1085,8 +1149,8 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie inpaint", { model: modelId, images: imageUrls.length });
 
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
-    const taskId = await submitTask(apiKey, modelId, input);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
   }
 
@@ -1118,8 +1182,8 @@ export class KieProvider extends BaseProvider {
       modelId,
       params.timeoutSeconds
     );
-    const taskId = await submitTask(apiKey, modelId, input, signal);
-    await pollUntilDone(apiKey, taskId, pollInterval, maxAttempts, signal);
+    const taskId = await submitTaskWithWebhook(apiKey, modelId, input, signal);
+    await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts, signal);
     return downloadResultBytes(apiKey, taskId, signal);
   }
 

--- a/packages/runtime/src/providers/kie-webhook-registry.ts
+++ b/packages/runtime/src/providers/kie-webhook-registry.ts
@@ -1,0 +1,117 @@
+/**
+ * In-memory registry for KIE webhook callbacks. When `KIE_WEBHOOK_URL` is
+ * configured, task submissions include a real `callBackUrl`. This registry
+ * bridges the HTTP callback handler and the async task-wait code: the provider
+ * registers a pending task, the webhook endpoint resolves it.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+
+const log = createLogger("nodetool.runtime.providers.kie-webhook");
+
+interface PendingTask {
+  resolve: (data: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, PendingTask>();
+
+/**
+ * Register a task and return a promise that resolves when the webhook fires.
+ * Rejects on timeout or abort.
+ */
+export function registerWebhookWait(
+  taskId: string,
+  timeoutMs: number,
+  signal?: AbortSignal
+): Promise<unknown> {
+  return new Promise<unknown>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new Error("Aborted")
+      );
+      return;
+    }
+
+    const cleanup = (): void => {
+      pending.delete(taskId);
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Webhook callback not received for task ${taskId} within ${Math.round(timeoutMs / 1000)}s. ` +
+            "The job may still complete on KIE — check the KIE dashboard. " +
+            "Verify that KIE_WEBHOOK_URL is reachable from the internet."
+        )
+      );
+    }, timeoutMs);
+
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      cleanup();
+      reject(
+        signal?.reason instanceof Error
+          ? signal.reason
+          : new Error("Aborted")
+      );
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    pending.set(taskId, {
+      resolve: (data: unknown) => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        cleanup();
+        resolve(data);
+      },
+      reject: (err: Error) => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        cleanup();
+        reject(err);
+      },
+      timer
+    });
+
+    log.debug("Registered webhook wait", { taskId, timeoutMs });
+  });
+}
+
+/**
+ * Called by the webhook HTTP handler when KIE posts a callback.
+ * Returns true if a pending task was found and resolved.
+ */
+export function resolveWebhook(taskId: string, data?: unknown): boolean {
+  const entry = pending.get(taskId);
+  if (!entry) {
+    log.debug("No pending task for webhook callback", { taskId });
+    return false;
+  }
+  log.info("Webhook callback received", { taskId });
+  entry.resolve(data);
+  return true;
+}
+
+/**
+ * Called by the webhook HTTP handler when KIE posts a failure callback.
+ */
+export function rejectWebhook(taskId: string, reason: string): boolean {
+  const entry = pending.get(taskId);
+  if (!entry) return false;
+  log.info("Webhook failure callback received", { taskId, reason });
+  entry.reject(new Error(`KIE task failed (webhook): ${reason} (taskId: ${taskId})`));
+  return true;
+}
+
+export function hasPendingWebhook(taskId: string): boolean {
+  return pending.has(taskId);
+}
+
+/** Visible for testing. */
+export function pendingCount(): number {
+  return pending.size;
+}

--- a/packages/runtime/tests/providers/kie-webhook-registry.test.ts
+++ b/packages/runtime/tests/providers/kie-webhook-registry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  registerWebhookWait,
+  resolveWebhook,
+  rejectWebhook,
+  hasPendingWebhook,
+  kieWebhookPendingCount
+} from "../../src/providers/index.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("kie-webhook-registry", () => {
+  it("resolves when webhook fires", async () => {
+    const promise = registerWebhookWait("task-1", 5000);
+    expect(hasPendingWebhook("task-1")).toBe(true);
+
+    const resolved = resolveWebhook("task-1", { status: "success" });
+    expect(resolved).toBe(true);
+    expect(hasPendingWebhook("task-1")).toBe(false);
+
+    const result = await promise;
+    expect(result).toEqual({ status: "success" });
+  });
+
+  it("rejects when webhook sends failure", async () => {
+    const promise = registerWebhookWait("task-2", 5000);
+    rejectWebhook("task-2", "GENERATE_AUDIO_FAILED");
+
+    await expect(promise).rejects.toThrow("KIE task failed (webhook)");
+    expect(hasPendingWebhook("task-2")).toBe(false);
+  });
+
+  it("rejects on timeout", async () => {
+    vi.useFakeTimers();
+    const promise = registerWebhookWait("task-3", 100);
+
+    vi.advanceTimersByTime(150);
+
+    await expect(promise).rejects.toThrow("Webhook callback not received");
+    expect(hasPendingWebhook("task-3")).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("returns false for unknown task", () => {
+    expect(resolveWebhook("unknown-task")).toBe(false);
+    expect(rejectWebhook("unknown-task", "error")).toBe(false);
+  });
+
+  it("rejects immediately when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("pre-aborted"));
+
+    const promise = registerWebhookWait("task-4", 5000, controller.signal);
+    await expect(promise).rejects.toThrow("pre-aborted");
+  });
+
+  it("rejects when signal aborts during wait", async () => {
+    const controller = new AbortController();
+    const promise = registerWebhookWait("task-5", 60000, controller.signal);
+
+    expect(hasPendingWebhook("task-5")).toBe(true);
+    controller.abort(new Error("cancelled"));
+
+    await expect(promise).rejects.toThrow("cancelled");
+    expect(hasPendingWebhook("task-5")).toBe(false);
+  });
+
+  it("cleans up timer on resolve", async () => {
+    vi.useFakeTimers();
+    const promise = registerWebhookWait("task-6", 1000);
+    resolveWebhook("task-6", "done");
+    await promise;
+
+    // Advancing past the timeout should not cause issues
+    vi.advanceTimersByTime(2000);
+    vi.useRealTimers();
+  });
+
+  it("tracks pending count", async () => {
+    const initialCount = kieWebhookPendingCount();
+    const p1 = registerWebhookWait("count-1", 5000);
+    const p2 = registerWebhookWait("count-2", 5000);
+    expect(kieWebhookPendingCount()).toBe(initialCount + 2);
+
+    resolveWebhook("count-1");
+    resolveWebhook("count-2");
+    await p1;
+    await p2;
+    expect(kieWebhookPendingCount()).toBe(initialCount);
+  });
+});

--- a/packages/websocket/src/routes/kie-webhook.ts
+++ b/packages/websocket/src/routes/kie-webhook.ts
@@ -1,0 +1,80 @@
+import type { FastifyPluginAsync } from "fastify";
+import { resolveWebhook, rejectWebhook } from "@nodetool-ai/runtime";
+
+/**
+ * Extract a task ID from the KIE callback body. KIE may nest it under
+ * `data.taskId` or send it at the top level — try both.
+ */
+function extractTaskId(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const b = body as Record<string, unknown>;
+  if (typeof b.taskId === "string" && b.taskId) return b.taskId;
+  if (typeof b.task_id === "string" && b.task_id) return b.task_id;
+  const data = b.data;
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.taskId === "string" && d.taskId) return d.taskId;
+    if (typeof d.task_id === "string" && d.task_id) return d.task_id;
+  }
+  return undefined;
+}
+
+function extractStatus(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const b = body as Record<string, unknown>;
+  if (typeof b.status === "string") return b.status;
+  if (typeof b.state === "string") return b.state;
+  const data = b.data;
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.status === "string") return d.status;
+    if (typeof d.state === "string") return d.state;
+  }
+  return undefined;
+}
+
+const FAILURE_STATES = new Set([
+  "failed",
+  "fail",
+  "CREATE_TASK_FAILED",
+  "GENERATE_AUDIO_FAILED",
+  "CALLBACK_EXCEPTION",
+  "SENSITIVE_WORD_ERROR"
+]);
+
+const kieWebhookRoute: FastifyPluginAsync = async (app) => {
+  // Per-task URL: KIE calls POST /api/kie/webhook/:taskId
+  app.post<{ Params: { taskId: string } }>(
+    "/api/kie/webhook/:taskId",
+    async (req, reply) => {
+      const { taskId } = req.params;
+      const status = extractStatus(req.body);
+
+      if (status && FAILURE_STATES.has(status)) {
+        rejectWebhook(taskId, status);
+      } else {
+        resolveWebhook(taskId, req.body);
+      }
+      reply.send({ status: "accepted" });
+    }
+  );
+
+  // Generic URL: KIE calls POST /api/kie/webhook with taskId in body
+  app.post("/api/kie/webhook", async (req, reply) => {
+    const taskId = extractTaskId(req.body);
+    if (!taskId) {
+      reply.status(400).send({ error: "No taskId in request body" });
+      return;
+    }
+
+    const status = extractStatus(req.body);
+    if (status && FAILURE_STATES.has(status)) {
+      rejectWebhook(taskId, status);
+    } else {
+      resolveWebhook(taskId, req.body);
+    }
+    reply.send({ status: "accepted" });
+  });
+};
+
+export default kieWebhookRoute;

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -96,6 +96,7 @@ import falPricingRoute from "./routes/fal-pricing.js";
 import falPricingEstimateRoute from "./routes/fal-pricing-estimate.js";
 import kieCreditsRoute from "./routes/kie-credits.js";
 import kiePricingRoute from "./routes/kie-pricing.js";
+import kieWebhookRoute from "./routes/kie-webhook.js";
 import {
   agentSocketRoute,
   getAgentRuntime,
@@ -787,6 +788,7 @@ app.addHook("onRequest", async (req, reply) => {
     pathname.startsWith("/api/assets/packages/") ||
     pathname === "/api/nodes/metadata" ||
     pathname === "/api/node/metadata" ||
+    pathname.startsWith("/api/kie/webhook") ||
     isPublicWorkflowMetadataRequest(pathname, req.method)
   ) {
     return;
@@ -1104,6 +1106,7 @@ await app.register(falPricingRoute);
 await app.register(falPricingEstimateRoute);
 await app.register(kieCreditsRoute);
 await app.register(kiePricingRoute);
+await app.register(kieWebhookRoute);
 // MCP endpoints are only available in local/dev mode — not in production.
 // The configuration endpoints moved to the tRPC `mcpConfig` router; the
 // `/mcp` proxy below is a bare MCP over-HTTP transport and stays on REST.

--- a/packages/websocket/tests/kie-webhook.test.ts
+++ b/packages/websocket/tests/kie-webhook.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+vi.mock("@nodetool-ai/runtime", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/runtime")>();
+  return {
+    ...actual,
+    resolveWebhook: vi.fn(),
+    rejectWebhook: vi.fn()
+  };
+});
+
+import { resolveWebhook, rejectWebhook } from "@nodetool-ai/runtime";
+import kieWebhookRoute from "../src/routes/kie-webhook.js";
+
+const mockResolve = resolveWebhook as unknown as ReturnType<typeof vi.fn>;
+const mockReject = rejectWebhook as unknown as ReturnType<typeof vi.fn>;
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  app = Fastify();
+  await app.register(kieWebhookRoute);
+  await app.ready();
+  mockResolve.mockReturnValue(true);
+  mockReject.mockReturnValue(true);
+});
+
+afterEach(async () => {
+  await app.close();
+  vi.clearAllMocks();
+});
+
+describe("POST /api/kie/webhook/:taskId", () => {
+  it("resolves a pending task on success callback", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook/task-abc",
+      payload: { state: "success", data: { taskId: "task-abc" } }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: "accepted" });
+    expect(mockResolve).toHaveBeenCalledWith("task-abc", {
+      state: "success",
+      data: { taskId: "task-abc" }
+    });
+  });
+
+  it("rejects a pending task on failure callback", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook/task-xyz",
+      payload: { state: "failed" }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockReject).toHaveBeenCalledWith("task-xyz", "failed");
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("detects Suno failure statuses", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook/task-suno",
+      payload: { data: { status: "CREATE_TASK_FAILED" } }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockReject).toHaveBeenCalledWith("task-suno", "CREATE_TASK_FAILED");
+  });
+});
+
+describe("POST /api/kie/webhook (generic)", () => {
+  it("extracts taskId from body and resolves", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook",
+      payload: { taskId: "task-gen-1", state: "success" }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockResolve).toHaveBeenCalledWith("task-gen-1", {
+      taskId: "task-gen-1",
+      state: "success"
+    });
+  });
+
+  it("extracts taskId from data.taskId", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook",
+      payload: { data: { taskId: "task-nested" } }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockResolve).toHaveBeenCalledWith("task-nested", {
+      data: { taskId: "task-nested" }
+    });
+  });
+
+  it("returns 400 when no taskId found", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook",
+      payload: { something: "else" }
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: "No taskId in request body" });
+  });
+
+  it("handles empty body", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/kie/webhook",
+      payload: {}
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
When `KIE_WEBHOOK_URL` is set, KIE tasks use webhook callbacks instead of polling.

Closes #3216

Generated with [Claude Code](https://claude.ai/code)