### PR TITLE
Add keyboard shortcuts to the fullscreen Assets page

### DIFF
--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -1,6 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import React, { useCallback, useEffect, useMemo, useRef, memo } from "react";
-import { Text, Tooltip, Divider, Box, Z_INDEX } from "../ui_primitives";
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Text,
+  Tooltip,
+  Divider,
+  Box,
+  Z_INDEX,
+  ToolbarIconButton
+} from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 
 import AudioPlayer from "../audio/AudioPlayer";
@@ -19,6 +27,7 @@ import AssetFoldersPanel from "./panels/AssetFoldersPanel";
 import AssetFilesPanel from "./panels/AssetFilesPanel";
 import assetGridStyles from "./assetGridStyles";
 import useClickOutsideDeselect from "./hooks/useClickOutsideDeselect";
+import { useAssetGridShortcuts } from "../../hooks/assets/useAssetGridShortcuts";
 
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { useKeyPressedStore } from "../../stores/KeyPressedStore";
@@ -62,11 +71,12 @@ const styles = assetGridStyles;
 const FOLDERS_PANEL_HEIGHT = 200;
 const FOLDERS_PANEL_WIDTH = 200;
 
-/** Displays count and total size of selected assets */
+/** Displays count and total size of selected assets, with a clear button */
 const SelectedItemsInfo: React.FC<{
   selectedAssetIds: string[];
   assets: Asset[];
-}> = memo(({ selectedAssetIds, assets }) => {
+  onClear: () => void;
+}> = memo(({ selectedAssetIds, assets, onClear }) => {
   const totalSize = useMemo(() => {
     if (selectedAssetIds.length === 0) return 0;
     const selectedSet = new Set(selectedAssetIds);
@@ -94,6 +104,16 @@ const SelectedItemsInfo: React.FC<{
             </Tooltip>
           )}
         </Text>
+        <ToolbarIconButton
+          className="clear-selection"
+          icon={<CloseIcon />}
+          tooltip="Clear selection"
+          shortcut={["Esc"]}
+          tooltipPlacement="top"
+          onClick={onClear}
+          size="small"
+          sx={{ ml: 0.5, "& .MuiSvgIcon-root": { fontSize: 14 } }}
+        />
       </div>
     </div>
   );
@@ -231,6 +251,15 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     }
   }, [F2KeyPressed, selectedAssetIds, setRenameDialogOpen]);
 
+  // File-manager shortcuts (select-all, delete, deselect, open) on the
+  // fullscreen page, where there's no workflow canvas to collide with. The
+  // list mirrors what the grid displays so Cmd+A selects the visible assets.
+  const shortcutAssets = useMemo(
+    () => sortedAssets ?? folderFilesFiltered ?? [],
+    [sortedAssets, folderFilesFiltered]
+  );
+  useAssetGridShortcuts(shortcutAssets, Boolean(isFullscreenAssets));
+
   const uploadFiles = useCallback(
     (files: File[]) => {
       files.forEach((file: File) => {
@@ -354,6 +383,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
         <SelectedItemsInfo
           selectedAssetIds={selectedAssetIds}
           assets={sortedAssets || folderFilesFiltered || []}
+          onClear={() => setSelectedAssetIds([])}
         />
       )}
       {/* Drag-and-drop enabled region; upload button now in toolbar */}

--- a/web/src/components/assets/assetGridStyles.ts
+++ b/web/src/components/assets/assetGridStyles.ts
@@ -56,6 +56,8 @@ export const assetGridStyles = (theme: Theme) => {
       userSelect: "none"
     },
     ".selected-asset-info": {
+      display: "flex",
+      alignItems: "center",
       fontSize: `${theme.vars.fontSizeSmall} !important`,
       color: theme.vars.palette.grey[400],
       minHeight: "25px",

--- a/web/src/hooks/assets/__tests__/useAssetGridShortcuts.test.ts
+++ b/web/src/hooks/assets/__tests__/useAssetGridShortcuts.test.ts
@@ -1,0 +1,157 @@
+import { renderHook } from "@testing-library/react";
+import { useAssetGridShortcuts } from "../useAssetGridShortcuts";
+import { Asset } from "../../../stores/ApiTypes";
+
+// Capture every useCombo registration so tests can assert the active flags and
+// invoke the callbacks directly, without wiring the real global key bus.
+type Registration = {
+  combo: string[];
+  callback: () => void;
+  active: boolean;
+};
+let registrations: Registration[] = [];
+
+jest.mock("../../../stores/KeyPressedStore", () => ({
+  useCombo: (
+    combo: string[],
+    callback: () => void,
+    _preventDefault?: boolean,
+    active?: boolean
+  ) => {
+    registrations.push({ combo, callback, active: active ?? true });
+  }
+}));
+
+jest.mock("zustand/react/shallow", () => ({
+  useShallow: (selector: unknown) => selector
+}));
+
+const storeState = {
+  selectedAssetIds: [] as string[],
+  setSelectedAssetIds: jest.fn(),
+  setSelectedAssets: jest.fn(),
+  setDeleteDialogOpen: jest.fn(),
+  openAsset: null as Asset | null,
+  deleteDialogOpen: false,
+  renameDialogOpen: false,
+  moveToFolderDialogOpen: false,
+  createFolderDialogOpen: false
+};
+
+jest.mock("../../../stores/AssetGridStore", () => ({
+  useAssetGridStore: (selector: (state: typeof storeState) => unknown) =>
+    selector(storeState)
+}));
+
+const createAsset = (id: string, content_type = "image/png"): Asset =>
+  ({
+    id,
+    user_id: "u",
+    workflow_id: null,
+    parent_id: "p",
+    name: id,
+    content_type,
+    metadata: null,
+    created_at: "0",
+    get_url: "url",
+    thumb_url: null,
+    duration: null
+  } as unknown as Asset);
+
+const comboKey = (combo: string[]) => [...combo].sort().join("+");
+const find = (combo: string[]) =>
+  registrations.find((r) => comboKey(r.combo) === comboKey(combo));
+
+const resetStore = () => {
+  storeState.selectedAssetIds = [];
+  storeState.openAsset = null;
+  storeState.deleteDialogOpen = false;
+  storeState.renameDialogOpen = false;
+  storeState.moveToFolderDialogOpen = false;
+  storeState.createFolderDialogOpen = false;
+  jest.clearAllMocks();
+};
+
+beforeEach(() => {
+  registrations = [];
+  resetStore();
+});
+
+const assets = [createAsset("1"), createAsset("2"), createAsset("3")];
+
+describe("useAssetGridShortcuts", () => {
+  it("registers select-all, delete and deselect combos", () => {
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    expect(find(["meta", "a"])).toBeDefined();
+    expect(find(["control", "a"])).toBeDefined();
+    expect(find(["delete"])).toBeDefined();
+    expect(find(["backspace"])).toBeDefined();
+    expect(find(["escape"])).toBeDefined();
+  });
+
+  it("does not bind Enter", () => {
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    expect(find(["enter"])).toBeUndefined();
+  });
+
+  it("disables every combo when not enabled", () => {
+    storeState.selectedAssetIds = ["1"];
+    renderHook(() => useAssetGridShortcuts(assets, false));
+    for (const reg of registrations) {
+      expect(reg.active).toBe(false);
+    }
+  });
+
+  it("disables every combo while an overlay is open", () => {
+    storeState.selectedAssetIds = ["1"];
+    storeState.deleteDialogOpen = true;
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    for (const reg of registrations) {
+      expect(reg.active).toBe(false);
+    }
+  });
+
+  it("select-all resolves ids against the passed assets", () => {
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    find(["meta", "a"])!.callback();
+    expect(storeState.setSelectedAssets).toHaveBeenCalledWith(assets);
+    expect(storeState.setSelectedAssetIds).toHaveBeenCalledWith(["1", "2", "3"]);
+  });
+
+  it("select-all stays active even with an empty selection", () => {
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    expect(find(["meta", "a"])!.active).toBe(true);
+  });
+
+  it("delete opens the confirm dialog only with a selection", () => {
+    const { rerender } = renderHook(
+      ({ ids }) => {
+        storeState.selectedAssetIds = ids;
+        return useAssetGridShortcuts(assets, true);
+      },
+      { initialProps: { ids: [] as string[] } }
+    );
+    // No selection: combo inactive.
+    expect(find(["delete"])!.active).toBe(false);
+
+    registrations = [];
+    rerender({ ids: ["1", "2"] });
+    expect(find(["delete"])!.active).toBe(true);
+    find(["delete"])!.callback();
+    expect(storeState.setDeleteDialogOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("escape clears the selection", () => {
+    storeState.selectedAssetIds = ["1"];
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    expect(find(["escape"])!.active).toBe(true);
+    find(["escape"])!.callback();
+    expect(storeState.setSelectedAssetIds).toHaveBeenCalledWith([]);
+    expect(storeState.setSelectedAssets).toHaveBeenCalledWith([]);
+  });
+
+  it("escape is inactive with no selection", () => {
+    renderHook(() => useAssetGridShortcuts(assets, true));
+    expect(find(["escape"])!.active).toBe(false);
+  });
+});

--- a/web/src/hooks/assets/useAssetGridShortcuts.ts
+++ b/web/src/hooks/assets/useAssetGridShortcuts.ts
@@ -1,0 +1,84 @@
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useCombo } from "../../stores/KeyPressedStore";
+import { Asset } from "../../stores/ApiTypes";
+import { useAssetGridStore } from "../../stores/AssetGridStore";
+
+/**
+ * File-manager keyboard shortcuts for the fullscreen Assets page:
+ *   - Cmd/Ctrl+A      select every visible asset
+ *   - Delete/Backspace delete the current selection (opens the confirm dialog)
+ *   - Escape          clear the selection
+ *
+ * Combos register on the global key bus but the default "canvas" scope keeps
+ * them suppressed while the user is typing (search box, rename field). They are
+ * also disabled whenever a dialog or the asset viewer is open, so they never
+ * fight the confirmation dialogs, and Escape only fires while something is
+ * selected so it stays free for closing overlays. Pass `enabled = false` on
+ * surfaces that share the screen with the workflow canvas (the in-editor
+ * sidebar), where Delete/Cmd+A would collide with node shortcuts.
+ *
+ * Enter is deliberately not bound: a global Enter handler would hijack the
+ * native activation of focused toolbar buttons and Selects (which are not
+ * "editable elements"). Double-click still opens an asset in the viewer.
+ */
+export const useAssetGridShortcuts = (assets: Asset[], enabled: boolean) => {
+  const {
+    selectedAssetIds,
+    setSelectedAssetIds,
+    setSelectedAssets,
+    setDeleteDialogOpen,
+    openAsset,
+    deleteDialogOpen,
+    renameDialogOpen,
+    moveToFolderDialogOpen,
+    createFolderDialogOpen
+  } = useAssetGridStore(
+    useShallow((state) => ({
+      selectedAssetIds: state.selectedAssetIds,
+      setSelectedAssetIds: state.setSelectedAssetIds,
+      setSelectedAssets: state.setSelectedAssets,
+      setDeleteDialogOpen: state.setDeleteDialogOpen,
+      openAsset: state.openAsset,
+      deleteDialogOpen: state.deleteDialogOpen,
+      renameDialogOpen: state.renameDialogOpen,
+      moveToFolderDialogOpen: state.moveToFolderDialogOpen,
+      createFolderDialogOpen: state.createFolderDialogOpen
+    }))
+  );
+
+  const overlayOpen =
+    !!openAsset ||
+    deleteDialogOpen ||
+    renameDialogOpen ||
+    moveToFolderDialogOpen ||
+    createFolderDialogOpen;
+
+  const active = enabled && !overlayOpen;
+  const hasSelection = selectedAssetIds.length > 0;
+
+  const selectAll = useCallback(() => {
+    // Set the resolved assets first so the store's setSelectedAssetIds can
+    // resolve every id against a populated list (the fullscreen page never
+    // populates the store's `filteredAssets`).
+    setSelectedAssets(assets);
+    setSelectedAssetIds(assets.map((asset) => asset.id));
+  }, [assets, setSelectedAssets, setSelectedAssetIds]);
+
+  const deleteSelected = useCallback(() => {
+    if (selectedAssetIds.length > 0) {
+      setDeleteDialogOpen(true);
+    }
+  }, [selectedAssetIds, setDeleteDialogOpen]);
+
+  const deselect = useCallback(() => {
+    setSelectedAssetIds([]);
+    setSelectedAssets([]);
+  }, [setSelectedAssetIds, setSelectedAssets]);
+
+  useCombo(["meta", "a"], selectAll, true, active);
+  useCombo(["control", "a"], selectAll, true, active);
+  useCombo(["delete"], deleteSelected, true, active && hasSelection);
+  useCombo(["backspace"], deleteSelected, true, active && hasSelection);
+  useCombo(["escape"], deselect, true, active && hasSelection);
+};


### PR DESCRIPTION
## Summary

Quality-of-life improvements for the asset manager. The fullscreen Assets page had almost no keyboard support (only F2 to rename and Space for the audio player) — no way to select-all, delete, or clear a selection from the keyboard, which is table-stakes for a file manager. This adds those shortcuts on the fullscreen page, where there's no workflow canvas to collide with.

## Changes

- **New `useAssetGridShortcuts` hook** (`web/src/hooks/assets/useAssetGridShortcuts.ts`) wiring:
  - **Cmd/Ctrl+A** — select every visible asset
  - **Delete / Backspace** — open the delete confirmation for the current selection
  - **Escape** — clear the selection
- **Gated behind `isFullscreenAssets`** in `AssetGrid`, so the in-editor Library sidebar (which shares the screen with the node canvas, where Delete/Cmd+A already mean something) is untouched.
- Combos register on the existing global key bus (`useCombo`). The default `"canvas"` scope keeps them suppressed while typing in the search/rename fields, and every combo is disabled while a dialog or the asset viewer is open so they never fight the confirmation dialogs. Escape only fires while something is selected, leaving it free to close overlays.
- **Enter is intentionally not bound** — a global Enter handler would hijack the native activation of focused toolbar buttons and Selects (which aren't "editable elements"). Double-click still opens an asset.
- **Clear-selection button** added to the selected-items header (with an `Esc` shortcut hint) so the gesture is discoverable for mouse users.

## Testing

- New unit test `useAssetGridShortcuts.test.ts` (9 cases) covering combo registration, the enabled/overlay gating, and each callback's store effect.
- `npx jest src/hooks/assets src/components/assets src/stores/__tests__/AssetGridStore.test.ts` → 124 passed.
- ESLint clean on all changed files.

The repo's `tsc` has pre-existing `Cannot find module '@nodetool-ai/*'` errors that require `npm run build:packages` (the documented decorator-package pitfall); none involve the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E47gXFUx9BkC26KQ4miZr5

---
_Generated by [Claude Code](https://claude.ai/code/session_01E47gXFUx9BkC26KQ4miZr5)_