### PR TITLE
timeline: add discoverable keyboard-shortcut reference

### DIFF
--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -183,7 +183,9 @@ export const TimelineShortcutsDialog: React.FC<TimelineShortcutsDialogProps> =
         >
           <Caption sx={{ opacity: 0.7 }}>Press</Caption>
           <ShortcutHint shortcut={["?"]} />
-          <Caption sx={{ opacity: 0.7 }}>any time to toggle this panel</Caption>
+          <Caption sx={{ opacity: 0.7 }}>
+            any time to toggle this panel · Ctrl also responds to ⌘ on macOS
+          </Caption>
         </FlexRow>
       </Dialog>
     );

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -71,7 +71,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "Move",
     shortcuts: [
-      { keys: ["←"], action: "Nudge left one frame", alt: ["→"] },
+      { keys: ["←"], action: "Nudge one frame", alt: ["→"] },
       { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] }
     ]
   },

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -1,0 +1,194 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * TimelineShortcutsDialog — a reference sheet for every timeline keyboard
+ * shortcut, grouped by task. Opened with `?` (or the toolbar help button) and
+ * closed with Escape / the close button.
+ *
+ * The shortcut set is authored here to match the window-level handler in
+ * TracksRegion; keep the two in sync when adding a shortcut.
+ */
+import React, { memo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import {
+  Dialog,
+  FlexColumn,
+  FlexRow,
+  ShortcutHint,
+  Text,
+  Caption,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+
+interface Shortcut {
+  keys: string[];
+  action: string;
+  /** Alternate binding shown after the primary one (e.g. "or Backspace"). */
+  alt?: string[];
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+/**
+ * Mirrors the bindings registered in TracksRegion's window keydown handler.
+ * `Ctrl` renders as `⌘` on macOS via ShortcutHint's key formatting when the
+ * author uses "Cmd"; here we use "Ctrl" to match the handler's `ctrlKey ||
+ * metaKey` check, which accepts either.
+ */
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: "Tools",
+    shortcuts: [
+      { keys: ["V"], action: "Select tool" },
+      { keys: ["C"], action: "Cut (blade) tool" },
+      { keys: ["Esc"], action: "Clear selection · back to Select" }
+    ]
+  },
+  {
+    title: "Editing",
+    shortcuts: [
+      { keys: ["S"], action: "Split selected clips at playhead" },
+      { keys: ["Delete"], action: "Delete selected clips", alt: ["Backspace"] },
+      { keys: ["Ctrl", "D"], action: "Duplicate (after each source)" },
+      { keys: ["Ctrl", "Shift", "D"], action: "Duplicate with a 1 s gap" },
+      { keys: ["Ctrl", "A"], action: "Select all clips" }
+    ]
+  },
+  {
+    title: "Clipboard",
+    shortcuts: [
+      { keys: ["Ctrl", "C"], action: "Copy selected clips" },
+      { keys: ["Ctrl", "X"], action: "Cut selected clips" },
+      { keys: ["Ctrl", "V"], action: "Paste at playhead" }
+    ]
+  },
+  {
+    title: "Move",
+    shortcuts: [
+      { keys: ["←"], action: "Nudge left one frame", alt: ["→"] },
+      { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] }
+    ]
+  },
+  {
+    title: "Zoom & view",
+    shortcuts: [
+      { keys: ["+"], action: "Zoom in", alt: ["="] },
+      { keys: ["-"], action: "Zoom out", alt: ["_"] },
+      { keys: ["Shift", "Z"], action: "Zoom to fit content" }
+    ]
+  },
+  {
+    title: "History",
+    shortcuts: [
+      { keys: ["Ctrl", "Z"], action: "Undo" },
+      { keys: ["Ctrl", "Shift", "Z"], action: "Redo", alt: ["Ctrl", "Y"] }
+    ]
+  }
+];
+
+const groupStyles = css({
+  minWidth: 0
+});
+
+const rowStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: getSpacingPx(SPACING.lg),
+    padding: `${getSpacingPx(SPACING.xs)} 0`,
+    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    "&:last-of-type": { borderBottom: "none" }
+  });
+
+const groupTitleSx = {
+  color: "text.secondary",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  fontWeight: 600
+} as const;
+
+const keysCellStyles = css({
+  display: "flex",
+  alignItems: "center",
+  gap: getSpacingPx(SPACING.xs),
+  flexShrink: 0
+});
+
+const ShortcutRow: React.FC<{ shortcut: Shortcut }> = ({ shortcut }) => {
+  const theme = useTheme();
+  return (
+    <div css={rowStyles(theme)}>
+      <Text size="small" sx={{ minWidth: 0 }}>
+        {shortcut.action}
+      </Text>
+      <div css={keysCellStyles}>
+        <ShortcutHint shortcut={shortcut.keys} />
+        {shortcut.alt ? (
+          <>
+            <Caption sx={{ opacity: 0.6 }}>or</Caption>
+            <ShortcutHint shortcut={shortcut.alt} />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export interface TimelineShortcutsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Two-column masonry of grouped shortcut rows inside a standard Dialog. */
+export const TimelineShortcutsDialog: React.FC<TimelineShortcutsDialogProps> =
+  memo(({ open, onClose }) => {
+    const theme = useTheme();
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        title="Keyboard shortcuts"
+        minWidth="min(680px, 100vw - 32px)"
+      >
+        <div
+          css={css({
+            display: "grid",
+            gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+            gap: getSpacingPx(SPACING.xl),
+            paddingTop: getSpacingPx(SPACING.sm),
+            "@media (max-width: 560px)": { gridTemplateColumns: "1fr" }
+          })}
+        >
+          {SHORTCUT_GROUPS.map((group) => (
+            <FlexColumn key={group.title} gap={0.5} css={groupStyles}>
+              <Caption sx={groupTitleSx}>{group.title}</Caption>
+              {group.shortcuts.map((shortcut) => (
+                <ShortcutRow key={shortcut.action} shortcut={shortcut} />
+              ))}
+            </FlexColumn>
+          ))}
+        </div>
+        <FlexRow
+          justify="center"
+          align="center"
+          gap={0.5}
+          sx={{ pt: 2, mt: 1, borderTop: `1px solid ${theme.vars.palette.divider}` }}
+        >
+          <Caption sx={{ opacity: 0.7 }}>Press</Caption>
+          <ShortcutHint shortcut={["?"]} />
+          <Caption sx={{ opacity: 0.7 }}>any time to toggle this panel</Caption>
+        </FlexRow>
+      </Dialog>
+    );
+  });
+
+TimelineShortcutsDialog.displayName = "TimelineShortcutsDialog";
+
+export default TimelineShortcutsDialog;

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -36,10 +36,10 @@ interface ShortcutGroup {
 }
 
 /**
- * Mirrors the bindings registered in TracksRegion's window keydown handler.
- * `Ctrl` renders as `⌘` on macOS via ShortcutHint's key formatting when the
- * author uses "Cmd"; here we use "Ctrl" to match the handler's `ctrlKey ||
- * metaKey` check, which accepts either.
+ * Mirrors the bindings registered in TracksRegion's window keydown handler,
+ * which fire on `ctrlKey || metaKey`. We label those keys "Ctrl" — rendered
+ * verbatim by ShortcutHint on every platform — since the sheet is shared
+ * across macOS and Windows/Linux and a single label keeps it compact.
  */
 const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -26,7 +26,12 @@
  *   + / =  and  - / _ → zoom in / out (keyboard; playhead stays pinned)
  *   Shift+Z          → zoom to fit all content in the viewport
  *   Ctrl+Z / Ctrl+Y  → undo / redo
+ *   ?                → toggle the keyboard-shortcut reference sheet
  * Shortcuts are skipped when focus is in a text input or contenteditable.
+ *
+ * The user-facing reference for these bindings lives in
+ * ../TimelineShortcutsDialog.tsx — keep the two in sync when a shortcut
+ * changes.
  *
  * Zoom: Ctrl/Cmd+wheel (or a trackpad pinch) on the lane area changes msPerPx,
  *   anchored at the cursor.

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -551,8 +551,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
 
         const isCtrl = e.ctrlKey || e.metaKey;
 
-        // ? → toggle the keyboard-shortcut reference sheet.
-        if (!isCtrl && !e.altKey && e.key === "?") {
+        // ? → toggle the keyboard-shortcut reference sheet. Match the resolved
+        // character, not the modifier state: some layouts produce "?" via AltGr
+        // (reported as ctrlKey+altKey), so gating on modifiers would hide the
+        // shortcut there. Editable targets are already excluded above.
+        if (e.key === "?") {
           e.preventDefault();
           setShortcutsOpen((open) => !open);
           return;

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -79,7 +79,8 @@ import {
 } from "./ScriptLane";
 import { FX_PANEL_HEIGHT_PX } from "./trackHeight";
 import { ToolToggle } from "../ToolToggle";
-import { FlexRow, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
+import { TimelineShortcutsDialog } from "../TimelineShortcutsDialog";
+import { FlexRow, HelpButton, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 import { useHasScript } from "../../../hooks/timeline/useHasScript";
 import { useVideoAudioImport } from "../../../hooks/timeline/useVideoAudioImport";
 import { deserializeDragData } from "../../../lib/dragdrop";
@@ -255,6 +256,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
 
     const scrollableRef = useRef<HTMLDivElement>(null);
     const headerColumnRef = useRef<HTMLDivElement>(null);
+
+    // Keyboard-shortcut reference sheet (opened with `?` or the toolbar button).
+    const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
     // Drop on empty area: auto-create a track of matching type.
     const isAssetDrag = useCallback((e: React.DragEvent): boolean => {
@@ -546,6 +550,14 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         }
 
         const isCtrl = e.ctrlKey || e.metaKey;
+
+        // ? → toggle the keyboard-shortcut reference sheet.
+        if (!isCtrl && !e.altKey && e.key === "?") {
+          e.preventDefault();
+          setShortcutsOpen((open) => !open);
+          return;
+        }
+
         // Read on demand instead of subscribing reactively — subscribing
         // would re-render the region and re-attach this listener on every
         // selection change (e.g. every rubber-band drag tick).
@@ -810,6 +822,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           <div style={{ flex: "1 1 auto" }} />
           <ScriptToggleButton />
           <AddTrackButton />
+          <HelpButton
+            onClick={() => setShortcutsOpen(true)}
+            iconVariant="helpOutline"
+            tooltip="Keyboard shortcuts (?)"
+          />
         </FlexRow>
 
         {/* ── Sub-header: TRACKS label + ruler ────────────────────────── */}
@@ -933,6 +950,12 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             trackAreaOffsetPx={0}
           />
         </div>
+
+        {/* ── Keyboard-shortcut reference (`?` / toolbar help button) ──── */}
+        <TimelineShortcutsDialog
+          open={shortcutsOpen}
+          onClose={() => setShortcutsOpen(false)}
+        />
       </div>
     );
   }

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -562,7 +562,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         // shortcut there. Editable targets are already excluded above.
         if (e.key === "?") {
           e.preventDefault();
-          setShortcutsOpen((open) => !open);
+          // Ignore auto-repeat so holding the key doesn't flip the dialog
+          // open/closed every repeat tick and land on an unpredictable state.
+          if (!e.repeat) setShortcutsOpen((open) => !open);
           return;
         }
 

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -92,6 +92,26 @@ describe("TracksRegion keyboard shortcuts", () => {
     expect(useTimelineUIStore.getState().msPerPx).toBeGreaterThan(zoomedIn);
   });
 
+  it("? opens the keyboard-shortcut reference", () => {
+    const { queryByText, getByText } = setup();
+    expect(queryByText("Keyboard shortcuts")).toBeNull();
+    act(() => {
+      fireEvent.keyDown(window, { key: "?" });
+    });
+    expect(getByText("Keyboard shortcuts")).toBeTruthy();
+  });
+
+  it("does not open the shortcut reference while typing in an input", () => {
+    const { container, queryByText } = setup();
+    const input = document.createElement("input");
+    container.appendChild(input);
+    input.focus();
+    act(() => {
+      fireEvent.keyDown(input, { key: "?" });
+    });
+    expect(queryByText("Keyboard shortcuts")).toBeNull();
+  });
+
   it("does not fire shortcuts while typing in an input", () => {
     const { container } = setup();
     const input = document.createElement("input");

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -109,6 +109,20 @@ describe("TracksRegion keyboard shortcuts", () => {
     expect(getByText("Keyboard shortcuts")).toBeTruthy();
   });
 
+  it("? ignores auto-repeat so a held key doesn't flip the dialog", () => {
+    const { getByText } = setup();
+    act(() => {
+      fireEvent.keyDown(window, { key: "?" });
+    });
+    expect(getByText("Keyboard shortcuts")).toBeTruthy();
+    // A held key streams repeat events; none should toggle the dialog closed.
+    act(() => {
+      fireEvent.keyDown(window, { key: "?", repeat: true });
+      fireEvent.keyDown(window, { key: "?", repeat: true });
+    });
+    expect(getByText("Keyboard shortcuts")).toBeTruthy();
+  });
+
   it("does not open the shortcut reference while typing in an input", () => {
     const { container, queryByText } = setup();
     const input = document.createElement("input");

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -101,6 +101,14 @@ describe("TracksRegion keyboard shortcuts", () => {
     expect(getByText("Keyboard shortcuts")).toBeTruthy();
   });
 
+  it("? opens the reference even on AltGr layouts (Ctrl+Alt produce ?)", () => {
+    const { getByText } = setup();
+    act(() => {
+      fireEvent.keyDown(window, { key: "?", ctrlKey: true, altKey: true });
+    });
+    expect(getByText("Keyboard shortcuts")).toBeTruthy();
+  });
+
   it("does not open the shortcut reference while typing in an input", () => {
     const { container, queryByText } = setup();
     const input = document.createElement("input");


### PR DESCRIPTION
## What

The timeline editor already registers a rich set of window-level keyboard shortcuts (Select/Cut tools, split, duplicate, clipboard, frame nudge, zoom, zoom-to-fit, undo/redo) but nothing in the UI surfaced them, so they were effectively undiscoverable. This adds a keyboard-shortcut reference sheet.

- **`?`** toggles a shortcut reference dialog from anywhere in the editor (skipped while typing in an input / contenteditable, like the other shortcuts).
- A **help button** in the tracks toolbar opens the same dialog for mouse users.
- The dialog groups every binding by task (Tools, Editing, Clipboard, Move, Zoom & view, History) in a responsive two-column layout, rendered with the existing `ShortcutHint` primitive.

## Changes

- **New** `web/src/components/timeline/TimelineShortcutsDialog.tsx` — data-driven shortcut sheet built on the `Dialog`, `ShortcutHint`, and layout primitives.
- **`TracksRegion.tsx`** — a `?` toggle in the window keydown handler, a `HelpButton` in the toolbar, and the dialog wiring.
- **`TracksRegionShortcuts.test.tsx`** — covers the open path and the "don't fire while typing" guard.

## Testing

- `npx jest TracksRegionShortcuts` — 7/7 pass.
- `eslint` and `tsc` clean on the touched files.

## Notes

The shortcut list is authored in the dialog to mirror the handler in `TracksRegion`; a comment in each file points at the other to keep them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TR1BDmvyopfvgtMUSarC77

---
_Generated by [Claude Code](https://claude.ai/code/session_01TR1BDmvyopfvgtMUSarC77)_