### PR TITLE
Forward Prompt variables on pass-through output handles

### DIFF
--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -2583,6 +2583,10 @@ export class PromptNode extends BaseNode {
   };
 
   static readonly supportsDynamicInputs = true;
+  // Every variable is also forwarded on an output handle of the same name, so
+  // an image used as `{{ var }}` in the text can additionally be wired into a
+  // downstream node that wants the real asset (e.g. reference images).
+  static readonly supportsDynamicOutputs = true;
   static readonly inputFields: string[] = ["prompt"];
 
 
@@ -2619,7 +2623,15 @@ export class PromptNode extends BaseNode {
       await Promise.all(pending);
     }
 
-    return { output: renderTemplate(template, tokenizeAssetVars(props)) };
+    // Pass every variable through on a handle of its own name, carrying the
+    // raw value (an image ref stays an image ref — only the rendered text gets
+    // asset tokens). Keys without an outgoing edge are dropped by the runner.
+    // The rendered text is assigned last so a variable named "output" can't
+    // shadow it.
+    return {
+      ...props,
+      output: renderTemplate(template, tokenizeAssetVars(props))
+    };
   }
 }
 

--- a/packages/text-nodes/tests/prompt-node-context.test.ts
+++ b/packages/text-nodes/tests/prompt-node-context.test.ts
@@ -102,6 +102,39 @@ describe("PromptNode asset variables", () => {
   });
 });
 
+describe("PromptNode variable pass-through", () => {
+  it("forwards each variable on an output handle of the same name", async () => {
+    const image = { type: "image", uri: "asset://abc.png" };
+    const node = new PromptNode();
+    node.assign({ prompt: "Describe {{ img }} for {{ who }}" });
+    node.setDynamic("img", image);
+    node.setDynamic("who", "kids");
+
+    const result = await node.process();
+
+    expect(result.output).toBe("Describe asset://abc.png for kids");
+    // The pass-through carries the raw ref, not the asset:// token.
+    expect(result.img).toEqual(image);
+    expect(result.who).toBe("kids");
+  });
+
+  it("forwards a value resolved from a variable channel", async () => {
+    const ctx = ctxWith("subject", "a dragon");
+    const node = new PromptNode();
+    node.assign({ prompt: "Describe {{ subject }}" });
+
+    expect((await node.process(ctx)).subject).toBe("a dragon");
+  });
+
+  it("does not let a variable named output shadow the rendered text", async () => {
+    const node = new PromptNode();
+    node.assign({ prompt: "{{ output }}!" });
+    node.setDynamic("output", "hello");
+
+    expect((await node.process()).output).toBe("hello!");
+  });
+});
+
 describe("TemplateTextNode asset variables", () => {
   it("expands an asset-ref variable into its asset:// token", async () => {
     const node = new TemplateTextNode();

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -43,7 +43,11 @@ import { NodeInputs } from "../../node/NodeInputs";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
 
-import type { NodeMetadata, Property } from "../../../stores/ApiTypes";
+import type {
+  NodeMetadata,
+  Property,
+  TypeMetadata
+} from "../../../stores/ApiTypes";
 import type { NodeData } from "../../../stores/NodeData";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useDynamicProperty } from "../../../hooks/nodes/useDynamicProperty";
@@ -59,6 +63,7 @@ import {
 } from "./promptComposer/promptEditorState";
 import { variablesInPrompt } from "./promptComposer/promptTokens";
 import { PromptComposerContext } from "./promptComposer/promptComposerContext";
+import { useVariablePassthroughOutputs } from "./promptComposer/useVariablePassthroughOutputs";
 import { useGraphVariableNames } from "./useGraphVariables";
 import { PROMPT_NODE_TYPE } from "../../../constants/nodeTypes";
 
@@ -246,6 +251,14 @@ const PromptComposerBodyInner: React.FC<PromptComposerBodyProps> = ({
   const knownVariables = useMemo(
     () => new Set(variableNames),
     [variableNames]
+  );
+
+  // Each variable also gets an output handle carrying its raw value.
+  useVariablePassthroughOutputs(
+    id,
+    variableNames,
+    (data.dynamic_inputs ?? {}) as Record<string, TypeMetadata>,
+    (data.dynamic_outputs ?? {}) as Record<string, TypeMetadata>
   );
 
   // Variables defined by Set Variable nodes anywhere in the workflow. They

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.commit.test.tsx
@@ -86,6 +86,11 @@ jest.mock("../../../node/NodeOutputs", () => ({
   NodeOutputs: () => <div data-testid="node-outputs" />
 }));
 
+// Covered by its own test; needs a NodeContext this suite does not provide.
+jest.mock("../promptComposer/useVariablePassthroughOutputs", () => ({
+  useVariablePassthroughOutputs: jest.fn()
+}));
+
 jest.mock("../../../node/NodeProgress", () => ({
   __esModule: true,
   default: () => <div data-testid="node-progress" />

--- a/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PromptComposerBody.test.tsx
@@ -43,6 +43,11 @@ jest.mock("../../../node/NodeOutputs", () => ({
   NodeOutputs: () => <div data-testid="node-outputs" />
 }));
 
+// Covered by its own test; needs a NodeContext this suite does not provide.
+jest.mock("../promptComposer/useVariablePassthroughOutputs", () => ({
+  useVariablePassthroughOutputs: jest.fn()
+}));
+
 jest.mock("../../../node/NodeProgress", () => ({
   __esModule: true,
   default: () => <div data-testid="node-progress" />

--- a/web/src/components/node_types/editing/__tests__/useVariablePassthroughOutputs.test.ts
+++ b/web/src/components/node_types/editing/__tests__/useVariablePassthroughOutputs.test.ts
@@ -1,0 +1,151 @@
+import { renderHook } from "@testing-library/react";
+import type { Edge, Node } from "@xyflow/react";
+
+import { useVariablePassthroughOutputs } from "../promptComposer/useVariablePassthroughOutputs";
+import { useNodes } from "../../../../contexts/NodeContext";
+import useMetadataStore from "../../../../stores/MetadataStore";
+import type { NodeData } from "../../../../stores/NodeData";
+import type { TypeMetadata } from "../../../../stores/ApiTypes";
+
+jest.mock("../../../../contexts/NodeContext", () => ({
+  useNodes: jest.fn()
+}));
+
+jest.mock("../../../../stores/MetadataStore", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const mockUpdateNodeData = jest.fn();
+
+const IMAGE_TYPE: TypeMetadata = {
+  type: "image",
+  optional: false,
+  values: null,
+  type_args: [],
+  type_name: null
+};
+const ANY_TYPE: TypeMetadata = {
+  type: "any",
+  optional: false,
+  values: null,
+  type_args: [],
+  type_name: null
+};
+
+const imageSourceNode = {
+  id: "img-1",
+  type: "test.ImageNode",
+  position: { x: 0, y: 0 },
+  data: {
+    properties: {},
+    selectable: true,
+    dynamic_properties: {},
+    workflow_id: "wf-1"
+  }
+} as Node<NodeData>;
+
+const imageSourceMetadata = {
+  node_type: "test.ImageNode",
+  properties: [],
+  outputs: [{ name: "output", type: IMAGE_TYPE, stream: false }]
+};
+
+const setupStore = (edges: Edge[]) => {
+  (useNodes as unknown as jest.Mock).mockImplementation(
+    (selector: (s: unknown) => unknown) =>
+      selector({
+        edges,
+        findNode: (id: string) => (id === "img-1" ? imageSourceNode : undefined),
+        updateNodeData: mockUpdateNodeData
+      })
+  );
+  (useMetadataStore as unknown as jest.Mock).mockImplementation(
+    (selector: (s: unknown) => unknown) =>
+      selector({ getMetadata: () => imageSourceMetadata })
+  );
+};
+
+describe("useVariablePassthroughOutputs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("mirrors variables onto dynamic inputs and outputs as `any` when unconnected", () => {
+    setupStore([]);
+
+    renderHook(() =>
+      useVariablePassthroughOutputs("node-1", ["var_1", "var_2"], {}, {})
+    );
+
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+      dynamic_inputs: { var_1: ANY_TYPE, var_2: ANY_TYPE },
+      dynamic_outputs: { var_1: ANY_TYPE, var_2: ANY_TYPE }
+    });
+  });
+
+  it("adopts the type of whatever is wired into the variable", () => {
+    setupStore([
+      {
+        id: "e1",
+        source: "img-1",
+        sourceHandle: "output",
+        target: "node-1",
+        targetHandle: "var_1"
+      }
+    ]);
+
+    renderHook(() => useVariablePassthroughOutputs("node-1", ["var_1"], {}, {}));
+
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+      dynamic_inputs: { var_1: IMAGE_TYPE },
+      dynamic_outputs: { var_1: IMAGE_TYPE }
+    });
+  });
+
+  it("does not write when the maps already match", () => {
+    setupStore([]);
+
+    renderHook(() =>
+      useVariablePassthroughOutputs(
+        "node-1",
+        ["var_1"],
+        { var_1: ANY_TYPE },
+        { var_1: ANY_TYPE }
+      )
+    );
+
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+
+  it("drops handles for deleted variables", () => {
+    setupStore([]);
+
+    renderHook(() =>
+      useVariablePassthroughOutputs(
+        "node-1",
+        ["var_1"],
+        { var_1: ANY_TYPE, var_2: ANY_TYPE },
+        { var_1: ANY_TYPE, var_2: ANY_TYPE }
+      )
+    );
+
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+      dynamic_inputs: { var_1: ANY_TYPE },
+      dynamic_outputs: { var_1: ANY_TYPE }
+    });
+  });
+
+  it("skips a variable named output so the rendered text keeps its handle", () => {
+    setupStore([]);
+
+    renderHook(() =>
+      useVariablePassthroughOutputs("node-1", ["output", "var_1"], {}, {})
+    );
+
+    expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+      dynamic_inputs: { var_1: ANY_TYPE },
+      dynamic_outputs: { var_1: ANY_TYPE }
+    });
+  });
+});

--- a/web/src/components/node_types/editing/promptComposer/useVariablePassthroughOutputs.ts
+++ b/web/src/components/node_types/editing/promptComposer/useVariablePassthroughOutputs.ts
@@ -1,0 +1,100 @@
+/**
+ * Mirrors a Prompt node's variables onto `dynamic_inputs` / `dynamic_outputs`.
+ *
+ * Every `{{ variable }}` also gets an output handle of the same name carrying
+ * the raw value, so an image wired into `var_1` can additionally feed a
+ * downstream node that wants the real asset (reference images, image-to-video,
+ * …) instead of the `asset://` token the rendered text carries.
+ *
+ * The handles adopt the type of whatever is wired into the variable, so edge
+ * colors and connection validation match the value that actually flows. An
+ * unconnected variable stays `any` — it holds a literal typed into the node.
+ *
+ * Both maps are written: `dynamic_inputs` is what keeps the name resolving as
+ * an input handle now that it also appears in `dynamic_outputs` (see
+ * `findInputHandle` / `getAllInputHandles`), which otherwise treat a name in
+ * `dynamic_outputs` as output-only.
+ */
+import { useEffect } from "react";
+import { shallow } from "zustand/shallow";
+
+import type { TypeMetadata } from "../../../../stores/ApiTypes";
+import { useNodes } from "../../../../contexts/NodeContext";
+import useMetadataStore from "../../../../stores/MetadataStore";
+import { findOutputHandle } from "../../../../utils/handleUtils";
+import isEqual from "../../../../utils/isEqual";
+
+const ANY_TYPE: TypeMetadata = {
+  type: "any",
+  optional: false,
+  values: null,
+  type_args: [],
+  type_name: null
+};
+
+export const useVariablePassthroughOutputs = (
+  nodeId: string,
+  variableNames: string[],
+  dynamicInputs: Record<string, TypeMetadata>,
+  dynamicOutputs: Record<string, TypeMetadata>
+): void => {
+  const { edges, findNode, updateNodeData } = useNodes(
+    (state) => ({
+      edges: state.edges,
+      findNode: state.findNode,
+      updateNodeData: state.updateNodeData
+    }),
+    shallow
+  );
+  const getMetadata = useMetadataStore((state) => state.getMetadata);
+
+  useEffect(() => {
+    const incomingByHandle = new Map<string, (typeof edges)[number]>();
+    for (const edge of edges) {
+      if (edge.target === nodeId && edge.targetHandle) {
+        incomingByHandle.set(edge.targetHandle, edge);
+      }
+    }
+
+    const next: Record<string, TypeMetadata> = {};
+    for (const name of variableNames) {
+      // A variable named "output" would supersede the node's own string
+      // output handle in NodeOutputs — leave that one alone.
+      if (name === "output") continue;
+
+      const incoming = incomingByHandle.get(name);
+      const sourceNode = incoming ? findNode(incoming.source) : undefined;
+      const sourceMetadata = sourceNode
+        ? getMetadata(sourceNode.type || "")
+        : undefined;
+      const sourceHandle =
+        sourceNode && sourceMetadata
+          ? findOutputHandle(
+              sourceNode,
+              incoming?.sourceHandle || "",
+              sourceMetadata
+            )
+          : undefined;
+      next[name] = sourceHandle?.type ?? ANY_TYPE;
+    }
+
+    if (isEqual(dynamicInputs, next) && isEqual(dynamicOutputs, next)) {
+      return;
+    }
+    updateNodeData(nodeId, {
+      dynamic_inputs: next,
+      dynamic_outputs: next
+    });
+  }, [
+    nodeId,
+    variableNames,
+    dynamicInputs,
+    dynamicOutputs,
+    edges,
+    findNode,
+    getMetadata,
+    updateNodeData
+  ]);
+};
+
+export default useVariablePassthroughOutputs;

--- a/web/src/utils/handleUtils.test.ts
+++ b/web/src/utils/handleUtils.test.ts
@@ -203,6 +203,26 @@ describe("findInputHandle", () => {
 
     expect(findInputHandle(node, "out_only", meta)).toBeUndefined();
   });
+
+  it("resolves a pass-through name in both directions", () => {
+    // Prompt variables are mirrored onto dynamic_inputs *and* dynamic_outputs;
+    // the same name must stay an input handle so the incoming edge isn't
+    // dropped on load.
+    const meta = makeMetadata({ properties: [] });
+    const node = makeNode({
+      data: {
+        properties: {},
+        selectable: true,
+        dynamic_properties: { var_1: "" },
+        workflow_id: "wf-1",
+        dynamic_inputs: { var_1: makeType("image") },
+        dynamic_outputs: { var_1: makeType("image") },
+      },
+    });
+
+    expect(findInputHandle(node, "var_1", meta)!.type.type).toBe("image");
+    expect(findOutputHandle(node, "var_1", meta)!.type.type).toBe("image");
+  });
 });
 
 describe("getAllOutputHandles", () => {
@@ -286,6 +306,24 @@ describe("getAllInputHandles", () => {
 
     const handles = getAllInputHandles(node, meta);
     expect(handles.find((h) => h.name === "out_only")).toBeUndefined();
+  });
+
+  it("keeps pass-through names as input handles", () => {
+    const meta = makeMetadata({ properties: [] });
+    const node = makeNode({
+      data: {
+        properties: {},
+        selectable: true,
+        dynamic_properties: { var_1: "" },
+        workflow_id: "wf-1",
+        dynamic_inputs: { var_1: makeType("image") },
+        dynamic_outputs: { var_1: makeType("image") },
+      },
+    });
+
+    expect(
+      getAllInputHandles(node, meta).find((h) => h.name === "var_1")
+    ).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Problem

An image wired into a Prompt variable is consumed by the template: the rendered text gets an `asset://` token and the ref itself goes nowhere. A downstream node that wants the real asset — reference images, image-to-video — had to be wired straight to the source instead, duplicating the edge and letting the reference image and the prompt variable drift apart.

## What changed

Every `{{ variable }}` now also gets an output handle of its own name, carrying the raw value.

- `PromptNode` declares `supportsDynamicOutputs` and returns its variables alongside the rendered string. The pass-through carries the raw ref (an image stays an image); only the rendered text gets asset tokens. The rendered `output` is assigned last so a variable named `output` cannot shadow it.
- `PromptComposerBody` mirrors the variables onto `dynamic_inputs` / `dynamic_outputs` via a new `useVariablePassthroughOutputs` hook, adopting the type of whatever is wired into each variable so handle colors and connection validation match the value that actually flows. Unconnected variables stay `any`.
- Writing `dynamic_inputs` is what keeps the name resolving as an input handle: `findInputHandle` / `getAllInputHandles` treat a name that appears only in `dynamic_outputs` as output-only, and that guard still protects stale entries (Image Editor `layer_out_*`). No changes to `handleUtils` were needed.

`NodeOutputs` already merges `dynamic_outputs` into the output column, so the handles render with no new UI code. Handles with no outgoing edge are dropped by the runner, so unwired variables cost nothing at runtime.

## Testing

- `npm run lint`, `npm run typecheck` (web + electron; mobile fails on missing React Native deps in this container, unrelated)
- Full web Jest suite: 996 suites / 11,930 tests pass
- `packages/text-nodes` Vitest suite passes; new cases cover raw-ref pass-through, channel-resolved variables, and the `output` name collision
- New unit test for `useVariablePassthroughOutputs` (type adoption, deletion, no-op when unchanged)
- End-to-end via `nodetool workflows run`: a graph wiring both `prompt.output` and `prompt.subject` into Output nodes yields `"Describe a dragon"` and `"a dragon"` respectively

---
_Generated by [Claude Code](https://claude.ai/code/session_01UErdgyJq9z9yW8u2knN35e)_