### PR TITLE
Expand asset variables in Prompt/Template nodes

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -120,6 +120,7 @@ export {
 } from "./python-graph-resolver.js";
 export { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 export {
+  assetRefToPromptToken,
   classifyAssetToken,
   classifyTextToken,
   expandAssetReferences,

--- a/packages/runtime/src/prompt-asset-refs.ts
+++ b/packages/runtime/src/prompt-asset-refs.ts
@@ -150,6 +150,99 @@ function extForContentType(contentType: string): string | null {
   return null;
 }
 
+/**
+ * Reverse of the ext→mime tables: the extension whose mime matches. Tries the
+ * media tables first (via {@link extForContentType}, which also normalizes
+ * `+suffix` and audio/video aliases), then falls back to a text-document match.
+ * Returns null for an unrecognized mime.
+ */
+function extForMime(mime: string): string | null {
+  const viaMedia = extForContentType(mime);
+  if (viaMedia) return viaMedia;
+  const ct = (mime ?? "").toLowerCase().split(";")[0].trim();
+  for (const [ext, m] of Object.entries(TEXT_EXT_MIME)) {
+    if (m === ct) return ext;
+  }
+  return null;
+}
+
+/** Fallback extension per ref `type` when the mime is missing/unrecognized. */
+const DEFAULT_EXT_BY_KIND: Record<string, string> = {
+  image: "png",
+  audio: "mp3",
+  video: "mp4",
+  document: "txt",
+  text: "txt"
+};
+
+/** Pick an extension for a ref from its mime, else its declared `type`. */
+function extForRef(ref: {
+  type?: unknown;
+  mimeType?: unknown;
+  content_type?: unknown;
+}): string | null {
+  const mime =
+    typeof ref.mimeType === "string"
+      ? ref.mimeType
+      : typeof ref.content_type === "string"
+        ? ref.content_type
+        : "";
+  const byMime = mime ? extForMime(mime) : null;
+  if (byMime) return byMime;
+  const kind = typeof ref.type === "string" ? ref.type.toLowerCase() : "";
+  return Object.hasOwn(DEFAULT_EXT_BY_KIND, kind)
+    ? DEFAULT_EXT_BY_KIND[kind]
+    : null;
+}
+
+/**
+ * Convert a media / document ref — the `{ type, uri, asset_id, mimeType }` shape
+ * image / audio / video / document outputs carry — into the inline
+ * `asset://<id>.<ext>` token the prompt-expansion machinery understands.
+ *
+ * This lets an asset wired into a Prompt node's `{{ variable }}` flow through
+ * the same path as an inline `@`-mention: once rendered, the token is picked up
+ * by {@link expandAssetReferences} (LLM message blocks), `mapPromptAssetsToInputs`
+ * (typed provider inputs), or {@link inlineTextAssetRefs} (text documents),
+ * instead of stringifying to `"[object Object]"`.
+ *
+ * Returns null for values that aren't asset refs (strings, numbers, plain
+ * objects with no `uri`/`asset_id`) so callers fall back to normal stringify.
+ * A ref pointing only at a non-asset uri (http / data / file) yields that uri
+ * verbatim — it won't route as media, but it still beats `"[object Object]"`.
+ */
+export function assetRefToPromptToken(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const ref = value as {
+    type?: unknown;
+    uri?: unknown;
+    asset_id?: unknown;
+    mimeType?: unknown;
+    content_type?: unknown;
+  };
+  const uri = typeof ref.uri === "string" ? ref.uri.trim() : "";
+  const assetId = typeof ref.asset_id === "string" ? ref.asset_id.trim() : "";
+
+  if (uri.startsWith("asset://")) {
+    // Drop any query/hash; keep the id (and any existing extension) intact.
+    const id = uri.slice("asset://".length).split(/[?#]/)[0];
+    if (!id) return null;
+    if (id.includes(".")) return `asset://${id}`;
+    const ext = extForRef(ref);
+    return ext ? `asset://${id}.${ext}` : `asset://${id}`;
+  }
+
+  if (assetId) {
+    const ext = extForRef(ref);
+    return ext ? `asset://${assetId}.${ext}` : `asset://${assetId}`;
+  }
+
+  // Asset-less ref that still points somewhere resolvable.
+  if (uri) return uri;
+
+  return null;
+}
+
 export interface PromptAssetRef {
   /** Full `asset://<id>.<ext>` token, trailing sentence punctuation trimmed. */
   uri: string;

--- a/packages/runtime/tests/prompt-asset-refs.test.ts
+++ b/packages/runtime/tests/prompt-asset-refs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  assetRefToPromptToken,
   classifyAssetToken,
   classifyTextToken,
   expandAssetReferences,
@@ -573,5 +574,85 @@ describe("mapPromptAssetsToInputs entity mentions", () => {
       "describe Marta\n\nConsistency references:\n" +
         "- Marta: red-haired detective in a beige trench coat"
     );
+  });
+});
+
+describe("assetRefToPromptToken", () => {
+  it("returns null for non-ref values", () => {
+    expect(assetRefToPromptToken("plain string")).toBeNull();
+    expect(assetRefToPromptToken(42)).toBeNull();
+    expect(assetRefToPromptToken(null)).toBeNull();
+    expect(assetRefToPromptToken(undefined)).toBeNull();
+    expect(assetRefToPromptToken({})).toBeNull();
+    expect(assetRefToPromptToken({ foo: "bar" })).toBeNull();
+  });
+
+  it("keeps an asset:// uri that already carries an extension", () => {
+    expect(
+      assetRefToPromptToken({ type: "image", uri: "asset://abc.png" })
+    ).toBe("asset://abc.png");
+  });
+
+  it("strips a query/hash off an asset:// uri", () => {
+    expect(
+      assetRefToPromptToken({ type: "image", uri: "asset://abc.png?v=2#x" })
+    ).toBe("asset://abc.png");
+  });
+
+  it("appends an extension to a bare asset:// uri from the mime", () => {
+    expect(
+      assetRefToPromptToken({
+        type: "image",
+        uri: "asset://abc",
+        mimeType: "image/jpeg"
+      })
+    ).toBe("asset://abc.jpeg");
+  });
+
+  it("builds a token from asset_id + type default when no uri", () => {
+    expect(assetRefToPromptToken({ type: "image", asset_id: "xyz" })).toBe(
+      "asset://xyz.png"
+    );
+    expect(assetRefToPromptToken({ type: "audio", asset_id: "aud" })).toBe(
+      "asset://aud.mp3"
+    );
+    expect(assetRefToPromptToken({ type: "video", asset_id: "vid" })).toBe(
+      "asset://vid.mp4"
+    );
+  });
+
+  it("prefers the ref mime over the type default", () => {
+    expect(
+      assetRefToPromptToken({
+        type: "image",
+        asset_id: "xyz",
+        mimeType: "image/webp"
+      })
+    ).toBe("asset://xyz.webp");
+  });
+
+  it("resolves a text-document mime to its extension", () => {
+    expect(
+      assetRefToPromptToken({
+        type: "document",
+        asset_id: "doc",
+        content_type: "text/markdown"
+      })
+    ).toBe("asset://doc.md");
+  });
+
+  it("passes a non-asset uri through verbatim", () => {
+    expect(
+      assetRefToPromptToken({ type: "image", uri: "https://x/y.png" })
+    ).toBe("https://x/y.png");
+  });
+
+  it("produces a token that expandAssetReferences then routes as an image", () => {
+    const token = assetRefToPromptToken({ type: "image", asset_id: "xyz" });
+    const parts = expandAssetReferences(`look at ${token}`);
+    expect(parts).toEqual([
+      { type: "text", text: "look at " },
+      { type: "image_url", image: { uri: "asset://xyz.png", mimeType: "image/png" } }
+    ]);
   });
 });

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -2,6 +2,7 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { Platform } from "@nodetool-ai/protocol";
 import type { OutputCorrelation } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { assetRefToPromptToken } from "@nodetool-ai/runtime";
 import {
   tagAsServer,
   renderTemplate,
@@ -14,6 +15,23 @@ import {
 } from "@nodetool-ai/nodes-utils";
 
 const NODE_ONLY: readonly Platform[] = ["node"];
+
+/**
+ * Turn any asset-ref values in a template's variable bag into their
+ * `asset://<id>.<ext>` token so a wired image / audio / video / document
+ * expands like an inline `@`-mention instead of rendering as `"[object
+ * Object]"`. Non-asset values (strings, numbers, other refs) pass through
+ * untouched for the normal `String(value)` substitution.
+ */
+function tokenizeAssetVars(
+  vars: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    out[key] = assetRefToPromptToken(value) ?? value;
+  }
+  return out;
+}
 
 function flagsFromOpts(opts: {
   dotall?: unknown;
@@ -2601,7 +2619,7 @@ export class PromptNode extends BaseNode {
       await Promise.all(pending);
     }
 
-    return { output: renderTemplate(template, props) };
+    return { output: renderTemplate(template, tokenizeAssetVars(props)) };
   }
 }
 
@@ -2627,7 +2645,9 @@ export class TemplateTextNode extends BaseNode {
 
   async process(): Promise<Record<string, unknown>> {
     let result = String(this.string ?? "");
-    const props: Record<string, unknown> = Object.fromEntries(this.dynamicProps);
+    const props = tokenizeAssetVars(
+      Object.fromEntries(this.dynamicProps)
+    );
 
     for (const [key, value] of Object.entries(props)) {
       const strValue = String(value ?? "");

--- a/packages/text-nodes/tests/prompt-node-context.test.ts
+++ b/packages/text-nodes/tests/prompt-node-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ProcessingContext } from "@nodetool-ai/runtime";
-import { PromptNode } from "@nodetool-ai/text-nodes";
+import { PromptNode, TemplateTextNode } from "@nodetool-ai/text-nodes";
 
 function ctxWith(name: string, value: unknown): ProcessingContext {
   const ctx = new ProcessingContext({ jobId: "prompt-context-test" });
@@ -62,5 +62,52 @@ describe("PromptNode variable channels", () => {
     node.assign({ prompt: "{{ missing }}" });
 
     expect((await node.process()).output).toBe("{{ missing }}");
+  });
+});
+
+describe("PromptNode asset variables", () => {
+  it("expands an asset-ref dynamic input into its asset:// token", async () => {
+    const node = new PromptNode();
+    node.assign({ prompt: "Describe {{ img }}" });
+    node.setDynamic("img", { type: "image", uri: "asset://abc.png" });
+
+    expect((await node.process()).output).toBe("Describe asset://abc.png");
+  });
+
+  it("builds a token from an asset_id-only ref", async () => {
+    const node = new PromptNode();
+    node.assign({ prompt: "{{ img }}" });
+    node.setDynamic("img", { type: "image", asset_id: "xyz" });
+
+    expect((await node.process()).output).toBe("asset://xyz.png");
+  });
+
+  it("expands an asset delivered over a variable channel", async () => {
+    const ctx = new ProcessingContext({ jobId: "prompt-asset-channel" });
+    ctx.registerChannelWriters("clip", 1);
+    ctx.getChannel("clip").send({ type: "audio", uri: "asset://a.mp3" });
+
+    const node = new PromptNode();
+    node.assign({ prompt: "Transcribe {{ clip }}" });
+
+    expect((await node.process(ctx)).output).toBe("Transcribe asset://a.mp3");
+  });
+
+  it("leaves plain-string variables untouched", async () => {
+    const node = new PromptNode();
+    node.assign({ prompt: "{{ subject }}" });
+    node.setDynamic("subject", "a dragon");
+
+    expect((await node.process()).output).toBe("a dragon");
+  });
+});
+
+describe("TemplateTextNode asset variables", () => {
+  it("expands an asset-ref variable into its asset:// token", async () => {
+    const node = new TemplateTextNode();
+    node.assign({ string: "look at {{ img }}" });
+    node.setDynamic("img", { type: "image", asset_id: "xyz" });
+
+    expect((await node.process()).output).toBe("look at asset://xyz.png");
   });
 });


### PR DESCRIPTION
## What

Wiring an image / audio / video / document output into a `{{ variable }}` on a **Prompt** (`nodetool.text.Prompt`) or **Template** (`nodetool.text.Template`) node used to render as the literal string `[object Object]`. `renderTemplate` coerces every variable with `String(value)`, and an asset value is a plain object (`{ type, uri, asset_id, mimeType }`) with no useful `toString`. The asset never became an `asset://` token, so none of the downstream asset-expansion machinery could see it — the referenced media was silently lost.

This closes the gap between the two prompt subsystems: `{{ }}` template variables and `asset://` mention expansion.

## How

- **`packages/runtime/src/prompt-asset-refs.ts`** — new `assetRefToPromptToken(value)` converts a media/document ref into its inline `asset://<id>.<ext>` token:
  - an `asset://` uri that already has an extension is kept (query/hash stripped);
  - a bare `asset://` uri or an `asset_id`-only ref gets an extension derived from the ref's mime, falling back to a per-`type` default (`image→png`, `audio→mp3`, `video→mp4`, `document/text→txt`);
  - a non-asset uri (http/data/file) passes through verbatim;
  - non-refs return `null` so callers keep normal stringify behavior.
- **`packages/text-nodes/src/nodes/text-extra.ts`** — `PromptNode` and `TemplateTextNode` run their variable bag through the helper before rendering, so a wired asset (from a dynamic input *or* a variable channel) becomes an `asset://` token.

Once rendered, the token flows through the existing path unchanged — picked up by `expandAssetReferences` (LLM message blocks), `mapPromptAssetsToInputs` (typed provider inputs), or `inlineTextAssetRefs` (text documents), then dereferenced to bytes just before the provider call. Same behavior as an inline `@`-mention.

## Tests

- `packages/runtime/tests/prompt-asset-refs.test.ts` — unit coverage for `assetRefToPromptToken` (uri-with-ext, bare uri + mime, `asset_id` + type default, mime-over-default, text-document mime, non-asset uri passthrough, non-ref null, and an end-to-end check that the produced token routes through `expandAssetReferences` as an image).
- `packages/text-nodes/tests/prompt-node-context.test.ts` — node-level coverage for `PromptNode` (dynamic-input ref, `asset_id`-only ref, asset over a variable channel, plain-string untouched) and `TemplateTextNode`.

Runtime (2352) and text-nodes (270) suites pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpuNkh4gMHL1SJxuBPY15Z)_