### PR TITLE
feat(web): QoL improvements for chat sidebar, command palette, collections

### DIFF
--- a/web/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/web/src/components/chat/sidebar/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useState, useCallback, memo } from "react";
+import React, { useState, useCallback, useEffect, useRef, memo } from "react";
 import { FlexRow, FlexColumn, ToolbarIconButton, Text, ScrollArea, SearchInput, NavButton, MOTION, BORDER_RADIUS, reducedMotion, Z_INDEX, SPACING, getSpacingPx } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import MenuIcon from "@mui/icons-material/Menu";
@@ -34,10 +34,27 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
 }) => {
     const theme = useTheme();
     const [searchQuery, setSearchQuery] = useState("");
+    const searchInputRef = useRef<HTMLInputElement>(null);
 
     const handleSearchChange = useCallback((value: string) => {
         setSearchQuery(value);
     }, []);
+
+    // ⌘K / Ctrl+K focuses the thread search while the sidebar is open.
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+                event.preventDefault();
+                searchInputRef.current?.focus();
+                searchInputRef.current?.select();
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen]);
 
     const handleOpen = useCallback(() => {
         onOpenChange(true);
@@ -217,30 +234,32 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
                         }}
                     >
                         <SearchInput
+                            ref={searchInputRef}
                             placeholder="Search threads..."
                             value={searchQuery}
                             onChange={handleSearchChange}
                             fullWidth
-                            showClear={false}
                         />
-                        <Text
-                            aria-hidden
-                            size="smaller"
-                            sx={{
-                                position: "absolute",
-                                right: 8,
-                                top: "50%",
-                                transform: "translateY(-50%)",
-                                pointerEvents: "none",
-                                color: theme.vars.palette.grey[500],
-                                border: `1px solid ${theme.vars.palette.grey[700]}`,
-                                borderRadius: BORDER_RADIUS.xs,
-                                px: 0.5,
-                                lineHeight: 1.4
-                            }}
-                        >
-                            ⌘K
-                        </Text>
+                        {!searchQuery && (
+                            <Text
+                                aria-hidden
+                                size="smaller"
+                                sx={{
+                                    position: "absolute",
+                                    right: 8,
+                                    top: "50%",
+                                    transform: "translateY(-50%)",
+                                    pointerEvents: "none",
+                                    color: theme.vars.palette.grey[500],
+                                    border: `1px solid ${theme.vars.palette.grey[700]}`,
+                                    borderRadius: BORDER_RADIUS.xs,
+                                    px: 0.5,
+                                    lineHeight: 1.4
+                                }}
+                            >
+                                ⌘K
+                            </Text>
+                        )}
                     </FlexRow>
                     <NavButton
                         icon={<AddIcon sx={{ fontSize: "var(--fontSizeBig)" }} />}
@@ -268,6 +287,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
                         onSelectThread={handleSelectThread}
                         onDeleteThread={onDeleteThread}
                         getThreadPreview={getThreadPreview}
+                        isFiltered={searchQuery.trim().length > 0}
                     />
                 </ScrollArea>
             </FlexColumn>

--- a/web/src/components/chat/thread/EmptyThreadList.tsx
+++ b/web/src/components/chat/thread/EmptyThreadList.tsx
@@ -4,14 +4,20 @@ import { useTheme } from "@mui/material/styles";
 import { createStyles } from "./EmptyThreadList.styles";
 import { EmptyState } from "../../ui_primitives";
 
-export const EmptyThreadList: React.FC = () => {
+export const EmptyThreadList: React.FC<{ isFiltered?: boolean }> = ({
+  isFiltered = false
+}) => {
   const theme = useTheme();
   return (
     <li css={createStyles(theme)}>
       <EmptyState
         variant="empty"
-        title="No conversations yet"
-        description="Start a conversation to explore AI workflows with natural language."
+        title={isFiltered ? "No matching conversations" : "No conversations yet"}
+        description={
+          isFiltered
+            ? "Try a different search term."
+            : "Start a conversation to explore AI workflows with natural language."
+        }
         size="small"
       />
     </li>

--- a/web/src/components/chat/thread/ThreadList.tsx
+++ b/web/src/components/chat/thread/ThreadList.tsx
@@ -25,7 +25,8 @@ const ThreadList: React.FC<ThreadListProps> = ({
   currentThreadId,
   onSelectThread,
   onDeleteThread,
-  getThreadPreview
+  getThreadPreview,
+  isFiltered = false
 }) => {
   const theme = useTheme<Theme>();
   const componentStyles = createStyles(theme);
@@ -94,7 +95,7 @@ const ThreadList: React.FC<ThreadListProps> = ({
     <div className="thread-list-container" css={componentStyles}>
       <ul className="thread-list">
         {!threads || Object.keys(threads).length === 0 || listElements.length === 0 ? (
-          <EmptyThreadList />
+          <EmptyThreadList isFiltered={isFiltered} />
         ) : (
           listElements
         )}

--- a/web/src/components/chat/thread/__tests__/EmptyThreadList.test.tsx
+++ b/web/src/components/chat/thread/__tests__/EmptyThreadList.test.tsx
@@ -1,0 +1,21 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+import { EmptyThreadList } from "../EmptyThreadList";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("EmptyThreadList", () => {
+  it("shows the default empty message when not filtered", () => {
+    renderWithTheme(<EmptyThreadList />);
+    expect(screen.getByText("No conversations yet")).toBeInTheDocument();
+  });
+
+  it("shows a no-match message when filtered", () => {
+    renderWithTheme(<EmptyThreadList isFiltered />);
+    expect(screen.getByText("No matching conversations")).toBeInTheDocument();
+    expect(screen.getByText("Try a different search term.")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/types/thread.types.ts
+++ b/web/src/components/chat/types/thread.types.ts
@@ -14,6 +14,8 @@ export interface ThreadListProps {
   onSelectThread: (id: string) => void;
   onDeleteThread: (id: string) => void;
   getThreadPreview: (id: string) => string;
+  /** True when the list is showing the result of an active search filter. */
+  isFiltered?: boolean;
 }
 
 export interface ThreadItemProps {

--- a/web/src/components/collections/CollectionList.tsx
+++ b/web/src/components/collections/CollectionList.tsx
@@ -11,10 +11,12 @@ import {
   CreateFab,
   Dialog,
   EditorButton,
+  EmptyState,
   FlexColumn,
   FlexRow,
   ListGroup,
   ListItemRow,
+  LoadingSpinner,
   Surface,
   Text,
   BORDER_RADIUS
@@ -132,13 +134,20 @@ const CollectionList = () => {
           </FlexRow>
 
           {collections?.collections.length ? <CollectionHeader /> : null}
-          {error && (
-            <Text color="error" sx={{ mt: 2 }}>
-              Error loading collections
-            </Text>
-          )}
           {isLoading ? (
-            <Text sx={{ mt: 2 }}>Loading collections…</Text>
+            <FlexColumn gap={2} justify="center" align="center" sx={{ mt: 4 }}>
+              <LoadingSpinner size="large" text="Loading collections" />
+            </FlexColumn>
+          ) : error ? (
+            <FlexColumn gap={2} justify="center" align="center" sx={{ mt: 4, px: 2 }}>
+              <EmptyState
+                variant="error"
+                title="Couldn't load collections"
+                description="Try again later."
+                actionText="Retry"
+                onAction={() => fetchCollections()}
+              />
+            </FlexColumn>
           ) : !collections?.collections.length ? (
             <EmptyCollectionState />
           ) : (

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -645,18 +645,11 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
   }, [executeAndClose, reactFlowWrapper]);
 
   useEffect(() => {
-    const focusInput = () => {
-      const inputElement = document.querySelector("input[cmdk-input]");
-      if (inputElement instanceof HTMLInputElement) {
-        inputElement.focus();
-      }
-    };
-
     if (open) {
       if (focusInputTimeoutRef.current) {
         clearTimeout(focusInputTimeoutRef.current);
       }
-      focusInputTimeoutRef.current = setTimeout(focusInput, 0);
+      focusInputTimeoutRef.current = setTimeout(() => input.current?.focus(), 0);
     }
 
     return () => {
@@ -688,7 +681,11 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
       css={styles()}
     >
       <Command label="Command Menu" className="command-menu">
-        <CommandInput ref={input} />
+        <CommandInput
+          ref={input}
+          placeholder="Type a command or search…"
+          aria-label="Command menu search"
+        />
         <Command.List>
           <Command.Empty>No results found.</Command.Empty>
           <WorkflowCommands />


### PR DESCRIPTION
## Summary

A set of small, self-contained quality-of-life fixes for the web UI, targeting places that deviated from the app's established list/search/empty-state patterns.

### Chat sidebar (`ChatSidebar`, `ThreadList`, `EmptyThreadList`)
- **Clear button on thread search.** The thread search set `showClear={false}`, the only search input in the app without a clear affordance. Enabling it restores the X button and Escape-to-clear that every other search already has.
- **The ⌘K badge now does something.** A decorative `⌘K` pill sat next to the search implying a shortcut, but nothing was wired. Added a keydown handler that focuses (and selects) the thread search on ⌘K / Ctrl+K while the sidebar is open, and hides the badge once the user has typed.
- **Correct empty state when filtering.** Searching with no matches showed "No conversations yet / Start a conversation…", which is wrong when you *have* conversations that just don't match. It now shows "No matching conversations / Try a different search term." — mirroring `WorkflowList`/`ScriptListPanel`.

### Command palette (`CommandMenu`)
- Added a `placeholder` ("Type a command or search…") and `aria-label` to the previously bare, unlabeled input.
- Focus the input through its existing `ref` instead of a `document.querySelector("input[cmdk-input]")` lookup.

### Collections (`CollectionList`)
- Replaced plain-text "Loading collections…" / "Error loading collections" (the latter with no recovery) with the shared `LoadingSpinner` and an `EmptyState` error that offers a **Retry** action, matching the other list panels.

## Testing
- `npx tsc --noEmit` (web) — clean
- `npx eslint` on all changed files — clean
- `npx jest src/components/chat src/components/collections` — 167 passing
- Added `EmptyThreadList.test.tsx` covering the filtered vs. default empty message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146ckckdntg21J8x8PfvShj

---
_Generated by [Claude Code](https://claude.ai/code/session_0146ckckdntg21J8x8PfvShj)_