### PR TITLE
feat(cli): expose RAG collections and cost tracking on the CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,6 +483,33 @@ npm run dev:nodetool -- assets list --content-type image/png    # Filter by type
 npm run dev:nodetool -- assets get <asset_id>                   # Asset details
 ```
 
+### nodetool collections (RAG Vector Store)
+
+Requires a running server. Manages the vector-store collections that back RAG:
+CRUD, document indexing, and semantic search.
+
+```bash
+npm run dev:nodetool -- collections list                        # List collections + counts
+npm run dev:nodetool -- collections create my_docs --embedding-model <id>
+npm run dev:nodetool -- collections index my_docs notes.md report.txt   # Chunk + index files
+npm run dev:nodetool -- collections query my_docs "how does X work" -n 5 # Semantic search
+npm run dev:nodetool -- collections get my_docs                 # Metadata + document count
+npm run dev:nodetool -- collections delete my_docs --yes        # Delete (skip confirm)
+```
+
+### nodetool costs
+
+Requires a running server. Aggregates the per-call cost/token records NodeTool
+tracks for every LLM call.
+
+```bash
+npm run dev:nodetool -- costs summary                           # Overall + per-provider/model
+npm run dev:nodetool -- costs list --limit 20                   # Recent calls
+npm run dev:nodetool -- costs list --provider anthropic         # Filter by provider/model
+npm run dev:nodetool -- costs by-provider                       # Grouped by provider
+npm run dev:nodetool -- costs by-model --provider openai        # Grouped by model
+```
+
 ### nodetool secrets
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,8 +485,10 @@ npm run dev:nodetool -- assets get <asset_id>                   # Asset details
 
 ### nodetool collections (RAG Vector Store)
 
-Requires a running server. Manages the vector-store collections that back RAG:
-CRUD, document indexing, and semantic search.
+Manages the vector-store collections that back RAG: CRUD, document indexing,
+and semantic search. Runs in-process against the default vector provider
+(sqlite-vec unless `NODETOOL_VECTOR_PROVIDER` points elsewhere) — no server
+needed.
 
 ```bash
 npm run dev:nodetool -- collections list                        # List collections + counts
@@ -499,8 +501,8 @@ npm run dev:nodetool -- collections delete my_docs --yes        # Delete (skip c
 
 ### nodetool costs
 
-Requires a running server. Aggregates the per-call cost/token records NodeTool
-tracks for every LLM call.
+Aggregates the per-call cost/token records NodeTool tracks for every LLM call,
+read straight from the local DB — no server needed.
 
 ```bash
 npm run dev:nodetool -- costs summary                           # Overall + per-provider/model

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -53,7 +53,12 @@ export function registerCollectionCommands(program: Command): void {
         await setupLocalDb();
         const provider = getDefaultVectorProvider();
         const infos = await provider.listCollections();
-        const rows = [];
+        const rows: {
+          name: string;
+          count: number;
+          embedding_model: string | number | boolean;
+          workflow: string;
+        }[] = [];
         for (const info of infos) {
           try {
             const collection = await provider.getCollection({ name: info.name });
@@ -230,12 +235,17 @@ export function registerCollectionCommands(program: Command): void {
             const fileName = basename(file);
             const chunks = splitDocument(text, fileName);
             if (chunks.length > 0) {
+              // Derive the record-id prefix from the full path (sanitized) so
+              // two files with the same basename (a/foo.txt, b/foo.txt) don't
+              // collide and overwrite each other's chunks. Re-indexing the same
+              // path stays idempotent.
+              const idPrefix = file.replace(/[^A-Za-z0-9._-]+/g, "_");
               await collection.upsert(
                 chunks.map((c, i) => ({
-                  id: `${fileName}#${i}`,
+                  id: `${idPrefix}#${i}`,
                   document: c.text,
                   metadata: {
-                    source: c.source_id,
+                    source: file,
                     start_index: String(c.start_index)
                   }
                 }))

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -73,8 +73,13 @@ export function registerCollectionCommands(program: Command): void {
               workflow:
                 (await workflowName(metadata["workflow"])) ?? ""
             });
-          } catch {
-            // Skip a collection that races a delete between list and get.
+          } catch (err) {
+            // A collection can race a delete between listCollections() and
+            // getCollection(); skip only that. Surface anything else (corrupt
+            // collection, provider failure) instead of hiding it.
+            if (!(err instanceof CollectionNotFoundError)) {
+              throw err;
+            }
           }
         }
         if (opts.json) {

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -1,0 +1,253 @@
+/**
+ * `nodetool collections` — manage RAG vector-store collections.
+ *
+ * CRUD + semantic query go through the tRPC `collections` router; document
+ * indexing uses the REST multipart endpoint (`POST /api/collections/:name/index`)
+ * which tRPC's JSON link can't carry. All commands talk to a running server
+ * (default http://localhost:7777), so start one with `nodetool serve` first.
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import type { Command } from "commander";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@nodetool-ai/websocket/trpc";
+
+import { asJson, printTable, printKv, confirm } from "./deploy-helpers.js";
+
+const DEFAULT_API_URL =
+  process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";
+
+function apiClient(apiUrl: string) {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${apiUrl}/trpc`,
+        // POST keeps batched input in the body, under reverse-proxy URL limits.
+        methodOverride: "POST"
+      })
+    ]
+  });
+}
+
+function fail(e: unknown): never {
+  console.error(String(e instanceof Error ? e.message : e));
+  process.exit(1);
+}
+
+export function registerCollectionCommands(program: Command): void {
+  const collections = program
+    .command("collections")
+    .description("Manage RAG vector-store collections");
+
+  collections
+    .command("list")
+    .description("List collections with document counts")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+      try {
+        const data = await apiClient(opts.apiUrl).collections.list.query();
+        if (opts.json) {
+          asJson(data);
+          return;
+        }
+        printTable(
+          data.collections.map((c) => ({
+            name: c.name,
+            count: c.count,
+            embedding_model: c.metadata["embedding_model"] ?? "",
+            workflow: c.workflow_name ?? ""
+          }))
+        );
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  collections
+    .command("get <name>")
+    .description("Show a collection's metadata and document count")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(async (name: string, opts: { apiUrl: string; json?: boolean }) => {
+      try {
+        const data = await apiClient(opts.apiUrl).collections.get.query({ name });
+        if (opts.json) {
+          asJson(data);
+          return;
+        }
+        printKv({ name: data.name, count: data.count, ...data.metadata });
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  collections
+    .command("create <name>")
+    .description("Create a collection")
+    .option("--embedding-model <model>", "Embedding model id")
+    .option("--embedding-provider <provider>", "Embedding provider id")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        name: string,
+        opts: {
+          apiUrl: string;
+          embeddingModel?: string;
+          embeddingProvider?: string;
+          json?: boolean;
+        }
+      ) => {
+        try {
+          const data = await apiClient(opts.apiUrl).collections.create.mutate({
+            name,
+            ...(opts.embeddingModel
+              ? { embedding_model: opts.embeddingModel }
+              : {}),
+            ...(opts.embeddingProvider
+              ? { embedding_provider: opts.embeddingProvider }
+              : {})
+          });
+          if (opts.json) {
+            asJson(data);
+            return;
+          }
+          console.log(`Created collection '${data.name}'.`);
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+
+  collections
+    .command("delete <name>")
+    .description("Delete a collection and all its documents")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .action(
+      async (name: string, opts: { apiUrl: string; yes?: boolean }) => {
+        try {
+          const ok = await confirm(
+            `Delete collection '${name}' and all its documents?`,
+            { force: opts.yes }
+          );
+          if (!ok) {
+            console.error("Aborted.");
+            process.exit(1);
+          }
+          const data = await apiClient(opts.apiUrl).collections.delete.mutate({
+            name
+          });
+          console.log(data.message);
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+
+  collections
+    .command("query <name> <text...>")
+    .description("Semantic search over a collection")
+    .option("-n, --n-results <n>", "Number of results per query", "10")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        name: string,
+        text: string[],
+        opts: { apiUrl: string; nResults: string; json?: boolean }
+      ) => {
+        try {
+          const nResults = Number.parseInt(opts.nResults, 10);
+          if (!Number.isFinite(nResults) || nResults <= 0) {
+            console.error(`Invalid --n-results value: ${opts.nResults}`);
+            process.exit(1);
+          }
+          const query = text.join(" ");
+          const data = await apiClient(opts.apiUrl).collections.query.query({
+            name,
+            query_texts: [query],
+            n_results: nResults
+          });
+          if (opts.json) {
+            asJson(data);
+            return;
+          }
+          const ids = data.ids[0] ?? [];
+          const documents = data.documents[0] ?? [];
+          const distances = data.distances[0] ?? [];
+          if (ids.length === 0) {
+            console.log("(no matches)");
+            return;
+          }
+          printTable(
+            ids.map((id, i) => ({
+              id,
+              distance: distances[i]?.toFixed(4) ?? "",
+              document: (documents[i] ?? "").replace(/\s+/g, " ").slice(0, 80)
+            }))
+          );
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+
+  collections
+    .command("index <name> <file...>")
+    .description("Chunk and index one or more text documents into a collection")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        name: string,
+        files: string[],
+        opts: { apiUrl: string; json?: boolean }
+      ) => {
+        const apiUrl = opts.apiUrl.replace(/\/+$/, "");
+        const results: { file: string; chunks: number; error: string }[] = [];
+        for (const file of files) {
+          try {
+            const bytes = await readFile(file);
+            const form = new FormData();
+            form.append(
+              "file",
+              new Blob([bytes]),
+              basename(file)
+            );
+            const res = await fetch(
+              `${apiUrl}/api/collections/${encodeURIComponent(name)}/index`,
+              { method: "POST", body: form }
+            );
+            const body = (await res.json().catch(() => ({}))) as {
+              chunks?: number;
+              detail?: string;
+            };
+            if (!res.ok) {
+              results.push({
+                file,
+                chunks: 0,
+                error: body.detail ?? `HTTP ${res.status}`
+              });
+            } else {
+              results.push({ file, chunks: body.chunks ?? 0, error: "" });
+            }
+          } catch (e) {
+            results.push({
+              file,
+              chunks: 0,
+              error: String(e instanceof Error ? e.message : e)
+            });
+          }
+        }
+        if (opts.json) {
+          asJson(results);
+        } else {
+          printTable(results);
+        }
+        if (results.some((r) => r.error)) process.exit(1);
+      }
+    );
+}

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -13,7 +13,7 @@ import type { Command } from "commander";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@nodetool-ai/websocket/trpc";
 
-import { asJson, printTable, printKv, confirm } from "./deploy-helpers.js";
+import { asJson, printTable, printKv, confirm } from "./output.js";
 
 const DEFAULT_API_URL =
   process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";
@@ -126,8 +126,12 @@ export function registerCollectionCommands(program: Command): void {
     .description("Delete a collection and all its documents")
     .option("-y, --yes", "Skip the confirmation prompt")
     .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
     .action(
-      async (name: string, opts: { apiUrl: string; yes?: boolean }) => {
+      async (
+        name: string,
+        opts: { apiUrl: string; yes?: boolean; json?: boolean }
+      ) => {
         try {
           const ok = await confirm(
             `Delete collection '${name}' and all its documents?`,
@@ -140,6 +144,10 @@ export function registerCollectionCommands(program: Command): void {
           const data = await apiClient(opts.apiUrl).collections.delete.mutate({
             name
           });
+          if (opts.json) {
+            asJson(data);
+            return;
+          }
           console.log(data.message);
         } catch (e) {
           fail(e);

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -156,7 +156,8 @@ export function registerCollectionCommands(program: Command): void {
           { force: opts.yes }
         );
         if (!ok) {
-          console.error("Aborted.");
+          if (opts.json) asJson({ deleted: false, aborted: true });
+          else console.error("Aborted.");
           process.exit(1);
         }
         await setupLocalDb();

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -1,38 +1,42 @@
 /**
  * `nodetool collections` — manage RAG vector-store collections.
  *
- * CRUD + semantic query go through the tRPC `collections` router; document
- * indexing uses the REST multipart endpoint (`POST /api/collections/:name/index`)
- * which tRPC's JSON link can't carry. All commands talk to a running server
- * (default http://localhost:7777), so start one with `nodetool serve` first.
+ * Runs in-process against the default vector provider (sqlite-vec unless
+ * NODETOOL_VECTOR_PROVIDER points elsewhere), so it works without a running
+ * server. Indexing chunks documents with the same splitter the server uses.
  */
 
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import type { Command } from "commander";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
-import type { AppRouter } from "@nodetool-ai/websocket/trpc";
+import {
+  getDefaultVectorProvider,
+  splitDocument,
+  CollectionNotFoundError
+} from "@nodetool-ai/vectorstore";
+import { Workflow } from "@nodetool-ai/models";
 
 import { asJson, printTable, printKv, confirm } from "./output.js";
-
-const DEFAULT_API_URL =
-  process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";
-
-function apiClient(apiUrl: string) {
-  return createTRPCClient<AppRouter>({
-    links: [
-      httpBatchLink({
-        url: `${apiUrl}/trpc`,
-        // POST keeps batched input in the body, under reverse-proxy URL limits.
-        methodOverride: "POST"
-      })
-    ]
-  });
-}
+import { setupLocalDb } from "./local-db.js";
 
 function fail(e: unknown): never {
+  if (e instanceof CollectionNotFoundError) {
+    console.error(e.message);
+    process.exit(1);
+  }
   console.error(String(e instanceof Error ? e.message : e));
   process.exit(1);
+}
+
+/** Resolve a workflow's name from an id, forgivingly (null on any failure). */
+async function workflowName(id: unknown): Promise<string | null> {
+  if (typeof id !== "string" || !id) return null;
+  try {
+    const wf = (await Workflow.get(id)) as { name?: string } | null;
+    return wf?.name ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export function registerCollectionCommands(program: Command): void {
@@ -43,23 +47,34 @@ export function registerCollectionCommands(program: Command): void {
   collections
     .command("list")
     .description("List collections with document counts")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+    .action(async (opts: { json?: boolean }) => {
       try {
-        const data = await apiClient(opts.apiUrl).collections.list.query();
+        await setupLocalDb();
+        const provider = getDefaultVectorProvider();
+        const infos = await provider.listCollections();
+        const rows = [];
+        for (const info of infos) {
+          try {
+            const collection = await provider.getCollection({ name: info.name });
+            const count = await collection.count();
+            const metadata = info.metadata ?? {};
+            rows.push({
+              name: info.name,
+              count,
+              embedding_model: metadata["embedding_model"] ?? "",
+              workflow:
+                (await workflowName(metadata["workflow"])) ?? ""
+            });
+          } catch {
+            // Skip a collection that races a delete between list and get.
+          }
+        }
         if (opts.json) {
-          asJson(data);
+          asJson(rows);
           return;
         }
-        printTable(
-          data.collections.map((c) => ({
-            name: c.name,
-            count: c.count,
-            embedding_model: c.metadata["embedding_model"] ?? "",
-            workflow: c.workflow_name ?? ""
-          }))
-        );
+        printTable(rows);
       } catch (e) {
         fail(e);
       }
@@ -68,16 +83,20 @@ export function registerCollectionCommands(program: Command): void {
   collections
     .command("get <name>")
     .description("Show a collection's metadata and document count")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(async (name: string, opts: { apiUrl: string; json?: boolean }) => {
+    .action(async (name: string, opts: { json?: boolean }) => {
       try {
-        const data = await apiClient(opts.apiUrl).collections.get.query({ name });
+        await setupLocalDb();
+        const collection = await getDefaultVectorProvider().getCollection({
+          name
+        });
+        const count = await collection.count();
+        const metadata = collection.metadata ?? {};
         if (opts.json) {
-          asJson(data);
+          asJson({ name: collection.name, count, metadata });
           return;
         }
-        printKv({ name: data.name, count: data.count, ...data.metadata });
+        printKv({ name: collection.name, count, ...metadata });
       } catch (e) {
         fail(e);
       }
@@ -88,33 +107,32 @@ export function registerCollectionCommands(program: Command): void {
     .description("Create a collection")
     .option("--embedding-model <model>", "Embedding model id")
     .option("--embedding-provider <provider>", "Embedding provider id")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
     .action(
       async (
         name: string,
         opts: {
-          apiUrl: string;
           embeddingModel?: string;
           embeddingProvider?: string;
           json?: boolean;
         }
       ) => {
         try {
-          const data = await apiClient(opts.apiUrl).collections.create.mutate({
+          await setupLocalDb();
+          const metadata: Record<string, string> = {};
+          if (opts.embeddingModel)
+            metadata["embedding_model"] = opts.embeddingModel;
+          if (opts.embeddingProvider)
+            metadata["embedding_provider"] = opts.embeddingProvider;
+          const collection = await getDefaultVectorProvider().createCollection({
             name,
-            ...(opts.embeddingModel
-              ? { embedding_model: opts.embeddingModel }
-              : {}),
-            ...(opts.embeddingProvider
-              ? { embedding_provider: opts.embeddingProvider }
-              : {})
+            metadata
           });
           if (opts.json) {
-            asJson(data);
+            asJson({ name: collection.name, metadata: collection.metadata });
             return;
           }
-          console.log(`Created collection '${data.name}'.`);
+          console.log(`Created collection '${collection.name}'.`);
         } catch (e) {
           fail(e);
         }
@@ -125,76 +143,68 @@ export function registerCollectionCommands(program: Command): void {
     .command("delete <name>")
     .description("Delete a collection and all its documents")
     .option("-y, --yes", "Skip the confirmation prompt")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(
-      async (
-        name: string,
-        opts: { apiUrl: string; yes?: boolean; json?: boolean }
-      ) => {
-        try {
-          const ok = await confirm(
-            `Delete collection '${name}' and all its documents?`,
-            { force: opts.yes }
-          );
-          if (!ok) {
-            console.error("Aborted.");
-            process.exit(1);
-          }
-          const data = await apiClient(opts.apiUrl).collections.delete.mutate({
-            name
-          });
-          if (opts.json) {
-            asJson(data);
-            return;
-          }
-          console.log(data.message);
-        } catch (e) {
-          fail(e);
+    .action(async (name: string, opts: { yes?: boolean; json?: boolean }) => {
+      try {
+        const ok = await confirm(
+          `Delete collection '${name}' and all its documents?`,
+          { force: opts.yes }
+        );
+        if (!ok) {
+          console.error("Aborted.");
+          process.exit(1);
         }
+        await setupLocalDb();
+        await getDefaultVectorProvider().deleteCollection(name);
+        const message = `Collection ${name} deleted successfully`;
+        if (opts.json) {
+          asJson({ message });
+          return;
+        }
+        console.log(message);
+      } catch (e) {
+        fail(e);
       }
-    );
+    });
 
   collections
     .command("query <name> <text...>")
     .description("Semantic search over a collection")
-    .option("-n, --n-results <n>", "Number of results per query", "10")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("-n, --n-results <n>", "Number of results", "10")
     .option("--json", "Output as JSON")
     .action(
       async (
         name: string,
         text: string[],
-        opts: { apiUrl: string; nResults: string; json?: boolean }
+        opts: { nResults: string; json?: boolean }
       ) => {
+        const nResults = Number.parseInt(opts.nResults, 10);
+        if (!Number.isFinite(nResults) || nResults <= 0) {
+          console.error(`Invalid --n-results value: ${opts.nResults}`);
+          process.exit(1);
+        }
         try {
-          const nResults = Number.parseInt(opts.nResults, 10);
-          if (!Number.isFinite(nResults) || nResults <= 0) {
-            console.error(`Invalid --n-results value: ${opts.nResults}`);
-            process.exit(1);
-          }
-          const query = text.join(" ");
-          const data = await apiClient(opts.apiUrl).collections.query.query({
-            name,
-            query_texts: [query],
-            n_results: nResults
+          await setupLocalDb();
+          const collection = await getDefaultVectorProvider().getCollection({
+            name
+          });
+          const matches = await collection.query({
+            text: text.join(" "),
+            topK: nResults
           });
           if (opts.json) {
-            asJson(data);
+            asJson(matches);
             return;
           }
-          const ids = data.ids[0] ?? [];
-          const documents = data.documents[0] ?? [];
-          const distances = data.distances[0] ?? [];
-          if (ids.length === 0) {
+          if (matches.length === 0) {
             console.log("(no matches)");
             return;
           }
           printTable(
-            ids.map((id, i) => ({
-              id,
-              distance: distances[i]?.toFixed(4) ?? "",
-              document: (documents[i] ?? "").replace(/\s+/g, " ").slice(0, 80)
+            matches.map((m) => ({
+              id: m.id,
+              distance: m.distance?.toFixed(4) ?? "",
+              document: (m.document ?? "").replace(/\s+/g, " ").slice(0, 80)
             }))
           );
         } catch (e) {
@@ -206,42 +216,32 @@ export function registerCollectionCommands(program: Command): void {
   collections
     .command("index <name> <file...>")
     .description("Chunk and index one or more text documents into a collection")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(
-      async (
-        name: string,
-        files: string[],
-        opts: { apiUrl: string; json?: boolean }
-      ) => {
-        const apiUrl = opts.apiUrl.replace(/\/+$/, "");
+    .action(async (name: string, files: string[], opts: { json?: boolean }) => {
+      try {
+        await setupLocalDb();
+        const collection = await getDefaultVectorProvider().getCollection({
+          name
+        });
         const results: { file: string; chunks: number; error: string }[] = [];
         for (const file of files) {
           try {
-            const bytes = await readFile(file);
-            const form = new FormData();
-            form.append(
-              "file",
-              new Blob([bytes]),
-              basename(file)
-            );
-            const res = await fetch(
-              `${apiUrl}/api/collections/${encodeURIComponent(name)}/index`,
-              { method: "POST", body: form }
-            );
-            const body = (await res.json().catch(() => ({}))) as {
-              chunks?: number;
-              detail?: string;
-            };
-            if (!res.ok) {
-              results.push({
-                file,
-                chunks: 0,
-                error: body.detail ?? `HTTP ${res.status}`
-              });
-            } else {
-              results.push({ file, chunks: body.chunks ?? 0, error: "" });
+            const text = await readFile(file, "utf8");
+            const fileName = basename(file);
+            const chunks = splitDocument(text, fileName);
+            if (chunks.length > 0) {
+              await collection.upsert(
+                chunks.map((c, i) => ({
+                  id: `${fileName}#${i}`,
+                  document: c.text,
+                  metadata: {
+                    source: c.source_id,
+                    start_index: String(c.start_index)
+                  }
+                }))
+              );
             }
+            results.push({ file, chunks: chunks.length, error: "" });
           } catch (e) {
             results.push({
               file,
@@ -256,6 +256,8 @@ export function registerCollectionCommands(program: Command): void {
           printTable(results);
         }
         if (results.some((r) => r.error)) process.exit(1);
+      } catch (e) {
+        fail(e);
       }
-    );
+    });
 }

--- a/packages/cli/src/commands/collections.ts
+++ b/packages/cli/src/commands/collections.ts
@@ -30,7 +30,9 @@ function fail(e: unknown): never {
 
 /** Resolve a workflow's name from an id, forgivingly (null on any failure). */
 async function workflowName(id: unknown): Promise<string | null> {
-  if (typeof id !== "string" || !id) return null;
+  if (typeof id !== "string" || !id) {
+    return null;
+  }
   try {
     const wf = (await Workflow.get(id)) as { name?: string } | null;
     return wf?.name ?? null;
@@ -125,10 +127,12 @@ export function registerCollectionCommands(program: Command): void {
         try {
           await setupLocalDb();
           const metadata: Record<string, string> = {};
-          if (opts.embeddingModel)
+          if (opts.embeddingModel) {
             metadata["embedding_model"] = opts.embeddingModel;
-          if (opts.embeddingProvider)
+          }
+          if (opts.embeddingProvider) {
             metadata["embedding_provider"] = opts.embeddingProvider;
+          }
           const collection = await getDefaultVectorProvider().createCollection({
             name,
             metadata
@@ -156,8 +160,11 @@ export function registerCollectionCommands(program: Command): void {
           { force: opts.yes }
         );
         if (!ok) {
-          if (opts.json) asJson({ deleted: false, aborted: true });
-          else console.error("Aborted.");
+          if (opts.json) {
+            asJson({ deleted: false, aborted: true });
+          } else {
+            console.error("Aborted.");
+          }
           process.exit(1);
         }
         await setupLocalDb();
@@ -266,7 +273,9 @@ export function registerCollectionCommands(program: Command): void {
         } else {
           printTable(results);
         }
-        if (results.some((r) => r.error)) process.exit(1);
+        if (results.some((r) => r.error)) {
+          process.exit(1);
+        }
       } catch (e) {
         fail(e);
       }

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -1,0 +1,186 @@
+/**
+ * `nodetool costs` — inspect LLM/provider spend tracked in the local DB.
+ *
+ * Reads the tRPC `costs` router on a running server (default
+ * http://localhost:7777). Every LLM call NodeTool makes is recorded as a
+ * Prediction with token counts and cost; these commands aggregate them.
+ */
+
+import type { Command } from "commander";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@nodetool-ai/websocket/trpc";
+
+import { asJson, printTable, printKv } from "./deploy-helpers.js";
+
+const DEFAULT_API_URL =
+  process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";
+
+function apiClient(apiUrl: string) {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${apiUrl}/trpc`,
+        methodOverride: "POST"
+      })
+    ]
+  });
+}
+
+function fail(e: unknown): never {
+  console.error(String(e instanceof Error ? e.message : e));
+  process.exit(1);
+}
+
+function usd(n: number | null | undefined): string {
+  return `$${(n ?? 0).toFixed(4)}`;
+}
+
+export function registerCostsCommands(program: Command): void {
+  const costs = program
+    .command("costs")
+    .description("Inspect tracked LLM/provider spend");
+
+  costs
+    .command("summary")
+    .description("Overall spend plus per-provider and per-model breakdowns")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+      try {
+        const data = await apiClient(opts.apiUrl).costs.summary.query();
+        if (opts.json) {
+          asJson(data);
+          return;
+        }
+        console.log("\nOverall");
+        printKv({
+          total_cost: usd(data.overall.total_cost),
+          total_tokens: data.overall.total_tokens,
+          calls: data.overall.call_count
+        });
+        console.log("\nBy provider");
+        printTable(
+          data.by_provider.map((p) => ({
+            provider: p.provider,
+            cost: usd(p.total_cost),
+            tokens: p.total_tokens,
+            calls: p.call_count
+          }))
+        );
+        console.log("\nBy model");
+        printTable(
+          data.by_model.map((m) => ({
+            provider: m.provider,
+            model: m.model,
+            cost: usd(m.total_cost),
+            tokens: m.total_tokens,
+            calls: m.call_count
+          }))
+        );
+        console.log();
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  costs
+    .command("list")
+    .description("List recent LLM calls with cost and token counts")
+    .option("--provider <name>", "Filter by provider")
+    .option("--model <id>", "Filter by model")
+    .option("--limit <n>", "Max results", "50")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        apiUrl: string;
+        provider?: string;
+        model?: string;
+        limit: string;
+        json?: boolean;
+      }) => {
+        try {
+          const data = await apiClient(opts.apiUrl).costs.list.query({
+            limit: Number.parseInt(opts.limit, 10),
+            ...(opts.provider ? { provider: opts.provider } : {}),
+            ...(opts.model ? { model: opts.model } : {})
+          });
+          if (opts.json) {
+            asJson(data);
+            return;
+          }
+          printTable(
+            data.calls.map((c) => ({
+              created_at: c.created_at ?? "",
+              provider: c.provider,
+              model: c.model,
+              cost: usd(c.cost),
+              in: c.input_tokens ?? "",
+              out: c.output_tokens ?? ""
+            }))
+          );
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+
+  costs
+    .command("by-provider")
+    .description("Aggregate spend grouped by provider")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+      try {
+        const data =
+          await apiClient(opts.apiUrl).costs.aggregateByProvider.query();
+        if (opts.json) {
+          asJson(data);
+          return;
+        }
+        printTable(
+          data.map((p) => ({
+            provider: p.provider,
+            cost: usd(p.total_cost),
+            input_tokens: p.total_input_tokens,
+            output_tokens: p.total_output_tokens,
+            calls: p.call_count
+          }))
+        );
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  costs
+    .command("by-model")
+    .description("Aggregate spend grouped by model")
+    .option("--provider <name>", "Filter by provider")
+    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: { apiUrl: string; provider?: string; json?: boolean }) => {
+        try {
+          const data = await apiClient(opts.apiUrl).costs.aggregateByModel.query(
+            opts.provider ? { provider: opts.provider } : {}
+          );
+          if (opts.json) {
+            asJson(data);
+            return;
+          }
+          printTable(
+            data.map((m) => ({
+              provider: m.provider,
+              model: m.model,
+              cost: usd(m.total_cost),
+              input_tokens: m.total_input_tokens,
+              output_tokens: m.total_output_tokens,
+              calls: m.call_count
+            }))
+          );
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+}

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -99,9 +99,14 @@ export function registerCostsCommands(program: Command): void {
         limit: string;
         json?: boolean;
       }) => {
+        const limit = Number.parseInt(opts.limit, 10);
+        if (!Number.isFinite(limit) || limit <= 0) {
+          console.error(`Invalid --limit value: ${opts.limit}`);
+          process.exit(1);
+        }
         try {
           const data = await apiClient(opts.apiUrl).costs.list.query({
-            limit: Number.parseInt(opts.limit, 10),
+            limit,
             ...(opts.provider ? { provider: opts.provider } : {}),
             ...(opts.model ? { model: opts.model } : {})
           });

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -1,30 +1,16 @@
 /**
  * `nodetool costs` — inspect LLM/provider spend tracked in the local DB.
  *
- * Reads the tRPC `costs` router on a running server (default
- * http://localhost:7777). Every LLM call NodeTool makes is recorded as a
+ * Reads the local SQLite `predictions` table directly (in-process), so it works
+ * without a running server. Every LLM call NodeTool makes is recorded as a
  * Prediction with token counts and cost; these commands aggregate them.
  */
 
 import type { Command } from "commander";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
-import type { AppRouter } from "@nodetool-ai/websocket/trpc";
+import { Prediction } from "@nodetool-ai/models";
 
 import { asJson, printTable, printKv } from "./output.js";
-
-const DEFAULT_API_URL =
-  process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";
-
-function apiClient(apiUrl: string) {
-  return createTRPCClient<AppRouter>({
-    links: [
-      httpBatchLink({
-        url: `${apiUrl}/trpc`,
-        methodOverride: "POST"
-      })
-    ]
-  });
-}
+import { setupLocalDb, LOCAL_USER_ID } from "./local-db.js";
 
 function fail(e: unknown): never {
   console.error(String(e instanceof Error ? e.message : e));
@@ -43,24 +29,28 @@ export function registerCostsCommands(program: Command): void {
   costs
     .command("summary")
     .description("Overall spend plus per-provider and per-model breakdowns")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+    .action(async (opts: { json?: boolean }) => {
       try {
-        const data = await apiClient(opts.apiUrl).costs.summary.query();
+        await setupLocalDb();
+        const [overall, byProvider, byModel] = await Promise.all([
+          Prediction.aggregateByUser(LOCAL_USER_ID),
+          Prediction.aggregateByProvider(LOCAL_USER_ID),
+          Prediction.aggregateByModel(LOCAL_USER_ID)
+        ]);
         if (opts.json) {
-          asJson(data);
+          asJson({ overall, by_provider: byProvider, by_model: byModel });
           return;
         }
         console.log("\nOverall");
         printKv({
-          total_cost: usd(data.overall.total_cost),
-          total_tokens: data.overall.total_tokens,
-          calls: data.overall.call_count
+          total_cost: usd(overall.total_cost),
+          total_tokens: overall.total_tokens,
+          calls: overall.call_count
         });
         console.log("\nBy provider");
         printTable(
-          data.by_provider.map((p) => ({
+          byProvider.map((p) => ({
             provider: p.provider,
             cost: usd(p.total_cost),
             tokens: p.total_tokens,
@@ -69,7 +59,7 @@ export function registerCostsCommands(program: Command): void {
         );
         console.log("\nBy model");
         printTable(
-          data.by_model.map((m) => ({
+          byModel.map((m) => ({
             provider: m.provider,
             model: m.model,
             cost: usd(m.total_cost),
@@ -89,11 +79,9 @@ export function registerCostsCommands(program: Command): void {
     .option("--provider <name>", "Filter by provider")
     .option("--model <id>", "Filter by model")
     .option("--limit <n>", "Max results", "50")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
     .action(
       async (opts: {
-        apiUrl: string;
         provider?: string;
         model?: string;
         limit: string;
@@ -105,17 +93,18 @@ export function registerCostsCommands(program: Command): void {
           process.exit(1);
         }
         try {
-          const data = await apiClient(opts.apiUrl).costs.list.query({
+          await setupLocalDb();
+          const [calls] = await Prediction.paginate(LOCAL_USER_ID, {
             limit,
             ...(opts.provider ? { provider: opts.provider } : {}),
             ...(opts.model ? { model: opts.model } : {})
           });
           if (opts.json) {
-            asJson(data);
+            asJson(calls);
             return;
           }
           printTable(
-            data.calls.map((c) => ({
+            calls.map((c) => ({
               created_at: c.created_at ?? "",
               provider: c.provider,
               model: c.model,
@@ -133,12 +122,11 @@ export function registerCostsCommands(program: Command): void {
   costs
     .command("by-provider")
     .description("Aggregate spend grouped by provider")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(async (opts: { apiUrl: string; json?: boolean }) => {
+    .action(async (opts: { json?: boolean }) => {
       try {
-        const data =
-          await apiClient(opts.apiUrl).costs.aggregateByProvider.query();
+        await setupLocalDb();
+        const data = await Prediction.aggregateByProvider(LOCAL_USER_ID);
         if (opts.json) {
           asJson(data);
           return;
@@ -161,31 +149,30 @@ export function registerCostsCommands(program: Command): void {
     .command("by-model")
     .description("Aggregate spend grouped by model")
     .option("--provider <name>", "Filter by provider")
-    .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
     .option("--json", "Output as JSON")
-    .action(
-      async (opts: { apiUrl: string; provider?: string; json?: boolean }) => {
-        try {
-          const data = await apiClient(opts.apiUrl).costs.aggregateByModel.query(
-            opts.provider ? { provider: opts.provider } : {}
-          );
-          if (opts.json) {
-            asJson(data);
-            return;
-          }
-          printTable(
-            data.map((m) => ({
-              provider: m.provider,
-              model: m.model,
-              cost: usd(m.total_cost),
-              input_tokens: m.total_input_tokens,
-              output_tokens: m.total_output_tokens,
-              calls: m.call_count
-            }))
-          );
-        } catch (e) {
-          fail(e);
+    .action(async (opts: { provider?: string; json?: boolean }) => {
+      try {
+        await setupLocalDb();
+        const data = await Prediction.aggregateByModel(
+          LOCAL_USER_ID,
+          opts.provider ? { provider: opts.provider } : {}
+        );
+        if (opts.json) {
+          asJson(data);
+          return;
         }
+        printTable(
+          data.map((m) => ({
+            provider: m.provider,
+            model: m.model,
+            cost: usd(m.total_cost),
+            input_tokens: m.total_input_tokens,
+            output_tokens: m.total_output_tokens,
+            calls: m.call_count
+          }))
+        );
+      } catch (e) {
+        fail(e);
       }
-    );
+    });
 }

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -33,11 +33,28 @@ export function registerCostsCommands(program: Command): void {
     .action(async (opts: { json?: boolean }) => {
       try {
         await setupLocalDb();
-        const [overall, byProvider, byModel] = await Promise.all([
-          Prediction.aggregateByUser(LOCAL_USER_ID),
+        const [byProvider, byModel] = await Promise.all([
           Prediction.aggregateByProvider(LOCAL_USER_ID),
           Prediction.aggregateByModel(LOCAL_USER_ID)
         ]);
+        // Derive the overall totals by summing the provider aggregates rather
+        // than issuing a third full-table scan (aggregateByUser).
+        const overall = byProvider.reduce(
+          (acc, p) => ({
+            total_cost: acc.total_cost + p.total_cost,
+            total_input_tokens: acc.total_input_tokens + p.total_input_tokens,
+            total_output_tokens: acc.total_output_tokens + p.total_output_tokens,
+            total_tokens: acc.total_tokens + p.total_tokens,
+            call_count: acc.call_count + p.call_count
+          }),
+          {
+            total_cost: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_tokens: 0,
+            call_count: 0
+          }
+        );
         if (opts.json) {
           asJson({ overall, by_provider: byProvider, by_model: byModel });
           return;

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -10,7 +10,7 @@ import type { Command } from "commander";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@nodetool-ai/websocket/trpc";
 
-import { asJson, printTable, printKv } from "./deploy-helpers.js";
+import { asJson, printTable, printKv } from "./output.js";
 
 const DEFAULT_API_URL =
   process.env["NODETOOL_API_URL"] ?? "http://localhost:7777";

--- a/packages/cli/src/commands/deploy-helpers.ts
+++ b/packages/cli/src/commands/deploy-helpers.ts
@@ -5,7 +5,6 @@
  * prompt utilities, output formatters, and stubs used by `deploy add`.
  */
 
-import { createInterface } from "node:readline";
 import { spawnSync } from "node:child_process";
 
 import {
@@ -32,47 +31,18 @@ import { Asset, Workflow } from "@nodetool-ai/models";
 import { FileStorageAdapter } from "@nodetool-ai/runtime";
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
 
-// ---------------------------------------------------------------------------
-// Output helpers (duplicated from nodetool.ts so the CLI root stays simple)
-// ---------------------------------------------------------------------------
-
-/** Print a table to stdout. Missing values render as empty. */
-export function printTable(
-  rows: Record<string, unknown>[],
-  columns?: string[]
-): void {
-  if (rows.length === 0) {
-    console.log("(no results)");
-    return;
-  }
-  const cols = columns ?? Object.keys(rows[0]!);
-  const widths = cols.map((c) =>
-    Math.max(c.length, ...rows.map((r) => String(r[c] ?? "").length))
-  );
-  const sep = widths.map((w) => "─".repeat(w + 2)).join("┼");
-  const header = cols.map((c, i) => ` ${c.padEnd(widths[i]!)} `).join("│");
-  console.log(header);
-  console.log(sep);
-  for (const row of rows) {
-    console.log(
-      cols
-        .map((c, i) => ` ${String(row[c] ?? "").padEnd(widths[i]!)} `)
-        .join("│")
-    );
-  }
-}
-
-export function asJson(data: unknown): void {
-  console.log(JSON.stringify(data, null, 2));
-}
-
-export function printKv(rows: Record<string, unknown>): void {
-  const list = Object.entries(rows).map(([key, value]) => ({
-    key,
-    value: String(value ?? "")
-  }));
-  printTable(list, ["key", "value"]);
-}
+// Pure output + prompt helpers live in ./output.js so lightweight command
+// modules can import them without pulling in the heavy deploy stack above.
+// Re-exported here for the existing callers that import them from this module.
+import { promptHidden } from "./output.js";
+export {
+  printTable,
+  asJson,
+  printKv,
+  promptLine,
+  promptHidden,
+  confirm
+} from "./output.js";
 
 // ---------------------------------------------------------------------------
 // Config / manager factories
@@ -194,88 +164,6 @@ export async function getUserManager(
   const serverUrl = requireServerUrl(deployment, deploymentName);
   const token = await resolveAdminToken(opts);
   return new APIUserManager(serverUrl, token);
-}
-
-// ---------------------------------------------------------------------------
-// Prompts
-// ---------------------------------------------------------------------------
-
-/** Prompt for a line on stdin (echoes). TTY only — exits if non-TTY. */
-export async function promptLine(
-  message: string,
-  opts?: { default?: string }
-): Promise<string> {
-  if (!process.stdin.isTTY) {
-    console.error(`Missing value for interactive prompt: ${message}`);
-    process.exit(1);
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stderr
-  });
-  return new Promise<string>((resolve) => {
-    const suffix = opts?.default ? ` [${opts.default}]` : "";
-    rl.question(`${message}${suffix}: `, (answer) => {
-      rl.close();
-      const trimmed = answer.trim();
-      resolve(trimmed || (opts?.default ?? ""));
-    });
-  });
-}
-
-/** Prompt for hidden input (typed but not echoed). TTY only. */
-export async function promptHidden(message: string): Promise<string> {
-  if (!process.stdin.isTTY) {
-    console.error(`Missing value for interactive prompt: ${message}`);
-    process.exit(1);
-  }
-  process.stderr.write(message);
-  return new Promise<string>((resolve) => {
-    let value = "";
-    const stdin = process.stdin;
-    const wasRaw = stdin.isRaw;
-    stdin.setRawMode(true);
-    stdin.resume();
-    stdin.setEncoding("utf8");
-
-    const onData = (data: string): void => {
-      for (const ch of data) {
-        if (ch === "\r" || ch === "\n") {
-          stdin.setRawMode(wasRaw ?? false);
-          stdin.pause();
-          stdin.removeListener("data", onData);
-          process.stderr.write("\n");
-          resolve(value);
-          return;
-        }
-        if (ch === "\x03") {
-          stdin.setRawMode(wasRaw ?? false);
-          stdin.pause();
-          process.exit(130);
-        }
-        if (ch === "" || ch === "\b") {
-          value = value.slice(0, -1);
-          continue;
-        }
-        value += ch;
-      }
-    };
-    stdin.on("data", onData);
-  });
-}
-
-/** Yes/no confirm. Non-TTY returns the `force` value (default: false). */
-export async function confirm(
-  message: string,
-  opts?: { force?: boolean; default?: boolean }
-): Promise<boolean> {
-  if (opts?.force) return true;
-  if (!process.stdin.isTTY) return false;
-  const defaultYes = opts?.default ?? false;
-  const hint = defaultYes ? "[Y/n]" : "[y/N]";
-  const answer = await promptLine(`${message} ${hint}`);
-  if (!answer) return defaultYes;
-  return /^y(es)?$/i.test(answer);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/local-db.ts
+++ b/packages/cli/src/commands/local-db.ts
@@ -14,8 +14,11 @@ export const LOCAL_USER_ID = "1";
 let ready: Promise<void> | null = null;
 
 /**
- * Initialize the local SQLite DB and unlock the secret store (needed for any
- * provider that resolves API keys, e.g. embeddings). Idempotent.
+ * Initialize the local SQLite DB and best-effort unlock the secret store
+ * (needed for any provider that resolves API keys, e.g. embeddings). If the
+ * store can't be unlocked it warns to stderr and still resolves — a command
+ * that then needs a secret fails at that later point, so the DB stays usable
+ * for commands that don't. Idempotent.
  */
 export function setupLocalDb(): Promise<void> {
   ready ??= (async () => {

--- a/packages/cli/src/commands/local-db.ts
+++ b/packages/cli/src/commands/local-db.ts
@@ -1,0 +1,34 @@
+/**
+ * Local single-user DB bootstrap for CLI commands that run in-process rather
+ * than against a running server. Mirrors the `setupDb` in nodetool.ts (secrets
+ * commands) without pulling in the heavy deploy stack.
+ */
+
+import { initDb } from "@nodetool-ai/models";
+import { initMasterKey } from "@nodetool-ai/security";
+import { getDefaultDbPath } from "@nodetool-ai/config";
+
+/** Local single-user id used across the TS stack. */
+export const LOCAL_USER_ID = "1";
+
+let ready: Promise<void> | null = null;
+
+/**
+ * Initialize the local SQLite DB and unlock the secret store (needed for any
+ * provider that resolves API keys, e.g. embeddings). Idempotent.
+ */
+export function setupLocalDb(): Promise<void> {
+  ready ??= (async () => {
+    initDb(getDefaultDbPath());
+    try {
+      await initMasterKey();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `Could not unlock the secret store: ${msg}\n` +
+          `Tip: set SECRETS_MASTER_KEY or grant keychain access.\n`
+      );
+    }
+  })();
+  return ready;
+}

--- a/packages/cli/src/commands/models-hf.ts
+++ b/packages/cli/src/commands/models-hf.ts
@@ -17,7 +17,7 @@ import {
   type DownloadUpdate
 } from "@nodetool-ai/huggingface";
 
-import { asJson, printTable } from "./deploy-helpers.js";
+import { asJson, printTable } from "./output.js";
 
 // ---------------------------------------------------------------------------
 // Formatting helpers

--- a/packages/cli/src/commands/models-recommended.ts
+++ b/packages/cli/src/commands/models-recommended.ts
@@ -15,7 +15,7 @@ import {
 } from "@nodetool-ai/runtime";
 import type { UnifiedModel } from "@nodetool-ai/protocol";
 
-import { asJson, printTable } from "./deploy-helpers.js";
+import { asJson, printTable } from "./output.js";
 
 // ---------------------------------------------------------------------------
 // Category filters

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -1,0 +1,126 @@
+/**
+ * Lightweight CLI output + prompt helpers.
+ *
+ * These are pure (only `node:readline`), so command modules can format tables /
+ * JSON and prompt the user without pulling in the heavy deploy stack that
+ * `deploy-helpers.ts` imports at top level. `deploy-helpers.ts` re-exports
+ * everything here for backward compatibility.
+ */
+
+import { createInterface } from "node:readline";
+
+/** Print a table to stdout. Missing values render as empty. */
+export function printTable(
+  rows: Record<string, unknown>[],
+  columns?: string[]
+): void {
+  if (rows.length === 0) {
+    console.log("(no results)");
+    return;
+  }
+  const cols = columns ?? Object.keys(rows[0]!);
+  const widths = cols.map((c) =>
+    Math.max(c.length, ...rows.map((r) => String(r[c] ?? "").length))
+  );
+  const sep = widths.map((w) => "─".repeat(w + 2)).join("┼");
+  const header = cols.map((c, i) => ` ${c.padEnd(widths[i]!)} `).join("│");
+  console.log(header);
+  console.log(sep);
+  for (const row of rows) {
+    console.log(
+      cols
+        .map((c, i) => ` ${String(row[c] ?? "").padEnd(widths[i]!)} `)
+        .join("│")
+    );
+  }
+}
+
+export function asJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function printKv(rows: Record<string, unknown>): void {
+  const list = Object.entries(rows).map(([key, value]) => ({
+    key,
+    value: String(value ?? "")
+  }));
+  printTable(list, ["key", "value"]);
+}
+
+/** Prompt for a line on stdin (echoes). TTY only — exits if non-TTY. */
+export async function promptLine(
+  message: string,
+  opts?: { default?: string }
+): Promise<string> {
+  if (!process.stdin.isTTY) {
+    console.error(`Missing value for interactive prompt: ${message}`);
+    process.exit(1);
+  }
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr
+  });
+  return new Promise<string>((resolve) => {
+    const suffix = opts?.default ? ` [${opts.default}]` : "";
+    rl.question(`${message}${suffix}: `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim();
+      resolve(trimmed || (opts?.default ?? ""));
+    });
+  });
+}
+
+/** Prompt for hidden input (typed but not echoed). TTY only. */
+export async function promptHidden(message: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    console.error(`Missing value for interactive prompt: ${message}`);
+    process.exit(1);
+  }
+  process.stderr.write(message);
+  return new Promise<string>((resolve) => {
+    let value = "";
+    const stdin = process.stdin;
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    const onData = (data: string): void => {
+      for (const ch of data) {
+        if (ch === "\r" || ch === "\n") {
+          stdin.setRawMode(wasRaw ?? false);
+          stdin.pause();
+          stdin.removeListener("data", onData);
+          process.stderr.write("\n");
+          resolve(value);
+          return;
+        }
+        if (ch === "\x03") {
+          stdin.setRawMode(wasRaw ?? false);
+          stdin.pause();
+          process.exit(130);
+        }
+        if (ch === "" || ch === "\b") {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += ch;
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+/** Yes/no confirm. Non-TTY returns the `force` value (default: false). */
+export async function confirm(
+  message: string,
+  opts?: { force?: boolean; default?: boolean }
+): Promise<boolean> {
+  if (opts?.force) return true;
+  if (!process.stdin.isTTY) return false;
+  const defaultYes = opts?.default ?? false;
+  const hint = defaultYes ? "[Y/n]" : "[y/N]";
+  const answer = await promptLine(`${message} ${hint}`);
+  if (!answer) return defaultYes;
+  return /^y(es)?$/i.test(answer);
+}

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -100,7 +100,8 @@ export async function promptHidden(message: string): Promise<string> {
           stdin.pause();
           process.exit(130);
         }
-        if (ch === "" || ch === "\b") {
+        // DEL (\x7f, most terminals) or BS (\b) erases the last character.
+        if (ch === "\x7f" || ch === "\b") {
           value = value.slice(0, -1);
           continue;
         }

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -117,11 +117,17 @@ export async function confirm(
   message: string,
   opts?: { force?: boolean; default?: boolean }
 ): Promise<boolean> {
-  if (opts?.force) return true;
-  if (!process.stdin.isTTY) return false;
+  if (opts?.force) {
+    return true;
+  }
+  if (!process.stdin.isTTY) {
+    return false;
+  }
   const defaultYes = opts?.default ?? false;
   const hint = defaultYes ? "[Y/n]" : "[y/N]";
   const answer = await promptLine(`${message} ${hint}`);
-  if (!answer) return defaultYes;
+  if (!answer) {
+    return defaultYes;
+  }
   return /^y(es)?$/i.test(answer);
 }

--- a/packages/cli/src/commands/output.ts
+++ b/packages/cli/src/commands/output.ts
@@ -19,9 +19,19 @@ export function printTable(
     return;
   }
   const cols = columns ?? Object.keys(rows[0]!);
-  const widths = cols.map((c) =>
-    Math.max(c.length, ...rows.map((r) => String(r[c] ?? "").length))
-  );
+  // Compute widths in a loop rather than Math.max(...spread): a large table
+  // would spread thousands of args into one call, risking a max-arguments
+  // RangeError and extra allocations.
+  const widths = cols.map((c) => {
+    let width = c.length;
+    for (const r of rows) {
+      const len = String(r[c] ?? "").length;
+      if (len > width) {
+        width = len;
+      }
+    }
+    return width;
+  });
   const sep = widths.map((w) => "─".repeat(w + 2)).join("┼");
   const header = cols.map((c, i) => ` ${c.padEnd(widths[i]!)} `).join("│");
   console.log(header);

--- a/packages/cli/src/commands/worker-models.ts
+++ b/packages/cli/src/commands/worker-models.ts
@@ -14,7 +14,7 @@ import {
   WebsocketPythonBridge,
   type ModelDownloadUpdate
 } from "@nodetool-ai/runtime";
-import { printTable, asJson } from "./deploy-helpers.js";
+import { printTable, asJson } from "./output.js";
 
 // ---------------------------------------------------------------------------
 // Formatting helpers

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -57,6 +57,8 @@ import { registerNodeCommands } from "./commands/node.js";
 import { registerGenerateCommand } from "./commands/generate.js";
 import { registerEvalCommand } from "./commands/eval.js";
 import { registerAffectedCommand } from "./commands/affected.js";
+import { registerCollectionCommands } from "./commands/collections.js";
+import { registerCostsCommands } from "./commands/costs.js";
 import {
   listConfiguredProviderInfo,
   listProviderModels,
@@ -1836,6 +1838,8 @@ registerNodeCommands(program);
 registerGenerateCommand(program);
 registerEvalCommand(program);
 registerAffectedCommand(program);
+registerCollectionCommands(program);
+registerCostsCommands(program);
 
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/tests/collections-action.test.ts
+++ b/packages/cli/tests/collections-action.test.ts
@@ -103,6 +103,39 @@ beforeEach(() => {
   readFile.mockReset();
 });
 
+describe("collections list", () => {
+  it("skips a collection that raced a delete but keeps healthy ones", async () => {
+    listCollections.mockResolvedValueOnce([
+      { name: "good", metadata: { embedding_model: "m" } },
+      { name: "gone", metadata: {} }
+    ]);
+    getCollection.mockReset().mockImplementation(async ({ name }) => {
+      if (name === "gone") {
+        throw new CollectionNotFoundError("gone");
+      }
+      return { name, metadata: {}, count: async () => 3, query, upsert };
+    });
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "collections", "list", "--json"])
+    );
+    const rows = JSON.parse(stdout.trim()) as Array<{ name: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("good");
+  });
+
+  it("surfaces a non-not-found error instead of hiding it (exit 1)", async () => {
+    listCollections.mockResolvedValueOnce([{ name: "bad", metadata: {} }]);
+    getCollection.mockReset().mockRejectedValueOnce(new Error("provider boom"));
+    const program = await buildProgram();
+    const { exitCode, stderr } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "collections", "list"])
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("provider boom");
+  });
+});
+
 describe("collections create", () => {
   it("creates with embedding metadata", async () => {
     createCollection.mockResolvedValueOnce({ name: "docs", metadata: {} });

--- a/packages/cli/tests/collections-action.test.ts
+++ b/packages/cli/tests/collections-action.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Action-level tests for `nodetool collections` (src/commands/collections.ts).
+ *
+ * Mocks the vector provider, the document splitter, the local-db bootstrap and
+ * fs so CRUD, query, index (id derivation) and the --json abort path are
+ * exercised without a real vector store or filesystem.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Command } from "commander";
+
+const count = vi.fn();
+const query = vi.fn();
+const upsert = vi.fn();
+const getCollection = vi.fn();
+const createCollection = vi.fn();
+const deleteCollection = vi.fn();
+const listCollections = vi.fn();
+const splitDocument = vi.fn();
+const readFile = vi.fn();
+
+const collection = {
+  name: "c",
+  metadata: {} as Record<string, unknown>,
+  count,
+  query,
+  upsert
+};
+
+class CollectionNotFoundError extends Error {}
+
+vi.mock("@nodetool-ai/vectorstore", () => ({
+  getDefaultVectorProvider: () => ({
+    listCollections,
+    getCollection,
+    createCollection,
+    deleteCollection
+  }),
+  splitDocument,
+  CollectionNotFoundError
+}));
+
+vi.mock("@nodetool-ai/models", () => ({
+  Workflow: { get: vi.fn().mockResolvedValue(null) }
+}));
+
+vi.mock("../src/commands/local-db.js", () => ({
+  setupLocalDb: vi.fn().mockResolvedValue(undefined),
+  LOCAL_USER_ID: "1"
+}));
+
+vi.mock("node:fs/promises", () => ({ readFile }));
+
+async function captureOutput(
+  fn: () => Promise<void> | void
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  let stdout = "";
+  let stderr = "";
+  let exitCode: number | null = null;
+  const origLog = console.log;
+  const origErr = console.error;
+  const origExit = process.exit;
+  console.log = (...args: unknown[]) => {
+    stdout += args.map(String).join(" ") + "\n";
+  };
+  console.error = (...args: unknown[]) => {
+    stderr += args.map(String).join(" ") + "\n";
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__EXIT__${code ?? 0}`);
+  }) as typeof process.exit;
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith("__EXIT__")) throw e;
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { stdout, stderr, exitCode };
+}
+
+async function buildProgram(): Promise<Command> {
+  const { registerCollectionCommands } = await import(
+    "../src/commands/collections.js"
+  );
+  const program = new Command();
+  program.exitOverride();
+  registerCollectionCommands(program);
+  return program;
+}
+
+beforeEach(() => {
+  count.mockReset();
+  query.mockReset();
+  upsert.mockReset();
+  getCollection.mockReset().mockResolvedValue(collection);
+  createCollection.mockReset();
+  deleteCollection.mockReset();
+  listCollections.mockReset();
+  splitDocument.mockReset();
+  readFile.mockReset();
+});
+
+describe("collections create", () => {
+  it("creates with embedding metadata", async () => {
+    createCollection.mockResolvedValueOnce({ name: "docs", metadata: {} });
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "collections",
+        "create",
+        "docs",
+        "--embedding-model",
+        "text-embedding-3-small"
+      ])
+    );
+    expect(createCollection).toHaveBeenCalledWith({
+      name: "docs",
+      metadata: { embedding_model: "text-embedding-3-small" }
+    });
+    expect(stdout).toContain("Created collection 'docs'");
+  });
+});
+
+describe("collections delete", () => {
+  it("deletes with --yes and emits JSON", async () => {
+    deleteCollection.mockResolvedValueOnce(undefined);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "collections",
+        "delete",
+        "docs",
+        "--yes",
+        "--json"
+      ])
+    );
+    expect(deleteCollection).toHaveBeenCalledWith("docs");
+    expect(JSON.parse(stdout.trim())).toHaveProperty("message");
+  });
+
+  it("emits JSON (not plain text) on a non-TTY abort with --json", async () => {
+    const program = await buildProgram();
+    const { stdout, exitCode } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "collections",
+        "delete",
+        "docs",
+        "--json"
+      ])
+    );
+    // Non-TTY + no --yes → confirm() returns false → abort.
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stdout.trim())).toEqual({
+      deleted: false,
+      aborted: true
+    });
+    expect(deleteCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe("collections query", () => {
+  it("renders matches and prints (no matches) when empty", async () => {
+    query.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "collections", "query", "docs", "hi"])
+    );
+    expect(query).toHaveBeenCalledWith({ text: "hi", topK: 10 });
+    expect(stdout).toContain("(no matches)");
+  });
+
+  it("exits(1) on invalid --n-results", async () => {
+    const program = await buildProgram();
+    const { exitCode, stderr } = await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "collections",
+        "query",
+        "docs",
+        "hi",
+        "-n",
+        "zero"
+      ])
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid --n-results");
+  });
+});
+
+describe("collections index", () => {
+  it("derives distinct record ids from the full path, not the basename", async () => {
+    readFile.mockResolvedValue("some text");
+    splitDocument.mockReturnValue([
+      { text: "some text", source_id: "foo.txt", start_index: 0 }
+    ]);
+    upsert.mockResolvedValue(undefined);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "collections",
+        "index",
+        "docs",
+        "a/foo.txt",
+        "b/foo.txt"
+      ])
+    );
+    expect(upsert).toHaveBeenCalledTimes(2);
+    const idA = upsert.mock.calls[0]![0][0].id as string;
+    const idB = upsert.mock.calls[1]![0][0].id as string;
+    expect(idA).not.toBe(idB);
+    expect(idA).toBe("a_foo.txt#0");
+    expect(idB).toBe("b_foo.txt#0");
+  });
+});

--- a/packages/cli/tests/collections-command.test.ts
+++ b/packages/cli/tests/collections-command.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for `nodetool collections` and `nodetool costs` command registration
+ * (src/commands/collections.ts, src/commands/costs.ts).
+ *
+ * Heavy deps (tRPC client, fetch) are only touched inside the actions, so
+ * registration and the option surface are testable without a running server.
+ */
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { registerCollectionCommands } from "../src/commands/collections.js";
+import { registerCostsCommands } from "../src/commands/costs.js";
+
+function group(
+  register: (program: Command) => void,
+  name: string
+): Command {
+  const program = new Command();
+  register(program);
+  const cmd = program.commands.find((c) => c.name() === name);
+  if (!cmd) throw new Error(`${name} command not registered`);
+  return cmd;
+}
+
+describe("registerCollectionCommands", () => {
+  it("registers the collections command group", () => {
+    expect(group(registerCollectionCommands, "collections").description()).toMatch(
+      /vector-store collections/i
+    );
+  });
+
+  it("exposes the full CRUD + index + query surface", () => {
+    const subNames = group(registerCollectionCommands, "collections")
+      .commands.map((c) => c.name())
+      .sort();
+    expect(subNames).toEqual([
+      "create",
+      "delete",
+      "get",
+      "index",
+      "list",
+      "query"
+    ]);
+  });
+
+  it("gives query an --n-results flag and delete a --yes flag", () => {
+    const collections = group(registerCollectionCommands, "collections");
+    const query = collections.commands.find((c) => c.name() === "query")!;
+    const del = collections.commands.find((c) => c.name() === "delete")!;
+    expect(query.options.map((o) => o.long)).toContain("--n-results");
+    expect(del.options.map((o) => o.long)).toContain("--yes");
+  });
+});
+
+describe("registerCostsCommands", () => {
+  it("registers the costs command group", () => {
+    expect(group(registerCostsCommands, "costs").description()).toMatch(
+      /spend/i
+    );
+  });
+
+  it("exposes summary, list, and the aggregate breakdowns", () => {
+    const subNames = group(registerCostsCommands, "costs")
+      .commands.map((c) => c.name())
+      .sort();
+    expect(subNames).toEqual(["by-model", "by-provider", "list", "summary"]);
+  });
+
+  it("gives list --provider/--model/--limit filters", () => {
+    const list = group(registerCostsCommands, "costs").commands.find(
+      (c) => c.name() === "list"
+    )!;
+    const flags = list.options.map((o) => o.long);
+    expect(flags).toEqual(
+      expect.arrayContaining(["--provider", "--model", "--limit"])
+    );
+  });
+});

--- a/packages/cli/tests/costs-command.test.ts
+++ b/packages/cli/tests/costs-command.test.ts
@@ -60,17 +60,6 @@ async function buildProgram(): Promise<Command> {
   return program;
 }
 
-const emptyAggregate = {
-  user_id: "1",
-  provider: null,
-  model: null,
-  total_cost: 0,
-  total_input_tokens: 0,
-  total_output_tokens: 0,
-  total_tokens: 0,
-  call_count: 0
-};
-
 beforeEach(() => {
   aggregateByUser.mockReset();
   aggregateByProvider.mockReset();
@@ -79,13 +68,7 @@ beforeEach(() => {
 });
 
 describe("costs summary", () => {
-  it("aggregates overall/provider/model and emits JSON", async () => {
-    aggregateByUser.mockResolvedValueOnce({
-      ...emptyAggregate,
-      total_cost: 1.5,
-      total_tokens: 300,
-      call_count: 2
-    });
+  it("derives overall by summing provider aggregates, no aggregateByUser scan", async () => {
     aggregateByProvider.mockResolvedValueOnce([
       {
         provider: "openai",
@@ -94,6 +77,14 @@ describe("costs summary", () => {
         total_output_tokens: 100,
         total_tokens: 300,
         call_count: 2
+      },
+      {
+        provider: "anthropic",
+        total_cost: 0.5,
+        total_input_tokens: 50,
+        total_output_tokens: 25,
+        total_tokens: 75,
+        call_count: 1
       }
     ]);
     aggregateByModel.mockResolvedValueOnce([]);
@@ -102,9 +93,12 @@ describe("costs summary", () => {
       program.parseAsync(["node", "cli", "costs", "summary", "--json"])
     );
     const parsed = JSON.parse(stdout.trim());
-    expect(parsed.overall.total_cost).toBe(1.5);
+    // 1.5 + 0.5 summed from the two provider rows.
+    expect(parsed.overall.total_cost).toBe(2);
+    expect(parsed.overall.call_count).toBe(3);
     expect(parsed.by_provider[0].provider).toBe("openai");
     expect(parsed).toHaveProperty("by_model");
+    expect(aggregateByUser).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/tests/costs-command.test.ts
+++ b/packages/cli/tests/costs-command.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Action-level tests for `nodetool costs` (src/commands/costs.ts).
+ *
+ * Mocks the Prediction model and the local-db bootstrap so the command's
+ * aggregation, validation and output formatting are exercised without a DB.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Command } from "commander";
+
+const aggregateByUser = vi.fn();
+const aggregateByProvider = vi.fn();
+const aggregateByModel = vi.fn();
+const paginate = vi.fn();
+
+vi.mock("@nodetool-ai/models", () => ({
+  Prediction: { aggregateByUser, aggregateByProvider, aggregateByModel, paginate }
+}));
+
+vi.mock("../src/commands/local-db.js", () => ({
+  setupLocalDb: vi.fn().mockResolvedValue(undefined),
+  LOCAL_USER_ID: "1"
+}));
+
+async function captureOutput(
+  fn: () => Promise<void> | void
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  let stdout = "";
+  let stderr = "";
+  let exitCode: number | null = null;
+  const origLog = console.log;
+  const origErr = console.error;
+  const origExit = process.exit;
+  console.log = (...args: unknown[]) => {
+    stdout += args.map(String).join(" ") + "\n";
+  };
+  console.error = (...args: unknown[]) => {
+    stderr += args.map(String).join(" ") + "\n";
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__EXIT__${code ?? 0}`);
+  }) as typeof process.exit;
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith("__EXIT__")) throw e;
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { stdout, stderr, exitCode };
+}
+
+async function buildProgram(): Promise<Command> {
+  const { registerCostsCommands } = await import("../src/commands/costs.js");
+  const program = new Command();
+  program.exitOverride();
+  registerCostsCommands(program);
+  return program;
+}
+
+const emptyAggregate = {
+  user_id: "1",
+  provider: null,
+  model: null,
+  total_cost: 0,
+  total_input_tokens: 0,
+  total_output_tokens: 0,
+  total_tokens: 0,
+  call_count: 0
+};
+
+beforeEach(() => {
+  aggregateByUser.mockReset();
+  aggregateByProvider.mockReset();
+  aggregateByModel.mockReset();
+  paginate.mockReset();
+});
+
+describe("costs summary", () => {
+  it("aggregates overall/provider/model and emits JSON", async () => {
+    aggregateByUser.mockResolvedValueOnce({
+      ...emptyAggregate,
+      total_cost: 1.5,
+      total_tokens: 300,
+      call_count: 2
+    });
+    aggregateByProvider.mockResolvedValueOnce([
+      {
+        provider: "openai",
+        total_cost: 1.5,
+        total_input_tokens: 200,
+        total_output_tokens: 100,
+        total_tokens: 300,
+        call_count: 2
+      }
+    ]);
+    aggregateByModel.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "costs", "summary", "--json"])
+    );
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.overall.total_cost).toBe(1.5);
+    expect(parsed.by_provider[0].provider).toBe("openai");
+    expect(parsed).toHaveProperty("by_model");
+  });
+});
+
+describe("costs list", () => {
+  it("forwards --provider/--model/--limit to paginate", async () => {
+    paginate.mockResolvedValueOnce([[], ""]);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "costs",
+        "list",
+        "--provider",
+        "anthropic",
+        "--model",
+        "claude-sonnet-4-6",
+        "--limit",
+        "7"
+      ])
+    );
+    expect(paginate).toHaveBeenCalledWith("1", {
+      limit: 7,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6"
+    });
+  });
+
+  it("exits(1) on a non-numeric --limit before touching the DB", async () => {
+    const program = await buildProgram();
+    const { exitCode, stderr } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "costs", "list", "--limit", "abc"])
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid --limit");
+    expect(paginate).not.toHaveBeenCalled();
+  });
+});
+
+describe("costs by-model", () => {
+  it("passes the --provider filter through", async () => {
+    aggregateByModel.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    await captureOutput(() =>
+      program.parseAsync([
+        "node",
+        "cli",
+        "costs",
+        "by-model",
+        "--provider",
+        "openai",
+        "--json"
+      ])
+    );
+    expect(aggregateByModel).toHaveBeenCalledWith("1", { provider: "openai" });
+  });
+});


### PR DESCRIPTION
## Summary

Two important features were reachable over the server API but had no `nodetool`
CLI surface. This PR exposes both. They run **in-process** (no running server
required), consistent with the other local-first commands (`secrets`,
`workflows run`, `models by-provider`), with `--json` output on every
subcommand.

### `nodetool collections` — RAG vector store

Full management of the vector-store collections that back retrieval-augmented
generation, talking to the default vector provider in-process (sqlite-vec
unless `NODETOOL_VECTOR_PROVIDER` selects pinecone/supabase):

- `list` — collections with document counts and embedding model
- `get <name>` — metadata + count
- `create <name>` — with `--embedding-model` / `--embedding-provider`
- `delete <name>` — with `-y/--yes` to skip the confirm prompt
- `query <name> <text...>` — semantic search (`-n/--n-results`)
- `index <name> <file...>` — chunk and index text documents with the same
  `splitDocument` chunker the server's index endpoint uses

### `nodetool costs` — spend tracking

Aggregates the per-call cost/token `Prediction` records NodeTool writes for
every LLM call, read straight from the local SQLite DB:

- `summary` — overall totals plus per-provider and per-model breakdowns
- `list` — recent calls, filterable by `--provider` / `--model` / `--limit`
- `by-provider` — grouped provider totals
- `by-model` — grouped model totals (`--provider` filter)

## Changes

- `packages/cli/src/commands/collections.ts` — new command group (in-process vector provider)
- `packages/cli/src/commands/costs.ts` — new command group (local Prediction aggregates)
- `packages/cli/src/commands/output.ts` — dependency-free table/JSON/prompt helpers, extracted out of `deploy-helpers.ts` so the lightweight command groups don't pull in the deploy stack at startup; `deploy-helpers.ts` re-exports them
- `packages/cli/src/commands/local-db.ts` — small local single-user DB bootstrap (init DB + unlock secret store)
- `packages/cli/src/commands/nodetool.ts` — register both groups
- `packages/cli/tests/collections-command.test.ts` — registration + option-surface tests
- `CLAUDE.md` — document the new commands

## Testing

- `npm run lint --workspace=packages/cli` — clean typecheck
- `npm run build:packages` — all packages build
- Full CLI test suite green (367 tests)
- Live end-to-end **with no server running**: collections create → index →
  get (count updates) → delete, same-basename files indexed without id
  collision, and all `costs` subcommands render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)