### PR TITLE
Fix provider onboarding dialog crash when rendered outside the router

### DIFF
--- a/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import { memo, useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import { useShallow } from "zustand/react/shallow";
 import BoltRoundedIcon from "@mui/icons-material/BoltRounded";
@@ -22,6 +21,7 @@ import {
 } from "../ui_primitives";
 import { useSecrets } from "../../hooks/useSecrets";
 import useProviderOnboardingStore from "../../stores/ProviderOnboardingStore";
+import { navigateTo } from "../../lib/appNavigation";
 import ollamaIcon from "../../icons/providers/ollama.svg";
 import ProviderOnboardingCard from "./ProviderOnboardingCard";
 import CostGuide from "./CostGuide";
@@ -69,7 +69,6 @@ const SectionHeading = ({
  */
 const ProviderOnboardingDialog: React.FC = () => {
   const theme = useTheme();
-  const navigate = useNavigate();
   const { open, capability, reason, highlightSecretKey, dismiss } =
     useProviderOnboardingStore(
       useShallow((s) => ({
@@ -106,8 +105,8 @@ const ProviderOnboardingDialog: React.FC = () => {
 
   const handleOpenSettings = useCallback(() => {
     dismiss();
-    navigate("/settings?tab=1");
-  }, [dismiss, navigate]);
+    navigateTo("/settings?tab=1");
+  }, [dismiss]);
 
   if (!open) {
     return null;

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import ProviderOnboardingDialog from "../ProviderOnboardingDialog";
+import useProviderOnboardingStore from "../../../stores/ProviderOnboardingStore";
+import { useSecrets } from "../../../hooks/useSecrets";
+import { navigateTo } from "../../../lib/appNavigation";
+import { useOAuthConnection } from "../../../hooks/useOAuthConnection";
+import useSecretsStore from "../../../stores/SecretsStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+
+jest.mock("../../../stores/ProviderOnboardingStore");
+jest.mock("../../../hooks/useSecrets");
+jest.mock("../../../lib/appNavigation");
+jest.mock("../../../hooks/useOAuthConnection");
+jest.mock("../../../stores/SecretsStore");
+jest.mock("../../../stores/NotificationStore");
+
+const mockUseProviderOnboardingStore =
+  useProviderOnboardingStore as unknown as jest.Mock;
+const mockUseSecrets = useSecrets as jest.MockedFunction<typeof useSecrets>;
+const mockNavigateTo = navigateTo as jest.MockedFunction<typeof navigateTo>;
+const mockUseOAuthConnection = useOAuthConnection as jest.MockedFunction<
+  typeof useOAuthConnection
+>;
+const mockUseSecretsStore = useSecretsStore as unknown as jest.Mock;
+const mockUseNotificationStore = useNotificationStore as unknown as jest.Mock;
+
+const dismiss = jest.fn();
+
+const storeState = {
+  open: true,
+  capability: null,
+  reason: null,
+  highlightSecretKey: null,
+  dismiss
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseProviderOnboardingStore.mockImplementation(
+    (selector: (s: unknown) => unknown) => selector(storeState)
+  );
+  mockUseSecrets.mockReturnValue({ secrets: [] } as ReturnType<
+    typeof useSecrets
+  >);
+  mockUseOAuthConnection.mockReturnValue({
+    label: "",
+    isConnected: false,
+    isConnecting: false,
+    canDisconnect: false,
+    connect: jest.fn(),
+    disconnect: jest.fn()
+  });
+  mockUseSecretsStore.mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({ updateSecret: jest.fn() })
+  );
+  mockUseNotificationStore.mockImplementation(
+    (selector: (s: unknown) => unknown) => selector({ addNotification: jest.fn() })
+  );
+});
+
+const renderDialog = () =>
+  render(
+    // Intentionally NOT wrapped in a Router — this dialog is mounted as a
+    // sibling of <RouterProvider>, so it must not depend on router context.
+    <ThemeProvider theme={mockTheme}>
+      <ProviderOnboardingDialog />
+    </ThemeProvider>
+  );
+
+describe("ProviderOnboardingDialog", () => {
+  it("renders outside a Router without crashing", () => {
+    renderDialog();
+    expect(screen.getByText("Connect an AI provider")).toBeInTheDocument();
+  });
+
+  it("navigates to settings via the router singleton, not useNavigate", async () => {
+    renderDialog();
+    await userEvent.click(
+      screen.getByRole("button", { name: /see all providers in settings/i })
+    );
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    expect(mockNavigateTo).toHaveBeenCalledWith("/settings?tab=1");
+  });
+});

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -45,9 +45,12 @@ beforeEach(() => {
   mockUseProviderOnboardingStore.mockImplementation(
     (selector: (s: unknown) => unknown) => selector(storeState)
   );
-  mockUseSecrets.mockReturnValue({ secrets: [] } as ReturnType<
-    typeof useSecrets
-  >);
+  mockUseSecrets.mockReturnValue({
+    secrets: [],
+    isLoading: false,
+    isSuccess: true,
+    isApiKeySet: () => false
+  } as unknown as ReturnType<typeof useSecrets>);
   mockUseOAuthConnection.mockReturnValue({
     label: "",
     isConnected: false,

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -75,6 +75,7 @@ const ProviderOnboardingDialog = React.lazy(
 
 import { installIpcLogBridge } from "./logging/ipcLogBridge";
 import MobileClassProvider from "./components/MobileClassProvider";
+import { registerAppRouter } from "./lib/appNavigation";
 import { SkipLinks } from "./components/ui_primitives";
 
 import ChatComposerLayout from "./components/chat/containers/ChatComposerLayout";
@@ -547,6 +548,9 @@ const handleHashRoute = () => {
 handleHashRoute();
 
 const router = createBrowserRouter(getRoutes());
+// Expose the router singleton to components rendered outside the router tree
+// (global dialogs), so they can navigate without the useNavigate hook.
+registerAppRouter(router);
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element #root not found");
 const root = ReactDOM.createRoot(rootElement);

--- a/web/src/lib/appNavigation.ts
+++ b/web/src/lib/appNavigation.ts
@@ -23,5 +23,9 @@ export const navigateTo = (to: string): void => {
     void appRouter.navigate(to);
     return;
   }
-  window.location.assign(to);
+  // No router registered (preview harness, or a node-environment test where
+  // `window` is undefined). Fall back to a location change only in the DOM.
+  if (typeof window !== "undefined") {
+    window.location.assign(to);
+  }
 };

--- a/web/src/lib/appNavigation.ts
+++ b/web/src/lib/appNavigation.ts
@@ -1,0 +1,27 @@
+/**
+ * Router-independent navigation for components that render outside the
+ * `<RouterProvider>` tree.
+ *
+ * Global dialogs (e.g. the provider onboarding dialog) are mounted as siblings
+ * of `<RouterProvider>`, so they cannot call the `useNavigate` hook — it throws
+ * "useNavigate() may be used only in the context of a <Router> component". The
+ * app router is a singleton created once at startup; index.tsx registers it
+ * here, and callers navigate through the singleton's `navigate` method, which
+ * works from any context. When no router is registered (preview harnesses,
+ * tests) navigation falls back to a plain location change.
+ */
+type AppRouter = { navigate: (to: string) => void | Promise<void> };
+
+let appRouter: AppRouter | null = null;
+
+export const registerAppRouter = (router: AppRouter): void => {
+  appRouter = router;
+};
+
+export const navigateTo = (to: string): void => {
+  if (appRouter) {
+    void appRouter.navigate(to);
+    return;
+  }
+  window.location.assign(to);
+};


### PR DESCRIPTION
## Problem

`ProviderOnboardingDialog` is mounted as a **sibling** of `<RouterProvider>`, not a descendant:

- `web/src/index.tsx` renders it next to `<RouterProvider>` (alongside the other global dialogs).
- `web/src/components/preview/ComponentPreview.tsx` renders it in a preview harness with no router at all.

The component called the `useNavigate` hook unconditionally on every render (before its `if (!open)` early return). Because there is no `<Router>` ancestor, React Router throws:

> useNavigate() may be used only in the context of a `<Router>` component.

…the moment the dialog mounts, crashing the app.

## Fix

Route navigation through the app-router **singleton** instead of the `useNavigate` hook — the same pattern `MenuNavigationBridge` already uses (`router.navigate("/settings")`), which works from any context.

- Add `web/src/lib/appNavigation.ts`: a tiny registry holding the router singleton, with `registerAppRouter(router)` and `navigateTo(to)`. When no router is registered (preview harness, tests) it falls back to a plain `window.location.assign`.
- `index.tsx` registers the router on startup, right after `createBrowserRouter`.
- `ProviderOnboardingDialog` drops `useNavigate`/`react-router-dom` and calls `navigateTo("/settings?tab=1")`.

## Testing

- New `ProviderOnboardingDialog.test.tsx` renders the dialog with **no Router wrapper** (the exact crash scenario) and asserts it renders, and that clicking "See all providers in Settings" dismisses and calls `navigateTo("/settings?tab=1")`.
- Existing provider-onboarding tests still pass; lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gMv7A5DSywoQE2JJG6XG9)_