### PR TITLE
test(kernel): harden kernel tests against surviving mutants

### DIFF
--- a/packages/kernel/MUTATION_TESTING.md
+++ b/packages/kernel/MUTATION_TESTING.md
@@ -43,53 +43,52 @@ Two settings differ from a vanilla Stryker setup and exist for concrete reasons
 
 ## Current baseline
 
-This is the baseline captured when the harness was added. Unlike
-`@nodetool-ai/security` (a small, fully-hardened 100% package), the kernel is
-large and these numbers are a **starting point to ratchet up**, not a finished
-target.
+Captured from a full run of 3,889 mutants (~21 min on 4 cores). Eleven of the
+thirteen mutated files are at 100%; the execution core is not, and is where the
+remaining work is.
 
 ```
 File                    | % score | % covered | killed | timeout | survived | no cov
 ------------------------|---------|-----------|--------|---------|----------|-------
-actor.ts                |   53.66 |     64.83 |    406 |       5 |      223 |    132
-channel.ts              |   75.89 |     77.98 |     83 |       2 |       24 |      3
-correlation-analysis.ts |   65.54 |     74.38 |    326 |       5 |      114 |     60
-durable-inbox.ts        |   63.57 |     63.57 |     81 |       1 |       47 |      0
+actor.ts                |   83.43 |     88.38 |    694 |      21 |       94 |     48
+correlation-analysis.ts |  100.00 |    100.00 |    440 |       4 |        0 |      0
+durable-inbox.ts        |  100.00 |    100.00 |    113 |       1 |        0 |      0
 edge-ids.ts             |  100.00 |    100.00 |      4 |       0 |        0 |      0
-graph-utils.ts          |   72.38 |     83.97 |    126 |       5 |       25 |     25
-graph.ts                |   66.99 |     69.73 |    404 |       6 |      178 |     24
-inbox.ts                |   84.98 |     89.58 |    204 |      11 |       25 |     13
-io.ts                   |   80.52 |     88.57 |     62 |       0 |        8 |      7
-runner.ts               |   50.30 |     55.99 |    421 |       4 |      334 |     86
-suspendable.ts          |   63.64 |     68.29 |     28 |       0 |       13 |      3
-trigger-manager.ts      |   33.59 |     53.75 |     43 |       0 |       37 |     48
-trigger-wakeup.ts       |   53.75 |     54.43 |     43 |       0 |       36 |      1
-trigger.ts              |   74.65 |     76.81 |     53 |       0 |       16 |      2
+graph-utils.ts          |  100.00 |    100.00 |    157 |       5 |        0 |      0
+graph.ts                |  100.00 |    100.00 |    594 |       6 |        0 |      0
+inbox.ts                |  100.00 |    100.00 |    235 |      12 |        0 |      0
+io.ts                   |  100.00 |    100.00 |     78 |       0 |        0 |      0
+runner.ts               |   79.73 |     80.66 |    826 |       0 |      198 |     12
+suspendable.ts          |  100.00 |    100.00 |     27 |       0 |        0 |      0
+trigger-manager.ts      |   99.03 |     99.03 |    102 |       0 |        1 |      0
+trigger-wakeup.ts       |  100.00 |    100.00 |     99 |       0 |        0 |      0
+trigger.ts              |  100.00 |    100.00 |     68 |       1 |        0 |      0
 ------------------------|---------|-----------|--------|---------|----------|-------
-All files               |   61.02 |     68.26 |   2284 |      39 |     1080 |    404
+All files               |   90.81 |     92.25 |   3437 |      50 |      293 |     60
 ```
 
 - **`% score`** counts every mutant (no-coverage mutants count against you).
 - **`% covered`** scores only mutants that at least one test exercised — the
   fairer measure of test *quality* vs. test *reach*.
 
-The config gate (`stryker.config.json`) **breaks below 55%**, a few points under
-the current 61% so it gates a test-quality regression while absorbing
+The config gate (`stryker.config.json`) **breaks below 85%**, a few points under
+the current 90.81% so it gates a test-quality regression while absorbing
 run-to-run timeout variance. Raise `thresholds.break` (and `low`/`high`) as the
 suite is hardened — treat the baseline as a floor that only moves up.
 
 ## Where to focus
 
-Ranked by surviving mutants (highest leverage first):
+Only two files still have meaningful survivors, and both are the execution core:
 
-1. **`runner.ts`** (334 survived, 50%) and **`actor.ts`** (223, 54%) — the
-   execution core. Many survivors are *no-coverage* (86 / 132), so start by
-   covering untested branches, then pin observable behaviour on the rest.
-2. **`graph.ts`** (178) and **`correlation-analysis.ts`** (114) — graph
-   validation and join/scope logic; survivors here are usually missing boundary
-   and error-path assertions.
-3. **`trigger-manager.ts`** (33% score, 48 no-coverage) — lowest-scoring file;
-   largely a coverage gap.
+1. **`runner.ts`** (198 survived, 79.73%) — the largest remaining block is
+   span-attribute and message-payload literals in the correlation and
+   edge-counter regions, best attacked from the correlation test files rather
+   than a runner fixture.
+2. **`actor.ts`** (94 survived, 48 no-coverage, 83.43%) — the no-coverage
+   cluster is in `isReady`'s list-input branches and `collect()` for multi-edge
+   list handles gated on `inbox.isOpen`. Reaching those needs a max-scope list
+   handle with a live driver, i.e. a real correlation graph rather than a
+   synthetic actor.
 
 When killing a mutant, target **observable behaviour**, not implementation
 details — each test should pin one externally-meaningful property and read as
@@ -107,3 +106,21 @@ The most common class here is **logger-name string literals**
 (`createLogger("nodetool.kernel.trigger")` → `createLogger("")`): the logger
 name is a diagnostic label for humans, not a behavioural contract, so it is
 deliberately not asserted.
+
+Suppression is the one tool here that can *lie*. A wrong or misplaced `disable`
+raises the score without any test behind it, and nothing in the report flags it.
+Two failure modes have already been found in this package:
+
+- **A wrong equivalence claim.** Two guards in `graph.ts` were suppressed as
+  "equivalent" when they were load-bearing: a string-valued `dynamic_properties`
+  spreads its character indices into node properties via `Object.assign`, and a
+  string-valued `propertyTypes` derives bogus declared keys. Both are now killed
+  by tests instead.
+- **A comment on the wrong line.** `next-line` binds to exactly one line, so a
+  comment above a multi-line `log.warn(...)` or a chained template covers only
+  the first line — the mutants on lines 2+ survive, and the comment reads as if
+  they were handled.
+
+Before suppressing, apply the mutant by hand and confirm no test *could*
+observe it. If writing the test is merely awkward, that is not equivalence —
+leave the mutant surviving rather than papering over it.

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -633,14 +633,10 @@ export class NodeActor {
         if (cls === "max") {
           const bucket = maxBuckets.get(h)!.get(key);
           if (!bucket || bucket.length === 0) {
-            // No driver value: not ready unless a non-driver max handle has
-            // sticky from a side-input semantic — which only applies when a
-            // repeating driver exists.
-            if (driverHandle && h !== driverHandle) {
-              // Side input must have produced for this exact key. v1: still
-              // wait for it to arrive.
-              return false;
-            }
+            // Not ready. v1 has no side-input sticky at max scope: a
+            // non-driver max handle must still have produced for this exact
+            // key, so the answer is `false` with or without a repeating
+            // driver.
             return false;
           }
           // Multi-edge list inputs aggregate every envelope: wait for the
@@ -836,9 +832,13 @@ export class NodeActor {
             // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
             log.warn(
               `Node "${this.node.id}" handle "${handle}" received multiple ` +
+                // Stryker disable next-line StringLiteral: diagnostic log args only
                 `values at empty scope; only the last is kept. Declare ` +
+                // Stryker disable next-line StringLiteral: diagnostic log args only
                 `output_correlation (chunk/iteration) on the upstream output ` +
+                // Stryker disable next-line StringLiteral: diagnostic log args only
                 `to preserve the stream.`,
+              // Stryker disable next-line ObjectLiteral: diagnostic log args only
               { nodeId: this.node.id, handle }
             );
           }
@@ -921,17 +921,24 @@ export class NodeActor {
           // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
           log.warn(
             `Node "${this.node.id}" dropped ${bucket.length} envelope(s) on ` +
+              // Stryker disable next-line StringLiteral: diagnostic log args only
               `handle "${handle}" for key "${key}" already fired without a ` +
+              // Stryker disable next-line StringLiteral: diagnostic log args only
               `repeating driver; declare output_correlation to fan out per ` +
+              // Stryker disable next-line StringLiteral: diagnostic log args only
               `item.`,
+            // Stryker disable next-line ObjectLiteral: diagnostic log args only
             { nodeId: this.node.id, handle, key, count: bucket.length }
           );
         } else {
           // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
           log.warn(
             `Node "${this.node.id}" left ${bucket.length} envelope(s) on ` +
+              // Stryker disable next-line StringLiteral: diagnostic log args only
               `handle "${handle}" for key "${key}" unfired at close; its ` +
+              // Stryker disable next-line StringLiteral: diagnostic log args only
               `inputs never completed for this key.`,
+            // Stryker disable next-line ObjectLiteral: diagnostic log args only
             { nodeId: this.node.id, handle, key, count: bucket.length }
           );
         }

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -91,10 +91,10 @@ function nodeTypeToJsonSchema(typeStr: string | undefined): string {
     case "float":
     case "number":
       return "number";
-    // Stryker disable next-line StringLiteral: equivalent — the "str" case falls through to "string", which returns the same value as the default branch
+    // Stryker disable StringLiteral: equivalent — both labels return "string", the same value as the default branch
     case "str":
-    // Stryker disable next-line StringLiteral: equivalent — "string" maps to "string", identical to the default branch
     case "string":
+      // Stryker restore StringLiteral
       return "string";
     case "bool":
     case "boolean":
@@ -243,7 +243,6 @@ export class Graph {
       // Merge dynamic_properties into the node's properties so that
       // dynamic nodes (e.g. WorkflowNode) receive user-provided values
       // for inputs that aren't connected via edges.
-      // Stryker disable next-line all: equivalent — Object.assign with a non-object dynamic_properties value adds no keys (no-op)
       if (
         nodeObj.dynamic_properties &&
         typeof nodeObj.dynamic_properties === "object"
@@ -258,7 +257,6 @@ export class Graph {
         // Only validate against propertyTypes when it is explicitly provided.
         // Using properties itself as a source of truth would defeat the purpose
         // of this check, since every property key would always be "defined".
-        // Stryker disable next-line all: these operands all guard the same thing — a non-object or empty propertyTypes disables the check (the empty-object case has a dedicated test)
         const hasPropertyTypes =
           nodeObj.propertyTypes != null &&
           typeof nodeObj.propertyTypes === "object" &&
@@ -480,6 +478,7 @@ export class Graph {
     for (const edge of edges) {
       if (isControlEdge(edge)) controlledIds.add(edge.target);
     }
+    // Stryker disable next-line ConditionalExpression: equivalent — with no control edges the map below returns every node unchanged, so the early return only avoids allocating a new array
     if (controlledIds.size === 0) return nodes;
     return nodes.map((node) =>
       // Stryker disable next-line ConditionalExpression,LogicalOperator,BooleanLiteral: equivalent — re-copying an already-controlled node yields the same is_controlled value; the guard only preserves object identity (a micro-optimization)
@@ -539,8 +538,8 @@ export class Graph {
   getControllerNodes(): NodeDescriptor[];
   getControllerNodes(targetId: string): NodeDescriptor[];
   getControllerNodes(targetId?: string): NodeDescriptor[] {
-    // Stryker disable next-line all: redundant ternary — getControlEdges(undefined) already returns all control edges, identical to getControlEdges()
     const controlEdges =
+      // Stryker disable next-line ConditionalExpression: redundant ternary — getControlEdges(undefined) already returns all control edges, identical to getControlEdges()
       targetId === undefined
         ? this.getControlEdges()
         : this.getControlEdges(targetId);
@@ -660,8 +659,8 @@ export class Graph {
 
     const isInScope = (node: NodeDescriptor): boolean => {
       const directlyInScope = (node.parent_id ?? null) === parentId;
-      // Stryker disable next-line ConditionalExpression: the `!= null` guard is redundant — groupNodeIds only holds real node-id strings, so has(null/undefined) is already false
       const inScopedGroup =
+        // Stryker disable next-line ConditionalExpression: the `!= null` guard is redundant — groupNodeIds only holds real node-id strings, so has(null/undefined) is already false
         node.parent_id != null && groupNodeIds.has(node.parent_id);
       return directlyInScope || inScopedGroup;
     };

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -24,6 +24,7 @@ import type {
 } from "@nodetool-ai/protocol";
 import { TypeMetadata } from "@nodetool-ai/protocol";
 
+// Stryker disable next-line StringLiteral: logger name is a diagnostic label, not a behavioural contract
 const log = createLogger("nodetool.kernel.runner");
 
 /** Node type that publishes to a variable channel (see runtime VariableChannel). */
@@ -608,6 +609,7 @@ export class WorkflowRunner {
       // checked first, then suspend takes priority over node errors so a
       // human-in-the-loop pause isn't masked by an incidental sibling error.
       if (!this._cancelled && this._suspend) {
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
         log.info("Workflow suspended", {
           jobId: request.job_id,
           nodeId: this._suspend.node_id,
@@ -634,6 +636,7 @@ export class WorkflowRunner {
         const error = [...this._nodeErrors]
           .map(([nodeId, msg]) => `Node "${nodeId}" failed: ${msg}`)
           .join("; ");
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
         log.error("Workflow failed", { jobId: request.job_id, error });
         this._emit({
           type: "job_update",
@@ -651,6 +654,7 @@ export class WorkflowRunner {
       }
 
       const status = this._cancelled ? "cancelled" : "completed";
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.info("Workflow completed", { jobId: request.job_id, status });
 
       this._emit({
@@ -667,6 +671,7 @@ export class WorkflowRunner {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.error("Workflow failed", { jobId: request.job_id, error: message });
       // Drain active edges on error for front-end cleanup
       this._drainActiveEdges();
@@ -737,6 +742,7 @@ export class WorkflowRunner {
   }
 
   cancel(): void {
+    // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
     log.info("Job cancelled", { jobId: this.jobId });
     // Latch the request so a cancel before run() survives _resetRunState. §17.
     this._cancelRequested = true;
@@ -766,7 +772,9 @@ export class WorkflowRunner {
         this._graph.findNode(edge.target) !== undefined
     );
     if (validEdges.length < this._graph.edges.length) {
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.warn("Filtered invalid edges", {
+        // Stryker disable next-line ArithmeticOperator: diagnostic log arg only
         removed: this._graph.edges.length - validEdges.length,
         remaining: validEdges.length
       });
@@ -1231,7 +1239,9 @@ export class WorkflowRunner {
     const pendingNodes = this._checkPendingInboxWork();
     if (pendingNodes.length > 0) {
       log.warn(
+        // Stryker disable next-line StringLiteral: diagnostic log args only
         "Pending inbox work detected after all actors completed — possible data loss",
+        // Stryker disable next-line ObjectLiteral: diagnostic log args only
         {
           pendingNodes
         }
@@ -1370,6 +1380,7 @@ export class WorkflowRunner {
 
       const value = outputs[edge.sourceHandle];
       if (value === undefined) {
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
         log.debug("_sendMessages skip edge (no matching output)", {
           sourceNodeId,
           sourceHandle: edge.sourceHandle,
@@ -1380,12 +1391,14 @@ export class WorkflowRunner {
 
       const targetInbox = this._inboxes.get(edge.target);
       if (!targetInbox) {
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
         log.debug("_sendMessages skip edge (no target inbox)", {
           target: edge.target
         });
         continue;
       }
 
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.debug("_sendMessages delivering", {
         sourceNodeId,
         sourceHandle: edge.sourceHandle,
@@ -1873,6 +1886,7 @@ export class WorkflowRunner {
     if (this._options.executionContext) {
       this._options.executionContext.emit(msg);
     }
+    // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
     log.debug("Message emitted", { jobId: this.jobId, type: msg.type });
   }
 

--- a/packages/kernel/stryker.config.json
+++ b/packages/kernel/stryker.config.json
@@ -12,9 +12,9 @@
     "related": false
   },
   "thresholds": {
-    "high": 80,
-    "low": 60,
-    "break": 55
+    "high": 95,
+    "low": 88,
+    "break": 85
   },
   "timeoutMS": 60000,
   "concurrency": 4

--- a/packages/kernel/tests/actor-mutation-kills.test.ts
+++ b/packages/kernel/tests/actor-mutation-kills.test.ts
@@ -1,0 +1,848 @@
+/**
+ * Behavioural contracts of `NodeActor` that the rest of the suite leaves
+ * unpinned. Written against the mutation-testing survivor list for
+ * `src/actor.ts`; every test here pins one externally-observable contract:
+ *
+ *  - `generation_complete.properties` — the scalar filter (what the relay
+ *    persists into asset metadata).
+ *  - Streaming-input `NodeOutputs` callbacks — per-slot lineage minting,
+ *    aggregate collapse, early slot EOS, `drop()`, `emitGroup()`.
+ *  - The correlated scheduler's final "no max-scope inputs" fire-once block —
+ *    prefix sticky, prefix-list aggregation across parent keys, empty-scope
+ *    list aggregation.
+ *  - Iteration-token bookkeeping — one token per group per frame, counters
+ *    scoped per parent key.
+ *  - `_executeWithInputs` merge order and control-context injection.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  NodeActor,
+  type NodeExecutor,
+  type OutputRoutingHints
+} from "../src/actor.js";
+import { NodeInbox, type MessageEnvelope } from "../src/inbox.js";
+import type { NodeInputs, NodeOutputs } from "../src/io.js";
+import type { InputAnalysis, NodeAnalysis } from "../src/correlation-analysis.js";
+import type {
+  CorrelationLineage,
+  GenerationComplete,
+  NodeDescriptor
+} from "@nodetool-ai/protocol";
+
+const EMPTY_ANALYSIS: NodeAnalysis = {
+  invocationScope: [],
+  inputs: new Map(),
+  outputs: new Map()
+};
+
+/** Build a `NodeAnalysis` from an invocation scope and per-handle scopes. */
+function analysis(
+  invocationScope: string[],
+  inputs: Record<string, { scope: string[]; repeatsPerKey?: boolean }> = {}
+): NodeAnalysis {
+  const map = new Map<string, InputAnalysis>();
+  for (const [handle, spec] of Object.entries(inputs)) {
+    map.set(handle, {
+      scope: spec.scope,
+      repeatsPerKey: spec.repeatsPerKey ?? false,
+      isMultiEdge: false,
+      possibleChildRoots: new Set<string>()
+    });
+  }
+  return { invocationScope, inputs: map, outputs: new Map() };
+}
+
+function makeNode(overrides: Partial<NodeDescriptor> = {}): NodeDescriptor {
+  return { id: "n1", type: "test.Node", ...overrides };
+}
+
+interface Sent {
+  nodeId: string;
+  outputs: Record<string, unknown>;
+  hints: OutputRoutingHints | undefined;
+}
+
+interface Harness {
+  actor: NodeActor;
+  sent: Sent[];
+  messages: unknown[];
+  eos: Array<[string, string]>;
+}
+
+function createActor(
+  node: NodeDescriptor,
+  inbox: NodeInbox,
+  executor: NodeExecutor,
+  opts: Partial<ConstructorParameters<typeof NodeActor>[0]> = {}
+): Harness {
+  const sent: Sent[] = [];
+  const messages: unknown[] = [];
+  const eos: Array<[string, string]> = [];
+  const actor = new NodeActor({
+    node,
+    inbox,
+    executor,
+    correlation: EMPTY_ANALYSIS,
+    sendOutputs: async (nodeId, outputs, hints) => {
+      sent.push({ nodeId, outputs, hints });
+    },
+    emitMessage: (msg) => messages.push(msg),
+    signalSlotEos: (nodeId, slot) => eos.push([nodeId, slot]),
+    ...opts
+  });
+  return { actor, sent, messages, eos };
+}
+
+function generationCompletes(messages: unknown[]): GenerationComplete[] {
+  return messages.filter(
+    (m) => (m as { type?: string }).type === "generation_complete"
+  ) as GenerationComplete[];
+}
+
+/** A streaming-input executor that consumes `handle` then runs `body`. */
+function streamThen(
+  handle: string,
+  body: (outputs: NodeOutputs, envelopes: MessageEnvelope[]) => Promise<void>
+): NodeExecutor {
+  return {
+    async process() {
+      return {};
+    },
+    async run(inputs: NodeInputs, outputs: NodeOutputs) {
+      const envelopes: MessageEnvelope[] = [];
+      for await (const env of inputs.streamWithEnvelope(handle)) {
+        envelopes.push(env);
+      }
+      await body(outputs, envelopes);
+    }
+  };
+}
+
+/** Feed one envelope with `lineage` on `handle`, then close the handle. */
+async function feedOne(
+  inbox: NodeInbox,
+  handle: string,
+  value: unknown,
+  lineage: CorrelationLineage
+): Promise<void> {
+  inbox.addUpstream(handle, 1);
+  await inbox.put(handle, value, { correlation_lineage: lineage });
+  inbox.markSourceDone(handle);
+}
+
+// ---------------------------------------------------------------------------
+// generation_complete: the scalar `properties` filter
+// ---------------------------------------------------------------------------
+
+describe("generation_complete properties — scalar filter", () => {
+  it("carries only string/number/boolean inputs, dropping nested values and internals", async () => {
+    // Arrange: a source node whose resolved inputs mix scalars, nested
+    // values and a reserved `_`-prefixed internal.
+    const node = makeNode({
+      properties: {
+        prompt: "a red fox",
+        seed: 7,
+        hires: true,
+        ref: { uri: "asset://x" },
+        tags: ["a", "b"],
+        missing: null,
+        absent: undefined,
+        _internal: 5
+      }
+    });
+    const { actor, messages } = createActor(node, new NodeInbox(), {
+      async process() {
+        return { image: "bytes" };
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert: exactly the three scalars ride along.
+    const gen = generationCompletes(messages);
+    expect(gen).toHaveLength(1);
+    expect(gen[0].properties).toEqual({
+      prompt: "a red fox",
+      seed: 7,
+      hires: true
+    });
+  });
+
+  it("reports null (not an empty object) when no input is scalar", async () => {
+    // Arrange
+    const node = makeNode({
+      properties: { ref: { uri: "asset://x" }, tags: [1, 2], missing: null }
+    });
+    const { actor, messages } = createActor(node, new NodeInbox(), {
+      async process() {
+        return { image: "bytes" };
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(generationCompletes(messages)[0].properties).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming-input NodeOutputs callbacks
+// ---------------------------------------------------------------------------
+
+describe("streaming-input emit — routing hints", () => {
+  it("attaches no per-slot lineage when the slot declares no output_correlation", async () => {
+    // Arrange
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", "v");
+      })
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    await actor.run();
+
+    // Assert: the invocation lineage is inherited, nothing is overridden.
+    expect(sent).toHaveLength(1);
+    expect(sent[0].hints?.invocationLineage).toEqual({ r1: { index: 2 } });
+    expect(sent[0].hints?.perSlotLineage).toBeUndefined();
+  });
+
+  it("mints an ascending iteration token per emit, keeping the inherited parent roots", async () => {
+    // Arrange
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        item: { kind: "iteration", source: "items", group: "g" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("item", "a");
+        await outputs.emit("item", "b");
+      })
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    await actor.run();
+
+    // Assert: each emit is its own logical item under the same parent.
+    expect(sent.map((s) => s.hints?.perSlotLineage?.item)).toEqual([
+      { r1: { index: 2 }, "n1:g": { index: 0 } },
+      { r1: { index: 2 }, "n1:g": { index: 1 } }
+    ]);
+  });
+
+  it("drops the innermost root for an aggregate(innermost) output", async () => {
+    // Arrange: `out` aggregates `items`, whose static scope ends with r1.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        out: { kind: "aggregate", source: "items", collapse: "innermost" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", ["a"]);
+      }),
+      { correlation: analysis(["r1"], { items: { scope: ["r1"] } }) }
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    await actor.run();
+
+    // Assert: the emission sits at the parent scope.
+    expect(sent[0].hints?.invocationLineage).toEqual({ r1: { index: 2 } });
+    expect(sent[0].hints?.perSlotLineage?.out).toEqual({});
+  });
+
+  it("keeps the full lineage for an aggregate output that does not collapse", async () => {
+    // Arrange: same wiring, but no `collapse: "innermost"`.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: { out: { kind: "aggregate", source: "items" } }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", ["a"]);
+      }),
+      { correlation: analysis(["r1"], { items: { scope: ["r1"] } }) }
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    await actor.run();
+
+    // Assert: no collapse, so no per-slot override.
+    expect(sent[0].hints?.invocationLineage).toEqual({ r1: { index: 2 } });
+    expect(sent[0].hints?.perSlotLineage).toBeUndefined();
+  });
+
+  it("emits without collapsing when no correlation analysis is available", async () => {
+    // Arrange: an aggregate(innermost) output on an unanalyzed node.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        out: { kind: "aggregate", source: "items", collapse: "innermost" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", ["a"]);
+      }),
+      { correlation: undefined }
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    const result = await actor.run();
+
+    // Assert: the emission still goes out, uncollapsed.
+    expect(result.error).toBeUndefined();
+    expect(sent[0].outputs).toEqual({ out: ["a"] });
+    expect(sent[0].hints?.perSlotLineage).toBeUndefined();
+  });
+
+  it("emits without collapsing when the aggregate source handle is not connected", async () => {
+    // Arrange: `source` names a handle absent from the analysis.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        out: { kind: "aggregate", source: "unconnected", collapse: "innermost" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", ["a"]);
+      }),
+      { correlation: analysis(["r1"], { items: { scope: ["r1"] } }) }
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    const result = await actor.run();
+
+    // Assert
+    expect(result.error).toBeUndefined();
+    expect(sent[0].hints?.perSlotLineage).toBeUndefined();
+  });
+
+  it("emits without collapsing when the aggregate source sits at the root scope", async () => {
+    // Arrange: nothing to collapse — the source handle has an empty scope.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        out: { kind: "aggregate", source: "items", collapse: "innermost" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emit("out", ["a"]);
+      }),
+      { correlation: analysis([], { items: { scope: [] } }) }
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 2 } });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(sent[0].hints?.perSlotLineage).toBeUndefined();
+  });
+});
+
+describe("streaming-input outputs.complete / drop / emitGroup", () => {
+  it("signals early EOS for the named slot, defaulting an empty name to 'output'", async () => {
+    // Arrange
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+    const { actor, eos } = createActor(node, inbox, {
+      async process() {
+        return {};
+      },
+      async run(_inputs: NodeInputs, outputs: NodeOutputs) {
+        outputs.complete("");
+        outputs.complete("images");
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(eos).toEqual([
+      ["n1", "output"],
+      ["n1", "images"]
+    ]);
+  });
+
+  it("tolerates outputs.complete() when the runner wired no EOS callback", async () => {
+    // Arrange: no `signalSlotEos` (e.g. a standalone actor fixture).
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      {
+        async process() {
+          return {};
+        },
+        async run(_inputs: NodeInputs, outputs: NodeOutputs) {
+          outputs.complete("out");
+          await outputs.emit("out", 1);
+        }
+      },
+      { signalSlotEos: undefined }
+    );
+
+    // Act
+    const result = await actor.run();
+
+    // Assert
+    expect(result.error).toBeUndefined();
+    expect(sent[0].outputs).toEqual({ out: 1 });
+  });
+
+  it("routes outputs.drop() as a lineage_done for that slot at the envelope's lineage", async () => {
+    // Arrange
+    const node = makeNode({ is_streaming_input: true });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs, envelopes) => {
+        await outputs.drop("out", envelopes[0]);
+      })
+    );
+    await feedOne(inbox, "items", "in", { r1: { index: 4 } });
+
+    // Act
+    await actor.run();
+
+    // Assert: the slot must be present in the routed frame so the runner
+    // knows which edges to signal.
+    expect(sent).toHaveLength(1);
+    expect("out" in sent[0].outputs).toBe(true);
+    expect(sent[0].hints?.lineageDoneSlots).toEqual(new Set(["out"]));
+    expect(sent[0].hints?.perSlotLineage?.out).toEqual({ r1: { index: 4 } });
+  });
+
+  it("emitGroup shares one minted token across sibling slots and honours an explicit lineage", async () => {
+    // Arrange: `left`/`right` are one iteration group; `meta` is undeclared.
+    const node = makeNode({
+      is_streaming_input: true,
+      output_correlation: {
+        left: { kind: "iteration", source: "items", group: "pair" },
+        right: { kind: "iteration", source: "items", group: "pair" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      streamThen("items", async (outputs) => {
+        await outputs.emitGroup(
+          { left: 1, right: 2, meta: "m" },
+          { lineage: { r0: { index: 7 } } }
+        );
+      })
+    );
+    // A different ambient lineage, to prove the explicit one wins.
+    await feedOne(inbox, "items", "in", { r1: { index: 9 } });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(sent).toHaveLength(1);
+    expect(sent[0].outputs).toEqual({ left: 1, right: 2, meta: "m" });
+    expect(sent[0].hints?.invocationLineage).toEqual({ r0: { index: 7 } });
+    const perSlot = sent[0].hints?.perSlotLineage;
+    expect(perSlot?.meta).toEqual({ r0: { index: 7 } });
+    expect(perSlot?.left).toEqual({
+      r0: { index: 7 },
+      "n1:pair": { index: 0 }
+    });
+    expect(perSlot?.right).toEqual(perSlot?.left);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correlated scheduler — the final "no max-scope inputs" fire-once block
+// ---------------------------------------------------------------------------
+
+describe("correlated scheduler — fire-once with no max-scope inputs", () => {
+  it("fires once with the sticky value of a strict-prefix handle", async () => {
+    // Arrange: `cfg` sits one root above the invocation scope, so it is a
+    // strict-prefix sticky input and the node has no max-scope input at all.
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(
+      node,
+      inbox,
+      {
+        async process(inputs) {
+          calls.push(inputs);
+          return {};
+        }
+      },
+      { correlation: analysis(["r1", "r2"], { cfg: { scope: ["r1"] } }) }
+    );
+    await feedOne(inbox, "cfg", "hello", { r1: { index: 0 } });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(calls).toEqual([{ cfg: "hello" }]);
+  });
+
+  it("aggregates a prefix list input across every parent key into one array", async () => {
+    // Arrange: a multi-edge list handle at prefix scope receives values under
+    // two different parent keys.
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(
+      node,
+      inbox,
+      {
+        async process(inputs) {
+          calls.push(inputs);
+          return {};
+        }
+      },
+      {
+        correlation: analysis(["r1", "r2"], { items: { scope: ["r1"] } }),
+        listInputHandles: new Set(["items"])
+      }
+    );
+    inbox.addUpstream("items", 1);
+    await inbox.put("items", "a", { correlation_lineage: { r1: { index: 0 } } });
+    await inbox.put("items", "b", { correlation_lineage: { r1: { index: 1 } } });
+    inbox.markSourceDone("items");
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(calls).toEqual([{ items: ["a", "b"] }]);
+  });
+
+  it("aggregates every envelope of an empty-scope list input", async () => {
+    // Arrange
+    const node = makeNode();
+    const inbox = new NodeInbox();
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(
+      node,
+      inbox,
+      {
+        async process(inputs) {
+          calls.push(inputs);
+          return {};
+        }
+      },
+      { correlation: analysis([]), listInputHandles: new Set(["items"]) }
+    );
+    inbox.addUpstream("items", 1);
+    await inbox.put("items", "a");
+    await inbox.put("items", "b");
+    inbox.markSourceDone("items");
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(calls).toEqual([{ items: ["a", "b"] }]);
+  });
+
+  it("leaves the declared default in place when an empty-scope list input never receives a value", async () => {
+    // Arrange: the upstream closes without emitting.
+    const node = makeNode({ properties: { items: "declared-default" } });
+    const inbox = new NodeInbox();
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(
+      node,
+      inbox,
+      {
+        async process(inputs) {
+          calls.push(inputs);
+          return {};
+        }
+      },
+      { correlation: analysis([]), listInputHandles: new Set(["items"]) }
+    );
+    inbox.addUpstream("items", 1);
+    inbox.markSourceDone("items");
+
+    // Act
+    await actor.run();
+
+    // Assert: the node fires with its own default, NOT an empty array.
+    expect(calls).toEqual([{ items: "declared-default" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Iteration-token bookkeeping
+// ---------------------------------------------------------------------------
+
+describe("iteration tokens", () => {
+  it("gives sibling slots of one group the same token in a single process() result", async () => {
+    // Arrange
+    const node = makeNode({
+      output_correlation: {
+        left: { kind: "iteration", source: "a", group: "pair" },
+        right: { kind: "iteration", source: "a", group: "pair" }
+      }
+    });
+    const { actor, sent } = createActor(node, new NodeInbox(), {
+      async process() {
+        return { left: 1, right: 2 };
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert: one logical item, not two.
+    const perSlot = sent[0].hints?.perSlotLineage;
+    expect(perSlot?.left).toEqual({ "n1:pair": { index: 0 } });
+    expect(perSlot?.right).toEqual({ "n1:pair": { index: 0 } });
+  });
+
+  it("overwrites a genProcess-supplied `index` with the actor-minted token and matches the routed lineage", async () => {
+    // Arrange: the node yields its own (stale) index alongside a sibling
+    // value slot and an undeclared passthrough slot.
+    const node = makeNode({
+      is_streaming_output: true,
+      output_correlation: {
+        index: { kind: "iteration", source: "a", group: "g" },
+        value: { kind: "iteration", source: "a", group: "g" }
+      }
+    });
+    const { actor, sent } = createActor(node, new NodeInbox(), {
+      async process() {
+        return {};
+      },
+      async *genProcess() {
+        yield { index: 99, value: "x", extra: "e" };
+      }
+    });
+
+    // Act
+    const result = await actor.run();
+
+    // Assert: the emitted index, the collected result and the lineage token
+    // all agree on the actor-minted 0.
+    expect(result.error).toBeUndefined();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].outputs).toEqual({ index: 0, value: "x", extra: "e" });
+    expect(result.outputs).toEqual({ index: 0, value: "x", extra: "e" });
+    const perSlot = sent[0].hints?.perSlotLineage;
+    expect(perSlot?.index).toEqual({ "n1:g": { index: 0 } });
+    expect(perSlot?.value).toEqual({ "n1:g": { index: 0 } });
+  });
+
+  it("restarts iteration token numbering for each parent key", async () => {
+    // Arrange: one max-scope input delivers two envelopes with distinct
+    // parent keys; each invocation mints its own group token.
+    const node = makeNode({
+      is_streaming_output: true,
+      output_correlation: {
+        item: { kind: "iteration", source: "src", group: "g" }
+      }
+    });
+    const inbox = new NodeInbox();
+    const { actor, sent } = createActor(
+      node,
+      inbox,
+      {
+        async process() {
+          return {};
+        },
+        async *genProcess(inputs) {
+          yield { item: inputs.src };
+        }
+      },
+      { correlation: analysis(["r1"], { src: { scope: ["r1"] } }) }
+    );
+    inbox.addUpstream("src", 1);
+    await inbox.put("src", "a", { correlation_lineage: { r1: { index: 0 } } });
+    await inbox.put("src", "b", { correlation_lineage: { r1: { index: 1 } } });
+    inbox.markSourceDone("src");
+
+    // Act
+    await actor.run();
+
+    // Assert: both parent keys start at 0 — counters are per (root, parent).
+    expect(sent).toHaveLength(2);
+    expect(sent.map((s) => s.hints?.perSlotLineage?.item)).toEqual([
+      { r1: { index: 0 }, "n1:g": { index: 0 } },
+      { r1: { index: 1 }, "n1:g": { index: 0 } }
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// genProcess frame filtering and execution-mode selection
+// ---------------------------------------------------------------------------
+
+describe("genProcess frames", () => {
+  it("routes nothing for a yield whose values are all null or undefined", async () => {
+    // Arrange
+    const node = makeNode({ is_streaming_output: true });
+    const { actor, sent } = createActor(node, new NodeInbox(), {
+      async process() {
+        return {};
+      },
+      async *genProcess() {
+        yield { a: null, b: undefined };
+        yield { a: 1 };
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(sent).toHaveLength(1);
+    expect(sent[0].outputs).toEqual({ a: 1 });
+  });
+
+  it("falls back to process() when a node declares is_streaming_output but has no genProcess", async () => {
+    // Arrange
+    const node = makeNode({ is_streaming_output: true });
+    const { actor, sent } = createActor(node, new NodeInbox(), {
+      async process() {
+        return { out: "buffered" };
+      }
+    });
+
+    // Act
+    const result = await actor.run();
+
+    // Assert
+    expect(result.error).toBeUndefined();
+    expect(sent.map((s) => s.outputs)).toEqual([{ out: "buffered" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _executeWithInputs: property merge and control context
+// ---------------------------------------------------------------------------
+
+describe("resolved inputs", () => {
+  it("lets dynamic_properties override declared properties", async () => {
+    // Arrange
+    const node = makeNode({
+      properties: { a: 1, b: 2 },
+      dynamic_properties: { b: 3, c: 4 }
+    });
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(node, new NodeInbox(), {
+      async process(inputs) {
+        calls.push(inputs);
+        return {};
+      }
+    });
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(calls).toEqual([{ a: 1, b: 3, c: 4 }]);
+  });
+
+  it("injects the control context as _control_context alongside the merged inputs", async () => {
+    // Arrange
+    const node = makeNode({ properties: { a: 1 } });
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(
+      node,
+      new NodeInbox(),
+      {
+        async process(inputs) {
+          calls.push(inputs);
+          return {};
+        }
+      },
+      { controlContext: { node_id: "ctrl" } }
+    );
+
+    // Act
+    await actor.run();
+
+    // Assert
+    expect(calls).toEqual([{ a: 1, _control_context: { node_id: "ctrl" } }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controlled mode: caching data inputs that arrive while waiting
+// ---------------------------------------------------------------------------
+
+describe("controlled mode — waiting for data inputs", () => {
+  it("keeps every data handle that arrives during the wait, not just the last one", async () => {
+    // Arrange: neither handle is buffered when the actor starts, so both are
+    // collected by the wait loop before the first control event runs.
+    const node = makeNode({ is_controlled: true });
+    const inbox = new NodeInbox();
+    inbox.addUpstream("__control__", 1);
+    inbox.addUpstream("a", 1);
+    inbox.addUpstream("b", 1);
+    const calls: Array<Record<string, unknown>> = [];
+    const { actor } = createActor(node, inbox, {
+      async process(inputs) {
+        calls.push(inputs);
+        return {};
+      }
+    });
+
+    // Act
+    const running = actor.run();
+    await inbox.put("a", "A");
+    await inbox.put("b", "B");
+    await inbox.put("__control__", {
+      event_type: "run" as const,
+      properties: {}
+    });
+    inbox.markSourceDone("a");
+    inbox.markSourceDone("b");
+    inbox.markSourceDone("__control__");
+    await running;
+
+    // Assert
+    expect(calls).toEqual([{ a: "A", b: "B" }]);
+  });
+});

--- a/packages/kernel/tests/graph-mutation-kills.test.ts
+++ b/packages/kernel/tests/graph-mutation-kills.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Mutation-kill tests for src/graph.ts.
+ *
+ * Each test pins one externally-visible contract that a surviving Stryker
+ * mutant would break: the type guards around `dynamic_properties` /
+ * `propertyTypes` in `fromDict`, and every branch plus the error payload of
+ * `validateDataEdgeSourceHandles`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Graph, GraphValidationError } from "../src/graph.js";
+import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
+
+function n(
+  id: string,
+  type: string,
+  extra: Partial<NodeDescriptor> = {}
+): NodeDescriptor {
+  return { id, type, ...extra };
+}
+
+function e(
+  source: string,
+  sourceHandle: string,
+  target: string,
+  targetHandle: string,
+  extra: Partial<Edge> = {}
+): Edge {
+  return { source, sourceHandle, target, targetHandle, ...extra };
+}
+
+const propsOf = (graph: Graph, id: string): Record<string, unknown> =>
+  (graph.findNode(id)?.properties ?? {}) as Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// fromDict – dynamic_properties merge guard
+// ---------------------------------------------------------------------------
+
+describe("Graph.fromDict – dynamic_properties type guard", () => {
+  it("ignores a non-object dynamic_properties instead of spreading it", () => {
+    // Arrange: a string dynamic_properties — Object.assign would copy its
+    // character indices ("0", "1", "2") onto the node's properties.
+    const data = {
+      nodes: [
+        {
+          id: "a",
+          type: "test.A",
+          properties: { keep: 1 },
+          dynamic_properties: "abc"
+        }
+      ],
+      edges: []
+    };
+
+    // Act
+    const graph = Graph.fromDict(data);
+
+    // Assert
+    expect(propsOf(graph, "a")).toEqual({ keep: 1 });
+  });
+
+  it("merges a real dynamic_properties object into properties", () => {
+    // Arrange
+    const data = {
+      nodes: [
+        {
+          id: "a",
+          type: "test.A",
+          properties: { keep: 1 },
+          dynamic_properties: { extra: "v" }
+        }
+      ],
+      edges: []
+    };
+
+    // Act
+    const graph = Graph.fromDict(data);
+
+    // Assert
+    expect(propsOf(graph, "a")).toEqual({ keep: 1, extra: "v" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fromDict – propertyTypes guard (only active with allowUndefinedProperties:false)
+// ---------------------------------------------------------------------------
+
+describe("Graph.fromDict – propertyTypes type guard", () => {
+  it("treats a null propertyTypes as 'no declaration' and keeps properties", () => {
+    // Arrange: typeof null === "object", so only the != null guard stops
+    // Object.keys(null) from throwing.
+    const data = {
+      nodes: [
+        { id: "a", type: "test.A", properties: { foo: 1 }, propertyTypes: null }
+      ],
+      edges: []
+    };
+
+    // Act
+    const graph = Graph.fromDict(data, {
+      allowUndefinedProperties: false,
+      skipErrors: false
+    });
+
+    // Assert
+    expect(propsOf(graph, "a")).toEqual({ foo: 1 });
+  });
+
+  it("treats a non-object propertyTypes as 'no declaration' and keeps properties", () => {
+    // Arrange: Object.keys("ab") would yield ["0","1"], making "foo" undeclared.
+    const data = {
+      nodes: [
+        { id: "a", type: "test.A", properties: { foo: 1 }, propertyTypes: "ab" }
+      ],
+      edges: []
+    };
+
+    // Act
+    const graph = Graph.fromDict(data, {
+      allowUndefinedProperties: false,
+      skipErrors: false
+    });
+
+    // Assert
+    expect(propsOf(graph, "a")).toEqual({ foo: 1 });
+  });
+
+  it("keeps rejecting undeclared properties when propertyTypes is a real map", () => {
+    // Arrange
+    const data = {
+      nodes: [
+        {
+          id: "a",
+          type: "test.A",
+          properties: { foo: 1 },
+          propertyTypes: { bar: "str" }
+        }
+      ],
+      edges: []
+    };
+
+    // Act / Assert
+    expect(() =>
+      Graph.fromDict(data, {
+        allowUndefinedProperties: false,
+        skipErrors: false
+      })
+    ).toThrow(/Property foo does not exist on node a/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDataEdgeSourceHandles – skip branches
+// ---------------------------------------------------------------------------
+
+describe("Graph.validateDataEdgeSourceHandles – skipped edges", () => {
+  it("does not check sourceHandle on control edges", () => {
+    // Arrange: "ctrl" is not a declared output of the source node.
+    const graph = new Graph({
+      nodes: [
+        n("a", "test.A", { outputs: { output: "str" } }),
+        n("b", "test.B")
+      ],
+      edges: [
+        e("a", "ctrl", "b", "__control__", {
+          id: "c1",
+          edge_type: "control"
+        })
+      ]
+    });
+
+    // Act / Assert
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+
+  it("does not check edges whose source node is missing from the graph", () => {
+    // Arrange: dangling source — endpoint existence is validateEdgeEndpoints' job.
+    const graph = new Graph({
+      nodes: [n("b", "test.B")],
+      edges: [e("ghost", "output", "b", "in", { id: "d1" })]
+    });
+
+    // Act / Assert
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+
+  it("does not check nodes without a non-empty static outputs map", () => {
+    // Arrange
+    const noOutputs = new Graph({
+      nodes: [n("a", "test.A"), n("b", "test.B")],
+      edges: [e("a", "whatever", "b", "in", { id: "d1" })]
+    });
+    const emptyOutputs = new Graph({
+      nodes: [n("a", "test.A", { outputs: {} }), n("b", "test.B")],
+      edges: [e("a", "whatever", "b", "in", { id: "d2" })]
+    });
+
+    // Act / Assert
+    expect(() => noOutputs.validateDataEdgeSourceHandles()).not.toThrow();
+    expect(() => emptyOutputs.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+
+  it("still checks handles when dynamic_outputs is present but empty", () => {
+    // Arrange: only a *non-empty* dynamic_outputs map suppresses the check.
+    const graph = new Graph({
+      nodes: [
+        n("a", "test.A", { outputs: { output: "str" }, dynamic_outputs: {} }),
+        n("b", "test.B")
+      ],
+      edges: [e("a", "missing", "b", "in", { id: "d1" })]
+    });
+
+    // Act / Assert
+    expect(() => graph.validateDataEdgeSourceHandles()).toThrow(
+      GraphValidationError
+    );
+  });
+
+  it("skips the check when the node declares non-empty dynamic_outputs", () => {
+    // Arrange
+    const graph = new Graph({
+      nodes: [
+        n("a", "test.A", {
+          outputs: { output: "str" },
+          dynamic_outputs: { extra: { type: "str" } }
+        }),
+        n("b", "test.B")
+      ],
+      edges: [e("a", "extra", "b", "in", { id: "d1" })]
+    });
+
+    // Act / Assert
+    expect(() => graph.validateDataEdgeSourceHandles()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDataEdgeSourceHandles – error payload
+// ---------------------------------------------------------------------------
+
+describe("Graph.validateDataEdgeSourceHandles – error payload", () => {
+  const failingGraph = (nodeType: string, edgeId?: string): Graph =>
+    new Graph({
+      nodes: [
+        n("src", nodeType, { outputs: { output: "str" } }),
+        n("dst", "test.Dst")
+      ],
+      edges: [e("src", "missing", "dst", "in", edgeId ? { id: edgeId } : {})]
+    });
+
+  const catchError = (graph: Graph): GraphValidationError => {
+    try {
+      graph.validateDataEdgeSourceHandles();
+    } catch (err) {
+      return err as GraphValidationError;
+    }
+    throw new Error("expected validateDataEdgeSourceHandles to throw");
+  };
+
+  it("names the edge id, the unknown handle, the node and its type", () => {
+    // Arrange
+    const graph = failingGraph("test.Src", "e1");
+
+    // Act
+    const err = catchError(graph);
+
+    // Assert
+    expect(err.message).toBe(
+      'Edge e1 references unknown output "missing" on node "src" (test.Src)'
+    );
+  });
+
+  it("falls back to the synthetic edge id when the edge carries none", () => {
+    // Arrange
+    const graph = failingGraph("test.Src");
+
+    // Act
+    const err = catchError(graph);
+
+    // Assert
+    expect(err.message).toBe(
+      'Edge src:missing->dst:in references unknown output "missing" on node "src" (test.Src)'
+    );
+  });
+
+  it("omits the type suffix entirely when the source node has no type", () => {
+    // Arrange
+    const graph = failingGraph("", "e1");
+
+    // Act
+    const err = catchError(graph);
+
+    // Assert
+    expect(err.message).toBe(
+      'Edge e1 references unknown output "missing" on node "src"'
+    );
+  });
+
+  it("reports one issue pointing at the node, type and handle", () => {
+    // Arrange
+    const graph = failingGraph("test.Src", "e1");
+
+    // Act
+    const err = catchError(graph);
+
+    // Assert
+    expect(err.issues).toEqual([
+      {
+        nodeId: "src",
+        nodeType: "test.Src",
+        property: "missing",
+        message: 'Unknown output "missing"'
+      }
+    ]);
+  });
+});

--- a/packages/kernel/tests/runner-mutation-kills.test.ts
+++ b/packages/kernel/tests/runner-mutation-kills.test.ts
@@ -1,0 +1,792 @@
+/**
+ * Behavioural contracts of WorkflowRunner that were previously unpinned.
+ *
+ * Each test fixes ONE externally observable guarantee:
+ *  - variable-channel lifecycle (register / mark-done / close-all)
+ *  - sendControlEvent rejection paths and pending-response rejection
+ *  - updateNodeProperties return contract
+ *  - validation_issues on the failure job_update
+ *  - workflow_id propagation into terminal job_updates
+ *  - input-node process() failure wrapping
+ *  - retained-message cap
+ *  - sink output collection
+ *  - client-facing output names
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner, type NodeValidator } from "../src/runner.js";
+import type {
+  NodeDescriptor,
+  Edge,
+  JobUpdate,
+  OutputUpdate,
+  ProcessingMessage
+} from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { NodeExecutor } from "../src/actor.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SET_VARIABLE = "nodetool.variable.SetVariable";
+
+function simpleExecutor(
+  fn: (inputs: Record<string, unknown>) => Record<string, unknown>
+): NodeExecutor {
+  return {
+    async process(inputs) {
+      return fn(inputs);
+    }
+  };
+}
+
+function makeRunner(
+  executorMap: Record<string, NodeExecutor> = {},
+  executionContext?: ProcessingContext,
+  validateNode?: NodeValidator
+): WorkflowRunner {
+  return new WorkflowRunner("mut-job", {
+    resolveExecutor: (node) =>
+      executorMap[node.id] ??
+      executorMap[node.type] ??
+      simpleExecutor(() => ({})),
+    executionContext,
+    validateNode
+  });
+}
+
+interface ChannelSpy {
+  registered: Array<[string, number]>;
+  done: string[];
+  closedAll: number;
+  emitted: ProcessingMessage[];
+  context: ProcessingContext;
+}
+
+/** Execution context that records the variable-channel calls it receives. */
+function makeChannelSpy(): ChannelSpy {
+  const spy: ChannelSpy = {
+    registered: [],
+    done: [],
+    closedAll: 0,
+    emitted: [],
+    context: undefined as unknown as ProcessingContext
+  };
+  spy.context = {
+    emit(msg: ProcessingMessage) {
+      spy.emitted.push(msg);
+    },
+    registerChannelWriters(name: string, count: number) {
+      spy.registered.push([name, count]);
+    },
+    markChannelWriterDone(name: string) {
+      spy.done.push(name);
+    },
+    closeAllChannels() {
+      spy.closedAll += 1;
+    }
+  } as unknown as ProcessingContext;
+  return spy;
+}
+
+function jobUpdates(messages: ProcessingMessage[]): JobUpdate[] {
+  return messages.filter((m): m is JobUpdate => m.type === "job_update");
+}
+
+function outputUpdates(messages: ProcessingMessage[]): OutputUpdate[] {
+  return messages.filter((m): m is OutputUpdate => m.type === "output_update");
+}
+
+type RunnerInternals = {
+  _messages: ProcessingMessage[];
+  _emit(msg: ProcessingMessage): void;
+};
+const internals = (r: WorkflowRunner) => r as unknown as RunnerInternals;
+
+// ---------------------------------------------------------------------------
+// R1 – Variable-channel lifecycle
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – variable channel registration", () => {
+  it("registers exactly one writer per Set Variable node, trimming the name", async () => {
+    const spy = makeChannelSpy();
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "sv", type: SET_VARIABLE, properties: { name: "  chan  " } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "sv",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner({}, spy.context).run(
+      { job_id: "j-reg", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(spy.registered).toEqual([["chan", 1]]);
+  });
+
+  it("skips Set Variable nodes without a usable channel name, and non-Set-Variable nodes", async () => {
+    const spy = makeChannelSpy();
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      // blank after trim
+      { id: "blank", type: SET_VARIABLE, properties: { name: "   " } },
+      // no properties at all
+      { id: "bare", type: SET_VARIABLE },
+      // name present but not a string
+      { id: "numeric", type: SET_VARIABLE, properties: { name: 42 } },
+      // properties is not an object — must not be read as a property bag
+      {
+        id: "fnprops",
+        type: SET_VARIABLE,
+        properties: function namedChannel() {} as unknown as Record<
+          string,
+          unknown
+        >
+      },
+      // a different node type that happens to carry a name property
+      { id: "other", type: "test.Sink", properties: { name: "not-a-channel" } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "blank",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "bare",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "numeric",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "fnprops",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "other",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner({}, spy.context).run(
+      { job_id: "j-skip", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(spy.registered).toEqual([]);
+  });
+
+  it("marks the writer done for the finished Set Variable node only, then closes all channels", async () => {
+    const spy = makeChannelSpy();
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "sv", type: SET_VARIABLE, properties: { name: "chan" } },
+      // a Set Variable with no channel name must not report a writer done
+      { id: "svblank", type: SET_VARIABLE, properties: { name: "" } },
+      // a non-Set-Variable actor with a name property must not touch channels
+      { id: "other", type: "test.Sink", properties: { name: "othername" } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "sv",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "svblank",
+        targetHandle: "value"
+      },
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "other",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner({}, spy.context).run(
+      { job_id: "j-done", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(spy.done).toEqual(["chan"]);
+    expect(spy.closedAll).toBe(1);
+  });
+
+  it("runs a Set Variable graph when the execution context has no channel API", async () => {
+    const emitted: ProcessingMessage[] = [];
+    const ctx = {
+      emit(msg: ProcessingMessage) {
+        emitted.push(msg);
+      }
+    } as unknown as ProcessingContext;
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "sv", type: SET_VARIABLE, properties: { name: "chan" } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "sv",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner({}, ctx).run(
+      { job_id: "j-noapi", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+  });
+
+  it("runs a Set Variable graph with no execution context at all", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "sv", type: SET_VARIABLE, properties: { name: "chan" } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "sv",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner().run(
+      { job_id: "j-noctx", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R2 – Control-event rejection paths
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – sendControlEvent rejections", () => {
+  it("names the missing target node in the rejection", async () => {
+    const runner = makeRunner();
+
+    await expect(runner.sendControlEvent("ghost", { x: 1 })).rejects.toThrow(
+      "Target node not found or no inbox: ghost"
+    );
+  });
+
+  it("rejects a pending response with the controlled node's own error, then reports it completed", async () => {
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "ctrl",
+        type: "test.Controller",
+        is_streaming_output: true,
+        outputs: { __control__: "control" }
+      },
+      {
+        id: "worker",
+        type: "test.Worker",
+        is_controlled: true,
+        outputs: { result: "int" }
+      }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "ce1",
+        source: "ctrl",
+        sourceHandle: "__control__",
+        target: "worker",
+        targetHandle: "__control__",
+        edge_type: "control"
+      }
+    ];
+
+    let started!: () => void;
+    const ctrlStarted = new Promise<void>((r) => {
+      started = r;
+    });
+    const stop = { requested: false };
+
+    const runner = new WorkflowRunner("job-reject", {
+      resolveExecutor: (node) => {
+        if (node.id === "ctrl") {
+          return {
+            async *genProcess() {
+              started();
+              yield { __control__: { event_type: "run", properties: {} } };
+              while (!stop.requested) {
+                await new Promise((r) => setTimeout(r, 10));
+              }
+              yield { __control__: { event_type: "stop" } };
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        return {
+          process: async (inputs: Record<string, unknown>) => {
+            // The controller's own kickoff event carries no `x`; only the
+            // test's sendControlEvent does, and that one kills the actor.
+            if (inputs.x !== undefined) throw new Error("worker exploded");
+            return { result: 0 };
+          }
+        };
+      }
+    });
+
+    const runPromise = runner.run({ job_id: "job-reject" }, { nodes, edges });
+    await ctrlStarted;
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The worker throws → its pending control response carries that message.
+    await expect(runner.sendControlEvent("worker", { x: 1 })).rejects.toThrow(
+      "worker exploded"
+    );
+
+    // A later send to the now-terminated worker is refused up front.
+    await expect(runner.sendControlEvent("worker", { x: 2 })).rejects.toThrow(
+      "Target node already completed and cannot handle control events: worker"
+    );
+
+    stop.requested = true;
+    await runPromise;
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// R3 – updateNodeProperties
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – updateNodeProperties", () => {
+  it("forwards properties to a live executor that supports them and reports true", async () => {
+    const applied: Array<Record<string, unknown>> = [];
+    let seen = false;
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "live", type: "test.Live" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "live",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-props", {
+      resolveExecutor: (node) => {
+        if (node.id !== "live") return simpleExecutor(() => ({}));
+        return {
+          applyProperties(props: Record<string, unknown>) {
+            applied.push(props);
+          },
+          async process() {
+            // Give the test a window in which the executor is registered.
+            while (!seen) await new Promise((r) => setTimeout(r, 5));
+            return {};
+          }
+        } as unknown as NodeExecutor;
+      }
+    });
+
+    const runPromise = runner.run(
+      { job_id: "job-props", params: { x: 1 } },
+      { nodes, edges }
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(runner.updateNodeProperties("live", { gain: 0.5 })).toBe(true);
+    expect(applied).toEqual([{ gain: 0.5 }]);
+
+    seen = true;
+    await runPromise;
+  }, 10000);
+
+  it("reports false for an unknown node and for an executor without live updates", async () => {
+    const runner = makeRunner();
+
+    // No run has happened — no executors are registered at all.
+    expect(runner.updateNodeProperties("nope", { gain: 1 })).toBe(false);
+
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "plain", type: "test.Plain" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "plain",
+        targetHandle: "value"
+      }
+    ];
+    await runner.run(
+      { job_id: "job-noprops", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    // The executor exists but has no applyProperties hook.
+    expect(runner.updateNodeProperties("plain", { gain: 1 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 – validation_issues on the failure job_update
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – failure job_update validation_issues", () => {
+  it("carries one structured issue per validated node", async () => {
+    const validator: NodeValidator = (node) =>
+      node.type === "test.NeedsModel"
+        ? [{ property: "model", message: 'Property "model" requires a model' }]
+        : [];
+    const runner = makeRunner({}, undefined, validator);
+
+    const nodes: NodeDescriptor[] = [
+      { id: "n1", type: "test.NeedsModel", name: "needs", properties: {} }
+    ];
+    const result = await runner.run(
+      { job_id: "j-vi", workflow_id: "wf-vi" },
+      { nodes, edges: [] }
+    );
+
+    expect(result.status).toBe("failed");
+    const failed = jobUpdates(result.messages as ProcessingMessage[]).find(
+      (m) => m.status === "failed"
+    );
+    expect(failed).toBeDefined();
+    expect(failed?.workflow_id).toBe("wf-vi");
+    expect(
+      (failed as unknown as { validation_issues?: unknown }).validation_issues
+    ).toEqual([
+      {
+        node_id: "n1",
+        node_type: "test.NeedsModel",
+        property: "model",
+        message: 'Property "model" requires a model'
+      }
+    ]);
+  });
+
+  it("reports null validation_issues for a graph error that carries no issues", async () => {
+    const runner = makeRunner();
+
+    // An edge type mismatch aborts the run with an issue-less
+    // GraphValidationError.
+    const nodes: NodeDescriptor[] = [
+      { id: "src", type: "test.Src", outputs: { out: "str" } },
+      { id: "dst", type: "test.Dst", propertyTypes: { value: "int" } }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "src",
+        sourceHandle: "out",
+        target: "dst",
+        targetHandle: "value"
+      }
+    ];
+    const result = await runner.run({ job_id: "j-noissues" }, { nodes, edges });
+
+    expect(result.status).toBe("failed");
+    const failed = jobUpdates(result.messages as ProcessingMessage[]).find(
+      (m) => m.status === "failed"
+    );
+    expect(
+      (failed as unknown as { validation_issues?: unknown }).validation_issues
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R5 – workflow_id on terminal job_updates
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – terminal job_update carries workflow_id", () => {
+  it("keeps workflow_id on the failed update produced by a node error", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "boom", type: "test.Boom" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "boom",
+        targetHandle: "value"
+      }
+    ];
+    const runner = makeRunner({
+      boom: {
+        async process() {
+          throw new Error("node blew up");
+        }
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "j-nodefail", workflow_id: "wf-nodefail", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("failed");
+    const failed = jobUpdates(result.messages as ProcessingMessage[]).find(
+      (m) => m.status === "failed"
+    );
+    expect(failed?.workflow_id).toBe("wf-nodefail");
+    expect(failed?.error).toContain("node blew up");
+  });
+
+  it("keeps workflow_id on the completed update", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "sink", type: "test.Sink" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner().run(
+      { job_id: "j-ok", workflow_id: "wf-ok", params: { x: 1 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    const done = jobUpdates(result.messages as ProcessingMessage[]).find(
+      (m) => m.status === "completed"
+    );
+    expect(done?.workflow_id).toBe("wf-ok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R6 – input node process() failure
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – input node process() failure", () => {
+  it("fails the run naming the input node's name and type", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in_id", type: "test.Input", name: "prompt" },
+      { id: "sink", type: "test.Sink" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in_id",
+        sourceHandle: "value",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+    const runner = makeRunner({
+      in_id: {
+        async process() {
+          throw new Error("bad input");
+        }
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "j-inputfail", params: { prompt: "hi" } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe(
+      'Input node "prompt" (test.Input) failed: bad input'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R8 – retained-message cap
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – retained message cap", () => {
+  it("drops the oldest half once the cap is reached", () => {
+    const runner = makeRunner();
+    const cap = 10_000;
+    const inner = internals(runner);
+    inner._messages = Array.from(
+      { length: cap },
+      (_, i) =>
+        ({
+          type: "job_update",
+          status: "running",
+          job_id: `m${i}`
+        }) as unknown as ProcessingMessage
+    );
+
+    inner._emit({
+      type: "job_update",
+      status: "running",
+      job_id: "fresh"
+    } as unknown as ProcessingMessage);
+
+    expect(inner._messages).toHaveLength(cap / 2 + 1);
+    expect((inner._messages[0] as JobUpdate).job_id).toBe(`m${cap / 2}`);
+    expect(
+      (inner._messages[inner._messages.length - 1] as JobUpdate).job_id
+    ).toBe("fresh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R9 – sink output collection
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – output collection", () => {
+  it("merges two sinks sharing a name and ignores intermediate nodes", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      { id: "mid", type: "test.Mid" },
+      { id: "s1", type: "test.Sink", name: "res" },
+      { id: "s2", type: "test.Sink", name: "res" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: "mid",
+        targetHandle: "value"
+      },
+      {
+        source: "mid",
+        sourceHandle: "out",
+        target: "s1",
+        targetHandle: "value"
+      },
+      {
+        source: "mid",
+        sourceHandle: "out",
+        target: "s2",
+        targetHandle: "value"
+      }
+    ];
+
+    const result = await makeRunner({
+      mid: simpleExecutor((inputs) => ({ out: inputs.value })),
+      s1: simpleExecutor((inputs) => ({ value: `a:${String(inputs.value)}` })),
+      s2: simpleExecutor((inputs) => ({ value: `b:${String(inputs.value)}` }))
+    }).run({ job_id: "j-outs", params: { x: 7 } }, { nodes, edges });
+
+    expect(result.status).toBe("completed");
+    expect(Object.keys(result.outputs)).toEqual(["res"]);
+    expect([...(result.outputs.res as string[])].sort()).toEqual([
+      "a:7",
+      "b:7"
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R10 – client-facing output names
+// ---------------------------------------------------------------------------
+
+describe("WorkflowRunner – output_update naming", () => {
+  async function namesFor(sink: NodeDescriptor): Promise<string[]> {
+    const nodes: NodeDescriptor[] = [
+      { id: "in", type: "test.Input", name: "x" },
+      sink
+    ];
+    const edges: Edge[] = [
+      {
+        source: "in",
+        sourceHandle: "value",
+        target: sink.id,
+        targetHandle: "value"
+      }
+    ];
+    const result = await makeRunner({
+      [sink.id]: simpleExecutor((inputs) => ({ output: inputs.value }))
+    }).run({ job_id: "j-name", params: { x: 1 } }, { nodes, edges });
+    expect(result.status).toBe("completed");
+    return outputUpdates(result.messages as ProcessingMessage[])
+      .filter((m) => m.node_id === sink.id)
+      .map((m) => m.output_name);
+  }
+
+  it("uses the trimmed properties.name for Output sinks (exact and suffix type)", async () => {
+    await expect(
+      namesFor({
+        id: "o1",
+        type: "nodetool.output.Output",
+        properties: { name: "  pin  " }
+      })
+    ).resolves.toEqual(["pin"]);
+
+    await expect(
+      namesFor({
+        id: "o2",
+        type: "custom.output.Output",
+        properties: { name: "pin2" }
+      })
+    ).resolves.toEqual(["pin2"]);
+  });
+
+  it("uses the trimmed properties.name for Preview sinks (exact and suffix type)", async () => {
+    await expect(
+      namesFor({
+        id: "p1",
+        type: "nodetool.workflows.base_node.Preview",
+        properties: { name: "shown" }
+      })
+    ).resolves.toEqual(["shown"]);
+
+    await expect(
+      namesFor({
+        id: "p2",
+        type: "custom.workflows.base_node.Preview",
+        properties: { name: "shown2" }
+      })
+    ).resolves.toEqual(["shown2"]);
+  });
+
+  it("falls back to the handle for a blank name and for non-sink node types", async () => {
+    await expect(
+      namesFor({
+        id: "o3",
+        type: "nodetool.output.Output",
+        properties: { name: "   " }
+      })
+    ).resolves.toEqual(["output"]);
+
+    await expect(
+      namesFor({
+        id: "s3",
+        type: "test.Sink",
+        properties: { name: "ignored" }
+      })
+    ).resolves.toEqual(["output"]);
+  });
+});

--- a/packages/kernel/tests/trigger-manager-mutation-kills.test.ts
+++ b/packages/kernel/tests/trigger-manager-mutation-kills.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  TriggerWorkflowManager,
+  type StartJobFn,
+  type HasTriggerNodesFn,
+  type TriggerJob
+} from "../src/trigger-manager.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+/** Let queued microtasks (promise continuations) run. */
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("TriggerWorkflowManager — stop racing an in-flight start", () => {
+  let startJob: ReturnType<typeof vi.fn<StartJobFn>>;
+  let hasTriggerNodes: ReturnType<typeof vi.fn<HasTriggerNodesFn>>;
+  let manager: TriggerWorkflowManager;
+
+  beforeEach(() => {
+    TriggerWorkflowManager.resetInstance();
+    startJob = vi.fn(async () => ({
+      jobId: "job-1",
+      completion: new Promise<void>(() => {})
+    }));
+    hasTriggerNodes = vi.fn(async () => true);
+    manager = TriggerWorkflowManager.getInstance({
+      startJob,
+      hasTriggerNodes
+    });
+  });
+
+  afterEach(() => {
+    manager.stopWatchdog();
+    TriggerWorkflowManager.resetInstance();
+  });
+
+  it("stops the job a still-pending start is about to produce", async () => {
+    // Arrange: hold the start open so the job exists only in _pendingStarts.
+    const gate = deferred<boolean>();
+    hasTriggerNodes.mockReturnValue(gate.promise);
+    const startPromise = manager.startTriggerWorkflow("wf-1", "user-1");
+    await flush();
+    expect(manager.isWorkflowRunning("wf-1")).toBe(false); // not tracked yet
+
+    // Act: the user stops it before the start lands.
+    const stopPromise = manager.stopTriggerWorkflow("wf-1");
+    gate.resolve(true);
+    const stopped = await stopPromise;
+    const job = await startPromise;
+
+    // Assert: the stop waited for the start and cancelled its job, rather than
+    // finding nothing and leaving the workflow running behind the user's back.
+    expect(stopped).toBe(true);
+    expect(job).not.toBeNull();
+    expect((job as TriggerJob).status).toBe("cancelled");
+    expect((job as TriggerJob).abortController.signal.aborted).toBe(true);
+    expect(manager.isWorkflowRunning("wf-1")).toBe(false);
+  });
+
+  it("returns false instead of propagating when the in-flight start rejects", async () => {
+    // Arrange: the start fails after the stop has begun awaiting it.
+    const gate = deferred<boolean>();
+    hasTriggerNodes.mockReturnValue(gate.promise);
+    const startPromise = manager.startTriggerWorkflow("wf-1", "user-1");
+    const startFailure = startPromise.catch(() => "start rejected");
+    await flush();
+
+    // Act
+    const stopPromise = manager.stopTriggerWorkflow("wf-1");
+    gate.reject(new Error("lookup exploded"));
+
+    // Assert: a failed start leaves nothing to stop — the caller of stop sees
+    // false, not the start's error.
+    await expect(stopPromise).resolves.toBe(false);
+    await expect(startFailure).resolves.toBe("start rejected");
+    expect(manager.isWorkflowRunning("wf-1")).toBe(false);
+  });
+});
+
+describe("TriggerWorkflowManager — job completion failures", () => {
+  let startJob: ReturnType<typeof vi.fn<StartJobFn>>;
+  let manager: TriggerWorkflowManager;
+  let completion: Deferred<void>;
+
+  beforeEach(() => {
+    TriggerWorkflowManager.resetInstance();
+    completion = deferred<void>();
+    startJob = vi.fn(async () => ({
+      jobId: "job-1",
+      completion: completion.promise
+    }));
+    manager = TriggerWorkflowManager.getInstance({
+      startJob,
+      hasTriggerNodes: async () => true
+    });
+  });
+
+  afterEach(() => {
+    manager.stopWatchdog();
+    TriggerWorkflowManager.resetInstance();
+  });
+
+  it("marks the job failed when the completion rejects with a non-Error value", async () => {
+    // Arrange
+    const job = await manager.startTriggerWorkflow("wf-1", "user-1");
+    expect(job).not.toBeNull();
+
+    // Act: a rejection carrying no `.name` at all (not an Error, not even an
+    // object) — the handler must classify it, not throw while inspecting it.
+    completion.reject(undefined);
+    await flush();
+
+    // Assert
+    expect((job as TriggerJob).status).toBe("failed");
+    expect(manager.isWorkflowRunning("wf-1")).toBe(false);
+  });
+});

--- a/packages/kernel/tests/trigger-mutation-kills.test.ts
+++ b/packages/kernel/tests/trigger-mutation-kills.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { TriggerState, TriggerInactivityTimeout } from "../src/trigger.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TriggerState.waitForTriggerEvent deadline boundary", () => {
+  it("rejects without waiting on a timer when the timeout is already exhausted", async () => {
+    vi.useFakeTimers();
+    const state = new TriggerState("n1");
+
+    let settled = false;
+    const outcome = state.waitForTriggerEvent(0).then(
+      () => "resolved" as const,
+      (err: unknown) => {
+        settled = true;
+        return err;
+      }
+    );
+
+    // Drain microtasks without advancing fake timers. An already-elapsed
+    // deadline must reject on the spot; re-arming a timer instead would leave
+    // the caller hanging until something advances the clock.
+    for (let i = 0; i < 50; i++) await Promise.resolve();
+
+    expect(settled).toBe(true);
+    expect(await outcome).toBeInstanceOf(TriggerInactivityTimeout);
+  });
+
+  it("keeps a later event deliverable after an exhausted wait rejects", async () => {
+    const state = new TriggerState("n1");
+
+    await expect(state.waitForTriggerEvent(0)).rejects.toBeInstanceOf(
+      TriggerInactivityTimeout
+    );
+
+    // The rejected waiter must have been removed, so the next event is queued
+    // for the following waiter instead of being swallowed by a dead promise.
+    state.sendTriggerEvent({ kind: "tick" });
+
+    await expect(state.waitForTriggerEvent(60)).resolves.toEqual({
+      kind: "tick",
+    });
+  });
+});

--- a/packages/kernel/tests/trigger-wakeup-mutation-kills.test.ts
+++ b/packages/kernel/tests/trigger-wakeup-mutation-kills.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi } from "vitest";
+import { TriggerWakeupService } from "../src/trigger-wakeup.js";
+
+/**
+ * The per-(runId, nodeId) DurableInbox cache is the service's only unbounded
+ * structure: a long-lived service accumulates one entry per run forever unless
+ * cleanupProcessed/disposeRun evict exactly the right keys. The map is private
+ * and has no public accessor, so these tests read it directly — the bounded
+ * memory contract is real even though it is not observable through the API.
+ */
+interface WakeupInternals {
+  _inboxes: Map<string, unknown>;
+}
+
+const inboxKeys = (svc: TriggerWakeupService): string[] =>
+  [...(svc as unknown as WakeupInternals)._inboxes.keys()].sort();
+
+const key = (runId: string, nodeId: string): string =>
+  JSON.stringify([runId, nodeId]);
+
+describe("TriggerWakeupService — inbox cache eviction", () => {
+  it("cleanupProcessed evicts only the cleaned (runId, nodeId) inbox, keeping same-run and same-node neighbours", async () => {
+    // Arrange: three distinct (run, node) pairs share a run id or a node id
+    // with the pair being cleaned, so a filter that matches on either field
+    // alone would evict the wrong entries.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const svc = new TriggerWakeupService();
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "a",
+        payload: {}
+      });
+      await svc.deliverTriggerInput({
+        runId: "r2",
+        nodeId: "n1",
+        inputId: "b",
+        payload: {}
+      });
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n2",
+        inputId: "c",
+        payload: {}
+      });
+      svc.markProcessed("a");
+      vi.setSystemTime(new Date("2024-01-01T01:00:00Z"));
+
+      // Act: purge (r1, n1) — its only input is processed, so nothing remains.
+      const removed = svc.cleanupProcessed("r1", "n1", 0);
+
+      // Assert
+      expect(removed).toBe(1);
+      expect(inboxKeys(svc)).toEqual([key("r1", "n2"), key("r2", "n1")].sort());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cleanupProcessed keeps the cached inbox while any input remains for that (runId, nodeId)", async () => {
+    // Arrange: (r1, n1) keeps an unprocessed input; (r2, n1) exists so a
+    // whole-array predicate (every) would wrongly report "nothing remains".
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const svc = new TriggerWakeupService();
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "a",
+        payload: {}
+      });
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "b",
+        payload: {}
+      });
+      await svc.deliverTriggerInput({
+        runId: "r2",
+        nodeId: "n1",
+        inputId: "c",
+        payload: {}
+      });
+      svc.markProcessed("a");
+      vi.setSystemTime(new Date("2024-01-01T01:00:00Z"));
+
+      // Act
+      const removed = svc.cleanupProcessed("r1", "n1", 0);
+
+      // Assert: "b" still belongs to (r1, n1), so its inbox must survive.
+      expect(removed).toBe(1);
+      expect(svc.getPendingInputs("r1", "n1").map((i) => i.inputId)).toEqual([
+        "b"
+      ]);
+      expect(inboxKeys(svc)).toContain(key("r1", "n1"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("disposeRun drops one run's inputs and inboxes while another run stays intact", async () => {
+    // Arrange: two runs, one sharing a node id with the disposed run.
+    const svc = new TriggerWakeupService();
+    await svc.deliverTriggerInput({
+      runId: "r1",
+      nodeId: "n1",
+      inputId: "a",
+      payload: { from: "r1" }
+    });
+    await svc.deliverTriggerInput({
+      runId: "r1",
+      nodeId: "n2",
+      inputId: "b",
+      payload: { from: "r1" }
+    });
+    await svc.deliverTriggerInput({
+      runId: "r2",
+      nodeId: "n1",
+      inputId: "c",
+      payload: { from: "r2" }
+    });
+
+    // Act
+    svc.disposeRun("r1");
+
+    // Assert: r1 is gone entirely, r2 is untouched and still queryable.
+    expect(svc.getPendingInputs("r1", "n1")).toHaveLength(0);
+    expect(svc.getPendingInputs("r1", "n2")).toHaveLength(0);
+    const r2Pending = svc.getPendingInputs("r2", "n1");
+    expect(r2Pending.map((i) => i.inputId)).toEqual(["c"]);
+    expect(r2Pending[0].payload).toEqual({ from: "r2" });
+    expect(inboxKeys(svc)).toEqual([key("r2", "n1")]);
+  });
+});
+
+describe("TriggerWakeupService — stored input fields", () => {
+  it("round-trips the cursor of a delivered input, leaving it undefined when omitted", async () => {
+    // Arrange
+    const svc = new TriggerWakeupService();
+
+    // Act
+    await svc.deliverTriggerInput({
+      runId: "r1",
+      nodeId: "n1",
+      inputId: "with-cursor",
+      payload: {},
+      cursor: "page-2"
+    });
+    await svc.deliverTriggerInput({
+      runId: "r1",
+      nodeId: "n1",
+      inputId: "no-cursor",
+      payload: {}
+    });
+
+    // Assert: the cursor is the caller's resume token — it must survive storage.
+    const pending = svc.getPendingInputs("r1", "n1");
+    expect(pending.map((i) => i.cursor)).toEqual(["page-2", undefined]);
+  });
+
+  it("records createdAt at delivery and processedAt at markProcessed", async () => {
+    // Arrange
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const svc = new TriggerWakeupService();
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "i1",
+        payload: {}
+      });
+      const stored = svc.getPendingInputs("r1", "n1")[0];
+      expect(stored.createdAt).toEqual(new Date("2024-01-01T00:00:00Z"));
+      expect(stored.processedAt).toBeUndefined();
+
+      // Act
+      vi.setSystemTime(new Date("2024-01-01T00:05:00Z"));
+      svc.markProcessed("i1");
+
+      // Assert: processedAt is the cleanup clock, stamped when marking, not at
+      // delivery.
+      expect(stored.processed).toBe(true);
+      expect(stored.processedAt).toEqual(new Date("2024-01-01T00:05:00Z"));
+      expect(stored.createdAt).toEqual(new Date("2024-01-01T00:00:00Z"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("TriggerWakeupService — defaults", () => {
+  it("getPendingInputs returns at most 100 inputs when no limit is given", async () => {
+    // Arrange
+    const svc = new TriggerWakeupService();
+    for (let i = 0; i < 150; i++) {
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: `i${i}`,
+        payload: { i }
+      });
+    }
+
+    // Act
+    const pending = svc.getPendingInputs("r1", "n1");
+
+    // Assert
+    expect(pending).toHaveLength(100);
+    expect(pending[0].inputId).toBe("i0");
+    expect(pending[99].inputId).toBe("i99");
+  });
+
+  it("cleanupProcessed defaults to a 24 hour retention window", async () => {
+    // Arrange: two processed inputs straddling the default cutoff.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+      const svc = new TriggerWakeupService();
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "old",
+        payload: {}
+      });
+      svc.markProcessed("old"); // processedAt = T0
+
+      vi.setSystemTime(new Date("2024-01-01T02:00:00Z"));
+      await svc.deliverTriggerInput({
+        runId: "r1",
+        nodeId: "n1",
+        inputId: "recent",
+        payload: {}
+      });
+      svc.markProcessed("recent"); // processedAt = T0 + 2h
+
+      // Act: 25h after "old" was processed, 23h after "recent" was.
+      vi.setSystemTime(new Date("2024-01-02T01:00:00Z"));
+      const removed = svc.cleanupProcessed("r1", "n1");
+
+      // Assert
+      expect(removed).toBe(1);
+      // "recent" (processed 23h ago) survived the default call and is still
+      // removable with a shorter window.
+      expect(svc.cleanupProcessed("r1", "n1", 22)).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("TriggerWakeupService — idempotency scope (current behaviour)", () => {
+  it("CURRENT BEHAVIOUR: a repeated inputId is rejected even for a different run and node", async () => {
+    // Arrange: the idempotency check keys on inputId alone, ignoring
+    // runId/nodeId. This test pins today's behaviour, not a desired one — see
+    // the note below.
+    const svc = new TriggerWakeupService();
+    const first = await svc.deliverTriggerInput({
+      runId: "r1",
+      nodeId: "n1",
+      inputId: "event-1",
+      payload: { a: 1 }
+    });
+    expect(first).toBe(true);
+
+    // Act: same event id, entirely different run and node.
+    const second = await svc.deliverTriggerInput({
+      runId: "r2",
+      nodeId: "n2",
+      inputId: "event-1",
+      payload: { a: 2 }
+    });
+
+    // Assert: it is treated as a duplicate and nothing is stored for (r2, n2).
+    // If inputIds are ever scoped per run/node rather than globally unique,
+    // this drops real events silently and the check must widen to the
+    // (runId, nodeId, inputId) triple.
+    expect(second).toBe(false);
+    expect(svc.getPendingInputs("r2", "n2")).toHaveLength(0);
+    expect(svc.getPendingInputs("r1", "n1")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Runs mutation testing (Stryker) across `@nodetool-ai/kernel` and kills the surviving mutants it found. Adds 71 tests; the kernel suite goes from 823 to 894 passing.

## Measured baseline

A full run (3,889 mutants, 23m30s) scored **84.06%**, not the 61.02% recorded in `MUTATION_TESTING.md` — that table was stale and still listed a `channel.ts` that no longer exists. Seven files were already at 100%. Survivors concentrated in:

| File | Score | Survived | No coverage |
|---|---|---|---|
| runner.ts | 68.77 | 275 | 56 |
| actor.ts | 72.69 | 160 | 79 |
| trigger-wakeup.ts | 77.78 | 22 | 0 |
| graph.ts | 96.21 | 22 | 1 |
| trigger-manager.ts | 96.12 | 2 | 2 |
| trigger.ts | 98.55 | 1 | 0 |

## What changed

New test files, one per area — no existing test file was modified:

- **`runner-mutation-kills.test.ts`** (19 tests) — the variable-channel lifecycle (`registerChannelWriters` / `markChannelWriterDone` / `closeAllChannels`) had zero test references and was the largest dark region in the package. Also `sendControlEvent` rejection paths, `updateNodeProperties` (previously uncovered), `validation_issues` on the failure `job_update`, `_emit` retention trimming, and sink output merging.
- **`actor-mutation-kills.test.ts`** (25 tests) — `scalarInputProperties` and the `generation_complete` payload, streaming-input `NodeOutputs` callbacks, the fire-once block for nodes with no max-scope inputs, and frame-token reuse across sibling slots.
- **`graph-mutation-kills.test.ts`** (14 tests) — edge-validation guards and the exact message and `issues` array of `GraphValidationError`.
- **`trigger-*-mutation-kills.test.ts`** (13 tests) — inbox-cache eviction scoped to `(runId, nodeId)`, `disposeRun` retaining other runs, cursor round-trip, both default arguments, a stop racing an in-flight start, and an exhausted deadline rejecting without waiting on a timer.

Source changes are suppression comments only, plus one dead-branch deletion in `actor.ts` `isReady` where the guarded body returned `false` immediately before an unconditional `return false` — every mutant on it was equivalent by construction.

## Two things worth a reviewer's attention

**A latent bug, pinned but not fixed.** `trigger-wakeup.ts` keys delivery idempotency on `inputId` alone, ignoring `runId`/`nodeId`. The same `inputId` delivered to a different `(run, node)` is silently rejected as a duplicate — no durable message, no error, the workflow never wakes. It is harmless only while `inputId` is a globally-unique provider event id, and breaks if ids are ever scoped per run/node or one external event fans out to two trigger nodes. The durable layer beneath is already correctly scoped, so a fix is confined to that in-memory check. A test pins today's behaviour under an explicit `CURRENT BEHAVIOUR:` name rather than quietly changing it. Say the word and I'll fix it here or file it separately.

**Two pre-existing suppressions were wrong.** `graph.ts` carried `Stryker disable` comments asserting two guards were equivalent. They aren't: a string-valued `dynamic_properties` spreads its character indices into node properties via `Object.assign`, and a string-valued `propertyTypes` derives bogus declared keys. Those suppressions are replaced by tests. Three others sat above the first line of a multi-line expression while the mutants live on lines 2–3, so they had been suppressing nothing.

That is the general hazard of this approach — a wrong or misplaced `disable` silently inflates the score — so the suppressions added here deserve the same skepticism. Where a mutant was classified as equivalent, the reasoning is in the comment.

## Verification

`npx vitest run` 894 passed / 3 skipped / 6 todo; `npx tsc --noEmit` clean. A confirming Stryker re-run is in flight; I'll post the resulting score and update the `MUTATION_TESTING.md` baseline table on this branch when it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3vgjC4XFKVzbmcesLbovD)_