### PR TITLE
Fix asset resolution for asset_id-only refs and storage-key parsing

### DIFF
--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -188,5 +188,13 @@ export function getAssetFilePath(key: string): string {
  * backend) or proxied/redirected to cloud storage by the storage handler.
  */
 export function buildAssetUrl(key: string): string {
-  return `/api/storage/${key.replace(/^\/+/, "")}`;
+  // Encode each path segment so reserved chars (`#`, `?`, space, `%`) survive
+  // the round-trip through the decoding route (storage-api.ts decodeURIComponent
+  // and FileStorageAdapter.keyFromUri). `/` separators are preserved.
+  const encoded = key
+    .replace(/^\/+/, "")
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
+  return `/api/storage/${encoded}`;
 }

--- a/packages/config/tests/paths.test.ts
+++ b/packages/config/tests/paths.test.ts
@@ -192,4 +192,23 @@ describe("buildAssetUrl", () => {
       "/api/storage/temp/uuid.png"
     );
   });
+
+  it("percent-encodes reserved chars while preserving / separators", () => {
+    expect(buildAssetUrl("my file.png")).toBe("/api/storage/my%20file.png");
+    expect(buildAssetUrl("a#b.png")).toBe("/api/storage/a%23b.png");
+    expect(buildAssetUrl("dir/my file#1.png")).toBe(
+      "/api/storage/dir/my%20file%231.png"
+    );
+  });
+
+  it("round-trips reserved chars through decodeURIComponent per segment", () => {
+    const key = "dir/my file#1.png";
+    const url = buildAssetUrl(key);
+    const decoded = url
+      .replace("/api/storage/", "")
+      .split("/")
+      .map(decodeURIComponent)
+      .join("/");
+    expect(decoded).toBe(key);
+  });
 });

--- a/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
+++ b/packages/elevenlabs-nodes/src/nodes/speech-to-text.ts
@@ -1,5 +1,7 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
+import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import type { MediaRefValue } from "@nodetool-ai/runtime";
 import { getElevenLabsApiKey } from "../elevenlabs-base.js";
 
 export class SpeechToTextNode extends BaseNode {
@@ -103,7 +105,7 @@ export class SpeechToTextNode extends BaseNode {
     const apiKey = getElevenLabsApiKey(this._secrets);
 
     const audio = this.audio as Record<string, unknown> | undefined;
-    if (!audio?.uri && !audio?.data) {
+    if (!audio || typeof audio !== "object") {
       throw new Error("Audio input is required");
     }
 
@@ -117,35 +119,15 @@ export class SpeechToTextNode extends BaseNode {
     const diarize = Boolean(this.diarize ?? false);
     const fileFormat = String(this.file_format ?? "other");
 
-    // Get audio bytes from inline data, an asset/package ref resolved via the
-    // processing context, or a direct HTTP(S) fetch as a fallback.
-    let audioBytes: Buffer;
-    if (audio.data && typeof audio.data === "string") {
-      const match = (audio.data as string).match(/^data:[^;]+;base64,(.+)$/);
-      if (match) {
-        audioBytes = Buffer.from(match[1], "base64");
-      } else {
-        throw new Error("Invalid audio data URI");
-      }
-    } else if (audio.uri && typeof audio.uri === "string") {
-      const uri = audio.uri;
-      if (/^https?:\/\//i.test(uri)) {
-        const resp = await fetch(uri);
-        if (!resp.ok)
-          throw new Error(`Failed to fetch audio: ${resp.statusText}`);
-        audioBytes = Buffer.from(await resp.arrayBuffer());
-      } else {
-        // asset://, package://, or any storage/relative URI — must be resolved
-        // through the processing context, not fetched directly.
-        const resolved = await context?.resolveAssetBytes?.(uri);
-        if (!resolved?.bytes) {
-          throw new Error(`Failed to resolve audio reference: ${uri}`);
-        }
-        audioBytes = Buffer.from(resolved.bytes);
-      }
-    } else {
-      throw new Error("Audio must have a data URI or uri field");
+    // Resolve audio bytes through the canonical resolver, which handles inline
+    // `data` (raw base64 or `data:` URI), `asset://<id>` / `asset_id`, package
+    // and storage URIs, local files, and local http(s) — routing each through
+    // the appropriate guarded path rather than fetching arbitrary URLs.
+    const resolved = await loadMediaRefBytes(audio as MediaRefValue, context);
+    if (!resolved) {
+      throw new Error("Failed to resolve audio input for transcription");
     }
+    const audioBytes = Buffer.from(resolved);
 
     const formData = new FormData();
     formData.append("model_id", modelId);

--- a/packages/elevenlabs-nodes/tests/speech-to-text.test.ts
+++ b/packages/elevenlabs-nodes/tests/speech-to-text.test.ts
@@ -84,14 +84,29 @@ describe("SpeechToTextNode", () => {
     await expect(node.process()).rejects.toThrow("ELEVENLABS_API_KEY");
   });
 
-  it("throws when audio input is missing", async () => {
-    const node = makeNode({ audio: {} });
+  it("throws when audio input is not an object", async () => {
+    const node = makeNode({ audio: null });
     await expect(node.process()).rejects.toThrow("Audio input is required");
   });
 
-  it("throws on invalid audio data URI", async () => {
-    const node = makeNode({ audio: { data: "not-a-data-uri" } });
-    await expect(node.process()).rejects.toThrow("Invalid audio data URI");
+  it("throws when audio ref carries no resolvable source", async () => {
+    const node = makeNode({ audio: { type: "audio" } });
+    await expect(node.process()).rejects.toThrow(
+      "Failed to resolve audio input for transcription"
+    );
+  });
+
+  it("accepts a native ref carrying raw base64 (no data: prefix)", async () => {
+    // MiniMax and other native refs carry raw base64 in `data` with no
+    // `data:` prefix. The canonical resolver decodes it instead of rejecting it.
+    const node = makeNode({ audio: { type: "audio", data: WAV_BASE64 } });
+    const result = await node.process();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://api.elevenlabs.io/v1/speech-to-text"
+    );
+    expect(result.text).toBe("Hello world");
   });
 
   it("fetches audio from a URI when data is absent", async () => {

--- a/packages/fal-nodes/src/fal-base.ts
+++ b/packages/fal-nodes/src/fal-base.ts
@@ -107,7 +107,13 @@ export async function assetToFalUrl(
   ref: Record<string, unknown>,
   context?: UploadContext
 ): Promise<string | null> {
-  const uri = ref.uri as string | undefined;
+  let uri = ref.uri as string | undefined;
+  // A library-picked or generated ref may carry only `asset_id` (empty `uri`).
+  // Encode it as an `asset://<id>` URI so the trusted context-resolver branch
+  // below uploads it instead of dropping the ref.
+  if (!uri && typeof ref.asset_id === "string" && ref.asset_id) {
+    uri = `asset://${ref.asset_id}`;
+  }
   // Only pass through URLs that FAL can definitely access (their own CDN)
   if (uri?.includes("fal.media") || uri?.includes("fal.run")) return uri;
   const data = ref.data as string | undefined;
@@ -161,7 +167,8 @@ export async function assetToFalUrl(
 // ---------------------------------------------------------------------------
 
 export async function imageToDataUrl(
-  ref: Record<string, unknown>
+  ref: Record<string, unknown>,
+  context?: UploadContext
 ): Promise<string | null> {
   const data = ref.data as string | undefined;
   const mime = inferMimeFromRef(ref) ?? "image/png";
@@ -172,6 +179,21 @@ export async function imageToDataUrl(
     const contentType = res.headers?.get?.("content-type") ?? mime;
     const buf = Buffer.from(await res.arrayBuffer());
     return `data:${contentType};base64,${buf.toString("base64")}`;
+  }
+  // Asset/package refs — including a library-picked ref carrying only
+  // `asset_id` — resolve through the trusted context resolver, never a direct
+  // fetch (storage adapters return null for these schemes).
+  const assetUri =
+    uri?.startsWith("asset://") || uri?.startsWith("package://")
+      ? uri
+      : typeof ref.asset_id === "string" && ref.asset_id
+        ? `asset://${ref.asset_id}`
+        : null;
+  if (assetUri && context?.resolveAssetBytes) {
+    const { bytes } = await context.resolveAssetBytes(assetUri);
+    if (bytes) {
+      return `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`;
+    }
   }
   return null;
 }
@@ -215,7 +237,10 @@ export function inferContentType(assetType: string | undefined): string {
 export function isRefSet(ref: unknown): boolean {
   if (!ref || typeof ref !== "object") return false;
   const r = ref as Record<string, unknown>;
-  return Boolean(r.data || r.uri);
+  // A library-picked or freshly-generated ref carries only `asset_id` (with an
+  // empty `uri`); it still resolves to bytes via the processing context, so
+  // treat a non-empty `asset_id` as a source. `null`/`""` stay unset.
+  return Boolean(r.data || r.uri || r.asset_id);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -328,7 +328,7 @@ async function buildArgs(
         if (isRefSet(ref)) {
           const url =
             kind === "image"
-              ? ((await imageToDataUrl(ref!)) ??
+              ? ((await imageToDataUrl(ref!, context)) ??
                 (await assetToFalUrl(apiKey, ref!, context)))
               : await assetToFalUrl(apiKey, ref!, context);
           if (url) args[apiName] = url;

--- a/packages/fal-nodes/tests/fal-base.test.ts
+++ b/packages/fal-nodes/tests/fal-base.test.ts
@@ -153,8 +153,12 @@ describe("isRefSet", () => {
     expect(isRefSet({ data: "abc" })).toBe(true));
   it("returns true for { uri: 'https://...' }", () =>
     expect(isRefSet({ uri: "https://example.com/img.png" })).toBe(true));
-  it("returns false for asset_id-only refs because they cannot be uploaded", () =>
-    expect(isRefSet({ asset_id: "123" })).toBe(false));
+  it("returns true for asset_id-only refs (resolved via the context)", () =>
+    expect(isRefSet({ asset_id: "123" })).toBe(true));
+  it("returns false for a null asset_id", () =>
+    expect(isRefSet({ uri: "", data: null, asset_id: null })).toBe(false));
+  it("returns false for an empty-string asset_id", () =>
+    expect(isRefSet({ asset_id: "" })).toBe(false));
   it("returns true for object with all three fields", () =>
     expect(
       isRefSet({ data: "abc", uri: "https://x.com", asset_id: "id" })
@@ -351,7 +355,29 @@ describe("assetToFalUrl", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns null when no uri and no data", async () => {
+  it("resolves an asset_id-only ref via context.resolveAssetBytes and uploads", async () => {
+    const context = {
+      storage: { retrieve: vi.fn(async () => null) },
+      resolveAssetBytes: vi.fn(async () => ({
+        bytes: Uint8Array.from([137, 80, 78, 71])
+      }))
+    };
+    mockStorageUpload.mockResolvedValueOnce(
+      "https://v3.fal.media/files/asset-id-resolved.png"
+    );
+
+    const url = await assetToFalUrl(
+      apiKey,
+      { type: "image", uri: "", asset_id: "asset-456" },
+      context
+    );
+
+    expect(url).toBe("https://v3.fal.media/files/asset-id-resolved.png");
+    expect(context.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-456");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no uri, data, or asset_id", async () => {
     const url = await assetToFalUrl(apiKey, { type: "image" });
     expect(url).toBeNull();
   });
@@ -406,6 +432,37 @@ describe("imageToDataUrl", () => {
     expect(
       await imageToDataUrl({ uri: "http://insecure.example.com/img.png" })
     ).toBeNull();
+  });
+
+  it("resolves an asset_id-only ref to a data URL via context.resolveAssetBytes", async () => {
+    const bytes = Uint8Array.from([137, 80, 78, 71]);
+    const context = {
+      resolveAssetBytes: vi.fn(async () => ({ bytes }))
+    };
+    const url = await imageToDataUrl(
+      { type: "image", uri: "", asset_id: "asset-789" },
+      context
+    );
+    expect(context.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-789");
+    expect(url).toBe(
+      `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves an asset:// uri to a data URL via context.resolveAssetBytes", async () => {
+    const bytes = Uint8Array.from([1, 2, 3, 4]);
+    const context = {
+      resolveAssetBytes: vi.fn(async () => ({ bytes }))
+    };
+    const url = await imageToDataUrl(
+      { type: "image", uri: "asset://abc" },
+      context
+    );
+    expect(context.resolveAssetBytes).toHaveBeenCalledWith("asset://abc");
+    expect(url).toBe(
+      `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`
+    );
   });
 
   it("infers MIME from URI extension", async () => {

--- a/packages/kie-nodes/src/kie-base.ts
+++ b/packages/kie-nodes/src/kie-base.ts
@@ -261,7 +261,10 @@ export async function uploadVideoInput(
 function isRefSet(ref: unknown): boolean {
   if (!ref || typeof ref !== "object") return false;
   const r = ref as Record<string, unknown>;
-  return !!(r.data || r.uri);
+  // A library-picked or freshly-generated ref carries only `asset_id` (with an
+  // empty `uri`); `resolveUploadBytes` → `loadMediaRefBytes` resolves it via the
+  // context, so treat a non-empty `asset_id` as a source. `null`/`""` stay unset.
+  return !!(r.data || r.uri || r.asset_id);
 }
 
 export { isRefSet };

--- a/packages/kie-nodes/tests/kie-base.test.ts
+++ b/packages/kie-nodes/tests/kie-base.test.ts
@@ -91,6 +91,15 @@ describe("isRefSet", () => {
   it("returns false when data and uri are null", () => {
     expect(isRefSet({ data: null, uri: null })).toBe(false);
   });
+
+  it("returns true for an asset_id-only ref (resolved via the context)", () => {
+    expect(isRefSet({ uri: "", data: null, asset_id: "asset-123" })).toBe(true);
+  });
+
+  it("returns false when asset_id is null or empty", () => {
+    expect(isRefSet({ uri: "", data: null, asset_id: null })).toBe(false);
+    expect(isRefSet({ asset_id: "" })).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -317,6 +317,16 @@ export function normalizeBinaryRef(
     out.mimeType = record.mimeType;
   if (typeof record.mime_type === "string" && record.mime_type)
     out.mimeType = record.mime_type;
+  // A library-picked or freshly-generated ref carries only `asset_id` (with an
+  // empty `uri`). Encode it as an `asset://<id>` URI so `buildUserMessage` keeps
+  // the image/audio part and `ProcessingContext.resolveMessageMediaUris`
+  // dereferences it to bytes before the provider call.
+  if (!out.uri && !out.data) {
+    const assetId = record.asset_id;
+    if (typeof assetId === "string" && assetId) {
+      out.uri = `asset://${assetId}`;
+    }
+  }
   return out.uri || out.data ? out : null;
 }
 

--- a/packages/llm-nodes/tests/agent-media-refs.test.ts
+++ b/packages/llm-nodes/tests/agent-media-refs.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+// Import from source (not the package's stale dist) so the test exercises the
+// current normalizeBinaryRef / buildUserMessage.
+import {
+  normalizeBinaryRef,
+  buildUserMessage
+} from "../src/nodes/agent-utils.js";
+
+describe("normalizeBinaryRef", () => {
+  it("returns null for non-objects", () => {
+    expect(normalizeBinaryRef(null)).toBeNull();
+    expect(normalizeBinaryRef("x")).toBeNull();
+    expect(normalizeBinaryRef(42)).toBeNull();
+  });
+
+  it("keeps a uri-backed ref", () => {
+    expect(normalizeBinaryRef({ uri: "https://x.com/a.png" })).toEqual({
+      uri: "https://x.com/a.png"
+    });
+  });
+
+  it("keeps a data-backed ref", () => {
+    expect(normalizeBinaryRef({ data: "abc" })).toEqual({ data: "abc" });
+  });
+
+  it("encodes an asset_id-only ref (empty uri) as an asset:// uri", () => {
+    expect(
+      normalizeBinaryRef({
+        type: "image",
+        uri: "",
+        data: null,
+        asset_id: "asset-123"
+      })
+    ).toEqual({ uri: "asset://asset-123" });
+  });
+
+  it("prefers an explicit uri over asset_id", () => {
+    expect(
+      normalizeBinaryRef({ uri: "asset://real", asset_id: "asset-123" })
+    ).toEqual({ uri: "asset://real" });
+  });
+
+  it("returns null when asset_id is null or empty and there is no uri/data", () => {
+    expect(
+      normalizeBinaryRef({ uri: "", data: null, asset_id: null })
+    ).toBeNull();
+    expect(normalizeBinaryRef({ asset_id: "" })).toBeNull();
+  });
+});
+
+describe("buildUserMessage", () => {
+  it("keeps an asset_id-only image as an image_url part with an asset:// uri", () => {
+    const msg = buildUserMessage(
+      "describe this",
+      { type: "image", uri: "", data: null, asset_id: "asset-abc" },
+      null
+    );
+    expect(msg.role).toBe("user");
+    const parts = Array.isArray(msg.content) ? msg.content : [];
+    const imagePart = parts.find(
+      (p): p is { type: "image_url"; image: { uri?: string } } =>
+        (p as { type?: string }).type === "image_url"
+    );
+    expect(imagePart?.image.uri).toBe("asset://asset-abc");
+  });
+
+  it("keeps an asset_id-only audio as an audio part with an asset:// uri", () => {
+    const msg = buildUserMessage("transcribe", null, {
+      type: "audio",
+      uri: "",
+      data: null,
+      asset_id: "audio-xyz"
+    });
+    const parts = Array.isArray(msg.content) ? msg.content : [];
+    const audioPart = parts.find(
+      (p): p is { type: "audio"; audio: { uri?: string } } =>
+        (p as { type?: string }).type === "audio"
+    );
+    expect(audioPart?.audio.uri).toBe("asset://audio-xyz");
+  });
+});

--- a/packages/replicate-nodes/src/replicate-base.ts
+++ b/packages/replicate-nodes/src/replicate-base.ts
@@ -51,11 +51,14 @@ export function removeNulls(obj: Record<string, unknown>): void {
   }
 }
 
-/** Check if an asset ref has meaningful content (uri or data). */
+/** Check if an asset ref has meaningful content (uri, data, or asset_id). */
 export function isRefSet(ref: unknown): boolean {
   if (!ref || typeof ref !== "object") return false;
   const r = ref as Record<string, unknown>;
-  return Boolean(r.data || r.uri);
+  // A library-picked or freshly-generated ref carries only `asset_id` (with an
+  // empty `uri`); it still resolves to bytes via the upload context, so treat a
+  // non-empty `asset_id` as a source. `null`/`""` stay unset.
+  return Boolean(r.data || r.uri || r.asset_id);
 }
 
 interface UploadContext {
@@ -79,7 +82,13 @@ export async function assetToUrl(
   apiKey?: string,
   context?: UploadContext
 ): Promise<string | null> {
-  const uri = ref.uri as string | undefined;
+  let uri = ref.uri as string | undefined;
+  // A library-picked or generated ref may carry only `asset_id` (empty `uri`).
+  // Encode it as an `asset://<id>` URI so the trusted context-resolver branch
+  // below uploads it instead of dropping the ref.
+  if (!uri && typeof ref.asset_id === "string" && ref.asset_id) {
+    uri = `asset://${ref.asset_id}`;
+  }
   if (uri) {
     // Replicate-hosted URLs can be used directly
     if (

--- a/packages/replicate-nodes/tests/replicate-base.test.ts
+++ b/packages/replicate-nodes/tests/replicate-base.test.ts
@@ -141,8 +141,12 @@ describe("isRefSet", () => {
     expect(isRefSet({ data: "abc" })).toBe(true));
   it("returns true for { uri: 'https://...' }", () =>
     expect(isRefSet({ uri: "https://example.com/img.png" })).toBe(true));
-  it("returns false for asset_id-only refs because they cannot be uploaded", () =>
-    expect(isRefSet({ asset_id: "123" })).toBe(false));
+  it("returns true for asset_id-only refs (resolved via the context)", () =>
+    expect(isRefSet({ asset_id: "123" })).toBe(true));
+  it("returns false for a null asset_id", () =>
+    expect(isRefSet({ uri: "", data: null, asset_id: null })).toBe(false));
+  it("returns false for an empty-string asset_id", () =>
+    expect(isRefSet({ asset_id: "" })).toBe(false));
 });
 
 /* ================================================================== */
@@ -203,6 +207,28 @@ describe("assetToUrl", () => {
     expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-123");
     expect(result).toBe("https://replicate.delivery/uploaded/asset-123.png");
     expect(result).not.toBe("asset://asset-123");
+  });
+
+  it("resolves an asset_id-only ref (empty uri) via context.resolveAssetBytes", async () => {
+    mockFilesCreate.mockResolvedValueOnce({
+      urls: { get: "https://replicate.delivery/uploaded/asset-456.png" }
+    });
+
+    const ctx = {
+      storage: { retrieve: vi.fn().mockResolvedValue(null) },
+      resolveAssetBytes: vi
+        .fn()
+        .mockResolvedValue({ bytes: Uint8Array.from([137, 80, 78, 71]) })
+    };
+
+    const result = await assetToUrl(
+      { type: "image", uri: "", asset_id: "asset-456" },
+      "api-key",
+      ctx
+    );
+
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://asset-456");
+    expect(result).toBe("https://replicate.delivery/uploaded/asset-456.png");
   });
 });
 

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -2171,16 +2171,33 @@ export class ProcessingContext {
     if (!trimmed) {
       return [];
     }
-    const raw = trimmed.startsWith("asset://")
-      ? trimmed.slice("asset://".length)
-      : trimmed;
+    // Strip a leading reference prefix down to the bare storage key. `asset://`
+    // is the ref scheme; `/api/storage/` (and its slash-less variant) is the
+    // browser-facing storage route that older messages / callers still carry —
+    // treating that whole path as the id probes a bogus key and builds a
+    // double-prefixed, percent-encoded HTTP url that 404s.
+    let raw = trimmed;
+    if (raw.startsWith("asset://")) {
+      raw = raw.slice("asset://".length);
+    } else if (raw.startsWith("/api/storage/")) {
+      raw = raw.slice("/api/storage/".length);
+    } else if (raw.startsWith("api/storage/")) {
+      raw = raw.slice("api/storage/".length);
+    }
     // Preserve sub-paths: `asset://user-1/image.png` -> primary `user-1/image.png`,
-    // so storage keys with hierarchical layouts still resolve.
+    // so storage keys with hierarchical layouts still resolve. Drop any
+    // `?query`/`#hash` before deriving the key.
     const primary = raw.split(/[?#]/)[0];
     if (!primary) {
       return [];
     }
-    const withoutExt = primary.replace(/\.[^.]+$/, "");
+    // Strip the extension from the LAST path segment only. A `.` in an earlier
+    // segment (`folder.v2/img`) is part of the id, not an extension — slicing
+    // across `/` would yield a wrong-bytes candidate (`folder`).
+    const slash = primary.lastIndexOf("/");
+    const dir = slash >= 0 ? primary.slice(0, slash + 1) : "";
+    const lastSegment = slash >= 0 ? primary.slice(slash + 1) : primary;
+    const withoutExt = dir + lastSegment.replace(/\.[^.]+$/, "");
     return Array.from(new Set([primary, withoutExt].filter(Boolean)));
   }
 
@@ -2322,9 +2339,23 @@ export class ProcessingContext {
         ): Promise<Uint8Array | null> => {
           try {
             const listing = await this.storage!.list(prefix);
+            const bareEndsWithThumb = bareId.endsWith("_thumb");
             const match = listing.entries.find((entry) => {
-              const base = entry.key.split("/").pop() ?? "";
-              return base.startsWith(`${bareId}.`) && !base.includes("_thumb");
+              const key = entry.key;
+              const lastSegment = key.split("/").pop() ?? "";
+              // A hierarchical id (`user-1/image`) lives in the full key, a flat
+              // id in the last segment — match against whichever form fits.
+              const matches =
+                key.startsWith(`${bareId}.`) ||
+                lastSegment.startsWith(`${bareId}.`);
+              if (!matches) {
+                return false;
+              }
+              // Skip generated thumbnails (`<id>_thumb.<ext>`) — but only ones
+              // that aren't the id we're resolving, so a legit `banner_thumb`
+              // still matches instead of being dropped by a substring test.
+              const isThumb = /_thumb\.[^./]+$/.test(lastSegment);
+              return !isThumb || bareEndsWithThumb;
             });
             if (match) {
               return await tryStorageUri(match.uri);
@@ -2546,7 +2577,10 @@ export class ProcessingContext {
    * as opaque storage URIs (memory/file/s3) via the storage adapter.
    */
   private async retrieveMediaBytes(uri: string): Promise<Uint8Array | null> {
-    if (uri.startsWith("asset://")) {
+    // `/api/storage/<key>` is the browser-facing route, not a storage-adapter
+    // uri — the InMemory/S3 adapters only accept `memory://`/`s3://`, so route
+    // it through resolveAssetBytes (which parses the key) like `asset://`.
+    if (uri.startsWith("asset://") || uri.startsWith("/api/storage/")) {
       const { bytes } = await this.resolveAssetBytes(uri);
       return bytes;
     }
@@ -3100,11 +3134,24 @@ export class ProcessingContext {
     if (decoded) return decoded;
 
     const uri = asset.uri;
-    if (typeof uri !== "string" || !this.storage) return null;
-    const stored = await this.storage.retrieve(uri);
-    if (stored) return stored;
-    if (uri.startsWith("asset://") || uri.startsWith("/api/storage/")) {
-      return (await this.resolveAssetBytes(uri)).bytes;
+    if (typeof uri === "string" && this.storage) {
+      const stored = await this.storage.retrieve(uri);
+      if (stored) return stored;
+    }
+    if (
+      typeof uri === "string" &&
+      (uri.startsWith("asset://") || uri.startsWith("/api/storage/"))
+    ) {
+      const { bytes } = await this.resolveAssetBytes(uri);
+      if (bytes) return bytes;
+    }
+    // No usable uri but an asset_id is present: resolve directly by id.
+    // resolveAssetBytes has its own HTTP fallback, so this works even without a
+    // storage adapter (which the early `!this.storage` return used to preclude).
+    const assetId = asset.asset_id;
+    if (typeof assetId === "string" && assetId) {
+      const { bytes } = await this.resolveAssetBytes(`asset://${assetId}`);
+      if (bytes) return bytes;
     }
     return null;
   }

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -145,12 +145,24 @@ export async function loadMediaRefBytes(
   }
 
   const uri = value.uri;
-  if (!uri) {
+  if (!uri && !value.asset_id) {
     return null;
   }
 
-  if ((uri.startsWith("asset://") || isPackageAssetUri(uri)) && context) {
+  if (uri && (uri.startsWith("asset://") || isPackageAssetUri(uri)) && context) {
     const { bytes } = await context.resolveAssetBytes(uri);
+    if (bytes) {
+      return bytes;
+    }
+  }
+
+  // No usable uri but an asset_id is present: resolve the asset directly by id.
+  // The early-return above only bails when both uri and asset_id are absent, so
+  // an empty-uri ref like `{ asset_id, uri: "" }` still reaches this path.
+  if (!uri && value.asset_id && context) {
+    const { bytes } = await context.resolveAssetBytes(
+      `asset://${value.asset_id}`
+    );
     if (bytes) {
       return bytes;
     }
@@ -158,7 +170,9 @@ export async function loadMediaRefBytes(
 
   if (context?.storage) {
     const candidates = new Set<string>();
-    candidates.add(uri);
+    if (uri) {
+      candidates.add(uri);
+    }
 
     if (value.asset_id) {
       const refType = (value.type ?? "").toLowerCase();
@@ -174,6 +188,10 @@ export async function loadMediaRefBytes(
         return stored;
       }
     }
+  }
+
+  if (!uri) {
+    return null;
   }
 
   const fromUri = await readUriBytes(uri);

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -877,6 +877,51 @@ describe("ProcessingContext.resolveAssetBytes", () => {
     expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([4, 5, 6]));
   });
 
+  it("resolves a bare `/api/storage/<key>` path against the storage adapter", async () => {
+    // Regression: parseAssetIdCandidates treated the whole `/api/storage/...`
+    // path as the id, probing a bogus key and building a double-prefixed url.
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("abc.png", new Uint8Array([7, 8, 9]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("/api/storage/abc.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([7, 8, 9]));
+  });
+
+  it("strips the extension from the last segment only (dotted sub-path id)", async () => {
+    // Regression: `folder.v2/img` produced a bogus `folder` candidate that could
+    // resolve wrong bytes. Store a decoy at `folder.png` to prove it isn't hit.
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("folder.v2/img.webp", new Uint8Array([1, 2, 3]), "image/webp");
+    await storage.store("folder.png", new Uint8Array([9, 9]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    // Extension mismatch (.png vs stored .webp) forces the prefix listing.
+    const { bytes } = await ctx.resolveAssetBytes("asset://folder.v2/img.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("matches a hierarchical (sub-path) id in the listing fallback", async () => {
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("user-1/image.webp", new Uint8Array([4, 5, 6]), "image/webp");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://user-1/image.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("resolves a legit `_thumb` id instead of filtering it out", async () => {
+    // Regression: the blanket `_thumb` substring filter dropped a genuine id
+    // like `banner_thumb`.
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("banner_thumb.png", new Uint8Array([1, 1]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    // Extension mismatch (.jpg vs stored .png) forces the prefix listing.
+    const { bytes } = await ctx.resolveAssetBytes("asset://banner_thumb.jpg");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([1, 1]));
+  });
+
   it("falls back to the /api/storage route when no adapter is configured", async () => {
     const ctx = new ProcessingContext({
       jobId: "j1",

--- a/packages/runtime/tests/media-ref-bytes.test.ts
+++ b/packages/runtime/tests/media-ref-bytes.test.ts
@@ -102,6 +102,43 @@ describe("loadMediaRefBytes", () => {
     expect(bytes).toEqual(new Uint8Array([7, 8, 9]));
     expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://abc-123.png");
   });
+
+  it("resolves an asset_id-only ref (empty uri) via resolveAssetBytes", async () => {
+    // Regression: the early `if (!uri) return null` bailed before the asset_id
+    // fallback, so `{ asset_id, uri: "" }` never resolved.
+    const ctx = {
+      resolveAssetBytes: vi.fn(async () => ({
+        bytes: new Uint8Array([10, 11, 12]),
+        attempts: []
+      }))
+    } as unknown as ProcessingContext;
+
+    const bytes = await loadMediaRefBytes(
+      { type: "image", uri: "", asset_id: "abc" },
+      ctx
+    );
+
+    expect(bytes).toEqual(new Uint8Array([10, 11, 12]));
+    expect(ctx.resolveAssetBytes).toHaveBeenCalledWith("asset://abc");
+  });
+
+  it("resolves an asset_id-only ref via storage candidates", async () => {
+    const ctx = {
+      resolveAssetBytes: vi.fn(async () => ({ bytes: null, attempts: [] })),
+      storage: {
+        retrieve: vi.fn(async (uri: string) =>
+          uri === "/api/storage/abc.png" ? new Uint8Array([13, 14, 15]) : null
+        )
+      }
+    } as unknown as ProcessingContext;
+
+    const bytes = await loadMediaRefBytes(
+      { type: "image", asset_id: "abc" },
+      ctx
+    );
+
+    expect(bytes).toEqual(new Uint8Array([13, 14, 15]));
+  });
 });
 
 describe("encodeBase64", () => {

--- a/packages/storage/src/file-storage-adapter.ts
+++ b/packages/storage/src/file-storage-adapter.ts
@@ -13,6 +13,20 @@ import { isWithinRoot, normalizeStorageKey } from "./storage-keys.js";
 import { assertUploadWithinLimit } from "./storage-limits.js";
 
 /**
+ * Percent-decode a storage key extracted from an `/api/storage/<key>` URL so it
+ * matches the on-disk key. The HTTP route (`storage-api.ts`) decodes the same
+ * way; keeping them in sync means `retrieve("…/my%20file.png")` resolves to
+ * `my file.png`. Malformed escapes (`decodeURIComponent` throws) are left as-is.
+ */
+function decodeKey(key: string): string {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+}
+
+/**
  * File-system storage adapter rooted to a single base directory.
  *
  * URI scheme: `file:///abs/path`. Also accepts `/api/storage/<key>` paths
@@ -54,13 +68,16 @@ export class FileStorageAdapter implements StorageAdapter {
       return rel || null;
     }
     if (uri.startsWith("/api/storage/") || uri.startsWith("api/storage/")) {
-      return uri.replace(/^\/?api\/storage\//, "");
+      // Strip any ?query / #fragment before decoding — the HTTP route keys off
+      // the decoded path only (storage-api.ts decodeURIComponent).
+      const withoutSuffix = uri.replace(/[?#].*$/, "");
+      return decodeKey(withoutSuffix.replace(/^\/?api\/storage\//, ""));
     }
     if (/^https?:\/\//.test(uri)) {
       try {
         const parsed = new URL(uri);
         if (parsed.pathname.startsWith("/api/storage/")) {
-          return parsed.pathname.replace(/^\/api\/storage\//, "");
+          return decodeKey(parsed.pathname.replace(/^\/api\/storage\//, ""));
         }
       } catch {
         return null;

--- a/packages/storage/src/s3-storage-adapter.ts
+++ b/packages/storage/src/s3-storage-adapter.ts
@@ -51,6 +51,21 @@ export class S3StorageAdapter implements StorageAdapter {
     return this.client;
   }
 
+  /**
+   * Strip the adapter's bucket-side prefix from a raw S3 key, returning the key
+   * relative to the adapter's logical root. A literal string strip — not a
+   * RegExp — so a prefix containing regex metacharacters (`.`, `+`, `[`, …)
+   * strips correctly instead of being interpreted as a pattern.
+   */
+  private stripPrefix(rawKey: string): string {
+    if (!this.prefix) return rawKey;
+    if (rawKey.startsWith(`${this.prefix}/`)) {
+      return rawKey.slice(this.prefix.length + 1);
+    }
+    if (rawKey === this.prefix) return "";
+    return rawKey;
+  }
+
   private parseUri(uri: string): { bucket: string; key: string } | null {
     if (!uri.startsWith("s3://")) return null;
     const withoutScheme = uri.slice("s3://".length);
@@ -151,9 +166,7 @@ export class S3StorageAdapter implements StorageAdapter {
         if (!obj.key) continue;
         // Strip the bucket-side prefix so callers see keys relative to the
         // adapter's logical root.
-        const key = this.prefix
-          ? obj.key.replace(new RegExp(`^${this.prefix}/?`), "")
-          : obj.key;
+        const key = this.stripPrefix(obj.key);
         entries.push({
           key,
           uri: `s3://${this.bucket}/${obj.key}`,
@@ -163,10 +176,7 @@ export class S3StorageAdapter implements StorageAdapter {
       }
       for (const cp of response.commonPrefixes) {
         if (!cp) continue;
-        const stripped = this.prefix
-          ? cp.replace(new RegExp(`^${this.prefix}/?`), "")
-          : cp;
-        commonPrefixes.push(stripped);
+        commonPrefixes.push(this.stripPrefix(cp));
       }
       if (!response.isTruncated || !response.nextContinuationToken) break;
       continuationToken = response.nextContinuationToken;
@@ -210,11 +220,8 @@ export class S3StorageAdapter implements StorageAdapter {
         bucket: parsed.bucket,
         key: parsed.key
       });
-      const stripped = this.prefix
-        ? parsed.key.replace(new RegExp(`^${this.prefix}/?`), "")
-        : parsed.key;
       return {
-        key: stripped,
+        key: this.stripPrefix(parsed.key),
         size: response.contentLength,
         modifiedAt: response.lastModified?.getTime() ?? 0,
         ...(response.contentType ? { contentType: response.contentType } : {})

--- a/packages/storage/tests/file-storage-adapter-coverage.test.ts
+++ b/packages/storage/tests/file-storage-adapter-coverage.test.ts
@@ -110,6 +110,38 @@ describe("FileStorageAdapter", () => {
     it("returns null for a missing file", async () => {
       expect(await adapter.retrieve("/api/storage/nope.txt")).toBeNull();
     });
+
+    it("percent-decodes a key with a space (https URL)", async () => {
+      await adapter.store("my file.png", Buffer.from("spaced"));
+      const got = await adapter.retrieve(
+        "https://host.example/api/storage/my%20file.png"
+      );
+      expect(Buffer.from(got!).toString()).toBe("spaced");
+    });
+
+    it("percent-decodes a key with a space (relative path)", async () => {
+      await adapter.store("my file.png", Buffer.from("spaced"));
+      const got = await adapter.retrieve("/api/storage/my%20file.png");
+      expect(Buffer.from(got!).toString()).toBe("spaced");
+    });
+
+    it("strips a ?query suffix before resolving the key", async () => {
+      await adapter.store("x.png", Buffer.from("q"));
+      const got = await adapter.retrieve("/api/storage/x.png?thumb=1");
+      expect(Buffer.from(got!).toString()).toBe("q");
+    });
+
+    it("strips a #fragment suffix before resolving the key", async () => {
+      await adapter.store("x.png", Buffer.from("h"));
+      const got = await adapter.retrieve("/api/storage/x.png#frag");
+      expect(Buffer.from(got!).toString()).toBe("h");
+    });
+
+    it("leaves a malformed percent-escape as-is instead of throwing", async () => {
+      // %ZZ is not a valid escape — decodeURIComponent throws; retrieve must
+      // not throw, just fail to find the (non-existent) literal key.
+      expect(await adapter.retrieve("/api/storage/bad%ZZname.txt")).toBeNull();
+    });
   });
 
   describe("exists", () => {

--- a/packages/storage/tests/s3-storage-adapter-coverage.test.ts
+++ b/packages/storage/tests/s3-storage-adapter-coverage.test.ts
@@ -219,6 +219,34 @@ describe("S3StorageAdapter list", () => {
     });
   });
 
+  it("strips a prefix containing regex metacharacters literally", async () => {
+    // A prefix like `my.data+v1` must be stripped as a literal string, not as a
+    // regex where `.` and `+` are wildcards.
+    const client = makeClient({
+      listObjectsV2: vi.fn(async () => ({
+        contents: [
+          { key: "my.data+v1/a.txt", size: 1, lastModified: new Date(1) },
+          // A key that a `.`/`+`-as-wildcard regex would mis-strip: `myXdataYv1`
+          // is not under the prefix and must be left untouched.
+          { key: "myXdataYv1z/b.txt", size: 2, lastModified: new Date(2) }
+        ],
+        commonPrefixes: ["my.data+v1/sub/"],
+        isTruncated: false
+      }))
+    });
+    const adapter = new S3StorageAdapter({
+      bucket: "b",
+      prefix: "my.data+v1",
+      client
+    });
+    const result = await adapter.list("files", { delimiter: "/" });
+    expect(result.entries.map((e) => e.key)).toEqual([
+      "a.txt",
+      "myXdataYv1z/b.txt"
+    ]);
+    expect(result.commonPrefixes).toEqual(["sub/"]);
+  });
+
   it("paginates across continuation tokens", async () => {
     const pages = [
       {

--- a/packages/websocket/src/storage-api.ts
+++ b/packages/websocket/src/storage-api.ts
@@ -17,12 +17,24 @@ const MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".gif": "image/gif",
   ".webp": "image/webp",
+  ".bmp": "image/bmp",
   ".mp4": "video/mp4",
+  ".webm": "video/webm",
   ".mp3": "audio/mpeg",
   ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".aac": "audio/aac",
+  ".flac": "audio/flac",
+  ".glb": "model/gltf-binary",
   ".json": "application/json",
   ".txt": "text/plain",
-  ".pdf": "application/pdf"
+  ".pdf": "application/pdf",
+  // Serve user-authored HTML as text/plain — never image/svg+xml-style inline
+  // rendering — so a stored `.html` asset can't execute script in the app's
+  // origin. `.svg` is deliberately omitted for the same reason (falls through
+  // to application/octet-stream).
+  ".html": "text/plain",
+  ".htm": "text/plain"
 };
 
 function getMimeType(filePath: string): string {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -318,6 +318,23 @@ function getAssetStoragePath(): string {
   return getDefaultAssetsPath();
 }
 
+/**
+ * Return a public/signed HTTPS URL for a cloud URI if the adapter exposes a
+ * `getPublicUrl(uri)` method (the Supabase adapter does). Duck-typed because
+ * `getPublicUrl` is adapter-specific, not part of the `StorageAdapter`
+ * interface. Returns null when the adapter has no such method or it declines.
+ */
+function getAdapterPublicUrl(adapter: unknown, uri: string): string | null {
+  const fn = (adapter as { getPublicUrl?: (uri: string) => string | null })
+    .getPublicUrl;
+  if (typeof fn !== "function") return null;
+  try {
+    return fn.call(adapter, uri) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /** Extract the object key from a cloud storage URI, or return null for file URIs. */
 function extractCloudKey(uri: string): string | null {
   for (const scheme of ["supabase://", "s3://"]) {
@@ -856,10 +873,19 @@ function createRuntimeContext(opts: {
     workspaceStorage: workspaceAdapter,
     authToken: opts.authToken,
     tempUrlResolver: (uri: string) => {
-      // Cloud backends: key becomes /api/storage/<key> — the HTTP handler
-      // will redirect to a signed URL (once signed URL support is wired in).
+      // Cloud backends (s3://, supabase://). The local /api/storage/ route only
+      // reads local disk, so it can't serve a cloud object. When the adapter
+      // exposes a public/signed URL (Supabase does via getPublicUrl), hand that
+      // back so the client fetches directly from the bucket.
       const cloudKey = extractCloudKey(uri);
       if (cloudKey !== null) {
+        const publicUrl = getAdapterPublicUrl(tempAdapter, uri);
+        if (publicUrl) return publicUrl;
+        // No public-URL method (e.g. the S3 adapter has none yet). Falling back
+        // to /api/storage/<key> would 404 on a cloud backend — this is a known
+        // gap. TODO: wire S3 presigned GET URLs here. Returning the local route
+        // keeps behaviour unchanged for the file backend and is no worse than
+        // before for S3.
         return buildAssetUrl(cloudKey);
       }
       // File: convert file:///path/to/storage/uuid.png → /api/storage/uuid.png

--- a/packages/websocket/tests/storage-api.test.ts
+++ b/packages/websocket/tests/storage-api.test.ts
@@ -107,6 +107,40 @@ describe("MIME type detection", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
   });
+
+  it.each([
+    ["clip.webm", "video/webm"],
+    ["sound.ogg", "audio/ogg"],
+    ["model.glb", "model/gltf-binary"],
+    ["pic.bmp", "image/bmp"],
+    ["track.flac", "audio/flac"],
+    ["voice.aac", "audio/aac"]
+  ])(
+    "serves %s inline with the right Content-Type (%s)",
+    async (name, expected) => {
+      const handler = makeHandler();
+      await fs.writeFile(path.join(tmpDir, name), "data");
+      const res = await handler(makeRequest(`/api/storage/${name}`, "HEAD"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe(expected);
+    }
+  );
+
+  it("serves user HTML as text/plain, not text/html (no XSS)", async () => {
+    const handler = makeHandler();
+    await fs.writeFile(path.join(tmpDir, "page.html"), "<script>alert(1)</script>");
+    const res = await handler(makeRequest("/api/storage/page.html", "HEAD"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/plain");
+  });
+
+  it("does not serve SVG as image/svg+xml (leaves it octet-stream)", async () => {
+    const handler = makeHandler();
+    await fs.writeFile(path.join(tmpDir, "vec.svg"), "<svg/>");
+    const res = await handler(makeRequest("/api/storage/vec.svg", "HEAD"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -73,6 +73,7 @@ import type {
 import type { Entity } from "@nodetool-ai/protocol";
 import type { MediaGenerationRequest } from "../types/media.types";
 import { assetToUri } from "../../node_types/editing/promptComposer/promptTokens";
+import { resolveAssetUri } from "../../node/output";
 import { useTextareaAssetMention } from "./useTextareaAssetMention";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
@@ -263,7 +264,11 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
       addDroppedFiles([
         {
           id: "",
-          dataUri: refUri,
+          // The preview needs a displayable URL (data:/http(s):/`/`-prefixed);
+          // a raw `asset://…` ref renders as a generic file icon. Resolve it to
+          // the storage URL for the thumbnail while keeping the `asset://` ref
+          // in `assetUri` for the model.
+          dataUri: resolveAssetUri(refUri),
           type: ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/png",
           name: entity.name || entity.id,
           assetUri: ext

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -260,6 +260,19 @@ export function useImageAssets(value: unknown): { assets: Asset[]; urls: string[
             // Blob creation failed (may be due to shared ArrayBuffer), use empty URL
             url = "";
           }
+        } else if (imageItem.id) {
+          // A bare asset ref carrying only `id` (no uri/data/bitmap). The
+          // storage route serves by filename, so `/api/storage/<id>` with no
+          // extension 404s. Build an `asset://<id>.<ext>` ref — extension from
+          // the item name, falling back to the content type — and resolve it
+          // the same way as `uri`.
+          const cleanName = (imageItem.name ?? "").split(/[?#]/)[0];
+          const dot = cleanName.lastIndexOf(".");
+          const ext =
+            dot > 0 && dot < cleanName.length - 1
+              ? cleanName.slice(dot + 1).toLowerCase()
+              : "png";
+          url = resolveAssetUri(`asset://${imageItem.id}.${ext}`);
         }
         return {
           id: imageItem.id || `output-image-${index}`,

--- a/web/src/hooks/nodes/useMediaSrc.ts
+++ b/web/src/hooks/nodes/useMediaSrc.ts
@@ -9,7 +9,7 @@
  * (e.g. ExtractVideoFrameBody) that drive their own `<video>` / `<audio>`
  * element instead of the generic OutputRenderer.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useSignedUrl,
   getMimeTypeFromUri,
@@ -17,6 +17,36 @@ import {
 } from "../../components/node/output";
 
 export type MediaKind = "audio" | "video";
+
+/**
+ * Cheap content signature for a media payload, so the object-URL effect only
+ * re-runs when the *bytes* change — not on every render when an unmemoized
+ * selector hands back a fresh typed-array/object identity for the same data.
+ * Samples length + a few bytes rather than hashing the whole (possibly large)
+ * buffer.
+ */
+const mediaDataSignature = (data: unknown): string | undefined => {
+  if (!data) return undefined;
+  let view: Uint8Array | undefined;
+  if (data instanceof Uint8Array) {
+    view = data;
+  } else if (data instanceof ArrayBuffer) {
+    view = new Uint8Array(data);
+  } else if (ArrayBuffer.isView(data)) {
+    view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  } else if (Array.isArray(data)) {
+    const n = data.length;
+    if (n === 0) return undefined;
+    return `arr:${n}:${data[0]}:${data[n >> 1]}:${data[n - 1]}`;
+  } else if (typeof data === "string") {
+    if (data.length === 0) return undefined;
+    return `str:${data.length}:${data.slice(0, 16)}:${data.slice(-16)}`;
+  }
+  if (!view) return undefined;
+  const n = view.byteLength;
+  if (n === 0) return undefined;
+  return `buf:${n}:${view[0]}:${view[n >> 1]}:${view[n - 1]}`;
+};
 
 export const useMediaSrc = (
   value: unknown,
@@ -48,12 +78,22 @@ export const useMediaSrc = (
     (format ? `${kind}/${format}` : "") ||
     "";
 
-  const [blobUrl, setBlobUrl] = useState<string>("");
-  useEffect(() => {
+  // Key the byte extraction on a stable content signature, not on `data`'s
+  // identity — an unmemoized selector value would otherwise recreate the
+  // object URL every render and briefly reference a just-revoked URL.
+  const dataSignature = mediaDataSignature(data);
+  const bytes = useMemo(() => {
     // Shared helper handles Uint8Array, ArrayBuffer, ArrayBufferView, and
     // plain number[] — and returns a copy backed by a non-shared ArrayBuffer
     // suitable for Blob construction.
-    const bytes = toUint8Array(data);
+    const b = toUint8Array(data);
+    return b && b.byteLength > 0 ? b : undefined;
+    // `data` is intentionally excluded: `dataSignature` is its content proxy.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataSignature]);
+
+  const [blobUrl, setBlobUrl] = useState<string>("");
+  useEffect(() => {
     if (bytes && bytes.byteLength > 0) {
       const blob = blobMime
         ? new Blob([bytes], { type: blobMime })
@@ -64,7 +104,7 @@ export const useMediaSrc = (
     }
     setBlobUrl("");
     return undefined;
-  }, [data, blobMime]);
+  }, [bytes, blobMime]);
 
   return blobUrl || signedUrl || "";
 };

--- a/web/src/hooks/sketch/ensureSketchDocumentForAsset.ts
+++ b/web/src/hooks/sketch/ensureSketchDocumentForAsset.ts
@@ -14,12 +14,41 @@ export function readSketchDocumentId(asset: Asset): string | null {
   return typeof id === "string" && id.length > 0 ? id : null;
 }
 
-/** Resolve an asset to a fetchable image URL for measuring its dimensions. */
+/** Common image content types → file extension for building storage keys. */
+const IMAGE_MIME_EXTENSION: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg"
+};
+
+/** Best-effort file extension for an asset, from its name or content type. */
+function assetExtension(asset: Asset): string | null {
+  const name = (asset.name ?? "").split(/[?#]/)[0];
+  const dot = name.lastIndexOf(".");
+  if (dot > 0 && dot < name.length - 1) {
+    return name.slice(dot + 1).toLowerCase();
+  }
+  const contentType = asset.content_type?.toLowerCase();
+  return (contentType && IMAGE_MIME_EXTENSION[contentType]) || null;
+}
+
+/**
+ * Resolve an asset to a fetchable image URL for measuring its dimensions. The
+ * storage route serves files by name, so the fallback key needs an extension —
+ * a bare `/api/storage/<id>` (no extension) 404s. Derive one from the asset's
+ * name or content type the same way `assetLayerUri` lifts the key from a URL.
+ */
 function assetImageUrl(asset: Asset): string {
   const direct = asset.get_url ?? asset.thumb_url;
   if (direct && /^(https?:|data:|blob:)/.test(direct)) return direct;
   if (direct?.startsWith("/")) return `${BASE_URL}${direct}`;
-  return `${BASE_URL}/api/storage/${asset.id}`;
+  const ext = assetExtension(asset);
+  const key = ext ? `${asset.id}.${ext}` : asset.id;
+  return `${BASE_URL}/api/storage/${key}`;
 }
 
 /**
@@ -50,7 +79,8 @@ function loadImageSize(
     img.crossOrigin = "anonymous";
     img.onload = () =>
       resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    img.onerror = () => reject(new Error("Failed to load image"));
+    img.onerror = () =>
+      reject(new Error(`Failed to load image for measurement: ${url}`));
     img.src = url;
   });
 }

--- a/web/src/utils/__tests__/createAssetFile.test.ts
+++ b/web/src/utils/__tests__/createAssetFile.test.ts
@@ -237,4 +237,32 @@ describe("createAssetFile", () => {
     expect(result.filename).toBe("fal-video.mp4");
     expect(result.file.size).toBe(3);
   });
+
+  it("uses the server content_type for MIME/extension when the ref lacks an inline mime_type", async () => {
+    // Server reports a WEBP asset with no name, and the ref carries no inline
+    // mime_type — so both the File MIME and the generated extension must come
+    // from the server's content_type.
+    assetGetQuery.mockResolvedValueOnce({
+      id: "asset-2",
+      content_type: "image/webp",
+      get_url: "/api/storage/asset-2.webp"
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([82, 73, 70, 70]).buffer
+    });
+
+    const [result] = await createAssetFile(
+      {
+        type: "image",
+        uri: "asset://asset-2.webp",
+        asset_id: "asset-2"
+      },
+      "node"
+    );
+
+    // Without the fix this would fall back to image/png and a .png extension.
+    expect(result.type).toBe("image/webp");
+    expect(result.filename).toBe("preview_node.webp");
+  });
 });

--- a/web/src/utils/createAssetFile.ts
+++ b/web/src/utils/createAssetFile.ts
@@ -460,6 +460,10 @@ const createSingleAssetFile = async (
   const outputUri = typeof typedOutput?.uri === "string" ? typedOutput.uri : undefined;
   const isAssetUri = typeof outputUri === "string" && outputUri.startsWith("asset://");
   let desiredFilename = typedOutput?.filename;
+  // Content type reported by the server when the bytes are fetched via
+  // `asset_id`. Used as the MIME/extension fallback so a JPEG/WEBP asset with
+  // no inline `mime_type` isn't mislabeled `image/png`.
+  let serverContentType: string | undefined;
 
   // Fetch from URI whenever inline `data` isn't a usable binary payload.
   // This covers asset://, /api/storage/, http(s)://, and also the ExtData
@@ -478,6 +482,9 @@ const createSingleAssetFile = async (
       });
       const downloadUrl = assetResponse.get_url;
       desiredFilename = assetResponse.name || desiredFilename;
+      if (typeof assetResponse.content_type === "string" && assetResponse.content_type.includes("/")) {
+        serverContentType = assetResponse.content_type;
+      }
       if (downloadUrl) {
         data = await fetchBinaryFromUri(downloadUrl);
       } else if (outputUri) {
@@ -511,7 +518,7 @@ const createSingleAssetFile = async (
 
   switch (type) {
     case "image": {
-      mimeType = getMimeType(output, "image/png");
+      mimeType = getMimeType(output, serverContentType ?? "image/png");
       const extension = getExtension(mimeType, "png");
       const bytes = toUint8Array(data);
       if (bytes.length === 0) {
@@ -525,14 +532,14 @@ const createSingleAssetFile = async (
       break;
     }
     case "video": {
-      mimeType = getMimeType(output, "video/mp4");
+      mimeType = getMimeType(output, serverContentType ?? "video/mp4");
       const extension = getExtension(mimeType, "mp4");
       content = toArrayBuffer(toUint8Array(data));
       filename = buildFilename(desiredFilename, id, suffix, extension, index);
       break;
     }
     case "audio": {
-      mimeType = getMimeType(output, "audio/mp3");
+      mimeType = getMimeType(output, serverContentType ?? "audio/mp3");
       const extension = getExtension(mimeType, "mp3");
       content = toArrayBuffer(toUint8Array(data));
       filename = buildFilename(desiredFilename, id, suffix, extension, index);


### PR DESCRIPTION
## Summary

A codebase scan for asset-resolution bugs turned up a coherent class of failures plus several storage-key parsing bugs. The core issue generalizes the recently-merged AtlasCloud fix (#4426): a media ref carrying only `asset_id` (with an empty `uri`) — the common shape for **library-picked and freshly-generated media wired into a downstream node** — was silently dropped by the shared resolvers and by most provider nodes.

## Bugs fixed

### Core runtime (`packages/runtime`)
- **`loadMediaRefBytes`** returned `null` on an empty `uri` *before* the `asset_id` fallback ran, so `{ asset_id, uri: "" }` never resolved. This feeds the Python bridge, Save Image, KIE, entity resolution, and prompt→input mapping.
- **`resolveAssetBytes` / `parseAssetIdCandidates`**: didn't strip a leading `/api/storage/` prefix (→ double-prefixed, percent-encoded 404 URL); stripped the extension across `/` (`asset://folder.v2/img` → bogus `folder` candidate → wrong-bytes hazard); the listing fallback could never match a hierarchical sub-path id; the `_thumb` filter used a substring test that excluded legit ids like `banner_thumb`.
- **`retrieveMediaBytes` / `getAssetBytes`**: `/api/storage/<key>` message media now routes through `resolveAssetBytes` (InMemory/S3 adapters reject the browser route), and `getAssetBytes` falls back to `asset_id` when `uri` is missing.

### Provider nodes
- **FAL / Replicate / KIE** `isRefSet` now treat a non-empty `asset_id` as a source (matching the canonical `imageRefHasSource` in `image.ts`); FAL/Replicate resolvers encode an `asset_id`-only ref as `asset://<id>` and resolve it through the context.
- **`llm-nodes` `normalizeBinaryRef`** keeps `asset_id`-only image/audio parts instead of dropping them from the agent/summarizer message.
- **ElevenLabs speech-to-text** delegates to `loadMediaRefBytes`, fixing rejection of `asset_id`-only refs and of raw-base64 `data` (no `data:` prefix), and removing a direct arbitrary-URL `fetch` (SSRF).

### Server / storage
- **`storage-api` MIME map** now covers `webm`/`ogg`/`aac`/`flac`/`bmp`/`glb` (inline playback); `.html` served as `text/plain` and `.svg` left as octet-stream to avoid stored-content XSS.
- **`FileStorageAdapter.keyFromUri`** URL-decodes the key and strips `?query`/`#fragment`; **`buildAssetUrl`** encodes segments so they round-trip.
- **`S3StorageAdapter`** strips its prefix with a literal string op (regex-metachar-safe).
- **`tempUrlResolver`** uses an adapter public/signed URL for cloud backends (Supabase's `getPublicUrl`) instead of the local route. *S3 presigned GET is left as a documented TODO* — the file backend is unchanged and S3 is no worse than before.

### Web
- **`useImageAssets` / `ensureSketchDocumentForAsset`** build `<id>.<ext>` storage keys (a bare `/api/storage/<id>` 404s).
- **`createAssetFile`** uses the server-reported `content_type` for MIME/extension so a JPEG/WEBP fetched by `asset_id` isn't mislabeled `image/png`.
- **`MediaChatComposer`** resolves entity preview thumbnails to a displayable URL (keeping the `asset://` ref for the model).
- **`useMediaSrc`** keys its object URL on a content signature, stopping per-render churn / premature revocation.

## Testing

All changed packages typecheck clean and their test suites pass:
- runtime: media-ref (47) + context (159)
- providers: fal (150), replicate (65), kie (58), llm (491), elevenlabs (38)
- storage (348), config (139), websocket storage-api (32)
- web (Jest): createAssetFile (14), output hooks + sketch (40)

New tests cover each fix (asset_id-only resolution, `/api/storage/` key stripping, hierarchical ids, MIME types, key encode/decode round-trips, S3 metachar prefixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sptM2cdH4THpBk5PBoUM5

---
_Generated by [Claude Code](https://claude.ai/code/session_014sptM2cdH4THpBk5PBoUM5)_