### PR TITLE
Add one-command server startup and a Claude starter kit

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,42 @@
+# Claude starter kit
+
+Everything here exists so a fresh session can build, run, and verify NodeTool
+without being told how.
+
+## What's in it
+
+| Path | What it does |
+| :--- | :--- |
+| `hooks/session-start.sh` | Installs dependencies when a Claude Code **web** session starts, using the flags that survive sandboxed/proxied containers. No-ops locally and on repeat runs. |
+| `settings.json` | Registers the hook. |
+| `commands/serve.md` | `/serve` — start the API on :7777 in the background and poll until it answers. |
+| `commands/verify.md` | `/verify` — typecheck, lint, test, and fix what breaks. |
+| `commands/onboard.md` | `/onboard <area>` — locate the owning workspace, entry point, nearest example, and the pitfalls that apply. |
+| `skills/` | 18 NodeTool skills (workflow building, custom nodes, API reference, deployment, troubleshooting, code review). Claude loads these on its own when a task matches. |
+
+## Running things
+
+```bash
+./start.sh          # API on :7777 — installs and builds on first run
+./start.sh full     # API + web UI on :3000
+./start.sh check    # typecheck + lint + test
+./start.sh doctor   # what's set up, what isn't
+```
+
+`./start.sh` is the same path the hook prepares, so the first command in a
+session works whether or not the hook ran.
+
+## Why the hook is web-only
+
+It guards on `CLAUDE_CODE_REMOTE=true`. Web sessions get a fresh container each
+time and would otherwise start with no `node_modules`; your local checkout
+already has one and shouldn't pay an install check on every session.
+
+To make it run locally too, drop the guard at the top of `session-start.sh`.
+
+## Changing it
+
+The hook runs synchronously — the session waits for the install to finish, so
+Claude never starts a test run against a half-installed tree. For a faster
+session start at the cost of that guarantee, emit
+`{"async": true, "asyncTimeout": 600000}` as the script's first line of stdout.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,0 +1,26 @@
+---
+description: Orient yourself in this repo — layout, entry points, and where the thing you are about to change lives
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+Give a working orientation for someone about to change: **$ARGUMENTS**
+(if that is empty, orient on the repo generally).
+
+Read `CLAUDE.md` first — it is the source of truth for commands, architecture,
+and pitfalls. Then find and report:
+
+- **Which workspace owns this.** 55 packages under `packages/`, plus `web/`,
+  `electron/`, `mobile/`. Name the specific one and its dependencies.
+- **The entry point.** Where execution actually starts for this area —
+  `packages/websocket/src/server.ts` for the API, `web/src/` for UI, a
+  `BaseNode` subclass for node behavior.
+- **The nearest existing example.** The closest analogous code already in the
+  repo, so the change matches surrounding conventions instead of inventing new
+  ones.
+- **What to run to see it work.** The specific command — `./start.sh`, a
+  targeted test file, `npm run dev:nodetool -- node run <type>`.
+- **The pitfalls that apply here.** From `CLAUDE.md § Common Pitfalls`: the
+  `dist/` decorator packages, MsgPack framing on the WebSocket, `ui_primitives`
+  and design tokens for anything in `web/`, ESM `.js` import extensions.
+
+Be concrete — cite `file:line`. Skip anything that does not bear on the change.

--- a/.claude/commands/serve.md
+++ b/.claude/commands/serve.md
@@ -1,0 +1,21 @@
+---
+description: Start the NodeTool API server on :7777 in the background and verify it is up
+allowed-tools: Bash, Read
+---
+
+Start the NodeTool backend and confirm it is actually serving.
+
+1. Run `./start.sh` with `run_in_background: true`. First run installs
+   dependencies and builds packages, which takes several minutes — that is
+   expected, not a hang.
+2. Poll `curl -s http://localhost:7777/health` until it responds (the server is
+   ready when it returns without a connection error). Do not use `sleep` loops
+   longer than needed.
+3. Report the URL and whether node types registered. If startup fails, read the
+   background output and diagnose — the usual causes are a missing
+   `packages/base-nodes/dist` (run `npm run build:packages`) or a
+   `NODE_MODULE_VERSION` mismatch (run `npm run rebuild:native`).
+
+Leave the server running in the background when done.
+
+$ARGUMENTS

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,29 @@
+---
+description: Run the checks that must pass before committing (typecheck, lint, tests)
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+Run the pre-commit gate and fix what breaks.
+
+Run these three, in this order, and stop at the first failure:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+```
+
+Scope the work: if the change only touched one workspace, prefer the targeted
+script (`npm run typecheck:web`, `npm test --workspace=web`) over the full
+sweep, and only run everything before an actual commit.
+
+If you changed anything under `packages/base-nodes`, `packages/node-sdk`,
+`fal-nodes`, `replicate-nodes`, or `elevenlabs-nodes`, run
+`npm run build:packages` first — those packages load from `dist/`, so stale
+output produces confusing failures.
+
+Fix every failure you find rather than reporting it back unfixed, then re-run
+to confirm green. Report the actual final output — do not claim a pass you did
+not observe.
+
+$ARGUMENTS

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook — makes a fresh Claude Code (web) container ready to run the
+# server, typecheck, lint, and test with no manual setup.
+#
+# Installs npm dependencies using the flags that survive sandboxed/proxied
+# environments (see CLAUDE.md § Common Pitfalls). Idempotent: exits fast when the
+# dependency tree is already there. Runs only in the remote (web) environment so
+# local terminal sessions start instantly.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT"
+
+log() { echo "[session-start] $*"; }
+
+if [ -d node_modules/.package-lock.json ] || [ -f node_modules/.package-lock.json ]; then
+  log "dependencies already installed"
+  exit 0
+fi
+
+# keytar compiles against libsecret. Without the headers npm rolls the whole
+# node_modules tree back. Only attempted when we can install without prompting;
+# failure is non-fatal because --ignore-scripts below still yields a usable tree.
+if ! dpkg -s libsecret-1-dev >/dev/null 2>&1 && [ "$(id -u)" = "0" ] && command -v apt-get >/dev/null 2>&1; then
+  log "installing libsecret-1-dev (keytar build dependency)"
+  apt-get update -y >/dev/null 2>&1 || true
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libsecret-1-dev >/dev/null 2>&1 \
+    || log "libsecret-1-dev unavailable — continuing"
+fi
+
+# Electron and onnxruntime download binaries in postinstall; proxies 403 those,
+# and any postinstall failure rolls back the entire install.
+export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+export npm_config_onnxruntime_node_install_cuda=skip
+
+log "installing npm dependencies (first run is slow; the container caches it)"
+if ! npm install --prefer-offline --no-audit --fund=false; then
+  log "install with scripts failed — retrying with --ignore-scripts"
+  log "(lint/typecheck/tests still work; 'npm run rebuild:native' fixes SQLite)"
+  npm install --prefer-offline --no-audit --fund=false --ignore-scripts
+fi
+
+# Generate .env + SECRETS_MASTER_KEY. Headless containers have no system
+# keychain, and without the key the server aborts during startup.
+node scripts/ensure-dev-env.mjs || log "could not prepare .env — run 'node scripts/ensure-dev-env.mjs'"
+
+log "ready — ./start.sh serves the API on http://localhost:7777"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ __pycache__
 *.safetensors
 .claude/*
 !.claude/skills/
+# Shared Claude starter kit — checked in so every session gets the same setup.
+!.claude/README.md
+!.claude/settings.json
+!.claude/hooks/
+!.claude/commands/
+# Personal overrides stay local.
+.claude/settings.local.json
 .pi/*
 build/
 coverage/
@@ -78,6 +85,11 @@ web/public/e2e-suite/
 cert.pem
 key.pem
 .aider*
+
+# Local dev database created by running the server
+nodetool.db
+nodetool.db-shm
+nodetool.db-wal
 
 # Dev
 .codegen-cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,19 @@ npm run electron:dev # Electron dev (auto-rebuilds native modules)
 - Python 3.11+ with conda (optional, for Python nodes)
 
 ```bash
-# First-time setup
+# First-time setup — start.sh does all of it, then starts the server
+./start.sh           # API on :7777   (full | web | check | doctor)
+
+# Or by hand:
 nvm use              # Reads .nvmrc, activates Node 22.22.1
 npm install          # Install all workspace dependencies
 npm run build:packages  # Build backend packages
 ```
+
+In Claude Code **web** sessions, `.claude/hooks/session-start.sh` installs
+dependencies before the session starts, so `npm run typecheck`/`lint`/`test`
+work immediately. Slash commands: `/serve`, `/verify`, `/onboard`. See
+[.claude/README.md](.claude/README.md).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,26 @@ ______________________________________________________________________
 ### Quick Start
 
 ```bash
+./start.sh          # API server on http://localhost:7777
+./start.sh full     # API + web UI on http://localhost:3000
+```
+
+That's the whole setup. On first run `start.sh` checks your Node version, copies
+`.env.example` to `.env`, installs dependencies, rebuilds the native SQLite
+module, and builds the backend packages — then starts the server. Every run
+after skips straight to starting it. Other modes:
+
+```bash
+./start.sh web      # web UI only
+./start.sh check    # typecheck + lint + test
+./start.sh doctor   # report what's set up and what isn't
+PORT=8080 ./start.sh
+```
+
+<details>
+<summary>Doing it by hand</summary>
+
+```bash
 nvm use                    # Activate Node 22.22.1 (reads .nvmrc)
 npm install
 npm run build:packages     # Build all TS packages in dependency order
@@ -204,6 +224,19 @@ npm run build:packages     # Build all TS packages in dependency order
 # Uses tsx --watch for the backend, so startup skips a full websocket package rebuild.
 npm run dev
 ```
+
+`npm run build:packages` is not optional on a fresh checkout: `base-nodes` and
+the other decorator packages resolve from `dist/`, so until it has run once the
+server starts with no node types registered.
+
+</details>
+
+### Working with Claude Code
+
+The repo ships a starter kit in [`.claude/`](.claude/README.md): a SessionStart
+hook that installs dependencies in web sessions, slash commands (`/serve`,
+`/verify`, `/onboard`), and 18 NodeTool skills covering workflow building,
+custom nodes, the API, deployment, and troubleshooting.
 
 ### Python Nodes (optional)
 

--- a/scripts/ensure-dev-env.mjs
+++ b/scripts/ensure-dev-env.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Prepare a usable `.env` for local development.
+ *
+ * Creates `.env` from `.env.example` when missing, then ensures
+ * `SECRETS_MASTER_KEY` is set. Without that key the server resolves the master
+ * key through the system keychain, which has no backend on a headless Linux
+ * box (Docker, CI, a dev container) — keytar fails to load and startup aborts.
+ *
+ * Idempotent: an existing key is never overwritten, so secrets already
+ * encrypted under it stay readable.
+ */
+import { randomBytes } from "node:crypto";
+import { appendFileSync, copyFileSync, existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const envPath = resolve(root, ".env");
+const examplePath = resolve(root, ".env.example");
+
+const created = !existsSync(envPath);
+if (created) {
+  if (existsSync(examplePath)) {
+    copyFileSync(examplePath, envPath);
+  } else {
+    appendFileSync(envPath, "");
+  }
+  console.log("created .env" + (existsSync(examplePath) ? " from .env.example" : ""));
+}
+
+// Only an uncommented assignment counts — .env.example ships the key commented out.
+const hasKey = readFileSync(envPath, "utf8")
+  .split(/\r?\n/)
+  .some((line) => /^\s*(export\s+)?SECRETS_MASTER_KEY\s*=\s*\S/.test(line));
+
+if (hasKey || process.env.SECRETS_MASTER_KEY) {
+  process.exit(0);
+}
+
+const key = randomBytes(32).toString("base64");
+appendFileSync(
+  envPath,
+  `\n# Generated for local development so the server does not need a system keychain.\n` +
+    `# Keep it: secrets stored locally are encrypted with this key.\n` +
+    `SECRETS_MASTER_KEY=${key}\n`
+);
+console.log("generated SECRETS_MASTER_KEY in .env");

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# One command to get NodeTool running.
+#
+#   ./start.sh            backend API on :7777 (hot-reloads TypeScript source)
+#   ./start.sh full       backend + web UI on :3000
+#   ./start.sh web        web UI only
+#   ./start.sh check      typecheck + lint + tests
+#   ./start.sh doctor     report environment state without starting anything
+#
+# Everything it needs — dependencies, native module, package build — is set up
+# on first run and skipped on every run after. Override the port with PORT=8080.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [ -t 1 ]; then
+  B='\033[1m'; G='\033[0;32m'; Y='\033[1;33m'; R='\033[0;31m'; N='\033[0m'
+else
+  B=''; G=''; Y=''; R=''; N=''
+fi
+step() { echo -e "\n${B}==>${N} $*"; }
+ok()   { echo -e "${G}ok${N}   $*"; }
+warn() { echo -e "${Y}warn${N} $*"; }
+die()  { echo -e "${R}error${N} $*" >&2; exit 1; }
+
+MODE="${1:-server}"
+case "$MODE" in
+  server|full|web|check|doctor) ;;
+  *) die "Unknown mode '${MODE}'. Use: server | full | web | check | doctor" ;;
+esac
+
+# ── Node version ────────────────────────────────────────────────────────────
+WANT_NODE="$(tr -d '[:space:]' < .nvmrc 2>/dev/null || echo 22)"
+command -v node >/dev/null 2>&1 || die "Node.js not found. Install Node ${WANT_NODE} (https://nodejs.org) or run 'nvm install'."
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" != "22" ]; then
+  # Try to switch automatically before giving up.
+  if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    nvm use >/dev/null 2>&1 || nvm install "$WANT_NODE" >/dev/null 2>&1 || true
+    NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+  fi
+  [ "$NODE_MAJOR" = "22" ] || die "Node 22.x required (found $(node -v)). Run 'nvm use' — it reads .nvmrc."
+fi
+
+# ── Doctor: report only, change nothing ─────────────────────────────────────
+if [ "$MODE" = "doctor" ]; then
+  PORT="${PORT:-7777}"
+  step "Environment"
+  echo "  node            $(node -v)"
+  echo "  npm             $(npm -v)"
+  echo "  .env            $([ -f .env ] && echo present || echo 'missing — created on next run')"
+  echo "  node_modules    $([ -d node_modules ] && echo present || echo 'missing — installed on next run')"
+  echo "  packages built  $([ -d packages/base-nodes/dist ] && echo yes || echo 'no — built on next run')"
+  echo "  better-sqlite3  $([ -d node_modules/better-sqlite3/build ] && echo built || echo 'not built')"
+  if node -e "process.exit(0)" 2>/dev/null; then
+    PORT_STATE=$(node -e "
+      const net = require('net');
+      const s = net.createConnection({ host: '127.0.0.1', port: ${PORT} });
+      s.setTimeout(1000);
+      const done = (v) => { console.log(v); s.destroy(); process.exit(0); };
+      s.on('connect', () => done('in use'));
+      s.on('timeout', () => done('free'));
+      s.on('error', () => done('free'));
+    ")
+    echo "  port ${PORT}      ${PORT_STATE}"
+  fi
+  exit 0
+fi
+
+# ── Environment file ────────────────────────────────────────────────────────
+# Creates .env and generates SECRETS_MASTER_KEY so the server never has to reach
+# for a system keychain that headless Linux containers do not have.
+node scripts/ensure-dev-env.mjs
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+if [ ! -d node_modules ]; then
+  step "Installing dependencies (a few minutes, only the first time)"
+  # Postinstall binary downloads 403 behind proxies, and any postinstall failure
+  # rolls back the whole tree — skip the ones dev never needs.
+  export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+  export npm_config_onnxruntime_node_install_cuda=skip
+  npm install --no-audit --fund=false || die "npm install failed. See CLAUDE.md § Common Pitfalls."
+  ok "dependencies installed"
+fi
+
+# ── Native module ───────────────────────────────────────────────────────────
+# The backend runs on vanilla Node, so better-sqlite3 must match Node's ABI.
+if [ "$MODE" != "web" ] && [ -d node_modules/better-sqlite3 ] && [ ! -d node_modules/better-sqlite3/build ]; then
+  step "Rebuilding better-sqlite3 against Node headers"
+  npm run rebuild:native || warn "native rebuild failed — database features may not work"
+fi
+
+# ── Package build ───────────────────────────────────────────────────────────
+# base-nodes and the other decorator packages always resolve from dist/, so the
+# server has no node types at all until this has run once.
+if [ "$MODE" != "web" ] && [ ! -d packages/base-nodes/dist ]; then
+  step "Building backend packages (only the first time)"
+  npm run build:packages || die "build:packages failed"
+  ok "packages built"
+fi
+
+PORT="${PORT:-7777}"
+
+case "$MODE" in
+  server)
+    step "Starting API server on http://localhost:${PORT}"
+    echo "   health check: curl http://localhost:${PORT}/health"
+    echo "   TypeScript source hot-reloads; Ctrl-C to stop."
+    exec npm run dev:server
+    ;;
+  full)
+    step "Starting API (:${PORT}) and web UI (http://localhost:3000)"
+    exec npm run dev
+    ;;
+  web)
+    step "Starting web UI on http://localhost:3000"
+    exec npm run dev:web
+    ;;
+  check)
+    step "Typechecking"
+    npm run typecheck || die "typecheck failed"
+    step "Linting"
+    npm run lint || die "lint failed"
+    step "Testing"
+    npm run test || die "tests failed"
+    ok "typecheck, lint, and tests all pass"
+    ;;
+esac


### PR DESCRIPTION
## Why

Getting the server up from a fresh checkout took four steps with three ways to fail:

- wrong Node version,
- an `npm install` that rolls its whole tree back behind a proxy (keytar/libsecret, Electron and onnxruntime postinstall downloads),
- a package build that's easy to skip — `base-nodes` resolves from `dist/`, so skipping it starts a server with **zero node types registered** and no obvious error.

On headless Linux there was a fourth, which I hit while testing this branch: `keytar` can't load without a system keychain, and the server **aborts during startup**:

```
ERROR | nodetool.security.master-key | keytar native module failed to load...
ERROR | nodetool.websocket.server | Database setup failed KeychainAccessError
```

## What changed

**`./start.sh`** — one command, does each setup step only when it's actually missing:

```bash
./start.sh          # API on :7777
./start.sh full     # API + web UI on :3000
./start.sh web      # web UI only
./start.sh check    # typecheck + lint + test
./start.sh doctor   # report state, change nothing
PORT=8080 ./start.sh
```

**`scripts/ensure-dev-env.mjs`** — creates `.env` and generates a `SECRETS_MASTER_KEY`, which short-circuits the keychain lookup that fails in containers. Never overwrites an existing key, so secrets stay readable.

**`.claude/` starter kit** — gives web sessions the same setup automatically:

| Path | Purpose |
| :--- | :--- |
| `hooks/session-start.sh` | Installs dependencies on web-session start, using the flags that survive sandboxed/proxied containers. No-ops locally and on repeat runs. |
| `settings.json` | Registers the hook. |
| `commands/serve.md` | `/serve` — start the API and poll until it answers. |
| `commands/verify.md` | `/verify` — typecheck, lint, test, fix what breaks. |
| `commands/onboard.md` | `/onboard <area>` — owning workspace, entry point, nearest example, applicable pitfalls. |

**`.gitignore`** — `.claude/*` previously excluded everything but `skills/`, so the kit would never have been committed; the shared files are now un-ignored explicitly while `settings.local.json` stays local. The local SQLite database is now ignored instead of appearing as untracked noise after any server run.

**Docs** — README quick start now leads with `./start.sh` (manual steps kept in a `<details>` block, with a note that `build:packages` isn't optional on a fresh checkout). CLAUDE.md points at the kit.

## Validation

Run in a fresh container with no `node_modules`:

- ✅ Hook completed exit 0 — 3622 packages installed, `better-sqlite3` compiled
- ✅ `./start.sh` → health 200 in ~4s, `{"database":"ok","server":"ok"}`
- ✅ **2376 node types** registered via `/api/nodes/metadata`
- ✅ `./start.sh doctor` reports without mutating (caught and fixed a bug where it triggered a full build)
- ✅ `./start.sh sever` rejects in <1s without building
- ✅ `npm run lint:packages` exit 0 (warnings are pre-existing, untouched files)
- ✅ `npm run test --workspace=packages/security` — 76/76 passing
- ✅ `ensure-dev-env.mjs` idempotent across repeat runs

## Notes

The SessionStart hook runs **synchronously**, so dependencies are guaranteed present before the session starts — no race where a test run hits a half-installed tree. The trade-off is that a web session waits on the first install. Switching to async is a one-line change documented in `.claude/README.md`.

The hook only runs when `CLAUDE_CODE_REMOTE=true`, so local terminal sessions are unaffected. It uses `apt-get` only when already running as root and treats failure as non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjDfVouuTcuKGNq6LXTjUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjDfVouuTcuKGNq6LXTjUA)_