### PR TITLE
Address review feedback on script/storyboard undo

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -298,6 +298,8 @@ const ScriptDocumentPane = ({
   const redo = useScriptStore((s) => s.redo);
   const canUndo = useScriptCanUndo(scriptId);
   const canRedo = useScriptCanRedo(scriptId);
+  const onUndo = useCallback(() => undo(scriptId), [undo, scriptId]);
+  const onRedo = useCallback(() => redo(scriptId), [redo, scriptId]);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
   const [voicingAll, setVoicingAll] = useState(false);
@@ -475,8 +477,8 @@ const ScriptDocumentPane = ({
           <UndoRedoButtons
             canUndo={canUndo}
             canRedo={canRedo}
-            onUndo={() => undo(scriptId)}
-            onRedo={() => redo(scriptId)}
+            onUndo={onUndo}
+            onRedo={onRedo}
             undoTooltip="Undo (⌘Z)"
             redoTooltip="Redo (⌘⇧Z)"
           />

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -227,6 +227,8 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const redo = useStoryboardStore((state) => state.redo);
   const canUndo = useStoryboardCanUndo(boardId);
   const canRedo = useStoryboardCanRedo(boardId);
+  const onUndo = useCallback(() => undo(boardId), [undo, boardId]);
+  const onRedo = useCallback(() => redo(boardId), [redo, boardId]);
 
   const [shotCount, setShotCount] = useState<number>(6);
   const [confirmRedirect, setConfirmRedirect] = useState(false);
@@ -397,8 +399,8 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                 <UndoRedoButtons
                   canUndo={canUndo}
                   canRedo={canRedo}
-                  onUndo={() => undo(boardId)}
-                  onRedo={() => redo(boardId)}
+                  onUndo={onUndo}
+                  onRedo={onRedo}
                   undoTooltip="Undo (⌘Z)"
                   redoTooltip="Redo (⌘⇧Z)"
                 />

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -216,7 +216,11 @@ const withLiveTransient = (
   current: StoryboardBoard
 ): StoryboardBoard => ({
   ...restored,
-  activeShotId: current.activeShotId,
+  // Keep the live selection, but only if that shot survives in the checkpoint;
+  // a selection undone out of existence resets rather than dangling.
+  activeShotId: restored.shots.some((s) => s.id === current.activeShotId)
+    ? current.activeShotId
+    : null,
   updatedAt: Date.now(),
   shots: restored.shots.map((s) => {
     const live = current.shots.find((c) => c.id === s.id);
@@ -336,7 +340,15 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
       }
       const boards = { ...state.boards };
       delete boards[id];
-      return { boards, history: clearHistory(state.history, id) };
+      // Drop the CAS token too, so re-creating this id later can't reuse a
+      // stale revision (mirrors ScriptStore.removeScript).
+      const serverRevisions = { ...state.serverRevisions };
+      delete serverRevisions[id];
+      return {
+        boards,
+        serverRevisions,
+        history: clearHistory(state.history, id)
+      };
     }),
 
   setScreenplay: (boardId, screenplay) =>

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -335,7 +335,14 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
 
   removeBoard: (id) =>
     set((state) => {
-      if (!state.boards[id]) {
+      // A board entry can be gone while its revision/history linger — e.g.
+      // useStoryboardServerSync sets the CAS token after `create` before any
+      // loadBoard. Clear whichever of the three still holds the id.
+      if (
+        !(id in state.boards) &&
+        !(id in state.serverRevisions) &&
+        !(id in state.history)
+      ) {
         return state;
       }
       const boards = { ...state.boards };

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -240,3 +240,15 @@ describe("undo/redo", () => {
     expect(useStoryboardStore.getState().history[BOARD]).toBeUndefined();
   });
 });
+
+describe("removeBoard cleanup", () => {
+  it("clears a lingering server revision even when no board exists", () => {
+    const store = useStoryboardStore.getState();
+    // Autosave can set the CAS token before loadBoard ever runs.
+    store.setServerRevision(BOARD, "rev-1");
+    expect(useStoryboardStore.getState().serverRevisions[BOARD]).toBe("rev-1");
+
+    store.removeBoard(BOARD);
+    expect(useStoryboardStore.getState().serverRevisions[BOARD]).toBeUndefined();
+  });
+});

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -252,3 +252,26 @@ describe("removeBoard cleanup", () => {
     expect(useStoryboardStore.getState().serverRevisions[BOARD]).toBeUndefined();
   });
 });
+
+describe("undo selection safety", () => {
+  it("clears activeShotId when undo removes the selected shot", () => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    // upsertShot is tracked, so its checkpoint predates the shot's existence.
+    store.upsertShot(BOARD, {
+      type: "shot",
+      id: "s0",
+      index: 0,
+      action: "shot 0",
+      status: "planned"
+    });
+    store.selectShot(BOARD, "s0");
+    expect(useStoryboardStore.getState().boards[BOARD]?.activeShotId).toBe("s0");
+
+    // Undo the creation of the selected shot: the selection must not dangle.
+    store.undo(BOARD);
+    const board = useStoryboardStore.getState().boards[BOARD];
+    expect(board?.shots).toHaveLength(0);
+    expect(board?.activeShotId).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #4431 (merged) — applies the four Copilot review comments from that PR.

## Changes

- **Storyboard undo — no dangling selection.** `withLiveTransient` now resets `activeShotId` to `null` when the selected shot isn't present in the restored checkpoint (e.g. undoing the addition of the shot you had selected), instead of leaving `activeShotId` pointing at a nonexistent shot — which otherwise leaks into agent snapshots (`selectedShotId`) and "selected" shot resolution.
- **`removeBoard` clears the CAS token.** It now also deletes `serverRevisions[id]`, matching `ScriptStore.removeScript`, so re-creating a board under the same id can't reuse a stale revision and misfire an autosave.
- **Memoization holds on the toolbars.** `UndoRedoButtons`' `onUndo`/`onRedo` are wrapped in `useCallback` in both `StoryboardBoard` and `ScriptDocumentPane`, so the memoized button group isn't re-rendered by fresh inline-arrow identities each render.

## Verification

`npm run typecheck` (web) clean, targeted `eslint` clean, `StoryboardStore` and `ScriptStore` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xzaZWfW4sCTyJeFNizThk

---
_Generated by [Claude Code](https://claude.ai/code/session_015xzaZWfW4sCTyJeFNizThk)_