### PR TITLE
feat(web): QoL improvements for the Package Manager

### DIFF
--- a/web/src/components/packages/ConsolePanel.tsx
+++ b/web/src/components/packages/ConsolePanel.tsx
@@ -6,7 +6,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 import {
   BORDER_RADIUS,
@@ -41,12 +41,31 @@ interface ConsolePanelProps {
 const ConsolePanel = ({ lines, onClear, busy = false }: ConsolePanelProps) => {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const preRef = useRef<HTMLPreElement>(null);
 
   // Auto-open when an operation begins so its live output is visible without a
   // manual toggle; the user can still hide it mid-run.
   useEffect(() => {
     if (busy) setOpen(true);
   }, [busy]);
+
+  // Follow the tail as new lines stream in while the console is open.
+  useEffect(() => {
+    if (!open) return;
+    const el = preRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [open, lines]);
+
+  const handleCopy = () => {
+    void navigator.clipboard?.writeText(lines.join("\n")).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => {}
+    );
+  };
 
   return (
     <FlexColumn gap={1}>
@@ -61,13 +80,18 @@ const ConsolePanel = ({ lines, onClear, busy = false }: ConsolePanelProps) => {
           {lines.length > 0 ? ` (${lines.length})` : ""}
         </EditorButton>
         {open && lines.length > 0 && (
-          <EditorButton variant="text" density="compact" onClick={onClear}>
-            Clear
-          </EditorButton>
+          <FlexRow gap={0.5} align="center">
+            <EditorButton variant="text" density="compact" onClick={handleCopy}>
+              {copied ? "Copied" : "Copy"}
+            </EditorButton>
+            <EditorButton variant="text" density="compact" onClick={onClear}>
+              Clear
+            </EditorButton>
+          </FlexRow>
         )}
       </FlexRow>
       {open && (
-        <pre css={consoleStyles(theme)}>
+        <pre ref={preRef} css={consoleStyles(theme)}>
           {lines.length > 0
             ? lines.join("\n")
             : "No output yet. Logs appear here during install."}

--- a/web/src/components/packages/PackageManager.tsx
+++ b/web/src/components/packages/PackageManager.tsx
@@ -8,7 +8,7 @@
  * category. Data and derivation live in {@link usePackageManager}. Rendered
  * full-screen by {@link PackagesPage} (title/back live in the page hero).
  */
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 
@@ -38,6 +38,33 @@ import {
 const DEFAULT_CAT: Record<PMTab, string> = {
   software: "all",
   packs: "included"
+};
+
+/** Persist the active tab + category so reopening the Package Manager lands
+ *  where the user left off. */
+const STORAGE_KEY = "nodetool.packageManager.location";
+
+const loadLocation = (): { tab: PMTab; cat: string } => {
+  const fallback = { tab: "packs" as PMTab, cat: "included" };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as { tab?: PMTab; cat?: string };
+    if (parsed.tab === "software" || parsed.tab === "packs") {
+      return { tab: parsed.tab, cat: parsed.cat ?? DEFAULT_CAT[parsed.tab] };
+    }
+  } catch {
+    // Corrupt/blocked storage — fall back to the default landing spot.
+  }
+  return fallback;
+};
+
+const saveLocation = (tab: PMTab, cat: string) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ tab, cat }));
+  } catch {
+    // Storage unavailable (private mode / quota) — persistence is optional.
+  }
 };
 
 /**
@@ -155,27 +182,49 @@ const PackageRowItem = memo(function PackageRowItem({ row }: { row: PMRow }) {
 });
 
 function PackageManager() {
-  const [tab, setTab] = useState<PMTab>("packs");
-  const [cat, setCat] = useState<string>("included");
+  const [{ tab, cat }, setLocation] = useState(loadLocation);
   const [q, setQ] = useState("");
   const [filter, setFilter] = useState("all");
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const model = usePackageManager({ tab, cat, q, filter });
 
+  useEffect(() => {
+    saveLocation(tab, cat);
+  }, [tab, cat]);
+
   const handleTab = useCallback((next: PMTab) => {
-    setTab(next);
-    setCat(DEFAULT_CAT[next]);
+    setLocation({ tab: next, cat: DEFAULT_CAT[next] });
     setFilter("all");
     setQ("");
   }, []);
 
   const handleCat = useCallback((id: string) => {
-    setCat(id);
+    setLocation((prev) => ({ ...prev, cat: id }));
     setFilter("all");
   }, []);
 
   const showSearch = !model.isThirdParty && !model.notice;
   const showChips = showSearch && model.chips.length > 0;
+
+  // "/" focuses the search box (unless the user is already typing somewhere).
+  useEffect(() => {
+    if (!showSearch) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const el = document.activeElement;
+      const typing =
+        el instanceof HTMLElement &&
+        (el.tagName === "INPUT" ||
+          el.tagName === "TEXTAREA" ||
+          el.isContentEditable);
+      if (typing) return;
+      e.preventDefault();
+      searchRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [showSearch]);
 
   return (
     <FlexRow sx={{ width: "100%", height: "100%", minHeight: 0 }}>
@@ -251,14 +300,29 @@ function PackageManager() {
               </Text>
             </FlexColumn>
             {showSearch && (
-              <Box sx={{ width: 250, flexShrink: 0 }}>
-                <SearchInput
-                  value={q}
-                  onChange={setQ}
-                  placeholder="Search…"
-                  showClear
-                />
-              </Box>
+              <FlexRow gap={1.5} align="center" sx={{ flexShrink: 0 }}>
+                {model.bulkUpdate && (
+                  <EditorButton
+                    variant="contained"
+                    density="compact"
+                    disabled={model.bulkUpdate.busy}
+                    onClick={model.bulkUpdate.onUpdateAll}
+                  >
+                    {model.bulkUpdate.busy
+                      ? "Updating…"
+                      : `Update all (${model.bulkUpdate.count})`}
+                  </EditorButton>
+                )}
+                <Box sx={{ width: 250 }}>
+                  <SearchInput
+                    ref={searchRef}
+                    value={q}
+                    onChange={setQ}
+                    placeholder="Search…  (press /)"
+                    showClear
+                  />
+                </Box>
+              </FlexRow>
             )}
           </FlexRow>
 

--- a/web/src/components/packages/__tests__/usePackageManager.test.ts
+++ b/web/src/components/packages/__tests__/usePackageManager.test.ts
@@ -115,6 +115,41 @@ describe("usePackageManager", () => {
     expect(result.current.notice).toBeNull();
   });
 
+  it("offers a bulk Update all action on the registry tab when packs have updates", () => {
+    useNodePacksStore.setState({
+      availablePacks: [],
+      installed: [
+        {
+          name: "Cool",
+          description: "Cool nodes.",
+          version: "1.0.0",
+          repo_id: "acme/cool",
+          latestVersion: "1.1.0",
+          hasUpdate: true
+        },
+        {
+          name: "Plain",
+          description: "Up to date.",
+          version: "2.0.0",
+          repo_id: "acme/plain"
+        }
+      ]
+    });
+    const { result } = renderHook(() =>
+      usePackageManager({ tab: "packs", cat: "python", q: "", filter: "all" })
+    );
+    expect(result.current.bulkUpdate?.count).toBe(1);
+    expect(result.current.bulkUpdate?.busy).toBe(false);
+  });
+
+  it("hides the bulk Update all action when nothing needs updating", () => {
+    const { result } = renderHook(() =>
+      usePackageManager({ tab: "packs", cat: "python", q: "", filter: "all" })
+    );
+    // Seed default has one uninstalled pack → no updates available.
+    expect(result.current.bulkUpdate).toBeNull();
+  });
+
   it("shows a desktop-only notice for software without the runtime IPC", () => {
     const { result } = renderHook(() =>
       usePackageManager({ tab: "software", cat: "all", q: "", filter: "all" })

--- a/web/src/components/packages/usePackageManager.ts
+++ b/web/src/components/packages/usePackageManager.ts
@@ -112,6 +112,9 @@ export interface PackageManagerModel {
   error: string | null;
   console: { lines: string[]; onClear: () => void; busy: boolean } | null;
   thirdPartyCount: number;
+  /** Bulk "update everything with an upgrade" action for the registry tab;
+   *  `null` when it doesn't apply (wrong tab, or nothing to update). */
+  bulkUpdate: { count: number; busy: boolean; onUpdateAll: () => void } | null;
 }
 
 /** Join the registry list with installed records by repo_id (see registry tab). */
@@ -216,6 +219,7 @@ export function usePackageManager(params: {
     pyInstall,
     pyUninstall,
     pyUpdate,
+    pyUpdateAll,
     pySubscribe,
     pyUnsubscribe,
     pyClear,
@@ -231,6 +235,7 @@ export function usePackageManager(params: {
       pyInstall: s.install,
       pyUninstall: s.uninstall,
       pyUpdate: s.update,
+      pyUpdateAll: s.updateAll,
       pySubscribe: s.subscribeConsole,
       pyUnsubscribe: s.unsubscribeConsole,
       pyClear: s.clearConsole,
@@ -502,6 +507,19 @@ export function usePackageManager(params: {
           : null
         : null;
 
+    const updatableCount =
+      cat === "python"
+        ? pythonPacks.filter((p) => p.installed?.hasUpdate).length
+        : 0;
+    const bulkUpdate =
+      cat === "python" && pyAvailable && updatableCount > 0
+        ? {
+            count: updatableCount,
+            busy: pyBusy.length > 0,
+            onUpdateAll: () => void pyUpdateAll()
+          }
+        : null;
+
     return {
       isSoftware,
       isThirdParty,
@@ -516,7 +534,8 @@ export function usePackageManager(params: {
       notice,
       error: isSoftware ? rtError : cat === "python" ? pyError : builtinsError,
       console: consoleModel,
-      thirdPartyCount: thirdPartyPacks.length
+      thirdPartyCount: thirdPartyPacks.length,
+      bulkUpdate
     };
   }, [
     tab,
@@ -544,6 +563,7 @@ export function usePackageManager(params: {
     rtUninstall,
     pyInstall,
     pyUpdate,
+    pyUpdateAll,
     pyUninstall,
     selectInstallLocation,
     rtClear,

--- a/web/src/stores/NodePacksStore.ts
+++ b/web/src/stores/NodePacksStore.ts
@@ -58,6 +58,9 @@ interface NodePacksStore {
   install: (repoId: string) => Promise<boolean>;
   uninstall: (repoId: string) => Promise<boolean>;
   update: (repoId: string) => Promise<boolean>;
+  /** Update every installed pack that has an available upgrade, restarting the
+   *  backend once at the end rather than after each pack. */
+  updateAll: () => Promise<boolean>;
   subscribeConsole: () => void;
   unsubscribeConsole: () => void;
   clearConsole: () => void;
@@ -173,6 +176,45 @@ const useNodePacksStore = create<NodePacksStore>((set, get) => ({
     const api = packagesApi();
     if (!api?.update) return false;
     return runPackOp(set, get, repoId, () => api.update!(repoId), "update", true);
+  },
+
+  updateAll: async () => {
+    const api = packagesApi();
+    if (!api?.update) return false;
+    const repoIds = get()
+      .installed.filter((p) => p.hasUpdate)
+      .map((p) => p.repo_id);
+    if (repoIds.length === 0) return false;
+
+    set((s) => ({ busyIds: [...new Set([...s.busyIds, ...repoIds])] }));
+    let allOk = true;
+    let lastMessage = "";
+    for (const repoId of repoIds) {
+      try {
+        const res = await api.update!(repoId);
+        if (!res.success) {
+          allOk = false;
+          lastMessage = res.message;
+        }
+      } catch (err: unknown) {
+        allOk = false;
+        lastMessage = createErrorMessage(err, "Failed to update pack").message;
+      }
+    }
+    await get().refresh();
+    set((s) => ({
+      busyIds: s.busyIds.filter((p) => !repoIds.includes(p)),
+      error: allOk ? s.error : lastMessage
+    }));
+    // One restart after the batch so the registry reloads all updated packs.
+    if (allOk) {
+      try {
+        void window.api?.server?.restart?.();
+      } catch {
+        // Best-effort: changes are on disk; the user can restart manually.
+      }
+    }
+    return allOk;
   },
 
   subscribeConsole: () => {

--- a/web/src/stores/__tests__/NodePacksStore.test.ts
+++ b/web/src/stores/__tests__/NodePacksStore.test.ts
@@ -101,6 +101,79 @@ describe("NodePacksStore", () => {
     expect(restart).toHaveBeenCalled();
   });
 
+  it("updateAll updates every pack with an upgrade and restarts once", async () => {
+    useNodePacksStore.setState({
+      installed: [
+        {
+          name: "Base",
+          description: "",
+          version: "1.0.0",
+          repo_id: "nodetool-ai/nodetool-base",
+          hasUpdate: true
+        },
+        {
+          name: "HF",
+          description: "",
+          version: "1.0.0",
+          repo_id: "nodetool-ai/nodetool-huggingface",
+          hasUpdate: true
+        },
+        {
+          name: "Current",
+          description: "",
+          version: "2.0.0",
+          repo_id: "nodetool-ai/nodetool-current"
+        }
+      ]
+    });
+    const ok = await useNodePacksStore.getState().updateAll();
+    expect(ok).toBe(true);
+    expect(api.update).toHaveBeenCalledTimes(2);
+    expect(api.update).toHaveBeenCalledWith("nodetool-ai/nodetool-base");
+    expect(api.update).toHaveBeenCalledWith("nodetool-ai/nodetool-huggingface");
+    // A pack without an update is left alone.
+    expect(api.update).not.toHaveBeenCalledWith("nodetool-ai/nodetool-current");
+    // One restart for the whole batch, not one per pack.
+    expect(restart).toHaveBeenCalledTimes(1);
+    expect(useNodePacksStore.getState().busyIds).toEqual([]);
+  });
+
+  it("updateAll no-ops when nothing has an update", async () => {
+    useNodePacksStore.setState({
+      installed: [
+        {
+          name: "Current",
+          description: "",
+          version: "2.0.0",
+          repo_id: "nodetool-ai/nodetool-current"
+        }
+      ]
+    });
+    const ok = await useNodePacksStore.getState().updateAll();
+    expect(ok).toBe(false);
+    expect(api.update).not.toHaveBeenCalled();
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("updateAll reports a failure and does not restart when a pack fails", async () => {
+    api.update.mockResolvedValueOnce({ success: false, message: "nope" });
+    useNodePacksStore.setState({
+      installed: [
+        {
+          name: "Base",
+          description: "",
+          version: "1.0.0",
+          repo_id: "nodetool-ai/nodetool-base",
+          hasUpdate: true
+        }
+      ]
+    });
+    const ok = await useNodePacksStore.getState().updateAll();
+    expect(ok).toBe(false);
+    expect(useNodePacksStore.getState().error).toBe("nope");
+    expect(restart).not.toHaveBeenCalled();
+  });
+
   it("surfaces a failure message when install fails", async () => {
     api.install.mockResolvedValueOnce({ success: false, message: "boom" });
     const ok = await useNodePacksStore


### PR DESCRIPTION
## Summary

A handful of small quality-of-life improvements to the unified Package Manager (`/packages`).

- **Update all registry packs at once.** When installed node packs have upgrades available, the Registry tab shows an `Update all (N)` button in the header. It updates each pack sequentially and restarts the backend **once** for the whole batch instead of after every pack (new `updateAll` action on `NodePacksStore`).
- **Console log: Copy + follow-tail.** The install console gets a `Copy` button (grab the full log for a bug report), and it now auto-scrolls to the bottom as new lines stream in while open.
- **Remember where you were.** The active tab (Software / Node Packs) and category persist to `localStorage`, so reopening the Package Manager lands where you left off instead of resetting to Included.
- **`/` focuses search.** Press `/` (when not already typing) to jump to the search box; `Escape` still clears it.

## Changes

| File | What |
| --- | --- |
| `stores/NodePacksStore.ts` | `updateAll()` — batch-update packs with upgrades, single restart |
| `components/packages/usePackageManager.ts` | `bulkUpdate` view-model field for the Registry tab |
| `components/packages/PackageManager.tsx` | Update-all button, tab/category persistence, `/` shortcut |
| `components/packages/ConsolePanel.tsx` | Copy button + auto-scroll to tail |

## Testing

- `NodePacksStore.test.ts` — `updateAll` batch update / no-op / failure paths (3 new cases)
- `usePackageManager.test.ts` — `bulkUpdate` present with updates, null without (2 new cases)
- Web `tsc --noEmit`, `eslint`, and the package-manager Jest suites pass locally (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29TmuHcGi3tvs7QRLyKsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01W29TmuHcGi3tvs7QRLyKsR)_