### PR TITLE
feat(web): direct shot management + styled revise dialog in storyboard

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -10,11 +10,14 @@
  * has a still.
  */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import type { Shot, ShotStatus } from "@nodetool-ai/protocol";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 
 import {
   Card,
@@ -26,6 +29,10 @@ import {
   Text,
   Caption,
   VideoPlayer,
+  Dialog,
+  TextInput,
+  ToolbarIconButton,
+  HoverActionGroup,
   SPACING,
   getSpacingPx,
   BORDER_RADIUS,
@@ -44,6 +51,10 @@ interface ShotCardProps {
   boardId: string;
   shot: Shot;
   readOnly?: boolean;
+  /** True when this is the first shot on the board (disables "move up"). */
+  isFirst?: boolean;
+  /** True when this is the last shot on the board (disables "move down"). */
+  isLast?: boolean;
 }
 
 const STATUS_META: Record<ShotStatus, { status: StatusType; label: string; pulse?: boolean }> = {
@@ -149,9 +160,17 @@ const cameraLine = (shot: Shot): string =>
 
 const EMPTY_IDS: string[] = [];
 
-const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => {
+const ShotCardInner: React.FC<ShotCardProps> = ({
+  boardId,
+  shot,
+  readOnly,
+  isFirst,
+  isLast
+}) => {
   const theme = useTheme();
   const toggleShotEntity = useStoryboardStore((state) => state.toggleShotEntity);
+  const moveShot = useStoryboardStore((state) => state.moveShot);
+  const removeShot = useStoryboardStore((state) => state.removeShot);
   const boardEntityIds = useStoryboardStore(
     (state) => state.boards[boardId]?.entityIds ?? EMPTY_IDS
   );
@@ -170,11 +189,16 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
     };
   }, [allEntities, boardEntityIds, shot]);
 
+  const [reviseOpen, setReviseOpen] = useState(false);
+  const [reviseText, setReviseText] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
   const meta = STATUS_META[shot.status];
   const isGenerating =
     shot.status === "keyframe_generating" || shot.status === "clip_generating";
   const camera = cameraLine(shot);
   const clipUri = shot.clip?.uri;
+  const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
 
   const handleGenerateStill = useCallback(() => {
     void generateKeyframe(boardId, shot);
@@ -184,14 +208,27 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
     void generateClip(boardId, shot);
   }, [generateClip, boardId, shot]);
 
-  const handleRevise = useCallback(() => {
-    const instruction = window.prompt(
-      "Describe the change to make (e.g. 'make it darker, add rain')"
-    );
-    if (instruction && instruction.trim().length > 0) {
-      void generateRevisedClip(boardId, shot, instruction.trim());
+  const handleReviseConfirm = useCallback(() => {
+    const instruction = reviseText.trim();
+    if (instruction.length > 0) {
+      void generateRevisedClip(boardId, shot, instruction);
     }
-  }, [generateRevisedClip, boardId, shot]);
+    setReviseOpen(false);
+    setReviseText("");
+  }, [reviseText, generateRevisedClip, boardId, shot]);
+
+  const handleMoveUp = useCallback(() => {
+    moveShot(boardId, shot.id, "up");
+  }, [moveShot, boardId, shot.id]);
+
+  const handleMoveDown = useCallback(() => {
+    moveShot(boardId, shot.id, "down");
+  }, [moveShot, boardId, shot.id]);
+
+  const handleDelete = useCallback(() => {
+    removeShot(boardId, shot.id);
+    setConfirmDelete(false);
+  }, [removeShot, boardId, shot.id]);
 
   return (
     <Card
@@ -226,7 +263,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
       <FlexColumn className="details">
         <FlexRow align="center" justify="space-between" gap={1} wrap>
           <Text size="small" weight={600} truncate>
-            {`${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`}
+            {shotName}
           </Text>
           <FlexRow align="center" gap={1}>
             {typeof shot.cost_estimate === "number" && (
@@ -241,6 +278,32 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
               label={meta.label}
               pulse={meta.pulse}
             />
+            {!readOnly && (
+              <HoverActionGroup triggerSelector=".shot-card:hover" gap={0}>
+                <ToolbarIconButton
+                  icon={<ArrowUpwardIcon sx={{ fontSize: 16 }} />}
+                  tooltip="Move up"
+                  ariaLabel="Move shot up"
+                  onClick={handleMoveUp}
+                  disabled={isFirst}
+                />
+                <ToolbarIconButton
+                  icon={<ArrowDownwardIcon sx={{ fontSize: 16 }} />}
+                  tooltip="Move down"
+                  ariaLabel="Move shot down"
+                  onClick={handleMoveDown}
+                  disabled={isLast}
+                />
+                <ToolbarIconButton
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 16 }} />}
+                  tooltip="Delete shot"
+                  ariaLabel="Delete shot"
+                  variant="error"
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={isGenerating}
+                />
+              </HoverActionGroup>
+            )}
           </FlexRow>
         </FlexRow>
 
@@ -308,13 +371,53 @@ const ShotCardInner: React.FC<ShotCardProps> = ({ boardId, shot, readOnly }) => 
               {shot.clip ? "New clip" : "Generate clip"}
             </EditorButton>
             {shot.clip && (
-              <EditorButton onClick={handleRevise} disabled={isGenerating}>
+              <EditorButton
+                onClick={() => setReviseOpen(true)}
+                disabled={isGenerating}
+              >
                 Revise clip
               </EditorButton>
             )}
           </FlexRow>
         )}
       </FlexColumn>
+
+      <Dialog
+        open={reviseOpen}
+        onClose={() => setReviseOpen(false)}
+        title="Revise clip"
+        onConfirm={handleReviseConfirm}
+        confirmText="Revise"
+        confirmDisabled={reviseText.trim().length === 0}
+      >
+        <FlexColumn gap={1}>
+          <Caption color="secondary">
+            Describe the change to make. The current clip is re-rendered with
+            your note applied.
+          </Caption>
+          <TextInput
+            value={reviseText}
+            placeholder="e.g. make it darker, add rain"
+            onChange={(e) => setReviseText(e.target.value)}
+            multiline
+            rows={3}
+            autoFocus
+          />
+        </FlexColumn>
+      </Dialog>
+
+      <Dialog
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        title="Delete shot?"
+        onConfirm={handleDelete}
+        confirmText="Delete"
+        destructive
+      >
+        <Text size="small">
+          {`Remove “${shotName}” from the board. Generated stills and clips stay in your asset library.`}
+        </Text>
+      </Dialog>
     </Card>
   );
 };

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -437,12 +437,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
             {`${shots.length} shot${shots.length === 1 ? "" : "s"}`}
           </Text>
           <div className="shot-list">
-            {shots.map((shot) => (
+            {shots.map((shot, i) => (
               <ShotCard
                 key={shot.id}
                 boardId={boardId}
                 shot={shot}
                 readOnly={readOnly}
+                isFirst={i === 0}
+                isLast={i === shots.length - 1}
               />
             ))}
           </div>

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import type { Shot, ShotStatus } from "@nodetool-ai/protocol";
@@ -15,6 +15,28 @@ jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
     generateRevisedClip: generateRevisedClipMock
   })
 }));
+
+const moveShotMock = jest.fn();
+const removeShotMock = jest.fn();
+jest.mock("../../../stores/storyboard/StoryboardStore", () => {
+  const actual = jest.requireActual(
+    "../../../stores/storyboard/StoryboardStore"
+  );
+  return {
+    ...actual,
+    // Serve the actions the card reads via selectors; keep sameMediaRef and the
+    // other real exports (the nested takes gallery uses them).
+    useStoryboardStore: (selector: (s: unknown) => unknown) =>
+      selector({
+        toggleShotEntity: jest.fn(),
+        moveShot: moveShotMock,
+        removeShot: removeShotMock,
+        selectKeyframeVersion: jest.fn(),
+        selectClipVersion: jest.fn(),
+        boards: {}
+      })
+  };
+});
 
 jest.mock("../../node/ImageRefPreview", () => ({
   __esModule: true,
@@ -41,14 +63,19 @@ const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
   ...overrides
 });
 
-const renderCard = (shot: Shot) =>
+const renderCard = (shot: Shot, props: Partial<React.ComponentProps<typeof ShotCard>> = {}) =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <ShotCard boardId="board-1" shot={shot} />
+      <ShotCard boardId="board-1" shot={shot} {...props} />
     </ThemeProvider>
   );
 
 describe("ShotCard", () => {
+  beforeEach(() => {
+    moveShotMock.mockClear();
+    removeShotMock.mockClear();
+  });
+
   it("renders the shot action and status label", () => {
     renderCard(makeShot());
     expect(screen.getByText("A lighthouse at dusk")).toBeInTheDocument();
@@ -87,7 +114,7 @@ describe("ShotCard", () => {
     expect(screen.getByRole("button", { name: "Generate clip" })).toBeEnabled();
   });
 
-  it("shows Revise clip only once a clip exists and prompts for an instruction", async () => {
+  it("shows Revise clip only once a clip exists and collects an instruction in a dialog", async () => {
     generateRevisedClipMock.mockClear();
     // No clip yet: the revise affordance is absent.
     const { unmount } = renderCard(makeShot({ status: "keyframe_ready" }));
@@ -101,20 +128,64 @@ describe("ShotCard", () => {
       clip: { type: "video", uri: "http://example.com/clip.mp4" }
     });
     renderCard(shot);
-    const reviseButton = screen.getByRole("button", { name: "Revise clip" });
-    expect(reviseButton).toBeEnabled();
+    await userEvent.click(screen.getByRole("button", { name: "Revise clip" }));
 
-    const promptSpy = jest
-      .spyOn(window, "prompt")
-      .mockReturnValue("make it darker, add rain");
-    await userEvent.click(reviseButton);
-    expect(promptSpy).toHaveBeenCalled();
+    // The dialog opens; confirm is gated until an instruction is typed.
+    const dialog = await screen.findByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: "Revise" });
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "make it darker, add rain"
+    );
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+
     expect(generateRevisedClipMock).toHaveBeenCalledWith(
       "board-1",
       shot,
       "make it darker, add rain"
     );
-    promptSpy.mockRestore();
+  });
+
+  it("reorders a shot with the move controls", async () => {
+    renderCard(makeShot(), { isFirst: false, isLast: false });
+    await userEvent.click(screen.getByRole("button", { name: "Move shot up" }));
+    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "up");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move shot down" })
+    );
+    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "down");
+  });
+
+  it("disables move-up on the first shot and move-down on the last", () => {
+    renderCard(makeShot(), { isFirst: true, isLast: true });
+    expect(screen.getByRole("button", { name: "Move shot up" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move shot down" })
+    ).toBeDisabled();
+  });
+
+  it("deletes a shot only after confirming", async () => {
+    renderCard(makeShot());
+    await userEvent.click(screen.getByRole("button", { name: "Delete shot" }));
+    // Nothing removed until the confirmation is accepted.
+    expect(removeShotMock).not.toHaveBeenCalled();
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+    expect(removeShotMock).toHaveBeenCalledWith("board-1", "shot-1");
+  });
+
+  it("hides the management controls in read-only mode", () => {
+    renderCard(makeShot(), { readOnly: true });
+    expect(
+      screen.queryByRole("button", { name: "Move shot up" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete shot" })
+    ).not.toBeInTheDocument();
   });
 
   it("disables the still button while generating", () => {

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -123,6 +123,11 @@ interface StoryboardStoreState {
   removeShot: (boardId: string, shotId: string) => void;
   /** Reorder shots to match `orderedIds`; re-stamps each shot's `index`. */
   reorderShots: (boardId: string, orderedIds: string[]) => void;
+  /**
+   * Move one shot a single position earlier ("up") or later ("down") in the
+   * board order, re-stamping every shot's `index`. No-op at the ends.
+   */
+  moveShot: (boardId: string, shotId: string, direction: "up" | "down") => void;
   selectShot: (boardId: string, shotId: string | null) => void;
 
   getBoard: (id: string) => StoryboardBoard | undefined;
@@ -476,6 +481,27 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
           }
         }
         return { ...b, shots: reordered };
+      })
+    ),
+
+  moveShot: (boardId, shotId, direction) =>
+    set((state) =>
+      withBoard(state, boardId, (b) => {
+        const from = b.shots.findIndex((s) => s.id === shotId);
+        if (from === -1) {
+          return null;
+        }
+        const to = direction === "up" ? from - 1 : from + 1;
+        if (to < 0 || to >= b.shots.length) {
+          return null;
+        }
+        const shots = [...b.shots];
+        const [moved] = shots.splice(from, 1);
+        shots.splice(to, 0, moved);
+        return {
+          ...b,
+          shots: shots.map((s, i) => (s.index === i ? s : { ...s, index: i }))
+        };
       })
     ),
 

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -102,6 +102,48 @@ describe("selectKeyframeVersion", () => {
   });
 });
 
+describe("moveShot", () => {
+  const seedThree = (): void => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    for (let i = 0; i < 3; i++) {
+      store.upsertShot(BOARD, {
+        type: "shot",
+        id: `s${i}`,
+        index: i,
+        action: `shot ${i}`,
+        status: "planned"
+      });
+    }
+  };
+
+  const order = () =>
+    useStoryboardStore.getState().boards[BOARD]?.shots.map((s) => s.id);
+
+  it("moves a shot later and re-stamps index to match order", () => {
+    seedThree();
+    useStoryboardStore.getState().moveShot(BOARD, "s0", "down");
+
+    expect(order()).toEqual(["s1", "s0", "s2"]);
+    const shots = useStoryboardStore.getState().boards[BOARD]?.shots;
+    expect(shots?.map((s) => s.index)).toEqual([0, 1, 2]);
+  });
+
+  it("moves a shot earlier", () => {
+    seedThree();
+    useStoryboardStore.getState().moveShot(BOARD, "s2", "up");
+    expect(order()).toEqual(["s0", "s2", "s1"]);
+  });
+
+  it("is a no-op at the ends", () => {
+    seedThree();
+    const store = useStoryboardStore.getState();
+    store.moveShot(BOARD, "s0", "up");
+    store.moveShot(BOARD, "s2", "down");
+    expect(order()).toEqual(["s0", "s1", "s2"]);
+  });
+});
+
 describe("setShotClip / selectClipVersion", () => {
   it("accumulates takes and switches between them", () => {
     seed();


### PR DESCRIPTION
## Summary

Quality-of-life improvements for the Storyboard surface, closing the gap between what the store can do and what the UI exposes.

- **Reorder & delete shots directly on the card.** The store already supported reordering and removal, but those actions were only reachable by asking the agent. Each `ShotCard` now gets hover-revealed **move up / move down / delete** controls in its header (also revealed on keyboard focus). Move buttons disable at the ends; delete is disabled while a shot is generating.
- **Confirmed delete.** Deleting a shot asks first and notes that generated stills and clips stay in the asset library — only the shot's curation is removed.
- **Styled "Revise clip" dialog.** Replaced the native `window.prompt` with a proper `Dialog` + multiline `TextInput`; the confirm button stays disabled until an instruction is entered.

## Implementation

- Added a `moveShot(boardId, shotId, "up" | "down")` action to `StoryboardStore` — a single-position reorder that re-stamps each shot's `index` to match array order, and no-ops at the ends.
- `StoryboardBoard` passes `isFirst` / `isLast` to each card for edge gating.
- `ShotCard` uses `ToolbarIconButton`, `HoverActionGroup`, and `Dialog` from `ui_primitives` — no raw MUI components, design tokens throughout.

## Testing

- `web`: typecheck clean, lint clean.
- `ShotCard.test.tsx` — new coverage for reorder, edge gating, confirm-before-delete, read-only hiding, and the revise dialog (replacing the old `window.prompt` spy).
- `StoryboardStore.test.ts` — new `moveShot` cases (move later/earlier, index re-stamping, end no-ops).
- 19 tests pass across the two suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SD8acnMfnicGpnNRnrp5i

---
_Generated by [Claude Code](https://claude.ai/code/session_012SD8acnMfnicGpnNRnrp5i)_