### PR TITLE
Add undo/redo to script and storyboard editors

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -16,6 +16,7 @@ import {
   TextInput,
   EditorButton,
   ToolbarIconButton,
+  UndoRedoButtons,
   EmptyState,
   AlertBanner,
   LoadingSpinner,
@@ -28,6 +29,8 @@ import {
 import {
   useScript,
   useScriptStore,
+  useScriptCanUndo,
+  useScriptCanRedo,
   type ScriptSection
 } from "../../stores/script/ScriptStore";
 import { voiceAll } from "../../stores/script/scriptVoicing";
@@ -291,6 +294,10 @@ const ScriptDocumentPane = ({
   const insertLine = useScriptStore((s) => s.insertLine);
   const patchLine = useScriptStore((s) => s.patchLine);
   const removeLine = useScriptStore((s) => s.removeLine);
+  const undo = useScriptStore((s) => s.undo);
+  const redo = useScriptStore((s) => s.redo);
+  const canUndo = useScriptCanUndo(scriptId);
+  const canRedo = useScriptCanRedo(scriptId);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
   const [voicingAll, setVoicingAll] = useState(false);
@@ -464,6 +471,16 @@ const ScriptDocumentPane = ({
           zIndex: Z_INDEX.sticky
         }}
       >
+        {!readOnly && (
+          <UndoRedoButtons
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onUndo={() => undo(scriptId)}
+            onRedo={() => redo(scriptId)}
+            undoTooltip="Undo (⌘Z)"
+            redoTooltip="Redo (⌘⇧Z)"
+          />
+        )}
         {!readOnly &&
           (voicingAll ? (
             <FlexRow align="center" gap={SPACING.xs}>

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -23,6 +23,7 @@ import {
   TextInput,
   SelectField,
   EditorButton,
+  UndoRedoButtons,
   EmptyState,
   Dialog,
   Divider,
@@ -34,7 +35,12 @@ import {
   BORDER_RADIUS,
   MOTION
 } from "../ui_primitives";
-import { useBoard, useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import {
+  useBoard,
+  useStoryboardStore,
+  useStoryboardCanUndo,
+  useStoryboardCanRedo
+} from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import {
   useImageModelsByProvider,
@@ -217,6 +223,10 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const setDirectorModel = useStoryboardStore((state) => state.setDirectorModel);
   const setImageModel = useStoryboardStore((state) => state.setImageModel);
   const setVideoModel = useStoryboardStore((state) => state.setVideoModel);
+  const undo = useStoryboardStore((state) => state.undo);
+  const redo = useStoryboardStore((state) => state.redo);
+  const canUndo = useStoryboardCanUndo(boardId);
+  const canRedo = useStoryboardCanRedo(boardId);
 
   const [shotCount, setShotCount] = useState<number>(6);
   const [confirmRedirect, setConfirmRedirect] = useState(false);
@@ -384,6 +394,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                     : "Direct writes the screenplay and seeds your shots.")}
               </Text>
               <FlexRow gap={2} align="center">
+                <UndoRedoButtons
+                  canUndo={canUndo}
+                  canRedo={canRedo}
+                  onUndo={() => undo(boardId)}
+                  onRedo={() => redo(boardId)}
+                  undoTooltip="Undo (⌘Z)"
+                  redoTooltip="Redo (⌘⇧Z)"
+                />
                 <EditorButton
                   variant="outlined"
                   onClick={handleGenerateAllStills}

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -26,8 +26,12 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       setAspectRatio: jest.fn(),
       setDirectorModel: jest.fn(),
       setImageModel: jest.fn(),
-      setVideoModel: jest.fn()
-    })
+      setVideoModel: jest.fn(),
+      undo: jest.fn(),
+      redo: jest.fn()
+    }),
+  useStoryboardCanUndo: () => false,
+  useStoryboardCanRedo: () => false
 }));
 
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({

--- a/web/src/components/workspace/ScriptSurface.tsx
+++ b/web/src/components/workspace/ScriptSurface.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import GroupsIcon from "@mui/icons-material/Groups";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
@@ -10,6 +10,7 @@ import {
 import { useScriptStore, useScript } from "../../stores/script/ScriptStore";
 import { useScriptServerSync } from "../../hooks/script/useScriptServerSync";
 import { useScriptAgentBridge } from "../../hooks/script/useScriptAgentBridge";
+import { useDocumentUndoShortcuts } from "../../hooks/useDocumentUndoShortcuts";
 import { FlexColumn, FlexRow, TabGroup } from "../ui_primitives";
 import ScriptDocumentPane from "../script/ScriptDocumentPane";
 import ScriptCastPanel from "../script/ScriptCastPanel";
@@ -33,9 +34,11 @@ type DockTab = "cast" | "assistant";
  * pane beside a right dock that toggles between the cast panel and the
  * assistant (ElevenLabs-Studio style).
  */
-const ScriptSurface = ({ refId, mode }: ScriptSurfaceProps) => {
+const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
   const theme = useTheme();
   const ensureScript = useScriptStore((state) => state.ensureScript);
+  const undo = useScriptStore((state) => state.undo);
+  const redo = useScriptStore((state) => state.redo);
   const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
   const { title, cast } = useScript(refId);
   const readOnly = mode === "view";
@@ -47,6 +50,13 @@ const ScriptSurface = ({ refId, mode }: ScriptSurfaceProps) => {
 
   useScriptServerSync(refId);
   useScriptAgentBridge(refId);
+
+  useDocumentUndoShortcuts({
+    active,
+    enabled: !readOnly,
+    onUndo: useCallback(() => undo(refId), [undo, refId]),
+    onRedo: useCallback(() => redo(refId), [redo, refId])
+  });
 
   useEffect(() => {
     setTabTitle(refId, "script", title || "Untitled script");

--- a/web/src/components/workspace/StoryboardSurface.tsx
+++ b/web/src/components/workspace/StoryboardSurface.tsx
@@ -11,6 +11,7 @@ import { useStoryboardAgentBridge } from "../../hooks/storyboard/useStoryboardAg
 import { useDirectScreenplay } from "../../hooks/storyboard/useDirectScreenplay";
 import { useStoryboardServerSync } from "../../hooks/storyboard/useStoryboardServerSync";
 import { useAssembleTimeline } from "../../hooks/storyboard/useAssembleTimeline";
+import { useDocumentUndoShortcuts } from "../../hooks/useDocumentUndoShortcuts";
 import { FlexColumn } from "../ui_primitives";
 import StoryboardBoard from "../storyboard/StoryboardBoard";
 import StoryboardSidebar from "../storyboard/StoryboardSidebar";
@@ -31,9 +32,11 @@ interface StoryboardSurfaceProps {
  * board under its id for the ui_storyboard_* tools) and the generation
  * subscriptions, and renders the board read-only in view mode.
  */
-const StoryboardSurface = ({ refId, mode }: StoryboardSurfaceProps) => {
+const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
   const theme = useTheme();
   const ensureBoard = useStoryboardStore((state) => state.ensureBoard);
+  const undo = useStoryboardStore((state) => state.undo);
+  const redo = useStoryboardStore((state) => state.redo);
   const boardTitle = useStoryboardStore(
     (state) => state.boards[refId]?.title ?? ""
   );
@@ -44,6 +47,13 @@ const StoryboardSurface = ({ refId, mode }: StoryboardSurfaceProps) => {
   }, [ensureBoard, refId]);
 
   useStoryboardServerSync(refId);
+
+  useDocumentUndoShortcuts({
+    active,
+    enabled: mode !== "view",
+    onUndo: useCallback(() => undo(refId), [undo, refId]),
+    onRedo: useCallback(() => redo(refId), [redo, refId])
+  });
 
   // Keep the tab label in sync with the board's title field.
   useEffect(() => {

--- a/web/src/hooks/useDocumentUndoShortcuts.ts
+++ b/web/src/hooks/useDocumentUndoShortcuts.ts
@@ -1,0 +1,53 @@
+/**
+ * useDocumentUndoShortcuts
+ *
+ * Wires Cmd/Ctrl+Z (undo) and Cmd/Ctrl+Shift+Z / Ctrl+Y (redo) for a
+ * singleton-store editor surface (script, storyboard). Only the active tab's
+ * surface listens — every open surface stays mounted, so the `active` guard
+ * keeps the shortcut bound to the focused document.
+ *
+ * The surface's text fields are store-controlled, so the browser's native
+ * input undo can't reach them; intercepting the shortcut even while a field is
+ * focused routes it to the document's own history, which is the source of truth.
+ */
+
+import { useEffect } from "react";
+
+interface Options {
+  /** True when this surface's tab is the focused one. */
+  active: boolean;
+  /** False in read-only/view mode, where there is nothing to undo. */
+  enabled?: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+}
+
+export const useDocumentUndoShortcuts = ({
+  active,
+  enabled = true,
+  onUndo,
+  onRedo
+}: Options): void => {
+  useEffect(() => {
+    if (!active || !enabled) {
+      return;
+    }
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (!e.metaKey && !e.ctrlKey) {
+        return;
+      }
+      const key = e.key.toLowerCase();
+      if (key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        onUndo();
+      } else if ((key === "z" && e.shiftKey) || key === "y") {
+        e.preventDefault();
+        onRedo();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [active, enabled, onUndo, onRedo]);
+};
+
+export default useDocumentUndoShortcuts;

--- a/web/src/stores/__tests__/documentHistory.test.ts
+++ b/web/src/stores/__tests__/documentHistory.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ *
+ * Per-document undo/redo stack mechanics: checkpoints push and pop, redo
+ * mirrors undo and is cleared by a fresh edit, rapid same-key edits coalesce
+ * into one step, and the stack honours its size limit.
+ */
+
+import {
+  pushHistory,
+  undoHistory,
+  redoHistory,
+  clearHistory,
+  canUndo,
+  canRedo,
+  HISTORY_LIMIT,
+  HISTORY_COALESCE_MS,
+  type HistoryMap
+} from "../documentHistory";
+
+interface Doc {
+  v: number;
+}
+
+const ID = "doc-1";
+
+describe("pushHistory / undo / redo", () => {
+  it("records a checkpoint and undoes to it", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, null, 1000);
+    expect(canUndo(h, ID)).toBe(true);
+    expect(canRedo(h, ID)).toBe(false);
+
+    const res = undoHistory(h, ID, { v: 1 });
+    expect(res).not.toBeNull();
+    expect(res?.restored).toEqual({ v: 0 });
+    expect(canUndo(res!.history, ID)).toBe(false);
+    expect(canRedo(res!.history, ID)).toBe(true);
+  });
+
+  it("redo returns the document undo moved onto the future stack", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, null, 1000);
+    const undone = undoHistory(h, ID, { v: 1 })!;
+    const redone = redoHistory(undone.history, ID, { v: 0 })!;
+    expect(redone.restored).toEqual({ v: 1 });
+    expect(canRedo(redone.history, ID)).toBe(false);
+    expect(canUndo(redone.history, ID)).toBe(true);
+  });
+
+  it("returns null when there is nothing to undo or redo", () => {
+    const h: HistoryMap<Doc> = {};
+    expect(undoHistory(h, ID, { v: 1 })).toBeNull();
+    expect(redoHistory(h, ID, { v: 1 })).toBeNull();
+  });
+
+  it("a fresh edit clears the redo stack", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, null, 1000);
+    h = undoHistory(h, ID, { v: 1 })!.history;
+    expect(canRedo(h, ID)).toBe(true);
+    h = pushHistory(h, ID, { v: 0 }, null, 2000);
+    expect(canRedo(h, ID)).toBe(false);
+  });
+});
+
+describe("coalescing", () => {
+  it("folds rapid same-key edits into a single checkpoint", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, "title", 1000);
+    h = pushHistory(h, ID, { v: 1 }, "title", 1000 + HISTORY_COALESCE_MS - 1);
+    h = pushHistory(h, ID, { v: 2 }, "title", 1000 + HISTORY_COALESCE_MS);
+    // Only the first checkpoint survives; undo steps back to the pre-typing v:0.
+    expect(h[ID].past).toEqual([{ v: 0 }]);
+    expect(undoHistory(h, ID, { v: 3 })!.restored).toEqual({ v: 0 });
+  });
+
+  it("does not fold once the window lapses", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, "title", 1000);
+    h = pushHistory(h, ID, { v: 1 }, "title", 1000 + HISTORY_COALESCE_MS + 1);
+    expect(h[ID].past).toEqual([{ v: 0 }, { v: 1 }]);
+  });
+
+  it("does not fold across different keys", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, "title", 1000);
+    h = pushHistory(h, ID, { v: 1 }, "brief", 1000);
+    expect(h[ID].past).toEqual([{ v: 0 }, { v: 1 }]);
+  });
+
+  it("a null key never coalesces", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, null, 1000);
+    h = pushHistory(h, ID, { v: 1 }, null, 1000);
+    expect(h[ID].past).toEqual([{ v: 0 }, { v: 1 }]);
+  });
+});
+
+describe("limit and clear", () => {
+  it("drops the oldest checkpoint past the limit", () => {
+    let h: HistoryMap<Doc> = {};
+    for (let i = 0; i <= HISTORY_LIMIT; i++) {
+      h = pushHistory(h, ID, { v: i }, null, i);
+    }
+    expect(h[ID].past.length).toBe(HISTORY_LIMIT);
+    // The very first checkpoint (v:0) has been evicted.
+    expect(h[ID].past[0]).toEqual({ v: 1 });
+  });
+
+  it("clearHistory drops a document's stacks", () => {
+    let h: HistoryMap<Doc> = {};
+    h = pushHistory(h, ID, { v: 0 }, null, 1000);
+    h = clearHistory(h, ID);
+    expect(canUndo(h, ID)).toBe(false);
+    expect(h[ID]).toBeUndefined();
+  });
+});

--- a/web/src/stores/documentHistory.ts
+++ b/web/src/stores/documentHistory.ts
@@ -1,0 +1,162 @@
+/**
+ * documentHistory
+ *
+ * Per-document undo/redo stacks for the singleton, Record-keyed workspace
+ * stores (script, storyboard). Unlike the timeline/graph editors — one
+ * `temporal`-wrapped store per open document — these stores hold every open
+ * document in one map, so a single `temporal` wrapper would give one undo stack
+ * shared across all of them. Instead each document id gets its own past/future
+ * stack, keyed the same way its content is.
+ *
+ * A checkpoint is the whole document snapshot taken *before* a mutation. Undo
+ * restores the most recent checkpoint (pushing the current document onto the
+ * redo stack); redo reverses it. Rapid same-field edits (typing into one text
+ * field) fold into a single checkpoint via `coalesceKey` so undo steps back a
+ * word, not a keystroke.
+ *
+ * These are pure functions over the history map; the stores own the `Record`
+ * of documents and decide which mutations record a checkpoint.
+ */
+
+export interface DocHistory<Doc> {
+  /** Checkpoints oldest-first; the last is the most recent undo target. */
+  past: Doc[];
+  /** Redo checkpoints; the last is the next redo target. */
+  future: Doc[];
+  /** Field key of the last checkpoint, for folding rapid same-field edits. */
+  coalesceKey: string | null;
+  /** Epoch ms of the last checkpoint, paired with `coalesceKey`. */
+  coalesceAt: number;
+}
+
+export type HistoryMap<Doc> = Record<string, DocHistory<Doc>>;
+
+/** Max checkpoints retained per document; oldest dropped first. */
+export const HISTORY_LIMIT = 100;
+/** Same-field edits within this window fold into one checkpoint. */
+export const HISTORY_COALESCE_MS = 500;
+
+const emptyHistory = <Doc>(): DocHistory<Doc> => ({
+  past: [],
+  future: [],
+  coalesceKey: null,
+  coalesceAt: 0
+});
+
+/**
+ * Record `prevDoc` (the document as it was before the mutation) as an undo
+ * checkpoint for `id`, clearing the redo stack. When `coalesceKey` matches the
+ * previous checkpoint's and lands within {@link HISTORY_COALESCE_MS}, the edit
+ * folds into that checkpoint instead of pushing a new one, so a run of
+ * keystrokes collapses to a single undo step.
+ */
+export const pushHistory = <Doc>(
+  history: HistoryMap<Doc>,
+  id: string,
+  prevDoc: Doc,
+  coalesceKey: string | null,
+  now: number
+): HistoryMap<Doc> => {
+  const entry = history[id] ?? emptyHistory<Doc>();
+
+  const fold =
+    coalesceKey !== null &&
+    entry.coalesceKey === coalesceKey &&
+    now - entry.coalesceAt < HISTORY_COALESCE_MS &&
+    entry.past.length > 0;
+
+  if (fold) {
+    // Keep the existing pre-edit checkpoint; just slide the coalesce clock and
+    // drop any redo branch (this is still a fresh edit).
+    const future = entry.future.length === 0 ? entry.future : [];
+    return { ...history, [id]: { ...entry, future, coalesceAt: now } };
+  }
+
+  const past =
+    entry.past.length >= HISTORY_LIMIT
+      ? entry.past.slice(entry.past.length - HISTORY_LIMIT + 1)
+      : entry.past;
+
+  return {
+    ...history,
+    [id]: {
+      past: [...past, prevDoc],
+      future: [],
+      coalesceKey,
+      coalesceAt: coalesceKey !== null ? now : 0
+    }
+  };
+};
+
+/**
+ * Pop the most recent checkpoint for `id`, returning the document to restore
+ * and the history with `currentDoc` moved onto the redo stack. Returns null
+ * when there is nothing to undo.
+ */
+export const undoHistory = <Doc>(
+  history: HistoryMap<Doc>,
+  id: string,
+  currentDoc: Doc
+): { restored: Doc; history: HistoryMap<Doc> } | null => {
+  const entry = history[id];
+  if (!entry || entry.past.length === 0) {
+    return null;
+  }
+  const restored = entry.past[entry.past.length - 1];
+  return {
+    restored,
+    history: {
+      ...history,
+      [id]: {
+        past: entry.past.slice(0, -1),
+        future: [...entry.future, currentDoc],
+        coalesceKey: null,
+        coalesceAt: 0
+      }
+    }
+  };
+};
+
+/** Mirror of {@link undoHistory} for the redo stack. */
+export const redoHistory = <Doc>(
+  history: HistoryMap<Doc>,
+  id: string,
+  currentDoc: Doc
+): { restored: Doc; history: HistoryMap<Doc> } | null => {
+  const entry = history[id];
+  if (!entry || entry.future.length === 0) {
+    return null;
+  }
+  const restored = entry.future[entry.future.length - 1];
+  return {
+    restored,
+    history: {
+      ...history,
+      [id]: {
+        past: [...entry.past, currentDoc],
+        future: entry.future.slice(0, -1),
+        coalesceKey: null,
+        coalesceAt: 0
+      }
+    }
+  };
+};
+
+/** Drop all history for `id` (document closed or replaced from the server). */
+export const clearHistory = <Doc>(
+  history: HistoryMap<Doc>,
+  id: string
+): HistoryMap<Doc> => {
+  if (!(id in history)) {
+    return history;
+  }
+  const next = { ...history };
+  delete next[id];
+  return next;
+};
+
+export const canUndo = <Doc>(history: HistoryMap<Doc>, id: string): boolean =>
+  (history[id]?.past.length ?? 0) > 0;
+
+export const canRedo = <Doc>(history: HistoryMap<Doc>, id: string): boolean =>
+  (history[id]?.future.length ?? 0) > 0;

--- a/web/src/stores/script/ScriptStore.ts
+++ b/web/src/stores/script/ScriptStore.ts
@@ -18,6 +18,15 @@
 
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
+import {
+  pushHistory,
+  undoHistory,
+  redoHistory,
+  clearHistory,
+  canUndo,
+  canRedo,
+  type HistoryMap
+} from "../documentHistory";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -106,6 +115,13 @@ interface ScriptStoreState {
   saveStatus: Record<string, ScriptSaveStatus>;
   /** Line ids currently generating a take — transient, not persisted. */
   voicingLineIds: Record<string, true>;
+  /** Per-script undo/redo checkpoints of the {@link ScriptDraft} document. */
+  history: HistoryMap<ScriptDraft>;
+
+  /** Restore the previous document checkpoint for a script. */
+  undo: (scriptId: string) => void;
+  /** Reapply the next document checkpoint for a script. */
+  redo: (scriptId: string) => void;
 
   setServerRevision: (scriptId: string, revision: string | null) => void;
   setSaveStatus: (scriptId: string, status: ScriptSaveStatus) => void;
@@ -206,25 +222,42 @@ export const emptyScript = (id: string): ScriptDraft => ({
 });
 
 /**
+ * How a mutation records undo history: `false` skips the checkpoint (for
+ * non-authoring links like the timeline handoff); an object records one,
+ * optionally folding rapid same-field edits under `coalesceKey`.
+ */
+type Track = false | { coalesceKey?: string };
+
+/**
  * Apply `mutate` to the script with `scriptId`. Returns the SAME state when the
  * script is absent or `mutate` returns `null`, so no-op edits don't churn
- * subscribers. Stamps `updatedAt` on every real mutation.
+ * subscribers. Stamps `updatedAt` and records an undo checkpoint (unless
+ * `track` is false) on every real mutation.
  */
 const withScript = (
   state: ScriptStoreState,
   scriptId: string,
-  mutate: (script: ScriptDraft) => ScriptDraft | null
+  mutate: (script: ScriptDraft) => ScriptDraft | null,
+  track: Track = {}
 ): Partial<ScriptStoreState> | ScriptStoreState => {
   const script = state.scripts[scriptId];
   if (!script) return state;
   const next = mutate(script);
   if (!next || next === script) return state;
-  return {
-    scripts: {
-      ...state.scripts,
-      [scriptId]: { ...next, updatedAt: Date.now() }
-    }
+  const now = Date.now();
+  const patch: Partial<ScriptStoreState> = {
+    scripts: { ...state.scripts, [scriptId]: { ...next, updatedAt: now } }
   };
+  if (track !== false) {
+    patch.history = pushHistory(
+      state.history,
+      scriptId,
+      script,
+      track.coalesceKey ?? null,
+      now
+    );
+  }
+  return patch;
 };
 
 /** Map every line in the script, returning the same script on a no-op. */
@@ -256,6 +289,37 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
   serverRevisions: {},
   saveStatus: {},
   voicingLineIds: {},
+  history: {},
+
+  undo: (scriptId) =>
+    set((state) => {
+      const current = state.scripts[scriptId];
+      if (!current) return state;
+      const result = undoHistory(state.history, scriptId, current);
+      if (!result) return state;
+      return {
+        scripts: {
+          ...state.scripts,
+          [scriptId]: { ...result.restored, updatedAt: Date.now() }
+        },
+        history: result.history
+      };
+    }),
+
+  redo: (scriptId) =>
+    set((state) => {
+      const current = state.scripts[scriptId];
+      if (!current) return state;
+      const result = redoHistory(state.history, scriptId, current);
+      if (!result) return state;
+      return {
+        scripts: {
+          ...state.scripts,
+          [scriptId]: { ...result.restored, updatedAt: Date.now() }
+        },
+        history: result.history
+      };
+    }),
 
   setServerRevision: (scriptId, revision) =>
     set((state) => {
@@ -304,22 +368,34 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
       delete serverRevisions[id];
       const saveStatus = { ...state.saveStatus };
       delete saveStatus[id];
-      return { scripts, serverRevisions, saveStatus };
+      return {
+        scripts,
+        serverRevisions,
+        saveStatus,
+        history: clearHistory(state.history, id)
+      };
     }),
 
   getScript: (id) => get().scripts[id],
 
   setTitle: (scriptId, title) =>
     set((state) =>
-      withScript(state, scriptId, (s) =>
-        s.title === title ? s : { ...s, title }
+      withScript(
+        state,
+        scriptId,
+        (s) => (s.title === title ? s : { ...s, title }),
+        { coalesceKey: "title" }
       )
     ),
 
   setTimelineLink: (scriptId, timelineId) =>
     set((state) =>
-      withScript(state, scriptId, (s) =>
-        s.timelineId === timelineId ? s : { ...s, timelineId }
+      withScript(
+        state,
+        scriptId,
+        (s) => (s.timelineId === timelineId ? s : { ...s, timelineId }),
+        // A timeline handoff isn't an authoring edit — keep it out of undo.
+        false
       )
     ),
 
@@ -375,12 +451,17 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
 
   setSectionTitle: (scriptId, sectionId, title) =>
     set((state) =>
-      withScript(state, scriptId, (s) => ({
-        ...s,
-        sections: s.sections.map((section) =>
-          section.id === sectionId ? { ...section, title } : section
-        )
-      }))
+      withScript(
+        state,
+        scriptId,
+        (s) => ({
+          ...s,
+          sections: s.sections.map((section) =>
+            section.id === sectionId ? { ...section, title } : section
+          )
+        }),
+        { coalesceKey: `section:${sectionId}` }
+      )
     ),
 
   removeSection: (scriptId, sectionId) =>
@@ -471,15 +552,26 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
   },
 
   patchLine: (scriptId, lineId, patch) =>
-    set((state) =>
-      withScript(state, scriptId, (s) =>
-        mapLine(s, lineId, (line) => {
-          const keys = Object.keys(patch) as Array<keyof typeof patch>;
-          const unchanged = keys.every((k) => Object.is(line[k], patch[k]));
-          return unchanged ? line : { ...line, ...patch };
-        })
-      )
-    ),
+    set((state) => {
+      const keys = Object.keys(patch).sort();
+      return withScript(
+        state,
+        scriptId,
+        (s) =>
+          mapLine(s, lineId, (line) => {
+            const unchanged = keys.every((k) =>
+              Object.is(
+                line[k as keyof typeof patch],
+                patch[k as keyof typeof patch]
+              )
+            );
+            return unchanged ? line : { ...line, ...patch };
+          }),
+        // Fold a run of edits to the same field of the same line (typing) into
+        // one undo step.
+        { coalesceKey: `line:${lineId}:${keys.join(",")}` }
+      );
+    }),
 
   removeLine: (scriptId, lineId) =>
     set((state) =>
@@ -636,6 +728,14 @@ export const useScript = (
 /** Reactive transient voicing flag for a line. */
 export const useLineVoicing = (lineId: string): boolean =>
   useScriptStore((state) => !!state.voicingLineIds[lineId]);
+
+/** Reactive "an undo step is available" flag for a script. */
+export const useScriptCanUndo = (scriptId: string): boolean =>
+  useScriptStore((state) => canUndo(state.history, scriptId));
+
+/** Reactive "a redo step is available" flag for a script. */
+export const useScriptCanRedo = (scriptId: string): boolean =>
+  useScriptStore((state) => canRedo(state.history, scriptId));
 
 /**
  * Reactive autosave status for a script. Defaults to `saved` (idle) before the

--- a/web/src/stores/script/__tests__/ScriptStore.test.ts
+++ b/web/src/stores/script/__tests__/ScriptStore.test.ts
@@ -278,3 +278,70 @@ describe("effectiveVoice", () => {
     expect(eff?.voice).toBe("echo");
   });
 });
+
+describe("undo/redo", () => {
+  const sectionCount = (): number =>
+    useScriptStore.getState().scripts[SCRIPT]?.sections.length ?? 0;
+  const lineText = (lineId: string): string | undefined =>
+    useScriptStore
+      .getState()
+      .scripts[SCRIPT]?.sections.flatMap((s) => s.lines)
+      .find((l) => l.id === lineId)?.text;
+
+  it("undoes and redoes a line addition", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    expect(sectionCount()).toBe(0);
+    store.addLine(SCRIPT);
+    expect(sectionCount()).toBe(1);
+
+    store.undo(SCRIPT);
+    expect(sectionCount()).toBe(0);
+
+    store.redo(SCRIPT);
+    expect(sectionCount()).toBe(1);
+  });
+
+  it("folds rapid text edits to one line into a single undo step", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    const lineId = store.addLine(SCRIPT);
+    store.patchLine(SCRIPT, lineId, { text: "h" });
+    store.patchLine(SCRIPT, lineId, { text: "he" });
+    store.patchLine(SCRIPT, lineId, { text: "hel" });
+    expect(lineText(lineId)).toBe("hel");
+
+    // One undo reverts the whole typing run, not one keystroke.
+    store.undo(SCRIPT);
+    expect(lineText(lineId)).toBe("");
+    // A second undo steps back past the line's creation.
+    store.undo(SCRIPT);
+    expect(sectionCount()).toBe(0);
+  });
+
+  it("a fresh edit clears the redo stack", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    store.undo(SCRIPT);
+    expect(useScriptStore.getState().history[SCRIPT]?.future.length).toBe(1);
+    store.addLine(SCRIPT);
+    expect(useScriptStore.getState().history[SCRIPT]?.future.length ?? 0).toBe(0);
+  });
+
+  it("undo is a no-op with an empty history", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    expect(() => store.undo(SCRIPT)).not.toThrow();
+    expect(sectionCount()).toBe(0);
+  });
+
+  it("removeScript drops the script's history", () => {
+    const store = useScriptStore.getState();
+    store.ensureScript(SCRIPT);
+    store.addLine(SCRIPT);
+    expect(useScriptStore.getState().history[SCRIPT]?.past.length).toBe(1);
+    store.removeScript(SCRIPT);
+    expect(useScriptStore.getState().history[SCRIPT]).toBeUndefined();
+  });
+});

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -25,6 +25,15 @@ import type {
   ShotStatus,
   VideoRef
 } from "@nodetool-ai/protocol";
+import {
+  pushHistory,
+  undoHistory,
+  redoHistory,
+  clearHistory,
+  canUndo,
+  canRedo,
+  type HistoryMap
+} from "../documentHistory";
 import type {
   ImageModelValue,
   LanguageModelValue,
@@ -63,7 +72,14 @@ interface StoryboardStoreState {
   boards: Record<string, StoryboardBoard>;
   /** Server `updated_at` token per board — the CAS base for the next save. */
   serverRevisions: Record<string, string>;
+  /** Per-board undo/redo checkpoints of the {@link StoryboardBoard} document. */
+  history: HistoryMap<StoryboardBoard>;
   setServerRevision: (boardId: string, revision: string | null) => void;
+
+  /** Restore the previous document checkpoint for a board. */
+  undo: (boardId: string) => void;
+  /** Reapply the next document checkpoint for a board. */
+  redo: (boardId: string) => void;
 
   /** Create an empty board for `id` if one does not already exist. */
   ensureBoard: (id: string) => void;
@@ -153,14 +169,23 @@ const emptyBoard = (id: string): StoryboardBoard => ({
 });
 
 /**
+ * How a mutation records undo history: `false` skips the checkpoint (for
+ * selection, generation status, and the timeline handoff); an object records
+ * one, optionally folding rapid same-field edits under `coalesceKey`.
+ */
+type Track = false | { coalesceKey?: string };
+
+/**
  * Apply `mutate` to the board with `boardId`. Returns the SAME state when the
  * board is absent or `mutate` returns `null`, so no-op edits don't churn
- * subscribers.
+ * subscribers. Stamps `updatedAt` and records an undo checkpoint (unless
+ * `track` is false) on every real mutation.
  */
 const withBoard = (
   state: StoryboardStoreState,
   boardId: string,
-  mutate: (board: StoryboardBoard) => StoryboardBoard | null
+  mutate: (board: StoryboardBoard) => StoryboardBoard | null,
+  track: Track = {}
 ): Partial<StoryboardStoreState> | StoryboardStoreState => {
   const board = state.boards[boardId];
   if (!board) {
@@ -170,10 +195,34 @@ const withBoard = (
   if (!next || next === board) {
     return state;
   }
-  return {
-    boards: { ...state.boards, [boardId]: { ...next, updatedAt: Date.now() } }
+  const now = Date.now();
+  const patch: Partial<StoryboardStoreState> = {
+    boards: { ...state.boards, [boardId]: { ...next, updatedAt: now } }
   };
+  if (track !== false) {
+    patch.history = pushHistory(state.history, boardId, board, track.coalesceKey ?? null, now);
+  }
+  return patch;
 };
+
+/**
+ * Restore a checkpoint while keeping the live selection and per-shot generation
+ * status, so undo/redo never resurrects a stale spinner or jumps the active
+ * shot. Content (screenplay, shot media, order, prompts) comes from the
+ * checkpoint; `activeShotId` and each surviving shot's `status` stay live.
+ */
+const withLiveTransient = (
+  restored: StoryboardBoard,
+  current: StoryboardBoard
+): StoryboardBoard => ({
+  ...restored,
+  activeShotId: current.activeShotId,
+  updatedAt: Date.now(),
+  shots: restored.shots.map((s) => {
+    const live = current.shots.find((c) => c.id === s.id);
+    return live && live.status !== s.status ? { ...s, status: live.status } : s;
+  })
+});
 
 /** Same generated asset: matched by asset_id when present, else by uri. */
 export const sameMediaRef = (
@@ -208,6 +257,37 @@ const patchShot = (
 export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
   boards: {},
   serverRevisions: {},
+  history: {},
+
+  undo: (boardId) =>
+    set((state) => {
+      const current = state.boards[boardId];
+      if (!current) return state;
+      const result = undoHistory(state.history, boardId, current);
+      if (!result) return state;
+      return {
+        boards: {
+          ...state.boards,
+          [boardId]: withLiveTransient(result.restored, current)
+        },
+        history: result.history
+      };
+    }),
+
+  redo: (boardId) =>
+    set((state) => {
+      const current = state.boards[boardId];
+      if (!current) return state;
+      const result = redoHistory(state.history, boardId, current);
+      if (!result) return state;
+      return {
+        boards: {
+          ...state.boards,
+          [boardId]: withLiveTransient(result.restored, current)
+        },
+        history: result.history
+      };
+    }),
 
   setServerRevision: (boardId, revision) =>
     set((state) => {
@@ -256,12 +336,13 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
       }
       const boards = { ...state.boards };
       delete boards[id];
-      return { boards };
+      return { boards, history: clearHistory(state.history, id) };
     }),
 
   setScreenplay: (boardId, screenplay) =>
     set((state) => {
-      const board = state.boards[boardId] ?? emptyBoard(boardId);
+      const prev = state.boards[boardId];
+      const board = prev ?? emptyBoard(boardId);
       const next: StoryboardBoard = {
         ...board,
         screenplay,
@@ -271,20 +352,34 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         style: screenplay.style_bible ?? board.style,
         updatedAt: Date.now()
       };
-      return { boards: { ...state.boards, [boardId]: next } };
+      const patch: Partial<StoryboardStoreState> = {
+        boards: { ...state.boards, [boardId]: next }
+      };
+      // A (re-)direct that replaces an existing board is undoable; the first
+      // screenplay on an empty board has nothing to step back to.
+      if (prev) {
+        patch.history = pushHistory(state.history, boardId, prev, null, Date.now());
+      }
+      return patch;
     }),
 
   setBrief: (boardId, brief) =>
     set((state) =>
-      withBoard(state, boardId, (b) =>
-        b.brief === brief ? null : { ...b, brief }
+      withBoard(
+        state,
+        boardId,
+        (b) => (b.brief === brief ? null : { ...b, brief }),
+        { coalesceKey: "brief" }
       )
     ),
 
   setStyle: (boardId, style) =>
     set((state) =>
-      withBoard(state, boardId, (b) =>
-        b.style === style ? null : { ...b, style }
+      withBoard(
+        state,
+        boardId,
+        (b) => (b.style === style ? null : { ...b, style }),
+        { coalesceKey: "style" }
       )
     ),
 
@@ -315,8 +410,11 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   setTitle: (boardId, title) =>
     set((state) =>
-      withBoard(state, boardId, (b) =>
-        b.title === title ? null : { ...b, title }
+      withBoard(
+        state,
+        boardId,
+        (b) => (b.title === title ? null : { ...b, title }),
+        { coalesceKey: "title" }
       )
     ),
 
@@ -359,8 +457,12 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   setTimelineLink: (boardId, timelineId) =>
     set((state) =>
-      withBoard(state, boardId, (b) =>
-        b.timelineId === timelineId ? null : { ...b, timelineId }
+      withBoard(
+        state,
+        boardId,
+        (b) => (b.timelineId === timelineId ? null : { ...b, timelineId }),
+        // A timeline handoff isn't an authoring edit — keep it out of undo.
+        false
       )
     ),
 
@@ -378,11 +480,18 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
     ),
 
   updateShot: (boardId, shotId, patch) =>
-    set((state) => withBoard(state, boardId, (b) => patchShot(b, shotId, patch))),
+    set((state) =>
+      withBoard(state, boardId, (b) => patchShot(b, shotId, patch), {
+        // Fold a run of edits to the same field(s) of one shot (typing a
+        // prompt) into a single undo step.
+        coalesceKey: `shot:${shotId}:${Object.keys(patch).sort().join(",")}`
+      })
+    ),
 
   setShotStatus: (boardId, shotId, status) =>
     set((state) =>
-      withBoard(state, boardId, (b) => patchShot(b, shotId, { status }))
+      // Generation lifecycle, not an authoring edit — keep it out of undo.
+      withBoard(state, boardId, (b) => patchShot(b, shotId, { status }), false)
     ),
 
   setShotKeyframe: (boardId, shotId, keyframe) =>
@@ -507,8 +616,12 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   selectShot: (boardId, shotId) =>
     set((state) =>
-      withBoard(state, boardId, (b) =>
-        b.activeShotId === shotId ? null : { ...b, activeShotId: shotId }
+      withBoard(
+        state,
+        boardId,
+        (b) => (b.activeShotId === shotId ? null : { ...b, activeShotId: shotId }),
+        // Selection is transient UI state, not an authoring edit.
+        false
       )
     ),
 
@@ -579,6 +692,14 @@ export const useBoard = (
       };
     })
   );
+
+/** Reactive "an undo step is available" flag for a board. */
+export const useStoryboardCanUndo = (boardId: string): boolean =>
+  useStoryboardStore((state) => canUndo(state.history, boardId));
+
+/** Reactive "a redo step is available" flag for a board. */
+export const useStoryboardCanRedo = (boardId: string): boolean =>
+  useStoryboardStore((state) => canRedo(state.history, boardId));
 
 /** Reactive single shot, or undefined when absent. */
 export const useShot = (

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -161,3 +161,82 @@ describe("setShotClip / selectClipVersion", () => {
     expect(shot?.clip_versions).toEqual([video(1), video(2)]);
   });
 });
+
+describe("undo/redo", () => {
+  const board = () => useStoryboardStore.getState().boards[BOARD];
+  const seedShots = (): void => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    for (let i = 0; i < 3; i++) {
+      store.upsertShot(BOARD, {
+        type: "shot",
+        id: `s${i}`,
+        index: i,
+        action: `shot ${i}`,
+        status: "planned"
+      });
+    }
+  };
+
+  it("undoes and redoes a shot removal", () => {
+    seedShots();
+    const store = useStoryboardStore.getState();
+    store.removeShot(BOARD, "s1");
+    expect(board()?.shots.map((s) => s.id)).toEqual(["s0", "s2"]);
+
+    store.undo(BOARD);
+    expect(board()?.shots.map((s) => s.id)).toEqual(["s0", "s1", "s2"]);
+
+    store.redo(BOARD);
+    expect(board()?.shots.map((s) => s.id)).toEqual(["s0", "s2"]);
+  });
+
+  it("keeps selection and shot status live across undo", () => {
+    seedShots();
+    const store = useStoryboardStore.getState();
+    // A tracked content edit, then transient changes that must survive undo.
+    store.updateShot(BOARD, "s0", { action: "revised" });
+    store.selectShot(BOARD, "s2");
+    store.setShotStatus(BOARD, "s0", "keyframe_ready");
+
+    store.undo(BOARD);
+    const b = board();
+    // Content reverts…
+    expect(b?.shots.find((s) => s.id === "s0")?.action).toBe("shot 0");
+    // …but selection and generation status stay where they are now.
+    expect(b?.activeShotId).toBe("s2");
+    expect(b?.shots.find((s) => s.id === "s0")?.status).toBe("keyframe_ready");
+  });
+
+  it("does not record selection or status as undo steps", () => {
+    seedShots();
+    const store = useStoryboardStore.getState();
+    const before =
+      useStoryboardStore.getState().history[BOARD]?.past.length ?? 0;
+    store.selectShot(BOARD, "s1");
+    store.setShotStatus(BOARD, "s1", "keyframe_generating");
+    const after =
+      useStoryboardStore.getState().history[BOARD]?.past.length ?? 0;
+    expect(after).toBe(before);
+  });
+
+  it("folds rapid edits to one shot field into a single undo step", () => {
+    seedShots();
+    const store = useStoryboardStore.getState();
+    store.updateShot(BOARD, "s0", { action: "a" });
+    store.updateShot(BOARD, "s0", { action: "ab" });
+    store.updateShot(BOARD, "s0", { action: "abc" });
+
+    store.undo(BOARD);
+    expect(board()?.shots.find((s) => s.id === "s0")?.action).toBe("shot 0");
+  });
+
+  it("removeBoard drops the board's history", () => {
+    seedShots();
+    expect(
+      useStoryboardStore.getState().history[BOARD]?.past.length
+    ).toBeGreaterThan(0);
+    useStoryboardStore.getState().removeBoard(BOARD);
+    expect(useStoryboardStore.getState().history[BOARD]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds undo/redo to the **script** and **storyboard** workspace editors — via `Cmd/Ctrl+Z` / `Cmd/Ctrl+Shift+Z` (and `Ctrl+Y`) and toolbar buttons.

## Why the timeline pattern didn't fit

The timeline and graph editors wrap a **per-instance** store in the `temporal` middleware. Script and storyboard are **singleton stores keyed by document id** (`scripts` / `boards` maps), so a single `temporal` wrapper would give one undo stack shared across every open document. Instead each document id gets its own past/future stack.

## Approach

- **`web/src/stores/documentHistory.ts`** — a small pure-function history utility: per-id `past`/`future` checkpoint stacks, a size limit, and same-field edit coalescing (a run of keystrokes folds into one undo step).
- **Recording seam** — both stores already funnel every document mutation through `withScript` / `withBoard`, so a checkpoint is recorded there and covers all edits in one place.
- **Transient state stays out of undo** — script voicing/save/server maps aren't routed through `withScript`; storyboard selection, generation status, and the timeline handoff pass `track: false`. On storyboard restore the live selection and per-shot generation status are preserved, so undo never resurrects a stale spinner or jumps the active shot. A (re-)direct that replaces an existing board is a single undoable step.
- **Keyboard wiring** — `useDocumentUndoShortcuts` binds the shortcuts only for the active tab (all surfaces stay mounted). Text fields are store-controlled, so the shortcut routes to the document's own history rather than the browser's inert native input undo.
- **UI** — `UndoRedoButtons` added to the script document toolbar and the storyboard header, disabled when their stacks are empty.

## Tests

- `documentHistory.test.ts` — push/undo/redo, redo-clear-on-edit, coalescing (window, key, null-key), size limit, clear.
- Extended `ScriptStore` / `StoryboardStore` tests — undo/redo of edits, keystroke coalescing, storyboard keeping selection + status live across undo, transient mutations not recorded, history dropped on document removal.
- Updated the `StoryboardBoard` test mock for the two new store hooks.

`npm run typecheck` (web), targeted `eslint`, and the full `web/src/stores` suite (2214 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xzaZWfW4sCTyJeFNizThk

---
_Generated by [Claude Code](https://claude.ai/code/session_015xzaZWfW4sCTyJeFNizThk)_