### PR TITLE
Make the settings page mobile-friendly

### DIFF
--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React, { memo, useState, useCallback, useMemo } from "react";
+import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -482,6 +483,7 @@ export const ProviderCard = memo(function ProviderCard({
   onDelete
 }: ProviderCardProps) {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const oauth = useOAuthConnection(meta.oauth ?? null);
   const isConnected = secret.is_configured;
 
@@ -503,7 +505,10 @@ export const ProviderCard = memo(function ProviderCard({
       padding="compact"
       sx={{
         display: "flex",
-        alignItems: "center",
+        // Stack on mobile so the status band + action buttons drop below the
+        // icon/info instead of overflowing the narrow row.
+        flexDirection: isMobile ? "column" : "row",
+        alignItems: isMobile ? "stretch" : "center",
         gap: theme.spacing(3),
         borderRadius: BORDER_RADIUS.lg,
         border: `1px solid ${theme.vars.palette.divider}`,
@@ -515,6 +520,8 @@ export const ProviderCard = memo(function ProviderCard({
         }
       }}
     >
+      {/* Icon + info stay a row even when the card stacks on mobile. */}
+      <FlexRow align="center" gap={3} sx={{ flex: 1, minWidth: 0 }}>
       {/* Icon */}
       <FlexRow
         align="center"
@@ -584,10 +591,18 @@ export const ProviderCard = memo(function ProviderCard({
           </Caption>
         )}
       </FlexColumn>
+      </FlexRow>
 
-      {/* Status + Actions — one vertically centered band */}
-      <FlexRow align="center" gap={3} sx={{ flexShrink: 0 }}>
-        <FlexColumn align="flex-end" gap={1}>
+      {/* Status + Actions — one vertically centered band. On mobile it drops
+          below the icon/info and spreads full width, letting the action
+          buttons wrap instead of overflowing. */}
+      <FlexRow
+        align="center"
+        gap={3}
+        justify={isMobile ? "space-between" : "flex-start"}
+        sx={{ flexShrink: 0, flexWrap: "wrap" }}
+      >
+        <FlexColumn align={isMobile ? "flex-start" : "flex-end"} gap={1}>
           <FlexRow
             align="center"
             gap={1}
@@ -660,7 +675,7 @@ export const ProviderCard = memo(function ProviderCard({
           )}
         </FlexColumn>
 
-        <FlexRow align="center" gap={0.5}>
+        <FlexRow align="center" gap={0.5} sx={{ flexWrap: "wrap" }}>
           <EditorButton
             density="compact"
             variant="text"

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import React, { memo, useState, useCallback, useMemo } from "react";
-import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -483,7 +482,6 @@ export const ProviderCard = memo(function ProviderCard({
   onDelete
 }: ProviderCardProps) {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const oauth = useOAuthConnection(meta.oauth ?? null);
   const isConnected = secret.is_configured;
 
@@ -505,10 +503,11 @@ export const ProviderCard = memo(function ProviderCard({
       padding="compact"
       sx={{
         display: "flex",
-        // Stack on mobile so the status band + action buttons drop below the
-        // icon/info instead of overflowing the narrow row.
-        flexDirection: isMobile ? "column" : "row",
-        alignItems: isMobile ? "stretch" : "center",
+        // Stack on mobile (<sm) so the status band + action buttons drop below
+        // the icon/info instead of overflowing the narrow row. Pure CSS
+        // breakpoints keep this a layout concern with no per-card matchMedia.
+        flexDirection: { xs: "column", sm: "row" },
+        alignItems: { xs: "stretch", sm: "center" },
         gap: theme.spacing(3),
         borderRadius: BORDER_RADIUS.lg,
         border: `1px solid ${theme.vars.palette.divider}`,
@@ -599,10 +598,16 @@ export const ProviderCard = memo(function ProviderCard({
       <FlexRow
         align="center"
         gap={3}
-        justify={isMobile ? "space-between" : "flex-start"}
-        sx={{ flexShrink: 0, flexWrap: "wrap" }}
+        sx={{
+          flexShrink: 0,
+          flexWrap: "wrap",
+          justifyContent: { xs: "space-between", sm: "flex-start" }
+        }}
       >
-        <FlexColumn align={isMobile ? "flex-start" : "flex-end"} gap={1}>
+        <FlexColumn
+          gap={1}
+          sx={{ alignItems: { xs: "flex-start", sm: "flex-end" } }}
+        >
           <FlexRow
             align="center"
             gap={1}

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -559,6 +559,8 @@ function SettingsPage() {
                 onChange={handleTabChange}
                 className="settings-tabs"
                 aria-label="settings tabs"
+                variant={isMobile ? "scrollable" : "standard"}
+                scrollButtons={false}
               >
                 <Tab label="General" id="settings-tab-0" />
                 <Tab label="API Keys" id="settings-tab-1" />

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -516,5 +516,29 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
   },
   ".MuiButton-root": {
     fontSize: theme.fontSizeNormal
+  },
+  // Mobile (<600px): the fixed sidebars are already dropped in JS, so here we
+  // reclaim the horizontal breathing room the desktop layout reserves —
+  // trim the oversized header/content padding and let the capped content
+  // columns run edge-to-edge so form fields aren't squeezed into a thin strip.
+  [theme.breakpoints.down("sm")]: {
+    ".settings-page-header": {
+      padding: theme.spacing(3, 3, 2),
+      gap: theme.spacing(3)
+    },
+    ".sticky-header": {
+      padding: `0 ${getSpacingPx(SPACING.md)}`
+    },
+    ".settings-tabs": {
+      marginBottom: `${getSpacingPx(SPACING.md)}`
+    },
+    ".settings-content": {
+      padding: `0 ${getSpacingPx(SPACING.md)}`,
+      maxWidth: "100%"
+    },
+    ".settings-content--api-keys": {
+      padding: `${getSpacingPx(SPACING.xl)} ${getSpacingPx(SPACING.md)}`,
+      maxWidth: "100%"
+    }
   }
 });


### PR DESCRIPTION
## Summary

The settings page was built for desktop: it reserved large fixed padding and laid out the API-key provider cards as a single wide flex row. Both broke on narrow phones — content squeezed into a thin strip and the provider cards overflowed horizontally. This makes the page usable on mobile.

## Changes

- **Real mobile CSS** (`settingsMenuStyles.ts`): add `theme.breakpoints.down("sm")` media queries that trim the page-header, sticky-tab, and content padding, and let the capped content columns run edge-to-edge below 600px. Replaces the previously dead `settings-page--mobile` class hook (it was applied but had no CSS attached) with breakpoint-driven styling.
- **Scrollable tabs** (`SettingsMenu.tsx`): the four tabs (General, API Keys, Integrations, About) switch to `variant="scrollable"` on mobile so all stay reachable when they no longer fit side by side.
- **Stacking provider cards** (`APIKeysTab.tsx`): each provider card becomes a vertical stack on mobile — icon + info stay a row on top, and the status/actions band drops below full width with wrapping action buttons instead of overflowing the row.

The desktop layout is unchanged; all new behavior is gated behind the `sm` breakpoint. This follows the same `useMediaQuery(theme.breakpoints.down("sm"))` pattern used by the recent script/storyboard mobile PRs.

## Testing

- `npx tsc --noEmit` — no errors in `web/src` (remaining errors are unbuilt `@nodetool-ai/*` packages, unrelated).
- `eslint` on the three changed files — clean.
- `jest` settings test suites (`settingsMenuStyles.test.ts`, `RemoteSettingsMenu.test.tsx`) — 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBgenyfk9BVzzJZJbbfvkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBgenyfk9BVzzJZJbbfvkJ)_