### PR TITLE
feat(web): guided model onboarding in the Model Manager

### DIFF
--- a/web/src/components/hugging_face/model_list/ModelListHeader.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListHeader.tsx
@@ -82,6 +82,7 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
     }))
   );
   const theme = useTheme();
+  const isOnboarding = source === "onboarding";
 
   const handleSliderChange = (_: Event, value: number | number[]) => {
     const v = Array.isArray(value) ? value[0] : value;
@@ -97,14 +98,16 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
 
   return (
     <>
-      <SearchInput
-        focusOnTyping={true}
-        focusSearchInput={false}
-        width={250}
-        maxWidth={"300px"}
-        onSearchChange={setModelSearchTerm}
-        searchTerm={modelSearchTerm}
-      />
+      {!isOnboarding && (
+        <SearchInput
+          focusOnTyping={true}
+          focusSearchInput={false}
+          width={250}
+          maxWidth={"300px"}
+          onSearchChange={setModelSearchTerm}
+          searchTerm={modelSearchTerm}
+        />
+      )}
 
       <FlexRow
         sx={{
@@ -115,32 +118,38 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
           pr: 2
         }}
       >
-        <Text
-          size="small"
-          color="secondary"
-          sx={{ whiteSpace: "nowrap", mr: "auto", ml: 2 }}
-        >
-          {source === "hub"
-            ? filteredCount >= HUB_RESULT_LIMIT
-              ? `Top ${HUB_RESULT_LIMIT} results`
-              : `${filteredCount} result${filteredCount === 1 ? "" : "s"}`
-            : filteredCount !== totalCount
-              ? `${filteredCount} of ${totalCount} models`
-              : `${totalCount} models`}
-        </Text>
+        {!isOnboarding && (
+          <Text
+            size="small"
+            color="secondary"
+            sx={{ whiteSpace: "nowrap", mr: "auto", ml: 2 }}
+          >
+            {source === "hub"
+              ? filteredCount >= HUB_RESULT_LIMIT
+                ? `Top ${HUB_RESULT_LIMIT} results`
+                : `${filteredCount} result${filteredCount === 1 ? "" : "s"}`
+              : filteredCount !== totalCount
+                ? `${filteredCount} of ${totalCount} models`
+                : `${totalCount} models`}
+          </Text>
+        )}
 
         <SourceToggle source={source} onChange={onSourceChange} />
 
-        <ScopeToggle
-          scope={scope}
-          onChange={onScopeChange}
-          workerName={workerName}
-          supported={workerSupported}
-        />
+        {!isOnboarding && (
+          <ScopeToggle
+            scope={scope}
+            onChange={onScopeChange}
+            workerName={workerName}
+            supported={workerSupported}
+          />
+        )}
 
-        <Box sx={dividerSx(theme)} />
+        {!isOnboarding && (
+          <>
+            <Box sx={dividerSx(theme)} />
 
-        <FlexRow align="center" gap={1.25}>
+            <FlexRow align="center" gap={1.25}>
           <Text size="small" color="secondary" sx={{ whiteSpace: "nowrap" }}>
             Sort
           </Text>
@@ -254,6 +263,8 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
             {maxModelSizeGB === 0 ? "All" : `${maxModelSizeGB} GB`}
           </Text>
         </FlexRow>
+          </>
+        )}
       </FlexRow>
     </>
   );

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -138,7 +138,8 @@ const ModelListIndex: React.FC = () => {
     selectedModelType, setSelectedModelType,
     modelSearchTerm, setModelSearchTerm,
     scope, setScope,
-    source, setSource
+    source, setSource,
+    sourceInitialized, setSourceInitialized
   } = useModelManagerStore(
     useShallow((state) => ({
       selectedModelType: state.selectedModelType,
@@ -148,7 +149,9 @@ const ModelListIndex: React.FC = () => {
       scope: state.scope,
       setScope: state.setScope,
       source: state.source,
-      setSource: state.setSource
+      setSource: state.setSource,
+      sourceInitialized: state.sourceInitialized,
+      setSourceInitialized: state.setSourceInitialized
     }))
   );
   const { activeWorker } = useWorkers();
@@ -232,10 +235,18 @@ const ModelListIndex: React.FC = () => {
       // view filters so the new one starts clean instead of inheriting stale
       // type/status selections.
       setSource(nextSource);
+      // An explicit choice settles the source: don't auto-default afterwards.
+      setSourceInitialized(true);
       setModelSearchTerm("");
       setSelectedModelType("All");
     },
-    [source, setSource, setModelSearchTerm, setSelectedModelType]
+    [
+      source,
+      setSource,
+      setSourceInitialized,
+      setModelSearchTerm,
+      setSelectedModelType
+    ]
   );
 
   const flattenedList = useMemo(() => {
@@ -339,6 +350,37 @@ const ModelListIndex: React.FC = () => {
       setScope("local");
     }
   }, [scope, workerName, setScope]);
+
+  // First-run onboarding: when the local install is confirmed empty, open the
+  // "Get Started" guide instead of a blank Installed list. One-shot per session
+  // (sourceInitialized) so opening the still-empty Installed tab doesn't bounce
+  // back. Only for the plain local view — a worker or a non-default source means
+  // the user is already somewhere deliberate.
+  useEffect(() => {
+    if (
+      !sourceInitialized &&
+      source === "installed" &&
+      scope === "local" &&
+      workerName == null &&
+      !isLoading &&
+      !isFetching &&
+      Array.isArray(allModels) &&
+      allModels.length === 0
+    ) {
+      setSource("onboarding");
+      setSourceInitialized(true);
+    }
+  }, [
+    sourceInitialized,
+    source,
+    scope,
+    workerName,
+    isLoading,
+    isFetching,
+    allModels,
+    setSource,
+    setSourceInitialized
+  ]);
 
   if (isLoading) {
     return (

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -20,6 +20,7 @@ import { useModelManagerStore } from "../../../stores/ModelManagerStore";
 import ModelListItem from "./ModelListItem";
 import ModelsRightSidebar from "./ModelsRightSidebar";
 import LocalModelsHero from "./LocalModelsHero";
+import ModelOnboarding from "../onboarding/ModelOnboarding";
 import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
 import type { UnifiedModel } from "../../../stores/ApiTypes";
 import { useModelCompatibility } from "./useModelCompatibility";
@@ -430,6 +431,12 @@ const ModelListIndex: React.FC = () => {
         />
       </Box>
       <Box className="main">
+        {source === "onboarding" ? (
+          <Box className="content">
+            <ModelOnboarding onDownload={handleStartDownload} />
+          </Box>
+        ) : (
+          <>
         <Box className="sidebar">
           <ModelTypeSidebar />
         </Box>
@@ -657,6 +664,8 @@ const ModelListIndex: React.FC = () => {
         <Box className="right-sidebar">
           <ModelsRightSidebar />
         </Box>
+          </>
+        )}
       </Box>
     </Box>
   );

--- a/web/src/components/hugging_face/model_list/SourceToggle.tsx
+++ b/web/src/components/hugging_face/model_list/SourceToggle.tsx
@@ -8,10 +8,11 @@ interface SourceToggleProps {
 }
 
 /**
- * Catalog source toggle for the ModelManager. "Installed" lists models on disk
- * (or the attached worker); "Recommended" lists the curated catalog aggregated
- * from installed nodes; "Hub" searches the live HuggingFace Hub. The latter two
- * are browsable for download.
+ * Catalog source toggle for the ModelManager. "Get Started" is the guided,
+ * hardware-aware onboarding; "Installed" lists models on disk (or the attached
+ * worker); "Recommended" lists the curated catalog aggregated from installed
+ * nodes; "Hub" searches the live HuggingFace Hub. The last three are browsable
+ * for download.
  */
 const SourceToggleInternal: React.FC<SourceToggleProps> = ({
   source,
@@ -34,6 +35,9 @@ const SourceToggleInternal: React.FC<SourceToggleProps> = ({
       onChange={handleChange}
       aria-label="model source"
     >
+      <ToggleOption value="onboarding" aria-label="get started">
+        Get Started
+      </ToggleOption>
       <ToggleOption value="installed" aria-label="installed models">
         Installed
       </ToggleOption>

--- a/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
@@ -33,6 +33,10 @@ jest.mock("../LocalModelsHero", () => ({
   __esModule: true,
   default: () => null
 }));
+jest.mock("../../onboarding/ModelOnboarding", () => ({
+  __esModule: true,
+  default: () => null
+}));
 
 import ModelListIndex from "../ModelListIndex";
 import { useModelManagerStore } from "../../../../stores/ModelManagerStore";
@@ -82,6 +86,9 @@ beforeEach(() => {
   useModelManagerStore.setState({
     scope: "local",
     source: "installed",
+    // These tests exercise the Installed/Recommended views directly, so pin the
+    // source as already-settled to bypass the empty-install onboarding default.
+    sourceInitialized: true,
     modelSearchTerm: "",
     selectedModelType: "All"
   });
@@ -154,6 +161,60 @@ describe("ModelListIndex scope toggle", () => {
     expect(
       screen.getByText(/gathered from the nodes you have installed/i)
     ).toBeInTheDocument();
+  });
+
+  it("defaults to onboarding when nothing is installed locally", async () => {
+    mockUseWorkers.mockReturnValue({ activeWorker: null });
+    useModelManagerStore.setState({
+      source: "installed",
+      sourceInitialized: false
+    });
+    renderIndex();
+    await waitFor(() =>
+      expect(useModelManagerStore.getState().source).toBe("onboarding")
+    );
+    expect(useModelManagerStore.getState().sourceInitialized).toBe(true);
+  });
+
+  it("stays on Installed when local models exist", async () => {
+    mockUseWorkers.mockReturnValue({ activeWorker: null });
+    mockUseModels.mockReturnValue({
+      ...EMPTY_MODELS,
+      allModels: [{ id: "org/m", name: "m", type: "hf.text_generation" }],
+      filteredModels: [{ id: "org/m", name: "m", type: "hf.text_generation" }]
+    });
+    useModelManagerStore.setState({
+      source: "installed",
+      sourceInitialized: false
+    });
+    renderIndex();
+    // Give the auto-default effect a chance to (not) run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useModelManagerStore.getState().source).toBe("installed");
+  });
+
+  it("does not auto-default to onboarding while a worker is attached", async () => {
+    mockUseWorkers.mockReturnValue({ activeWorker: makeInstance() });
+    useModelManagerStore.setState({
+      scope: "local",
+      source: "installed",
+      sourceInitialized: false
+    });
+    renderIndex();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useModelManagerStore.getState().source).toBe("installed");
+  });
+
+  it("does not bounce back to onboarding after the user opens Installed", async () => {
+    mockUseWorkers.mockReturnValue({ activeWorker: null });
+    // User has explicitly settled on Installed even though it's empty.
+    useModelManagerStore.setState({
+      source: "installed",
+      sourceInitialized: true
+    });
+    renderIndex();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useModelManagerStore.getState().source).toBe("installed");
   });
 
   it("falls back to Local scope when the worker detaches", async () => {

--- a/web/src/components/hugging_face/model_list/useModels.ts
+++ b/web/src/components/hugging_face/model_list/useModels.ts
@@ -194,6 +194,8 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
   });
 
   const allModels = useMemo(() => {
+    // Onboarding renders its own curated guidance; it needs no model list here.
+    if (source === "onboarding") return [];
     if (source === "recommended") return recommendedCatalog;
     if (source === "hub") return hubModels;
     return rawModels?.filter(isManageableModel);

--- a/web/src/components/hugging_face/onboarding/EngineGuide.tsx
+++ b/web/src/components/hugging_face/onboarding/EngineGuide.tsx
@@ -80,18 +80,15 @@ const EngineCard: React.FC<{ engine: OnboardingEngine }> = ({ engine }) => {
 
 const NodePackRow: React.FC<{ pack: OnboardingNodePack }> = ({ pack }) => {
   const theme = useTheme();
-  const { available, installedNames, busyIds, install } = useNodePacksStore(
-    useShallow((state) => ({
-      available: state.available,
-      installedNames: state.installed.map((p) => p.repo_id),
-      busyIds: state.busyIds,
-      install: state.install
-    }))
+  // Select primitives only — deriving a new array inside the selector would
+  // change the snapshot on every render and loop useSyncExternalStore.
+  const available = useNodePacksStore((state) => state.available);
+  const install = useNodePacksStore((state) => state.install);
+  const isInstalled = useNodePacksStore((state) =>
+    state.installed.some((p) => p.repo_id === pack.repoId)
   );
+  const isBusy = useNodePacksStore((state) => state.busyIds.includes(pack.repoId));
   const openPackageManager = useOpenPackageManager();
-
-  const isInstalled = installedNames.includes(pack.repoId);
-  const isBusy = busyIds.includes(pack.repoId);
 
   const handleInstall = useCallback(() => {
     if (available) {

--- a/web/src/components/hugging_face/onboarding/EngineGuide.tsx
+++ b/web/src/components/hugging_face/onboarding/EngineGuide.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback, useEffect, useMemo } from "react";
+import { useTheme } from "@mui/material/styles";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ExtensionOutlinedIcon from "@mui/icons-material/ExtensionOutlined";
+import {
+  Card,
+  Caption,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  Text,
+  TextLink,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import useNodePacksStore from "../../../stores/NodePacksStore";
+import { useShallow } from "zustand/react/shallow";
+import { useOpenPackageManager } from "../../../hooks/useOpenPackageManager";
+import {
+  ONBOARDING_ENGINES,
+  ONBOARDING_NODE_PACKS,
+  type OnboardingEngine,
+  type OnboardingNodePack
+} from "./onboardingCatalog";
+
+const EngineCard: React.FC<{ engine: OnboardingEngine }> = ({ engine }) => {
+  const theme = useTheme();
+  const statusChip = engine.bundled ? (
+    <Chip label="Bundled" compact color="success" variant="outlined" />
+  ) : engine.runtimeId ? (
+    <Chip label="Runtime" compact variant="outlined" />
+  ) : null;
+
+  return (
+    <Card
+      variant="outlined"
+      padding="normal"
+      sx={{
+        borderRadius: BORDER_RADIUS.md,
+        border: `1px solid ${theme.vars.palette.divider}`,
+        backgroundColor: theme.vars.palette.background.paper,
+        height: "100%"
+      }}
+    >
+      <FlexColumn gap={1} sx={{ height: "100%" }}>
+        <FlexRow gap={1} align="center" justify="space-between">
+          <Text size="normal" weight={600}>
+            {engine.name}
+          </Text>
+          {statusChip}
+        </FlexRow>
+        <Caption sx={{ color: theme.vars.palette.primary.main }}>
+          {engine.tagline}
+        </Caption>
+        <Caption sx={{ opacity: 0.7, lineHeight: 1.5, flex: 1 }}>
+          {engine.description}
+        </Caption>
+        {engine.platform && (
+          <Caption sx={{ opacity: 0.55 }}>{engine.platform}</Caption>
+        )}
+        <FlexRow gap={0.5} sx={{ flexWrap: "wrap", mt: 0.5 }}>
+          {engine.formats.map((fmt) => (
+            <Chip key={fmt} label={fmt} compact variant="outlined" />
+          ))}
+        </FlexRow>
+        <TextLink
+          href={engine.docsUrl}
+          external
+          sx={{ mt: 0.5, fontSize: "var(--fontSizeSmall)" }}
+        >
+          Learn more <OpenInNewIcon sx={{ fontSize: 12, ml: 0.25 }} />
+        </TextLink>
+      </FlexColumn>
+    </Card>
+  );
+};
+
+const NodePackRow: React.FC<{ pack: OnboardingNodePack }> = ({ pack }) => {
+  const theme = useTheme();
+  const { available, installedNames, busyIds, install } = useNodePacksStore(
+    useShallow((state) => ({
+      available: state.available,
+      installedNames: state.installed.map((p) => p.repo_id),
+      busyIds: state.busyIds,
+      install: state.install
+    }))
+  );
+  const openPackageManager = useOpenPackageManager();
+
+  const isInstalled = installedNames.includes(pack.repoId);
+  const isBusy = busyIds.includes(pack.repoId);
+
+  const handleInstall = useCallback(() => {
+    if (available) {
+      void install(pack.repoId);
+    } else {
+      openPackageManager();
+    }
+  }, [available, install, openPackageManager, pack.repoId]);
+
+  return (
+    <FlexRow
+      gap={2}
+      align="center"
+      justify="space-between"
+      sx={{
+        padding: "0.65rem 0.85rem",
+        borderRadius: BORDER_RADIUS.sm,
+        border: `1px solid ${theme.vars.palette.divider}`,
+        backgroundColor: theme.vars.palette.background.paper
+      }}
+    >
+      <FlexColumn gap={0.25} sx={{ minWidth: 0 }}>
+        <Text size="small" weight={600}>
+          {pack.name}
+        </Text>
+        <Caption sx={{ opacity: 0.7, lineHeight: 1.4 }}>
+          {pack.description}
+        </Caption>
+      </FlexColumn>
+      {isInstalled ? (
+        <FlexRow gap={0.5} align="center" sx={{ flexShrink: 0 }}>
+          <CheckCircleIcon
+            sx={{ fontSize: 16, color: theme.vars.palette.success.main }}
+          />
+          <Caption color="secondary">Installed</Caption>
+        </FlexRow>
+      ) : (
+        <EditorButton
+          variant="outlined"
+          density="compact"
+          size="small"
+          disabled={isBusy}
+          onClick={handleInstall}
+          startIcon={
+            isBusy ? (
+              <LoadingSpinner inline size={14} />
+            ) : (
+              <ExtensionOutlinedIcon sx={{ fontSize: 15 }} />
+            )
+          }
+          sx={{ flexShrink: 0 }}
+        >
+          {available ? "Install" : "Open Manager"}
+        </EditorButton>
+      )}
+    </FlexRow>
+  );
+};
+
+const EngineGuide: React.FC = () => {
+  const theme = useTheme();
+  const { available, refresh } = useNodePacksStore(
+    useShallow((state) => ({
+      available: state.available,
+      refresh: state.refresh
+    }))
+  );
+  const openPackageManager = useOpenPackageManager();
+
+  useEffect(() => {
+    if (available) {
+      void refresh();
+    }
+  }, [available, refresh]);
+
+  const engines = useMemo(() => ONBOARDING_ENGINES, []);
+
+  return (
+    <FlexColumn gap={3}>
+      <FlexColumn gap={1.5}>
+        <FlexColumn gap={0.25}>
+          <Text size="big" weight={600}>
+            Local engines
+          </Text>
+          <Caption sx={{ opacity: 0.7 }}>
+            NodeTool runs models through these engines. Ollama is the easiest
+            start; the others unlock more model types.
+          </Caption>
+        </FlexColumn>
+        <div
+          css={{
+            display: "grid",
+            gap: "0.75rem",
+            gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))"
+          }}
+        >
+          {engines.map((engine) => (
+            <EngineCard key={engine.id} engine={engine} />
+          ))}
+        </div>
+      </FlexColumn>
+
+      <FlexColumn gap={1.5}>
+        <FlexRow gap={1} align="center" justify="space-between">
+          <FlexColumn gap={0.25}>
+            <Text size="big" weight={600}>
+              Node packs
+            </Text>
+            <Caption sx={{ opacity: 0.7 }}>
+              {available
+                ? "Install the packs that add the nodes you want to use."
+                : "Node packs install from the desktop app's Package Manager."}
+            </Caption>
+          </FlexColumn>
+          <EditorButton
+            variant="text"
+            density="compact"
+            size="small"
+            endIcon={<OpenInNewIcon sx={{ fontSize: 13 }} />}
+            onClick={openPackageManager}
+          >
+            Package Manager
+          </EditorButton>
+        </FlexRow>
+        <FlexColumn gap={1}>
+          {ONBOARDING_NODE_PACKS.map((pack) => (
+            <NodePackRow key={pack.repoId} pack={pack} />
+          ))}
+        </FlexColumn>
+        {!available && (
+          <Caption sx={{ opacity: 0.55, color: theme.vars.palette.text.secondary }}>
+            Running in the browser? Model downloads still work here — node packs
+            and runtimes are managed in the desktop app.
+          </Caption>
+        )}
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+export default memo(EngineGuide);

--- a/web/src/components/hugging_face/onboarding/HardwareCard.tsx
+++ b/web/src/components/hugging_face/onboarding/HardwareCard.tsx
@@ -1,0 +1,182 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback, useMemo } from "react";
+import { useTheme } from "@mui/material/styles";
+import MemoryIcon from "@mui/icons-material/Memory";
+import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard";
+import {
+  Card,
+  Caption,
+  Chip,
+  FlexColumn,
+  FlexRow,
+  SelectField,
+  Text,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { useModelManagerStore } from "../../../stores/ModelManagerStore";
+import { TIER_LABELS, type HardwareProfile } from "./useHardwareProfile";
+
+interface HardwareCardProps {
+  profile: HardwareProfile;
+}
+
+const AUTO_VALUE = "auto";
+const OVERRIDE_OPTIONS = [
+  { value: AUTO_VALUE, label: "Auto-detect" },
+  { value: "4", label: "4 GB" },
+  { value: "6", label: "6 GB" },
+  { value: "8", label: "8 GB" },
+  { value: "12", label: "12 GB" },
+  { value: "16", label: "16 GB" },
+  { value: "24", label: "24 GB" },
+  { value: "32", label: "32 GB" },
+  { value: "48", label: "48 GB" }
+];
+
+const budgetNote = (profile: HardwareProfile): string => {
+  switch (profile.budgetSource) {
+    case "gpu":
+      return "Detected from your GPU.";
+    case "unified-memory":
+      return "Estimated from system memory — set your GPU's VRAM for a sharper match.";
+    case "manual":
+      return "Using the value you set.";
+    default:
+      return "We couldn't detect your hardware. Pick your GPU memory to get recommendations.";
+  }
+};
+
+const HardwareCard: React.FC<HardwareCardProps> = ({ profile }) => {
+  const theme = useTheme();
+  const setVramOverrideGb = useModelManagerStore(
+    (state) => state.setVramOverrideGb
+  );
+  const override = useModelManagerStore((state) => state.vramOverrideGb);
+
+  const handleOverrideChange = useCallback(
+    (value: string) => {
+      setVramOverrideGb(value === AUTO_VALUE ? null : Number(value));
+    },
+    [setVramOverrideGb]
+  );
+
+  const selectValue = useMemo(
+    () => (override != null && override > 0 ? String(override) : AUTO_VALUE),
+    [override]
+  );
+
+  return (
+    <Card
+      variant="outlined"
+      padding="comfortable"
+      sx={{
+        borderRadius: BORDER_RADIUS.lg,
+        border: `1px solid ${theme.vars.palette.divider}`,
+        backgroundColor: theme.vars.palette.background.paper
+      }}
+    >
+      <FlexRow gap={2} align="center" justify="space-between" sx={{ flexWrap: "wrap" }}>
+        <FlexRow gap={1.5} align="center" sx={{ minWidth: 0 }}>
+          <FlexRow
+            align="center"
+            justify="center"
+            sx={{
+              width: 44,
+              height: 44,
+              minWidth: 44,
+              borderRadius: BORDER_RADIUS.md,
+              backgroundColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+              color: theme.vars.palette.primary.main
+            }}
+          >
+            <DeveloperBoardIcon sx={{ fontSize: 22 }} />
+          </FlexRow>
+          <FlexColumn sx={{ minWidth: 0 }}>
+            <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap" }}>
+              <Text size="normal" weight={600}>
+                Your machine
+              </Text>
+              {profile.tier && (
+                <Chip label={TIER_LABELS[profile.tier]} compact variant="outlined" />
+              )}
+            </FlexRow>
+            <Caption sx={{ opacity: 0.65, lineHeight: 1.45 }}>
+              {budgetNote(profile)}
+            </Caption>
+          </FlexColumn>
+        </FlexRow>
+
+        <FlexRow gap={3} align="center" sx={{ flexWrap: "wrap" }}>
+          <Stat
+            icon={<DeveloperBoardIcon sx={{ fontSize: 14 }} />}
+            label="GPU memory"
+            value={
+              profile.vramGb != null ? `${Math.round(profile.vramGb)} GB` : "—"
+            }
+          />
+          <Stat
+            icon={<MemoryIcon sx={{ fontSize: 14 }} />}
+            label="System RAM"
+            value={
+              profile.ramGb != null ? `${Math.round(profile.ramGb)} GB` : "—"
+            }
+          />
+          <Stat
+            label="Recommend for"
+            value={
+              profile.budgetGb != null ? `${profile.budgetGb} GB` : "Not set"
+            }
+            highlight
+          />
+          <FlexColumn gap={0.25} sx={{ minWidth: 128 }}>
+            <Caption sx={{ opacity: 0.55, whiteSpace: "nowrap" }}>
+              GPU memory
+            </Caption>
+            <SelectField
+              label="GPU memory budget"
+              hideLabel
+              variant="outlined"
+              value={selectValue}
+              onChange={handleOverrideChange}
+              options={OVERRIDE_OPTIONS}
+            />
+          </FlexColumn>
+        </FlexRow>
+      </FlexRow>
+    </Card>
+  );
+};
+
+interface StatProps {
+  label: string;
+  value: string;
+  icon?: React.ReactNode;
+  highlight?: boolean;
+}
+
+const Stat: React.FC<StatProps> = ({ label, value, icon, highlight }) => {
+  const theme = useTheme();
+  return (
+    <FlexColumn align="flex-start" gap={0.25} sx={{ minWidth: 0 }}>
+      <FlexRow align="center" gap={0.5}>
+        {icon}
+        <Text
+          size="big"
+          weight={600}
+          sx={{
+            lineHeight: 1.1,
+            fontVariantNumeric: "tabular-nums",
+            color: highlight
+              ? theme.vars.palette.primary.main
+              : theme.vars.palette.text.primary
+          }}
+        >
+          {value}
+        </Text>
+      </FlexRow>
+      <Caption sx={{ opacity: 0.55, whiteSpace: "nowrap" }}>{label}</Caption>
+    </FlexColumn>
+  );
+};
+
+export default memo(HardwareCard);

--- a/web/src/components/hugging_face/onboarding/ModelOnboarding.tsx
+++ b/web/src/components/hugging_face/onboarding/ModelOnboarding.tsx
@@ -1,0 +1,181 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useEffect, useMemo, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import RocketLaunchOutlinedIcon from "@mui/icons-material/RocketLaunchOutlined";
+import {
+  Caption,
+  FlexColumn,
+  FlexRow,
+  Text,
+  ToggleGroup,
+  ToggleOption,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { useShallow } from "zustand/react/shallow";
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+import { useHfCacheStatusStore } from "../../../stores/HfCacheStatusStore";
+import {
+  buildHfCacheRequest,
+  canCheckHfCache,
+  getHfCacheKey
+} from "../../../utils/hfCache";
+import { useHardwareProfile } from "./useHardwareProfile";
+import HardwareCard from "./HardwareCard";
+import EngineGuide from "./EngineGuide";
+import OnboardingModelRow from "./OnboardingModelRow";
+import {
+  CAPABILITY_LABELS,
+  ONBOARDING_MODELS,
+  sortModelsByFit,
+  type OnboardingCapability
+} from "./onboardingCatalog";
+
+interface ModelOnboardingProps {
+  /** Kicks off a real download through the shared download store. */
+  onDownload: (model: UnifiedModel) => void;
+}
+
+type Filter = "all" | OnboardingCapability;
+
+/** Capabilities in display order, only those that have catalog entries. */
+const CAPABILITY_ORDER: OnboardingCapability[] = [
+  "chat",
+  "vision",
+  "image",
+  "speech-to-text",
+  "text-to-speech",
+  "embedding"
+];
+
+const ModelOnboarding: React.FC<ModelOnboardingProps> = ({ onDownload }) => {
+  const theme = useTheme();
+  const profile = useHardwareProfile();
+  const [filter, setFilter] = useState<Filter>("all");
+
+  const { cacheStatuses, cacheVersion, ensureStatuses } = useHfCacheStatusStore(
+    useShallow((state) => ({
+      cacheStatuses: state.statuses,
+      cacheVersion: state.version,
+      ensureStatuses: state.ensureStatuses
+    }))
+  );
+
+  useEffect(() => {
+    const requests = ONBOARDING_MODELS.map((entry) =>
+      buildHfCacheRequest(entry.model)
+    ).filter((request): request is NonNullable<typeof request> => request !== null);
+    if (requests.length > 0) {
+      void ensureStatuses(requests);
+    }
+  }, [ensureStatuses, cacheVersion]);
+
+  const availableCapabilities = useMemo(() => {
+    const present = new Set(ONBOARDING_MODELS.map((m) => m.capability));
+    return CAPABILITY_ORDER.filter((c) => present.has(c));
+  }, []);
+
+  const groups = useMemo(() => {
+    const caps =
+      filter === "all" ? availableCapabilities : [filter as OnboardingCapability];
+    return caps
+      .map((capability) => {
+        const entries = sortModelsByFit(
+          ONBOARDING_MODELS.filter((m) => m.capability === capability),
+          profile.budgetGb
+        );
+        return { capability, entries };
+      })
+      .filter((g) => g.entries.length > 0);
+  }, [filter, availableCapabilities, profile.budgetGb]);
+
+  const isDownloaded = (model: UnifiedModel): boolean =>
+    canCheckHfCache(model) ? !!cacheStatuses[getHfCacheKey(model)] : false;
+
+  return (
+    <FlexColumn
+      gap={3}
+      sx={{ flex: 1, minHeight: 0, overflowY: "auto", pb: 4, pr: 1 }}
+    >
+      <FlexRow gap={1.5} align="center">
+        <FlexRow
+          align="center"
+          justify="center"
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: BORDER_RADIUS.md,
+            backgroundColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+            color: theme.vars.palette.primary.main
+          }}
+        >
+          <RocketLaunchOutlinedIcon sx={{ fontSize: 22 }} />
+        </FlexRow>
+        <FlexColumn gap={0.25}>
+          <Text size="big" weight={600}>
+            Get started with local models
+          </Text>
+          <Caption sx={{ opacity: 0.7 }}>
+            Run AI on your own machine — private, offline, and free. We match
+            recommendations to your hardware.
+          </Caption>
+        </FlexColumn>
+      </FlexRow>
+
+      <HardwareCard profile={profile} />
+
+      <EngineGuide />
+
+      <FlexColumn gap={1.5}>
+        <FlexColumn gap={0.25}>
+          <Text size="big" weight={600}>
+            Recommended models
+          </Text>
+          <Caption sx={{ opacity: 0.7 }}>
+            Current models in the 2–30 GB range, sorted to show what fits your
+            machine first. Sizes and memory are approximate.
+          </Caption>
+        </FlexColumn>
+
+        <ToggleGroup
+          value={filter}
+          exclusive
+          segmented
+          onChange={(_e, value) => value && setFilter(value as Filter)}
+          aria-label="filter recommended models by capability"
+        >
+          <ToggleOption value="all" aria-label="all capabilities">
+            All
+          </ToggleOption>
+          {availableCapabilities.map((capability) => (
+            <ToggleOption
+              key={capability}
+              value={capability}
+              aria-label={CAPABILITY_LABELS[capability]}
+            >
+              {CAPABILITY_LABELS[capability]}
+            </ToggleOption>
+          ))}
+        </ToggleGroup>
+
+        {groups.map((group) => (
+          <FlexColumn key={group.capability} gap={1} sx={{ mt: 1 }}>
+            <Text size="small" weight={600} color="secondary">
+              {CAPABILITY_LABELS[group.capability]}
+            </Text>
+            {group.entries.map((entry) => (
+              <OnboardingModelRow
+                key={entry.id}
+                entry={entry}
+                fit={profile.classify(entry.minVramGb)}
+                downloaded={isDownloaded(entry.model)}
+                onDownload={onDownload}
+              />
+            ))}
+          </FlexColumn>
+        ))}
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+export default memo(ModelOnboarding);

--- a/web/src/components/hugging_face/onboarding/OnboardingModelRow.tsx
+++ b/web/src/components/hugging_face/onboarding/OnboardingModelRow.tsx
@@ -1,0 +1,138 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo, useCallback } from "react";
+import { useTheme } from "@mui/material/styles";
+import DownloadIcon from "@mui/icons-material/Download";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import {
+  Box,
+  Caption,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Text,
+  Tooltip,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
+import { DownloadProgress } from "../DownloadProgress";
+import {
+  FIT_LABELS,
+  getEngine,
+  type FitLevel,
+  type OnboardingModel
+} from "./onboardingCatalog";
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+
+interface OnboardingModelRowProps {
+  entry: OnboardingModel;
+  fit: FitLevel;
+  downloaded: boolean;
+  onDownload: (model: UnifiedModel) => void;
+}
+
+const FIT_COLOR: Record<
+  FitLevel,
+  "success" | "warning" | "error" | "default"
+> = {
+  fits: "success",
+  tight: "warning",
+  over: "error",
+  unknown: "default"
+};
+
+const OnboardingModelRow: React.FC<OnboardingModelRowProps> = ({
+  entry,
+  fit,
+  downloaded,
+  onDownload
+}) => {
+  const theme = useTheme();
+  const downloadId = entry.model.repo_id || entry.model.id;
+  const download = useModelDownloadStore((state) => state.downloads[downloadId]);
+  const engine = getEngine(entry.engine);
+
+  const handleDownload = useCallback(() => {
+    onDownload(entry.model);
+  }, [onDownload, entry.model]);
+
+  return (
+    <FlexColumn
+      gap={1}
+      sx={{
+        padding: "0.85rem 1rem",
+        borderRadius: BORDER_RADIUS.md,
+        border: `1px solid ${theme.vars.palette.divider}`,
+        backgroundColor: theme.vars.palette.background.paper
+      }}
+    >
+      <FlexRow gap={2} align="flex-start" justify="space-between">
+        <FlexColumn gap={0.5} sx={{ minWidth: 0, flex: 1 }}>
+          <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap" }}>
+            <Text size="normal" weight={600} sx={{ lineHeight: 1.2 }}>
+              {entry.name}
+            </Text>
+            {entry.featured && (
+              <Chip label="Popular" compact color="primary" variant="outlined" />
+            )}
+            {engine && (
+              <Tooltip title={engine.description} delay={400}>
+                <Chip label={engine.name} compact variant="outlined" />
+              </Tooltip>
+            )}
+          </FlexRow>
+          <Caption sx={{ opacity: 0.7, lineHeight: 1.45 }}>
+            {entry.blurb}
+          </Caption>
+          <FlexRow gap={1} align="center" sx={{ mt: 0.25, flexWrap: "wrap" }}>
+            <Caption sx={{ fontVariantNumeric: "tabular-nums" }}>
+              ~{entry.approxSizeGb} GB{entry.quant ? ` · ${entry.quant}` : ""}
+            </Caption>
+            <Caption sx={{ opacity: 0.5 }}>·</Caption>
+            <Caption sx={{ fontVariantNumeric: "tabular-nums" }}>
+              ~{entry.minVramGb} GB memory
+            </Caption>
+          </FlexRow>
+        </FlexColumn>
+
+        <FlexColumn gap={0.75} align="flex-end" sx={{ flexShrink: 0 }}>
+          <Chip
+            label={FIT_LABELS[fit]}
+            compact
+            color={FIT_COLOR[fit]}
+            variant={fit === "unknown" ? "outlined" : "filled"}
+          />
+          {downloaded ? (
+            <FlexRow gap={0.5} align="center">
+              <CheckCircleIcon
+                sx={{
+                  fontSize: 16,
+                  color: theme.vars.palette.success.main
+                }}
+              />
+              <Caption color="secondary">Installed</Caption>
+            </FlexRow>
+          ) : (
+            <EditorButton
+              variant={fit === "over" ? "outlined" : "contained"}
+              density="compact"
+              size="small"
+              startIcon={<DownloadIcon sx={{ fontSize: 16 }} />}
+              onClick={handleDownload}
+            >
+              Download
+            </EditorButton>
+          )}
+        </FlexColumn>
+      </FlexRow>
+
+      {download && (
+        <Box sx={{ mt: 0.5 }}>
+          <DownloadProgress name={downloadId} />
+        </Box>
+      )}
+    </FlexColumn>
+  );
+};
+
+export default memo(OnboardingModelRow);

--- a/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
+++ b/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+// EngineGuide pulls in react-router (Package Manager link) and the node-pack
+// store; keep it inert — this test is about the hardware card and model rows.
+jest.mock("../EngineGuide", () => ({
+  __esModule: true,
+  default: () => <div data-testid="engine-guide" />
+}));
+
+// Avoid the HF cache network scan; report nothing installed.
+jest.mock("../../../../stores/HfCacheStatusStore", () => ({
+  useHfCacheStatusStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      statuses: {},
+      version: 0,
+      ensureStatuses: jest.fn()
+    })
+}));
+
+import ModelOnboarding from "../ModelOnboarding";
+import { useSystemStatsStore } from "../../../../stores/systemStatsHandler";
+import { useModelManagerStore } from "../../../../stores/ModelManagerStore";
+import type { SystemStats } from "../../../../stores/ApiTypes";
+
+const renderOnboarding = (onDownload = jest.fn()) => {
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ModelOnboarding onDownload={onDownload} />
+    </ThemeProvider>
+  );
+  return onDownload;
+};
+
+beforeEach(() => {
+  useSystemStatsStore.getState().setStats({
+    cpu_percent: 0,
+    memory_percent: 0,
+    vram_total_gb: 12,
+    memory_total_gb: 32
+  } as SystemStats);
+  useModelManagerStore.getState().setVramOverrideGb(null);
+});
+
+describe("ModelOnboarding", () => {
+  it("shows the hardware budget and headline", () => {
+    renderOnboarding();
+    expect(
+      screen.getByText(/Get started with local models/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("Your machine")).toBeInTheDocument();
+    // 12 GB detected VRAM is used as the recommendation budget.
+    expect(screen.getAllByText("12 GB").length).toBeGreaterThan(0);
+  });
+
+  it("renders the capability filter and recommended models", () => {
+    renderOnboarding();
+    expect(
+      screen.getByRole("button", { name: /all capabilities/i })
+    ).toBeInTheDocument();
+    // A well-known catalog model is shown.
+    expect(screen.getByText("Qwen2.5 7B")).toBeInTheDocument();
+  });
+
+  it("filters models when a capability is selected", async () => {
+    const user = userEvent.setup();
+    renderOnboarding();
+    await user.click(screen.getByRole("button", { name: /Image Generation/i }));
+    expect(screen.getByText("SDXL Turbo")).toBeInTheDocument();
+    expect(screen.queryByText("Qwen2.5 7B")).not.toBeInTheDocument();
+  });
+
+  it("starts a download when a model's Download button is clicked", async () => {
+    const user = userEvent.setup();
+    const onDownload = renderOnboarding();
+    const buttons = screen.getAllByRole("button", { name: /^Download$/i });
+    await user.click(buttons[0]);
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onDownload.mock.calls[0][0]).toHaveProperty("type");
+  });
+
+  it("marks models over budget as needing more memory", () => {
+    // Drop the budget so FLUX (24 GB) can't fit.
+    useModelManagerStore.getState().setVramOverrideGb(8);
+    renderOnboarding();
+    expect(screen.getByText("FLUX.1 schnell")).toBeInTheDocument();
+    // The over-budget fit chip appears for at least one model.
+    expect(
+      screen.getAllByText(/Needs more memory/i).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/hugging_face/onboarding/__tests__/onboardingCatalog.test.ts
+++ b/web/src/components/hugging_face/onboarding/__tests__/onboardingCatalog.test.ts
@@ -1,0 +1,101 @@
+import {
+  ONBOARDING_MODELS,
+  ONBOARDING_ENGINES,
+  ONBOARDING_NODE_PACKS,
+  classifyFit,
+  sortModelsByFit,
+  getEngine,
+  type OnboardingModel
+} from "../onboardingCatalog";
+
+describe("onboardingCatalog data", () => {
+  it("references a known engine on every model", () => {
+    for (const model of ONBOARDING_MODELS) {
+      expect(getEngine(model.engine)).toBeDefined();
+    }
+  });
+
+  it("keeps sizes and memory positive and mostly in the 2-30 GB range", () => {
+    for (const model of ONBOARDING_MODELS) {
+      expect(model.approxSizeGb).toBeGreaterThan(0);
+      expect(model.minVramGb).toBeGreaterThan(0);
+      expect(model.approxSizeGb).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("carries a real download descriptor with a type", () => {
+    for (const model of ONBOARDING_MODELS) {
+      expect(model.model.type).toBeTruthy();
+      expect(model.model.id).toBeTruthy();
+    }
+  });
+
+  it("uses unique catalog ids", () => {
+    const ids = ONBOARDING_MODELS.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has node packs with owner/repo ids", () => {
+    for (const pack of ONBOARDING_NODE_PACKS) {
+      expect(pack.repoId).toMatch(/^[^/]+\/[^/]+$/);
+    }
+  });
+
+  it("marks exactly one bundled engine (Ollama)", () => {
+    const bundled = ONBOARDING_ENGINES.filter((e) => e.bundled);
+    expect(bundled).toHaveLength(1);
+    expect(bundled[0].id).toBe("ollama");
+  });
+});
+
+describe("classifyFit", () => {
+  it("returns unknown when the budget is null", () => {
+    expect(classifyFit(8, null)).toBe("unknown");
+  });
+
+  it("returns fits with comfortable headroom", () => {
+    expect(classifyFit(8, 12)).toBe("fits");
+  });
+
+  it("returns tight when at the limit without headroom", () => {
+    expect(classifyFit(8, 8)).toBe("tight");
+    expect(classifyFit(8, 8.5)).toBe("tight");
+  });
+
+  it("returns over when the budget is below the requirement", () => {
+    expect(classifyFit(16, 8)).toBe("over");
+  });
+});
+
+describe("sortModelsByFit", () => {
+  const make = (id: string, minVramGb: number): OnboardingModel => ({
+    id,
+    name: id,
+    capability: "chat",
+    engine: "ollama",
+    blurb: "",
+    approxSizeGb: minVramGb,
+    minVramGb,
+    model: { id, name: id, type: "llama_model" }
+  });
+
+  it("orders fitting models before ones that need more memory", () => {
+    const models = [make("big", 24), make("small", 4), make("mid", 8)];
+    const sorted = sortModelsByFit(models, 8);
+    // 8 GB budget: mid (tight/fits) and small fit; big is over and goes last.
+    expect(sorted[sorted.length - 1].id).toBe("big");
+  });
+
+  it("puts the largest fitting model first", () => {
+    const models = [make("small", 4), make("mid", 8), make("tiny", 2)];
+    const sorted = sortModelsByFit(models, 24);
+    expect(sorted[0].id).toBe("mid");
+  });
+
+  it("does not mutate the input array", () => {
+    const models = [make("a", 4), make("b", 8)];
+    const copy = [...models];
+    sortModelsByFit(models, 8);
+    expect(models).toEqual(copy);
+  });
+});

--- a/web/src/components/hugging_face/onboarding/__tests__/useHardwareProfile.test.ts
+++ b/web/src/components/hugging_face/onboarding/__tests__/useHardwareProfile.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { useHardwareProfile } from "../useHardwareProfile";
+import { useSystemStatsStore } from "../../../../stores/systemStatsHandler";
+import { useModelManagerStore } from "../../../../stores/ModelManagerStore";
+import type { SystemStats } from "../../../../stores/ApiTypes";
+
+const setStats = (stats: Partial<SystemStats> | null) => {
+  if (stats === null) {
+    useSystemStatsStore.getState().clearStats();
+  } else {
+    useSystemStatsStore.getState().setStats({
+      cpu_percent: 0,
+      memory_percent: 0,
+      ...stats
+    } as SystemStats);
+  }
+};
+
+beforeEach(() => {
+  setStats(null);
+  useModelManagerStore.getState().setVramOverrideGb(null);
+});
+
+describe("useHardwareProfile", () => {
+  it("uses detected VRAM as the budget", () => {
+    setStats({ vram_total_gb: 12, memory_total_gb: 32 });
+    const { result } = renderHook(() => useHardwareProfile());
+    expect(result.current.budgetGb).toBe(12);
+    expect(result.current.budgetSource).toBe("gpu");
+    expect(result.current.tier).toBe("high");
+  });
+
+  it("falls back to a fraction of system RAM when VRAM is absent", () => {
+    setStats({ memory_total_gb: 32 });
+    const { result } = renderHook(() => useHardwareProfile());
+    // 70% of 32 = 22.4 → rounded to 22
+    expect(result.current.budgetGb).toBe(22);
+    expect(result.current.budgetSource).toBe("unified-memory");
+    expect(result.current.vramGb).toBeNull();
+  });
+
+  it("lets the manual override win over detection", () => {
+    setStats({ vram_total_gb: 8, memory_total_gb: 16 });
+    useModelManagerStore.getState().setVramOverrideGb(24);
+    const { result } = renderHook(() => useHardwareProfile());
+    expect(result.current.budgetGb).toBe(24);
+    expect(result.current.budgetSource).toBe("manual");
+    expect(result.current.isManual).toBe(true);
+  });
+
+  it("reports an unknown budget when nothing is detected", () => {
+    const { result } = renderHook(() => useHardwareProfile());
+    expect(result.current.budgetGb).toBeNull();
+    expect(result.current.budgetSource).toBe("unknown");
+    expect(result.current.tier).toBeNull();
+    expect(result.current.classify(8)).toBe("unknown");
+  });
+
+  it("classifies models against the budget", () => {
+    setStats({ vram_total_gb: 16 });
+    const { result } = renderHook(() => useHardwareProfile());
+    expect(result.current.classify(8)).toBe("fits");
+    expect(result.current.classify(16)).toBe("tight");
+    expect(result.current.classify(24)).toBe("over");
+  });
+});

--- a/web/src/components/hugging_face/onboarding/onboardingCatalog.ts
+++ b/web/src/components/hugging_face/onboarding/onboardingCatalog.ts
@@ -1,0 +1,466 @@
+/**
+ * Model-onboarding catalog.
+ *
+ * The static guidance behind the Model Manager's "Get Started" tab: which local
+ * inference engines exist, which node packs unlock them, and a curated set of
+ * current models in the 2–30 GB range with an approximate VRAM budget so the UI
+ * can tell the user what actually fits their machine.
+ *
+ * Everything here is guidance, not a live registry. Sizes and VRAM figures are
+ * approximate (quantized weights + a little runtime headroom) and labelled as
+ * such in the UI. Downloads still go through the real
+ * {@link useModelDownloadStore} flow, so the `model` descriptor on each entry is
+ * a genuine {@link UnifiedModel} the download service understands.
+ */
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+
+/** What a model is for — drives the capability grouping in the UI. */
+export type OnboardingCapability =
+  | "chat"
+  | "vision"
+  | "image"
+  | "speech-to-text"
+  | "text-to-speech"
+  | "embedding";
+
+export const CAPABILITY_LABELS: Record<OnboardingCapability, string> = {
+  chat: "Chat & Reasoning",
+  vision: "Vision (image understanding)",
+  image: "Image Generation",
+  "speech-to-text": "Speech to Text",
+  "text-to-speech": "Text to Speech",
+  embedding: "Embeddings & Search"
+};
+
+/** A local inference engine the user can run models on. */
+export interface OnboardingEngine {
+  id: string;
+  name: string;
+  /** One-line pitch. */
+  tagline: string;
+  /** Model file formats this engine loads. */
+  formats: string[];
+  /** What kinds of models it runs, in prose. */
+  description: string;
+  /** Platform restriction, when there is one (e.g. Apple Silicon only). */
+  platform?: string;
+  /**
+   * Runtime id in the desktop Package Manager's "Software" tab, when the engine
+   * is installed as a runtime rather than bundled. Matches
+   * {@link RuntimePackagesStore} status ids.
+   */
+  runtimeId?: string;
+  /** True when the desktop app bundles it (no install step needed). */
+  bundled?: boolean;
+  docsUrl: string;
+}
+
+/**
+ * The local engines, roughly ordered easiest-first. Ollama ships with the
+ * desktop app; the rest are installed from the Package Manager.
+ */
+export const ONBOARDING_ENGINES: readonly OnboardingEngine[] = [
+  {
+    id: "ollama",
+    name: "Ollama",
+    tagline: "One-click local LLMs",
+    formats: ["GGUF"],
+    description:
+      "The simplest way to run chat and reasoning models locally. Pull a model by name and it runs on your GPU or CPU. Bundled with the desktop app.",
+    bundled: true,
+    docsUrl: "https://ollama.com"
+  },
+  {
+    id: "node-llama-cpp",
+    name: "llama.cpp",
+    tagline: "GGUF models in-process",
+    formats: ["GGUF"],
+    description:
+      "Runs GGUF language models directly inside the NodeTool backend — no separate server. Great for GGUF weights pulled straight from Hugging Face.",
+    runtimeId: "node-llama-cpp",
+    docsUrl: "https://github.com/withcatai/node-llama-cpp"
+  },
+  {
+    id: "transformers-js",
+    name: "Transformers.js",
+    tagline: "ONNX models, anywhere",
+    formats: ["ONNX"],
+    description:
+      "Runs smaller models (embeddings, speech, classification) in-process via ONNX Runtime. Works on any platform, no Python required.",
+    runtimeId: "transformers-js",
+    docsUrl: "https://huggingface.co/docs/transformers.js"
+  },
+  {
+    id: "huggingface",
+    name: "Hugging Face / Diffusers",
+    tagline: "Image, video & audio via Python",
+    formats: ["Safetensors", "PyTorch"],
+    description:
+      "The full Python stack for diffusion (image/video) and large audio models. Needs the Python runtime and the Hugging Face node pack.",
+    docsUrl: "https://huggingface.co/docs/diffusers"
+  },
+  {
+    id: "mlx",
+    name: "MLX",
+    tagline: "Apple Silicon acceleration",
+    formats: ["MLX", "Safetensors"],
+    description:
+      "Apple's array framework, tuned for the unified memory of M-series chips. Fast local inference on modern Macs.",
+    platform: "Apple Silicon only",
+    docsUrl: "https://github.com/ml-explore/mlx"
+  }
+];
+
+export const getEngine = (id: string): OnboardingEngine | undefined =>
+  ONBOARDING_ENGINES.find((e) => e.id === id);
+
+/** A node pack that unlocks one or more capabilities. */
+export interface OnboardingNodePack {
+  /** Registry repo id passed to {@link useNodePacksStore.install}. */
+  repoId: string;
+  name: string;
+  description: string;
+  capabilities: OnboardingCapability[];
+}
+
+/**
+ * The node packs most people want first. `repoId` matches the Python registry
+ * ids the desktop Package Manager installs.
+ */
+export const ONBOARDING_NODE_PACKS: readonly OnboardingNodePack[] = [
+  {
+    repoId: "nodetool-ai/nodetool-base",
+    name: "Base",
+    description:
+      "Core text, chat, and agent nodes. The starting point for most workflows.",
+    capabilities: ["chat", "embedding"]
+  },
+  {
+    repoId: "nodetool-ai/nodetool-huggingface",
+    name: "Hugging Face",
+    description:
+      "Local image, audio, and speech models via Diffusers and Transformers.",
+    capabilities: ["image", "vision", "speech-to-text", "text-to-speech"]
+  },
+  {
+    repoId: "nodetool-ai/nodetool-ollama",
+    name: "Ollama",
+    description: "Chat and embedding nodes backed by your local Ollama models.",
+    capabilities: ["chat", "embedding"]
+  }
+];
+
+/** A curated, downloadable model with a rough hardware budget. */
+export interface OnboardingModel {
+  /** Stable unique id for this catalog entry. */
+  id: string;
+  name: string;
+  capability: OnboardingCapability;
+  /** Engine id from {@link ONBOARDING_ENGINES}. */
+  engine: string;
+  /** One-line description of what it's good at. */
+  blurb: string;
+  /** Approximate on-disk size, GB (quantized where applicable). */
+  approxSizeGb: number;
+  /** Approximate memory to run comfortably, GB (VRAM, or unified RAM). */
+  minVramGb: number;
+  /** Quantization label, when relevant (e.g. Q4_K_M). */
+  quant?: string;
+  /** Highlight as a current, notable pick. */
+  featured?: boolean;
+  /** The real download descriptor handed to the download service. */
+  model: UnifiedModel;
+}
+
+const ollama = (
+  id: string,
+  name: string,
+  blurb: string,
+  approxSizeGb: number,
+  minVramGb: number,
+  capability: OnboardingCapability,
+  extra?: Partial<OnboardingModel>
+): OnboardingModel => ({
+  id,
+  name,
+  capability,
+  engine: "ollama",
+  blurb,
+  approxSizeGb,
+  minVramGb,
+  quant: "Q4",
+  model: { id, name, type: "llama_model", provider: "ollama" },
+  ...extra
+});
+
+const hf = (
+  repoId: string,
+  name: string,
+  blurb: string,
+  approxSizeGb: number,
+  minVramGb: number,
+  capability: OnboardingCapability,
+  type: string,
+  pipelineTag: string,
+  extra?: Partial<OnboardingModel>
+): OnboardingModel => ({
+  id: repoId,
+  name,
+  capability,
+  engine: "huggingface",
+  blurb,
+  approxSizeGb,
+  minVramGb,
+  model: {
+    id: repoId,
+    name,
+    repo_id: repoId,
+    type,
+    pipeline_tag: pipelineTag,
+    provider: "huggingface"
+  },
+  ...extra
+});
+
+/**
+ * The curated models, mostly in the 2–30 GB range. Chat/vision run on Ollama
+ * (GGUF, one-click); image/speech run on the Hugging Face Python stack.
+ *
+ * Ollama tags and Hugging Face repo ids are real; sizes/VRAM are approximate
+ * and shown as such in the UI.
+ */
+export const ONBOARDING_MODELS: readonly OnboardingModel[] = [
+  // --- Chat & reasoning (Ollama, GGUF) --------------------------------------
+  ollama(
+    "llama3.2:3b",
+    "Llama 3.2 3B",
+    "Tiny and fast. Runs on almost anything, even without a GPU.",
+    2.0,
+    4,
+    "chat"
+  ),
+  ollama(
+    "qwen2.5:7b",
+    "Qwen2.5 7B",
+    "Strong all-round chat and tool use at a modest size.",
+    4.7,
+    6,
+    "chat",
+    { featured: true }
+  ),
+  ollama(
+    "llama3.1:8b",
+    "Llama 3.1 8B",
+    "Well-rounded general assistant with solid instruction following.",
+    4.9,
+    6,
+    "chat"
+  ),
+  ollama(
+    "gemma2:9b",
+    "Gemma 2 9B",
+    "Google's efficient open model, good quality per gigabyte.",
+    5.4,
+    8,
+    "chat"
+  ),
+  ollama(
+    "deepseek-r1:14b",
+    "DeepSeek-R1 14B",
+    "Reasoning-tuned model that shows its work — great for hard problems.",
+    9.0,
+    12,
+    "chat",
+    { featured: true }
+  ),
+  ollama(
+    "phi4:14b",
+    "Phi-4 14B",
+    "Microsoft's compact model, punches above its weight on reasoning.",
+    9.1,
+    12,
+    "chat"
+  ),
+  ollama(
+    "qwen2.5:14b",
+    "Qwen2.5 14B",
+    "A capable mid-size assistant for richer conversations and coding.",
+    9.0,
+    12,
+    "chat"
+  ),
+  ollama(
+    "mistral-small:24b",
+    "Mistral Small 24B",
+    "Near-flagship quality that still fits a 16 GB card.",
+    14.0,
+    16,
+    "chat"
+  ),
+  ollama(
+    "gemma2:27b",
+    "Gemma 2 27B",
+    "High-quality answers for machines with plenty of VRAM.",
+    16.0,
+    20,
+    "chat"
+  ),
+  ollama(
+    "qwen2.5:32b",
+    "Qwen2.5 32B",
+    "One of the strongest models you can run locally at this size.",
+    20.0,
+    24,
+    "chat",
+    { featured: true }
+  ),
+  // --- Vision (Ollama, GGUF) ------------------------------------------------
+  ollama(
+    "llama3.2-vision:11b",
+    "Llama 3.2 Vision 11B",
+    "Describe, read, and answer questions about images.",
+    7.9,
+    10,
+    "vision"
+  ),
+  ollama(
+    "llava:7b",
+    "LLaVA 7B",
+    "Lightweight image understanding for captions and Q&A.",
+    4.7,
+    6,
+    "vision"
+  ),
+  // --- Image generation (Hugging Face, Diffusers) ---------------------------
+  hf(
+    "stabilityai/sdxl-turbo",
+    "SDXL Turbo",
+    "Real-time image generation in a single step. A great first image model.",
+    6.9,
+    8,
+    "image",
+    "hf.stable_diffusion_xl",
+    "text-to-image",
+    { engine: "huggingface", featured: true }
+  ),
+  hf(
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    "Stable Diffusion XL",
+    "The classic high-quality open image model with a huge ecosystem.",
+    6.9,
+    8,
+    "image",
+    "hf.stable_diffusion_xl",
+    "text-to-image"
+  ),
+  hf(
+    "black-forest-labs/FLUX.1-schnell",
+    "FLUX.1 schnell",
+    "State-of-the-art open image quality. Needs a large GPU (or offloading).",
+    23.0,
+    24,
+    "image",
+    "hf.flux",
+    "text-to-image",
+    { featured: true }
+  ),
+  // --- Speech to text (Hugging Face, Transformers) --------------------------
+  hf(
+    "openai/whisper-large-v3",
+    "Whisper Large v3",
+    "Accurate multilingual transcription and translation.",
+    3.1,
+    4,
+    "speech-to-text",
+    "hf.automatic_speech_recognition",
+    "automatic-speech-recognition",
+    { featured: true }
+  ),
+  // --- Text to speech (Hugging Face) ----------------------------------------
+  hf(
+    "coqui/XTTS-v2",
+    "XTTS v2",
+    "Natural multilingual voice cloning from a few seconds of audio.",
+    2.0,
+    4,
+    "text-to-speech",
+    "hf.text_to_speech",
+    "text-to-speech"
+  ),
+  // --- Embeddings (Hugging Face) --------------------------------------------
+  hf(
+    "BAAI/bge-m3",
+    "BGE-M3",
+    "Multilingual embeddings for semantic search and RAG.",
+    2.3,
+    3,
+    "embedding",
+    "hf.feature_extraction",
+    "feature-extraction"
+  )
+];
+
+/** How well a model fits the machine's memory budget. */
+export type FitLevel = "fits" | "tight" | "over" | "unknown";
+
+/**
+ * Classify a model against a memory budget (GB). `null` budget → "unknown".
+ * A little headroom is required for a comfortable "fits"; running right at the
+ * limit is "tight"; above the limit is "over".
+ */
+export const classifyFit = (
+  minVramGb: number,
+  budgetGb: number | null
+): FitLevel => {
+  if (budgetGb == null) {
+    return "unknown";
+  }
+  if (budgetGb >= minVramGb * 1.15) {
+    return "fits";
+  }
+  if (budgetGb >= minVramGb) {
+    return "tight";
+  }
+  return "over";
+};
+
+export const FIT_LABELS: Record<FitLevel, string> = {
+  fits: "Fits your machine",
+  tight: "Tight fit",
+  over: "Needs more memory",
+  unknown: "Set your memory to check"
+};
+
+const FIT_ORDER: Record<FitLevel, number> = {
+  fits: 0,
+  tight: 1,
+  unknown: 2,
+  over: 3
+};
+
+/**
+ * Sort models best-fit-first for a given budget: models that fit come first
+ * (largest that still fits at the top, since bigger usually means better),
+ * then tight, then unknown, then over (smallest-over first — closest to
+ * runnable). Ties break on featured, then size.
+ */
+export const sortModelsByFit = (
+  models: readonly OnboardingModel[],
+  budgetGb: number | null
+): OnboardingModel[] =>
+  [...models].sort((a, b) => {
+    const fa = classifyFit(a.minVramGb, budgetGb);
+    const fb = classifyFit(b.minVramGb, budgetGb);
+    if (fa !== fb) {
+      return FIT_ORDER[fa] - FIT_ORDER[fb];
+    }
+    // Within "over", smaller (closer to fitting) first; otherwise larger first.
+    const bigFirst = fa === "over" ? -1 : 1;
+    if (a.minVramGb !== b.minVramGb) {
+      return bigFirst * (b.minVramGb - a.minVramGb);
+    }
+    if (!!a.featured !== !!b.featured) {
+      return a.featured ? -1 : 1;
+    }
+    return a.approxSizeGb - b.approxSizeGb;
+  });

--- a/web/src/components/hugging_face/onboarding/useHardwareProfile.ts
+++ b/web/src/components/hugging_face/onboarding/useHardwareProfile.ts
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { useSystemStatsStore } from "../../../stores/systemStatsHandler";
+import { useModelManagerStore } from "../../../stores/ModelManagerStore";
+import { classifyFit, type FitLevel } from "./onboardingCatalog";
+
+/** Where the memory budget used for recommendations comes from. */
+export type BudgetSource = "gpu" | "unified-memory" | "manual" | "unknown";
+
+export type HardwareTier = "entry" | "mid" | "high" | "workstation";
+
+export interface HardwareProfile {
+  /** Detected dedicated VRAM (GB), or null when unavailable. */
+  vramGb: number | null;
+  /** Detected system RAM (GB), or null when unavailable. */
+  ramGb: number | null;
+  /**
+   * The memory budget (GB) recommendations are measured against: the manual
+   * override if set, else detected VRAM, else a fraction of system RAM (unified
+   * memory), else null.
+   */
+  budgetGb: number | null;
+  budgetSource: BudgetSource;
+  /** Coarse tier for headline copy, or null when the budget is unknown. */
+  tier: HardwareTier | null;
+  /** True when the manual override is driving the budget. */
+  isManual: boolean;
+  /** Classify a model's memory requirement against this machine's budget. */
+  classify: (minVramGb: number) => FitLevel;
+}
+
+/**
+ * Fraction of system RAM treated as usable for models when there's no discrete
+ * VRAM figure (Apple Silicon unified memory, or CPU-only inference). The OS and
+ * app need the rest.
+ */
+const UNIFIED_MEMORY_FRACTION = 0.7;
+
+const tierFor = (budgetGb: number | null): HardwareTier | null => {
+  if (budgetGb == null) {
+    return null;
+  }
+  if (budgetGb < 6) {
+    return "entry";
+  }
+  if (budgetGb < 12) {
+    return "mid";
+  }
+  if (budgetGb < 24) {
+    return "high";
+  }
+  return "workstation";
+};
+
+export const TIER_LABELS: Record<HardwareTier, string> = {
+  entry: "Entry — small models run great",
+  mid: "Mid-range — 7–14B models are comfortable",
+  high: "High-end — up to ~24B and image models",
+  workstation: "Workstation — the largest local models"
+};
+
+/**
+ * Read hardware from the live system stats and combine it with the manual
+ * override into a single budget the onboarding UI recommends against.
+ *
+ * The default backend stats sampler often reports RAM but not VRAM, so the
+ * budget falls back to a fraction of system RAM, and the user can always set an
+ * explicit VRAM value that takes precedence.
+ */
+export const useHardwareProfile = (): HardwareProfile => {
+  const stats = useSystemStatsStore((state) => state.stats);
+  const override = useModelManagerStore((state) => state.vramOverrideGb);
+
+  return useMemo(() => {
+    const vramGb =
+      stats?.vram_total_gb != null && stats.vram_total_gb > 0
+        ? stats.vram_total_gb
+        : null;
+    const ramGb =
+      stats?.memory_total_gb != null && stats.memory_total_gb > 0
+        ? stats.memory_total_gb
+        : null;
+
+    let budgetGb: number | null;
+    let budgetSource: BudgetSource;
+    if (override != null && override > 0) {
+      budgetGb = override;
+      budgetSource = "manual";
+    } else if (vramGb != null) {
+      budgetGb = vramGb;
+      budgetSource = "gpu";
+    } else if (ramGb != null) {
+      budgetGb = Math.round(ramGb * UNIFIED_MEMORY_FRACTION);
+      budgetSource = "unified-memory";
+    } else {
+      budgetGb = null;
+      budgetSource = "unknown";
+    }
+
+    return {
+      vramGb,
+      ramGb,
+      budgetGb,
+      budgetSource,
+      tier: tierFor(budgetGb),
+      isManual: budgetSource === "manual",
+      classify: (minVramGb: number) => classifyFit(minVramGb, budgetGb)
+    };
+  }, [stats, override]);
+};

--- a/web/src/components/preview/ComponentPreview.tsx
+++ b/web/src/components/preview/ComponentPreview.tsx
@@ -35,6 +35,8 @@ import {
 } from "../../stores/ApiTypes";
 import useMetadataStore from "../../stores/MetadataStore";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
+import { useModelManagerStore } from "../../stores/ModelManagerStore";
+import { useSystemStatsStore } from "../../stores/systemStatsHandler";
 
 const CostsDashboard = React.lazy(() => import("../costs/CostsDashboard"));
 const ModelListIndex = React.lazy(
@@ -55,6 +57,9 @@ const DataframeEditorModal = React.lazy(
 const ImageComparer = React.lazy(() => import("../widgets/ImageComparer"));
 const RecommendedModels = React.lazy(
   () => import("../hugging_face/RecommendedModels")
+);
+const ModelOnboarding = React.lazy(
+  () => import("../hugging_face/onboarding/ModelOnboarding")
 );
 const DeleteModelDialog = React.lazy(
   () => import("../hugging_face/model_list/DeleteModelDialog")
@@ -101,6 +106,12 @@ const PREVIEWS: PreviewEntry[] = [
     label: "Models Manager",
     description: "Model list and download manager",
     viewport: { width: 1920, height: 1080 }
+  },
+  {
+    id: "model-onboarding",
+    label: "Model Onboarding",
+    description: "Hardware-aware 'Get Started' guide for local models",
+    viewport: { width: 1440, height: 1080 }
   },
   {
     id: "assets",
@@ -361,6 +372,42 @@ const PreviewModels: React.FC = () => (
     <ModelListIndex />
   </FullscreenBox>
 );
+
+const PreviewModelOnboarding: React.FC = () => {
+  const theme = useTheme();
+  const setSource = useModelManagerStore((s) => s.setSource);
+  const setStats = useSystemStatsStore((s) => s.setStats);
+  useEffect(() => {
+    // Drive the manager to the "Get Started" tab and seed plausible hardware so
+    // the hardware card and fit badges render without a live backend.
+    setSource("onboarding");
+    setStats({
+      cpu_percent: 12,
+      memory_percent: 38,
+      memory_total_gb: 32,
+      memory_used_gb: 12,
+      vram_total_gb: 16,
+      vram_used_gb: 3,
+      vram_percent: 18
+    });
+  }, [setSource, setStats]);
+  return (
+    <Box
+      data-preview="model-onboarding"
+      sx={{
+        width: "100%",
+        minHeight: "100vh",
+        p: 4,
+        bgcolor: theme.vars.palette.background.default,
+        color: theme.vars.palette.text.primary
+      }}
+    >
+      <Suspense fallback={<LoadingSpinner />}>
+        <ModelOnboarding onDownload={() => undefined} />
+      </Suspense>
+    </Box>
+  );
+};
 
 const PreviewAssets: React.FC = () => (
   <FullscreenBox preview="assets">
@@ -697,6 +744,7 @@ const COMPONENT_MAP: Record<string, React.FC> = {
   dashboard: PreviewDashboard,
   costs: PreviewCosts,
   models: PreviewModels,
+  "model-onboarding": PreviewModelOnboarding,
   assets: PreviewAssets,
   "confirm-dialog": PreviewConfirmDialog,
   "color-picker": PreviewColorPicker,

--- a/web/src/stores/ModelManagerStore.ts
+++ b/web/src/stores/ModelManagerStore.ts
@@ -10,8 +10,10 @@ export type ModelScope = "local" | "worker";
  * - "recommended": the curated recommended-models catalog aggregated from node
  *   metadata, browsable for download
  * - "hub": live search results from the HuggingFace Hub, browsable for download
+ * - "onboarding": the guided "Get Started" experience — hardware-aware model,
+ *   engine, and node-pack recommendations
  */
-export type ModelSource = "installed" | "recommended" | "hub";
+export type ModelSource = "onboarding" | "installed" | "recommended" | "hub";
 
 interface ModelManagerState {
   isOpen: boolean;
@@ -22,6 +24,12 @@ interface ModelManagerState {
   sortDirection: ModelSortDirection;
   scope: ModelScope;
   source: ModelSource;
+  /**
+   * Manual GPU-memory budget (GB) for the onboarding recommendations, used when
+   * hardware detection can't read VRAM (the default server sampler often can't).
+   * `null` means "use whatever was detected".
+   */
+  vramOverrideGb: number | null;
   setIsOpen: (isOpen: boolean) => void;
   setModelSearchTerm: (term: string) => void;
   setSelectedModelType: (type: string) => void;
@@ -31,6 +39,7 @@ interface ModelManagerState {
   toggleSortDirection: () => void;
   setScope: (scope: ModelScope) => void;
   setSource: (source: ModelSource) => void;
+  setVramOverrideGb: (gb: number | null) => void;
 }
 
 export const useModelManagerStore = create<ModelManagerState>((set) => ({
@@ -42,6 +51,7 @@ export const useModelManagerStore = create<ModelManagerState>((set) => ({
   sortDirection: "asc",
   scope: "local",
   source: "installed",
+  vramOverrideGb: null,
   setIsOpen: (isOpen) => set({ isOpen }),
   setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
   setSelectedModelType: (type) => set({ selectedModelType: type }),
@@ -53,5 +63,6 @@ export const useModelManagerStore = create<ModelManagerState>((set) => ({
       sortDirection: state.sortDirection === "asc" ? "desc" : "asc"
     })),
   setScope: (scope) => set({ scope }),
-  setSource: (source) => set({ source })
+  setSource: (source) => set({ source }),
+  setVramOverrideGb: (gb) => set({ vramOverrideGb: gb })
 }));

--- a/web/src/stores/ModelManagerStore.ts
+++ b/web/src/stores/ModelManagerStore.ts
@@ -25,6 +25,13 @@ interface ModelManagerState {
   scope: ModelScope;
   source: ModelSource;
   /**
+   * Whether the source has been settled for this session — either the user
+   * picked a tab or the manager auto-defaulted based on what's installed. Once
+   * true, the empty-install auto-default never fires again, so opening the
+   * (still empty) Installed tab doesn't bounce back to onboarding.
+   */
+  sourceInitialized: boolean;
+  /**
    * Manual GPU-memory budget (GB) for the onboarding recommendations, used when
    * hardware detection can't read VRAM (the default server sampler often can't).
    * `null` means "use whatever was detected".
@@ -39,6 +46,7 @@ interface ModelManagerState {
   toggleSortDirection: () => void;
   setScope: (scope: ModelScope) => void;
   setSource: (source: ModelSource) => void;
+  setSourceInitialized: (initialized: boolean) => void;
   setVramOverrideGb: (gb: number | null) => void;
 }
 
@@ -51,6 +59,7 @@ export const useModelManagerStore = create<ModelManagerState>((set) => ({
   sortDirection: "asc",
   scope: "local",
   source: "installed",
+  sourceInitialized: false,
   vramOverrideGb: null,
   setIsOpen: (isOpen) => set({ isOpen }),
   setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
@@ -64,5 +73,7 @@ export const useModelManagerStore = create<ModelManagerState>((set) => ({
     })),
   setScope: (scope) => set({ scope }),
   setSource: (source) => set({ source }),
+  setSourceInitialized: (initialized) =>
+    set({ sourceInitialized: initialized }),
   setVramOverrideGb: (gb) => set({ vramOverrideGb: gb })
 }));


### PR DESCRIPTION
## What

Adds a **"Get Started"** tab to the Model Manager — a guided, hardware-aware onboarding that answers the four questions a new user has about running models locally: which engines are possible, what runtimes/node packs to install and how, and which models to download.

It's a new `ModelSource` (`"onboarding"`), rendered in place of the model list, and the first option in the source toggle.

## How it works

**Hardware card** — reads live system stats (`vram_total_gb`, `memory_total_gb`) from `useSystemStatsStore`. The default backend sampler often can't read VRAM, so the recommendation budget falls back to ~70% of system RAM (unified memory), and a **manual GPU-memory override** (added as `vramOverrideGb` on `ModelManagerStore`) always wins. Shows detected GPU/RAM, the effective budget, and a coarse tier.

**Local engines** — cards for Ollama, llama.cpp, Transformers.js, Hugging Face / Diffusers, and MLX: what each runs, its file formats, and platform limits, with a docs link. Ollama is badged "Bundled".

**Node packs** — the packs people want first (Base, Hugging Face, Ollama), with one-click install on desktop via `useNodePacksStore`, or a link to the Package Manager in the browser.

**Recommended models** — a curated catalog of current models in the 2–30 GB range (Ollama GGUF chat/vision + Hugging Face image/speech/embeddings). Each row is badged **Fits / Tight / Needs more memory** against the detected budget and sorted best-fit-first; a capability filter narrows by task. Downloads reuse the existing `useModelDownloadStore` flow, so `Fits/Tight` classification is guidance only and doesn't block anything.

## Files

New `web/src/components/hugging_face/onboarding/`:
- `onboardingCatalog.ts` — engines, node packs, curated models, and the `classifyFit` / `sortModelsByFit` helpers
- `useHardwareProfile.ts` — VRAM/RAM detection + manual override + tier/fit
- `ModelOnboarding.tsx`, `HardwareCard.tsx`, `EngineGuide.tsx`, `OnboardingModelRow.tsx`

Wiring: `ModelManagerStore` (source + `vramOverrideGb`), `SourceToggle`, `useModels`, `ModelListIndex`, `ModelListHeader`.

## Notes

- Sizes and memory figures are approximate (quantized weights + headroom) and labelled as such in the UI. Ollama tags and Hugging Face repo ids are real download descriptors.
- Default source is unchanged (`installed`); "Get Started" is the first, discoverable tab rather than a forced default, so existing users' view isn't flipped.

## Testing

- `npm run typecheck` (web) — clean
- `eslint` on all changed files — clean
- New tests (23): fit classification, hardware-detection fallbacks (VRAM → RAM → override → unknown), and the onboarding view (render, capability filter, download, over-budget badge)
- Existing `hugging_face/model_list` suites (45) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1LDCrDMiXj3W1haiVYAYs)_