### PR TITLE
Guard destructive storyboard actions with confirmation

### DIFF
--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -24,8 +24,10 @@ import {
   SelectField,
   EditorButton,
   EmptyState,
+  Dialog,
   Divider,
   Text,
+  Caption,
   CONTROL,
   SPACING,
   getSpacingPx,
@@ -217,6 +219,9 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const setVideoModel = useStoryboardStore((state) => state.setVideoModel);
 
   const [shotCount, setShotCount] = useState<number>(6);
+  const [confirmRedirect, setConfirmRedirect] = useState(false);
+
+  const hasShots = shots.length > 0;
 
   // Entity reference images only reach generation through an editing model;
   // warn when entities are attached but the still model can't take them.
@@ -228,9 +233,24 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     entityIds.length > 0 &&
     !stillModelDetails?.supported_tasks?.includes("image_to_image");
 
-  const handleDirect = useCallback(() => {
+  const runDirect = useCallback(() => {
     onDirect?.(shotCount);
   }, [onDirect, shotCount]);
+
+  // Directing rewrites the whole screenplay, replacing every existing shot
+  // (and its generated stills and clips). Confirm before clobbering work.
+  const handleDirect = useCallback(() => {
+    if (hasShots) {
+      setConfirmRedirect(true);
+      return;
+    }
+    runDirect();
+  }, [hasShots, runDirect]);
+
+  const handleConfirmRedirect = useCallback(() => {
+    setConfirmRedirect(false);
+    runDirect();
+  }, [runDirect]);
 
   const hasRenderedShot = useMemo(
     () => shots.some((s) => s.status === "rendered" && !!s.clip?.asset_id),
@@ -359,7 +379,9 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               <Text size="small" color={directError || assembleError ? "error" : "secondary"}>
                 {directError ??
                   assembleError ??
-                  "Direct writes the screenplay and seeds your shots."}
+                  (hasShots
+                    ? "Re-directing rewrites the screenplay and replaces every shot."
+                    : "Direct writes the screenplay and seeds your shots.")}
               </Text>
               <FlexRow gap={2} align="center">
                 <EditorButton
@@ -389,13 +411,32 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                   onClick={handleDirect}
                   disabled={!onDirect || directing}
                 >
-                  {directing ? "Directing…" : "Direct"}
+                  {directing ? "Directing…" : hasShots ? "Re-direct" : "Direct"}
                 </EditorButton>
               </FlexRow>
             </FlexRow>
           </FlexColumn>
         </Panel>
       )}
+
+      <Dialog
+        open={confirmRedirect}
+        onClose={() => setConfirmRedirect(false)}
+        title="Re-direct this storyboard?"
+        onConfirm={handleConfirmRedirect}
+        confirmText="Re-direct"
+        destructive
+      >
+        <FlexColumn gap={1}>
+          <Text size="small">
+            {`Directing writes a new screenplay and replaces all ${shots.length} current shot${shots.length === 1 ? "" : "s"}.`}
+          </Text>
+          <Caption color="secondary">
+            Generated stills and clips stay in your asset library, but the
+            shots on this board are rebuilt from scratch.
+          </Caption>
+        </FlexColumn>
+      </Dialog>
 
       {directing ? (
         <>

--- a/web/src/components/storyboard/StoryboardSidebar.tsx
+++ b/web/src/components/storyboard/StoryboardSidebar.tsx
@@ -8,7 +8,7 @@
  * "recent work" view.
  */
 
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -20,6 +20,7 @@ import {
   FlexRow,
   Text,
   Caption,
+  Dialog,
   ToolbarIconButton,
   LoadingSpinner,
   SPACING,
@@ -78,6 +79,11 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
 
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
   const openBoard = useCallback(
     (id: string, title: string) => {
       openTab({
@@ -102,14 +108,16 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
     }
   }, [createStoryboard, openBoard]);
 
-  const deleteBoard = useCallback(
-    (id: string) => {
-      deleteStoryboard.mutate({ id });
-      removeLocalBoard(id);
-      closeTab(tabId("storyboard", id));
-    },
-    [deleteStoryboard, removeLocalBoard, closeTab]
-  );
+  const confirmDelete = useCallback(() => {
+    if (!pendingDelete) {
+      return;
+    }
+    const { id } = pendingDelete;
+    deleteStoryboard.mutate({ id });
+    removeLocalBoard(id);
+    closeTab(tabId("storyboard", id));
+    setPendingDelete(null);
+  }, [pendingDelete, deleteStoryboard, removeLocalBoard, closeTab]);
 
   const formatter = useMemo(
     () =>
@@ -164,7 +172,10 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
                 tooltip="Delete storyboard"
                 onClick={(e) => {
                   e.stopPropagation();
-                  deleteBoard(board.id);
+                  setPendingDelete({
+                    id: board.id,
+                    name: board.name || "Untitled storyboard"
+                  });
                 }}
               />
             </FlexRow>
@@ -176,6 +187,19 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
           )}
         </FlexColumn>
       )}
+
+      <Dialog
+        open={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        title="Delete storyboard?"
+        onConfirm={confirmDelete}
+        confirmText="Delete"
+        destructive
+      >
+        <Text size="small">
+          {`Delete “${pendingDelete?.name ?? ""}” and its shots. Generated stills and clips stay in your asset library.`}
+        </Text>
+      </Dialog>
     </div>
   );
 };

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Shot } from "@nodetool-ai/protocol";
+import mockTheme from "../../../__mocks__/themeMock";
+
+let mockShots: Shot[] = [];
+jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
+  useBoard: () => ({
+    title: "My film",
+    brief: "A brief",
+    style: "",
+    entityIds: [],
+    aspectRatio: "16:9",
+    directorModel: { id: "model-1" },
+    imageModel: null,
+    videoModel: null,
+    shots: mockShots
+  }),
+  useStoryboardStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      setTitle: jest.fn(),
+      setBrief: jest.fn(),
+      setStyle: jest.fn(),
+      setAspectRatio: jest.fn(),
+      setDirectorModel: jest.fn(),
+      setImageModel: jest.fn(),
+      setVideoModel: jest.fn()
+    })
+}));
+
+jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
+  useGenerateShot: () => ({
+    generateKeyframe: jest.fn(),
+    generateClip: jest.fn()
+  })
+}));
+
+jest.mock("../../../hooks/useModelsByProvider", () => ({
+  useImageModelsByProvider: () => ({ models: [] })
+}));
+
+const stub = (name: string) => ({
+  __esModule: true,
+  default: () => <div data-testid={name} />
+});
+jest.mock("../../properties/LanguageModelSelect", () => stub("lang-model"));
+jest.mock("../../properties/ImageModelSelect", () => stub("image-model"));
+jest.mock("../../properties/VideoModelSelect", () => stub("video-model"));
+jest.mock("../ShotCard", () => stub("shot-card"));
+jest.mock("../StoryboardEntitiesField", () => stub("entities"));
+
+import StoryboardBoard from "../StoryboardBoard";
+
+const makeShot = (id: string): Shot =>
+  ({ type: "shot", id, index: 0, slug: "Shot", action: "" }) as unknown as Shot;
+
+const renderBoard = (onDirect: (n: number) => void) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <StoryboardBoard boardId="board-1" onDirect={onDirect} />
+    </ThemeProvider>
+  );
+
+describe("StoryboardBoard direct guard", () => {
+  it("directs immediately when the board has no shots", async () => {
+    mockShots = [];
+    const onDirect = jest.fn();
+    const user = userEvent.setup();
+    renderBoard(onDirect);
+
+    await user.click(screen.getByRole("button", { name: "Direct" }));
+
+    expect(onDirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms before re-directing over existing shots", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2")];
+    const onDirect = jest.fn();
+    const user = userEvent.setup();
+    renderBoard(onDirect);
+
+    // The button relabels once shots exist.
+    await user.click(screen.getByRole("button", { name: "Re-direct" }));
+
+    // The run is held until the confirmation is accepted.
+    expect(onDirect).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("Re-direct this storyboard?")
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Re-direct" }));
+
+    expect(onDirect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -53,8 +53,14 @@ jest.mock("../StoryboardEntitiesField", () => stub("entities"));
 
 import StoryboardBoard from "../StoryboardBoard";
 
-const makeShot = (id: string): Shot =>
-  ({ type: "shot", id, index: 0, slug: "Shot", action: "" }) as unknown as Shot;
+const makeShot = (id: string): Shot => ({
+  type: "shot",
+  id,
+  index: 0,
+  slug: "Shot",
+  action: "",
+  status: "planned"
+});
 
 const renderBoard = (onDirect: (n: number) => void) =>
   render(

--- a/web/src/components/storyboard/__tests__/StoryboardSidebar.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardSidebar.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const deleteMutateMock = jest.fn();
+jest.mock("../../../hooks/storyboard/useStoryboards", () => ({
+  useStoryboards: () => ({
+    data: [
+      {
+        id: "board-1",
+        name: "My film",
+        shotCount: 3,
+        updatedAt: "2024-01-01T00:00:00.000Z"
+      }
+    ],
+    isLoading: false
+  }),
+  useCreateStoryboard: () => ({ mutateAsync: jest.fn() }),
+  useDeleteStoryboard: () => ({ mutate: deleteMutateMock })
+}));
+
+const removeBoardMock = jest.fn();
+jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
+  useStoryboardStore: (selector: (s: unknown) => unknown) =>
+    selector({ removeBoard: removeBoardMock })
+}));
+
+const closeTabMock = jest.fn();
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  tabId: (type: string, ref: string) => `${type}:${ref}`,
+  useWorkspaceTabsStore: (selector: (s: unknown) => unknown) =>
+    selector({ openTab: jest.fn(), closeTab: closeTabMock })
+}));
+
+import StoryboardSidebar from "../StoryboardSidebar";
+
+const renderSidebar = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <StoryboardSidebar activeBoardId="board-1" />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  deleteMutateMock.mockClear();
+  removeBoardMock.mockClear();
+  closeTabMock.mockClear();
+});
+
+describe("StoryboardSidebar delete confirmation", () => {
+  it("does not delete until the confirmation is accepted", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    await user.click(screen.getByRole("button", { name: "Delete storyboard" }));
+
+    // The mutation must not fire from the icon click alone.
+    expect(deleteMutateMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete storyboard?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(deleteMutateMock).toHaveBeenCalledWith({ id: "board-1" });
+    expect(removeBoardMock).toHaveBeenCalledWith("board-1");
+    expect(closeTabMock).toHaveBeenCalledWith("storyboard:board-1");
+  });
+
+  it("cancelling the dialog leaves the board untouched", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    await user.click(screen.getByRole("button", { name: "Delete storyboard" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(deleteMutateMock).not.toHaveBeenCalled();
+    expect(removeBoardMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Two storyboard actions silently discarded user work with no confirmation. This adds guards to both.

**Re-directing overwrote shots silently.** The "Direct" button runs the Director and writes the result through `setScreenplay`, which does `shots: [...screenplay.shots]` — replacing every existing shot (and its generated stills/clips) on the board. Pressing Direct a second time wiped all prior work with no warning.

- The button now relabels to **Re-direct** once the board has shots.
- Re-directing opens a confirmation dialog before overwriting; an empty board still directs immediately with no extra click.
- The helper line under the header reflects the overwrite ("Re-directing rewrites the screenplay and replaces every shot.").

**Deleting a storyboard was a single-click, no-confirm action.** The sidebar trash icon called the delete mutation directly, even though deleting a single *shot* already confirms. The sidebar delete now opens a confirmation dialog naming the board.

Both dialogs note that generated stills and clips stay in the asset library — only the board's shots are affected.

## Why

Data-loss footguns. Both actions are easy to trigger by accident (a stray Direct click, a mis-aimed trash icon) and both destroy generated media that took time and cost to produce.

## Tests

- `StoryboardBoard.test.tsx` — directs immediately on an empty board; holds the run behind the confirmation dialog when shots exist.
- `StoryboardSidebar.test.tsx` — the delete mutation only fires after the dialog is confirmed, and cancelling leaves the board untouched.

Full storyboard suite passes (7 suites, 39 tests); lint and typecheck clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbxNf7PrdgKzM8YvyB8c25

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbxNf7PrdgKzM8YvyB8c25)_