### PR TITLE
feat(web): provider onboarding flow for blocked capabilities

### DIFF
--- a/web/src/components/chat/containers/WelcomePlaceholder.tsx
+++ b/web/src/components/chat/containers/WelcomePlaceholder.tsx
@@ -15,8 +15,8 @@ import {
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
 import { memo, useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useLanguageModelProviders } from "../../../hooks/useProviders";
+import { openProviderOnboarding } from "../../../stores/ProviderOnboardingStore";
 
 import openaiIcon from "../../../icons/providers/openai.svg";
 import anthropicIcon from "../../../icons/providers/anthropic.svg";
@@ -109,7 +109,6 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
 }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
-  const navigate = useNavigate();
   const { providers, isLoading, error } = useLanguageModelProviders();
 
   const handleClick = useCallback(
@@ -119,9 +118,12 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
     [onSuggestionClick]
   );
 
-  const handleOpenSettings = useCallback(() => {
-    navigate("/settings?tab=1");
-  }, [navigate]);
+  const handleConnectProvider = useCallback(() => {
+    openProviderOnboarding({
+      capability: "generate_message",
+      reason: "Chat needs a language model. Connect a provider to start."
+    });
+  }, []);
 
   // Only treat the chat as "no provider" once the provider query has settled
   // successfully — while loading (or on a transient fetch error, which the
@@ -179,10 +181,10 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
               color="primary"
               size="small"
               startIcon={<KeyRoundedIcon sx={{ fontSize: 16 }} />}
-              onClick={handleOpenSettings}
+              onClick={handleConnectProvider}
               sx={{ mt: 1 }}
             >
-              Add API keys in Settings
+              Connect a provider
             </EditorButton>
           </FlexColumn>
         ) : (

--- a/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
+++ b/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
@@ -5,16 +5,18 @@ import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../../__mocks__/themeMock";
 import WelcomePlaceholder from "../WelcomePlaceholder";
 import { useLanguageModelProviders } from "../../../../hooks/useProviders";
-
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockNavigate
-}));
+import { openProviderOnboarding } from "../../../../stores/ProviderOnboardingStore";
 
 jest.mock("../../../../hooks/useProviders", () => ({
   useLanguageModelProviders: jest.fn()
 }));
+
+jest.mock("../../../../stores/ProviderOnboardingStore", () => ({
+  openProviderOnboarding: jest.fn()
+}));
+
+const mockOpenProviderOnboarding =
+  openProviderOnboarding as jest.MockedFunction<typeof openProviderOnboarding>;
 
 const mockUseLanguageModelProviders =
   useLanguageModelProviders as jest.MockedFunction<
@@ -51,9 +53,11 @@ describe("WelcomePlaceholder", () => {
     expect(screen.getByText("Gemini")).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Add API keys in Settings/i })
+      screen.getByRole("button", { name: /Connect a provider/i })
     );
-    expect(mockNavigate).toHaveBeenCalledWith("/settings?tab=1");
+    expect(mockOpenProviderOnboarding).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: "generate_message" })
+    );
   });
 
   it("shows prompt suggestions once a provider is configured", () => {

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -28,7 +28,7 @@ import {
   TOOLTIP_ENTER_NEXT_DELAY
 } from "../../config/constants";
 import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
-import { useNavigate } from "react-router-dom";
+import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 
 import {
   isHuggingFaceProvider,
@@ -607,11 +607,15 @@ const ProviderList: React.FC<ProviderListProps> = ({
     handleMenuClose();
   }, [menuProvider, isProviderEnabled, setProviderEnabled, handleMenuClose]);
 
-  const navigate = useNavigate();
-  const handleOpenSettings = useCallback(() => {
-    navigate("/settings?tab=1");
-    handleMenuClose();
-  }, [navigate, handleMenuClose]);
+  const handleAddKey = useCallback(
+    (secretKey: string | null) => {
+      handleMenuClose();
+      openProviderOnboarding(
+        secretKey ? { highlightSecretKey: secretKey } : undefined
+      );
+    },
+    [handleMenuClose]
+  );
 
   return (
     <List
@@ -927,7 +931,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                             }}
                           />
                         </Tooltip>
-                        <Tooltip className="model-menu__provider-add-key-tooltip" title="Open Settings to add API key">
+                        <Tooltip className="model-menu__provider-add-key-tooltip" title="Connect this provider">
                           <EditorButton
                             className="model-menu__provider-add-key-button"
                             density="compact"
@@ -938,7 +942,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                               fontSize: (theme: Theme) => theme.vars.fontSizeSmaller,
                               color: "warning.main"
                             }}
-                            onClick={handleOpenSettings}
+                            onClick={() => handleAddKey(env)}
                           >
                             Add key
                           </EditorButton>

--- a/web/src/components/node/ApiKeyValidation.tsx
+++ b/web/src/components/node/ApiKeyValidation.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { Text, EditorButton } from "../ui_primitives";
 import { useApiKeyValidation } from "../../hooks/useApiKeyValidation";
+import { getRequiredSecretKeyForNamespace } from "../../utils/nodeProvider";
+import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 
 interface ApiKeyValidationProps {
   nodeNamespace: string;
@@ -9,12 +10,15 @@ interface ApiKeyValidationProps {
 
 const ApiKeyValidation: React.FC<ApiKeyValidationProps> = React.memo(
   ({ nodeNamespace }) => {
-    const navigate = useNavigate();
     const missingAPIKey = useApiKeyValidation(nodeNamespace);
 
-    const handleOpenSettings = useCallback(() => {
-      navigate("/settings?tab=1");
-    }, [navigate]);
+    const handleConnectProvider = useCallback(() => {
+      openProviderOnboarding({
+        highlightSecretKey:
+          getRequiredSecretKeyForNamespace(nodeNamespace) ?? undefined,
+        reason: "This node needs a provider key. Connect it to run the node."
+      });
+    }, [nodeNamespace]);
 
     const content = useMemo(() => {
       if (!missingAPIKey || typeof missingAPIKey !== "string") {return null;}
@@ -39,7 +43,7 @@ const ApiKeyValidation: React.FC<ApiKeyValidationProps> = React.memo(
             variant="contained"
             color="primary"
             size="small"
-            onClick={handleOpenSettings}
+            onClick={handleConnectProvider}
             sx={{
               margin: "0 1em",
               padding: ".2em 0 0",
@@ -51,11 +55,11 @@ const ApiKeyValidation: React.FC<ApiKeyValidationProps> = React.memo(
               borderRadius: ".1em"
             }}
           >
-            Add key in Settings
+            Connect provider
           </EditorButton>
         </>
       );
-    }, [missingAPIKey, handleOpenSettings]);
+    }, [missingAPIKey, handleConnectProvider]);
 
     return content;
   }

--- a/web/src/components/node/ModelSetupCallout.tsx
+++ b/web/src/components/node/ModelSetupCallout.tsx
@@ -1,13 +1,13 @@
 /** @jsxImportSource @emotion/react */
 import { css, keyframes } from "@emotion/react";
 import { memo, useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
 import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 import { useProviders } from "../../hooks/useProviders";
+import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 import { Text, EditorButton, ToolbarIconButton, MOTION } from "../ui_primitives";
 
 const enter = keyframes({
@@ -72,15 +72,16 @@ interface ModelSetupCalloutProps {
 const ModelSetupCallout: React.FC<ModelSetupCalloutProps> = ({ onDismiss }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
-  const navigate = useNavigate();
   const { providers, isLoading, error } = useProviders();
 
   const noProvider = !isLoading && !error && providers.length === 0;
 
   const handleAddKeys = useCallback(() => {
     onDismiss();
-    navigate("/settings?tab=1");
-  }, [onDismiss, navigate]);
+    openProviderOnboarding({
+      reason: "This node needs an AI model. Connect a provider to run it."
+    });
+  }, [onDismiss]);
 
   return (
     <div css={cssStyles} className="nodrag nowheel">

--- a/web/src/components/preview/ComponentPreview.tsx
+++ b/web/src/components/preview/ComponentPreview.tsx
@@ -37,6 +37,7 @@ import useMetadataStore from "../../stores/MetadataStore";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
 import { useModelManagerStore } from "../../stores/ModelManagerStore";
 import { useSystemStatsStore } from "../../stores/systemStatsHandler";
+import { useProviderOnboardingStore } from "../../stores/ProviderOnboardingStore";
 
 const CostsDashboard = React.lazy(() => import("../costs/CostsDashboard"));
 const ModelListIndex = React.lazy(
@@ -73,6 +74,9 @@ const WorkflowFormModal = React.lazy(
 );
 const WorkflowDeleteDialog = React.lazy(
   () => import("../workflows/WorkflowDeleteDialog")
+);
+const ProviderOnboardingDialog = React.lazy(
+  () => import("../provider_onboarding/ProviderOnboardingDialog")
 );
 
 interface PreviewEntry {
@@ -173,6 +177,13 @@ const PREVIEWS: PreviewEntry[] = [
     id: "workflow-delete",
     label: "Workflow Delete Confirmation",
     description: "Safe-delete prompt for workflows"
+  },
+  {
+    id: "provider-onboarding",
+    label: "Provider Onboarding",
+    description:
+      "Blocked-provider onboarding: OAuth sign-in, API keys, and cost guidance",
+    viewport: { width: 900, height: 1200 }
   }
 ];
 
@@ -610,6 +621,23 @@ const PreviewWorkflowDelete: React.FC = () => (
   </Box>
 );
 
+const PreviewProviderOnboarding: React.FC = () => {
+  const show = useProviderOnboardingStore((s) => s.show);
+  useEffect(() => {
+    show({ capability: "generate_message" });
+  }, [show]);
+  return (
+    <Box
+      data-preview="provider-onboarding"
+      sx={{ width: "100%", height: "100vh" }}
+    >
+      <Suspense fallback={null}>
+        <ProviderOnboardingDialog />
+      </Suspense>
+    </Box>
+  );
+};
+
 const FORM_CONTROL_OPTIONS = [
   { value: "widescreen", label: "16:9 — Widescreen" },
   { value: "square", label: "1:1 — Square" }
@@ -757,6 +785,7 @@ const COMPONENT_MAP: Record<string, React.FC> = {
   "node-readme": PreviewNodeReadme,
   "workflow-form": PreviewWorkflowForm,
   "workflow-delete": PreviewWorkflowDelete,
+  "provider-onboarding": PreviewProviderOnboarding,
   "form-controls": PreviewFormControls
 };
 

--- a/web/src/components/provider_onboarding/CostGuide.tsx
+++ b/web/src/components/provider_onboarding/CostGuide.tsx
@@ -1,0 +1,112 @@
+/** @jsxImportSource @emotion/react */
+import { memo } from "react";
+import { useTheme } from "@mui/material/styles";
+import PaymentsOutlinedIcon from "@mui/icons-material/PaymentsOutlined";
+import DataUsageOutlinedIcon from "@mui/icons-material/DataUsageOutlined";
+import SavingsOutlinedIcon from "@mui/icons-material/SavingsOutlined";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import {
+  Caption,
+  Card,
+  CollapsibleSection,
+  FlexColumn,
+  FlexRow,
+  Text,
+  BORDER_RADIUS
+} from "../ui_primitives";
+
+interface CostPoint {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}
+
+const COST_POINTS: CostPoint[] = [
+  {
+    icon: <DataUsageOutlinedIcon sx={{ fontSize: 18 }} />,
+    title: "Chat is billed in tokens",
+    body: "A token is roughly ¾ of a word. Providers charge for the tokens you send (your prompt) and the tokens the model writes back. A short chat costs a fraction of a cent; long documents cost more."
+  },
+  {
+    icon: <ImageOutlinedIcon sx={{ fontSize: 18 }} />,
+    title: "Images, audio, and video are billed per result",
+    body: "Instead of tokens, these are usually priced per image, per second of audio or video, or per second of compute the model runs. A single image is typically a few cents."
+  },
+  {
+    icon: <PaymentsOutlinedIcon sx={{ fontSize: 18 }} />,
+    title: "You pay the provider, not NodeTool",
+    body: "Your API key bills your own account with each provider directly. NodeTool never adds a markup and never sees your card — set spending limits in the provider's dashboard to stay in control."
+  },
+  {
+    icon: <SavingsOutlinedIcon sx={{ fontSize: 18 }} />,
+    title: "Start cheap or free",
+    body: "Several providers give free credits or a free tier to experiment. Smaller and faster models cost much less than the largest ones — a great way to try things before scaling up."
+  }
+];
+
+/**
+ * Beginner-friendly explainer for how AI provider billing works — tokens,
+ * per-result pricing, who gets charged, and how to start cheaply. Collapsed by
+ * default so it doesn't crowd the connect actions but is one click away.
+ */
+const CostGuide: React.FC = () => {
+  const theme = useTheme();
+
+  return (
+    <CollapsibleSection
+      defaultOpen={false}
+      title={
+        <FlexRow align="center" gap={1}>
+          <PaymentsOutlinedIcon
+            sx={{ fontSize: 18, color: theme.vars.palette.primary.main }}
+          />
+          <Text size="small" weight={600}>
+            How do costs work?
+          </Text>
+        </FlexRow>
+      }
+    >
+      <FlexColumn gap={1.5} sx={{ mt: 1.5 }}>
+        {COST_POINTS.map((point) => (
+          <Card
+            key={point.title}
+            variant="outlined"
+            padding="compact"
+            sx={{
+              borderRadius: BORDER_RADIUS.lg,
+              border: `1px solid ${theme.vars.palette.divider}`,
+              backgroundColor: theme.vars.palette.background.paper
+            }}
+          >
+            <FlexRow align="flex-start" gap={1.5}>
+              <FlexRow
+                align="center"
+                justify="center"
+                sx={{
+                  width: 34,
+                  height: 34,
+                  minWidth: 34,
+                  borderRadius: BORDER_RADIUS.md,
+                  color: theme.vars.palette.primary.main,
+                  backgroundColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`
+                }}
+              >
+                {point.icon}
+              </FlexRow>
+              <FlexColumn gap={0.25}>
+                <Text size="small" weight={600}>
+                  {point.title}
+                </Text>
+                <Caption sx={{ opacity: 0.7, lineHeight: 1.5 }}>
+                  {point.body}
+                </Caption>
+              </FlexColumn>
+            </FlexRow>
+          </Card>
+        ))}
+      </FlexColumn>
+    </CollapsibleSection>
+  );
+};
+
+export default memo(CostGuide);

--- a/web/src/components/provider_onboarding/ProviderOnboardingCard.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingCard.tsx
@@ -1,0 +1,284 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, useEffect, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import LoginIcon from "@mui/icons-material/Login";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
+
+import {
+  Box,
+  Caption,
+  Card,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  Text,
+  TextInput,
+  BORDER_RADIUS,
+  MOTION
+} from "../ui_primitives";
+import { useOAuthConnection } from "../../hooks/useOAuthConnection";
+import useSecretsStore from "../../stores/SecretsStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import type { OnboardingProvider } from "./providerOnboardingCatalog";
+
+interface ProviderOnboardingCardProps {
+  provider: OnboardingProvider;
+  /** Already has a stored API key for this provider. */
+  configured: boolean;
+  /** Start expanded (e.g. the provider a per-node warning pointed at). */
+  defaultExpanded?: boolean;
+}
+
+/**
+ * One provider in the onboarding dialog. OAuth providers get a one-click
+ * "Sign in" button; every provider can also expand an inline API-key field so
+ * the user connects without leaving the flow. Reuses the same OAuth hook and
+ * secrets store as the full Settings page.
+ */
+const ProviderOnboardingCard: React.FC<ProviderOnboardingCardProps> = ({
+  provider,
+  configured,
+  defaultExpanded = false
+}) => {
+  const theme = useTheme();
+  const oauth = useOAuthConnection(provider.oauth ?? null);
+  const updateSecret = useSecretsStore((s) => s.updateSecret);
+  const addNotification = useNotificationStore((s) => s.addNotification);
+
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [keyValue, setKeyValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isConnected = configured || oauth.isConnected;
+
+  // Once the OAuth popup completes, collapse the inline key field — the card
+  // flips to its connected state on its own.
+  useEffect(() => {
+    if (isConnected) {
+      setExpanded(false);
+    }
+  }, [isConnected]);
+
+  const handleSaveKey = useCallback(async () => {
+    const trimmed = keyValue.trim();
+    if (!trimmed) {
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await updateSecret(provider.secretKey, trimmed);
+      setKeyValue("");
+      addNotification({
+        type: "success",
+        content: `${provider.name} connected`,
+        alert: true
+      });
+    } catch (err) {
+      setSaveError(
+        err instanceof Error
+          ? err.message
+          : "Couldn't save the key. Check your connection and try again."
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [keyValue, updateSecret, provider, addNotification]);
+
+  return (
+    <Card
+      variant="outlined"
+      padding="compact"
+      sx={{
+        borderRadius: BORDER_RADIUS.lg,
+        border: `1px solid ${
+          isConnected
+            ? `rgba(${theme.vars.palette.success.mainChannel} / 0.5)`
+            : theme.vars.palette.divider
+        }`,
+        backgroundColor: theme.vars.palette.background.paper,
+        transition: `${MOTION.border}, ${MOTION.background}`
+      }}
+    >
+      <FlexColumn gap={1.5}>
+        <FlexRow align="center" gap={1.5}>
+          {/* Icon */}
+          <FlexRow
+            align="center"
+            justify="center"
+            sx={{
+              width: 42,
+              height: 42,
+              minWidth: 42,
+              borderRadius: BORDER_RADIUS.lg,
+              backgroundColor: theme.vars.palette.background.default,
+              overflow: "hidden"
+            }}
+          >
+            <Box
+              component="img"
+              src={provider.icon}
+              alt=""
+              aria-hidden
+              sx={{
+                width: 24,
+                height: 24,
+                objectFit: "contain",
+                ...(provider.mono &&
+                  theme.applyStyles("dark", { filter: "invert(1)" }))
+              }}
+            />
+          </FlexRow>
+
+          {/* Info */}
+          <FlexColumn sx={{ flex: 1, minWidth: 0 }} gap={0.25}>
+            <FlexRow align="center" gap={0.75}>
+              <Text size="small" weight={600}>
+                {provider.name}
+              </Text>
+              {provider.oauth && !isConnected && (
+                <Chip
+                  label="1-click sign-in"
+                  compact
+                  variant="outlined"
+                  color="primary"
+                  sx={{ height: 18, fontWeight: 600 }}
+                />
+              )}
+              {provider.freeTier && !isConnected && (
+                <Chip
+                  label={provider.freeTier}
+                  compact
+                  variant="outlined"
+                  color="success"
+                  sx={{ height: 18, fontWeight: 600 }}
+                />
+              )}
+            </FlexRow>
+            <Caption sx={{ opacity: 0.7, lineHeight: 1.4 }}>
+              {provider.tagline}
+            </Caption>
+          </FlexColumn>
+
+          {/* Actions */}
+          <FlexRow align="center" gap={0.5} sx={{ flexShrink: 0 }}>
+            {isConnected ? (
+              <FlexRow align="center" gap={0.5}>
+                <CheckCircleRoundedIcon
+                  sx={{
+                    fontSize: 18,
+                    color: theme.vars.palette.success.main
+                  }}
+                />
+                <Caption size="small" color="success" sx={{ fontWeight: 600 }}>
+                  Connected
+                </Caption>
+              </FlexRow>
+            ) : (
+              <>
+                {provider.oauth && (
+                  <EditorButton
+                    density="compact"
+                    variant="contained"
+                    size="small"
+                    startIcon={
+                      oauth.isConnecting ? undefined : (
+                        <LoginIcon sx={{ fontSize: 14 }} />
+                      )
+                    }
+                    onClick={oauth.connect}
+                    disabled={oauth.isConnecting}
+                  >
+                    {oauth.isConnecting ? "Waiting…" : "Sign in"}
+                  </EditorButton>
+                )}
+                <EditorButton
+                  density="compact"
+                  variant={provider.oauth ? "outlined" : "contained"}
+                  size="small"
+                  startIcon={
+                    provider.oauth ? undefined : (
+                      <KeyRoundedIcon sx={{ fontSize: 14 }} />
+                    )
+                  }
+                  endIcon={
+                    <ExpandMoreRoundedIcon
+                      sx={{
+                        fontSize: 16,
+                        transition: MOTION.transform,
+                        transform: expanded ? "rotate(180deg)" : "none"
+                      }}
+                    />
+                  }
+                  onClick={() => setExpanded((v) => !v)}
+                >
+                  {provider.oauth ? "Use API key" : "Add API key"}
+                </EditorButton>
+              </>
+            )}
+          </FlexRow>
+        </FlexRow>
+
+        {/* Inline API-key entry */}
+        {expanded && !isConnected && (
+          <FlexColumn gap={0.75} className="nodrag nowheel">
+            <FlexRow gap={1} align="center">
+              <TextInput
+                size="small"
+                type="password"
+                placeholder={`Paste your ${provider.name} API key`}
+                value={keyValue}
+                onChange={(e) => setKeyValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleSaveKey();
+                  }
+                }}
+                fullWidth
+                autoFocus
+              />
+              <EditorButton
+                variant="contained"
+                density="compact"
+                size="small"
+                onClick={handleSaveKey}
+                disabled={saving || !keyValue.trim()}
+              >
+                {saving ? <LoadingSpinner size="small" inline /> : "Connect"}
+              </EditorButton>
+            </FlexRow>
+            <FlexRow justify="space-between" align="center" gap={1} wrap>
+              <EditorButton
+                density="compact"
+                variant="text"
+                size="small"
+                endIcon={<OpenInNewIcon sx={{ fontSize: 13 }} />}
+                onClick={() =>
+                  window.open(provider.keyUrl, "_blank", "noopener,noreferrer")
+                }
+              >
+                Get a {provider.name} key
+              </EditorButton>
+              <Caption size="smaller" sx={{ opacity: 0.6 }}>
+                {provider.costHint}
+              </Caption>
+            </FlexRow>
+            {saveError && (
+              <Caption size="small" color="error">
+                {saveError}
+              </Caption>
+            )}
+          </FlexColumn>
+        )}
+      </FlexColumn>
+    </Card>
+  );
+};
+
+export default memo(ProviderOnboardingCard);

--- a/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
@@ -1,0 +1,262 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import { useShallow } from "zustand/react/shallow";
+import BoltRoundedIcon from "@mui/icons-material/BoltRounded";
+import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
+import ComputerRoundedIcon from "@mui/icons-material/ComputerRounded";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+
+import {
+  Box,
+  Caption,
+  Card,
+  Dialog,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Text,
+  BORDER_RADIUS
+} from "../ui_primitives";
+import { useSecrets } from "../../hooks/useSecrets";
+import useProviderOnboardingStore from "../../stores/ProviderOnboardingStore";
+import ollamaIcon from "../../icons/providers/ollama.svg";
+import ProviderOnboardingCard from "./ProviderOnboardingCard";
+import CostGuide from "./CostGuide";
+import {
+  CAPABILITY_LABELS,
+  providersForCapability
+} from "./providerOnboardingCatalog";
+
+const SectionHeading = ({
+  icon,
+  title,
+  subtitle
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+}) => {
+  const theme = useTheme();
+  return (
+    <FlexRow align="center" gap={1}>
+      <FlexRow
+        align="center"
+        justify="center"
+        sx={{ color: theme.vars.palette.primary.main }}
+      >
+        {icon}
+      </FlexRow>
+      <FlexColumn gap={0}>
+        <Text size="small" weight={600}>
+          {title}
+        </Text>
+        <Caption size="smaller" sx={{ opacity: 0.6 }}>
+          {subtitle}
+        </Caption>
+      </FlexColumn>
+    </FlexRow>
+  );
+};
+
+/**
+ * Global onboarding dialog shown whenever a user is blocked by an unconfigured
+ * AI provider. Introduces providers in plain language, leads with one-click
+ * OAuth sign-in (OpenAI, Hugging Face), offers inline API-key entry for the
+ * rest, points at a free local option, and explains how costs work.
+ */
+const ProviderOnboardingDialog: React.FC = () => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const { open, capability, reason, highlightSecretKey, dismiss } =
+    useProviderOnboardingStore(
+      useShallow((s) => ({
+        open: s.open,
+        capability: s.capability,
+        reason: s.reason,
+        highlightSecretKey: s.highlightSecretKey,
+        dismiss: s.dismiss
+      }))
+    );
+
+  const { secrets } = useSecrets();
+  const configuredKeys = useMemo(
+    () => new Set(secrets.filter((s) => s.is_configured).map((s) => s.key)),
+    [secrets]
+  );
+
+  const providers = useMemo(
+    () => providersForCapability(capability),
+    [capability]
+  );
+  const oauthProviders = useMemo(
+    () => providers.filter((p) => p.oauth),
+    [providers]
+  );
+  const keyProviders = useMemo(
+    () => providers.filter((p) => !p.oauth),
+    [providers]
+  );
+
+  const subtitle = capability
+    ? `Connect a provider for ${CAPABILITY_LABELS[capability]} to continue.`
+    : "Connect a provider to unlock AI models across the editor and your workflows.";
+
+  const handleOpenSettings = useCallback(() => {
+    dismiss();
+    navigate("/settings?tab=1");
+  }, [dismiss, navigate]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={dismiss}
+      maxWidth="sm"
+      fullWidth
+      title={
+        <FlexColumn gap={0.25}>
+          <Text size="big" weight={600}>
+            Connect an AI provider
+          </Text>
+          <Caption sx={{ opacity: 0.7, lineHeight: 1.4 }}>
+            {reason ?? subtitle}
+          </Caption>
+        </FlexColumn>
+      }
+    >
+      <FlexColumn gap={2.5} sx={{ mt: 1 }}>
+        <Caption sx={{ opacity: 0.75, lineHeight: 1.55 }}>
+          NodeTool connects to AI providers with your own account. Pick one
+          below — your credentials are encrypted and stored locally, and you can
+          add more or switch anytime.
+        </Caption>
+
+        {oauthProviders.length > 0 && (
+          <FlexColumn gap={1.25}>
+            <SectionHeading
+              icon={<BoltRoundedIcon sx={{ fontSize: 18 }} />}
+              title="Fastest way to start"
+              subtitle="Sign in with one click — no key to copy."
+            />
+            {oauthProviders.map((provider) => (
+              <ProviderOnboardingCard
+                key={provider.id}
+                provider={provider}
+                configured={configuredKeys.has(provider.secretKey)}
+                defaultExpanded={highlightSecretKey === provider.secretKey}
+              />
+            ))}
+          </FlexColumn>
+        )}
+
+        {keyProviders.length > 0 && (
+          <FlexColumn gap={1.25}>
+            <SectionHeading
+              icon={<KeyRoundedIcon sx={{ fontSize: 18 }} />}
+              title="Connect with an API key"
+              subtitle="Create a key on the provider's site and paste it here."
+            />
+            {keyProviders.map((provider) => (
+              <ProviderOnboardingCard
+                key={provider.id}
+                provider={provider}
+                configured={configuredKeys.has(provider.secretKey)}
+                defaultExpanded={highlightSecretKey === provider.secretKey}
+              />
+            ))}
+          </FlexColumn>
+        )}
+
+        {/* Free local option */}
+        <FlexColumn gap={1.25}>
+          <SectionHeading
+            icon={<ComputerRoundedIcon sx={{ fontSize: 18 }} />}
+            title="Run locally, free"
+            subtitle="No API key or internet needed."
+          />
+          <Card
+            variant="outlined"
+            padding="compact"
+            sx={{
+              borderRadius: BORDER_RADIUS.lg,
+              border: `1px solid ${theme.vars.palette.divider}`
+            }}
+          >
+            <FlexRow align="center" gap={1.5}>
+              <FlexRow
+                align="center"
+                justify="center"
+                sx={{
+                  width: 42,
+                  height: 42,
+                  minWidth: 42,
+                  borderRadius: BORDER_RADIUS.lg,
+                  backgroundColor: theme.vars.palette.background.default
+                }}
+              >
+                <Box
+                  component="img"
+                  src={ollamaIcon}
+                  alt=""
+                  aria-hidden
+                  sx={{
+                    width: 24,
+                    height: 24,
+                    objectFit: "contain",
+                    ...theme.applyStyles("dark", { filter: "invert(1)" })
+                  }}
+                />
+              </FlexRow>
+              <FlexColumn sx={{ flex: 1, minWidth: 0 }} gap={0.25}>
+                <Text size="small" weight={600}>
+                  Ollama
+                </Text>
+                <Caption sx={{ opacity: 0.7, lineHeight: 1.4 }}>
+                  Download open models and run them on your own machine —
+                  private and free.
+                </Caption>
+              </FlexColumn>
+              <EditorButton
+                density="compact"
+                variant="outlined"
+                size="small"
+                endIcon={<OpenInNewIcon sx={{ fontSize: 13 }} />}
+                onClick={() =>
+                  window.open(
+                    "https://ollama.com/download",
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
+                }
+              >
+                Get Ollama
+              </EditorButton>
+            </FlexRow>
+          </Card>
+        </FlexColumn>
+
+        <CostGuide />
+
+        <FlexRow justify="center" sx={{ pt: 0.5 }}>
+          <EditorButton
+            density="compact"
+            variant="text"
+            size="small"
+            startIcon={<SettingsOutlinedIcon sx={{ fontSize: 15 }} />}
+            onClick={handleOpenSettings}
+          >
+            See all providers in Settings
+          </EditorButton>
+        </FlexRow>
+      </FlexColumn>
+    </Dialog>
+  );
+};
+
+export default memo(ProviderOnboardingDialog);

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import ProviderOnboardingCard from "../ProviderOnboardingCard";
+import { ONBOARDING_PROVIDERS } from "../providerOnboardingCatalog";
+import {
+  useOAuthConnection,
+  type OAuthConnection
+} from "../../../hooks/useOAuthConnection";
+import useSecretsStore from "../../../stores/SecretsStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+
+jest.mock("../../../hooks/useOAuthConnection");
+jest.mock("../../../stores/SecretsStore");
+jest.mock("../../../stores/NotificationStore");
+
+const mockUseOAuthConnection = useOAuthConnection as jest.MockedFunction<
+  typeof useOAuthConnection
+>;
+const mockUseSecretsStore = useSecretsStore as unknown as jest.Mock;
+const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
+
+const updateSecret = jest.fn().mockResolvedValue(undefined);
+const addNotification = jest.fn();
+
+const oauthState = (overrides: Partial<OAuthConnection>): OAuthConnection => ({
+  label: "",
+  isConnected: false,
+  isConnecting: false,
+  canDisconnect: false,
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  ...overrides
+});
+
+const openai = ONBOARDING_PROVIDERS.find((p) => p.id === "openai")!;
+const anthropic = ONBOARDING_PROVIDERS.find((p) => p.id === "anthropic")!;
+
+const renderCard = (
+  provider = anthropic,
+  props: Partial<React.ComponentProps<typeof ProviderOnboardingCard>> = {}
+) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProviderOnboardingCard
+        provider={provider}
+        configured={false}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseOAuthConnection.mockReturnValue(oauthState({}));
+  mockUseSecretsStore.mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({ updateSecret })
+  );
+  mockUseNotificationStore.mockImplementation(
+    (selector: (s: unknown) => unknown) => selector({ addNotification })
+  );
+});
+
+describe("ProviderOnboardingCard", () => {
+  it("shows a one-click sign-in for an OAuth provider", () => {
+    renderCard(openai);
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.getByText(/1-click sign-in/i)).toBeInTheDocument();
+  });
+
+  it("starts an OAuth flow when sign-in is clicked", async () => {
+    const connect = jest.fn();
+    mockUseOAuthConnection.mockReturnValue(oauthState({ connect }));
+    renderCard(openai);
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves a pasted API key for a key-based provider", async () => {
+    renderCard(anthropic);
+    await userEvent.click(
+      screen.getByRole("button", { name: /add api key/i })
+    );
+    const input = screen.getByPlaceholderText(/paste your anthropic api key/i);
+    await userEvent.type(input, "sk-test-123");
+    await userEvent.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    await waitFor(() =>
+      expect(updateSecret).toHaveBeenCalledWith(
+        "ANTHROPIC_API_KEY",
+        "sk-test-123"
+      )
+    );
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" })
+    );
+  });
+
+  it("expands the key field by default when highlighted", () => {
+    renderCard(anthropic, { defaultExpanded: true });
+    expect(
+      screen.getByPlaceholderText(/paste your anthropic api key/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a connected state and no actions when configured", () => {
+    renderCard(anthropic, { configured: true });
+    expect(screen.getByText(/^connected$/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add api key/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/provider_onboarding/__tests__/providerOnboardingCatalog.test.ts
+++ b/web/src/components/provider_onboarding/__tests__/providerOnboardingCatalog.test.ts
@@ -1,0 +1,60 @@
+import {
+  ONBOARDING_PROVIDERS,
+  CAPABILITY_LABELS,
+  providersForCapability
+} from "../providerOnboardingCatalog";
+import type { OnboardingCapability } from "../../../stores/ProviderOnboardingStore";
+
+describe("providerOnboardingCatalog", () => {
+  it("gives every provider a label, key, icon, and cost hint", () => {
+    for (const provider of ONBOARDING_PROVIDERS) {
+      expect(provider.name).toBeTruthy();
+      expect(provider.secretKey).toMatch(/^[A-Z0-9_]+$/);
+      expect(provider.icon).toBeTruthy();
+      expect(provider.capabilities.length).toBeGreaterThan(0);
+      expect(provider.keyUrl).toMatch(/^https:\/\//);
+      expect(provider.costHint).toBeTruthy();
+    }
+  });
+
+  it("has a friendly label for every capability", () => {
+    const capabilities = new Set<OnboardingCapability>();
+    for (const provider of ONBOARDING_PROVIDERS) {
+      provider.capabilities.forEach((c) => capabilities.add(c));
+    }
+    for (const capability of capabilities) {
+      expect(CAPABILITY_LABELS[capability]).toBeTruthy();
+    }
+  });
+
+  it("filters providers to a requested capability", () => {
+    const tts = providersForCapability("text_to_speech");
+    expect(tts.length).toBeGreaterThan(0);
+    expect(tts.every((p) => p.capabilities.includes("text_to_speech"))).toBe(
+      true
+    );
+    // A chat-only provider must not appear in the text-to-speech list.
+    expect(tts.some((p) => p.id === "anthropic")).toBe(false);
+  });
+
+  it("returns the full curated list when no capability is given", () => {
+    expect(providersForCapability()).toHaveLength(ONBOARDING_PROVIDERS.length);
+  });
+
+  it("orders recommended providers first", () => {
+    const ordered = providersForCapability("generate_message");
+    const firstNonRecommended = ordered.findIndex((p) => !p.recommended);
+    const lastRecommended = ordered
+      .map((p) => Boolean(p.recommended))
+      .lastIndexOf(true);
+    // No recommended provider appears after a non-recommended one.
+    if (firstNonRecommended !== -1) {
+      expect(lastRecommended).toBeLessThan(firstNonRecommended);
+    }
+  });
+
+  it("leads with one-click OAuth providers among the recommended set", () => {
+    expect(ONBOARDING_PROVIDERS.some((p) => p.oauth === "openai")).toBe(true);
+    expect(ONBOARDING_PROVIDERS.some((p) => p.oauth === "hf")).toBe(true);
+  });
+});

--- a/web/src/components/provider_onboarding/providerOnboardingCatalog.ts
+++ b/web/src/components/provider_onboarding/providerOnboardingCatalog.ts
@@ -1,0 +1,208 @@
+import type { OnboardingCapability } from "../../stores/ProviderOnboardingStore";
+
+import openaiIcon from "../../icons/providers/openai.svg";
+import anthropicIcon from "../../icons/providers/anthropic.svg";
+import geminiColorIcon from "../../icons/providers/gemini-color.svg";
+import huggingfaceColorIcon from "../../icons/providers/huggingface-color.svg";
+import groqIcon from "../../icons/providers/groq.svg";
+import mistralColorIcon from "../../icons/providers/mistral-color.svg";
+import falColorIcon from "../../icons/providers/fal-color.svg";
+import replicateIcon from "../../icons/providers/replicate.svg";
+import elevenlabsIcon from "../../icons/providers/elevenlabs.svg";
+
+export interface OnboardingProvider {
+  id: string;
+  name: string;
+  /** Secret key / env var this provider stores its credential under. */
+  secretKey: string;
+  icon: string;
+  /** Single-color (black) glyph — needs inverting in dark mode to stay visible. */
+  mono?: boolean;
+  /** Supports one-click OAuth sign-in instead of pasting a key. */
+  oauth?: "openai" | "hf";
+  /** Short, plain-language description of what the provider is good for. */
+  tagline: string;
+  /** Capabilities this provider unlocks (matches the providers endpoint). */
+  capabilities: OnboardingCapability[];
+  /** Page where the user creates an API key. */
+  keyUrl: string;
+  /** Provider pricing / docs page. */
+  pricingUrl: string;
+  /** One-line, beginner-friendly cost summary. */
+  costHint: string;
+  /** Whether a free tier or free credits are available to start. */
+  freeTier?: string;
+  /** Highlighted as an easy first choice. */
+  recommended?: boolean;
+}
+
+/**
+ * Curated set of providers surfaced in onboarding. Deliberately smaller than
+ * the full API-Keys registry — the goal is to give a beginner a short, clear
+ * menu of good first choices, not every option. OAuth providers come first
+ * because they're the easiest to connect (no key to copy).
+ */
+export const ONBOARDING_PROVIDERS: OnboardingProvider[] = [
+  {
+    id: "openai",
+    name: "OpenAI",
+    secretKey: "OPENAI_API_KEY",
+    icon: openaiIcon,
+    mono: true,
+    oauth: "openai",
+    tagline: "GPT for chat, plus image, speech, and embeddings.",
+    capabilities: [
+      "generate_message",
+      "text_to_image",
+      "text_to_speech",
+      "automatic_speech_recognition",
+      "generate_embedding"
+    ],
+    keyUrl: "https://platform.openai.com/api-keys",
+    pricingUrl: "https://openai.com/api/pricing/",
+    costHint: "Pay per token, ~$0.15–$5 per 1M tokens depending on the model.",
+    recommended: true
+  },
+  {
+    id: "huggingface",
+    name: "Hugging Face",
+    secretKey: "HF_TOKEN",
+    icon: huggingfaceColorIcon,
+    oauth: "hf",
+    tagline: "Thousands of open models for image, chat, and audio.",
+    capabilities: [
+      "generate_message",
+      "text_to_image",
+      "text_to_speech",
+      "automatic_speech_recognition"
+    ],
+    keyUrl: "https://huggingface.co/settings/tokens",
+    pricingUrl: "https://huggingface.co/docs/inference-providers/pricing",
+    costHint: "Pay for compute time on serverless inference providers.",
+    freeTier: "Free monthly credits",
+    recommended: true
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    secretKey: "ANTHROPIC_API_KEY",
+    icon: anthropicIcon,
+    mono: true,
+    tagline: "Claude models for reasoning, writing, and agents.",
+    capabilities: ["generate_message"],
+    keyUrl: "https://console.anthropic.com/settings/keys",
+    pricingUrl: "https://www.anthropic.com/pricing#api",
+    costHint: "Pay per token, ~$0.25–$15 per 1M tokens depending on the model.",
+    recommended: true
+  },
+  {
+    id: "gemini",
+    name: "Google Gemini",
+    secretKey: "GEMINI_API_KEY",
+    icon: geminiColorIcon,
+    tagline: "Gemini for chat and images, Veo for video.",
+    capabilities: [
+      "generate_message",
+      "text_to_image",
+      "text_to_video",
+      "generate_embedding"
+    ],
+    keyUrl: "https://aistudio.google.com/apikey",
+    pricingUrl: "https://ai.google.dev/pricing",
+    costHint: "Pay per token, with a generous free tier to experiment.",
+    freeTier: "Free tier available",
+    recommended: true
+  },
+  {
+    id: "groq",
+    name: "Groq",
+    secretKey: "GROQ_API_KEY",
+    icon: groqIcon,
+    mono: true,
+    tagline: "Very fast open-model chat on custom hardware.",
+    capabilities: ["generate_message", "automatic_speech_recognition"],
+    keyUrl: "https://console.groq.com/keys",
+    pricingUrl: "https://groq.com/pricing/",
+    costHint: "Low per-token pricing, among the cheapest for open models.",
+    freeTier: "Free tier available"
+  },
+  {
+    id: "mistral",
+    name: "Mistral",
+    secretKey: "MISTRAL_API_KEY",
+    icon: mistralColorIcon,
+    tagline: "European open models for chat and embeddings.",
+    capabilities: ["generate_message", "generate_embedding"],
+    keyUrl: "https://console.mistral.ai/api-keys/",
+    pricingUrl: "https://mistral.ai/pricing",
+    costHint: "Pay per token, competitive pricing for open models.",
+    freeTier: "Free tier available"
+  },
+  {
+    id: "fal",
+    name: "FAL",
+    secretKey: "FAL_API_KEY",
+    icon: falColorIcon,
+    tagline: "Fast image and video generation (FLUX and more).",
+    capabilities: ["text_to_image", "text_to_video"],
+    keyUrl: "https://fal.ai/dashboard/keys",
+    pricingUrl: "https://fal.ai/pricing",
+    costHint: "Pay per generation, priced per image or per second of video."
+  },
+  {
+    id: "replicate",
+    name: "Replicate",
+    secretKey: "REPLICATE_API_TOKEN",
+    icon: replicateIcon,
+    mono: true,
+    tagline: "Run open image, video, and audio models in the cloud.",
+    capabilities: [
+      "text_to_image",
+      "text_to_video",
+      "text_to_music",
+      "generate_message"
+    ],
+    keyUrl: "https://replicate.com/account/api-tokens",
+    pricingUrl: "https://replicate.com/pricing",
+    costHint: "Pay for compute by the second while a model runs."
+  },
+  {
+    id: "elevenlabs",
+    name: "ElevenLabs",
+    secretKey: "ELEVENLABS_API_KEY",
+    icon: elevenlabsIcon,
+    mono: true,
+    tagline: "High-quality, natural text-to-speech voices.",
+    capabilities: ["text_to_speech"],
+    keyUrl: "https://elevenlabs.io/app/settings/api-keys",
+    pricingUrl: "https://elevenlabs.io/pricing",
+    costHint: "Pay per character of speech generated.",
+    freeTier: "Free tier available"
+  }
+];
+
+/** Human-readable label for a required capability, for the dialog subtitle. */
+export const CAPABILITY_LABELS: Record<OnboardingCapability, string> = {
+  generate_message: "chat and language models",
+  text_to_image: "image generation",
+  text_to_speech: "text-to-speech",
+  automatic_speech_recognition: "speech-to-text",
+  text_to_music: "music generation",
+  text_to_video: "video generation",
+  generate_embedding: "embeddings"
+};
+
+/**
+ * Providers for a blocking capability, recommended ones first. With no
+ * capability we show the whole curated list (recommended first).
+ */
+export const providersForCapability = (
+  capability?: OnboardingCapability
+): OnboardingProvider[] => {
+  const matches = capability
+    ? ONBOARDING_PROVIDERS.filter((p) => p.capabilities.includes(capability))
+    : ONBOARDING_PROVIDERS;
+  return [...matches].sort(
+    (a, b) => Number(b.recommended ?? false) - Number(a.recommended ?? false)
+  );
+};

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -69,6 +69,9 @@ const RunWarningDialog = React.lazy(
 const SearchProviderSetupDialog = React.lazy(
   () => import("./components/dialogs/SearchProviderSetupDialog")
 );
+const ProviderOnboardingDialog = React.lazy(
+  () => import("./components/provider_onboarding/ProviderOnboardingDialog")
+);
 
 import { installIpcLogBridge } from "./logging/ipcLogBridge";
 import MobileClassProvider from "./components/MobileClassProvider";
@@ -710,6 +713,7 @@ const AppWrapper = () => {
                       <DownloadManagerDialog />
                       <RunWarningDialog />
                       <SearchProviderSetupDialog />
+                      <ProviderOnboardingDialog />
                     </>
                   )}
                 </KeyboardProvider>

--- a/web/src/stores/ProviderOnboardingStore.ts
+++ b/web/src/stores/ProviderOnboardingStore.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+
+/**
+ * Backend capability strings a blocking point can require. These match the
+ * `capabilities` returned by the providers endpoint (see useProviders.ts), so
+ * the onboarding dialog can filter its catalog to providers that unblock the
+ * feature the user was trying to use.
+ */
+export type OnboardingCapability =
+  | "generate_message"
+  | "text_to_image"
+  | "text_to_speech"
+  | "automatic_speech_recognition"
+  | "text_to_music"
+  | "text_to_video"
+  | "generate_embedding";
+
+interface OpenOptions {
+  /** Feature the user was blocked on — filters and orders the provider list. */
+  capability?: OnboardingCapability;
+  /** Friendly one-liner explaining why the dialog appeared. */
+  reason?: string;
+  /** Secret key of a provider to pre-expand (e.g. from a per-node warning). */
+  highlightSecretKey?: string;
+}
+
+interface ProviderOnboardingState {
+  open: boolean;
+  capability?: OnboardingCapability;
+  reason?: string;
+  highlightSecretKey?: string;
+  show: (options?: OpenOptions) => void;
+  dismiss: () => void;
+}
+
+/**
+ * Drives the global provider-onboarding dialog. Any place a user gets blocked
+ * by an unconfigured AI provider — the chat welcome screen, an inline model
+ * callout, a per-node "key missing" warning, the model menu — opens this
+ * instead of routing to Settings, so the user can connect a provider (OAuth or
+ * API key) in context and keep going.
+ */
+export const useProviderOnboardingStore = create<ProviderOnboardingState>(
+  (set) => ({
+    open: false,
+    capability: undefined,
+    reason: undefined,
+    highlightSecretKey: undefined,
+    show: (options) =>
+      set({
+        open: true,
+        capability: options?.capability,
+        reason: options?.reason,
+        highlightSecretKey: options?.highlightSecretKey
+      }),
+    dismiss: () =>
+      set({
+        open: false,
+        capability: undefined,
+        reason: undefined,
+        highlightSecretKey: undefined
+      })
+  })
+);
+
+/** Imperative opener for non-React call sites (run gate, event handlers). */
+export const openProviderOnboarding = (options?: OpenOptions): void => {
+  useProviderOnboardingStore.getState().show(options);
+};
+
+export default useProviderOnboardingStore;

--- a/web/src/stores/__tests__/ProviderOnboardingStore.test.ts
+++ b/web/src/stores/__tests__/ProviderOnboardingStore.test.ts
@@ -1,0 +1,50 @@
+import {
+  useProviderOnboardingStore,
+  openProviderOnboarding
+} from "../ProviderOnboardingStore";
+
+describe("ProviderOnboardingStore", () => {
+  beforeEach(() => {
+    useProviderOnboardingStore.getState().dismiss();
+  });
+
+  it("starts closed with no context", () => {
+    const state = useProviderOnboardingStore.getState();
+    expect(state.open).toBe(false);
+    expect(state.capability).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.highlightSecretKey).toBeUndefined();
+  });
+
+  it("opens with capability and reason context", () => {
+    useProviderOnboardingStore.getState().show({
+      capability: "text_to_image",
+      reason: "Need an image model"
+    });
+    const state = useProviderOnboardingStore.getState();
+    expect(state.open).toBe(true);
+    expect(state.capability).toBe("text_to_image");
+    expect(state.reason).toBe("Need an image model");
+  });
+
+  it("carries a highlighted secret key through the imperative opener", () => {
+    openProviderOnboarding({ highlightSecretKey: "FAL_API_KEY" });
+    expect(useProviderOnboardingStore.getState().highlightSecretKey).toBe(
+      "FAL_API_KEY"
+    );
+  });
+
+  it("clears all context on dismiss", () => {
+    openProviderOnboarding({
+      capability: "generate_message",
+      reason: "x",
+      highlightSecretKey: "OPENAI_API_KEY"
+    });
+    useProviderOnboardingStore.getState().dismiss();
+    const state = useProviderOnboardingStore.getState();
+    expect(state.open).toBe(false);
+    expect(state.capability).toBeUndefined();
+    expect(state.reason).toBeUndefined();
+    expect(state.highlightSecretKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a beginner-friendly **provider onboarding dialog** that appears wherever a user gets blocked by an unconfigured AI provider, instead of dumping them into the Settings page.

Before, every blocked spot just did `navigate("/settings?tab=1")`. Now they open a focused dialog that introduces providers, leads with the easiest ways to connect, and explains costs — so a first-time user can get unblocked in context and keep going.

## Where it hooks in

The dialog is a global overlay driven by a small Zustand store (`ProviderOnboardingStore`), mounted once at the app root next to the other global dialogs. It's opened from every existing block point:

- **Chat** — the empty-thread welcome screen (`WelcomePlaceholder`), filtered to `generate_message`.
- **Blocked run** — the inline model callout under a node's model selector (`ModelSetupCallout`).
- **Model menu** — a provider's "Add key" action (`ProviderList`), pre-expanding that provider.
- **Per-node** — the "key missing" warning on a node (`ApiKeyValidation`), pre-expanding the required provider.

Each call can pass the blocking `capability` (chat, image, TTS, …) so the dialog only shows providers that unblock it, and an optional `highlightSecretKey` to pre-open the right card.

## The dialog

- Plain-language intro to what providers are and that keys are stored locally.
- **Fastest way to start** — one-click OAuth sign-in for OpenAI and Hugging Face (reuses the existing `useOAuthConnection` hook).
- **Connect with an API key** — inline key entry per provider with a "get a key" link and a per-provider cost hint (reuses `SecretsStore.updateSecret`).
- **Run locally, free** — Ollama.
- **How do costs work?** — a collapsible, beginner explainer of tokens vs. per-result pricing, who gets billed, and how to start cheap or free.

## Tests

- `providerOnboardingCatalog.test.ts` — catalog integrity, capability filtering, recommended ordering.
- `ProviderOnboardingStore.test.ts` — open/dismiss and context propagation.
- `ProviderOnboardingCard.test.tsx` — OAuth sign-in, inline key save, connected state.
- Updated `WelcomePlaceholder.test.tsx` for the new "Connect a provider" action.

A `/preview/provider-onboarding` entry is added to the component-preview harness for screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014YPuL7DJ71XWugvnDw6o91)_