### PR TITLE
feat(web): shell-style prompt history in chat composers

### DIFF
--- a/web/src/components/chat/composer/ChatComposer.tsx
+++ b/web/src/components/chat/composer/ChatComposer.tsx
@@ -18,6 +18,7 @@ import { MessageInput } from "./MessageInput";
 import { ActionButtons } from "./ActionButtons";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
+import { usePromptHistory } from "../hooks/usePromptHistory";
 import { useMessageQueue } from "../../../hooks/useMessageQueue";
 import { createStyles } from "./ChatComposer.styles";
 
@@ -60,11 +61,19 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
     textareaRef
   });
 
+  const {
+    record: recordHistory,
+    handleKeyDown: handleHistoryKeyDown,
+    resetNavigation: resetHistoryNavigation
+  } = usePromptHistory({ value: prompt, setValue: setPrompt, textareaRef });
+
   const handleOnChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // A manual edit leaves history navigation so the next ArrowUp starts over.
+      resetHistoryNavigation();
       setPrompt(event.target.value);
     },
-    []
+    [resetHistoryNavigation]
   );
 
   const handleSend = useCallback(() => {
@@ -84,13 +93,18 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
     // Only clear the input when the message was actually sent or queued;
     // a dropped message (one already queued) keeps its text and attachments.
     if (sendMessage(fullContent, prompt)) {
+      recordHistory(prompt);
       setPrompt("");
       clearFiles();
     }
-  }, [prompt, droppedFiles, getFileContents, sendMessage, clearFiles]);
+  }, [prompt, droppedFiles, getFileContents, sendMessage, clearFiles, recordHistory]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Let history navigation (ArrowUp/ArrowDown) claim the key first.
+      if (handleHistoryKeyDown(e)) {
+        return;
+      }
       if (e.key === "Enter") {
         // Ignore the Enter that confirms an IME composition candidate — it
         // fires keydown with isComposing/keyCode 229 and must not send.
@@ -109,7 +123,7 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
         }
       }
     },
-    [handleSend]
+    [handleSend, handleHistoryKeyDown]
   );
 
   const isDisabled = disabled || isLoading || isStreaming;

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -77,6 +77,7 @@ import { useTextareaAssetMention } from "./useTextareaAssetMention";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
+import { usePromptHistory } from "../hooks/usePromptHistory";
 import { useMessageQueue } from "../../../hooks/useMessageQueue";
 import { createMediaComposerStyles } from "./MediaChatComposer.styles";
 import useModelPreferencesStore from "../../../stores/ModelPreferencesStore";
@@ -282,6 +283,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
       onSelectAsset: handleSelectAsset,
       onSelectEntity: handleSelectEntity
     });
+
+  const {
+    record: recordHistory,
+    handleKeyDown: handleHistoryKeyDown,
+    resetNavigation: resetHistoryNavigation
+  } = usePromptHistory({ value: prompt, setValue: setPrompt, textareaRef });
 
   const adjustHeight = useCallback(() => {
     const el = textareaRef.current;
@@ -495,6 +502,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     // Only clear the input when the message was actually sent or queued; a
     // dropped message (one already queued) keeps its text and attachments.
     if (sendMessage(fullContent, prompt)) {
+      recordHistory(prompt);
       setPrompt("");
       clearFiles();
     }
@@ -503,7 +511,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     canGenerate,
     getFileContents,
     sendMessage,
-    clearFiles
+    clearFiles,
+    recordHistory
   ]);
 
   const handlePaste = useCallback(
@@ -541,6 +550,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
       if (handleMentionKeyDown(e)) {
         return;
       }
+      // Then history navigation (ArrowUp/ArrowDown) when the picker is closed.
+      if (handleHistoryKeyDown(e)) {
+        return;
+      }
       if (e.key === "Enter") {
         // Read modifiers from the event, not the global KeyPressedStore, which
         // is stale when the textarea was click-focused with a modifier held.
@@ -553,7 +566,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         }
       }
     },
-    [handleMentionKeyDown, handleSend]
+    [handleMentionKeyDown, handleHistoryKeyDown, handleSend]
   );
 
   const modeIcon = useMemo(() => {
@@ -855,7 +868,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           className="media-compose-input"
           aria-label="Message prompt"
           value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
+          onChange={(e) => {
+            resetHistoryNavigation();
+            setPrompt(e.target.value);
+          }}
           onInput={adjustHeight}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}

--- a/web/src/components/chat/composer/__tests__/usePromptHistory.test.tsx
+++ b/web/src/components/chat/composer/__tests__/usePromptHistory.test.tsx
@@ -1,0 +1,189 @@
+// web/src/components/chat/composer/__tests__/usePromptHistory.test.tsx
+import React, { useRef, useState, useCallback } from "react";
+import "@testing-library/jest-dom";
+import { render, fireEvent, act } from "@testing-library/react";
+import { usePromptHistory } from "../../hooks/usePromptHistory";
+
+// jsdom's requestAnimationFrame fires async; run the caret-setting callback
+// synchronously so tests can assert caret state right after a key press.
+beforeAll(() => {
+  jest
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+function Harness() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [value, setValue] = useState("");
+  const { record, handleKeyDown, resetNavigation } = usePromptHistory({
+    value,
+    setValue,
+    textareaRef
+  });
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (handleKeyDown(e)) {
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        record(value);
+        setValue("");
+      }
+    },
+    [handleKeyDown, record, value]
+  );
+
+  return (
+    <textarea
+      data-testid="input"
+      ref={textareaRef}
+      value={value}
+      onChange={(e) => {
+        resetNavigation();
+        setValue(e.target.value);
+      }}
+      onKeyDown={onKeyDown}
+    />
+  );
+}
+
+function getInput() {
+  return document.querySelector<HTMLTextAreaElement>(
+    '[data-testid="input"]'
+  ) as HTMLTextAreaElement;
+}
+
+function type(text: string) {
+  const input = getInput();
+  fireEvent.change(input, { target: { value: text } });
+}
+
+function send(text: string) {
+  type(text);
+  const input = getInput();
+  input.setSelectionRange(text.length, text.length);
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+function setCaret(pos: number) {
+  getInput().setSelectionRange(pos, pos);
+}
+
+function arrowUp() {
+  fireEvent.keyDown(getInput(), { key: "ArrowUp" });
+}
+
+function arrowDown() {
+  fireEvent.keyDown(getInput(), { key: "ArrowDown" });
+}
+
+describe("usePromptHistory", () => {
+  it("recalls the last sent prompt on ArrowUp from an empty field", () => {
+    render(<Harness />);
+    send("hello world");
+    expect(getInput().value).toBe("");
+
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("hello world");
+  });
+
+  it("steps back through multiple entries, newest first", () => {
+    render(<Harness />);
+    send("first");
+    send("second");
+    send("third");
+
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("third");
+    arrowUp();
+    expect(getInput().value).toBe("second");
+    arrowUp();
+    expect(getInput().value).toBe("first");
+    // At the oldest entry ArrowUp is swallowed and stays put.
+    arrowUp();
+    expect(getInput().value).toBe("first");
+  });
+
+  it("steps forward with ArrowDown and restores the live draft past the newest", () => {
+    render(<Harness />);
+    send("alpha");
+    send("beta");
+
+    // Start a fresh draft, then navigate into history and back out.
+    type("draft in progress");
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("beta");
+    arrowUp();
+    expect(getInput().value).toBe("alpha");
+
+    arrowDown();
+    expect(getInput().value).toBe("beta");
+    arrowDown();
+    // Past the newest entry: the stashed draft comes back.
+    expect(getInput().value).toBe("draft in progress");
+  });
+
+  it("ignores ArrowUp when the caret is not at the start of the field", () => {
+    render(<Harness />);
+    send("remembered");
+    type("editing");
+    setCaret(3);
+    arrowUp();
+    // Caret was mid-text, so navigation must not hijack the key.
+    expect(getInput().value).toBe("editing");
+  });
+
+  it("does nothing when there is no history", () => {
+    render(<Harness />);
+    type("");
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("");
+  });
+
+  it("skips consecutive duplicate sends", () => {
+    render(<Harness />);
+    send("same");
+    send("same");
+    send("different");
+
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("different");
+    arrowUp();
+    expect(getInput().value).toBe("same");
+    // Only one "same" entry remains, so the next step is the oldest.
+    arrowUp();
+    expect(getInput().value).toBe("same");
+  });
+
+  it("resets navigation after a manual edit", () => {
+    render(<Harness />);
+    send("one");
+    send("two");
+
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("two");
+    // Edit the recalled text — navigation resets.
+    act(() => {
+      type("two edited");
+    });
+    // ArrowUp from the start begins a fresh walk at the newest entry again.
+    setCaret(0);
+    arrowUp();
+    expect(getInput().value).toBe("two");
+  });
+});

--- a/web/src/components/chat/hooks/usePromptHistory.ts
+++ b/web/src/components/chat/hooks/usePromptHistory.ts
@@ -1,0 +1,162 @@
+import { useCallback, useRef } from "react";
+
+interface UsePromptHistoryOptions {
+  /** Current textarea value (the live draft). */
+  value: string;
+  /** Setter for the textarea value. */
+  setValue: (next: string) => void;
+  /** Ref to the textarea, used to read/move the caret. */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /** Maximum number of prompts to keep. Oldest are dropped past this. */
+  maxEntries?: number;
+}
+
+interface UsePromptHistoryReturn {
+  /** Record a submitted prompt so it can be recalled later. */
+  record: (prompt: string) => void;
+  /**
+   * Shell-style history navigation for the composer. Returns `true` when the
+   * key was handled (the caller should stop processing the event).
+   *
+   * - ArrowUp at the very start of an empty-or-any field steps back through
+   *   previously sent prompts; once navigating, further ArrowUp keeps stepping
+   *   back regardless of caret position.
+   * - ArrowDown while navigating steps forward, and past the newest entry
+   *   restores the draft the user was typing before navigation began.
+   */
+  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  /** Reset navigation state — call when the user edits the field manually. */
+  resetNavigation: () => void;
+}
+
+/**
+ * Terminal-style prompt history for chat composers: ArrowUp/ArrowDown recall
+ * previously sent messages so they can be edited and resent. History is kept
+ * in memory for the life of the composer.
+ */
+export function usePromptHistory({
+  value,
+  setValue,
+  textareaRef,
+  maxEntries = 50
+}: UsePromptHistoryOptions): UsePromptHistoryReturn {
+  const historyRef = useRef<string[]>([]);
+  // -1 means "not navigating": the field holds the live draft.
+  const indexRef = useRef<number>(-1);
+  // The live draft captured when navigation begins, restored on the way back.
+  const stashRef = useRef<string>("");
+
+  const record = useCallback(
+    (prompt: string) => {
+      if (prompt.trim().length === 0) {
+        return;
+      }
+      const history = historyRef.current;
+      // Skip consecutive duplicates so repeated sends don't clutter history.
+      if (history[history.length - 1] !== prompt) {
+        history.push(prompt);
+        if (history.length > maxEntries) {
+          history.shift();
+        }
+      }
+      indexRef.current = -1;
+      stashRef.current = "";
+    },
+    [maxEntries]
+  );
+
+  const resetNavigation = useCallback(() => {
+    indexRef.current = -1;
+  }, []);
+
+  const applyValue = useCallback(
+    (next: string) => {
+      setValue(next);
+      // Move the caret to the end after React commits the new value so the next
+      // ArrowUp/ArrowDown reads a settled caret position.
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          const end = next.length;
+          textarea.setSelectionRange(end, end);
+        }
+      });
+    },
+    [setValue, textareaRef]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+        return false;
+      }
+      if (
+        e.nativeEvent.isComposing ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.altKey ||
+        e.shiftKey
+      ) {
+        return false;
+      }
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return false;
+      }
+      const history = historyRef.current;
+      if (history.length === 0) {
+        return false;
+      }
+      const caretStart = textarea.selectionStart;
+      const caretEnd = textarea.selectionEnd;
+
+      if (e.key === "ArrowUp") {
+        if (indexRef.current === -1) {
+          // Only hijack ArrowUp from the very start of the field, so it never
+          // interferes with moving the caret up through multi-line text.
+          if (caretStart !== 0 || caretEnd !== 0) {
+            return false;
+          }
+          stashRef.current = value;
+          indexRef.current = history.length - 1;
+          e.preventDefault();
+          applyValue(history[indexRef.current]);
+          return true;
+        }
+        if (indexRef.current > 0) {
+          indexRef.current -= 1;
+          e.preventDefault();
+          applyValue(history[indexRef.current]);
+          return true;
+        }
+        // Already at the oldest entry — swallow so the caret doesn't jump.
+        e.preventDefault();
+        return true;
+      }
+
+      // ArrowDown only acts while navigating history.
+      if (indexRef.current === -1) {
+        return false;
+      }
+      // Require the caret at the end so ArrowDown can still move down through
+      // multi-line recalled text.
+      if (caretStart !== value.length || caretEnd !== value.length) {
+        return false;
+      }
+      if (indexRef.current < history.length - 1) {
+        indexRef.current += 1;
+        e.preventDefault();
+        applyValue(history[indexRef.current]);
+        return true;
+      }
+      // Past the newest entry: restore the stashed live draft.
+      indexRef.current = -1;
+      e.preventDefault();
+      applyValue(stashRef.current);
+      return true;
+    },
+    [value, textareaRef, applyValue]
+  );
+
+  return { record, handleKeyDown, resetNavigation };
+}


### PR DESCRIPTION
## Summary

Adds terminal-style prompt history to the chat composers: press **ArrowUp** to recall previously sent messages and **ArrowDown** to step back forward, so a prompt can be edited and resent without retyping. This is a common chat/terminal affordance that was missing.

## Changes

- **New `usePromptHistory` hook** (`web/src/components/chat/hooks/usePromptHistory.ts`) — keeps sent prompts in memory (deduping consecutive repeats, capped at 50) and drives caret-aware navigation:
  - ArrowUp only hijacks the key when the caret is at the very start of the field, then keeps stepping back through history.
  - ArrowDown steps forward while navigating and restores the in-progress draft once you move past the newest entry.
  - Normal multi-line caret movement (ArrowUp/Down within text) is left untouched.
- **Wired into both composers** — `ChatComposer` (simple variant) and `MediaChatComposer` (media variant). In the media composer the history handler runs *after* the asset-mention picker so its arrow keys still win while its menu is open.
- Navigation resets on any manual edit so the next ArrowUp starts a fresh walk.

## Testing

- New `usePromptHistory.test.tsx` (7 cases): last-prompt recall, multi-entry stepping newest-first, forward stepping + draft restore, mid-text guard, empty history, consecutive-dedup, and reset-on-edit.
- `jest src/components/chat/composer` — 58 passed. Chat container/thread suites — 27 passed.
- Typecheck and lint clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013XiYzsx9YhUaKCBQmoE1d2)_