### PR TITLE
fix(web): keep ExtractFrame download button inside the node

### DIFF
--- a/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
+++ b/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
@@ -157,10 +157,17 @@ const styles = (theme: Theme) =>
     ".transport": {
       flex: "0 0 auto",
       display: "flex",
+      flexWrap: "wrap",
       alignItems: "center",
-      gap: theme.spacing(0.5)
+      justifyContent: "center",
+      gap: theme.spacing(0.5),
+      minWidth: 0
     },
     ".time-display": {
+      flex: "0 1 auto",
+      minWidth: 0,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
       fontFamily: theme.fontFamily2,
       fontSize: theme.fontSizeSmaller,
       fontVariantNumeric: "tabular-nums",
@@ -168,10 +175,17 @@ const styles = (theme: Theme) =>
       whiteSpace: "nowrap"
     },
     ".transport-buttons": {
+      flex: "1 1 auto",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.25),
-      margin: "0 auto"
+      justifyContent: "center",
+      gap: theme.spacing(0.25)
+    },
+    ".transport-actions": {
+      flex: "0 0 auto",
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing(0.25)
     },
     ".footer": {
       flex: "0 0 auto",
@@ -534,20 +548,22 @@ const ExtractVideoFrameBodyInner: React.FC<ExtractVideoFrameBodyProps> = ({
             onClick={() => stepFrame(1)}
           />
         </div>
-        <ToolbarIconButton
-          icon={muted ? <VolumeOffIcon /> : <VolumeUpIcon />}
-          tooltip={muted ? "Unmute" : "Mute"}
-          ariaLabel={muted ? "Unmute" : "Mute"}
-          disabled={!videoSrc}
-          onClick={handleToggleMute}
-        />
-        <ToolbarIconButton
-          icon={<DownloadIcon />}
-          tooltip="Download frame"
-          ariaLabel="Download frame"
-          disabled={!videoSrc}
-          onClick={handleDownloadFrame}
-        />
+        <div className="transport-actions">
+          <ToolbarIconButton
+            icon={muted ? <VolumeOffIcon /> : <VolumeUpIcon />}
+            tooltip={muted ? "Unmute" : "Mute"}
+            ariaLabel={muted ? "Unmute" : "Mute"}
+            disabled={!videoSrc}
+            onClick={handleToggleMute}
+          />
+          <ToolbarIconButton
+            icon={<DownloadIcon />}
+            tooltip="Download frame"
+            ariaLabel="Download frame"
+            disabled={!videoSrc}
+            onClick={handleDownloadFrame}
+          />
+        </div>
       </div>
 
       <div className="footer">

--- a/web/src/components/node_types/editing/bespokeRegistry.ts
+++ b/web/src/components/node_types/editing/bespokeRegistry.ts
@@ -140,6 +140,17 @@ export const BESPOKE_BODY_REGISTRY: Readonly<
 };
 
 /**
+ * Default widths for bespoke bodies that are wider than the generic node.
+ * Consumed by `graphNodeToReactFlowNode` — only applied when the node has no
+ * saved width yet, so user resizes are preserved.
+ */
+export const BESPOKE_DEFAULT_WIDTHS: Readonly<Record<string, number>> = {
+  // Extract Video Frame: the transport row (time readout + step/play/mute +
+  // download) needs more than the 200px generic default to fit on one line.
+  [EXTRACT_VIDEO_FRAME_NODE_TYPE]: 320
+};
+
+/**
  * Default heights for bespoke bodies that are taller than the generic node.
  * Consumed by `graphNodeToReactFlowNode` — only applied when the node has no
  * saved height yet, so user resizes are preserved.

--- a/web/src/stores/__tests__/graphNodeToReactFlowNode.test.ts
+++ b/web/src/stores/__tests__/graphNodeToReactFlowNode.test.ts
@@ -382,6 +382,31 @@ describe("graphNodeToReactFlowNode", () => {
     });
   });
 
+  describe("bespoke default dimensions", () => {
+    it("applies the bespoke default width for ExtractFrame nodes without a saved width", () => {
+      const workflow = createMockWorkflow();
+      const graphNode = createMockGraphNode({
+        type: "nodetool.video.ExtractFrame",
+      });
+
+      const result = graphNodeToReactFlowNode(workflow, graphNode);
+
+      expect(result.style?.width).toBe(320);
+    });
+
+    it("preserves a saved width for ExtractFrame nodes", () => {
+      const workflow = createMockWorkflow();
+      const graphNode = createMockGraphNode({
+        type: "nodetool.video.ExtractFrame",
+        ui_properties: { width: 500 },
+      });
+
+      const result = graphNodeToReactFlowNode(workflow, graphNode);
+
+      expect(result.style?.width).toBe(500);
+    });
+  });
+
   describe("expandParent property", () => {
     it("sets expandParent to false for Loop nodes", () => {
       const workflow = createMockWorkflow();

--- a/web/src/stores/graphNodeToReactFlowNode.ts
+++ b/web/src/stores/graphNodeToReactFlowNode.ts
@@ -11,7 +11,10 @@ import {
   COMMENT_NODE_TYPE,
   PREVIEW_NODE_TYPE
 } from "../constants/nodeTypes";
-import { BESPOKE_DEFAULT_HEIGHTS } from "../components/node_types/editing/bespokeRegistry";
+import {
+  BESPOKE_DEFAULT_HEIGHTS,
+  BESPOKE_DEFAULT_WIDTHS
+} from "../components/node_types/editing/bespokeRegistry";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -52,6 +55,9 @@ export function graphNodeToReactFlowNode(
   }
   if (isCompareImagesNode && !ui_properties?.height) {
     defaultHeight = 350;
+  }
+  if (!ui_properties?.width && node.type && node.type in BESPOKE_DEFAULT_WIDTHS) {
+    defaultWidth = BESPOKE_DEFAULT_WIDTHS[node.type];
   }
   if (!ui_properties?.height && node.type && node.type in BESPOKE_DEFAULT_HEIGHTS) {
     defaultHeight = BESPOKE_DEFAULT_HEIGHTS[node.type];

--- a/web/src/stores/graphNodeToReactFlowNode.ts
+++ b/web/src/stores/graphNodeToReactFlowNode.ts
@@ -56,10 +56,18 @@ export function graphNodeToReactFlowNode(
   if (isCompareImagesNode && !ui_properties?.height) {
     defaultHeight = 350;
   }
-  if (!ui_properties?.width && node.type && node.type in BESPOKE_DEFAULT_WIDTHS) {
+  if (
+    ui_properties?.width == null &&
+    node.type &&
+    Object.hasOwn(BESPOKE_DEFAULT_WIDTHS, node.type)
+  ) {
     defaultWidth = BESPOKE_DEFAULT_WIDTHS[node.type];
   }
-  if (!ui_properties?.height && node.type && node.type in BESPOKE_DEFAULT_HEIGHTS) {
+  if (
+    ui_properties?.height == null &&
+    node.type &&
+    Object.hasOwn(BESPOKE_DEFAULT_HEIGHTS, node.type)
+  ) {
     defaultHeight = BESPOKE_DEFAULT_HEIGHTS[node.type];
   }
 


### PR DESCRIPTION
## What

The **Download frame** button in the Extract Video Frame node's transport row rendered *outside* the node border by default (floating to the right of the purple node outline).

## Why

Two things combined:

1. **Too narrow by default.** The node only defined a bespoke default *height* (380px), so its width fell back to the 200px generic default — far too narrow for the transport row (time readout + prev/play/next + mute + download).
2. **The row didn't shrink or wrap.** The transport was a `nowrap` flex row with no shrink allowance, so once its intrinsic width exceeded the node body, the last item (download) simply spilled past the border instead of staying contained.

## Changes

- Add `BESPOKE_DEFAULT_WIDTHS` in `bespokeRegistry.ts` (mirroring the existing `BESPOKE_DEFAULT_HEIGHTS`) and wire it into `graphNodeToReactFlowNode`. `ExtractFrame` now defaults to **320px** wide, so the transport fits on one line out of the box. Saved widths are preserved, so user resizes aren't clobbered.
- Group mute + download into a `transport-actions` cluster and make the transport row overflow-safe: `flex-wrap`, centered controls, and a shrinkable time readout. The buttons now stay inside the node border at any width the user resizes to.

## Tests

- New cases in `graphNodeToReactFlowNode.test.ts` cover the bespoke default width (applied when unset, preserved when saved).
- Existing `ExtractVideoFrameBody` tests still pass (all transport buttons remain present and labeled).
- `web` typecheck + lint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKei7zfSoa2vAxvvHeTF2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKei7zfSoa2vAxvvHeTF2q)_