### PR TITLE
Fix CodeQL ReDoS and slash-less api/storage routing (follow-up to #4430)

### DIFF
--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -2577,10 +2577,15 @@ export class ProcessingContext {
    * as opaque storage URIs (memory/file/s3) via the storage adapter.
    */
   private async retrieveMediaBytes(uri: string): Promise<Uint8Array | null> {
-    // `/api/storage/<key>` is the browser-facing route, not a storage-adapter
-    // uri — the InMemory/S3 adapters only accept `memory://`/`s3://`, so route
-    // it through resolveAssetBytes (which parses the key) like `asset://`.
-    if (uri.startsWith("asset://") || uri.startsWith("/api/storage/")) {
+    // `/api/storage/<key>` (and its slash-less `api/storage/<key>` form) is the
+    // browser-facing route, not a storage-adapter uri — the InMemory/S3 adapters
+    // only accept `memory://`/`s3://`, so route it through resolveAssetBytes
+    // (which parses the key) like `asset://`.
+    if (
+      uri.startsWith("asset://") ||
+      uri.startsWith("/api/storage/") ||
+      uri.startsWith("api/storage/")
+    ) {
       const { bytes } = await this.resolveAssetBytes(uri);
       return bytes;
     }
@@ -3140,7 +3145,9 @@ export class ProcessingContext {
     }
     if (
       typeof uri === "string" &&
-      (uri.startsWith("asset://") || uri.startsWith("/api/storage/"))
+      (uri.startsWith("asset://") ||
+        uri.startsWith("/api/storage/") ||
+        uri.startsWith("api/storage/"))
     ) {
       const { bytes } = await this.resolveAssetBytes(uri);
       if (bytes) return bytes;

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -794,6 +794,27 @@ describe("output normalization", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("materializes an asset whose uri is a slash-less `api/storage/<key>`", async () => {
+    // Regression: getAssetBytes must route the slash-less `api/storage/` form
+    // through resolveAssetBytes (InMemory/S3 reject the raw route), else the
+    // ref never materializes to a data URI.
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("pic.png", new Uint8Array([1, 2, 3]), "image/png");
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      assetOutputMode: "data_uri",
+      storage
+    });
+
+    const normalized = (await ctx.normalizeOutputValue({
+      image: { type: "image", uri: "api/storage/pic.png" }
+    })) as { image: { uri: string } };
+    expect(normalized.image.uri.startsWith("data:image/png;base64,")).toBe(true);
+    expect(normalized.image.uri).toContain(
+      Buffer.from([1, 2, 3]).toString("base64")
+    );
+  });
 });
 
 describe("FileStorageAdapter", () => {
@@ -885,6 +906,17 @@ describe("ProcessingContext.resolveAssetBytes", () => {
     const ctx = new ProcessingContext({ jobId: "j1", storage });
 
     const { bytes } = await ctx.resolveAssetBytes("/api/storage/abc.png");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([7, 8, 9]));
+  });
+
+  it("resolves the slash-less `api/storage/<key>` form too", async () => {
+    // Regression: the slash-less route (handled elsewhere) must strip to the
+    // bare key like the leading-slash form, not be treated as the whole id.
+    const storage = new InMemoryStorageAdapter();
+    await storage.store("abc.png", new Uint8Array([7, 8, 9]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("api/storage/abc.png");
     expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([7, 8, 9]));
   });
 

--- a/packages/storage/src/file-storage-adapter.ts
+++ b/packages/storage/src/file-storage-adapter.ts
@@ -27,6 +27,21 @@ function decodeKey(key: string): string {
 }
 
 /**
+ * Return `uri` up to (excluding) the first `?` or `#`. A linear index scan, not
+ * a `/[?#].*$/` regex — that backtracks polynomially on adversarial input and
+ * CodeQL flags it as a ReDoS risk.
+ */
+function stripUriSuffix(uri: string): string {
+  const q = uri.indexOf("?");
+  const h = uri.indexOf("#");
+  let cut = -1;
+  if (q < 0) cut = h;
+  else if (h < 0) cut = q;
+  else cut = Math.min(q, h);
+  return cut < 0 ? uri : uri.slice(0, cut);
+}
+
+/**
  * File-system storage adapter rooted to a single base directory.
  *
  * URI scheme: `file:///abs/path`. Also accepts `/api/storage/<key>` paths
@@ -69,8 +84,10 @@ export class FileStorageAdapter implements StorageAdapter {
     }
     if (uri.startsWith("/api/storage/") || uri.startsWith("api/storage/")) {
       // Strip any ?query / #fragment before decoding — the HTTP route keys off
-      // the decoded path only (storage-api.ts decodeURIComponent).
-      const withoutSuffix = uri.replace(/[?#].*$/, "");
+      // the decoded path only (storage-api.ts decodeURIComponent). Cut at the
+      // first `?`/`#` with a linear scan rather than a backtracking regex
+      // (CodeQL flags `/[?#].*$/` as polynomial on uncontrolled input).
+      const withoutSuffix = stripUriSuffix(uri);
       return decodeKey(withoutSuffix.replace(/^\/?api\/storage\//, ""));
     }
     if (/^https?:\/\//.test(uri)) {

--- a/packages/storage/src/file-storage-adapter.ts
+++ b/packages/storage/src/file-storage-adapter.ts
@@ -27,9 +27,9 @@ function decodeKey(key: string): string {
 }
 
 /**
- * Return `uri` up to (excluding) the first `?` or `#`. A linear index scan, not
- * a `/[?#].*$/` regex — that backtracks polynomially on adversarial input and
- * CodeQL flags it as a ReDoS risk.
+ * Return `uri` up to (excluding) the first `?` or `#`. A linear index scan
+ * rather than a `/[?#].*$/` regex, which CodeQL flags as a potential ReDoS
+ * pattern on uncontrolled input.
  */
 function stripUriSuffix(uri: string): string {
   const q = uri.indexOf("?");
@@ -85,8 +85,8 @@ export class FileStorageAdapter implements StorageAdapter {
     if (uri.startsWith("/api/storage/") || uri.startsWith("api/storage/")) {
       // Strip any ?query / #fragment before decoding — the HTTP route keys off
       // the decoded path only (storage-api.ts decodeURIComponent). Cut at the
-      // first `?`/`#` with a linear scan rather than a backtracking regex
-      // (CodeQL flags `/[?#].*$/` as polynomial on uncontrolled input).
+      // first `?`/`#` with a linear scan rather than a `/[?#].*$/` regex, which
+      // CodeQL flags as a potential ReDoS pattern on uncontrolled input.
       const withoutSuffix = stripUriSuffix(uri);
       return decodeKey(withoutSuffix.replace(/^\/?api\/storage\//, ""));
     }

--- a/packages/storage/src/file-storage-adapter.ts
+++ b/packages/storage/src/file-storage-adapter.ts
@@ -35,9 +35,13 @@ function stripUriSuffix(uri: string): string {
   const q = uri.indexOf("?");
   const h = uri.indexOf("#");
   let cut = -1;
-  if (q < 0) cut = h;
-  else if (h < 0) cut = q;
-  else cut = Math.min(q, h);
+  if (q < 0) {
+    cut = h;
+  } else if (h < 0) {
+    cut = q;
+  } else {
+    cut = Math.min(q, h);
+  }
   return cut < 0 ? uri : uri.slice(0, cut);
 }
 

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -264,8 +264,9 @@ export function useImageAssets(value: unknown): { assets: Asset[]; urls: string[
           // A bare asset ref carrying only `id` (no uri/data/bitmap). The
           // storage route serves by filename, so `/api/storage/<id>` with no
           // extension 404s. Build an `asset://<id>.<ext>` ref — extension from
-          // the item name, falling back to the content type — and resolve it
-          // the same way as `uri`.
+          // the item name, defaulting to `png` when the name has none (these
+          // grid items carry no mime, and png is the assumed content type) —
+          // and resolve it the same way as `uri`.
           const cleanName = (imageItem.name ?? "").split(/[?#]/)[0];
           const dot = cleanName.lastIndexOf(".");
           const ext =


### PR DESCRIPTION
## Summary

Follow-up to #4430, which auto-merged before these post-review fixes could land. Addresses the CodeQL alert and two review comments left on that PR.

## Fixes

- **CodeQL ReDoS (alert #293, high severity)** — `packages/storage/src/file-storage-adapter.ts`: the `/[?#].*$/` query/fragment strip is flagged as a polynomial regex on uncontrolled input (a `/api/storage/` key with many leading `#`/`?` chars could backtrack). Replaced with a linear `indexOf`-based `stripUriSuffix`. Behavior is identical — the bare key is still cut at the first `?`/`#`.
- **Slash-less `api/storage/` routing** (Copilot) — `packages/runtime/src/context.ts`: `retrieveMediaBytes` and `getAssetBytes` now route the slash-less `api/storage/<key>` form through `resolveAssetBytes`, matching `parseAssetIdCandidates`. InMemory/S3 adapters reject the raw route, so these refs were otherwise unresolvable.
- **Misleading comment** (Copilot) — `web/src/components/node/output/hooks.ts`: corrected the id-only fallback comment to match the code (extension defaults to `png` when the item name has none; these grid items carry no mime).

## Testing

- `packages/storage` file-storage-adapter coverage: 41 passed (covers query/fragment stripping and URL-decode round-trips)
- `packages/runtime` context + media-ref: 172 passed
- Changed files typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sptM2cdH4THpBk5PBoUM5

---
_Generated by [Claude Code](https://claude.ai/code/session_014sptM2cdH4THpBk5PBoUM5)_