### PR TITLE
Make sketch editor mobile-friendly

### DIFF
--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -37,7 +37,8 @@ import {
   DisplayFrameCoordinator,
   useCanvasImperativeHandle,
   useTransformPreviewBridge,
-  useCanvasOrchestration
+  useCanvasOrchestration,
+  useCanvasTouchGestures
 } from "./sketchCanvasHooks";
 import { clientToDocumentCanvas } from "./tools/transform/handleGeometry";
 import type { StrokeEndOptions } from "./tools/types";
@@ -463,21 +464,53 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       ]
     );
 
+    // Two-finger pan / pinch-zoom. Runs before the drawing handlers and, once a
+    // pinch begins, consumes the touch events so a gesture never paints.
+    const touchGestures = useCanvasTouchGestures({
+      containerRef,
+      zoom,
+      pan,
+      onZoomChange,
+      onPanChange,
+      cancelDrawing: pointerHandlers.cancelDrawing
+    });
+
     const handlePointerMoveWithCoords = useCallback(
       (e: React.PointerEvent) => {
         lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
+        if (touchGestures.onPointerMove(e)) {
+          return;
+        }
         pointerHandlers.handlePointerMove(e);
         updateCursorDocPosFromClient(e.clientX, e.clientY);
       },
-      [lastPointerClientRef, pointerHandlers, updateCursorDocPosFromClient]
+      [
+        lastPointerClientRef,
+        pointerHandlers,
+        touchGestures,
+        updateCursorDocPosFromClient
+      ]
     );
 
     const handlePointerDownWithClient = useCallback(
       (e: React.PointerEvent) => {
         lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
+        if (touchGestures.onPointerDown(e)) {
+          return;
+        }
         pointerHandlers.handlePointerDown(e);
       },
-      [lastPointerClientRef, pointerHandlers]
+      [lastPointerClientRef, pointerHandlers, touchGestures]
+    );
+
+    const handlePointerUpWithGesture = useCallback(
+      (e: React.PointerEvent) => {
+        if (touchGestures.onPointerUp(e)) {
+          return;
+        }
+        pointerHandlers.handlePointerUp(e);
+      },
+      [pointerHandlers, touchGestures]
     );
 
     const handleMouseLeaveWithCoords = useCallback(() => {
@@ -517,7 +550,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         containerCursor={pointerHandlers.containerCursor}
         onPointerDown={handlePointerDownWithClient}
         onPointerMove={handlePointerMoveWithCoords}
-        onPointerUp={pointerHandlers.handlePointerUp}
+        onPointerUp={handlePointerUpWithGesture}
         onDoubleClick={pointerHandlers.handleDoubleClick}
         onPointerLeave={pointerHandlers.handlePointerLeave}
         onMouseLeave={handleMouseLeaveWithCoords}

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -513,6 +513,20 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       [pointerHandlers, touchGestures]
     );
 
+    // pointercancel (OS interrupts the touch, or pointer capture is lost) must
+    // tear down the gesture refs so a later touch isn't consumed by a stuck
+    // "always active" gesture. When it wasn't a gesture, treat it as an up so
+    // a one-finger stroke ends cleanly.
+    const handlePointerCancelWithGesture = useCallback(
+      (e: React.PointerEvent) => {
+        if (touchGestures.onPointerCancel(e)) {
+          return;
+        }
+        pointerHandlers.handlePointerUp(e);
+      },
+      [pointerHandlers, touchGestures]
+    );
+
     const handleMouseLeaveWithCoords = useCallback(() => {
       pointerHandlers.handleMouseLeave();
       setStoreCursorDocPos(null);
@@ -551,6 +565,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         onPointerDown={handlePointerDownWithClient}
         onPointerMove={handlePointerMoveWithCoords}
         onPointerUp={handlePointerUpWithGesture}
+        onPointerCancel={handlePointerCancelWithGesture}
         onDoubleClick={pointerHandlers.handleDoubleClick}
         onPointerLeave={pointerHandlers.handlePointerLeave}
         onMouseLeave={handleMouseLeaveWithCoords}

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -535,16 +535,17 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
 
     // pointercancel (OS interrupts the touch, or pointer capture is lost) must
     // tear down the gesture refs so a later touch isn't consumed by a stuck
-    // "always active" gesture. When it wasn't a gesture, treat it as an up so
-    // a one-finger stroke ends cleanly.
+    // "always active" gesture. When it wasn't a gesture, the input sequence was
+    // aborted — discard the in-progress stroke via cancelDrawing() rather than
+    // committing it like a normal pointerup would.
     const handlePointerCancelWithGesture = useCallback(
       (e: React.PointerEvent) => {
         if (onGesturePointerCancel(e)) {
           return;
         }
-        drawPointerUp(e);
+        cancelDrawing();
       },
-      [drawPointerUp, onGesturePointerCancel]
+      [cancelDrawing, onGesturePointerCancel]
     );
 
     const handleMouseLeaveWithCoords = useCallback(() => {

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -465,8 +465,16 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
     );
 
     // Two-finger pan / pinch-zoom. Runs before the drawing handlers and, once a
-    // pinch begins, consumes the touch events so a gesture never paints.
-    const touchGestures = useCanvasTouchGestures({
+    // pinch begins, consumes the touch events so a gesture never paints. The
+    // hook returns a fresh object each render, so destructure the individually
+    // memoized handlers and depend on those (not the wrapper object) to keep
+    // the pointer callbacks stable for the memoized presentation layer.
+    const {
+      onPointerDown: onGesturePointerDown,
+      onPointerMove: onGesturePointerMove,
+      onPointerUp: onGesturePointerUp,
+      onPointerCancel: onGesturePointerCancel
+    } = useCanvasTouchGestures({
       containerRef,
       zoom,
       pan,
@@ -478,7 +486,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
     const handlePointerMoveWithCoords = useCallback(
       (e: React.PointerEvent) => {
         lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
-        if (touchGestures.onPointerMove(e)) {
+        if (onGesturePointerMove(e)) {
           return;
         }
         pointerHandlers.handlePointerMove(e);
@@ -487,7 +495,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       [
         lastPointerClientRef,
         pointerHandlers,
-        touchGestures,
+        onGesturePointerMove,
         updateCursorDocPosFromClient
       ]
     );
@@ -495,22 +503,22 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
     const handlePointerDownWithClient = useCallback(
       (e: React.PointerEvent) => {
         lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
-        if (touchGestures.onPointerDown(e)) {
+        if (onGesturePointerDown(e)) {
           return;
         }
         pointerHandlers.handlePointerDown(e);
       },
-      [lastPointerClientRef, pointerHandlers, touchGestures]
+      [lastPointerClientRef, pointerHandlers, onGesturePointerDown]
     );
 
     const handlePointerUpWithGesture = useCallback(
       (e: React.PointerEvent) => {
-        if (touchGestures.onPointerUp(e)) {
+        if (onGesturePointerUp(e)) {
           return;
         }
         pointerHandlers.handlePointerUp(e);
       },
-      [pointerHandlers, touchGestures]
+      [pointerHandlers, onGesturePointerUp]
     );
 
     // pointercancel (OS interrupts the touch, or pointer capture is lost) must
@@ -519,12 +527,12 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
     // a one-finger stroke ends cleanly.
     const handlePointerCancelWithGesture = useCallback(
       (e: React.PointerEvent) => {
-        if (touchGestures.onPointerCancel(e)) {
+        if (onGesturePointerCancel(e)) {
           return;
         }
         pointerHandlers.handlePointerUp(e);
       },
-      [pointerHandlers, touchGestures]
+      [pointerHandlers, onGesturePointerCancel]
     );
 
     const handleMouseLeaveWithCoords = useCallback(() => {

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -464,6 +464,18 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       ]
     );
 
+    // `pointerHandlers` (from useCanvasOrchestration) is a fresh object each
+    // render, but the handlers inside it are useCallback-stable. Destructure
+    // the ones the wrappers below call so the wrappers depend on stable
+    // function identities, not the churning object — keeping SketchCanvas-
+    // Presentation's memoization intact.
+    const {
+      handlePointerDown: drawPointerDown,
+      handlePointerMove: drawPointerMove,
+      handlePointerUp: drawPointerUp,
+      cancelDrawing
+    } = pointerHandlers;
+
     // Two-finger pan / pinch-zoom. Runs before the drawing handlers and, once a
     // pinch begins, consumes the touch events so a gesture never paints. The
     // hook returns a fresh object each render, so destructure the individually
@@ -480,7 +492,7 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
       pan,
       onZoomChange,
       onPanChange,
-      cancelDrawing: pointerHandlers.cancelDrawing
+      cancelDrawing
     });
 
     const handlePointerMoveWithCoords = useCallback(
@@ -489,12 +501,12 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         if (onGesturePointerMove(e)) {
           return;
         }
-        pointerHandlers.handlePointerMove(e);
+        drawPointerMove(e);
         updateCursorDocPosFromClient(e.clientX, e.clientY);
       },
       [
         lastPointerClientRef,
-        pointerHandlers,
+        drawPointerMove,
         onGesturePointerMove,
         updateCursorDocPosFromClient
       ]
@@ -506,9 +518,9 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         if (onGesturePointerDown(e)) {
           return;
         }
-        pointerHandlers.handlePointerDown(e);
+        drawPointerDown(e);
       },
-      [lastPointerClientRef, pointerHandlers, onGesturePointerDown]
+      [lastPointerClientRef, drawPointerDown, onGesturePointerDown]
     );
 
     const handlePointerUpWithGesture = useCallback(
@@ -516,9 +528,9 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         if (onGesturePointerUp(e)) {
           return;
         }
-        pointerHandlers.handlePointerUp(e);
+        drawPointerUp(e);
       },
-      [pointerHandlers, onGesturePointerUp]
+      [drawPointerUp, onGesturePointerUp]
     );
 
     // pointercancel (OS interrupts the touch, or pointer capture is lost) must
@@ -530,9 +542,9 @@ const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
         if (onGesturePointerCancel(e)) {
           return;
         }
-        pointerHandlers.handlePointerUp(e);
+        drawPointerUp(e);
       },
-      [pointerHandlers, onGesturePointerCancel]
+      [drawPointerUp, onGesturePointerCancel]
     );
 
     const handleMouseLeaveWithCoords = useCallback(() => {

--- a/web/src/components/sketch/SketchCanvasPresentation.tsx
+++ b/web/src/components/sketch/SketchCanvasPresentation.tsx
@@ -105,6 +105,7 @@ export interface SketchCanvasPresentationProps {
   onPointerDown: (e: React.PointerEvent) => void;
   onPointerMove: (e: React.PointerEvent) => void;
   onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel?: (e: React.PointerEvent) => void;
   onDoubleClick: (e: React.MouseEvent) => void;
   onPointerLeave: () => void;
   onMouseLeave: () => void;
@@ -171,6 +172,7 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
       onPointerDown,
       onPointerMove,
       onPointerUp,
+      onPointerCancel,
       onDoubleClick,
       onPointerLeave,
       onMouseLeave,
@@ -198,6 +200,7 @@ const SketchCanvasPresentation = memo<SketchCanvasPresentationProps>(
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
         onDoubleClick={onDoubleClick}
         onPointerLeave={onPointerLeave}
         onMouseLeave={onMouseLeave}

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -40,6 +40,7 @@ import { css } from "@emotion/react";
 import React, { memo, forwardRef, useEffect } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import {
   Chip,
   CollapsibleSection,
@@ -53,7 +54,6 @@ import {
   Tooltip,
   Z_INDEX
 } from "../ui_primitives";
-import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import TransformContextMenu from "./TransformContextMenu";
 import type { SketchDocument } from "./types";
 import type { SketchPersistenceSnapshot } from "../../stores/sketch/persistence";
@@ -225,12 +225,18 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
 
     // The mobile panels sheet is a mobile-only surface. Clear its flag when the
     // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
-    // the next time the viewport shrinks back to mobile.
+    // the next time the viewport shrinks back to mobile. Also keep the two
+    // mobile bottom sheets mutually exclusive: when the Assistant opens (its
+    // toggle lives in the prompt bar), close the panels sheet so two stacked
+    // SwipeableDrawer modals never fight over focus/scroll.
     useEffect(() => {
-      if (!isMobile && mobilePanelsOpen) {
+      if (!mobilePanelsOpen) {
+        return;
+      }
+      if (!isMobile || assistantPanelOpen) {
         setMobilePanelsOpen(false);
       }
-    }, [isMobile, mobilePanelsOpen, setMobilePanelsOpen]);
+    }, [isMobile, assistantPanelOpen, mobilePanelsOpen, setMobilePanelsOpen]);
 
     // Register the agent bridge under this document's id so the `ui_sketch_*`
     // tools can address it whether or not this surface is focused. The session
@@ -599,7 +605,11 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
                 size="medium"
                 color="primary"
                 aria-label="Open layers and color panel"
-                onClick={() => setMobilePanelsOpen(true)}
+                onClick={() => {
+                  // Last action wins — never stack the two mobile sheets.
+                  setAssistantPanelOpen(false);
+                  setMobilePanelsOpen(true);
+                }}
                 sx={{
                   position: "absolute",
                   bottom: (t) => t.spacing(2),

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -45,18 +45,23 @@ import {
   CollapsibleSection,
   ColorSwatch,
   Container,
+  Fab,
   FlexColumn,
   FlexRow,
+  MobileBottomSheet,
   Text,
+  Tooltip,
   Z_INDEX
 } from "../ui_primitives";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import TransformContextMenu from "./TransformContextMenu";
 import type { SketchDocument } from "./types";
 import type { SketchPersistenceSnapshot } from "../../stores/sketch/persistence";
 import {
   useColorIntentRouter,
   useEditorSession,
-  useEditorCommands
+  useEditorCommands,
+  useSketchIsMobile
 } from "./hooks";
 import {
   ConnectedModePromptBar,
@@ -85,6 +90,7 @@ const styles = (theme: Theme) =>
     flexDirection: "column",
     width: "100%",
     height: "100%",
+    position: "relative",
     backgroundColor: theme.vars.palette.grey[900],
     overflow: "hidden"
   });
@@ -209,6 +215,14 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     const panelsHidden = useSketchStore((s) => s.panelsHidden);
     const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
 
+    // On narrow/touch viewports the fixed side columns can't sit beside the
+    // canvas, so the right panel and assistant move into bottom sheets and the
+    // canvas keeps the full width. See useSketchIsMobile (600px, app breakpoint).
+    const isMobile = useSketchIsMobile();
+    const mobilePanelsOpen = useSketchStore((s) => s.mobilePanelsOpen);
+    const setMobilePanelsOpen = useSketchStore((s) => s.setMobilePanelsOpen);
+    const setAssistantPanelOpen = useSketchStore((s) => s.setAssistantPanelOpen);
+
     // Register the agent bridge under this document's id so the `ui_sketch_*`
     // tools can address it whether or not this surface is focused. The session
     // store is the authority: a never-saved document has no id yet, and gains
@@ -277,6 +291,122 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     // workflow changed, merge paramOverrides against current Input* nodes,
     // and auto-resolve a missing selectedOutputNodeId.
     useSketchWorkflowFreshnessCheck(sessionDocumentId);
+
+    // Color / Layers / Canvas sections. Shared between the docked desktop
+    // column and the mobile bottom sheet so the two stay in lockstep.
+    const rightPanelSections = (
+      <>
+        <CollapsibleSection
+          className="sketch-editor__color-section"
+          title={<ColorSectionHeader />}
+          defaultOpen={false}
+          compact
+          sx={{
+            fontSize: theme.fontSizeSmall,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`,
+            "& > [role='button']": {
+              padding: theme.spacing(1, 1),
+              backgroundColor: theme.vars.palette.background.paper
+            }
+          }}
+        >
+          <ConnectedColorPanel />
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          className="sketch-editor__layers-section"
+          title={<SectionTitle>Layers</SectionTitle>}
+          defaultOpen
+          compact
+          sx={{
+            fontSize: theme.fontSizeSmall,
+            minHeight: 0,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`,
+            "& > [role='button']": {
+              padding: theme.spacing(1, 1),
+              backgroundColor: theme.vars.palette.background.paper
+            }
+          }}
+        >
+          <ConnectedLayersPanel
+            onClearLayer={session.canvasActions.handleClearLayer}
+            onFlipHorizontal={session.layerActions.handleFlipHorizontal}
+            onFlipVertical={session.layerActions.handleFlipVertical}
+            onRotate180={session.layerActions.handleRotate180}
+            onMergeDown={session.layerActions.handleMergeDown}
+            onFlattenVisible={session.layerActions.handleFlattenVisible}
+            onTrimLayerToBounds={session.canvasActions.handleTrimLayerToBounds}
+            onCropCanvasToActiveLayerVisiblePixels={
+              session.canvasActions.handleCropCanvasToActiveLayerVisiblePixels
+            }
+            onCropCanvasToActiveLayerExtents={
+              session.canvasActions.handleCropCanvasToActiveLayerExtents
+            }
+            onToggleVisibility={session.layerActions.handleToggleVisibility}
+            onAddLayer={(fillColor) =>
+              session.layerActions.handleAddLayer({
+                fillColor: fillColor ?? undefined
+              })
+            }
+            onRemoveLayer={session.layerActions.handleRemoveLayer}
+            onDuplicateLayer={session.layerActions.handleDuplicateLayer}
+            onReorderLayers={session.layerActions.handleReorderLayers}
+            onSetMaskLayer={session.layerActions.handleSetMaskLayer}
+            onToggleAlphaLock={session.layerActions.handleToggleAlphaLock}
+            onToggleExposedInput={session.layerActions.handleToggleExposedInput}
+            onToggleExposedOutput={
+              session.layerActions.handleToggleExposedOutput
+            }
+            onLayerOpacityChange={session.layerActions.handleSetLayerOpacity}
+            onLayerBlendModeChange={session.layerActions.handleSetLayerBlendMode}
+            onRenameLayer={session.layerActions.handleRenameLayer}
+            onAddGroup={session.layerActions.handleAddGroup}
+            onToggleGroupCollapsed={
+              session.layerActions.handleToggleGroupCollapsed
+            }
+            onMoveLayerToGroup={session.layerActions.handleMoveLayerToGroup}
+            onUngroupLayer={session.layerActions.handleUngroupLayer}
+            onGroupSelectedLayers={
+              session.layerActions.handleGroupSelectedLayers
+            }
+            onMergeSelectedLayers={
+              session.layerActions.handleMergeSelectedLayers
+            }
+            onDeleteSelectedLayers={
+              session.layerActions.handleDeleteSelectedLayers
+            }
+            onLoadLayerAsSelection={
+              session.canvasActions.handleLoadLayerAsSelection
+            }
+          />
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          className="sketch-editor__canvas-section"
+          title={<SectionTitle>Canvas</SectionTitle>}
+          defaultOpen={false}
+          compact
+          sx={{
+            fontSize: theme.fontSizeSmall,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`,
+            "& > [role='button']": {
+              padding: theme.spacing(1, 1),
+              backgroundColor: theme.vars.palette.background.paper
+            }
+          }}
+        >
+          <ConnectedCanvasSizePanel
+            onCanvasResize={session.canvasActions.handleCanvasResize}
+            canvasResizeHandlesEnabled={session.canvasResizeHandlesEnabled}
+            onCanvasResizeHandlesEnabledChange={
+              session.handleCanvasResizeHandlesEnabledChange
+            }
+          />
+        </CollapsibleSection>
+
+        <ConnectedGeneratedLayerSection />
+      </>
+    );
 
     return (
       <FlexColumn className="sketch-editor" css={styles(theme)} gap={0}>
@@ -403,8 +533,9 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
           {/* Right column: color, layers, canvas size sections. The wrapper
           itself is gated on `panelsHidden` so Tab collapses the column's
           reserved width (not just blanks its contents), giving the
-          canvas the freed real estate. */}
-          {!panelsHidden && (
+          canvas the freed real estate. On mobile the column is dropped here
+          and the same sections render in a bottom sheet below. */}
+          {!panelsHidden && !isMobile && (
             <FlexColumn
               className="sketch-editor__panel-right"
               sx={{
@@ -419,137 +550,15 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
               }}
               gap={0}
             >
-              <CollapsibleSection
-                className="sketch-editor__color-section"
-                title={<ColorSectionHeader />}
-                defaultOpen={false}
-                compact
-                sx={{
-                  fontSize: theme.fontSizeSmall,
-                  borderBottom: `1px solid ${theme.vars.palette.divider}`,
-                  "& > [role='button']": {
-                    padding: theme.spacing(1, 1),
-                    backgroundColor: theme.vars.palette.background.paper
-                  }
-                }}
-              >
-                <ConnectedColorPanel />
-              </CollapsibleSection>
-
-              <CollapsibleSection
-                className="sketch-editor__layers-section"
-                title={<SectionTitle>Layers</SectionTitle>}
-                defaultOpen
-                compact
-                sx={{
-                  fontSize: theme.fontSizeSmall,
-                  minHeight: 0,
-                  borderBottom: `1px solid ${theme.vars.palette.divider}`,
-                  "& > [role='button']": {
-                    padding: theme.spacing(1, 1),
-                    backgroundColor: theme.vars.palette.background.paper
-                  }
-                }}
-              >
-                <ConnectedLayersPanel
-                  onClearLayer={session.canvasActions.handleClearLayer}
-                  onFlipHorizontal={session.layerActions.handleFlipHorizontal}
-                  onFlipVertical={session.layerActions.handleFlipVertical}
-                  onRotate180={session.layerActions.handleRotate180}
-                  onMergeDown={session.layerActions.handleMergeDown}
-                  onFlattenVisible={session.layerActions.handleFlattenVisible}
-                  onTrimLayerToBounds={
-                    session.canvasActions.handleTrimLayerToBounds
-                  }
-                  onCropCanvasToActiveLayerVisiblePixels={
-                    session.canvasActions
-                      .handleCropCanvasToActiveLayerVisiblePixels
-                  }
-                  onCropCanvasToActiveLayerExtents={
-                    session.canvasActions.handleCropCanvasToActiveLayerExtents
-                  }
-                  onToggleVisibility={
-                    session.layerActions.handleToggleVisibility
-                  }
-                  onAddLayer={(fillColor) =>
-                    session.layerActions.handleAddLayer({
-                      fillColor: fillColor ?? undefined
-                    })
-                  }
-                  onRemoveLayer={session.layerActions.handleRemoveLayer}
-                  onDuplicateLayer={session.layerActions.handleDuplicateLayer}
-                  onReorderLayers={session.layerActions.handleReorderLayers}
-                  onSetMaskLayer={session.layerActions.handleSetMaskLayer}
-                  onToggleAlphaLock={session.layerActions.handleToggleAlphaLock}
-                  onToggleExposedInput={
-                    session.layerActions.handleToggleExposedInput
-                  }
-                  onToggleExposedOutput={
-                    session.layerActions.handleToggleExposedOutput
-                  }
-                  onLayerOpacityChange={
-                    session.layerActions.handleSetLayerOpacity
-                  }
-                  onLayerBlendModeChange={
-                    session.layerActions.handleSetLayerBlendMode
-                  }
-                  onRenameLayer={session.layerActions.handleRenameLayer}
-                  onAddGroup={session.layerActions.handleAddGroup}
-                  onToggleGroupCollapsed={
-                    session.layerActions.handleToggleGroupCollapsed
-                  }
-                  onMoveLayerToGroup={
-                    session.layerActions.handleMoveLayerToGroup
-                  }
-                  onUngroupLayer={session.layerActions.handleUngroupLayer}
-                  onGroupSelectedLayers={
-                    session.layerActions.handleGroupSelectedLayers
-                  }
-                  onMergeSelectedLayers={
-                    session.layerActions.handleMergeSelectedLayers
-                  }
-                  onDeleteSelectedLayers={
-                    session.layerActions.handleDeleteSelectedLayers
-                  }
-                  onLoadLayerAsSelection={
-                    session.canvasActions.handleLoadLayerAsSelection
-                  }
-                />
-              </CollapsibleSection>
-
-              <CollapsibleSection
-                className="sketch-editor__canvas-section"
-                title={<SectionTitle>Canvas</SectionTitle>}
-                defaultOpen={false}
-                compact
-                sx={{
-                  fontSize: theme.fontSizeSmall,
-                  borderBottom: `1px solid ${theme.vars.palette.divider}`,
-                  "& > [role='button']": {
-                    padding: theme.spacing(1, 1),
-                    backgroundColor: theme.vars.palette.background.paper
-                  }
-                }}
-              >
-                <ConnectedCanvasSizePanel
-                  onCanvasResize={session.canvasActions.handleCanvasResize}
-                  canvasResizeHandlesEnabled={
-                    session.canvasResizeHandlesEnabled
-                  }
-                  onCanvasResizeHandlesEnabledChange={
-                    session.handleCanvasResizeHandlesEnabledChange
-                  }
-                />
-              </CollapsibleSection>
-
-              <ConnectedGeneratedLayerSection />
+              {rightPanelSections}
             </FlexColumn>
           )}
 
           {/* AI assistant chat column — a toggleable right-most panel that
           drives the editor through the ui_sketch_* agent tools. Gated on the
-          same panelsHidden chrome toggle so Tab collapses it too. */}
-          {!panelsHidden && assistantPanelOpen && (
+          same panelsHidden chrome toggle so Tab collapses it too. On mobile
+          it moves into a bottom sheet (below). */}
+          {!panelsHidden && !isMobile && assistantPanelOpen && (
             <FlexColumn
               className="sketch-editor__assistant-panel"
               sx={{
@@ -568,6 +577,63 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
             </FlexColumn>
           )}
         </FlexRow>
+
+        {/* ── Mobile chrome ─────────────────────────────────────────────
+          On narrow viewports the right panel and assistant can't dock beside
+          the canvas, so they become bottom sheets and a floating button opens
+          the panels sheet. Gated on the same panelsHidden chrome toggle. */}
+        {isMobile && !panelsHidden && (
+          <>
+            <Tooltip title="Layers & color">
+              <Fab
+                className="sketch-editor__mobile-panels-fab"
+                size="medium"
+                color="primary"
+                aria-label="Open layers and color panel"
+                onClick={() => setMobilePanelsOpen(true)}
+                sx={{
+                  position: "absolute",
+                  bottom: (t) => t.spacing(2),
+                  right: (t) => t.spacing(2),
+                  zIndex: Z_INDEX.raised + 2
+                }}
+              >
+                <LayersOutlinedIcon />
+              </Fab>
+            </Tooltip>
+
+            <MobileBottomSheet
+              open={mobilePanelsOpen}
+              onClose={() => setMobilePanelsOpen(false)}
+              title="Layers & color"
+              ariaLabel="Layers and color panel"
+            >
+              <FlexColumn
+                className="sketch-editor__panel-right sketch-editor__panel-right--mobile"
+                sx={{ minHeight: 0, overflow: "auto" }}
+                gap={0}
+              >
+                {rightPanelSections}
+              </FlexColumn>
+            </MobileBottomSheet>
+
+            <MobileBottomSheet
+              open={assistantPanelOpen}
+              onClose={() => setAssistantPanelOpen(false)}
+              title="Assistant"
+              ariaLabel="AI assistant panel"
+              maxHeight="85vh"
+            >
+              <FlexColumn
+                className="sketch-editor__assistant-panel sketch-editor__assistant-panel--mobile"
+                sx={{ height: "70vh", minHeight: 0, overflow: "hidden" }}
+                gap={0}
+              >
+                <SketchAgentPanel />
+              </FlexColumn>
+            </MobileBottomSheet>
+          </>
+        )}
 
         {/* Full-width status bar — standalone editor only (gates internally). */}
         <ConnectedStatusBar />

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -223,6 +223,15 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     const setMobilePanelsOpen = useSketchStore((s) => s.setMobilePanelsOpen);
     const setAssistantPanelOpen = useSketchStore((s) => s.setAssistantPanelOpen);
 
+    // The mobile panels sheet is a mobile-only surface. Clear its flag when the
+    // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
+    // the next time the viewport shrinks back to mobile.
+    useEffect(() => {
+      if (!isMobile && mobilePanelsOpen) {
+        setMobilePanelsOpen(false);
+      }
+    }, [isMobile, mobilePanelsOpen, setMobilePanelsOpen]);
+
     // Register the agent bridge under this document's id so the `ui_sketch_*`
     // tools can address it whether or not this surface is focused. The session
     // store is the authority: a never-saved document has no id yet, and gains

--- a/web/src/components/sketch/__tests__/useSketchStore.test.ts
+++ b/web/src/components/sketch/__tests__/useSketchStore.test.ts
@@ -685,4 +685,24 @@ describe("useSketchStore", () => {
       }
     });
   });
+
+  describe("mobile panels sheet", () => {
+    it("starts closed", () => {
+      expect(useSketchStore.getState().mobilePanelsOpen).toBe(false);
+    });
+
+    it("toggles open and closed", () => {
+      act(() => useSketchStore.getState().toggleMobilePanels());
+      expect(useSketchStore.getState().mobilePanelsOpen).toBe(true);
+      act(() => useSketchStore.getState().toggleMobilePanels());
+      expect(useSketchStore.getState().mobilePanelsOpen).toBe(false);
+    });
+
+    it("sets open state directly", () => {
+      act(() => useSketchStore.getState().setMobilePanelsOpen(true));
+      expect(useSketchStore.getState().mobilePanelsOpen).toBe(true);
+      act(() => useSketchStore.getState().setMobilePanelsOpen(false));
+      expect(useSketchStore.getState().mobilePanelsOpen).toBe(false);
+    });
+  });
 });

--- a/web/src/components/sketch/__tests__/useSketchStore.test.ts
+++ b/web/src/components/sketch/__tests__/useSketchStore.test.ts
@@ -687,6 +687,12 @@ describe("useSketchStore", () => {
   });
 
   describe("mobile panels sheet", () => {
+    // resetDocument() (file-level beforeEach) doesn't touch UI-slice flags, so
+    // reset the sheet explicitly to isolate from state other tests may leak.
+    beforeEach(() => {
+      act(() => useSketchStore.getState().setMobilePanelsOpen(false));
+    });
+
     it("starts closed", () => {
       expect(useSketchStore.getState().mobilePanelsOpen).toBe(false);
     });

--- a/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedModePromptBar.tsx
@@ -239,6 +239,11 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
           // height than the utility tool-options bar below it. Generous
           // vertical room keeps the controls from feeling crammed.
           minHeight: 56,
+          // On narrow screens the prompt + model/size chips + actions can't fit
+          // on one line, so wrap them (prompt takes the first row via flex:1,
+          // controls flow onto the next) instead of overflowing off-screen.
+          flexWrap: "wrap",
+          rowGap: SKETCH_SPACING.md,
           padding: `${SKETCH_SPACING.lg} ${SKETCH_SPACING.xl}`,
           backgroundColor: theme.vars.palette.grey[900],
           borderBottom: `1px solid ${theme.vars.palette.grey[800]}`

--- a/web/src/components/sketch/hooks/index.ts
+++ b/web/src/components/sketch/hooks/index.ts
@@ -14,6 +14,7 @@ export { useExportSyncActions } from "./useExportSyncActions";
 export { useCanvasGeometryActions } from "./useCanvasGeometryActions";
 export { useColorActions } from "./useColorActions";
 export { useColorIntentRouter } from "./useColorIntentRouter";
+export { useSketchIsMobile } from "./useSketchIsMobile";
 export { useSegmentation } from "./useSegmentation";
 export { useEditorLifecycle } from "./useEditorLifecycle";
 export { useToolChromeActions } from "./useToolChromeActions";

--- a/web/src/components/sketch/hooks/useSketchIsMobile.ts
+++ b/web/src/components/sketch/hooks/useSketchIsMobile.ts
@@ -1,0 +1,17 @@
+/**
+ * useSketchIsMobile
+ *
+ * True on narrow/coarse-pointer viewports where the editor's fixed side
+ * columns (46px tool rail + 260px right panel + 340px assistant) can't sit
+ * beside the canvas. Mirrors the app-wide breakpoint used by
+ * MobileClassProvider (`theme.breakpoints.down("sm")` = 600px) so the sketch
+ * editor participates in the same mobile threshold as the rest of the app.
+ */
+
+import { useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+export function useSketchIsMobile(): boolean {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("sm"));
+}

--- a/web/src/components/sketch/hooks/useSketchIsMobile.ts
+++ b/web/src/components/sketch/hooks/useSketchIsMobile.ts
@@ -1,11 +1,12 @@
 /**
  * useSketchIsMobile
  *
- * True on narrow/coarse-pointer viewports where the editor's fixed side
- * columns (46px tool rail + 260px right panel + 340px assistant) can't sit
- * beside the canvas. Mirrors the app-wide breakpoint used by
- * MobileClassProvider (`theme.breakpoints.down("sm")` = 600px) so the sketch
- * editor participates in the same mobile threshold as the rest of the app.
+ * True on narrow viewports (width below the `sm` breakpoint = 600px) where the
+ * editor's fixed side columns (46px tool rail + 260px right panel + 340px
+ * assistant) can't sit beside the canvas. Mirrors the width query used by
+ * MobileClassProvider so the sketch editor shares the same mobile threshold as
+ * the rest of the app. (Pointer coarseness isn't factored in — a large touch
+ * screen still has room for the docked columns.)
  */
 
 import { useMediaQuery } from "@mui/material";

--- a/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
+++ b/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Tests for useCanvasTouchGestures — the two-finger pan/pinch-zoom layer.
+ *
+ * Covers the pure pinch math (computePinchStep) and the consume/abort behavior
+ * of the hook (second finger aborts a stroke, gesture events are consumed,
+ * one finger draws normally).
+ */
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import {
+  computePinchStep,
+  useCanvasTouchGestures
+} from "../useCanvasTouchGestures";
+import { SKETCH_ZOOM_MAX, SKETCH_ZOOM_MIN } from "../../state/useSketchStore";
+
+const RECT = { left: 0, top: 0, width: 400, height: 300 };
+
+describe("computePinchStep", () => {
+  it("pans by the midpoint delta when the distance is unchanged", () => {
+    const prev = { mid: { x: 200, y: 150 }, dist: 100 };
+    const cur = { mid: { x: 220, y: 160 }, dist: 100 };
+    const res = computePinchStep(prev, cur, 1, { x: 0, y: 0 }, RECT);
+    expect(res.zoom).toBe(1);
+    expect(res.pan).toEqual({ x: 20, y: 10 });
+  });
+
+  it("zooms in by the distance ratio", () => {
+    const prev = { mid: { x: 200, y: 150 }, dist: 100 };
+    const cur = { mid: { x: 200, y: 150 }, dist: 200 };
+    const res = computePinchStep(prev, cur, 1, { x: 0, y: 0 }, RECT);
+    expect(res.zoom).toBe(2);
+  });
+
+  it("keeps the pixel under the pinch midpoint anchored while zooming", () => {
+    // Midpoint at the rect center → offset is zero → pan stays put on zoom.
+    const prev = { mid: { x: 200, y: 150 }, dist: 100 };
+    const cur = { mid: { x: 200, y: 150 }, dist: 150 };
+    const res = computePinchStep(prev, cur, 1, { x: 0, y: 0 }, RECT);
+    expect(res.zoom).toBeCloseTo(1.5);
+    expect(res.pan.x).toBeCloseTo(0);
+    expect(res.pan.y).toBeCloseTo(0);
+  });
+
+  it("clamps zoom to the editor min/max", () => {
+    const prev = { mid: { x: 0, y: 0 }, dist: 1 };
+    const zoomedOut = computePinchStep(
+      prev,
+      { mid: { x: 0, y: 0 }, dist: 0.0001 },
+      SKETCH_ZOOM_MIN,
+      { x: 0, y: 0 },
+      RECT
+    );
+    expect(zoomedOut.zoom).toBe(SKETCH_ZOOM_MIN);
+
+    const zoomedIn = computePinchStep(
+      prev,
+      { mid: { x: 0, y: 0 }, dist: 1_000_000 },
+      SKETCH_ZOOM_MAX,
+      { x: 0, y: 0 },
+      RECT
+    );
+    expect(zoomedIn.zoom).toBe(SKETCH_ZOOM_MAX);
+  });
+});
+
+function touchEvent(pointerId: number, clientX: number, clientY: number) {
+  return {
+    pointerType: "touch",
+    pointerId,
+    clientX,
+    clientY
+  } as unknown as React.PointerEvent;
+}
+
+function mouseEvent() {
+  return { pointerType: "mouse", pointerId: 1 } as unknown as React.PointerEvent;
+}
+
+function setup() {
+  const cancelDrawing = jest.fn();
+  const onZoomChange = jest.fn();
+  const onPanChange = jest.fn();
+  const container = {
+    current: {
+      getBoundingClientRect: () => RECT
+    }
+  } as unknown as React.RefObject<HTMLDivElement | null>;
+
+  const { result } = renderHook(() =>
+    useCanvasTouchGestures({
+      containerRef: container,
+      zoom: 1,
+      pan: { x: 0, y: 0 },
+      onZoomChange,
+      onPanChange,
+      cancelDrawing
+    })
+  );
+  return { result, cancelDrawing, onZoomChange, onPanChange };
+}
+
+describe("useCanvasTouchGestures", () => {
+  it("does not consume a single touch (one finger still draws)", () => {
+    const { result } = setup();
+    let consumed = true;
+    act(() => {
+      consumed = result.current.onPointerDown(touchEvent(1, 100, 100));
+    });
+    expect(consumed).toBe(false);
+  });
+
+  it("ignores mouse pointers entirely", () => {
+    const { result } = setup();
+    expect(result.current.onPointerDown(mouseEvent())).toBe(false);
+    expect(result.current.onPointerMove(mouseEvent())).toBe(false);
+    expect(result.current.onPointerUp(mouseEvent())).toBe(false);
+  });
+
+  it("aborts the in-progress stroke and consumes when a second finger lands", () => {
+    const { result, cancelDrawing } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 100, 100));
+    });
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onPointerDown(touchEvent(2, 200, 100));
+    });
+    expect(consumed).toBe(true);
+    expect(cancelDrawing).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits zoom/pan updates on a two-finger move", () => {
+    const { result, onZoomChange, onPanChange } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 150, 150));
+      result.current.onPointerDown(touchEvent(2, 250, 150));
+    });
+    act(() => {
+      // Spread the fingers apart → zoom in.
+      result.current.onPointerMove(touchEvent(1, 100, 150));
+      result.current.onPointerMove(touchEvent(2, 300, 150));
+    });
+    expect(onZoomChange).toHaveBeenCalled();
+    expect(onPanChange).toHaveBeenCalled();
+    const lastZoom = onZoomChange.mock.calls.at(-1)?.[0] as number;
+    expect(lastZoom).toBeGreaterThan(1);
+  });
+
+  it("consumes the finger lift while a gesture is active", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 150, 150));
+      result.current.onPointerDown(touchEvent(2, 250, 150));
+    });
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onPointerUp(touchEvent(2, 250, 150));
+    });
+    expect(consumed).toBe(true);
+  });
+});

--- a/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
+++ b/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
@@ -159,4 +159,30 @@ describe("useCanvasTouchGestures", () => {
     });
     expect(consumed).toBe(true);
   });
+
+  it("keeps consuming the leftover finger until the last lifts", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 150, 150));
+      result.current.onPointerDown(touchEvent(2, 250, 150));
+      result.current.onPointerUp(touchEvent(2, 250, 150));
+    });
+    // One finger remains after the pinch — its moves and final lift must still
+    // be consumed so it can't resume a stroke mid-sequence.
+    let move = false;
+    let lift = false;
+    act(() => {
+      move = result.current.onPointerMove(touchEvent(1, 170, 160));
+      lift = result.current.onPointerUp(touchEvent(1, 170, 160));
+    });
+    expect(move).toBe(true);
+    expect(lift).toBe(true);
+
+    // Gesture fully ended: a fresh single touch draws again (not consumed).
+    let fresh = true;
+    act(() => {
+      fresh = result.current.onPointerDown(touchEvent(3, 100, 100));
+    });
+    expect(fresh).toBe(false);
+  });
 });

--- a/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
+++ b/web/src/components/sketch/sketchCanvasHooks/__tests__/useCanvasTouchGestures.test.tsx
@@ -185,4 +185,44 @@ describe("useCanvasTouchGestures", () => {
     });
     expect(fresh).toBe(false);
   });
+
+  it("rebaselines geometry when a 3rd finger lifts leaving two down", () => {
+    const { result, onZoomChange } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 100, 150));
+      result.current.onPointerDown(touchEvent(2, 200, 150));
+      result.current.onPointerDown(touchEvent(3, 300, 150));
+    });
+    onZoomChange.mockClear();
+    // Lift the middle finger; the surviving pair (1 @100, 3 @300, dist 200) must
+    // become the new baseline. A move that holds that distance → no zoom jump.
+    act(() => {
+      result.current.onPointerUp(touchEvent(2, 200, 150));
+      result.current.onPointerMove(touchEvent(1, 100, 150));
+      result.current.onPointerMove(touchEvent(3, 300, 150));
+    });
+    // Distance unchanged from the rebaseline → zoom stays at 1 (no jump).
+    for (const call of onZoomChange.mock.calls) {
+      expect(call[0]).toBeCloseTo(1);
+    }
+  });
+
+  it("tears down the gesture on pointercancel", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.onPointerDown(touchEvent(1, 150, 150));
+      result.current.onPointerDown(touchEvent(2, 250, 150));
+    });
+    act(() => {
+      result.current.onPointerCancel(touchEvent(1, 150, 150));
+      result.current.onPointerCancel(touchEvent(2, 250, 150));
+    });
+    // After cancel of all fingers the gesture is gone: a fresh single touch
+    // draws again instead of being consumed by a stuck gesture.
+    let fresh = true;
+    act(() => {
+      fresh = result.current.onPointerDown(touchEvent(3, 100, 100));
+    });
+    expect(fresh).toBe(false);
+  });
 });

--- a/web/src/components/sketch/sketchCanvasHooks/index.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/index.ts
@@ -46,6 +46,15 @@ export type {
 export { usePointerHandlers } from "./usePointerHandlers";
 export type { UsePointerHandlersParams, UsePointerHandlersResult } from "./usePointerHandlers";
 
+export {
+  useCanvasTouchGestures,
+  computePinchStep
+} from "./useCanvasTouchGestures";
+export type {
+  UseCanvasTouchGesturesParams,
+  UseCanvasTouchGesturesResult
+} from "./useCanvasTouchGestures";
+
 export { useTransformPreviewBridge } from "./useTransformPreviewBridge";
 export type { UseTransformPreviewBridgeResult } from "./useTransformPreviewBridge";
 

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
@@ -88,6 +88,8 @@ export interface UseCanvasTouchGesturesResult {
   onPointerDown: (e: React.PointerEvent) => boolean;
   onPointerMove: (e: React.PointerEvent) => boolean;
   onPointerUp: (e: React.PointerEvent) => boolean;
+  /** pointercancel — same teardown as onPointerUp so refs never get stuck. */
+  onPointerCancel: (e: React.PointerEvent) => boolean;
 }
 
 export function useCanvasTouchGestures({
@@ -195,18 +197,26 @@ export function useCanvasTouchGestures({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- containerRef is stable
   }, [onPanChange, onZoomChange]);
 
-  const onPointerUp = useCallback((e: React.PointerEvent): boolean => {
+  // Shared teardown for both pointerup and pointercancel: drop the pointer,
+  // rebaseline or clear the pinch geometry, and end the gesture once the last
+  // finger is gone.
+  const endPointer = useCallback((e: React.PointerEvent): boolean => {
     if (e.pointerType !== "touch") {
       return false;
     }
     const wasGesture = gestureActiveRef.current;
     pointersRef.current.delete(e.pointerId);
-    if (pointersRef.current.size < 2) {
+    if (pointersRef.current.size >= 2) {
+      // A finger left but two remain — rebaseline to the surviving pair so the
+      // next move doesn't jump on the midpoint/distance mismatch.
+      const [a, b] = firstTwoPoints();
+      lastSampleRef.current = pinchSample(a, b);
+    } else {
       // Pinch geometry is undefined below two fingers.
       lastSampleRef.current = null;
     }
     if (pointersRef.current.size === 0) {
-      // Gesture only ends once the last finger lifts.
+      // Gesture only ends once the last finger lifts (or is cancelled).
       gestureActiveRef.current = false;
     }
     // Consume every lift that belongs to the gesture sequence so the remaining
@@ -214,5 +224,10 @@ export function useCanvasTouchGestures({
     return wasGesture;
   }, []);
 
-  return { onPointerDown, onPointerMove, onPointerUp };
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: endPointer,
+    onPointerCancel: endPointer
+  };
 }

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
@@ -105,11 +105,16 @@ export function useCanvasTouchGestures({
   // gesture must accumulate against its own copy rather than the stale props.
   const runningZoomRef = useRef(zoom);
   const runningPanRef = useRef(pan);
+  // Stays true from the moment a two-finger gesture begins until the LAST
+  // finger lifts — not just while ≥2 fingers are down. This is what lets the
+  // handlers keep consuming touch events after a pinch drops to one finger, so
+  // the leftover finger never resumes a stroke mid-sequence.
+  const gestureActiveRef = useRef(false);
 
   // Keep the running values in sync with committed props while no gesture is
   // active, so the next pinch starts from the true viewport state.
   useEffect(() => {
-    if (!lastSampleRef.current) {
+    if (!gestureActiveRef.current) {
       runningZoomRef.current = zoom;
       runningPanRef.current = pan;
     }
@@ -127,13 +132,29 @@ export function useCanvasTouchGestures({
       }
       pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
       if (pointersRef.current.size >= 2) {
-        // Second finger — supersede the single-finger stroke that already
-        // started and begin the pinch/pan gesture.
-        cancelDrawing();
-        runningZoomRef.current = zoom;
-        runningPanRef.current = pan;
+        if (!gestureActiveRef.current) {
+          // First frame of the gesture — supersede the single-finger stroke
+          // that already started and seed the viewport baseline.
+          cancelDrawing();
+          gestureActiveRef.current = true;
+          runningZoomRef.current = zoom;
+          runningPanRef.current = pan;
+        }
+        // Rebaseline geometry to the current finger pair (also when a 3rd
+        // finger changes the set) so the next move doesn't jump.
         const [a, b] = firstTwoPoints();
         lastSampleRef.current = pinchSample(a, b);
+        // Capture every active pointer to the canvas so the pinch/pan stream
+        // keeps arriving even if a finger drifts off the canvas element. The
+        // drawing layer never captured the superseded fingers, so do it here.
+        const el = e.currentTarget as HTMLElement | undefined;
+        for (const id of pointersRef.current.keys()) {
+          try {
+            el?.setPointerCapture?.(id);
+          } catch {
+            // Pointer already released — nothing to capture.
+          }
+        }
         return true;
       }
       return false;
@@ -146,26 +167,30 @@ export function useCanvasTouchGestures({
       return false;
     }
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    if (pointersRef.current.size < 2 || !lastSampleRef.current) {
+    if (!gestureActiveRef.current) {
       return false;
     }
-    const [a, b] = firstTwoPoints();
-    const cur = pinchSample(a, b);
-    const rect = containerRef.current?.getBoundingClientRect();
-    if (rect) {
-      const next = computePinchStep(
-        lastSampleRef.current,
-        cur,
-        runningZoomRef.current,
-        runningPanRef.current,
-        rect
-      );
-      runningZoomRef.current = next.zoom;
-      runningPanRef.current = next.pan;
-      onPanChange(next.pan);
-      onZoomChange(next.zoom);
+    // Only drive zoom/pan while two fingers are down; with one finger the
+    // pinch is undefined, but we still consume the event so it can't draw.
+    if (pointersRef.current.size >= 2 && lastSampleRef.current) {
+      const [a, b] = firstTwoPoints();
+      const cur = pinchSample(a, b);
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (rect) {
+        const next = computePinchStep(
+          lastSampleRef.current,
+          cur,
+          runningZoomRef.current,
+          runningPanRef.current,
+          rect
+        );
+        runningZoomRef.current = next.zoom;
+        runningPanRef.current = next.pan;
+        onPanChange(next.pan);
+        onZoomChange(next.zoom);
+      }
+      lastSampleRef.current = cur;
     }
-    lastSampleRef.current = cur;
     return true;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- containerRef is stable
   }, [onPanChange, onZoomChange]);
@@ -174,13 +199,18 @@ export function useCanvasTouchGestures({
     if (e.pointerType !== "touch") {
       return false;
     }
-    const wasGesture = lastSampleRef.current !== null;
+    const wasGesture = gestureActiveRef.current;
     pointersRef.current.delete(e.pointerId);
     if (pointersRef.current.size < 2) {
+      // Pinch geometry is undefined below two fingers.
       lastSampleRef.current = null;
     }
-    // Consume the lift while a gesture was live so the remaining finger can't
-    // resume drawing from the same touch sequence.
+    if (pointersRef.current.size === 0) {
+      // Gesture only ends once the last finger lifts.
+      gestureActiveRef.current = false;
+    }
+    // Consume every lift that belongs to the gesture sequence so the remaining
+    // finger can't resume drawing from the same touch.
     return wasGesture;
   }, []);
 

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasTouchGestures.ts
@@ -1,0 +1,188 @@
+/**
+ * useCanvasTouchGestures
+ *
+ * Two-finger pan + pinch-zoom for touchscreens. The canvas is Pointer
+ * Events–based, so a single finger already draws; this layer adds the
+ * multi-touch navigation that mouse/trackpad users get from wheel + Space/Alt
+ * drag (see useWheelZoom / usePointerHandlers), which touch has no equivalent
+ * for.
+ *
+ * The wrapper calls these handlers before delegating to the drawing pointer
+ * handlers. When a second finger lands the in-progress stroke is aborted
+ * (`cancelDrawing`) and every subsequent touch event is consumed until all
+ * fingers lift, so a pinch never paints and the leftover finger never resumes
+ * a stroke. Each handler returns `true` when it consumed the event.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import type { Point } from "../types";
+import { SKETCH_ZOOM_MAX, SKETCH_ZOOM_MIN } from "../state/useSketchStore";
+
+interface PinchSample {
+  mid: Point;
+  dist: number;
+}
+
+interface DomRectLike {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * One incremental pinch step. Pans by the midpoint delta, then applies the
+ * distance-ratio zoom anchored at the current midpoint so the pixels under the
+ * fingers stay put — mirroring the cursor-anchored zoom in useWheelZoom. Pure
+ * for testability.
+ */
+export function computePinchStep(
+  prev: PinchSample,
+  cur: PinchSample,
+  curZoom: number,
+  curPan: Point,
+  rect: DomRectLike,
+  zoomMin: number = SKETCH_ZOOM_MIN,
+  zoomMax: number = SKETCH_ZOOM_MAX
+): { zoom: number; pan: Point } {
+  let newPanX = curPan.x + (cur.mid.x - prev.mid.x);
+  let newPanY = curPan.y + (cur.mid.y - prev.mid.y);
+  let newZoom = curZoom;
+
+  if (prev.dist > 0 && cur.dist > 0) {
+    const factor = cur.dist / prev.dist;
+    newZoom = Math.max(zoomMin, Math.min(zoomMax, curZoom * factor));
+    if (newZoom !== curZoom) {
+      const offsetX = cur.mid.x - rect.left - rect.width / 2 - newPanX;
+      const offsetY = cur.mid.y - rect.top - rect.height / 2 - newPanY;
+      const zoomRatio = newZoom / curZoom;
+      newPanX += offsetX * (1 - zoomRatio);
+      newPanY += offsetY * (1 - zoomRatio);
+    }
+  }
+
+  return { zoom: newZoom, pan: { x: newPanX, y: newPanY } };
+}
+
+function pinchSample(a: Point, b: Point): PinchSample {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return {
+    mid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+    dist: Math.hypot(dx, dy)
+  };
+}
+
+export interface UseCanvasTouchGesturesParams {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  zoom: number;
+  pan: Point;
+  onZoomChange: (zoom: number) => void;
+  onPanChange: (pan: Point) => void;
+  /** Abort a one-finger stroke when the pinch supersedes it. */
+  cancelDrawing: () => void;
+}
+
+export interface UseCanvasTouchGesturesResult {
+  /** @returns true when the event was consumed as a gesture (skip drawing). */
+  onPointerDown: (e: React.PointerEvent) => boolean;
+  onPointerMove: (e: React.PointerEvent) => boolean;
+  onPointerUp: (e: React.PointerEvent) => boolean;
+}
+
+export function useCanvasTouchGestures({
+  containerRef,
+  zoom,
+  pan,
+  onZoomChange,
+  onPanChange,
+  cancelDrawing
+}: UseCanvasTouchGesturesParams): UseCanvasTouchGesturesResult {
+  const pointersRef = useRef<Map<number, Point>>(new Map());
+  const lastSampleRef = useRef<PinchSample | null>(null);
+  // Running viewport values driven by the gesture itself. Multiple pointermove
+  // events fire before React re-renders with the new zoom/pan props, so the
+  // gesture must accumulate against its own copy rather than the stale props.
+  const runningZoomRef = useRef(zoom);
+  const runningPanRef = useRef(pan);
+
+  // Keep the running values in sync with committed props while no gesture is
+  // active, so the next pinch starts from the true viewport state.
+  useEffect(() => {
+    if (!lastSampleRef.current) {
+      runningZoomRef.current = zoom;
+      runningPanRef.current = pan;
+    }
+  }, [zoom, pan]);
+
+  const firstTwoPoints = (): [Point, Point] => {
+    const it = pointersRef.current.values();
+    return [it.next().value as Point, it.next().value as Point];
+  };
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent): boolean => {
+      if (e.pointerType !== "touch") {
+        return false;
+      }
+      pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (pointersRef.current.size >= 2) {
+        // Second finger — supersede the single-finger stroke that already
+        // started and begin the pinch/pan gesture.
+        cancelDrawing();
+        runningZoomRef.current = zoom;
+        runningPanRef.current = pan;
+        const [a, b] = firstTwoPoints();
+        lastSampleRef.current = pinchSample(a, b);
+        return true;
+      }
+      return false;
+    },
+    [zoom, pan, cancelDrawing]
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent): boolean => {
+    if (e.pointerType !== "touch" || !pointersRef.current.has(e.pointerId)) {
+      return false;
+    }
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointersRef.current.size < 2 || !lastSampleRef.current) {
+      return false;
+    }
+    const [a, b] = firstTwoPoints();
+    const cur = pinchSample(a, b);
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (rect) {
+      const next = computePinchStep(
+        lastSampleRef.current,
+        cur,
+        runningZoomRef.current,
+        runningPanRef.current,
+        rect
+      );
+      runningZoomRef.current = next.zoom;
+      runningPanRef.current = next.pan;
+      onPanChange(next.pan);
+      onZoomChange(next.zoom);
+    }
+    lastSampleRef.current = cur;
+    return true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- containerRef is stable
+  }, [onPanChange, onZoomChange]);
+
+  const onPointerUp = useCallback((e: React.PointerEvent): boolean => {
+    if (e.pointerType !== "touch") {
+      return false;
+    }
+    const wasGesture = lastSampleRef.current !== null;
+    pointersRef.current.delete(e.pointerId);
+    if (pointersRef.current.size < 2) {
+      lastSampleRef.current = null;
+    }
+    // Consume the lift while a gesture was live so the remaining finger can't
+    // resume drawing from the same touch sequence.
+    return wasGesture;
+  }, []);
+
+  return { onPointerDown, onPointerMove, onPointerUp };
+}

--- a/web/src/components/sketch/sketchCanvasHooks/usePointerHandlers.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/usePointerHandlers.ts
@@ -196,6 +196,12 @@ export interface UsePointerHandlersResult {
   selectStartRef: React.MutableRefObject<Point | null>;
   /** Cancel the active tool's in-progress operation (e.g. crop drag, transform). */
   cancelActiveTool: () => void;
+  /**
+   * Abort an in-progress pointer gesture (stroke or pan) without committing it.
+   * Resets the drawing/pan refs, discards the uncommitted stroke preview, and
+   * repaints. Used when a multi-touch pinch/pan supersedes a one-finger draw.
+   */
+  cancelDrawing: () => void;
   /** Apply pending crop rectangle (crop tool). */
   commitPendingCrop: () => void;
   /** Root container cursor (tool, space pan hint, or active pan). */
@@ -850,6 +856,37 @@ export function usePointerHandlers({
     }
   }, []);
 
+  const cancelDrawing = useCallback(() => {
+    if (isPanningRef.current) {
+      isPanningRef.current = false;
+      isSpacePanningRef.current = false;
+      setIsPanningUi(false);
+    }
+    if (isSizeDraggingRef.current) {
+      isSizeDraggingRef.current = false;
+    }
+    if (!isDrawingRef.current) {
+      return;
+    }
+    const gestureTool = gestureToolRef.current ?? interactionTool;
+    gestureToolRef.current = null;
+    isDrawingRef.current = false;
+    getToolHandler(gestureTool).onCancel?.(toolCtxRef.current);
+    // Drop the uncommitted stroke from the composite and restore the committed
+    // selection ants. The compositor reads activeStrokeRef, so nulling it and
+    // repainting removes the in-progress stroke.
+    activeStrokeRef.current = null;
+    clearOverlay();
+    drawSelectionOverlay();
+    requestRedraw();
+  }, [
+    interactionTool,
+    clearOverlay,
+    drawSelectionOverlay,
+    requestRedraw,
+    activeStrokeRef
+  ]);
+
   return {
     handlePointerDown,
     handlePointerMove,
@@ -864,6 +901,7 @@ export function usePointerHandlers({
     altHeldRef,
     selectStartRef,
     cancelActiveTool,
+    cancelDrawing,
     commitPendingCrop,
     containerCursor
   };

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -26,7 +26,7 @@ export interface UiSlice {
    * Whether the mobile panels sheet (color / layers / canvas) is open. On
    * narrow viewports the right column can't sit beside the canvas, so it moves
    * into a bottom sheet toggled by this flag. Ignored on desktop, where the
-   * column is always docked.
+   * column is docked (and hidden only by the `panelsHidden` chrome toggle).
    */
   mobilePanelsOpen: boolean;
   toggleMobilePanels: () => void;

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -22,6 +22,16 @@ export interface UiSlice {
   toggleAssistantPanel: () => void;
   setAssistantPanelOpen: (open: boolean) => void;
 
+  /**
+   * Whether the mobile panels sheet (color / layers / canvas) is open. On
+   * narrow viewports the right column can't sit beside the canvas, so it moves
+   * into a bottom sheet toggled by this flag. Ignored on desktop, where the
+   * column is always docked.
+   */
+  mobilePanelsOpen: boolean;
+  toggleMobilePanels: () => void;
+  setMobilePanelsOpen: (open: boolean) => void;
+
   /** Cleared whenever a single layer is chosen exclusively (normal click). */
   selectedLayerIds: string[];
   /**
@@ -74,6 +84,11 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
   toggleAssistantPanel: () =>
     set((state) => ({ assistantPanelOpen: !state.assistantPanelOpen })),
   setAssistantPanelOpen: (open: boolean) => set({ assistantPanelOpen: open }),
+
+  mobilePanelsOpen: false,
+  toggleMobilePanels: () =>
+    set((state) => ({ mobilePanelsOpen: !state.mobilePanelsOpen })),
+  setMobilePanelsOpen: (open: boolean) => set({ mobilePanelsOpen: open }),
 
   selectedLayerIds: [] as string[],
   layerShiftRangeAnchorId: null as string | null,


### PR DESCRIPTION
## Summary

The sketch editor docked fixed-width columns side by side — a 46px tool rail, a 260px right panel, and a 340px assistant panel — leaving no room for the canvas on phones, and it offered no touch pan/zoom. This adapts it for small, touch screens.

## Changes

**Responsive layout** (600px breakpoint via `useSketchIsMobile`, matching the app-wide `MobileClassProvider` threshold):
- The right panel (Color / Layers / Canvas sections) and the assistant panel move into `MobileBottomSheet` overlays on mobile instead of docked columns, so the canvas keeps the full viewport width. The section JSX is extracted to a shared const used by both the docked desktop column and the mobile sheet.
- A floating action button opens the layers/color sheet; the existing **Assistant** toggle opens the assistant sheet.
- The generation prompt bar (`ConnectedModePromptBar`) now wraps its controls instead of overflowing off-screen.
- New `mobilePanelsOpen` UI store flag drives the panels sheet.

**Touch gestures** (`useCanvasTouchGestures`):
- Two-finger pan + pinch-zoom. A single finger still draws; when a second finger lands the in-progress stroke is aborted and touch events are consumed until all fingers lift, so a pinch never paints and the leftover finger never resumes a stroke.
- Zoom anchors at the pinch midpoint, mirroring the cursor-anchored wheel-zoom.
- Adds `cancelDrawing()` to `usePointerHandlers` so the gesture layer can discard an uncommitted stroke cleanly.

## Testing

- `npm run typecheck` (web) — clean.
- `oxlint` on changed files — clean.
- New unit tests: `computePinchStep` math (pan/zoom/anchor/clamp), gesture consume-and-abort behavior (single finger draws, second finger aborts + consumes, two-finger move emits zoom/pan), and the mobile-panels store flags. All pass.
- Existing sketch UI suites (SketchModal, SketchToolbar, SketchLayersPanel, presentation, store) pass. The canvas/WebGPU pixel suites fail only in this sandbox because the native `canvas` module isn't built here — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaeKoTJnKsGoBBrWVo9K4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaeKoTJnKsGoBBrWVo9K4N)_