### PR TITLE
feat(web): keyboard shortcuts and QoL for the script editor

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { DragEvent } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
@@ -32,7 +32,7 @@ import { voiceAll } from "../../stores/script/scriptVoicing";
 import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
-import ScriptLineRow, { TEXT_INSET } from "./ScriptLineRow";
+import ScriptLineRow, { TEXT_INSET, type LineKeyNav } from "./ScriptLineRow";
 
 interface ScriptDocumentPaneProps {
   scriptId: string;
@@ -123,13 +123,15 @@ const SectionBlock = ({
   section,
   currentLineId,
   readOnly,
-  dnd
+  dnd,
+  onKeyNav
 }: {
   scriptId: string;
   section: ScriptSection;
   currentLineId: string | null;
   readOnly: boolean;
   dnd: LineDnd;
+  onKeyNav: (lineId: string, nav: LineKeyNav) => void;
 }) => {
   const cast = useScript(scriptId).cast;
   const setSectionTitle = useScriptStore((s) => s.setSectionTitle);
@@ -239,6 +241,7 @@ const SectionBlock = ({
               cast={cast}
               highlighted={line.id === currentLineId}
               readOnly={readOnly}
+              onKeyNav={onKeyNav}
               isDragging={dnd.draggingLineId === line.id}
               onDragStart={
                 readOnly ? undefined : () => dnd.onLineDragStart(line.id)
@@ -282,6 +285,9 @@ const ScriptDocumentPane = ({
   const addLine = useScriptStore((s) => s.addLine);
   const addSection = useScriptStore((s) => s.addSection);
   const moveLine = useScriptStore((s) => s.moveLine);
+  const insertLine = useScriptStore((s) => s.insertLine);
+  const patchLine = useScriptStore((s) => s.patchLine);
+  const removeLine = useScriptStore((s) => s.removeLine);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
   const [voicingAll, setVoicingAll] = useState(false);
@@ -313,6 +319,75 @@ const ScriptDocumentPane = ({
       setDropTarget(null);
     }
   };
+
+  // Flat, document-order line id list — drives arrow-key focus moves and
+  // delete-and-focus-previous.
+  const flatLineIds = useMemo(
+    () => sections.flatMap((s) => s.lines.map((l) => l.id)),
+    [sections]
+  );
+
+  // Focus a line's text field once React has committed the mutation, placing
+  // the caret at the start or end.
+  const focusLine = useCallback((lineId: string, caret: "start" | "end") => {
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLTextAreaElement>(
+        `[data-script-line="${lineId}"]`
+      );
+      if (!el) return;
+      el.focus();
+      const pos = caret === "start" ? 0 : el.value.length;
+      el.setSelectionRange(pos, pos);
+    });
+  }, []);
+
+  const onLineKeyNav = useCallback(
+    (lineId: string, nav: LineKeyNav) => {
+      const located = (() => {
+        for (const section of sections) {
+          const index = section.lines.findIndex((l) => l.id === lineId);
+          if (index >= 0) return { section, index };
+        }
+        return null;
+      })();
+      if (!located) return;
+      const { section, index } = located;
+      const line = section.lines[index];
+
+      if (nav.type === "split") {
+        patchLine(scriptId, lineId, { text: nav.before });
+        const newId = insertLine(scriptId, section.id, index + 1);
+        // Continue the same speaker so a run of dialogue doesn't need
+        // re-tagging after every Enter.
+        patchLine(scriptId, newId, {
+          text: nav.after,
+          speakerId: line.speakerId ?? null
+        });
+        focusLine(newId, "start");
+        return;
+      }
+      if (nav.type === "delete-empty") {
+        const pos = flatLineIds.indexOf(lineId);
+        const prevId = pos > 0 ? flatLineIds[pos - 1] : null;
+        removeLine(scriptId, lineId);
+        if (prevId) focusLine(prevId, "end");
+        return;
+      }
+      // Arrow move: hop to the sibling in document order.
+      const pos = flatLineIds.indexOf(lineId);
+      const targetId = flatLineIds[pos + nav.dir];
+      if (targetId) focusLine(targetId, nav.dir < 0 ? "end" : "start");
+    },
+    [
+      sections,
+      flatLineIds,
+      scriptId,
+      patchLine,
+      insertLine,
+      removeLine,
+      focusLine
+    ]
+  );
 
   const onVoiceAll = useCallback(async () => {
     setVoicingAll(true);
@@ -349,6 +424,17 @@ const ScriptDocumentPane = ({
   }, [scriptId]);
 
   const isEmpty = sections.every((s) => s.lines.length === 0);
+  const { lineCount, wordCount } = useMemo(() => {
+    let lines = 0;
+    let words = 0;
+    for (const section of sections)
+      for (const line of section.lines) {
+        lines += 1;
+        const trimmed = line.text.trim();
+        if (trimmed) words += trimmed.split(/\s+/).length;
+      }
+    return { lineCount: lines, wordCount: words };
+  }, [sections]);
   const hasVoicedLine = sections.some((section) =>
     section.lines.some((line) =>
       line.takes.some((t) => t.id === line.currentTakeId)
@@ -410,6 +496,12 @@ const ScriptDocumentPane = ({
           </EditorButton>
         )}
         <Box sx={{ flex: 1 }} />
+        {!isEmpty && (
+          <Text size="smaller" sx={{ color: "text.secondary" }}>
+            {lineCount} {lineCount === 1 ? "line" : "lines"} · {wordCount}{" "}
+            {wordCount === 1 ? "word" : "words"}
+          </Text>
+        )}
         {!readOnly && (
           <EditorButton
             size="small"
@@ -469,6 +561,7 @@ const ScriptDocumentPane = ({
             currentLineId={currentLineId}
             readOnly={readOnly}
             dnd={dnd}
+            onKeyNav={onLineKeyNav}
           />
         ))}
         {!readOnly && !isEmpty && (

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -1,8 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useState } from "react";
-import type { ChangeEvent, DragEvent, MouseEvent } from "react";
+import type {
+  ChangeEvent,
+  DragEvent,
+  KeyboardEvent,
+  MouseEvent
+} from "react";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import HistoryIcon from "@mui/icons-material/History";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import TheaterComedyIcon from "@mui/icons-material/TheaterComedy";
@@ -35,6 +41,21 @@ import { useAssetStore } from "../../stores/AssetStore";
 import { getAssetUrl } from "../../utils/assetHelpers";
 import ScriptTakeGallery from "./ScriptTakeGallery";
 
+/**
+ * A keyboard intent bubbled up from a line's text field. The pane owns the
+ * section/ordering, so it turns these into store mutations and cross-line
+ * focus moves:
+ * - `split`  — Enter: keep `before` on this line, carry `after` to a new line
+ *   below (inheriting the speaker) and focus it.
+ * - `delete-empty` — Backspace on an empty, unvoiced line: remove it and focus
+ *   the previous line's end.
+ * - `focus` — Arrow up/down at the text boundary: move focus to the sibling.
+ */
+export type LineKeyNav =
+  | { type: "split"; before: string; after: string }
+  | { type: "delete-empty" }
+  | { type: "focus"; dir: -1 | 1 };
+
 interface ScriptLineRowProps {
   scriptId: string;
   line: ScriptLine;
@@ -43,6 +64,7 @@ interface ScriptLineRowProps {
   readOnly: boolean;
   /** True while this row is the one being dragged (dimmed as it lifts out). */
   isDragging?: boolean;
+  onKeyNav?: (lineId: string, nav: LineKeyNav) => void;
   onDragStart?: (e: DragEvent<HTMLElement>) => void;
   onDragEnd?: (e: DragEvent<HTMLElement>) => void;
   onDragOver?: (e: DragEvent<HTMLElement>) => void;
@@ -88,6 +110,7 @@ const ScriptLineRow = ({
   highlighted,
   readOnly,
   isDragging = false,
+  onKeyNav,
   onDragStart,
   onDragEnd,
   onDragOver,
@@ -95,6 +118,7 @@ const ScriptLineRow = ({
 }: ScriptLineRowProps) => {
   const patchLine = useScriptStore((s) => s.patchLine);
   const removeLine = useScriptStore((s) => s.removeLine);
+  const duplicateLine = useScriptStore((s) => s.duplicateLine);
   const voicing = useLineVoicing(line.id);
   const [galleryAnchor, setGalleryAnchor] = useState<HTMLElement | null>(null);
   const [voiceError, setVoiceError] = useState<string | null>(null);
@@ -108,6 +132,41 @@ const ScriptLineRow = ({
     (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
       patchLine(scriptId, line.id, { text: e.target.value }),
     [patchLine, scriptId, line.id]
+  );
+
+  // Text-field keyboard shortcuts (ElevenLabs-Studio feel). The row reads the
+  // caret from the textarea and bubbles an intent; the pane applies it.
+  const onTextKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (readOnly || !onKeyNav) return;
+      const el = e.target as HTMLTextAreaElement;
+      // Enter splits the line at the caret; Shift+Enter keeps a soft newline.
+      // Skip while an IME composition is open so committing a candidate with
+      // Enter doesn't create a line.
+      if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+        e.preventDefault();
+        const caret = el.selectionStart ?? el.value.length;
+        onKeyNav(line.id, {
+          type: "split",
+          before: el.value.slice(0, caret),
+          after: el.value.slice(caret)
+        });
+        return;
+      }
+      const atStart = el.selectionStart === 0 && el.selectionEnd === 0;
+      const atEnd =
+        el.selectionStart === el.value.length &&
+        el.selectionEnd === el.value.length;
+      if (e.key === "Backspace" && el.value === "" && line.takes.length === 0) {
+        e.preventDefault();
+        onKeyNav(line.id, { type: "delete-empty" });
+      } else if (e.key === "ArrowUp" && atStart) {
+        onKeyNav(line.id, { type: "focus", dir: -1 });
+      } else if (e.key === "ArrowDown" && atEnd) {
+        onKeyNav(line.id, { type: "focus", dir: 1 });
+      }
+    },
+    [readOnly, onKeyNav, line.id, line.takes.length]
   );
 
   const onDirectionChange = useCallback(
@@ -265,6 +324,7 @@ const ScriptLineRow = ({
         <TextInput
           value={line.text}
           onChange={onTextChange}
+          onKeyDown={onTextKeyDown}
           placeholder="Write a line…"
           multiline
           hideLabel
@@ -272,6 +332,7 @@ const ScriptLineRow = ({
           compact
           fullWidth
           disabled={readOnly}
+          inputProps={{ "data-script-line": line.id }}
           sx={{
             ...quietField,
             "& .MuiOutlinedInput-input": { ...TYPOGRAPHY.sans.body }
@@ -376,6 +437,13 @@ const ScriptLineRow = ({
             }
             icon={<HistoryIcon fontSize="small" />}
           />
+          {!readOnly && (
+            <ToolbarIconButton
+              tooltip="Duplicate line"
+              onClick={() => duplicateLine(scriptId, line.id)}
+              icon={<ContentCopyIcon fontSize="small" />}
+            />
+          )}
           {!readOnly && (
             <ToolbarIconButton
               tooltip="Delete line"

--- a/web/src/stores/script/ScriptStore.ts
+++ b/web/src/stores/script/ScriptStore.ts
@@ -121,6 +121,13 @@ interface ScriptStoreState {
   // Lines
   addLine: (scriptId: string, sectionId?: string) => string;
   insertLine: (scriptId: string, sectionId: string, index: number) => string;
+  /**
+   * Copy `lineId` (text, speaker, direction, pause, voice override) into a
+   * fresh, unvoiced line placed directly after it in the same section. Takes
+   * are intentionally dropped — a duplicate starts as a draft. Returns the new
+   * line id, or null when the line is not found.
+   */
+  duplicateLine: (scriptId: string, lineId: string) => string | null;
   patchLine: (
     scriptId: string,
     lineId: string,
@@ -388,6 +395,39 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
       }))
     );
     return lineId;
+  },
+
+  duplicateLine: (scriptId, lineId) => {
+    const newId = uid("line");
+    let created = false;
+    set((state) =>
+      withScript(state, scriptId, (s) => {
+        let done = false;
+        const sections = s.sections.map((section) => {
+          if (done) return section;
+          const idx = section.lines.findIndex((l) => l.id === lineId);
+          if (idx < 0) return section;
+          const src = section.lines[idx];
+          const clone: ScriptLine = {
+            id: newId,
+            text: src.text,
+            speakerId: src.speakerId ?? null,
+            direction: src.direction,
+            pauseAfterMs: src.pauseAfterMs,
+            voiceOverride: src.voiceOverride,
+            takes: [],
+            currentTakeId: null
+          };
+          const lines = [...section.lines];
+          lines.splice(idx + 1, 0, clone);
+          done = true;
+          created = true;
+          return { ...section, lines };
+        });
+        return done ? { ...s, sections } : s;
+      })
+    );
+    return created ? newId : null;
   },
 
   patchLine: (scriptId, lineId, patch) =>

--- a/web/src/stores/script/__tests__/ScriptStore.test.ts
+++ b/web/src/stores/script/__tests__/ScriptStore.test.ts
@@ -95,6 +95,38 @@ describe("insertLine", () => {
   });
 });
 
+describe("duplicateLine", () => {
+  it("clones content into a fresh, unvoiced line right after the original", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    const lineId = firstLineId();
+    store.patchLine(SCRIPT, lineId, {
+      text: "hello",
+      speakerId: "spk1",
+      direction: "cheerful"
+    });
+    store.appendTake(SCRIPT, lineId, take({ id: "t1" }));
+
+    const newId = store.duplicateLine(SCRIPT, lineId);
+    const lines = useScriptStore.getState().scripts[SCRIPT].sections[0].lines;
+    expect(lines.map((l) => l.id)).toEqual([lineId, newId]);
+    const clone = lines[1];
+    expect(clone.text).toBe("hello");
+    expect(clone.speakerId).toBe("spk1");
+    expect(clone.direction).toBe("cheerful");
+    // Takes are dropped — a duplicate starts as a draft.
+    expect(clone.takes).toEqual([]);
+    expect(clone.currentTakeId).toBeNull();
+  });
+
+  it("returns null for an unknown line", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    expect(store.duplicateLine(SCRIPT, "missing")).toBeNull();
+  });
+});
+
 describe("moveLine", () => {
   const seed = (n: number): { sectionId: string; ids: string[] } => {
     const store = useScriptStore.getState();


### PR DESCRIPTION
## What

Quality-of-life improvements that make the script document pane feel like a real writing surface instead of a form of separate text boxes.

### Keyboard shortcuts in a line's text field
- **Enter** splits the line at the caret — the text before the caret stays, the remainder moves to a new line below (inheriting the current line's speaker), and focus jumps to it. **Shift+Enter** still inserts a soft newline within the line. IME compositions are respected, so committing a candidate with Enter doesn't create a line.
- **Backspace** on an empty, unvoiced line deletes it and moves the caret to the end of the previous line. Lines that carry takes are left alone so voiced audio isn't dropped by accident.
- **Arrow Up / Down** at the very start / end of a line hop focus to the sibling line, so you can walk the script with the keyboard.

### Duplicate line
- New `duplicateLine` store action and a row toolbar button (copy icon). It clones text, speaker, direction, pause and per-line voice override into a fresh line right below — takes are intentionally dropped so the duplicate starts as a draft.

### Header stats
- The toolbar shows a live `N lines · M words` count.

## Why

Writing a multi-line script previously meant reaching for the "Add line" button or the hover "+" gap for every line, re-tagging the speaker each time, and there was no way to duplicate a near-identical line. These shortcuts mirror the ElevenLabs-Studio editing feel the surface is modeled on.

## Implementation notes

- Cross-line focus is handled in `ScriptDocumentPane` (which owns section ordering): each line's textarea carries a `data-script-line` attribute, and the pane focuses the target after the mutation commits via `requestAnimationFrame`.
- `ScriptLineRow` only reads the caret and bubbles a typed `LineKeyNav` intent (`split` / `delete-empty` / `focus`); the pane turns it into store mutations. No new refs threaded through the tree.

## Tests

- Added `duplicateLine` unit tests (clone content + drop takes, null on unknown line) to `ScriptStore.test.ts`.
- Full script test suites pass (44 tests); lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY2zSWDh1mJCcCkdbDxJvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY2zSWDh1mJCcCkdbDxJvn)_