### PR TITLE
feat(web): fit-to-screen and layer reorder shortcuts in the sketch editor

### DIFF
--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -133,6 +133,8 @@ export interface SketchCanvasRef {
   commitPendingCrop: () => void;
   /** Get the raw layer canvas element for offset/bounds lookups (authoritative over layer.contentBounds). */
   getLayerCanvas: (layerId: string) => HTMLCanvasElement | null;
+  /** Current CSS size of the scrolling viewport that clips the artboard, or null before mount. */
+  getViewportSize: () => { width: number; height: number } | null;
 }
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -385,6 +387,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       ref,
       doc,
       runtime: compositing.runtime,
+      containerRef,
       displayCanvasRef: compositing.displayCanvasRef,
       overlayCanvasRef: compositing.overlayCanvasRef,
       redraw: compositing.redraw,

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -260,7 +260,8 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
           canvasRef.current?.getLayerData(layerId) ?? null,
         fillLayerWithColor: (layerId, color) =>
           canvasRef.current?.fillLayerWithColor(layerId, color),
-        clearActiveLayer: () => session.canvasActions.handleClearLayer()
+        clearActiveLayer: () => session.canvasActions.handleClearLayer(),
+        fitViewToScreen: () => session.canvasActions.handleZoomFit()
       });
       return () => {
         clearCanvasGetters();

--- a/web/src/components/sketch/__tests__/sessionAndCommands.test.tsx
+++ b/web/src/components/sketch/__tests__/sessionAndCommands.test.tsx
@@ -394,7 +394,7 @@ describe("useEditorCommands", () => {
       canvasActions: {
         handleZoomIn: jest.fn(),
         handleZoomOut: jest.fn(),
-        handleZoomReset: jest.fn(),
+        handleZoomFit: jest.fn(),
         handleExportPng: jest.fn(),
         handleClearLayer: jest.fn(),
         handleFillLayerWithColor: jest.fn(),

--- a/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
+++ b/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
@@ -11,7 +11,10 @@ import SketchCanvasPresentation from "../SketchCanvasPresentation";
 import type { SketchCanvasPresentationProps } from "../SketchCanvasPresentation";
 import { useSketchStore } from "../state";
 import { cursorStyleForTool } from "../sketchCursorStyle";
-import { canvasTransformStyle } from "../sketchCanvasPresentation.helpers";
+import {
+  canvasTransformStyle,
+  computeFitZoom
+} from "../sketchCanvasPresentation.helpers";
 import { TransformTool } from "../tools/TransformTool";
 
 // Mock MUI ThemeProvider — SketchCanvasPresentation uses useTheme.
@@ -134,6 +137,33 @@ describe("canvasTransformStyle", () => {
     );
     expect(style.transformOrigin).toBe("center center");
     expect(style.imageRendering).toBe("pixelated");
+  });
+});
+
+// ─── computeFitZoom ──────────────────────────────────────────────────────────
+
+describe("computeFitZoom", () => {
+  it("fits by the limiting axis with the default 90% margin", () => {
+    // Wide viewport, square canvas — height is limiting: 400/1000 * 0.9.
+    expect(computeFitZoom(2000, 400, 1000, 1000)).toBeCloseTo(0.36, 5);
+  });
+
+  it("uses the width axis when it is the limiting dimension", () => {
+    expect(computeFitZoom(500, 2000, 1000, 1000)).toBeCloseTo(0.45, 5);
+  });
+
+  it("can enlarge a small canvas past 100%", () => {
+    expect(computeFitZoom(1000, 1000, 100, 100)).toBeCloseTo(9, 5);
+  });
+
+  it("honors a custom margin", () => {
+    expect(computeFitZoom(1000, 1000, 1000, 1000, 1)).toBe(1);
+  });
+
+  it("falls back to 1 when any dimension is non-positive", () => {
+    expect(computeFitZoom(0, 500, 1000, 1000)).toBe(1);
+    expect(computeFitZoom(500, 500, 0, 1000)).toBe(1);
+    expect(computeFitZoom(-10, 500, 1000, 1000)).toBe(1);
   });
 });
 

--- a/web/src/components/sketch/__tests__/useEditorKeyboardShortcuts.test.tsx
+++ b/web/src/components/sketch/__tests__/useEditorKeyboardShortcuts.test.tsx
@@ -15,7 +15,7 @@ function makeParams(): UseEditorKeyboardShortcutsParams {
     handleRedo: jest.fn(),
     handleZoomIn: jest.fn(),
     handleZoomOut: jest.fn(),
-    handleZoomReset: jest.fn(),
+    handleZoomFit: jest.fn(),
     handleExportPng: jest.fn(),
     handleClearLayer: jest.fn(),
     handleFillLayerWithColor: jest.fn(),
@@ -47,6 +47,7 @@ function makeParams(): UseEditorKeyboardShortcutsParams {
     handleTransformRedo: jest.fn(),
     handleLayerViaCopy: jest.fn(),
     handleLayerViaCut: jest.fn(),
+    handleMoveActiveLayer: jest.fn(),
     handleFreeTransform: jest.fn(),
     handleRepeatLastTransform: jest.fn(),
     handleRepeatLastTransformOnCopy: jest.fn()

--- a/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
@@ -78,7 +78,7 @@ const ConnectedStatusBarInner: React.FC = () => {
         <span>
           {docW} × {docH} · sRGB · 8-bit ·
         </span>
-        <Tooltip title={FIT_LABEL}>
+        <Tooltip title={FIT_LABEL} disabled={!fitViewToScreen}>
           <button
             type="button"
             className="sketch-status-bar__zoom"

--- a/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
@@ -15,9 +15,10 @@
 import React, { memo, useMemo } from "react";
 import { useTheme } from "@mui/material/styles";
 
-import { ColorSwatch, FlexRow } from "../../ui_primitives";
+import { ColorSwatch, FlexRow, Tooltip } from "../../ui_primitives";
 import { useSketchStore } from "../state/useSketchStore";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
+import { useSketchCanvasRefStore } from "../../../stores/sketch/SketchCanvasRefStore";
 import { getSelectionBounds } from "../selection";
 import { colorToHex6 } from "../types";
 import { SKETCH_FONT } from "../sketchStyles";
@@ -34,6 +35,7 @@ const ConnectedStatusBarInner: React.FC = () => {
   const cursorDocPos = useSketchStore((s) => s.cursorDocPos);
   const selection = useSketchStore((s) => s.selection);
   const hasActiveSelection = useSketchStore((s) => s.hasActiveSelection);
+  const fitViewToScreen = useSketchCanvasRefStore((s) => s.fitViewToScreen);
 
   const selBounds = useMemo(
     () =>
@@ -68,9 +70,29 @@ const ConnectedStatusBarInner: React.FC = () => {
         whiteSpace: "nowrap"
       }}
     >
-      <span>
-        {docW} × {docH} · sRGB · 8-bit · {Math.round(zoom * 100)}%
-      </span>
+      <FlexRow align="center" gap={0.5}>
+        <span>
+          {docW} × {docH} · sRGB · 8-bit ·
+        </span>
+        <Tooltip title="Fit to screen (Ctrl+0)">
+          <button
+            type="button"
+            className="sketch-status-bar__zoom"
+            onClick={fitViewToScreen ?? undefined}
+            disabled={!fitViewToScreen}
+            style={{
+              font: "inherit",
+              color: "inherit",
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: fitViewToScreen ? "pointer" : "default"
+            }}
+          >
+            {Math.round(zoom * 100)}%
+          </button>
+        </Tooltip>
+      </FlexRow>
 
       <FlexRow align="center" gap={0.5}>
         <ColorSwatch color={fgHex} size={12} />

--- a/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
@@ -20,8 +20,12 @@ import { useSketchStore } from "../state/useSketchStore";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useSketchCanvasRefStore } from "../../../stores/sketch/SketchCanvasRefStore";
 import { getSelectionBounds } from "../selection";
+import { displayCombo } from "../shortcuts";
 import { colorToHex6 } from "../types";
 import { SKETCH_FONT } from "../sketchStyles";
+
+/** OS-aware combo for the fit-to-screen action ("⌘0" on Mac, "Ctrl+0" elsewhere). */
+const FIT_LABEL = `Fit to screen (${displayCombo("zoom-fit")})`;
 
 const ConnectedStatusBarInner: React.FC = () => {
   const theme = useTheme();
@@ -74,10 +78,11 @@ const ConnectedStatusBarInner: React.FC = () => {
         <span>
           {docW} × {docH} · sRGB · 8-bit ·
         </span>
-        <Tooltip title="Fit to screen (Ctrl+0)">
+        <Tooltip title={FIT_LABEL}>
           <button
             type="button"
             className="sketch-status-bar__zoom"
+            aria-label={FIT_LABEL}
             onClick={fitViewToScreen ?? undefined}
             disabled={!fitViewToScreen}
             style={{

--- a/web/src/components/sketch/hooks/useCanvasActions.ts
+++ b/web/src/components/sketch/hooks/useCanvasActions.ts
@@ -225,7 +225,7 @@ export function useCanvasActions({
     handleCanvasResizeDrag: geometryActions.handleCanvasResizeDrag,
     handleZoomIn: geometryActions.handleZoomIn,
     handleZoomOut: geometryActions.handleZoomOut,
-    handleZoomReset: geometryActions.handleZoomReset,
+    handleZoomFit: geometryActions.handleZoomFit,
     handleCropComplete: geometryActions.handleCropComplete,
     handleCropCommit,
     handleCropCancelPreview,

--- a/web/src/components/sketch/hooks/useCanvasGeometryActions.ts
+++ b/web/src/components/sketch/hooks/useCanvasGeometryActions.ts
@@ -24,6 +24,7 @@ import {
   getLayerGeometry
 } from "../transform/geometry/layerGeometry";
 import { getSelectionBounds, selectionHasAnyPixels } from "../selection";
+import { computeFitZoom } from "../sketchCanvasPresentation.helpers";
 import {
   buildSketchInternalClipboardCanvas,
   drawSketchPasteOnLayerContext,
@@ -444,10 +445,25 @@ export function useCanvasGeometryActions({
     },
     [setZoom]
   );
-  const handleZoomReset = useCallback(() => {
-    setZoom(1);
+  /**
+   * Fit the whole artboard into the viewport and re-center it. Falls back to
+   * 100% when the viewport size is not yet known. `setZoom` clamps the result
+   * to the sketch zoom range.
+   */
+  const handleZoomFit = useCallback(() => {
+    const viewport = canvasRef.current?.getViewportSize() ?? null;
+    const { document: doc } = useSketchStore.getState();
+    const fit = viewport
+      ? computeFitZoom(
+          viewport.width,
+          viewport.height,
+          doc.canvas.width,
+          doc.canvas.height
+        )
+      : 1;
+    setZoom(fit);
     setPan({ x: 0, y: 0 });
-  }, [setZoom, setPan]);
+  }, [canvasRef, setZoom, setPan]);
 
   // ─── Crop completion ───────────────────────────────────────────
   const handleCropComplete = useCallback(
@@ -1042,7 +1058,7 @@ export function useCanvasGeometryActions({
     handleCanvasResizeDrag,
     handleZoomIn,
     handleZoomOut,
-    handleZoomReset,
+    handleZoomFit,
     handleCropComplete,
     handleCropCanvasToActiveLayerVisiblePixels,
     handleCropCanvasToActiveLayerExtents,

--- a/web/src/components/sketch/hooks/useEditorCommands.ts
+++ b/web/src/components/sketch/hooks/useEditorCommands.ts
@@ -243,7 +243,7 @@ export function useEditorCommands({
     handleRedo,
     handleZoomIn: canvasActions.handleZoomIn,
     handleZoomOut: canvasActions.handleZoomOut,
-    handleZoomReset: canvasActions.handleZoomReset,
+    handleZoomFit: canvasActions.handleZoomFit,
     handleExportPng: canvasActions.handleExportPng,
     handleClearLayer: canvasActions.handleClearLayer,
     handleFillLayerWithColor: canvasActions.handleFillLayerWithColor,
@@ -275,6 +275,7 @@ export function useEditorCommands({
     handleTransformRedo: canvasActions.handleTransformRedo,
     handleLayerViaCopy,
     handleLayerViaCut,
+    handleMoveActiveLayer: layerActions.handleMoveActiveLayer,
     handleFreeTransform,
     handleRepeatLastTransform: canvasActions.handleRepeatLastTransform,
     handleRepeatLastTransformOnCopy:

--- a/web/src/components/sketch/hooks/useLayerActions.ts
+++ b/web/src/components/sketch/hooks/useLayerActions.ts
@@ -8,7 +8,7 @@
 import { useCallback, type RefObject } from "react";
 import type { SketchCanvasRef } from "../SketchCanvas";
 import type { BlendMode, PushHistoryOptions, SketchDocument } from "../types";
-import { findMergeDownTargetIndex } from "../types";
+import { findLayerMoveTargetIndex, findMergeDownTargetIndex } from "../types";
 import { useSketchStore } from "../state";
 import { getMergeSelectedLayersPlan } from "../layerMergeSelection";
 
@@ -159,6 +159,30 @@ export function useLayerActions({
     (fromIndex: number, toIndex: number) => {
       reorderLayers(fromIndex, toIndex);
       pushHistory("reorder layers");
+      scheduleDisplayRedraw();
+    },
+    [pushHistory, reorderLayers, scheduleDisplayRedraw]
+  );
+
+  /**
+   * Keyboard reorder of the active layer within its sibling list. A no-op when
+   * the neighbor in the move direction is a group or lives under a different
+   * parent (see `findLayerMoveTargetIndex`), so groups stay intact.
+   */
+  const handleMoveActiveLayer = useCallback(
+    (direction: "up" | "down") => {
+      const { document: doc } = useSketchStore.getState();
+      const activeId = doc.activeLayerId;
+      if (!activeId) {
+        return;
+      }
+      const fromIndex = doc.layers.findIndex((l) => l.id === activeId);
+      const toIndex = findLayerMoveTargetIndex(doc.layers, activeId, direction);
+      if (fromIndex < 0 || toIndex < 0) {
+        return;
+      }
+      reorderLayers(fromIndex, toIndex);
+      pushHistory(direction === "up" ? "move layer up" : "move layer down");
       scheduleDisplayRedraw();
     },
     [pushHistory, reorderLayers, scheduleDisplayRedraw]
@@ -451,6 +475,7 @@ export function useLayerActions({
     handleRemoveLayer,
     handleDuplicateLayer,
     handleReorderLayers,
+    handleMoveActiveLayer,
     handleToggleVisibility,
     handleSetLayerOpacity,
     handleSetLayerBlendMode,

--- a/web/src/components/sketch/shortcuts/actionHandlers.ts
+++ b/web/src/components/sketch/shortcuts/actionHandlers.ts
@@ -79,7 +79,7 @@ export const ACTION_HANDLERS: ActionHandlerMap = {
 
   // Canvas
   "export-png": (_e, p) => p.handleExportPng(),
-  "zoom-reset": (_e, p) => p.handleZoomReset(),
+  "zoom-fit": (_e, p) => p.handleZoomFit(),
   "zoom-100": (_e, p) => p.setZoom(1),
   "zoom-in": (_e, p) => p.handleZoomIn(),
   "zoom-out": (_e, p) => p.handleZoomOut(),
@@ -92,6 +92,8 @@ export const ACTION_HANDLERS: ActionHandlerMap = {
   // Layers
   "layer-via-copy": (_e, p) => p.handleLayerViaCopy(),
   "layer-via-cut": (_e, p) => p.handleLayerViaCut(),
+  "layer-move-up": (_e, p) => p.handleMoveActiveLayer("up"),
+  "layer-move-down": (_e, p) => p.handleMoveActiveLayer("down"),
 
   // Paint settings
   "tool-size-decrease": (_e, p) => adjustSize(p, -1),

--- a/web/src/components/sketch/shortcuts/actionRegistry.ts
+++ b/web/src/components/sketch/shortcuts/actionRegistry.ts
@@ -9,7 +9,7 @@ export const SKETCH_ACTION_IDS = [
   // Selection
   "select-all", "deselect", "reselect", "invert-selection",
   // Canvas
-  "export-png", "zoom-reset", "zoom-100", "zoom-in", "zoom-out", "toggle-panels",
+  "export-png", "zoom-fit", "zoom-100", "zoom-in", "zoom-out", "toggle-panels",
   // Color
   "swap-colors", "reset-colors",
   // Paint
@@ -18,6 +18,7 @@ export const SKETCH_ACTION_IDS = [
   "tool-opacity-preset",
   // Layers
   "layer-via-copy", "layer-via-cut",
+  "layer-move-up", "layer-move-down",
   "blend-mode-prev", "blend-mode-next",
   "canvas-preset-prev", "canvas-preset-next",
   // Tools
@@ -76,7 +77,7 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
   { id: "reselect", label: "Reselect", displayGroup: "Selection" },
   { id: "invert-selection", label: "Invert Selection", displayGroup: "Selection" },
   { id: "export-png", label: "Export Image", displayGroup: "Canvas" },
-  { id: "zoom-reset", label: "Reset Zoom", displayGroup: "Canvas" },
+  { id: "zoom-fit", label: "Fit to Screen", displayGroup: "Canvas" },
   { id: "zoom-100", label: "Zoom to 100%", displayGroup: "Canvas" },
   { id: "zoom-in", label: "Zoom In", displayGroup: "Canvas" },
   { id: "zoom-out", label: "Zoom Out", displayGroup: "Canvas" },
@@ -90,6 +91,8 @@ export const ACTION_REGISTRY: readonly ActionMeta[] = [
   { id: "tool-opacity-preset", label: "Set Opacity (0–9)", displayGroup: "Paint" },
   { id: "layer-via-copy", label: "Layer via Copy", displayGroup: "Layers" },
   { id: "layer-via-cut", label: "Layer via Cut", displayGroup: "Layers" },
+  { id: "layer-move-up", label: "Move Layer Up", displayGroup: "Layers" },
+  { id: "layer-move-down", label: "Move Layer Down", displayGroup: "Layers" },
   { id: "blend-mode-prev", label: "Previous Blend Mode", displayGroup: "Layers" },
   { id: "blend-mode-next", label: "Next Blend Mode", displayGroup: "Layers" },
   { id: "canvas-preset-prev", label: "Previous Canvas Preset", displayGroup: "Layers" },

--- a/web/src/components/sketch/shortcuts/bindingCatalog.ts
+++ b/web/src/components/sketch/shortcuts/bindingCatalog.ts
@@ -45,7 +45,7 @@ export const BINDING_CATALOG: readonly BindingEntry[] = [
   { key: "i", modifiers: { ctrl: true, shift: true }, actionId: "invert-selection", scope: "global" },
 
   // ── Global: Canvas ────────────────────────────────────────────────────────
-  { key: "0", modifiers: { ctrl: true }, actionId: "zoom-reset", scope: "global" },
+  { key: "0", modifiers: { ctrl: true }, actionId: "zoom-fit", scope: "global" },
   { key: "1", modifiers: { ctrl: true }, actionId: "zoom-100", scope: "global" },
   { key: "+", modifiers: {}, actionId: "zoom-in", scope: "global" },
   { key: "=", modifiers: {}, actionId: "zoom-in", scope: "global" },
@@ -59,6 +59,9 @@ export const BINDING_CATALOG: readonly BindingEntry[] = [
   // ── Global: Layers ────────────────────────────────────────────────────────
   { key: "j", modifiers: { ctrl: true }, actionId: "layer-via-copy", scope: "global" },
   { key: "j", modifiers: { ctrl: true, shift: true }, actionId: "layer-via-cut", scope: "global" },
+  // Photoshop-style stack order: Ctrl+] brings the active layer forward, Ctrl+[ sends it back.
+  { key: "]", modifiers: { ctrl: true }, actionId: "layer-move-up", scope: "global" },
+  { key: "[", modifiers: { ctrl: true }, actionId: "layer-move-down", scope: "global" },
 
   // ── Global: Paint settings ────────────────────────────────────────────────
   { key: "[", modifiers: {}, actionId: "tool-size-decrease", scope: "global" },

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
@@ -23,6 +23,8 @@ export interface UseCanvasImperativeHandleParams {
   doc: SketchDocument;
   /** The rendering runtime that owns layer storage and compositing. */
   runtime: SketchRuntime;
+  /** Scrolling viewport that clips the artboard (used for fit-to-screen). */
+  containerRef: React.RefObject<HTMLDivElement | null>;
   displayCanvasRef: React.RefObject<HTMLCanvasElement | null>;
   overlayCanvasRef: React.RefObject<HTMLCanvasElement | null>;
   redraw: () => void;
@@ -37,6 +39,7 @@ export function useCanvasImperativeHandle({
   ref,
   doc,
   runtime,
+  containerRef,
   displayCanvasRef,
   overlayCanvasRef,
   redraw,
@@ -222,6 +225,16 @@ export function useCanvasImperativeHandle({
       commitPendingCrop,
       getLayerCanvas: (layerId: string): HTMLCanvasElement | null => {
         return runtime.getLayerCanvas(layerId) ?? null;
+      },
+      getViewportSize: (): { width: number; height: number } | null => {
+        const container = containerRef.current;
+        if (!container) {
+          return null;
+        }
+        return {
+          width: container.clientWidth,
+          height: container.clientHeight
+        };
       }
     }),
     [
@@ -229,6 +242,7 @@ export function useCanvasImperativeHandle({
       runtime,
       redraw,
       drainPendingStrokeCommit,
+      containerRef,
       displayCanvasRef,
       overlayCanvasRef,
       zoom,

--- a/web/src/components/sketch/sketchCanvasPresentation.helpers.ts
+++ b/web/src/components/sketch/sketchCanvasPresentation.helpers.ts
@@ -8,3 +8,29 @@ export function canvasTransformStyle(pan: Point, zoom: number): CSSProperties {
     imageRendering: "pixelated"
   };
 }
+
+/**
+ * Zoom factor that fits the whole artboard inside the viewport, keeping the
+ * aspect ratio and leaving a small gutter (`margin`, default 90%). Returns 1
+ * when any dimension is unknown or non-positive, so callers can fall back to
+ * 100%. The result is not clamped — the store's `setZoom` applies the min/max.
+ */
+export function computeFitZoom(
+  viewportWidth: number,
+  viewportHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  margin = 0.9
+): number {
+  if (
+    viewportWidth <= 0 ||
+    viewportHeight <= 0 ||
+    canvasWidth <= 0 ||
+    canvasHeight <= 0
+  ) {
+    return 1;
+  }
+  return (
+    Math.min(viewportWidth / canvasWidth, viewportHeight / canvasHeight) * margin
+  );
+}

--- a/web/src/components/sketch/types/__tests__/document.test.ts
+++ b/web/src/components/sketch/types/__tests__/document.test.ts
@@ -10,6 +10,7 @@ import {
   getLayerDepth,
   getDescendantIds,
   findMergeDownTargetIndex,
+  findLayerMoveTargetIndex,
   isLayerCompositeVisible,
   layerAllowsTransformWhilePixelLocked,
 } from "../document";
@@ -321,6 +322,75 @@ describe("findMergeDownTargetIndex", () => {
 
   it("returns -1 for empty array", () => {
     expect(findMergeDownTargetIndex([], "any")).toBe(-1);
+  });
+});
+
+// ─── findLayerMoveTargetIndex ────────────────────────────────────────────────
+
+describe("findLayerMoveTargetIndex", () => {
+  it("moves up toward the top of the stack (higher index)", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "a" }),
+      makeLayer({ id: "b" }),
+      makeLayer({ id: "c" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "b", "up")).toBe(2);
+  });
+
+  it("moves down toward the bottom of the stack (lower index)", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "a" }),
+      makeLayer({ id: "b" }),
+      makeLayer({ id: "c" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "b", "down")).toBe(0);
+  });
+
+  it("returns -1 when already at the top and moving up", () => {
+    const layers: Layer[] = [makeLayer({ id: "a" }), makeLayer({ id: "b" })];
+    expect(findLayerMoveTargetIndex(layers, "b", "up")).toBe(-1);
+  });
+
+  it("returns -1 when already at the bottom and moving down", () => {
+    const layers: Layer[] = [makeLayer({ id: "a" }), makeLayer({ id: "b" })];
+    expect(findLayerMoveTargetIndex(layers, "a", "down")).toBe(-1);
+  });
+
+  it("returns -1 when the active layer is a group", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "a" }),
+      makeLayer({ id: "g", type: "group" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "g", "down")).toBe(-1);
+  });
+
+  it("returns -1 when the neighbor is a group (keeps the group block intact)", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "g", type: "group" }),
+      makeLayer({ id: "a" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "a", "down")).toBe(-1);
+  });
+
+  it("returns -1 when the neighbor has a different parent", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "a", parentId: "group1" }),
+      makeLayer({ id: "b", parentId: "group2" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "b", "down")).toBe(-1);
+  });
+
+  it("moves within the same parent group", () => {
+    const layers: Layer[] = [
+      makeLayer({ id: "a", parentId: "g" }),
+      makeLayer({ id: "b", parentId: "g" }),
+    ];
+    expect(findLayerMoveTargetIndex(layers, "a", "up")).toBe(1);
+  });
+
+  it("returns -1 when the active layer is not found", () => {
+    const layers: Layer[] = [makeLayer({ id: "a" })];
+    expect(findLayerMoveTargetIndex(layers, "missing", "up")).toBe(-1);
   });
 });
 

--- a/web/src/components/sketch/types/document.ts
+++ b/web/src/components/sketch/types/document.ts
@@ -943,6 +943,43 @@ export function findMergeDownTargetIndex(
   return idx - 1;
 }
 
+/**
+ * Flat target index for moving `activeId` one step "up" (toward the top of the
+ * stack — higher index, painted later) or "down", or `-1` when the move is not
+ * possible.
+ *
+ * The move is only allowed when the immediate neighbor in the move direction is
+ * a **sibling** (same `parentId`) and **not a group**. A group carries a
+ * contiguous block of descendants that a single-index swap would orphan, and
+ * hopping across a parent boundary would silently re-parent the layer — both
+ * are treated as no-ops rather than a corrupting reorder. This mirrors the
+ * safety rules of `findMergeDownTargetIndex`.
+ */
+export function findLayerMoveTargetIndex(
+  layers: Layer[],
+  activeId: string,
+  direction: "up" | "down"
+): number {
+  const idx = layers.findIndex((l) => l.id === activeId);
+  if (idx < 0) {
+    return -1;
+  }
+  if (layers[idx].type === "group") {
+    return -1;
+  }
+  const neighborIdx = direction === "up" ? idx + 1 : idx - 1;
+  if (neighborIdx < 0 || neighborIdx >= layers.length) {
+    return -1;
+  }
+  const active = layers[idx];
+  const neighbor = layers[neighborIdx];
+  const sameParent = (neighbor.parentId ?? null) === (active.parentId ?? null);
+  if (!sameParent || neighbor.type === "group") {
+    return -1;
+  }
+  return neighborIdx;
+}
+
 /** Recursively collect all descendant IDs of a group (children, grandchildren, etc.) */
 export function getDescendantIds(layers: Layer[], groupId: string): string[] {
   const ids: string[] = [];

--- a/web/src/components/sketch/useEditorKeyboardShortcuts.ts
+++ b/web/src/components/sketch/useEditorKeyboardShortcuts.ts
@@ -24,7 +24,7 @@ export interface UseEditorKeyboardShortcutsParams {
   handleRedo: () => void;
   handleZoomIn: () => void;
   handleZoomOut: () => void;
-  handleZoomReset: () => void;
+  handleZoomFit: () => void;
   handleExportPng: () => void;
   handleClearLayer: () => void;
   handleFillLayerWithColor: (color: string) => void;
@@ -64,6 +64,8 @@ export interface UseEditorKeyboardShortcutsParams {
   handleTransformRedo: () => void;
   handleLayerViaCopy: () => void;
   handleLayerViaCut: () => void;
+  /** Move the active layer one step up ("up") or down ("down") in the stack. */
+  handleMoveActiveLayer: (direction: "up" | "down") => void;
   handleFreeTransform: () => void;
   handleRepeatLastTransform: () => void;
   handleRepeatLastTransformOnCopy: () => void;

--- a/web/src/stores/sketch/SketchCanvasRefStore.ts
+++ b/web/src/stores/sketch/SketchCanvasRefStore.ts
@@ -18,6 +18,8 @@ export interface SketchCanvasRefState {
    * otherwise the whole layer. Pushes its own history entry.
    */
   clearActiveLayer: (() => void) | null;
+  /** Fit the whole artboard into the viewport and re-center it (Ctrl+0). */
+  fitViewToScreen: (() => void) | null;
 
   setGetters: (getters: {
     flattenToDataUrl: () => string;
@@ -26,6 +28,7 @@ export interface SketchCanvasRefState {
     getLayerData?: (layerId: string) => string | null;
     fillLayerWithColor?: (layerId: string, color: string) => void;
     clearActiveLayer: () => void;
+    fitViewToScreen?: () => void;
   }) => void;
   clearGetters: () => void;
 }
@@ -43,6 +46,7 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
     getLayerData: null,
     fillLayerWithColor: null,
     clearActiveLayer: null,
+    fitViewToScreen: null,
 
     setGetters: (getters) =>
       set({
@@ -51,7 +55,8 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
         setLayerData: getters.setLayerData,
         getLayerData: getters.getLayerData ?? null,
         fillLayerWithColor: getters.fillLayerWithColor ?? null,
-        clearActiveLayer: getters.clearActiveLayer
+        clearActiveLayer: getters.clearActiveLayer,
+        fitViewToScreen: getters.fitViewToScreen ?? null
       }),
 
     clearGetters: () =>
@@ -61,7 +66,8 @@ export const createSketchCanvasRefStore = (): SketchCanvasRefStoreApi =>
         setLayerData: null,
         getLayerData: null,
         fillLayerWithColor: null,
-        clearActiveLayer: null
+        clearActiveLayer: null,
+        fitViewToScreen: null
       })
   }));
 


### PR DESCRIPTION
## Summary

Fills two navigation quality-of-life gaps in the sketch editor.

### Fit to Screen (Ctrl+0)
`Ctrl+0` now fits the whole artboard into the viewport and re-centers it (Photoshop "Fit on Screen") instead of just resetting to 100% — there was previously no way to fit an oversized canvas short of manual wheel-zoom. `Ctrl+1` still snaps to 100%.

- New viewport-aware `computeFitZoom` helper (aspect-preserving, 90% gutter).
- New `getViewportSize` getter on the canvas imperative handle, reading the clipping container.
- Falls back to 100% before the viewport is measured; `setZoom` still clamps to the sketch zoom range.
- The zoom readout in the standalone status bar is now a button that triggers the same fit (tooltip "Fit to screen (Ctrl+0)"), so the feature is discoverable without the keyboard.

### Move layer up / down (Ctrl+] / Ctrl+[)
`Ctrl+]` brings the active layer forward, `Ctrl+[` sends it back — the store already supported reordering but nothing was bound to the keyboard.

- Sibling-safe: `findLayerMoveTargetIndex` no-ops when the neighbor in the move direction is a group or lives under a different parent, so group blocks stay contiguous (mirrors the existing `findMergeDownTargetIndex` safety rules). The common flat-layer case works exactly as expected.
- The active layer stays active after the move, so repeated presses keep shifting it.

Both actions are registered in the editor's action registry, so they show up in the keyboard-shortcuts list (renamed "Reset Zoom" → "Fit to Screen").

## Testing
- `npm run typecheck` (web) — clean.
- `oxlint` on the touched dirs — no new findings.
- New unit tests for `computeFitZoom` (limiting-axis, enlarge, custom margin, non-positive fallback) and `findLayerMoveTargetIndex` (up/down, edges, group/parent guards). All sketch shortcut/registry/status-bar/command suites pass (173 in the targeted run).

Note: rendering-runtime test suites that need a real canvas 2D context fail in this sandbox because the native `canvas` package can't be built here (`HTMLCanvasElement.prototype.getContext` not implemented under jsdom). Those suites are unrelated to this change and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tsUxoVytB3TQvHem1CNzT

---
_Generated by [Claude Code](https://claude.ai/code/session_017tsUxoVytB3TQvHem1CNzT)_