### PR TITLE
feat(script): make the script editor mobile-friendly

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useMemo, useState } from "react";
 import type { DragEvent } from "react";
+import { useTheme } from "@mui/material/styles";
+import { useMediaQuery } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
@@ -70,18 +72,20 @@ const InsertLineGap = ({
   onInsert,
   onDragOver,
   onDrop,
-  active
+  active,
+  inset
 }: {
   onInsert: () => void;
   onDragOver: (e: DragEvent<HTMLElement>) => void;
   onDrop: (e: DragEvent<HTMLElement>) => void;
   active: boolean;
+  inset: number;
 }) => (
   <Box
     onDragOver={onDragOver}
     onDrop={onDrop}
     sx={{
-      marginLeft: `${TEXT_INSET}px`,
+      marginLeft: `${inset}px`,
       height: 12,
       display: "flex",
       alignItems: "center",
@@ -129,6 +133,7 @@ const SectionBlock = ({
   section,
   currentLineId,
   readOnly,
+  mobile,
   dnd,
   onKeyNav
 }: {
@@ -136,6 +141,7 @@ const SectionBlock = ({
   section: ScriptSection;
   currentLineId: string | null;
   readOnly: boolean;
+  mobile: boolean;
   dnd: LineDnd;
   onKeyNav: (lineId: string, nav: LineKeyNav) => void;
 }) => {
@@ -144,6 +150,10 @@ const SectionBlock = ({
   const addLine = useScriptStore((s) => s.addLine);
   const insertLine = useScriptStore((s) => s.insertLine);
   const removeSection = useScriptStore((s) => s.removeSection);
+
+  // On mobile the wide speaker gutter collapses, so insert affordances and
+  // add-line buttons align to the left edge instead of under the dialogue.
+  const inset = mobile ? 0 : TEXT_INSET;
 
   const isTarget = (beforeLineId: string | null): boolean =>
     dnd.dropTarget?.sectionId === section.id &&
@@ -239,6 +249,7 @@ const SectionBlock = ({
                 onDragOver={onGapDragOver(line.id)}
                 onDrop={onGapDrop}
                 active={isTarget(line.id)}
+                inset={inset}
               />
             )}
             <ScriptLineRow
@@ -247,6 +258,7 @@ const SectionBlock = ({
               cast={cast}
               highlighted={line.id === currentLineId}
               readOnly={readOnly}
+              mobile={mobile}
               onKeyNav={onKeyNav}
               isDragging={dnd.draggingLineId === line.id}
               onDragStart={
@@ -265,10 +277,11 @@ const SectionBlock = ({
           onDragOver={onGapDragOver(null)}
           onDrop={onGapDrop}
           active={isTarget(null)}
+          inset={inset}
         />
       )}
       {!readOnly && (
-        <FlexRow sx={{ marginLeft: `${TEXT_INSET}px` }}>
+        <FlexRow sx={{ marginLeft: `${inset}px` }}>
           <EditorButton
             size="small"
             variant="text"
@@ -287,6 +300,8 @@ const ScriptDocumentPane = ({
   scriptId,
   readOnly
 }: ScriptDocumentPaneProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const { sections, timelineId } = useScript(scriptId);
   const addLine = useScriptStore((s) => s.addLine);
   const addSection = useScriptStore((s) => s.addSection);
@@ -462,9 +477,10 @@ const ScriptDocumentPane = ({
       <FlexRow
         align="center"
         gap={SPACING.sm}
+        wrap={isMobile}
         sx={{
           paddingY: SPACING.sm,
-          paddingX: SPACING.md,
+          paddingX: isMobile ? SPACING.sm : SPACING.md,
           borderBottom: "1px solid",
           borderColor: "divider",
           position: "sticky",
@@ -577,7 +593,10 @@ const ScriptDocumentPane = ({
       <FlexColumn
         gap={SPACING.xxl}
         style={{ maxWidth: 780, width: "100%", margin: "0 auto" }}
-        sx={{ paddingX: SPACING.xl, paddingY: SPACING.xl }}
+        sx={{
+          paddingX: isMobile ? SPACING.sm : SPACING.xl,
+          paddingY: isMobile ? SPACING.md : SPACING.xl
+        }}
       >
         {isEmpty && (
           <EmptyState
@@ -594,12 +613,16 @@ const ScriptDocumentPane = ({
             section={section}
             currentLineId={currentLineId}
             readOnly={readOnly}
+            mobile={isMobile}
             dnd={dnd}
             onKeyNav={onLineKeyNav}
           />
         ))}
         {!readOnly && !isEmpty && (
-          <FlexRow gap={SPACING.sm} sx={{ marginLeft: `${TEXT_INSET}px` }}>
+          <FlexRow
+            gap={SPACING.sm}
+            sx={{ marginLeft: isMobile ? 0 : `${TEXT_INSET}px` }}
+          >
             <EditorButton
               size="small"
               variant="text"

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -240,31 +240,43 @@ const ScriptLineRow = ({
     [onDragStart, line.id]
   );
 
+  const speakerDisabled = readOnly || !cast.length;
   const speakerButton = (
+    // The button is disabled read-only or with no cast, and a disabled element
+    // emits no hover events — so the Tooltip anchors to a wrapper span that
+    // carries the flex sizing, keeping the hint reachable in every state.
     <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
       <Box
-        component="button"
-        type="button"
-        disabled={readOnly || !cast.length}
-        onClick={readOnly ? undefined : cycleSpeaker}
+        component="span"
         sx={{
           flexShrink: 0,
+          display: "inline-flex",
           width: mobile ? "auto" : GUTTER,
-          marginTop: mobile ? SPACING.none : SPACING.sm,
-          padding: SPACING.none,
-          border: "none",
-          background: "none",
-          textAlign: mobile ? "left" : "right",
-          cursor: readOnly || !cast.length ? "default" : "pointer",
-          ...TYPOGRAPHY.sans.label,
-          letterSpacing: "0.06em",
-          textTransform: "uppercase",
-          color: speaker ? speaker.color ?? "text.primary" : "text.disabled",
-          transition: MOTION.fast,
-          "&:hover:not(:disabled)": { color: "primary.main" }
+          marginTop: mobile ? SPACING.none : SPACING.sm
         }}
       >
-        {speaker?.name ?? "no speaker"}
+        <Box
+          component="button"
+          type="button"
+          disabled={speakerDisabled}
+          onClick={readOnly ? undefined : cycleSpeaker}
+          sx={{
+            width: "100%",
+            padding: SPACING.none,
+            border: "none",
+            background: "none",
+            textAlign: mobile ? "left" : "right",
+            cursor: speakerDisabled ? "default" : "pointer",
+            ...TYPOGRAPHY.sans.label,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: speaker ? speaker.color ?? "text.primary" : "text.disabled",
+            transition: MOTION.fast,
+            "&:hover:not(:disabled)": { color: "primary.main" }
+          }}
+        >
+          {speaker?.name ?? "no speaker"}
+        </Box>
       </Box>
     </Tooltip>
   );

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -64,6 +64,12 @@ interface ScriptLineRowProps {
   readOnly: boolean;
   /** True while this row is the one being dragged (dimmed as it lifts out). */
   isDragging?: boolean;
+  /**
+   * Narrow layout: the wide screenplay gutter and hover-revealed actions/drag
+   * rail don't work on touch, so the row stacks vertically with the speaker tag
+   * above the text and the action bar always visible.
+   */
+  mobile?: boolean;
   onKeyNav?: (lineId: string, nav: LineKeyNav) => void;
   onDragStart?: (e: DragEvent<HTMLElement>) => void;
   onDragEnd?: (e: DragEvent<HTMLElement>) => void;
@@ -110,6 +116,7 @@ const ScriptLineRow = ({
   highlighted,
   readOnly,
   isDragging = false,
+  mobile = false,
   onKeyNav,
   onDragStart,
   onDragEnd,
@@ -221,7 +228,7 @@ const ScriptLineRow = ({
     });
   }, [hasDirection, patchLine, scriptId, line.id]);
 
-  const draggable = !readOnly && !!onDragStart;
+  const draggable = !readOnly && !mobile && !!onDragStart;
 
   const handleDragStart = useCallback(
     (e: DragEvent<HTMLElement>) => {
@@ -232,6 +239,213 @@ const ScriptLineRow = ({
     },
     [onDragStart, line.id]
   );
+
+  const speakerButton = (
+    <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
+      <Box
+        component="button"
+        type="button"
+        disabled={readOnly || !cast.length}
+        onClick={readOnly ? undefined : cycleSpeaker}
+        sx={{
+          flexShrink: 0,
+          width: mobile ? "auto" : GUTTER,
+          marginTop: mobile ? SPACING.none : SPACING.sm,
+          padding: SPACING.none,
+          border: "none",
+          background: "none",
+          textAlign: mobile ? "left" : "right",
+          cursor: readOnly || !cast.length ? "default" : "pointer",
+          ...TYPOGRAPHY.sans.label,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: speaker ? speaker.color ?? "text.primary" : "text.disabled",
+          transition: MOTION.fast,
+          "&:hover:not(:disabled)": { color: "primary.main" }
+        }}
+      >
+        {speaker?.name ?? "no speaker"}
+      </Box>
+    </Tooltip>
+  );
+
+  const textColumn = (
+    <FlexColumn gap={SPACING.none} style={{ flex: 1, minWidth: 0 }}>
+      <TextInput
+        value={line.text}
+        onChange={onTextChange}
+        onKeyDown={onTextKeyDown}
+        placeholder="Write a line…"
+        multiline
+        hideLabel
+        label="Line text"
+        compact
+        fullWidth
+        disabled={readOnly}
+        inputProps={{ "data-script-line": line.id }}
+        sx={{
+          ...quietField,
+          "& .MuiOutlinedInput-input": { ...TYPOGRAPHY.sans.body }
+        }}
+      />
+      {showDirection && (
+        <TextInput
+          autoFocus={!hasDirection}
+          value={line.direction ?? ""}
+          onChange={onDirectionChange}
+          placeholder="Direction (e.g. whispering, tired)…"
+          hideLabel
+          label="Direction"
+          compact
+          fullWidth
+          disabled={readOnly}
+          sx={{
+            ...quietField,
+            "& .MuiOutlinedInput-input": {
+              fontStyle: "italic",
+              color: "text.secondary"
+            }
+          }}
+        />
+      )}
+      {voiceError && (
+        <Text size="smaller" color="error" sx={{ paddingLeft: SPACING.sm }}>
+          {voiceError}
+        </Text>
+      )}
+    </FlexColumn>
+  );
+
+  const statusIndicator =
+    status === "stale" ? (
+      <Text size="smaller" color="warning">
+        Stale
+      </Text>
+    ) : (
+      <Tooltip title={status === "voiced" ? "Voiced" : "Not voiced yet"}>
+        <Box
+          sx={{
+            width: 6,
+            height: 6,
+            borderRadius: BORDER_RADIUS.circle,
+            backgroundColor:
+              status === "voiced" ? "success.main" : "action.disabled"
+          }}
+        />
+      </Tooltip>
+    );
+
+  const actions = (
+    <FlexRow
+      className={mobile ? undefined : "script-line-actions"}
+      gap={SPACING.none}
+      align="center"
+      wrap={mobile}
+      sx={mobile || voicing ? { opacity: "1 !important" } : undefined}
+    >
+      {voicing ? (
+        <LoadingSpinner size={20} />
+      ) : (
+        <Tooltip
+          title={
+            voice
+              ? status === "stale"
+                ? "Re-voice line"
+                : "Voice line"
+              : "Assign a voice to this speaker first"
+          }
+        >
+          <span>
+            <ToolbarIconButton
+              tooltip=""
+              disabled={readOnly || !voice}
+              onClick={() => void onVoice()}
+              icon={<GraphicEqIcon fontSize="small" />}
+            />
+          </span>
+        </Tooltip>
+      )}
+      {!readOnly && (
+        <ToolbarIconButton
+          tooltip={showDirection ? "Remove direction" : "Add direction"}
+          onClick={toggleDirection}
+          icon={<TheaterComedyIcon fontSize="small" />}
+          sx={showDirection ? { color: "primary.main" } : undefined}
+        />
+      )}
+      <ToolbarIconButton
+        tooltip="Play current take"
+        disabled={!hasCurrentTake}
+        onClick={() => void playCurrent()}
+        icon={<PlayArrowIcon fontSize="small" />}
+      />
+      <ToolbarIconButton
+        tooltip={`Takes (${line.takes.length})`}
+        onClick={(e: MouseEvent<HTMLElement>) =>
+          setGalleryAnchor(e.currentTarget)
+        }
+        icon={<HistoryIcon fontSize="small" />}
+      />
+      {!readOnly && (
+        <ToolbarIconButton
+          tooltip="Duplicate line"
+          onClick={() => duplicateLine(scriptId, line.id)}
+          icon={<ContentCopyIcon fontSize="small" />}
+        />
+      )}
+      {!readOnly && (
+        <ToolbarIconButton
+          tooltip="Delete line"
+          onClick={() => removeLine(scriptId, line.id)}
+          icon={<DeleteOutlineIcon fontSize="small" />}
+        />
+      )}
+    </FlexRow>
+  );
+
+  const gallery = (
+    <Popover
+      open={!!galleryAnchor}
+      anchorEl={galleryAnchor}
+      onClose={() => setGalleryAnchor(null)}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      transformOrigin={{ vertical: "top", horizontal: "right" }}
+    >
+      <ScriptTakeGallery
+        scriptId={scriptId}
+        lineId={line.id}
+        takes={line.takes}
+        currentTakeId={line.currentTakeId ?? null}
+      />
+    </Popover>
+  );
+
+  if (mobile) {
+    // Stacked layout: speaker tag + always-visible actions on top, dialogue
+    // below. No hover reveal, no drag rail — none of which work on touch.
+    return (
+      <FlexColumn
+        gap={SPACING.xs}
+        fullWidth
+        sx={{
+          position: "relative",
+          padding: SPACING.sm,
+          borderRadius: BORDER_RADIUS.sm,
+          backgroundColor: highlighted ? "action.selected" : "transparent",
+          transition: MOTION.background
+        }}
+      >
+        <FlexRow align="center" gap={SPACING.sm} fullWidth>
+          {speakerButton}
+          <Box sx={{ flex: 1 }} />
+          {statusIndicator}
+          {actions}
+        </FlexRow>
+        {textColumn}
+        {gallery}
+      </FlexColumn>
+    );
+  }
 
   return (
     <FlexRow
@@ -293,77 +507,9 @@ const ScriptLineRow = ({
         <Box sx={{ flexShrink: 0, width: DRAG_RAIL }} />
       )}
 
-      <Tooltip title={cast.length ? "Change speaker" : "Add a speaker first"}>
-        <Box
-          component="button"
-          type="button"
-          disabled={readOnly || !cast.length}
-          onClick={readOnly ? undefined : cycleSpeaker}
-          sx={{
-            flexShrink: 0,
-            width: GUTTER,
-            marginTop: SPACING.sm,
-            padding: SPACING.none,
-            border: "none",
-            background: "none",
-            textAlign: "right",
-            cursor: readOnly || !cast.length ? "default" : "pointer",
-            ...TYPOGRAPHY.sans.label,
-            letterSpacing: "0.06em",
-            textTransform: "uppercase",
-            color: speaker ? speaker.color ?? "text.primary" : "text.disabled",
-            transition: MOTION.fast,
-            "&:hover:not(:disabled)": { color: "primary.main" }
-          }}
-        >
-          {speaker?.name ?? "no speaker"}
-        </Box>
-      </Tooltip>
+      {speakerButton}
 
-      <FlexColumn gap={SPACING.none} style={{ flex: 1, minWidth: 0 }}>
-        <TextInput
-          value={line.text}
-          onChange={onTextChange}
-          onKeyDown={onTextKeyDown}
-          placeholder="Write a line…"
-          multiline
-          hideLabel
-          label="Line text"
-          compact
-          fullWidth
-          disabled={readOnly}
-          inputProps={{ "data-script-line": line.id }}
-          sx={{
-            ...quietField,
-            "& .MuiOutlinedInput-input": { ...TYPOGRAPHY.sans.body }
-          }}
-        />
-        {showDirection && (
-          <TextInput
-            autoFocus={!hasDirection}
-            value={line.direction ?? ""}
-            onChange={onDirectionChange}
-            placeholder="Direction (e.g. whispering, tired)…"
-            hideLabel
-            label="Direction"
-            compact
-            fullWidth
-            disabled={readOnly}
-            sx={{
-              ...quietField,
-              "& .MuiOutlinedInput-input": {
-                fontStyle: "italic",
-                color: "text.secondary"
-              }
-            }}
-          />
-        )}
-        {voiceError && (
-          <Text size="smaller" color="error" sx={{ paddingLeft: SPACING.sm }}>
-            {voiceError}
-          </Text>
-        )}
-      </FlexColumn>
+      {textColumn}
 
       <FlexRow
         align="center"
@@ -371,103 +517,11 @@ const ScriptLineRow = ({
         gap={SPACING.xs}
         sx={{ flexShrink: 0, marginTop: SPACING.xs }}
       >
-        {status === "stale" ? (
-          <Text size="smaller" color="warning">
-            Stale
-          </Text>
-        ) : (
-          <Tooltip title={status === "voiced" ? "Voiced" : "Not voiced yet"}>
-            <Box
-              sx={{
-                width: 6,
-                height: 6,
-                borderRadius: BORDER_RADIUS.circle,
-                backgroundColor:
-                  status === "voiced" ? "success.main" : "action.disabled"
-              }}
-            />
-          </Tooltip>
-        )}
-        <FlexRow
-          className="script-line-actions"
-          gap={SPACING.none}
-          align="center"
-          sx={voicing ? { opacity: "1 !important" } : undefined}
-        >
-          {voicing ? (
-            <LoadingSpinner size={20} />
-          ) : (
-            <Tooltip
-              title={
-                voice
-                  ? status === "stale"
-                    ? "Re-voice line"
-                    : "Voice line"
-                  : "Assign a voice to this speaker first"
-              }
-            >
-              <span>
-                <ToolbarIconButton
-                  tooltip=""
-                  disabled={readOnly || !voice}
-                  onClick={() => void onVoice()}
-                  icon={<GraphicEqIcon fontSize="small" />}
-                />
-              </span>
-            </Tooltip>
-          )}
-          {!readOnly && (
-            <ToolbarIconButton
-              tooltip={showDirection ? "Remove direction" : "Add direction"}
-              onClick={toggleDirection}
-              icon={<TheaterComedyIcon fontSize="small" />}
-              sx={showDirection ? { color: "primary.main" } : undefined}
-            />
-          )}
-          <ToolbarIconButton
-            tooltip="Play current take"
-            disabled={!hasCurrentTake}
-            onClick={() => void playCurrent()}
-            icon={<PlayArrowIcon fontSize="small" />}
-          />
-          <ToolbarIconButton
-            tooltip={`Takes (${line.takes.length})`}
-            onClick={(e: MouseEvent<HTMLElement>) =>
-              setGalleryAnchor(e.currentTarget)
-            }
-            icon={<HistoryIcon fontSize="small" />}
-          />
-          {!readOnly && (
-            <ToolbarIconButton
-              tooltip="Duplicate line"
-              onClick={() => duplicateLine(scriptId, line.id)}
-              icon={<ContentCopyIcon fontSize="small" />}
-            />
-          )}
-          {!readOnly && (
-            <ToolbarIconButton
-              tooltip="Delete line"
-              onClick={() => removeLine(scriptId, line.id)}
-              icon={<DeleteOutlineIcon fontSize="small" />}
-            />
-          )}
-        </FlexRow>
+        {statusIndicator}
+        {actions}
       </FlexRow>
 
-      <Popover
-        open={!!galleryAnchor}
-        anchorEl={galleryAnchor}
-        onClose={() => setGalleryAnchor(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        transformOrigin={{ vertical: "top", horizontal: "right" }}
-      >
-        <ScriptTakeGallery
-          scriptId={scriptId}
-          lineId={line.id}
-          takes={line.takes}
-          currentTakeId={line.currentTakeId ?? null}
-        />
-      </Popover>
+      {gallery}
     </FlexRow>
   );
 };

--- a/web/src/components/workspace/ScriptSurface.tsx
+++ b/web/src/components/workspace/ScriptSurface.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTheme } from "@mui/material/styles";
+import { useMediaQuery } from "@mui/material";
 import GroupsIcon from "@mui/icons-material/Groups";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import {
@@ -11,7 +12,15 @@ import { useScriptStore, useScript } from "../../stores/script/ScriptStore";
 import { useScriptServerSync } from "../../hooks/script/useScriptServerSync";
 import { useScriptAgentBridge } from "../../hooks/script/useScriptAgentBridge";
 import { useDocumentUndoShortcuts } from "../../hooks/useDocumentUndoShortcuts";
-import { FlexColumn, FlexRow, TabGroup } from "../ui_primitives";
+import {
+  FlexColumn,
+  FlexRow,
+  TabGroup,
+  EditorButton,
+  MobileBottomSheet,
+  SPACING,
+  Z_INDEX
+} from "../ui_primitives";
 import ScriptDocumentPane from "../script/ScriptDocumentPane";
 import ScriptCastPanel from "../script/ScriptCastPanel";
 import ScriptAgentPanel from "../script/ScriptAgentPanel";
@@ -36,6 +45,7 @@ type DockTab = "cast" | "assistant";
  */
 const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const ensureScript = useScriptStore((state) => state.ensureScript);
   const undo = useScriptStore((state) => state.undo);
   const redo = useScriptStore((state) => state.redo);
@@ -43,6 +53,12 @@ const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
   const { title, cast } = useScript(refId);
   const readOnly = mode === "view";
   const [dockTab, setDockTab] = useState<DockTab>("cast");
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const openSheet = useCallback((tab: DockTab) => {
+    setDockTab(tab);
+    setSheetOpen(true);
+  }, []);
 
   useEffect(() => {
     ensureScript(refId);
@@ -70,6 +86,83 @@ const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
     []
   );
 
+  const dockTabGroup = (
+    <TabGroup
+      tabs={dockTabs}
+      value={dockTab}
+      onChange={(value) => setDockTab(value as DockTab)}
+      size="small"
+      fullWidth
+      sx={{
+        flexShrink: 0,
+        borderBottom: `1px solid ${theme.vars.palette.divider}`
+      }}
+    />
+  );
+
+  const dockPanel =
+    dockTab === "cast" ? (
+      <ScriptCastPanel scriptId={refId} cast={cast} readOnly={readOnly} />
+    ) : (
+      <ScriptAgentPanel scriptId={refId} />
+    );
+
+  // On mobile the fixed 320px side dock would crush the document, so the cast
+  // and assistant panels move into a bottom sheet reached by two floating
+  // buttons; the document runs full-width.
+  if (isMobile) {
+    return (
+      <FlexColumn fullHeight sx={{ minHeight: 0, position: "relative" }}>
+        <ScriptDocumentPane scriptId={refId} readOnly={readOnly} />
+        {!readOnly && (
+          <>
+            <FlexRow
+              gap={SPACING.sm}
+              sx={{
+                position: "absolute",
+                right: SPACING.md,
+                bottom: SPACING.md,
+                zIndex: Z_INDEX.sticky
+              }}
+            >
+              <EditorButton
+                size="small"
+                variant="contained"
+                startIcon={<GroupsIcon fontSize="small" />}
+                onClick={() => openSheet("cast")}
+              >
+                Cast
+              </EditorButton>
+              <EditorButton
+                size="small"
+                variant="contained"
+                startIcon={<AutoAwesomeIcon fontSize="small" />}
+                onClick={() => openSheet("assistant")}
+              >
+                Assistant
+              </EditorButton>
+            </FlexRow>
+            <MobileBottomSheet
+              open={sheetOpen}
+              onClose={() => setSheetOpen(false)}
+              maxHeight="85dvh"
+              title={dockTab === "cast" ? "Cast" : "Assistant"}
+              headerExtras={dockTabGroup}
+              ariaLabel="Script cast and assistant"
+            >
+              <FlexColumn
+                fullWidth
+                sx={{ height: "70dvh", minHeight: 0, overflow: "hidden" }}
+              >
+                {dockPanel}
+              </FlexColumn>
+            </MobileBottomSheet>
+          </>
+        )}
+      </FlexColumn>
+    );
+  }
+
   return (
     <FlexRow fullHeight sx={{ minHeight: 0, position: "relative" }}>
       <ScriptDocumentPane scriptId={refId} readOnly={readOnly} />
@@ -83,30 +176,12 @@ const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
             borderLeft: `1px solid ${theme.vars.palette.divider}`
           }}
         >
-          <TabGroup
-            tabs={dockTabs}
-            value={dockTab}
-            onChange={(value) => setDockTab(value as DockTab)}
-            size="small"
-            fullWidth
-            sx={{
-              flexShrink: 0,
-              borderBottom: `1px solid ${theme.vars.palette.divider}`
-            }}
-          />
+          {dockTabGroup}
           <FlexColumn
             fullWidth
             sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}
           >
-            {dockTab === "cast" ? (
-              <ScriptCastPanel
-                scriptId={refId}
-                cast={cast}
-                readOnly={readOnly}
-              />
-            ) : (
-              <ScriptAgentPanel scriptId={refId} />
-            )}
+            {dockPanel}
           </FlexColumn>
         </FlexColumn>
       )}


### PR DESCRIPTION
## Summary

The script editor (`ScriptSurface` → `ScriptDocumentPane` → `ScriptLineRow`) assumed a desktop pointer and a wide viewport, so it was hard to use on phones: a fixed 320px side dock crushed the document, action buttons only appeared on hover (invisible on touch), and a wide screenplay gutter left little room for text. This adds narrow-viewport adaptations, gated on `useMediaQuery(theme.breakpoints.down("sm"))` — the pattern already used in `WorkspaceShell`, `PanelLeft`, etc. Desktop layout is unchanged.

## Changes

- **`ScriptLineRow.tsx`** — on mobile, the line stacks vertically: the speaker tag and an always-visible action bar sit above the dialogue, replacing the wide right-aligned gutter, the hover-revealed action buttons, and the drag rail (drag-to-reorder doesn't work on touch anyway). Shared JSX (speaker button, status dot, action bar, text fields, take gallery) is extracted so the two layouts share it.
- **`ScriptDocumentPane.tsx`** — the sticky toolbar wraps on mobile, the document column padding is trimmed, and the text inset collapses to 0 so lines and insert/add-line affordances use the full width. `InsertLineGap` and `SectionBlock` take an `inset`/`mobile` prop.
- **`ScriptSurface.tsx`** — on mobile the fixed 320px Cast/Assistant side dock becomes a `MobileBottomSheet` reached by two floating buttons; the document runs full-width.

## Testing

- `npx jest src/components/script` — 24 passed
- `eslint` on the three changed files — clean
- `tsc` — no new errors in the changed files (pre-existing repo errors come from unbuilt workspace packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyGYWXQzQx2JM4tFP3AUrN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyGYWXQzQx2JM4tFP3AUrN)_