### PR TITLE
Timeline editor: select-all, deselect, and keyboard zoom shortcuts

### DIFF
--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -16,11 +16,15 @@
  * Also registers window-level keyboard shortcuts for clip operations:
  *   Delete/Backspace → deleteSelected
  *   ← / →            → nudge selected clips one frame (Shift: 1 s)
+ *   Ctrl+A           → select every clip
+ *   Escape           → clear selection and return to the select tool
  *   Ctrl+C / X / V   → copy / cut / paste clips (paste lands at the playhead)
  *   Ctrl+D           → duplicateSelected (places duplicate right after source)
  *   Ctrl+Shift+D     → duplicateSelected with extra 1 s gap after source
  *   S                → splitSelectedAtPlayhead
  *   V / C            → select / cut tool
+ *   + / =  and  - / _ → zoom in / out (keyboard; playhead stays pinned)
+ *   Shift+Z          → zoom to fit all content in the viewport
  *   Ctrl+Z / Ctrl+Y  → undo / redo
  * Shortcuts are skipped when focus is in a text input or contenteditable.
  *
@@ -88,6 +92,11 @@ const DEFAULT_TRACK_HEIGHT_PX = 64;
 const ZOOM_SENSITIVITY = 0.001;
 /** Extra gap (ms) inserted after the source clip when using Ctrl+Shift+D. */
 const DUPLICATE_OFFSET_MS = 1000;
+/** Per-keypress zoom step (msPerPx smaller = zoomed in). */
+const ZOOM_IN_FACTOR = 0.8;
+const ZOOM_OUT_FACTOR = 1.25;
+/** Padding kept on each side when Shift+Z fits content to the viewport (px). */
+const ZOOM_FIT_PADDING_PX = 64;
 
 const containerStyles = (theme: Theme) =>
   css({
@@ -552,6 +561,25 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           return;
         }
 
+        // Ctrl/Cmd+A → select every clip
+        if (isCtrl && (e.key === "a" || e.key === "A")) {
+          e.preventDefault();
+          setSelection(docStore.getState().clips.map((c) => c.id));
+          return;
+        }
+
+        // Escape → clear selection and drop back to the select tool. No
+        // preventDefault so Escape still closes any open menu/dialog.
+        if (e.key === "Escape") {
+          if (selectedClipIds.size > 0) {
+            setSelection([]);
+          }
+          if (uiStoreApi.getState().activeTool !== "select") {
+            setActiveTool("select");
+          }
+          return;
+        }
+
         // ←/→ → nudge selected clips by one frame (Shift: 1 s)
         if (
           (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
@@ -640,6 +668,42 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         ) {
           e.preventDefault();
           setActiveTool(e.key === "v" ? "select" : "cut");
+          return;
+        }
+
+        // +/= → zoom in, -/_ → zoom out. setZoom triggers the scale-change
+        // layout effect above, which keeps the playhead pinned to the same
+        // viewport x as the lanes rescale.
+        if (!isCtrl && !e.altKey && (e.key === "+" || e.key === "=")) {
+          e.preventDefault();
+          const cur = uiStoreApi.getState().msPerPx;
+          uiStoreApi.getState().setZoom(cur * ZOOM_IN_FACTOR);
+          return;
+        }
+        if (!isCtrl && !e.altKey && (e.key === "-" || e.key === "_")) {
+          e.preventDefault();
+          const cur = uiStoreApi.getState().msPerPx;
+          uiStoreApi.getState().setZoom(cur * ZOOM_OUT_FACTOR);
+          return;
+        }
+
+        // Shift+Z → zoom so the whole content fits the visible lane width.
+        if (!isCtrl && e.shiftKey && (e.key === "z" || e.key === "Z")) {
+          e.preventDefault();
+          const el = scrollableRef.current;
+          if (el) {
+            let end = docStore.getState().durationMs || 0;
+            for (const c of docStore.getState().clips) {
+              end = Math.max(end, c.startMs + c.durationMs);
+            }
+            const viewport = el.clientWidth - ZOOM_FIT_PADDING_PX;
+            if (end > 0 && viewport > 0) {
+              // Pin the content start to the left edge as the lanes rescale,
+              // reusing the cursor-zoom anchor path (see the layout effect).
+              zoomAnchorRef.current = { timeMs: 0, cursorPx: 0 };
+              uiStoreApi.getState().setZoom(end / viewport);
+            }
+          }
           return;
         }
 

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * TracksRegion keyboard QoL shortcuts:
+ *   Ctrl/Cmd+A  → select every clip
+ *   Escape      → clear selection + return to the select tool
+ *   + / -       → zoom in / out
+ *
+ * The shortcuts are registered at the window level, so the events are fired on
+ * `window` rather than a specific element. Store state is seeded AFTER render
+ * so `getState()` routes to the mounted provider's instance (not the default).
+ */
+import React from "react";
+import { describe, it, expect, jest } from "@jest/globals";
+import { act, fireEvent, render } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { makeClip } from "@nodetool-ai/timeline";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { TracksRegion } from "../TracksRegion";
+import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
+import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+
+jest.mock("../../../../lib/rest-fetch", () => ({
+  restFetch: jest.fn()
+}));
+
+/** Render the region, then seed three clips and a clean UI baseline into the
+ *  mounted instance's stores. */
+const setup = () => {
+  const result = render(
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider>
+        <TracksRegion heightPx={400} />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+  act(() => {
+    useTimelineStore.getState().reset();
+    useTimelineStore.getState().addClips([
+      makeClip({ trackId: "t1", name: "a", startMs: 0, durationMs: 1000 }),
+      makeClip({ trackId: "t1", name: "b", startMs: 2000, durationMs: 1000 }),
+      makeClip({ trackId: "t1", name: "c", startMs: 5000, durationMs: 1000 })
+    ]);
+    useTimelineUIStore.getState().setSelection([]);
+    useTimelineUIStore.getState().setActiveTool("select");
+    useTimelineUIStore.getState().setZoom(10);
+  });
+  return result;
+};
+
+describe("TracksRegion keyboard shortcuts", () => {
+  it("Ctrl+A selects every clip", () => {
+    setup();
+    act(() => {
+      fireEvent.keyDown(window, { key: "a", ctrlKey: true });
+    });
+    expect(useTimelineUIStore.getState().selectedClipIds.size).toBe(3);
+  });
+
+  it("Escape clears the selection", () => {
+    setup();
+    act(() => {
+      fireEvent.keyDown(window, { key: "a", ctrlKey: true });
+    });
+    expect(useTimelineUIStore.getState().selectedClipIds.size).toBe(3);
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(useTimelineUIStore.getState().selectedClipIds.size).toBe(0);
+  });
+
+  it("Escape returns to the select tool", () => {
+    setup();
+    act(() => {
+      useTimelineUIStore.getState().setActiveTool("cut");
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(useTimelineUIStore.getState().activeTool).toBe("select");
+  });
+
+  it("+ zooms in (msPerPx decreases) and - zooms out", () => {
+    setup();
+    const start = useTimelineUIStore.getState().msPerPx;
+    act(() => {
+      fireEvent.keyDown(window, { key: "+" });
+    });
+    const zoomedIn = useTimelineUIStore.getState().msPerPx;
+    expect(zoomedIn).toBeLessThan(start);
+    act(() => {
+      fireEvent.keyDown(window, { key: "-" });
+    });
+    expect(useTimelineUIStore.getState().msPerPx).toBeGreaterThan(zoomedIn);
+  });
+
+  it("does not fire shortcuts while typing in an input", () => {
+    const { container } = setup();
+    const input = document.createElement("input");
+    container.appendChild(input);
+    input.focus();
+    act(() => {
+      fireEvent.keyDown(input, { key: "a", ctrlKey: true });
+    });
+    expect(useTimelineUIStore.getState().selectedClipIds.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Fills common gaps in the timeline editor's window-level keyboard shortcuts (registered in `TracksRegion`). These are operations most editors bind and users reach for reflexively:

| Shortcut | Action |
| --- | --- |
| `Ctrl`/`Cmd`+`A` | Select every clip |
| `Escape` | Clear the selection and return to the select tool |
| `+` / `=` | Zoom in |
| `-` / `_` | Zoom out |
| `Shift`+`Z` | Zoom to fit all content in the visible lane width |

## Why

The tracks region already handles delete, nudge, copy/cut/paste, duplicate, split, tool-switch, and undo/redo — but had no select-all, no deselect, and no keyboard zoom. Adding them removes friction from the most common selection and navigation actions.

## How

- Additions live in the existing window-level `keydown` handler in `TracksRegion`, following the established patterns (skip editable targets, read state imperatively from the store APIs, no new subscriptions or effect deps).
- Zoom in/out reuse the scale-change layout effect that already pins the playhead to the same viewport x as the lanes rescale.
- `Shift`+`Z` measures the visible lane width, derives the content extent from the clips, and reuses the cursor-zoom anchor path to pin the content start to the left edge.
- `Escape` does not `preventDefault`, so it still closes any open menu/dialog.
- The shortcut list in the `TracksRegion` doc comment is updated to match.

## Tests

New `TracksRegionShortcuts.test.tsx` covering select-all, deselect, tool reset, zoom in/out, and the editable-target guard. All 15 `Tracks` suites pass; the changed file is clean under `tsc` and `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dq2h8oAgjUeawMP47bQSYe)_