### PR TITLE
Model manager QoL: persist sort/filter prefs and copy-ID button

### DIFF
--- a/web/src/components/hugging_face/model_list/ModelListItemActions.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListItemActions.tsx
@@ -3,6 +3,7 @@ import Check from "@mui/icons-material/Check";
 import {
   BORDER_RADIUS,
   Chip,
+  CopyButton,
   DeleteButton,
   EditorButton,
   LoadingSpinner,
@@ -146,6 +147,11 @@ export const ModelListItemActions: React.FC<ModelListItemActionsProps> = ({
       )}
 
       <div className="model-actions">
+        <CopyButton
+          value={model.repo_id || model.id}
+          tooltip={isOllama ? "Copy model name" : "Copy repo ID"}
+          nodrag={false}
+        />
         {canShowExplorerButton && !isProduction && isElectron && (
           <ModelShowInExplorerButton
             onClick={handleShowInExplorerClick}

--- a/web/src/stores/ModelManagerStore.ts
+++ b/web/src/stores/ModelManagerStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type ModelSortField = "name" | "size" | "downloads" | "likes";
 export type ModelSortDirection = "asc" | "desc";
@@ -50,30 +51,47 @@ interface ModelManagerState {
   setVramOverrideGb: (gb: number | null) => void;
 }
 
-export const useModelManagerStore = create<ModelManagerState>((set) => ({
-  isOpen: false,
-  modelSearchTerm: "",
-  selectedModelType: "All",
-  maxModelSizeGB: 0,
-  sortField: "name",
-  sortDirection: "asc",
-  scope: "local",
-  source: "installed",
-  sourceInitialized: false,
-  vramOverrideGb: null,
-  setIsOpen: (isOpen) => set({ isOpen }),
-  setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
-  setSelectedModelType: (type) => set({ selectedModelType: type }),
-  setMaxModelSizeGB: (gb) => set({ maxModelSizeGB: gb }),
-  setSortField: (field) => set({ sortField: field }),
-  setSortDirection: (direction) => set({ sortDirection: direction }),
-  toggleSortDirection: () =>
-    set((state) => ({
-      sortDirection: state.sortDirection === "asc" ? "desc" : "asc"
-    })),
-  setScope: (scope) => set({ scope }),
-  setSource: (source) => set({ source }),
-  setSourceInitialized: (initialized) =>
-    set({ sourceInitialized: initialized }),
-  setVramOverrideGb: (gb) => set({ vramOverrideGb: gb })
-}));
+export const useModelManagerStore = create<ModelManagerState>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      modelSearchTerm: "",
+      selectedModelType: "All",
+      maxModelSizeGB: 0,
+      sortField: "name",
+      sortDirection: "asc",
+      scope: "local",
+      source: "installed",
+      sourceInitialized: false,
+      vramOverrideGb: null,
+      setIsOpen: (isOpen) => set({ isOpen }),
+      setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
+      setSelectedModelType: (type) => set({ selectedModelType: type }),
+      setMaxModelSizeGB: (gb) => set({ maxModelSizeGB: gb }),
+      setSortField: (field) => set({ sortField: field }),
+      setSortDirection: (direction) => set({ sortDirection: direction }),
+      toggleSortDirection: () =>
+        set((state) => ({
+          sortDirection: state.sortDirection === "asc" ? "desc" : "asc"
+        })),
+      setScope: (scope) => set({ scope }),
+      setSource: (source) => set({ source }),
+      setSourceInitialized: (initialized) =>
+        set({ sourceInitialized: initialized }),
+      setVramOverrideGb: (gb) => set({ vramOverrideGb: gb })
+    }),
+    {
+      name: "model-manager",
+      version: 1,
+      // Only the sort and size-filter preferences survive reloads. Session
+      // state (open flag, search term, active scope/source, the empty-install
+      // onboarding one-shot, VRAM override) is intentionally left ephemeral so
+      // each visit starts from a clean, predictable view.
+      partialize: (state) => ({
+        sortField: state.sortField,
+        sortDirection: state.sortDirection,
+        maxModelSizeGB: state.maxModelSizeGB
+      })
+    }
+  )
+);

--- a/web/src/stores/__tests__/ModelManagerStore.test.ts
+++ b/web/src/stores/__tests__/ModelManagerStore.test.ts
@@ -163,6 +163,42 @@ describe("ModelManagerStore", () => {
     });
   });
 
+  describe("persistence", () => {
+    test("persists sort and size-filter preferences to localStorage", () => {
+      act(() => {
+        useModelManagerStore.getState().setSortField("downloads");
+        useModelManagerStore.getState().setSortDirection("desc");
+        useModelManagerStore.getState().setMaxModelSizeGB(12);
+      });
+
+      const persisted = JSON.parse(
+        localStorage.getItem("model-manager") || "{}"
+      );
+      expect(persisted.state).toMatchObject({
+        sortField: "downloads",
+        sortDirection: "desc",
+        maxModelSizeGB: 12
+      });
+    });
+
+    test("does not persist ephemeral session state", () => {
+      act(() => {
+        useModelManagerStore.getState().setModelSearchTerm("llama");
+        useModelManagerStore.getState().setScope("worker");
+        useModelManagerStore.getState().setSource("hub");
+        useModelManagerStore.getState().setSelectedModelType("text-generation");
+      });
+
+      const persisted = JSON.parse(
+        localStorage.getItem("model-manager") || "{}"
+      );
+      expect(persisted.state).not.toHaveProperty("modelSearchTerm");
+      expect(persisted.state).not.toHaveProperty("scope");
+      expect(persisted.state).not.toHaveProperty("source");
+      expect(persisted.state).not.toHaveProperty("selectedModelType");
+    });
+  });
+
   describe("multiple state changes", () => {
     test("should handle multiple state changes", () => {
       act(() => {


### PR DESCRIPTION
## What

Two quality-of-life improvements for the Model Manager.

### Persist sort & size-filter preferences
`ModelManagerStore` now uses zustand `persist`. `sortField`, `sortDirection`, and `maxModelSizeGB` survive reloads, so the sort order and size cap you set last time are still there next visit. Everything session-scoped — the open flag, search term, active scope/source, the empty-install onboarding one-shot, and the VRAM override — is deliberately left out of `partialize` so each visit still starts from a clean, predictable view (matching the existing scope/source-change reset behavior).

### Copy repo-ID button on each model row
Each model row gets a copy-to-clipboard button (shared `CopyButton` primitive) that copies the HuggingFace repo ID, or the model name for Ollama models. Quick way to grab an ID to paste into a node or the CLI without opening the repo page.

## Testing

- `web` typecheck clean (after `npm run build:packages`)
- ESLint clean on touched files
- Added two persistence tests to `ModelManagerStore.test.ts` (persists sort/size prefs, does not persist session state) — full store suite (18) and `model_list` suites (49) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABEJ78jB9yZ9eiD2SK5ApD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABEJ78jB9yZ9eiD2SK5ApD)_