### PR TITLE
feat(web): node editor context-menu QoL improvements

### DIFF
--- a/web/src/components/context_menus/NodeContextMenu.tsx
+++ b/web/src/components/context_menus/NodeContextMenu.tsx
@@ -12,6 +12,10 @@ import BlockIcon from "@mui/icons-material/Block";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import DataArrayIcon from "@mui/icons-material/DataArray";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ContentCutIcon from "@mui/icons-material/ContentCut";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import QueueIcon from "@mui/icons-material/Queue";
 import SouthIcon from "@mui/icons-material/South";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
@@ -61,6 +65,34 @@ const NodeContextMenu: React.FC = () => {
       />
     ),
     <ContextMenuItem
+      key="copy"
+      onClick={handlers.handleCopy}
+      label="Copy"
+      IconComponent={<ContentCopyIcon />}
+      tooltip={
+        <div className="tooltip-span">
+          <div className="tooltip-title">Copy</div>
+          <div className="tooltip-key">
+            <kbd>CTRL</kbd>+<kbd>C</kbd> / <kbd>⌘</kbd>+<kbd>C</kbd>
+          </div>
+        </div>
+      }
+    />,
+    <ContextMenuItem
+      key="cut"
+      onClick={handlers.handleCut}
+      label="Cut"
+      IconComponent={<ContentCutIcon />}
+      tooltip={
+        <div className="tooltip-span">
+          <div className="tooltip-title">Cut</div>
+          <div className="tooltip-key">
+            <kbd>CTRL</kbd>+<kbd>X</kbd> / <kbd>⌘</kbd>+<kbd>X</kbd>
+          </div>
+        </div>
+      }
+    />,
+    <ContextMenuItem
       key="duplicate"
       onClick={handlers.handleDuplicate}
       label="Duplicate"
@@ -108,6 +140,24 @@ const NodeContextMenu: React.FC = () => {
           </div>
           <div className="tooltip-key">
             <kbd>B</kbd>
+          </div>
+        </div>
+      }
+    />,
+    <ContextMenuItem
+      key="toggle-collapsed"
+      onClick={handlers.handleToggleCollapsed}
+      label={conditions.isCollapsed ? "Expand Node" : "Collapse Node"}
+      IconComponent={
+        conditions.isCollapsed ? <UnfoldMoreIcon /> : <UnfoldLessIcon />
+      }
+      tooltip={
+        <div className="tooltip-span">
+          <div className="tooltip-title">
+            {conditions.isCollapsed ? "Expand Node" : "Collapse Node"}
+          </div>
+          <div className="tooltip-key">
+            <kbd>C</kbd>
           </div>
         </div>
       }

--- a/web/src/components/context_menus/PaneContextMenu.tsx
+++ b/web/src/components/context_menus/PaneContextMenu.tsx
@@ -306,7 +306,7 @@ const PaneContextMenu: React.FC = () => {
           tooltip={
             !isClipboardValid ? (
               <span>
-                {getShortcutTooltip("paste-selection")}
+                {getShortcutTooltip("paste")}
                 <br />
                 <span className="attention">
                   no valid node data <br />
@@ -314,7 +314,7 @@ const PaneContextMenu: React.FC = () => {
                 </span>
               </span>
             ) : (
-              getShortcutTooltip("paste-selection")
+              getShortcutTooltip("paste")
             )
           }
         />
@@ -322,7 +322,7 @@ const PaneContextMenu: React.FC = () => {
           onClick={handleFitViewAndClose}
           label="Fit Screen"
           IconComponent={<FitScreenIcon />}
-          tooltip={getShortcutTooltip("fit-view")}
+          tooltip={getShortcutTooltip("fitView")}
         />
         {favorites.length > 0 && [
           <Divider key="favorites-divider" />,

--- a/web/src/components/context_menus/SelectionContextMenu.tsx
+++ b/web/src/components/context_menus/SelectionContextMenu.tsx
@@ -15,14 +15,21 @@ import { useDuplicateNodes } from "../../hooks/useDuplicate";
 import useAlignNodes from "../../hooks/useAlignNodes";
 import { useSurroundWithGroup } from "../../hooks/nodes/useSurroundWithGroup";
 import { useRemoveFromGroup } from "../../hooks/nodes/useRemoveFromGroup";
+import { useGroupIntoSubgraph } from "../../hooks/nodes/useGroupIntoSubgraph";
+import { useRunSelectedNodes } from "../../hooks/nodes/useRunSelectedNodes";
+import { useToggleCollapse } from "../../hooks/nodes/useToggleCollapse";
 import { useSelectConnected } from "../../hooks/useSelectConnected";
 //icons
 import QueueIcon from "@mui/icons-material/Queue";
 import CopyAllIcon from "@mui/icons-material/CopyAll";
+import ContentCutIcon from "@mui/icons-material/ContentCut";
 import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import GroupWorkIcon from "@mui/icons-material/GroupWork";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import BlockIcon from "@mui/icons-material/Block";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CallSplitIcon from "@mui/icons-material/CallSplit";
@@ -36,7 +43,7 @@ interface SelectionContextMenuProps {
 }
 
 const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
-  const { handleCopy } = useCopyPaste();
+  const { handleCopy, handleCut } = useCopyPaste();
   const { deleteNodes, toggleBypassSelected } = useNodes((state) => ({
     deleteNodes: state.deleteNodes,
     toggleBypassSelected: state.toggleBypassSelected
@@ -45,6 +52,9 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
   const alignNodes = useAlignNodes();
   const surroundWithGroup = useSurroundWithGroup();
   const removeFromGroup = useRemoveFromGroup();
+  const groupIntoSubgraph = useGroupIntoSubgraph();
+  const { runSelectedNodes } = useRunSelectedNodes();
+  const toggleCollapse = useToggleCollapse();
   const selectConnectedAll = useSelectConnected({ direction: "both" });
   const selectConnectedInputs = useSelectConnected({ direction: "upstream" });
   const selectConnectedOutputs = useSelectConnected({ direction: "downstream" });
@@ -133,7 +143,32 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
 
   const handleCopyNodes = useCallback(() => {
     handleCopy();
-  }, [handleCopy]);
+    closeContextMenu();
+  }, [handleCopy, closeContextMenu]);
+
+  const handleCutNodes = useCallback(() => {
+    void handleCut();
+    closeContextMenu();
+  }, [handleCut, closeContextMenu]);
+
+  const handleRunSelected = useCallback(() => {
+    void runSelectedNodes();
+    closeContextMenu();
+  }, [runSelectedNodes, closeContextMenu]);
+
+  const handleGroupIntoSubgraph = useCallback(() => {
+    const ids = selectedNodes.map((node) => node.id);
+    if (ids.length === 0) {
+      return;
+    }
+    groupIntoSubgraph(ids);
+    closeContextMenu();
+  }, [groupIntoSubgraph, selectedNodes, closeContextMenu]);
+
+  const handleToggleCollapsed = useCallback(() => {
+    toggleCollapse(selectedNodes.map((node) => node.id));
+    closeContextMenu();
+  }, [toggleCollapse, selectedNodes, closeContextMenu]);
 
   const handleAlignNodesFalse = useCallback(() => {
     handleAlignNodes(false);
@@ -192,6 +227,25 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
           </div>
         }
       />
+      <ContextMenuItem
+        onClick={handleCutNodes}
+        label="Cut"
+        IconComponent={<ContentCutIcon />}
+        tooltip={
+          <div className="tooltip-span">
+            <div className="tooltip-title">Cut</div>
+            <div className="tooltip-key">
+              <kbd>CTRL</kbd>+<kbd>X</kbd> / <kbd>⌘</kbd>+<kbd>X</kbd>
+            </div>
+          </div>
+        }
+      />
+      <ContextMenuItem
+        onClick={handleRunSelected}
+        label="Run Selected"
+        IconComponent={<PlayArrowIcon />}
+        tooltip="Run the selected nodes as their own job"
+      />
       {selectedNodes?.length > 1 && (
         <ContextMenuItem
           onClick={handleAlignNodesFalse}
@@ -239,10 +293,24 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
         }
       />
 
+      <ContextMenuItem
+        onClick={handleToggleCollapsed}
+        label="Collapse / Expand"
+        IconComponent={<UnfoldLessIcon />}
+        tooltip={
+          <div className="tooltip-span">
+            <div className="tooltip-title">Collapse / Expand</div>
+            <div className="tooltip-key">
+              <kbd>C</kbd>
+            </div>
+          </div>
+        }
+      />
+
       {!anyHasParent && (
         <ContextMenuItem
           onClick={handleSurroundWithGroup}
-          label="Surrround With Group"
+          label="Surround With Group"
           IconComponent={<GroupWorkIcon />}
           tooltip={
             <div className="tooltip-span">
@@ -257,6 +325,16 @@ const SelectionContextMenu: React.FC<SelectionContextMenuProps> = () => {
           }`}
         />
       )}
+
+      <ContextMenuItem
+        onClick={handleGroupIntoSubgraph}
+        label="Group into Subgraph"
+        IconComponent={<AccountTreeIcon />}
+        tooltip="Move the selected nodes into a new subgraph node"
+        addButtonClassName={`action ${
+          selectedNodes.length < 1 ? "disabled" : ""
+        }`}
+      />
 
       {anyHasParent && (
         <ContextMenuItem

--- a/web/src/components/node/NodeHeader.tsx
+++ b/web/src/components/node/NodeHeader.tsx
@@ -6,7 +6,7 @@ import { shallow } from "zustand/shallow";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import isEqual from "../../utils/isEqual";
 import { NodeData } from "../../stores/NodeData";
-import { getCollapseTogglePatches } from "../../stores/collapseNodeLayout";
+import { useToggleCollapse } from "../../hooks/nodes/useToggleCollapse";
 import { useNodes } from "../../contexts/NodeContext";
 import { IconForType } from "../../config/IconForType";
 import ListAltIcon from "@mui/icons-material/ListAlt";
@@ -57,12 +57,11 @@ const NodeHeaderImpl: React.FC<NodeHeaderProps> = ({
   const { openContextMenu } = useContextMenuActions();
   // Combine multiple useNodes subscriptions into a single selector with shallow equality
   // to reduce unnecessary re-renders when other parts of the node state change
-  const { updateNode, updateNodeData, findNode, workflowId: nodeWorkflowId } =
+  const { updateNode, updateNodeData, workflowId: nodeWorkflowId } =
     useNodes(
       (state) => ({
         updateNode: state.updateNode,
         updateNodeData: state.updateNodeData,
-        findNode: state.findNode,
         workflowId: state.workflow?.id
       }),
       shallow
@@ -197,19 +196,10 @@ const NodeHeaderImpl: React.FC<NodeHeaderProps> = ({
     updateNode(id, { selected: true });
   }, [id, updateNode]);
 
+  const toggleCollapse = useToggleCollapse();
   const toggleCollapsed = useCallback(() => {
-    const node = findNode(id);
-    if (!node) {
-      return;
-    }
-    const next = !node.data.collapsed;
-    const { data: dataPatch, node: nodePatch } = getCollapseTogglePatches(
-      node,
-      next
-    );
-    updateNodeData(id, dataPatch);
-    updateNode(id, nodePatch);
-  }, [findNode, id, updateNode, updateNodeData]);
+    toggleCollapse([id]);
+  }, [toggleCollapse, id]);
 
   const handleIconDoubleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {

--- a/web/src/components/node/__tests__/CodeNodeUx.test.tsx
+++ b/web/src/components/node/__tests__/CodeNodeUx.test.tsx
@@ -44,7 +44,15 @@ jest.mock("../../../contexts/NodeContext", () => ({
       workflow: { id: "wf-1" },
       findNode: () => undefined
     })
-  )
+  ),
+  useNodeStoreRef: jest.fn(() => ({
+    getState: () => ({
+      getSelectedNodes: () => [],
+      findNode: () => undefined,
+      updateNodeData: mockUpdateNodeData,
+      updateNode: mockUpdateNode
+    })
+  }))
 }));
 
 jest.mock("../../../config/IconForType", () => ({

--- a/web/src/hooks/nodes/__tests__/useToggleCollapse.test.ts
+++ b/web/src/hooks/nodes/__tests__/useToggleCollapse.test.ts
@@ -1,0 +1,99 @@
+import { renderHook } from "@testing-library/react";
+
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodeStoreRef: jest.fn()
+}));
+
+jest.mock("../../../stores/collapseNodeLayout", () => ({
+  getCollapseTogglePatches: jest.fn((_node: unknown, collapsed: boolean) => ({
+    data: { collapsed },
+    node: {}
+  }))
+}));
+
+import { useToggleCollapse } from "../useToggleCollapse";
+import { useNodeStoreRef } from "../../../contexts/NodeContext";
+import { getCollapseTogglePatches } from "../../../stores/collapseNodeLayout";
+
+const mockUpdateNodeData = jest.fn();
+const mockUpdateNode = jest.fn();
+const mockGetSelectedNodes = jest.fn();
+const mockFindNode = jest.fn();
+
+const makeNode = (id: string, collapsed = false) => ({
+  id,
+  data: { collapsed },
+  position: { x: 0, y: 0 }
+});
+
+describe("useToggleCollapse", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const state = {
+      getSelectedNodes: mockGetSelectedNodes,
+      findNode: mockFindNode,
+      updateNodeData: mockUpdateNodeData,
+      updateNode: mockUpdateNode
+    };
+    (useNodeStoreRef as jest.Mock).mockReturnValue({
+      getState: () => state
+    });
+    mockFindNode.mockImplementation((id: string) => makeNode(id, false));
+  });
+
+  it("collapses the given node ids", () => {
+    const { result } = renderHook(() => useToggleCollapse());
+    result.current(["a"]);
+
+    expect(getCollapseTogglePatches).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a" }),
+      true
+    );
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("a", { collapsed: true });
+    expect(mockUpdateNode).toHaveBeenCalledWith("a", {});
+  });
+
+  it("drives a mixed selection to a uniform state from the first node", () => {
+    // First node expanded -> whole batch collapses (next = true).
+    mockFindNode.mockImplementation((id: string) =>
+      makeNode(id, id === "b")
+    );
+    const { result } = renderHook(() => useToggleCollapse());
+    result.current(["a", "b"]);
+
+    expect(mockUpdateNodeData).toHaveBeenCalledTimes(2);
+    expect(mockUpdateNodeData).toHaveBeenNthCalledWith(1, "a", {
+      collapsed: true
+    });
+    expect(mockUpdateNodeData).toHaveBeenNthCalledWith(2, "b", {
+      collapsed: true
+    });
+  });
+
+  it("falls back to the current selection when no ids are passed", () => {
+    mockGetSelectedNodes.mockReturnValue([makeNode("sel", true)]);
+    const { result } = renderHook(() => useToggleCollapse());
+    result.current();
+
+    // Selected node is collapsed -> expands (next = false).
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("sel", { collapsed: false });
+  });
+
+  it("does nothing when there are no target nodes", () => {
+    mockGetSelectedNodes.mockReturnValue([]);
+    const { result } = renderHook(() => useToggleCollapse());
+    result.current();
+    result.current([]);
+
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+    expect(mockUpdateNode).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown ids that findNode cannot resolve", () => {
+    mockFindNode.mockReturnValue(undefined);
+    const { result } = renderHook(() => useToggleCollapse());
+    result.current(["missing"]);
+
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/nodes/useNodeContextMenu.ts
+++ b/web/src/hooks/nodes/useNodeContextMenu.ts
@@ -14,6 +14,8 @@ import {
 } from "../../utils/NodeTypeMapping";
 import { useRunFromHere } from "./useRunFromHere";
 import { useDuplicateNodes } from "../useDuplicate";
+import { useCopyPaste } from "../handlers/useCopyPaste";
+import { useToggleCollapse } from "./useToggleCollapse";
 import { shallow } from "zustand/shallow";
 
 interface UseNodeContextMenuReturn {
@@ -34,6 +36,9 @@ interface UseNodeContextMenuReturn {
     handleConvertToConstant: () => void;
     handleDuplicate: () => void;
     handleDuplicateVertical: () => void;
+    handleCopy: () => void;
+    handleCut: () => void;
+    handleToggleCollapsed: () => void;
   };
   conditions: {
     hasCommentTitle: boolean;
@@ -42,6 +47,7 @@ interface UseNodeContextMenuReturn {
     canConvertToConstant: boolean;
     isWorkflowRunning: boolean;
     isInGroup: boolean;
+    isCollapsed: boolean;
   };
 }
 
@@ -240,6 +246,32 @@ export function useNodeContextMenu(): UseNodeContextMenuReturn {
     closeContextMenu
   ]);
 
+  const { handleCopy: copyNodes, handleCut: cutNodes } = useCopyPaste();
+  const toggleCollapse = useToggleCollapse();
+
+  const handleCopy = useCallback(() => {
+    if (nodeId) {
+      void copyNodes(nodeId);
+    }
+    closeContextMenu();
+  }, [copyNodes, nodeId, closeContextMenu]);
+
+  const handleCut = useCallback(() => {
+    if (nodeId) {
+      void cutNodes(nodeId);
+    }
+    closeContextMenu();
+  }, [cutNodes, nodeId, closeContextMenu]);
+
+  const handleToggleCollapsed = useCallback(() => {
+    if (nodeId) {
+      toggleCollapse([nodeId]);
+    }
+    closeContextMenu();
+  }, [toggleCollapse, nodeId, closeContextMenu]);
+
+  const isCollapsed = Boolean(nodeData?.collapsed);
+
   const canConvertToInput = Boolean(
     nodeId && constantToInputType(node?.type ?? "")
   );
@@ -265,7 +297,10 @@ export function useNodeContextMenu(): UseNodeContextMenuReturn {
       handleConvertToInput,
       handleConvertToConstant,
       handleDuplicate,
-      handleDuplicateVertical
+      handleDuplicateVertical,
+      handleCopy,
+      handleCut,
+      handleToggleCollapsed
     },
     conditions: {
       hasCommentTitle,
@@ -273,7 +308,8 @@ export function useNodeContextMenu(): UseNodeContextMenuReturn {
       canConvertToInput,
       canConvertToConstant,
       isWorkflowRunning,
-      isInGroup
+      isInGroup,
+      isCollapsed
     }
   };
 }

--- a/web/src/hooks/nodes/useToggleCollapse.ts
+++ b/web/src/hooks/nodes/useToggleCollapse.ts
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+import { useNodeStoreRef } from "../../contexts/NodeContext";
+import { getCollapseTogglePatches } from "../../stores/collapseNodeLayout";
+
+/**
+ * Toggles the collapsed (header-only) state of one or more nodes, applying the
+ * layout patches that preserve the expanded body height on re-expand.
+ *
+ * When multiple ids are given, the first node's next collapsed state drives the
+ * whole batch so a mixed selection ends up uniform instead of flip-flopping.
+ * Called with no ids, it toggles the current selection.
+ */
+export const useToggleCollapse = (): ((nodeIds?: string[]) => void) => {
+  const nodeStore = useNodeStoreRef();
+
+  return useCallback(
+    (nodeIds?: string[]) => {
+      const { getSelectedNodes, findNode, updateNodeData, updateNode } =
+        nodeStore.getState();
+
+      const targets =
+        nodeIds && nodeIds.length > 0
+          ? nodeIds.map((id) => findNode(id)).filter((n) => n != null)
+          : getSelectedNodes();
+
+      if (targets.length === 0) {
+        return;
+      }
+
+      const next = !targets[0].data.collapsed;
+      for (const node of targets) {
+        const { data: dataPatch, node: nodePatch } = getCollapseTogglePatches(
+          node,
+          next
+        );
+        updateNodeData(node.id, dataPatch);
+        updateNode(node.id, nodePatch);
+      }
+    },
+    [nodeStore]
+  );
+};

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -21,7 +21,7 @@ import { useNotificationStore } from "../stores/NotificationStore";
 import { useRightPanelStore } from "../stores/RightPanelStore";
 import { usePanelStore } from "../stores/PanelStore";
 import { NodeData } from "../stores/NodeData";
-import { getCollapseTogglePatches } from "../stores/collapseNodeLayout";
+import { useToggleCollapse } from "./nodes/useToggleCollapse";
 import { Node } from "@xyflow/react";
 import { isMac } from "../utils/platform";
 import { useFindInWorkflowStore } from "../stores/FindInWorkflowStore";
@@ -432,21 +432,10 @@ export const useNodeEditorShortcuts = (
     leftPanelToggle("settings");
   }, [leftPanelToggle]);
 
+  const toggleCollapse = useToggleCollapse();
   const handleToggleSelectedNodesCollapsed = useCallback(() => {
-    const selected = nodeStore.getState().getSelectedNodes();
-    if (selected.length === 0) {
-      return;
-    }
-    const { updateNodeData, updateNode, findNode } = nodeStore.getState();
-    for (const n of selected) {
-      const live = findNode(n.id) ?? n;
-      const next = !live.data.collapsed;
-      const { data: dataPatch, node: nodePatch } =
-        getCollapseTogglePatches(live, next);
-      updateNodeData(n.id, dataPatch);
-      updateNode(n.id, nodePatch);
-    }
-  }, [nodeStore]);
+    toggleCollapse();
+  }, [toggleCollapse]);
 
   useMenuHandler(handleMenuEvent);
 


### PR DESCRIPTION
## Summary

Quality-of-life improvements for the node editor's right-click menus. Most of these surface actions that already had working handlers or keyboard shortcuts but weren't reachable from the menus — so this is mostly wiring, plus a couple of genuine fixes.

## Changes

**Node context menu** (single node, right-click)
- Add **Copy** and **Cut** items (previously only available via keyboard; the multi-select menu already had Copy).
- Add **Collapse / Expand** item (the `C` shortcut existed but had no menu entry). Label and icon reflect the node's current collapsed state.

**Selection context menu** (multi-select, right-click)
- Add **Cut**, **Run Selected**, **Collapse / Expand**, and **Group into Subgraph** — closing the gap with the single-node menu, which already had Run and Group into Subgraph.
- Fix the **"Surrround With Group"** typo → "Surround With Group".

**Pane context menu**
- Fix broken tooltip slugs: `getShortcutTooltip("paste-selection")` → `"paste"` and `"fit-view"` → `"fitView"`. These slugs don't exist, so the Paste and Fit Screen items were rendering the literal slug text instead of their real key combos (`CTRL+V`, `F`).

**Refactor**
- Extract a shared `useToggleCollapse` hook, replacing the duplicated collapse-toggle logic in `NodeHeader` and `useNodeEditorShortcuts` and enabling the new menu items. A mixed selection now collapses to a uniform state (driven by the first node) instead of flip-flopping each node individually.

## Testing

- New `useToggleCollapse.test.ts` covering id targeting, uniform mixed-selection behavior, selection fallback, empty targets, and unresolved ids.
- Updated `CodeNodeUx.test.tsx` mock to provide `useNodeStoreRef` (now used by `NodeHeader`).
- `web` jest suites for `hooks/nodes`, `components/context_menus`, and `components/node` all pass (698 tests); lint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156K8dGhtAnDSQbA1SQbtej)_