### PR TITLE
Mobile documents: browse, edit, and drive storyboards, scripts and timelines from the agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ packages/           # 58 npm workspace packages (TypeScript backend)
 
 web/                # React 19 + Vite + MUI + Zustand + ReactFlow
 electron/           # Electron 39 desktop app
-mobile/             # React Native / Expo
+mobile/             # React Native / Expo (documents open one-per-screen, no tabs;
+                    # edits come through the chat agent's ui_* tools —
+                    # see mobile/ARCHITECTURE.md § Documents)
 demo/               # Remotion harness for product-demo videos (replays recorded
                     # graph-UI "casts"; see demo/README.md and web/src/demo/)
 ```

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -55,9 +55,13 @@ read the comment at the top of `metro.config.js` before changing any of it.
 - **Mini apps**: `components/app_runtime/` renders `workflow.app_doc` with native widgets on
   top of `@nodetool-ai/app-runtime` — the same core the web runtime and the CLI `app debug`
   harness use. See [ARCHITECTURE.md § Mini apps](ARCHITECTURE.md#mini-apps-srccomponentsapp_runtime).
-- **Documents**: `documents/` + the document screens open storyboards, timelines, and
-  sketches over `trpc.resources.*`. No tabs — one document per pushed screen. Edits are
-  expected to come from the chat agent through the `ui_*` tools registered there.
+- **Documents**: `documents/` + the document screens open storyboards, scripts, timelines,
+  and sketches. No tabs — one document per pushed screen. Edits are expected to come from
+  the chat agent through the `ui_*` tools registered there, so `kinds.ts` tracks
+  `agentEditable` separately from `surface`: the timeline has no touch editor but the agent
+  writes it. Each kind's transport lives in `backends.ts` (scripts are not a
+  `resources.*` kind — their table has no `revision`), which is why the store's
+  concurrency token is opaque.
   See [ARCHITECTURE.md § Documents](ARCHITECTURE.md#documents-srcdocuments).
 
 ## Testing

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -55,6 +55,10 @@ read the comment at the top of `metro.config.js` before changing any of it.
 - **Mini apps**: `components/app_runtime/` renders `workflow.app_doc` with native widgets on
   top of `@nodetool-ai/app-runtime` — the same core the web runtime and the CLI `app debug`
   harness use. See [ARCHITECTURE.md § Mini apps](ARCHITECTURE.md#mini-apps-srccomponentsapp_runtime).
+- **Documents**: `documents/` + the document screens open storyboards, timelines, and
+  sketches over `trpc.resources.*`. No tabs — one document per pushed screen. Edits are
+  expected to come from the chat agent through the `ui_*` tools registered there.
+  See [ARCHITECTURE.md § Documents](ARCHITECTURE.md#documents-srcdocuments).
 
 ## Testing
 

--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -56,7 +56,8 @@ mobile/
 │   │   ├── ChatScreen.tsx              # AI chat interface
 │   │   ├── DocumentsScreen.tsx         # Document browser (all kinds, no tabs)
 │   │   ├── StoryboardEditorScreen.tsx  # Storyboard editor
-│   │   ├── TimelineViewerScreen.tsx    # Read-only timeline
+│   │   ├── ScriptEditorScreen.tsx      # Script editor (cast, sections, lines)
+│   │   ├── TimelineViewerScreen.tsx    # Timeline: viewer, agent-editable
 │   │   ├── DocumentViewerScreen.tsx    # Fallback for kinds without a screen
 │   │   ├── AssetsScreen.tsx            # Asset browser
 │   │   ├── AssetViewerScreen.tsx       # Single-asset viewer
@@ -149,10 +150,9 @@ The shared package is compiled from source rather than from `dist`: see
 
 ## Documents (`src/documents/`)
 
-Storyboards, timelines, and sketches are documents on the server, reachable
-through the one `trpc.resources.*` envelope (`resources.list/read/create/update/
-delete` over `asset | timeline | storyboard | sketch`). Mobile browses them in
-`DocumentsScreen` and opens each in its own pushed screen.
+Storyboards, scripts, timelines, and sketches are documents on the server.
+Mobile browses them all in `DocumentsScreen` and opens each in its own pushed
+screen.
 
 **No tabs.** Web keys its whole document UX off `WorkspaceTabType` and keeps
 every tab mounted at once. On a phone the navigation stack *is* the tab model:
@@ -162,27 +162,44 @@ leaves the parts that never depended on focus — the agent bridge keys by
 document id, which ports unchanged.
 
 ```
-kinds.ts          # which kinds exist: label, icon, editor|viewer, route
-useDocuments.ts   # TanStack Query over resources.* for the browser
+kinds.ts          # which kinds exist: label, icon, surface, route, agentEditable
+backends.ts       # per-kind transport; the concurrency token is opaque above it
+useDocuments.ts   # React Query over the backends, for the browser
 documentStore.ts  # one Zustand store per open document (cached by kind+id)
 agentBridge.ts    # handler registry keyed by kind+id, plus the focus claim
 uiContext.ts      # the open/focused/selection block sent with each chat turn
+timelineEdits.ts  # pure, link-aware edits over {tracks, clips, markers}
 tools/            # the ui_* tools: registry, manifest, tool_call dispatch
 ```
 
-**Load and save.** `documentStore` holds the open document's body, name,
-revision, and dirty flag. `save()` sends `resources.update` carrying the
-revision it read; the server rejects a stale write rather than applying it,
-which surfaces as `status: 'conflict'` and a Reload banner. Two things the
-store handles that are easy to get wrong: saves are serialized (the user's Save
-button and an agent's `ui_*_save` would otherwise send the same revision and
-the second would be rejected as a conflict the user never caused), and a save
-only marks the document clean if nothing changed while it was in flight, so an
-agent edit landing mid-save is not silently dropped.
+**Two transports, one interface.** Three kinds ride the `resources.*` envelope,
+whose concurrency token is a numeric `revision`. Scripts cannot: the `scripts`
+table has no `revision` column, so the provider's conflict check would compare
+`undefined` to `undefined`, pass, and silently clobber concurrent writes. Their
+own router does the same job with `baseUpdatedAt`. Rather than migrate two
+schemas — which would also make `{kind:"script"}` a legal resource binding in
+every app document — `backends.ts` makes the token **opaque**: a backend hands
+one out on read and echoes it back on write, and only it knows the shape.
 
-**Agent-first.** The surfaces are deliberately thin — text fields and a shot
-list, not a desktop editor — because the intended way to change a document is
-to ask the assistant. That path is:
+**`surface` is not `agentEditable`.** `surface` says whether a person can edit
+by touch; `agentEditable` says whether the `ui_*` tools can write. The timeline
+is `viewer` + `agentEditable`: placing a cut accurately with a thumb is not
+possible at phone width, but "move the title card two seconds later" is a
+sentence.
+
+**Load and save.** `documentStore` holds the open document's body, name,
+concurrency token, and dirty flag. `save()` echoes back the token it read; the
+server rejects a stale write rather than applying it, which surfaces as
+`status: 'conflict'` and a Reload banner. Two things the store handles that are
+easy to get wrong: saves are serialized (the user's Save button and an agent's
+`ui_*_save` would otherwise send the same token and the second would be
+rejected as a conflict the user never caused), and a save only marks the
+document clean if nothing changed while it was in flight, so an agent edit
+landing mid-save is not silently dropped.
+
+**Agent-first.** The surfaces are deliberately thin — text fields and lists,
+not a desktop editor — because the intended way to change a document is to ask
+the assistant. That path is:
 
 1. On every socket open (including reconnects) `ChatStore` sends
    `client_tools_manifest` with the registered `ui_*` tools.
@@ -196,11 +213,34 @@ to ask the assistant. That path is:
 4. Handlers mutate the same store the screen renders from, so an agent edit
    repaints immediately and `ui_*_save` is the user's Save button's code path.
 
-Tools are trimmed to what a phone should do. Storyboards get read, shot and
-board editing, select, and save — generation and timeline assembly stay on
-desktop, where progress on a long, paid job can actually be supervised. The
-timeline is read-only, and its tool descriptions say so, so the agent answers
-questions about a sequence instead of attempting an edit and reporting failure.
+Tools are trimmed to what a phone should do. Everything that is a pure document
+edit is available; everything that dispatches a long, paid job or needs a
+browser stays on desktop, where its progress can actually be supervised. So
+storyboards get shot and board editing but not generation or timeline assembly;
+scripts get cast, section, and line editing but not TTS voicing, subtitle
+export, or send-to-timeline; timelines get the full set of structural edits but
+not clip generation or frame extraction. Each tool's description says which side
+of that line it is on, so the agent does not promise what it cannot do.
+
+**Timeline edits are link-aware** (`timelineEdits.ts`, pure functions over
+`{tracks, clips, markers, transcript}`). A video clip and the audio extracted
+from it share a `linkId` and must move, trim, split, and delete together: a
+split mints a fresh `linkId` for each side so neither becomes a three-member
+group, and a delete unlinks survivors when a group drops below two. Web's own
+agent handlers take a `patchClip` shortcut that bypasses this and desyncs the
+pair, so the logic here is ported from its store rather than its bridge.
+Anything that changes a generation input marks the clip `stale`, and an edit
+that would orphan a `transcript[].clipIds` reference is **refused** naming the
+line — web re-flows the transcript in 795 lines of code, and a clear refusal
+beats a dangling pointer.
+
+The split/trim primitives come from `@nodetool-ai/timeline`, compiled from
+source like `app-runtime` (`metro.config.js`, `tsconfig.json` paths,
+`jest.config.js` moduleNameMapper — all must agree). `splitClip` also partitions
+animations by role, rebases clip-local caption words, and clears the fades and
+transition the halves must not inherit; hand-rolling that would get it wrong.
+Its id factory calls `crypto.randomUUID`, which Hermes lacks, so
+`src/polyfills/randomUuid.ts` supplies one from `uuid` in `index.ts`.
 
 Kinds with no dedicated screen fall back to `DocumentViewerScreen`, so every
 document can at least be opened.

--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -54,6 +54,10 @@ mobile/
 │   │   ├── WorkflowsListScreen.tsx     # List of available workflows
 │   │   ├── GraphEditorScreen.tsx       # Chain-based graph editor
 │   │   ├── ChatScreen.tsx              # AI chat interface
+│   │   ├── DocumentsScreen.tsx         # Document browser (all kinds, no tabs)
+│   │   ├── StoryboardEditorScreen.tsx  # Storyboard editor
+│   │   ├── TimelineViewerScreen.tsx    # Read-only timeline
+│   │   ├── DocumentViewerScreen.tsx    # Fallback for kinds without a screen
 │   │   ├── AssetsScreen.tsx            # Asset browser
 │   │   ├── AssetViewerScreen.tsx       # Single-asset viewer
 │   │   ├── CollectionsScreen.tsx       # RAG collections
@@ -63,6 +67,8 @@ mobile/
 │   │   ├── SecretsScreen.tsx           # API-key management
 │   │   ├── SettingsScreen.tsx          # Server configuration
 │   │   └── LoginScreen.tsx             # Supabase / Google sign-in
+│   │
+│   ├── documents/           # Document layer (kinds, load/save, agent bridge, ui_* tools)
 │   │
 │   ├── components/          # Reusable components
 │   │   ├── app_runtime/       # Mini-app runtime (renders workflow.app_doc)
@@ -140,6 +146,64 @@ The shared package is compiled from source rather than from `dist`: see
 `metro.config.js` (bundler), the `paths` entry in `tsconfig.json` (types), and
 `moduleNameMapper` in `jest.config.js` (tests). All three point at
 `packages/app-runtime/src`, so no build step is needed to run the app.
+
+## Documents (`src/documents/`)
+
+Storyboards, timelines, and sketches are documents on the server, reachable
+through the one `trpc.resources.*` envelope (`resources.list/read/create/update/
+delete` over `asset | timeline | storyboard | sketch`). Mobile browses them in
+`DocumentsScreen` and opens each in its own pushed screen.
+
+**No tabs.** Web keys its whole document UX off `WorkspaceTabType` and keeps
+every tab mounted at once. On a phone the navigation stack *is* the tab model:
+one document per screen, the top of the stack is the focused one. That removes
+the tab store, the `openTab` indirection, and the per-surface `active` prop, and
+leaves the parts that never depended on focus — the agent bridge keys by
+document id, which ports unchanged.
+
+```
+kinds.ts          # which kinds exist: label, icon, editor|viewer, route
+useDocuments.ts   # TanStack Query over resources.* for the browser
+documentStore.ts  # one Zustand store per open document (cached by kind+id)
+agentBridge.ts    # handler registry keyed by kind+id, plus the focus claim
+uiContext.ts      # the open/focused/selection block sent with each chat turn
+tools/            # the ui_* tools: registry, manifest, tool_call dispatch
+```
+
+**Load and save.** `documentStore` holds the open document's body, name,
+revision, and dirty flag. `save()` sends `resources.update` carrying the
+revision it read; the server rejects a stale write rather than applying it,
+which surfaces as `status: 'conflict'` and a Reload banner. Two things the
+store handles that are easy to get wrong: saves are serialized (the user's Save
+button and an agent's `ui_*_save` would otherwise send the same revision and
+the second would be rejected as a conflict the user never caused), and a save
+only marks the document clean if nothing changed while it was in flight, so an
+agent edit landing mid-save is not silently dropped.
+
+**Agent-first.** The surfaces are deliberately thin — text fields and a shot
+list, not a desktop editor — because the intended way to change a document is
+to ask the assistant. That path is:
+
+1. On every socket open (including reconnects) `ChatStore` sends
+   `client_tools_manifest` with the registered `ui_*` tools.
+2. Each outgoing turn carries `ui_context` — the open documents, the focused
+   one, and the current selection. Every tool takes a **required** document id
+   and there is no "act on whatever is mounted" fallback, so this block is the
+   only thing that tells the agent which ids are valid.
+3. The server sends `tool_call`; `executeToolCall` runs it against the handler
+   the mounted screen registered and replies `tool_result` — always, including
+   for unknown tools, so the agent is never left waiting.
+4. Handlers mutate the same store the screen renders from, so an agent edit
+   repaints immediately and `ui_*_save` is the user's Save button's code path.
+
+Tools are trimmed to what a phone should do. Storyboards get read, shot and
+board editing, select, and save — generation and timeline assembly stay on
+desktop, where progress on a long, paid job can actually be supervised. The
+timeline is read-only, and its tool descriptions say so, so the agent answers
+questions about a sequence instead of attempting an edit and reporting failure.
+
+Kinds with no dedicated screen fall back to `DocumentViewerScreen`, so every
+document can at least be opened.
 
 ## Component Architecture
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -12,6 +12,10 @@ import GraphEditorScreen from './src/screens/GraphEditorScreen';
 import LoginScreen from './src/screens/LoginScreen';
 import AssetsScreen from './src/screens/AssetsScreen';
 import AssetViewerScreen from './src/screens/AssetViewerScreen';
+import DocumentsScreen from './src/screens/DocumentsScreen';
+import DocumentViewerScreen from './src/screens/DocumentViewerScreen';
+import StoryboardEditorScreen from './src/screens/StoryboardEditorScreen';
+import TimelineViewerScreen from './src/screens/TimelineViewerScreen';
 import SecretsScreen from './src/screens/SecretsScreen';
 import CollectionsScreen from './src/screens/CollectionsScreen';
 import JobsScreen from './src/screens/JobsScreen';
@@ -127,6 +131,26 @@ export default function App() {
                   name="AssetViewer"
                   component={AssetViewerScreen}
                   options={{ title: 'Asset' }}
+                />
+                <Stack.Screen
+                  name="Documents"
+                  component={DocumentsScreen}
+                  options={{ title: 'Documents' }}
+                />
+                <Stack.Screen
+                  name="StoryboardEditor"
+                  component={StoryboardEditorScreen}
+                  options={{ title: 'Storyboard' }}
+                />
+                <Stack.Screen
+                  name="TimelineViewer"
+                  component={TimelineViewerScreen}
+                  options={{ title: 'Timeline' }}
+                />
+                <Stack.Screen
+                  name="DocumentViewer"
+                  component={DocumentViewerScreen}
+                  options={{ title: 'Document' }}
                 />
                 <Stack.Screen
                   name="Secrets"

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -14,6 +14,7 @@ import AssetsScreen from './src/screens/AssetsScreen';
 import AssetViewerScreen from './src/screens/AssetViewerScreen';
 import DocumentsScreen from './src/screens/DocumentsScreen';
 import DocumentViewerScreen from './src/screens/DocumentViewerScreen';
+import ScriptEditorScreen from './src/screens/ScriptEditorScreen';
 import StoryboardEditorScreen from './src/screens/StoryboardEditorScreen';
 import TimelineViewerScreen from './src/screens/TimelineViewerScreen';
 import SecretsScreen from './src/screens/SecretsScreen';
@@ -141,6 +142,11 @@ export default function App() {
                   name="StoryboardEditor"
                   component={StoryboardEditorScreen}
                   options={{ title: 'Storyboard' }}
+                />
+                <Stack.Screen
+                  name="ScriptEditor"
+                  component={ScriptEditorScreen}
+                  options={{ title: 'Script' }}
                 />
                 <Stack.Screen
                   name="TimelineViewer"

--- a/mobile/index.ts
+++ b/mobile/index.ts
@@ -3,6 +3,13 @@ import 'react-native-get-random-values';
 
 import { registerRootComponent } from 'expo';
 
+import { installRandomUuid } from './src/polyfills/randomUuid';
+
+// Hermes has no `crypto.randomUUID`, and the import above only supplies
+// `getRandomValues`. `@nodetool-ai/timeline`'s id factory calls `randomUUID`,
+// so without this every makeClip/makeTrack/splitClip would throw on device.
+installRandomUuid();
+
 import App from './App';
 import { initErrorReporting } from './src/services/errorReporting';
 

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -17,7 +17,10 @@ module.exports = {
     // Shared mini-app runtime core, compiled from source (mirrors metro.config.js).
     '^@nodetool-ai/app-runtime$':
       '<rootDir>/../packages/app-runtime/src/index.ts',
-    // That package's source uses ESM `.js` specifiers for its own modules.
+    // Shared timeline engine (split/trim/factories), also from source.
+    '^@nodetool-ai/timeline$': '<rootDir>/../packages/timeline/src/index.ts',
+    '^@nodetool-ai/gpu$': '<rootDir>/../packages/gpu/src/index.ts',
+    // Those packages' sources use ESM `.js` specifiers for their own modules.
     '^(\\.{1,2}/.+)\\.js$': '$1',
   },
   collectCoverageFrom: [

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -2,9 +2,12 @@
  * Metro config.
  *
  * `mobile/` is not a root workspace — it has its own dependency tree — so the
- * one shared package it uses at runtime is wired in by hand.
- * `@nodetool-ai/app-runtime` is dependency-free TypeScript, so Metro compiles it
- * from source and no `build:packages` is needed before `expo start`.
+ * shared packages it uses at runtime are wired in by hand.
+ * `@nodetool-ai/app-runtime` and `@nodetool-ai/timeline` are dependency-free
+ * TypeScript, so Metro compiles them from source and no `build:packages` is
+ * needed before `expo start`. (`@nodetool-ai/timeline` names
+ * `@nodetool-ai/gpu` as a dependency, but only for a type-only `BlendMode`
+ * import that Babel erases, so no GPU stack reaches the bundle.)
  *
  * Three things have to be set for that to work:
  *
@@ -29,23 +32,34 @@ const projectRoot = __dirname;
 const repoRoot = path.resolve(projectRoot, "..");
 const appRuntimeRoot = path.resolve(repoRoot, "packages/app-runtime");
 const appRuntimeSrc = path.join(appRuntimeRoot, "src");
+const timelineRoot = path.resolve(repoRoot, "packages/timeline");
+const timelineSrc = path.join(timelineRoot, "src");
+const gpuRoot = path.resolve(repoRoot, "packages/gpu");
+const gpuSrc = path.join(gpuRoot, "src");
+
+/** Package entry points compiled from source, and the src roots they live in. */
+const SOURCE_PACKAGES = [
+  { name: "@nodetool-ai/app-runtime", src: appRuntimeSrc },
+  { name: "@nodetool-ai/timeline", src: timelineSrc },
+  { name: "@nodetool-ai/gpu", src: gpuSrc },
+];
 
 const config = getDefaultConfig(projectRoot);
 
 config.projectRoot = projectRoot;
-config.watchFolders = [projectRoot, appRuntimeRoot];
+config.watchFolders = [projectRoot, appRuntimeRoot, timelineRoot, gpuRoot];
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (moduleName === "@nodetool-ai/app-runtime") {
-    return {
-      type: "sourceFile",
-      filePath: path.join(appRuntimeSrc, "index.ts"),
-    };
+  const entry = SOURCE_PACKAGES.find((pkg) => pkg.name === moduleName);
+  if (entry) {
+    return { type: "sourceFile", filePath: path.join(entry.src, "index.ts") };
   }
   if (
     moduleName.startsWith(".") &&
     moduleName.endsWith(".js") &&
-    context.originModulePath.startsWith(appRuntimeSrc)
+    SOURCE_PACKAGES.some((pkg) =>
+      context.originModulePath.startsWith(pkg.src)
+    )
   ) {
     return context.resolveRequest(context, moduleName.slice(0, -3), platform);
   }

--- a/mobile/src/documents/__tests__/agentBridge.test.ts
+++ b/mobile/src/documents/__tests__/agentBridge.test.ts
@@ -1,0 +1,168 @@
+import {
+  focusedDocument,
+  getDocumentHandler,
+  hasDocumentHandler,
+  listOpenDocuments,
+  registerDocumentHandler,
+  resetDocumentHandlers,
+  setDocumentTitle,
+  setFocusedDocument,
+} from '../agentBridge';
+
+interface FakeHandler {
+  getSnapshot: () => { id: string };
+}
+
+const handler = (id: string): FakeHandler => ({ getSnapshot: () => ({ id }) });
+
+describe('agentBridge', () => {
+  beforeEach(() => {
+    resetDocumentHandlers();
+  });
+
+  it('resolves a registered handler by kind and id', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', handler('sb1'));
+
+    const resolved = getDocumentHandler<FakeHandler>('storyboard', 'sb1');
+
+    expect(resolved.getSnapshot()).toEqual({ id: 'sb1' });
+    expect(hasDocumentHandler('storyboard', 'sb1')).toBe(true);
+  });
+
+  it('keys handlers by kind, so the same id in two kinds does not collide', () => {
+    registerDocumentHandler('storyboard', 'shared', 'Board', handler('board'));
+    registerDocumentHandler('timeline', 'shared', 'Seq', handler('sequence'));
+
+    expect(
+      getDocumentHandler<FakeHandler>('storyboard', 'shared').getSnapshot()
+    ).toEqual({ id: 'board' });
+    expect(
+      getDocumentHandler<FakeHandler>('timeline', 'shared').getSnapshot()
+    ).toEqual({ id: 'sequence' });
+  });
+
+  it('names the open ids of the same kind when a lookup misses', () => {
+    registerDocumentHandler('storyboard', 'open-1', 'A', handler('a'));
+    registerDocumentHandler('storyboard', 'open-2', 'B', handler('b'));
+    // A different kind must not appear in a storyboard error message.
+    registerDocumentHandler('timeline', 'seq-9', 'S', handler('s'));
+
+    expect(() => getDocumentHandler('storyboard', 'missing')).toThrow(
+      /No storyboard "missing" is open\. Open storyboard ids: open-1, open-2\./
+    );
+  });
+
+  it('tells the agent to ask the user when nothing of that kind is open', () => {
+    expect(() => getDocumentHandler('timeline', 'nope')).toThrow(
+      /No timeline documents are currently open\. Ask the user to open one\./
+    );
+  });
+
+  it('unregisters via the returned function', () => {
+    const unregister = registerDocumentHandler(
+      'storyboard',
+      'sb1',
+      'Board',
+      handler('sb1')
+    );
+
+    unregister();
+
+    expect(hasDocumentHandler('storyboard', 'sb1')).toBe(false);
+    expect(listOpenDocuments()).toEqual([]);
+  });
+
+  it('clears focus when the focused document unregisters', () => {
+    const unregister = registerDocumentHandler(
+      'storyboard',
+      'sb1',
+      'Board',
+      handler('sb1')
+    );
+    setFocusedDocument('storyboard', 'sb1');
+    expect(focusedDocument()).toEqual({
+      kind: 'storyboard',
+      id: 'sb1',
+      title: 'Board',
+    });
+
+    unregister();
+
+    expect(focusedDocument()).toBeNull();
+  });
+
+  it('keeps focus across a re-registration', () => {
+    // A screen re-registers whenever the snapshot it closes over changes. That
+    // churn must not drop the focus hint, or ui_context reports no focused
+    // document while the user is looking straight at one.
+    const unregister = registerDocumentHandler(
+      'timeline',
+      'seq1',
+      'Seq',
+      handler('v1')
+    );
+    setFocusedDocument('timeline', 'seq1');
+
+    unregister();
+    registerDocumentHandler('timeline', 'seq1', 'Seq', handler('v2'));
+
+    expect(focusedDocument()).toEqual({
+      kind: 'timeline',
+      id: 'seq1',
+      title: 'Seq',
+    });
+  });
+
+  it('does not clear focus when a different document unregisters', () => {
+    registerDocumentHandler('storyboard', 'focused', 'Focused', handler('f'));
+    const unregisterOther = registerDocumentHandler(
+      'storyboard',
+      'other',
+      'Other',
+      handler('o')
+    );
+    setFocusedDocument('storyboard', 'focused');
+
+    unregisterOther();
+
+    expect(focusedDocument()?.id).toBe('focused');
+  });
+
+  it('lists open documents in registration order', () => {
+    registerDocumentHandler('storyboard', 'first', 'First', handler('1'));
+    registerDocumentHandler('timeline', 'second', 'Second', handler('2'));
+
+    expect(listOpenDocuments()).toEqual([
+      { kind: 'storyboard', id: 'first', title: 'First' },
+      { kind: 'timeline', id: 'second', title: 'Second' },
+    ]);
+  });
+
+  it('retitles without dropping the handler', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Untitled', handler('sb1'));
+
+    setDocumentTitle('storyboard', 'sb1', 'Chase scene');
+
+    expect(listOpenDocuments()[0].title).toBe('Chase scene');
+    expect(hasDocumentHandler('storyboard', 'sb1')).toBe(true);
+  });
+
+  it('re-registering the same document replaces its handler', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', handler('old'));
+    registerDocumentHandler('storyboard', 'sb1', 'Board', handler('new'));
+
+    expect(
+      getDocumentHandler<FakeHandler>('storyboard', 'sb1').getSnapshot()
+    ).toEqual({ id: 'new' });
+    expect(listOpenDocuments()).toHaveLength(1);
+  });
+
+  it('clears focus when asked with a null kind', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', handler('sb1'));
+    setFocusedDocument('storyboard', 'sb1');
+
+    setFocusedDocument(null);
+
+    expect(focusedDocument()).toBeNull();
+  });
+});

--- a/mobile/src/documents/__tests__/backends.test.ts
+++ b/mobile/src/documents/__tests__/backends.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The two transports behind the one document interface. Scripts do not ride the
+ * `resources` envelope (their table has no `revision` column), so the store's
+ * concurrency token is opaque — these tests pin that each backend hands out and
+ * echoes back the token its own router expects.
+ */
+
+import { documentBackend } from '../backends';
+
+const mockResources = {
+  read: { query: jest.fn() },
+  update: { mutate: jest.fn() },
+  list: { query: jest.fn() },
+  create: { mutate: jest.fn() },
+  delete: { mutate: jest.fn() },
+};
+
+const mockScripts = {
+  get: { query: jest.fn() },
+  update: { mutate: jest.fn() },
+  list: { query: jest.fn() },
+  create: { mutate: jest.fn() },
+  delete: { mutate: jest.fn() },
+};
+
+jest.mock('../../trpc/client', () => ({
+  createMobileTRPCClient: () => ({
+    resources: mockResources,
+    scripts: mockScripts,
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('resources backend', () => {
+  const detail = {
+    ref: { kind: 'storyboard', id: 'sb1', revision: 7 },
+    name: 'Chase scene',
+    projectId: 'default',
+    contentType: null,
+    updatedAt: '2026-07-01T00:00:00Z',
+    document: { shots: [] },
+  };
+
+  it('reads the revision out as the token', async () => {
+    mockResources.read.query.mockResolvedValue(detail);
+
+    const loaded = await documentBackend('storyboard').read('sb1');
+
+    expect(mockResources.read.query).toHaveBeenCalledWith({
+      ref: { kind: 'storyboard', id: 'sb1' },
+    });
+    expect(loaded).toEqual({
+      doc: { shots: [] },
+      name: 'Chase scene',
+      token: 7,
+      updatedAt: '2026-07-01T00:00:00Z',
+    });
+  });
+
+  it('echoes a numeric token back as the ref revision', async () => {
+    mockResources.update.mutate.mockResolvedValue(detail);
+
+    await documentBackend('storyboard').save('sb1', {
+      doc: { shots: [] },
+      name: 'Chase scene',
+      token: 6,
+    });
+
+    expect(mockResources.update.mutate).toHaveBeenCalledWith({
+      ref: { kind: 'storyboard', id: 'sb1', revision: 6 },
+      name: 'Chase scene',
+      document: { shots: [] },
+    });
+  });
+
+  it('sends no revision when the token is not a number', async () => {
+    mockResources.update.mutate.mockResolvedValue(detail);
+
+    await documentBackend('storyboard').save('sb1', {
+      doc: {},
+      name: 'x',
+      token: undefined,
+    });
+
+    expect(mockResources.update.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: { kind: 'storyboard', id: 'sb1', revision: undefined },
+      })
+    );
+  });
+
+  it('lists rows without a kind-specific detail line', async () => {
+    mockResources.list.query.mockResolvedValue([
+      { ...detail.ref, ref: detail.ref, name: 'A', updatedAt: '2026-01-01' },
+    ]);
+
+    const rows = await documentBackend('timeline').list(50);
+
+    expect(mockResources.list.query).toHaveBeenCalledWith({
+      kind: 'timeline',
+      limit: 50,
+    });
+    expect(rows).toEqual([
+      { id: 'sb1', name: 'A', updatedAt: '2026-01-01' },
+    ]);
+  });
+
+  it('renames without a revision, since a list row carries none to echo', async () => {
+    mockResources.update.mutate.mockResolvedValue(detail);
+
+    await documentBackend('storyboard').rename('sb1', 'New name');
+
+    expect(mockResources.update.mutate).toHaveBeenCalledWith({
+      ref: { kind: 'storyboard', id: 'sb1' },
+      name: 'New name',
+    });
+  });
+
+  it('deletes by ref', async () => {
+    mockResources.delete.mutate.mockResolvedValue({ ok: true });
+
+    await documentBackend('sketch').remove('sk1');
+
+    expect(mockResources.delete.mutate).toHaveBeenCalledWith({
+      ref: { kind: 'sketch', id: 'sk1' },
+    });
+  });
+});
+
+describe('scripts backend', () => {
+  const response = {
+    id: 'sc1',
+    projectId: 'default',
+    name: 'Pilot',
+    document: { cast: [], sections: [] },
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-02T00:00:00Z',
+  };
+
+  it('reads updatedAt out as the token', async () => {
+    mockScripts.get.query.mockResolvedValue(response);
+
+    const loaded = await documentBackend('script').read('sc1');
+
+    expect(mockScripts.get.query).toHaveBeenCalledWith({ id: 'sc1' });
+    expect(loaded).toEqual({
+      doc: { cast: [], sections: [] },
+      name: 'Pilot',
+      token: '2026-07-02T00:00:00Z',
+      updatedAt: '2026-07-02T00:00:00Z',
+    });
+  });
+
+  it('echoes a string token back as baseUpdatedAt', async () => {
+    mockScripts.update.mutate.mockResolvedValue(response);
+
+    await documentBackend('script').save('sc1', {
+      doc: { cast: [], sections: [] },
+      name: 'Pilot',
+      token: '2026-07-01T00:00:00Z',
+    });
+
+    expect(mockScripts.update.mutate).toHaveBeenCalledWith({
+      id: 'sc1',
+      name: 'Pilot',
+      document: { cast: [], sections: [] },
+      baseUpdatedAt: '2026-07-01T00:00:00Z',
+    });
+  });
+
+  it('omits baseUpdatedAt when the token is not a string', async () => {
+    mockScripts.update.mutate.mockResolvedValue(response);
+
+    await documentBackend('script').save('sc1', {
+      doc: {},
+      name: 'x',
+      token: 5,
+    });
+
+    expect(mockScripts.update.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUpdatedAt: undefined })
+    );
+  });
+
+  it('surfaces the line count as the row detail', async () => {
+    mockScripts.list.query.mockResolvedValue([
+      { id: 'sc1', projectId: 'p', name: 'Pilot', lineCount: 12, updatedAt: 'x' },
+      { id: 'sc2', projectId: 'p', name: 'One', lineCount: 1, updatedAt: 'y' },
+    ]);
+
+    const rows = await documentBackend('script').list(50);
+
+    expect(rows).toEqual([
+      { id: 'sc1', name: 'Pilot', updatedAt: 'x', detail: '12 lines' },
+      { id: 'sc2', name: 'One', updatedAt: 'y', detail: '1 line' },
+    ]);
+  });
+
+  it('creates and deletes through the scripts router', async () => {
+    mockScripts.create.mutate.mockResolvedValue(response);
+    mockScripts.delete.mutate.mockResolvedValue({ ok: true });
+
+    const created = await documentBackend('script').create('Pilot');
+    await documentBackend('script').remove('sc1');
+
+    expect(created).toEqual({
+      id: 'sc1',
+      name: 'Pilot',
+      updatedAt: '2026-07-02T00:00:00Z',
+    });
+    expect(mockScripts.delete.mutate).toHaveBeenCalledWith({ id: 'sc1' });
+    // Never the resources envelope: scripts have no revision column.
+    expect(mockResources.create.mutate).not.toHaveBeenCalled();
+    expect(mockResources.delete.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe('every document kind', () => {
+  it('is writable', () => {
+    for (const kind of ['storyboard', 'script', 'timeline', 'sketch'] as const) {
+      expect(documentBackend(kind).writable).toBe(true);
+    }
+  });
+});

--- a/mobile/src/documents/__tests__/documentStore.test.ts
+++ b/mobile/src/documents/__tests__/documentStore.test.ts
@@ -1,0 +1,260 @@
+import { documentStore, resetDocumentStores } from '../documentStore';
+
+const mockRead = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('../../trpc/client', () => ({
+  createMobileTRPCClient: () => ({
+    resources: {
+      read: { query: mockRead },
+      update: { mutate: mockUpdate },
+    },
+  }),
+}));
+
+interface Doc {
+  shots: string[];
+}
+
+const detail = (overrides: Record<string, unknown> = {}) => ({
+  ref: { kind: 'storyboard', id: 'sb1', revision: 3 },
+  name: 'Chase scene',
+  projectId: 'default',
+  contentType: null,
+  updatedAt: '2026-07-01T00:00:00Z',
+  document: { shots: ['a'] },
+  ...overrides,
+});
+
+describe('documentStore', () => {
+  beforeEach(() => {
+    resetDocumentStores();
+    mockRead.mockReset();
+    mockUpdate.mockReset();
+  });
+
+  it('returns the same store for the same document', () => {
+    expect(documentStore('storyboard', 'sb1')).toBe(
+      documentStore('storyboard', 'sb1')
+    );
+  });
+
+  it('returns distinct stores per id and per kind', () => {
+    expect(documentStore('storyboard', 'sb1')).not.toBe(
+      documentStore('storyboard', 'sb2')
+    );
+    expect(documentStore('storyboard', 'shared')).not.toBe(
+      documentStore('timeline', 'shared')
+    );
+  });
+
+  it('loads the document body, name and revision', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+
+    await store.getState().load();
+
+    expect(mockRead).toHaveBeenCalledWith({ ref: { kind: 'storyboard', id: 'sb1' } });
+    expect(store.getState()).toMatchObject({
+      doc: { shots: ['a'] },
+      name: 'Chase scene',
+      revision: 3,
+      updatedAt: '2026-07-01T00:00:00Z',
+      dirty: false,
+      status: 'idle',
+    });
+  });
+
+  it('surfaces a load failure without wiping the status', async () => {
+    mockRead.mockRejectedValue(new Error('offline'));
+    const store = documentStore<Doc>('storyboard', 'sb1');
+
+    await store.getState().load();
+
+    expect(store.getState().status).toBe('error');
+    expect(store.getState().error).toBe('offline');
+  });
+
+  it('marks dirty on edit and rename', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+
+    store.getState().edit((doc) => ({ shots: [...doc.shots, 'b'] }));
+
+    expect(store.getState().doc).toEqual({ shots: ['a', 'b'] });
+    expect(store.getState().dirty).toBe(true);
+
+    store.getState().rename('New name');
+    expect(store.getState().name).toBe('New name');
+  });
+
+  it('ignores an edit before the document has loaded', () => {
+    const store = documentStore<Doc>('storyboard', 'sb1');
+
+    store.getState().edit(() => ({ shots: ['x'] }));
+
+    expect(store.getState().doc).toBeNull();
+    expect(store.getState().dirty).toBe(false);
+  });
+
+  it('saves the body with the revision it read, then adopts the new one', async () => {
+    mockRead.mockResolvedValue(detail());
+    mockUpdate.mockResolvedValue(
+      detail({
+        ref: { kind: 'storyboard', id: 'sb1', revision: 4 },
+        updatedAt: '2026-07-02T00:00:00Z',
+      })
+    );
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['a', 'b'] }));
+
+    await store.getState().save();
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      ref: { kind: 'storyboard', id: 'sb1', revision: 3 },
+      name: 'Chase scene',
+      document: { shots: ['a', 'b'] },
+    });
+    expect(store.getState()).toMatchObject({
+      revision: 4,
+      updatedAt: '2026-07-02T00:00:00Z',
+      dirty: false,
+      status: 'idle',
+    });
+  });
+
+  it('does not write when there is nothing to save', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+
+    await store.getState().save();
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports a stale write as a conflict, not a generic error', async () => {
+    mockRead.mockResolvedValue(detail());
+    mockUpdate.mockRejectedValue(
+      new Error(
+        'storyboard resource was modified since it was read (optimistic concurrency conflict)'
+      )
+    );
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['b'] }));
+
+    await store.getState().save();
+
+    expect(store.getState().status).toBe('conflict');
+    // The local edit survives, so the user can retry after reloading.
+    expect(store.getState().dirty).toBe(true);
+  });
+
+  it('reports other save failures as errors', async () => {
+    mockRead.mockResolvedValue(detail());
+    mockUpdate.mockRejectedValue(new Error('network down'));
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['b'] }));
+
+    await store.getState().save();
+
+    expect(store.getState().status).toBe('error');
+    expect(store.getState().error).toBe('network down');
+  });
+
+  it('keeps the document dirty when an edit lands mid-save', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['a', 'b'] }));
+
+    // The agent adds a shot while the user's save is still on the wire.
+    mockUpdate.mockImplementation(async () => {
+      store.getState().edit((doc) => ({ shots: [...doc.shots, 'c'] }));
+      return detail({
+        ref: { kind: 'storyboard', id: 'sb1', revision: 4 },
+        document: { shots: ['a', 'b'] },
+      });
+    });
+
+    await store.getState().save();
+
+    // The third shot exists only locally, so the document must stay dirty —
+    // marking it clean would disable Save and lose the edit on reload.
+    expect(store.getState().doc).toEqual({ shots: ['a', 'b', 'c'] });
+    expect(store.getState().dirty).toBe(true);
+    // The new revision is adopted regardless, so the follow-up save is checked
+    // against the row we just wrote.
+    expect(store.getState().revision).toBe(4);
+  });
+
+  it('persists the mid-save edit on the next save, with the new revision', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['a', 'b'] }));
+
+    mockUpdate.mockImplementationOnce(async () => {
+      store.getState().edit((doc) => ({ shots: [...doc.shots, 'c'] }));
+      return detail({ ref: { kind: 'storyboard', id: 'sb1', revision: 4 } });
+    });
+    await store.getState().save();
+
+    mockUpdate.mockResolvedValueOnce(
+      detail({ ref: { kind: 'storyboard', id: 'sb1', revision: 5 } })
+    );
+    await store.getState().save();
+
+    expect(mockUpdate).toHaveBeenLastCalledWith({
+      ref: { kind: 'storyboard', id: 'sb1', revision: 4 },
+      name: 'Chase scene',
+      document: { shots: ['a', 'b', 'c'] },
+    });
+    expect(store.getState().dirty).toBe(false);
+  });
+
+  it('serializes overlapping saves instead of racing them into a conflict', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['a', 'b'] }));
+
+    const gate: { release?: () => void } = {};
+    mockUpdate.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        gate.release = resolve;
+      });
+      return detail({ ref: { kind: 'storyboard', id: 'sb1', revision: 4 } });
+    });
+
+    // The user's Save and the agent's save overlap.
+    const first = store.getState().save();
+    const second = store.getState().save();
+    await Promise.resolve();
+    gate.release?.();
+    await Promise.all([first, second]);
+
+    // The second save found nothing left to write rather than sending a stale
+    // revision the server would reject.
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(store.getState().status).toBe('idle');
+    expect(store.getState().dirty).toBe(false);
+  });
+
+  it('reverts by re-reading, discarding local edits', async () => {
+    mockRead.mockResolvedValue(detail());
+    const store = documentStore<Doc>('storyboard', 'sb1');
+    await store.getState().load();
+    store.getState().edit(() => ({ shots: ['local'] }));
+
+    await store.getState().revert();
+
+    expect(store.getState().doc).toEqual({ shots: ['a'] });
+    expect(store.getState().dirty).toBe(false);
+    expect(store.getState().status).toBe('idle');
+  });
+});

--- a/mobile/src/documents/__tests__/documentStore.test.ts
+++ b/mobile/src/documents/__tests__/documentStore.test.ts
@@ -48,7 +48,7 @@ describe('documentStore', () => {
     );
   });
 
-  it('loads the document body, name and revision', async () => {
+  it('loads the document body, name and concurrency token', async () => {
     mockRead.mockResolvedValue(detail());
     const store = documentStore<Doc>('storyboard', 'sb1');
 
@@ -58,7 +58,7 @@ describe('documentStore', () => {
     expect(store.getState()).toMatchObject({
       doc: { shots: ['a'] },
       name: 'Chase scene',
-      revision: 3,
+      token: 3,
       updatedAt: '2026-07-01T00:00:00Z',
       dirty: false,
       status: 'idle',
@@ -118,7 +118,7 @@ describe('documentStore', () => {
       document: { shots: ['a', 'b'] },
     });
     expect(store.getState()).toMatchObject({
-      revision: 4,
+      token: 4,
       updatedAt: '2026-07-02T00:00:00Z',
       dirty: false,
       status: 'idle',
@@ -187,9 +187,9 @@ describe('documentStore', () => {
     // marking it clean would disable Save and lose the edit on reload.
     expect(store.getState().doc).toEqual({ shots: ['a', 'b', 'c'] });
     expect(store.getState().dirty).toBe(true);
-    // The new revision is adopted regardless, so the follow-up save is checked
+    // The new token is adopted regardless, so the follow-up save is checked
     // against the row we just wrote.
-    expect(store.getState().revision).toBe(4);
+    expect(store.getState().token).toBe(4);
   });
 
   it('persists the mid-save edit on the next save, with the new revision', async () => {

--- a/mobile/src/documents/__tests__/scriptTypes.test.ts
+++ b/mobile/src/documents/__tests__/scriptTypes.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the pure script helpers.
+ *
+ * These four behaviours are what the screen and the tools both lean on: status
+ * derived from the take snapshot rather than stored, target resolution that
+ * fails with a message naming the valid ids, line edits that keep the take
+ * history, and speaker removal that leaves no dangling `speakerId`.
+ */
+
+import {
+  applyLinePatch,
+  flattenLines,
+  lineStatus,
+  lineToNode,
+  resolveLine,
+  resolveSectionIndex,
+  resolveSpeakerIndex,
+  withoutSpeaker,
+  type ScriptDocument,
+  type ScriptLine,
+  type ScriptTake,
+} from '../scriptTypes';
+
+const take = (id: string, textSnapshot: string): ScriptTake => ({
+  id,
+  assetId: `asset-${id}`,
+  durationMs: 1200,
+  words: [{ word: 'hi', startMs: 0, endMs: 200 }],
+  textSnapshot,
+  voiceSnapshot: null,
+  createdAt: '2026-07-26T00:00:00Z',
+});
+
+const line = (overrides: Partial<ScriptLine> = {}): ScriptLine => ({
+  id: 'line-a',
+  speakerId: 'speaker-a',
+  text: 'Hello there',
+  takes: [],
+  currentTakeId: null,
+  ...overrides,
+});
+
+const makeDocument = (): ScriptDocument => ({
+  cast: [
+    { id: 'speaker-a', name: 'Ada', color: '#6DB3F8' },
+    { id: 'speaker-b', name: 'Grace', voice: null },
+  ],
+  sections: [
+    {
+      id: 'section-1',
+      title: 'Cold open',
+      lines: [
+        line({ id: 'line-a' }),
+        line({ id: 'line-b', speakerId: 'speaker-b', text: 'Over here' }),
+      ],
+    },
+    {
+      id: 'section-2',
+      lines: [line({ id: 'line-c', speakerId: null, text: 'Silence' })],
+    },
+  ],
+});
+
+describe('lineStatus', () => {
+  it('is draft without a current take', () => {
+    expect(lineStatus(line())).toBe('draft');
+  });
+
+  it('is draft when currentTakeId names a take that is gone', () => {
+    expect(lineStatus(line({ currentTakeId: 'take-gone' }))).toBe('draft');
+  });
+
+  it('is voiced when the current take was voiced from the current text', () => {
+    const voiced = line({
+      takes: [take('take-1', 'Hello there')],
+      currentTakeId: 'take-1',
+    });
+    expect(lineStatus(voiced)).toBe('voiced');
+  });
+
+  it('is stale once the text has moved past the take', () => {
+    const stale = line({
+      text: 'Hello again',
+      takes: [take('take-1', 'Hello there')],
+      currentTakeId: 'take-1',
+    });
+    expect(lineStatus(stale)).toBe('stale');
+  });
+});
+
+describe('flattenLines and lineToNode', () => {
+  it('numbers lines across sections and names their speaker', () => {
+    const doc = makeDocument();
+    const flat = flattenLines(doc);
+
+    expect(flat.map((entry) => [entry.line.id, entry.index, entry.sectionId])).toEqual([
+      ['line-a', 0, 'section-1'],
+      ['line-b', 1, 'section-1'],
+      ['line-c', 2, 'section-2'],
+    ]);
+
+    const node = lineToNode(flat[1].line, flat[1].sectionId, flat[1].index, doc.cast);
+    expect(node).toMatchObject({
+      id: 'line-b',
+      index: 1,
+      sectionId: 'section-1',
+      speakerId: 'speaker-b',
+      speakerName: 'Grace',
+      status: 'draft',
+      takeCount: 0,
+    });
+  });
+
+  it('reports an unassigned line with a null speaker name', () => {
+    const doc = makeDocument();
+    const flat = flattenLines(doc);
+
+    expect(
+      lineToNode(flat[2].line, flat[2].sectionId, flat[2].index, doc.cast)
+    ).toMatchObject({ speakerId: null, speakerName: null });
+  });
+});
+
+describe('resolveLine', () => {
+  it('resolves by id, by document index, and by "selected"', () => {
+    const doc = makeDocument();
+
+    expect(resolveLine(doc, 'line-b', null).index).toBe(1);
+    expect(resolveLine(doc, '2', null).line.id).toBe('line-c');
+    expect(resolveLine(doc, 'selected', 'line-c').line.id).toBe('line-c');
+  });
+
+  it('throws listing the valid ids for an unknown target', () => {
+    expect(() => resolveLine(makeDocument(), 'line-zzz', null)).toThrow(
+      /No line matches "line-zzz".*Line ids: line-a, line-b, line-c/s
+    );
+  });
+
+  it('throws for an out-of-range index rather than clamping', () => {
+    expect(() => resolveLine(makeDocument(), '9', null)).toThrow(
+      /0-based index below 3/
+    );
+  });
+
+  it('explains itself when "selected" is passed with nothing selected', () => {
+    expect(() => resolveLine(makeDocument(), 'selected', null)).toThrow(
+      /No line is selected/
+    );
+  });
+});
+
+describe('resolveSpeakerIndex and resolveSectionIndex', () => {
+  it('resolve by id and by index', () => {
+    const doc = makeDocument();
+
+    expect(resolveSpeakerIndex(doc.cast, 'speaker-b')).toBe(1);
+    expect(resolveSpeakerIndex(doc.cast, '0')).toBe(0);
+    expect(resolveSectionIndex(doc.sections, 'section-2')).toBe(1);
+    expect(resolveSectionIndex(doc.sections, '0')).toBe(0);
+  });
+
+  it('throw listing the valid ids', () => {
+    const doc = makeDocument();
+
+    expect(() => resolveSpeakerIndex(doc.cast, 'nope')).toThrow(
+      /Speaker ids: speaker-a, speaker-b/
+    );
+    expect(() => resolveSectionIndex(doc.sections, 'nope')).toThrow(
+      /Section ids: section-1, section-2/
+    );
+  });
+
+  it('say so when there is nothing to address', () => {
+    expect(() => resolveSpeakerIndex([], 'nope')).toThrow(/no cast yet/);
+    expect(() => resolveSectionIndex([], 'nope')).toThrow(/no sections yet/);
+  });
+});
+
+describe('applyLinePatch', () => {
+  const voiced = line({
+    takes: [take('take-1', 'Hello there'), take('take-2', 'Hello there')],
+    currentTakeId: 'take-1',
+  });
+
+  it('keeps the take history when the text changes, so the line goes stale', () => {
+    const next = applyLinePatch(voiced, { text: 'Hello again' });
+
+    expect(next.takes).toHaveLength(2);
+    expect(next.currentTakeId).toBe('take-1');
+    expect(lineStatus(next)).toBe('stale');
+  });
+
+  it('leaves omitted fields alone', () => {
+    const next = applyLinePatch(
+      line({ direction: 'tired', pauseAfterMs: 400 }),
+      { text: 'New words' }
+    );
+
+    expect(next).toMatchObject({
+      text: 'New words',
+      direction: 'tired',
+      pauseAfterMs: 400,
+      speakerId: 'speaker-a',
+    });
+  });
+
+  it('clears the speaker when speakerId is passed as null', () => {
+    expect(applyLinePatch(line(), { speakerId: null }).speakerId).toBeNull();
+  });
+});
+
+describe('withoutSpeaker', () => {
+  it('drops the cast member and unassigns the lines that used it', () => {
+    const next = withoutSpeaker(makeDocument(), 'speaker-a');
+
+    expect(next.cast.map((speaker) => speaker.id)).toEqual(['speaker-b']);
+    expect(
+      flattenLines(next).map((entry) => [entry.line.id, entry.line.speakerId])
+    ).toEqual([
+      ['line-a', null],
+      ['line-b', 'speaker-b'],
+      ['line-c', null],
+    ]);
+  });
+
+  it('keeps the lines and their takes', () => {
+    const doc = makeDocument();
+    doc.sections[0].lines[0] = line({
+      takes: [take('take-1', 'Hello there')],
+      currentTakeId: 'take-1',
+    });
+
+    const next = withoutSpeaker(doc, 'speaker-a');
+
+    expect(flattenLines(next)).toHaveLength(3);
+    expect(next.sections[0].lines[0].takes).toHaveLength(1);
+  });
+});

--- a/mobile/src/documents/__tests__/timelineEdits.test.ts
+++ b/mobile/src/documents/__tests__/timelineEdits.test.ts
@@ -1,0 +1,712 @@
+/**
+ * Tests for the pure timeline edits.
+ *
+ * These carry the invariants the agent tools depend on, so they are exercised
+ * directly rather than through the screen: link groups that must not desync,
+ * staleness on a binding change, transcript references that must not dangle,
+ * and track ids that must never be a track *name*.
+ */
+
+import { makeClipVersion, type TimelineClip } from '@nodetool-ai/timeline';
+
+import {
+  addMarker,
+  addShapeClip,
+  addTextClip,
+  addTrack,
+  deleteClip,
+  deleteMarker,
+  duplicateClip,
+  moveClip,
+  setClipParams,
+  splitClipAt,
+  trimClip,
+} from '../timelineEdits';
+import type { TimelineDocument } from '../timelineTypes';
+
+const clip = (overrides: Partial<TimelineClip>): TimelineClip => ({
+  id: 'c',
+  trackId: 't1',
+  name: 'Clip',
+  startMs: 0,
+  durationMs: 1000,
+  mediaType: 'video',
+  sourceType: 'generated',
+  status: 'draft',
+  locked: false,
+  versions: [],
+  ...overrides,
+});
+
+const baseDoc = (): TimelineDocument => ({
+  tracks: [
+    { id: 't1', name: 'Video 1', type: 'video', index: 0, visible: true, locked: false },
+    { id: 't2', name: 'Music', type: 'audio', index: 1, visible: true, locked: false },
+    { id: 't3', name: 'Titles', type: 'overlay', index: 2, visible: true, locked: false },
+  ],
+  clips: [
+    clip({ id: 'c1', trackId: 't1', name: 'Opening shot', startMs: 1000, durationMs: 4000 }),
+    clip({
+      id: 'c2',
+      trackId: 't2',
+      name: 'Theme',
+      startMs: 0,
+      durationMs: 8000,
+      mediaType: 'audio',
+      sourceType: 'imported',
+    }),
+  ],
+  markers: [{ id: 'm1', timeMs: 2000, label: 'Cut' }],
+});
+
+/** A video clip and the audio extracted from it, aligned and linked. */
+const linkedDoc = (): TimelineDocument => ({
+  ...baseDoc(),
+  clips: [
+    clip({
+      id: 'v',
+      trackId: 't1',
+      name: 'Interview',
+      startMs: 2000,
+      durationMs: 6000,
+      linkId: 'L',
+    }),
+    clip({
+      id: 'a',
+      trackId: 't2',
+      name: 'Interview audio',
+      startMs: 2000,
+      durationMs: 6000,
+      mediaType: 'audio',
+      linkId: 'L',
+    }),
+    clip({ id: 'solo', trackId: 't1', name: 'Solo', startMs: 20_000, durationMs: 1000 }),
+  ],
+});
+
+const byId = (doc: TimelineDocument, id: string): TimelineClip => {
+  const found = doc.clips.find((entry) => entry.id === id);
+  if (found === undefined) {
+    throw new Error(`no clip ${id}`);
+  }
+  return found;
+};
+
+describe('addTrack', () => {
+  it('appends a track with the next index and a default name', () => {
+    const next = addTrack(baseDoc(), 'audio');
+
+    expect(next.track).toMatchObject({ type: 'audio', index: 3, name: 'audio 4' });
+    expect(next.doc.tracks).toHaveLength(4);
+  });
+
+  it('leaves the input document untouched', () => {
+    const doc = baseDoc();
+    addTrack(doc, 'video', 'B-roll');
+
+    expect(doc.tracks).toHaveLength(3);
+  });
+});
+
+describe('addTextClip', () => {
+  it('lands on the existing overlay track, appended after its content', () => {
+    const doc: TimelineDocument = {
+      ...baseDoc(),
+      clips: [
+        ...baseDoc().clips,
+        clip({ id: 'x', trackId: 't3', startMs: 0, durationMs: 2500, mediaType: 'text' }),
+      ],
+    };
+
+    const next = addTextClip(doc, { text: '  Chapter One  ' });
+
+    expect(next.clip).toMatchObject({
+      trackId: 't3',
+      name: 'Chapter One',
+      startMs: 2500,
+      durationMs: 3000,
+      mediaType: 'text',
+      status: 'generated',
+    });
+    expect(next.clip.textStyle).toMatchObject({ text: 'Chapter One', fontSizePx: 96 });
+  });
+
+  it('creates an overlay track when the sequence has none', () => {
+    const doc: TimelineDocument = {
+      ...baseDoc(),
+      tracks: baseDoc().tracks.filter((track) => track.type !== 'overlay'),
+    };
+
+    const next = addTextClip(doc, { text: 'Title' });
+
+    const created = next.doc.tracks.find((track) => track.type === 'overlay');
+    expect(created).toMatchObject({ name: 'Text' });
+    expect(next.clip.trackId).toBe(created?.id);
+  });
+
+  it('resolves a track name to its id rather than writing the name', () => {
+    const next = addTextClip(baseDoc(), { text: 'Title', trackId: 'titles' });
+
+    expect(next.clip.trackId).toBe('t3');
+  });
+
+  it('refuses an audio track', () => {
+    expect(() => addTextClip(baseDoc(), { text: 'Title', trackId: 'Music' })).toThrow(
+      /require a video or overlay track; "Music" is audio/
+    );
+  });
+
+  it('refuses a nonexistent track, naming the ones that exist', () => {
+    expect(() => addTextClip(baseDoc(), { text: 'Title', trackId: 'nope' })).toThrow(
+      /No track matches "nope".*t1 \("Video 1"\)/s
+    );
+  });
+
+  it('refuses empty text', () => {
+    expect(() => addTextClip(baseDoc(), { text: '   ' })).toThrow(/non-empty text/);
+  });
+
+  it('clamps a zero duration and a negative start to the bounds', () => {
+    const next = addTextClip(baseDoc(), {
+      text: 'Title',
+      startMs: -500,
+      durationMs: 0,
+    });
+
+    expect(next.clip).toMatchObject({ startMs: 0, durationMs: 1 });
+  });
+});
+
+describe('addShapeClip', () => {
+  it('fills a rectangle so it is visible', () => {
+    const next = addShapeClip(baseDoc(), { shape: { kind: 'rect' } });
+
+    expect(next.clip.shapeStyle).toEqual({ kind: 'rect', fill: '#FFFFFF' });
+    expect(next.clip.mediaType).toBe('shape');
+  });
+
+  it('strokes a line so it is visible', () => {
+    const next = addShapeClip(baseDoc(), { shape: { kind: 'line', x2: 1, y2: 1 } });
+
+    expect(next.clip.shapeStyle).toMatchObject({
+      stroke: '#FFFFFF',
+      strokeWidthPx: 8,
+    });
+  });
+});
+
+describe('moveClip', () => {
+  it('moves an unlinked clip and resolves the target track by name', () => {
+    const next = moveClip(baseDoc(), 'Opening shot', {
+      startMs: 3000,
+      trackId: 'titles',
+    });
+
+    expect(next.clips).toHaveLength(1);
+    expect(byId(next.doc, 'c1')).toMatchObject({ startMs: 3000, trackId: 't3' });
+  });
+
+  it('clamps a negative start to zero', () => {
+    const next = moveClip(baseDoc(), 'c1', { startMs: -1000 });
+
+    expect(byId(next.doc, 'c1').startMs).toBe(0);
+  });
+
+  it('rejects a move to a nonexistent track and changes nothing', () => {
+    const doc = baseDoc();
+
+    expect(() => moveClip(doc, 'c1', { startMs: 0, trackId: 'ghost' })).toThrow(
+      /No track matches "ghost"/
+    );
+    expect(byId(doc, 'c1').startMs).toBe(1000);
+  });
+
+  it('shifts every link sibling by the same delta, each keeping its own track', () => {
+    const next = moveClip(linkedDoc(), 'v', { startMs: 5000, trackId: 'Titles' });
+
+    expect(next.clips.map((entry) => entry.id).sort()).toEqual(['a', 'v']);
+    expect(byId(next.doc, 'v')).toMatchObject({ startMs: 5000, trackId: 't3' });
+    // Same delta, and the audio stays on the audio track.
+    expect(byId(next.doc, 'a')).toMatchObject({ startMs: 5000, trackId: 't2' });
+    expect(byId(next.doc, 'solo').startMs).toBe(20_000);
+  });
+
+  it('clamps the delta once for the group so a move against zero keeps alignment', () => {
+    const doc = linkedDoc();
+    // The audio sits 500ms ahead of the video, so the group cannot shift by more
+    // than -1500 without pushing the audio before zero.
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'a' ? { ...entry, startMs: 1500 } : entry
+    );
+
+    const next = moveClip(doc, 'v', { startMs: 0 });
+
+    expect(byId(next.doc, 'a').startMs).toBe(0);
+    // The video keeps its 500ms offset instead of both piling onto zero.
+    expect(byId(next.doc, 'v').startMs).toBe(500);
+  });
+});
+
+describe('trimClip', () => {
+  it('changes the on-timeline length and the source out-point together', () => {
+    const next = trimClip(baseDoc(), 'c1', { durationMs: 2000 });
+
+    expect(byId(next.doc, 'c1')).toMatchObject({
+      durationMs: 2000,
+      inPointMs: 0,
+      outPointMs: 2000,
+    });
+  });
+
+  it('maps the timeline delta through the clip speed', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1' ? { ...entry, speedMultiplier: 2 } : entry
+    );
+
+    // Growing 1000ms of timeline consumes 2000ms of source at 2x.
+    const next = trimClip(doc, 'c1', { durationMs: 5000 });
+
+    expect(byId(next.doc, 'c1').outPointMs).toBe(10_000);
+  });
+
+  it('refuses a duration below 1ms', () => {
+    expect(() => trimClip(baseDoc(), 'c1', { durationMs: 0 })).toThrow(
+      /at least 1ms/
+    );
+  });
+
+  it('sets the source window on the target only', () => {
+    const next = trimClip(linkedDoc(), 'v', { inPointMs: 500, outPointMs: 4000 });
+
+    expect(byId(next.doc, 'v')).toMatchObject({ inPointMs: 500, outPointMs: 4000 });
+    expect(byId(next.doc, 'a').inPointMs).toBeUndefined();
+  });
+
+  it('refuses an inverted source window', () => {
+    expect(() =>
+      trimClip(baseDoc(), 'c1', { inPointMs: 4000, outPointMs: 1000 })
+    ).toThrow(/must be greater than inPointMs/);
+  });
+
+  it('refuses a negative in-point', () => {
+    expect(() => trimClip(baseDoc(), 'c1', { inPointMs: -1 })).toThrow(
+      /cannot be negative/
+    );
+  });
+
+  it('refuses an empty patch', () => {
+    expect(() => trimClip(baseDoc(), 'c1', {})).toThrow(/Nothing to trim/);
+  });
+
+  it('applies the same length delta to every link sibling', () => {
+    const next = trimClip(linkedDoc(), 'v', { durationMs: 4000 });
+
+    expect(byId(next.doc, 'v').durationMs).toBe(4000);
+    expect(byId(next.doc, 'a').durationMs).toBe(4000);
+  });
+
+  it('aborts the whole trim when a sibling would go invalid, so the link cannot desync', () => {
+    const doc = linkedDoc();
+    // The audio has a source window with nothing left to reveal, so growing the
+    // pair is invalid for the audio but fine for the video.
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'a' ? { ...entry, inPointMs: 0, outPointMs: 6000 } : entry
+    );
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'a' ? { ...entry, startMs: 0, durationMs: 6000 } : entry
+    );
+    // Shrinking below zero duration is invalid for the audio (6000 - 7000 < 0)
+    // while the video would merely shrink.
+    expect(() => trimClip(doc, 'v', { durationMs: -1000 })).toThrow();
+    expect(byId(doc, 'v').durationMs).toBe(6000);
+    expect(byId(doc, 'a').durationMs).toBe(6000);
+  });
+});
+
+describe('splitClipAt', () => {
+  it('cuts a clip in two, mapping the source in/out points', () => {
+    const next = splitClipAt(baseDoc(), 'c1', 3000);
+
+    expect(next.clips).toHaveLength(2);
+    const [left, right] = next.clips;
+    expect(left).toMatchObject({ startMs: 1000, durationMs: 2000, outPointMs: 2000 });
+    expect(right).toMatchObject({ startMs: 3000, durationMs: 2000, inPointMs: 2000 });
+    expect(next.doc.clips).toHaveLength(3);
+  });
+
+  it('refuses a split time outside the clip', () => {
+    expect(() => splitClipAt(baseDoc(), 'c1', 1000)).toThrow(/outside clip "Opening shot"/);
+    expect(() => splitClipAt(baseDoc(), 'c1', 9000)).toThrow(/outside clip/);
+  });
+
+  it('drops the fades and transition an interior cut invalidates', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            fadeInMs: 200,
+            fadeOutMs: 300,
+            transitionIn: { type: 'crossfade' as const, durationMs: 400 },
+          }
+        : entry
+    );
+
+    const [left, right] = splitClipAt(doc, 'c1', 3000).clips;
+
+    expect(left.fadeInMs).toBe(200);
+    expect(left.fadeOutMs).toBeUndefined();
+    expect(right.fadeInMs).toBeUndefined();
+    expect(right.transitionIn).toBeUndefined();
+    expect(right.fadeOutMs).toBe(300);
+  });
+
+  it('splits every link sibling and gives each side its own fresh link id', () => {
+    const next = splitClipAt(linkedDoc(), 'v', 5000);
+
+    expect(next.clips).toHaveLength(4);
+    const lefts = next.clips.filter((entry) => entry.startMs === 2000);
+    const rights = next.clips.filter((entry) => entry.startMs === 5000);
+    expect(lefts).toHaveLength(2);
+    expect(rights).toHaveLength(2);
+    // One link id per side, and neither is the original — a 4-member group
+    // would pair nothing with anything.
+    expect(new Set(lefts.map((entry) => entry.linkId)).size).toBe(1);
+    expect(new Set(rights.map((entry) => entry.linkId)).size).toBe(1);
+    expect(lefts[0].linkId).not.toBe(rights[0].linkId);
+    expect(lefts[0].linkId).not.toBe('L');
+    expect(rights[0].linkId).not.toBe('L');
+  });
+
+  it('leaves the halves of an unlinked clip unlinked', () => {
+    const [left, right] = splitClipAt(baseDoc(), 'c1', 3000).clips;
+
+    expect(left.linkId).toBeUndefined();
+    expect(right.linkId).toBeUndefined();
+  });
+
+  it('leaves a sibling that does not span the cut alone', () => {
+    const doc = linkedDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'a' ? { ...entry, startMs: 30_000 } : entry
+    );
+
+    const next = splitClipAt(doc, 'v', 5000);
+
+    expect(next.clips).toHaveLength(2);
+    expect(byId(next.doc, 'a').startMs).toBe(30_000);
+  });
+
+  it('partitions clip-local caption words at the cut', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            caption: {
+              words: [
+                { word: 'one', startMs: 0, endMs: 500 },
+                { word: 'two', startMs: 2500, endMs: 3000 },
+              ],
+            },
+          }
+        : entry
+    );
+
+    const [left, right] = splitClipAt(doc, 'c1', 3000).clips;
+
+    expect(left.caption?.words).toEqual([{ word: 'one', startMs: 0, endMs: 500 }]);
+    // Rebased to the right half's own start.
+    expect(right.caption?.words).toEqual([{ word: 'two', startMs: 500, endMs: 1000 }]);
+  });
+
+  it('partitions animations by role and refreshes the right-hand ids', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            animations: [
+              { id: 'in-1', role: 'in' as const, preset: 'fade', durationMs: 300 },
+              { id: 'out-1', role: 'out' as const, preset: 'fade', durationMs: 300 },
+            ],
+          }
+        : entry
+    );
+
+    const [left, right] = splitClipAt(doc, 'c1', 3000).clips;
+
+    expect(left.animations?.map((a) => a.role)).toEqual(['in']);
+    expect(right.animations?.map((a) => a.role)).toEqual(['out']);
+    expect(right.animations?.[0].id).not.toBe('out-1');
+  });
+
+  it('refuses to split a clip a transcript line owns, naming the line', () => {
+    const doc: TimelineDocument = {
+      ...baseDoc(),
+      transcript: [
+        { id: 'line-1', text: 'And then we cut away.', beatStartMs: 0, clipIds: ['c1'] },
+      ],
+    };
+
+    expect(() => splitClipAt(doc, 'c1', 3000)).toThrow(
+      /Cannot split clip c1: transcript line "And then we cut away\." \(line-1\) owns it/
+    );
+  });
+
+  it('refuses when a link sibling of the target is transcribed', () => {
+    const doc: TimelineDocument = {
+      ...linkedDoc(),
+      transcript: [
+        { id: 'line-1', text: 'Spoken line.', beatStartMs: 0, clipIds: ['a'] },
+      ],
+    };
+
+    expect(() => splitClipAt(doc, 'v', 5000)).toThrow(/Cannot split clip a/);
+  });
+});
+
+describe('deleteClip', () => {
+  it('removes the clip', () => {
+    const next = deleteClip(baseDoc(), 'Opening shot');
+
+    expect(next.deleted.id).toBe('c1');
+    expect(next.doc.clips.map((entry) => entry.id)).toEqual(['c2']);
+  });
+
+  it('unlinks the survivor when the group drops below two members', () => {
+    const next = deleteClip(linkedDoc(), 'v');
+
+    expect(byId(next.doc, 'a').linkId).toBeUndefined();
+  });
+
+  it('keeps the link when two members remain', () => {
+    const doc = linkedDoc();
+    doc.clips = [...doc.clips, clip({ id: 'a2', trackId: 't2', linkId: 'L' })];
+
+    const next = deleteClip(doc, 'v');
+
+    expect(byId(next.doc, 'a').linkId).toBe('L');
+    expect(byId(next.doc, 'a2').linkId).toBe('L');
+  });
+
+  it('refuses to delete a clip a transcript line owns', () => {
+    const doc: TimelineDocument = {
+      ...baseDoc(),
+      transcript: [
+        { id: 'line-1', text: 'Spoken line.', beatStartMs: 0, clipIds: ['c1'] },
+      ],
+    };
+
+    expect(() => deleteClip(doc, 'c1')).toThrow(/Cannot delete clip c1/);
+    expect(doc.clips).toHaveLength(2);
+  });
+
+  it('resolves "selected"', () => {
+    const next = deleteClip(baseDoc(), 'selected', ['c2']);
+
+    expect(next.deleted.id).toBe('c2');
+  });
+
+  it('refuses "selected" when nothing is selected', () => {
+    expect(() => deleteClip(baseDoc(), 'selected', [])).toThrow(
+      /No clip is selected/
+    );
+  });
+});
+
+describe('duplicateClip', () => {
+  it('places the copy after the source and resets derived state', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            status: 'generated' as const,
+            currentAssetId: 'asset-1',
+            lastGeneratedHash: 'hash-1',
+            locked: true,
+            versions: [makeClipVersion({ assetId: 'asset-1' })],
+            prompt: 'a fox in snow',
+          }
+        : entry
+    );
+
+    const [copy] = duplicateClip(doc, 'c1', 250).clips;
+
+    expect(copy.startMs).toBe(5250);
+    expect(copy.status).toBe('draft');
+    expect(copy.currentAssetId).toBeUndefined();
+    expect(copy.lastGeneratedHash).toBeUndefined();
+    expect(copy.versions).toEqual([]);
+    expect(copy.locked).toBe(false);
+    // The binding survives, so the copy can be tweaked into a variation.
+    expect(copy.prompt).toBe('a fox in snow');
+    expect(copy.id).not.toBe('c1');
+  });
+
+  it('gives a lone copy no link id', () => {
+    const [copy] = duplicateClip(baseDoc(), 'c1').clips;
+
+    expect(copy.linkId).toBeUndefined();
+  });
+
+  it('duplicates a whole link group under one fresh shared link id', () => {
+    const next = duplicateClip(linkedDoc(), 'v');
+
+    expect(next.clips).toHaveLength(2);
+    const [first, second] = next.clips;
+    expect(first.linkId).toBe(second.linkId);
+    expect(first.linkId).not.toBe('L');
+    // Both shift by the primary's offset, so the group stays aligned.
+    expect(first.startMs).toBe(8000);
+    expect(second.startMs).toBe(8000);
+  });
+
+  it('gives the copy fresh animation ids', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            animations: [
+              { id: 'in-1', role: 'in' as const, preset: 'fade', durationMs: 300 },
+            ],
+          }
+        : entry
+    );
+
+    const [copy] = duplicateClip(doc, 'c1').clips;
+
+    expect(copy.animations?.[0].id).not.toBe('in-1');
+  });
+});
+
+describe('setClipParams', () => {
+  it('writes only the fields the patch names', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1' ? { ...entry, prompt: 'keep me' } : entry
+    );
+
+    const next = setClipParams(doc, 'c1', { name: 'Renamed' });
+
+    expect(next.clip).toMatchObject({ name: 'Renamed', prompt: 'keep me' });
+  });
+
+  it('clamps opacity and speed to their ranges', () => {
+    const next = setClipParams(baseDoc(), 'c1', {
+      opacity: 4,
+      speedMultiplier: 100,
+      fadeInMs: -5,
+    });
+
+    expect(next.clip).toMatchObject({
+      opacity: 1,
+      speedMultiplier: 8,
+      fadeInMs: 0,
+    });
+  });
+
+  it('marks a generated clip stale when a binding field changes', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? {
+            ...entry,
+            status: 'generated' as const,
+            currentAssetId: 'asset-1',
+            prompt: 'old prompt',
+          }
+        : entry
+    );
+
+    const next = setClipParams(doc, 'c1', { prompt: 'new prompt' });
+
+    expect(next.clip).toMatchObject({ prompt: 'new prompt', status: 'stale' });
+  });
+
+  it('marks stale on a lastGeneratedHash alone', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? { ...entry, status: 'failed' as const, lastGeneratedHash: 'hash-1' }
+        : entry
+    );
+
+    expect(setClipParams(doc, 'c1', { model: 'flux' }).clip.status).toBe('stale');
+  });
+
+  it('leaves a never-generated clip a draft', () => {
+    const next = setClipParams(baseDoc(), 'c1', { prompt: 'first prompt' });
+
+    expect(next.clip.status).toBe('draft');
+  });
+
+  it('does not mark stale for a non-binding change', () => {
+    const doc = baseDoc();
+    doc.clips = doc.clips.map((entry) =>
+      entry.id === 'c1'
+        ? { ...entry, status: 'generated' as const, currentAssetId: 'asset-1' }
+        : entry
+    );
+
+    expect(setClipParams(doc, 'c1', { muted: true }).clip.status).toBe('generated');
+  });
+
+  it('refuses a binding field on an imported clip', () => {
+    expect(() => setClipParams(baseDoc(), 'Theme', { prompt: 'nope' })).toThrow(
+      /is imported and has no generation binding/
+    );
+  });
+
+  it('refuses textStyle on a non-text clip and shapeStyle on a non-shape clip', () => {
+    expect(() =>
+      setClipParams(baseDoc(), 'c1', {
+        textStyle: { text: 'hi', fontSizePx: 40, color: '#fff' },
+      })
+    ).toThrow(/textStyle applies only to text clips/);
+
+    expect(() =>
+      setClipParams(baseDoc(), 'c1', { shapeStyle: { kind: 'rect' } })
+    ).toThrow(/shapeStyle applies only to shape clips/);
+  });
+
+  it('fills a shape style default when patching a shape clip', () => {
+    const doc = baseDoc();
+    doc.clips = [
+      ...doc.clips,
+      clip({ id: 's1', trackId: 't3', name: 'Box', mediaType: 'shape' }),
+    ];
+
+    const next = setClipParams(doc, 's1', { shapeStyle: { kind: 'rect' } });
+
+    expect(next.clip.shapeStyle).toEqual({ kind: 'rect', fill: '#FFFFFF' });
+  });
+});
+
+describe('markers', () => {
+  it('adds a marker with an id', () => {
+    const next = addMarker(baseDoc(), { timeMs: 4500, label: 'Beat' });
+
+    expect(next.marker).toMatchObject({ timeMs: 4500, label: 'Beat' });
+    expect(next.marker.id).toBeTruthy();
+    expect(next.doc.markers).toHaveLength(2);
+  });
+
+  it('refuses a marker before zero', () => {
+    expect(() => addMarker(baseDoc(), { timeMs: -1 })).toThrow(/before zero/);
+  });
+
+  it('deletes by id or by case-insensitive label', () => {
+    expect(deleteMarker(baseDoc(), 'm1').doc.markers).toEqual([]);
+    expect(deleteMarker(baseDoc(), 'cut').deleted.id).toBe('m1');
+  });
+
+  it('names the markers that exist when the target misses', () => {
+    expect(() => deleteMarker(baseDoc(), 'nope')).toThrow(
+      /No marker matches "nope".*m1 \("Cut"\)/s
+    );
+  });
+});

--- a/mobile/src/documents/__tests__/uiContext.test.ts
+++ b/mobile/src/documents/__tests__/uiContext.test.ts
@@ -25,9 +25,18 @@ describe('buildUiContext', () => {
     ]);
   });
 
-  it('omits kinds with no ui_* tools rather than advertising unusable ids', () => {
+  // Every current kind maps to a surface, so this guard only fires if a kind is
+  // added without one. Exercised through a cast, because a well-typed caller
+  // cannot reach it — and an unmapped kind must be dropped rather than handed to
+  // the agent as an id it has no tool for.
+  it('omits a kind with no ui_* surface rather than advertising an unusable id', () => {
     registerDocumentHandler('storyboard', 'sb1', 'Board', {});
-    registerDocumentHandler('asset', 'asset1', 'photo.png', {});
+    registerDocumentHandler(
+      'unmapped' as Parameters<typeof registerDocumentHandler>[0],
+      'x1',
+      'Mystery',
+      {}
+    );
 
     const open = buildUiContext()?.open;
 
@@ -35,10 +44,12 @@ describe('buildUiContext', () => {
     expect(open?.[0].id).toBe('sb1');
   });
 
-  it('is undefined when the only open document has no tools', () => {
-    registerDocumentHandler('asset', 'asset1', 'photo.png', {});
+  it('lists scripts, which are addressable by the agent', () => {
+    registerDocumentHandler('script', 'sc1', 'Pilot', {});
 
-    expect(buildUiContext()).toBeUndefined();
+    expect(buildUiContext()?.open).toEqual([
+      { type: 'script', id: 'sc1', title: 'Pilot' },
+    ]);
   });
 
   it('reports the focused document', () => {

--- a/mobile/src/documents/__tests__/uiContext.test.ts
+++ b/mobile/src/documents/__tests__/uiContext.test.ts
@@ -1,0 +1,87 @@
+import {
+  registerDocumentHandler,
+  resetDocumentHandlers,
+  setFocusedDocument,
+} from '../agentBridge';
+import { buildUiContext, clearUiSelection, setUiSelection } from '../uiContext';
+
+describe('buildUiContext', () => {
+  beforeEach(() => {
+    resetDocumentHandlers();
+    clearUiSelection();
+  });
+
+  it('is undefined when nothing is open, so the field is omitted from the turn', () => {
+    expect(buildUiContext()).toBeUndefined();
+  });
+
+  it('lists open documents with their protocol surface type', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Chase scene', {});
+    registerDocumentHandler('timeline', 'seq1', 'Cut 3', {});
+
+    expect(buildUiContext()?.open).toEqual([
+      { type: 'storyboard', id: 'sb1', title: 'Chase scene' },
+      { type: 'timeline', id: 'seq1', title: 'Cut 3' },
+    ]);
+  });
+
+  it('omits kinds with no ui_* tools rather than advertising unusable ids', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {});
+    registerDocumentHandler('asset', 'asset1', 'photo.png', {});
+
+    const open = buildUiContext()?.open;
+
+    expect(open).toHaveLength(1);
+    expect(open?.[0].id).toBe('sb1');
+  });
+
+  it('is undefined when the only open document has no tools', () => {
+    registerDocumentHandler('asset', 'asset1', 'photo.png', {});
+
+    expect(buildUiContext()).toBeUndefined();
+  });
+
+  it('reports the focused document', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {});
+    registerDocumentHandler('timeline', 'seq1', 'Seq', {});
+    setFocusedDocument('timeline', 'seq1');
+
+    expect(buildUiContext()?.focused).toEqual({
+      type: 'timeline',
+      id: 'seq1',
+      title: 'Seq',
+    });
+  });
+
+  it('reports a null focus when no screen claims it', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {});
+
+    expect(buildUiContext()?.focused).toBeNull();
+  });
+
+  it('carries the published selection', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {});
+    setUiSelection({ shotIds: ['shot-2'] });
+
+    expect(buildUiContext()?.selection).toEqual({
+      clip_ids: null,
+      shot_ids: ['shot-2'],
+      layer_ids: null,
+    });
+  });
+
+  it('sends a null selection rather than empty arrays', () => {
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {});
+    setUiSelection({ shotIds: [] });
+
+    expect(buildUiContext()?.selection).toBeNull();
+  });
+
+  it('drops the selection once cleared', () => {
+    registerDocumentHandler('timeline', 'seq1', 'Seq', {});
+    setUiSelection({ clipIds: ['clip-1'] });
+    clearUiSelection();
+
+    expect(buildUiContext()?.selection).toBeNull();
+  });
+});

--- a/mobile/src/documents/agentBridge.ts
+++ b/mobile/src/documents/agentBridge.ts
@@ -1,0 +1,142 @@
+/**
+ * The bridge between the `ui_*` tool layer and whatever document screen is
+ * currently mounted.
+ *
+ * Ported from web's per-surface bridges (`storyboardAgentBridge`,
+ * `timelineAgentBridge`), which key handlers by document id and never consult
+ * focus. That design ports unchanged: a mounted screen registers a handler
+ * under its kind + id and clears it on unmount, so a tool addresses a document
+ * explicitly and fails with a useful message when it is not open.
+ *
+ * The one mobile difference is `focused`. Web derives it from the active tab;
+ * with a native stack the screen the user is looking at is the top of the
+ * stack, so screens report focus via `useFocusEffect` and we track the latest.
+ *
+ * Everything crossing this bridge is a plain serializable value — the tools
+ * never touch a Zustand handle.
+ */
+
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+/** Identity of a document the agent can address. */
+export interface OpenDocument {
+  kind: ResourceKind;
+  id: string;
+  title: string;
+}
+
+/** Marker every per-kind handler interface extends. */
+export type DocumentAgentHandler = object;
+
+interface Entry {
+  kind: ResourceKind;
+  id: string;
+  title: string;
+  handler: DocumentAgentHandler;
+}
+
+const key = (kind: ResourceKind, id: string): string => `${kind}:${id}`;
+
+/** Insertion-ordered, so `listOpenDocuments` reflects open order. */
+const entries = new Map<string, Entry>();
+
+/**
+ * Which document the user is looking at, held as a key rather than a resolved
+ * entry and validated on read.
+ *
+ * A screen re-registers its handler whenever the snapshot it closes over
+ * changes, which is an unregister/register pair. If unregistering cleared focus,
+ * that churn would silently drop the focus hint and never restore it — the
+ * screen only claims focus on navigation, not on every repaint. Validating on
+ * read instead makes focus survive re-registration and still go quiet the moment
+ * the document actually closes.
+ */
+let focusedKey: string | null = null;
+
+/**
+ * Register the handler for one mounted document. Returns the unregister
+ * function, so a screen can hand it straight to a `useEffect` cleanup.
+ */
+export function registerDocumentHandler(
+  kind: ResourceKind,
+  id: string,
+  title: string,
+  handler: DocumentAgentHandler
+): () => void {
+  const k = key(kind, id);
+  entries.set(k, { kind, id, title, handler });
+  return () => {
+    entries.delete(k);
+  };
+}
+
+/** Update the title the agent sees without re-registering the handler. */
+export function setDocumentTitle(
+  kind: ResourceKind,
+  id: string,
+  title: string
+): void {
+  const entry = entries.get(key(kind, id));
+  if (entry) {
+    entry.title = title;
+  }
+}
+
+/** Mark a document as the one the user is looking at (or clear with null). */
+export function setFocusedDocument(
+  kind: ResourceKind | null,
+  id?: string
+): void {
+  focusedKey = kind && id ? key(kind, id) : null;
+}
+
+export function hasDocumentHandler(kind: ResourceKind, id: string): boolean {
+  return entries.has(key(kind, id));
+}
+
+export function listOpenDocuments(): OpenDocument[] {
+  return [...entries.values()].map(({ kind, id, title }) => ({
+    kind,
+    id,
+    title,
+  }));
+}
+
+export function focusedDocument(): OpenDocument | null {
+  if (!focusedKey) {
+    return null;
+  }
+  // A focus claim for a document that has since closed is stale, not focus.
+  const entry = entries.get(focusedKey);
+  return entry ? { kind: entry.kind, id: entry.id, title: entry.title } : null;
+}
+
+/**
+ * Resolve the handler for a document, or throw naming the ids that *are* open.
+ * The tool layer surfaces that message to the agent verbatim, which is what
+ * lets it recover by calling the right id instead of guessing again.
+ */
+export function getDocumentHandler<T extends DocumentAgentHandler>(
+  kind: ResourceKind,
+  id: string
+): T {
+  const entry = entries.get(key(kind, id));
+  if (!entry) {
+    const open = listOpenDocuments()
+      .filter((doc) => doc.kind === kind)
+      .map((doc) => doc.id);
+    throw new Error(
+      `No ${kind} "${id}" is open. ` +
+        (open.length > 0
+          ? `Open ${kind} ids: ${open.join(', ')}.`
+          : `No ${kind} documents are currently open. Ask the user to open one.`)
+    );
+  }
+  return entry.handler as T;
+}
+
+/** Test seam: drop all registrations. */
+export function resetDocumentHandlers(): void {
+  entries.clear();
+  focusedKey = null;
+}

--- a/mobile/src/documents/agentBridge.ts
+++ b/mobile/src/documents/agentBridge.ts
@@ -16,11 +16,11 @@
  * never touch a Zustand handle.
  */
 
-import type { ResourceKind } from '@nodetool-ai/app-runtime';
+import type { DocumentKind } from './kinds';
 
 /** Identity of a document the agent can address. */
 export interface OpenDocument {
-  kind: ResourceKind;
+  kind: DocumentKind;
   id: string;
   title: string;
 }
@@ -29,13 +29,13 @@ export interface OpenDocument {
 export type DocumentAgentHandler = object;
 
 interface Entry {
-  kind: ResourceKind;
+  kind: DocumentKind;
   id: string;
   title: string;
   handler: DocumentAgentHandler;
 }
 
-const key = (kind: ResourceKind, id: string): string => `${kind}:${id}`;
+const key = (kind: DocumentKind, id: string): string => `${kind}:${id}`;
 
 /** Insertion-ordered, so `listOpenDocuments` reflects open order. */
 const entries = new Map<string, Entry>();
@@ -58,7 +58,7 @@ let focusedKey: string | null = null;
  * function, so a screen can hand it straight to a `useEffect` cleanup.
  */
 export function registerDocumentHandler(
-  kind: ResourceKind,
+  kind: DocumentKind,
   id: string,
   title: string,
   handler: DocumentAgentHandler
@@ -72,7 +72,7 @@ export function registerDocumentHandler(
 
 /** Update the title the agent sees without re-registering the handler. */
 export function setDocumentTitle(
-  kind: ResourceKind,
+  kind: DocumentKind,
   id: string,
   title: string
 ): void {
@@ -84,13 +84,13 @@ export function setDocumentTitle(
 
 /** Mark a document as the one the user is looking at (or clear with null). */
 export function setFocusedDocument(
-  kind: ResourceKind | null,
+  kind: DocumentKind | null,
   id?: string
 ): void {
   focusedKey = kind && id ? key(kind, id) : null;
 }
 
-export function hasDocumentHandler(kind: ResourceKind, id: string): boolean {
+export function hasDocumentHandler(kind: DocumentKind, id: string): boolean {
   return entries.has(key(kind, id));
 }
 
@@ -117,7 +117,7 @@ export function focusedDocument(): OpenDocument | null {
  * lets it recover by calling the right id instead of guessing again.
  */
 export function getDocumentHandler<T extends DocumentAgentHandler>(
-  kind: ResourceKind,
+  kind: DocumentKind,
   id: string
 ): T {
   const entry = entries.get(key(kind, id));

--- a/mobile/src/documents/backends.ts
+++ b/mobile/src/documents/backends.ts
@@ -1,0 +1,192 @@
+/**
+ * Per-kind transport for reading and writing a document.
+ *
+ * Three of the four kinds ride the `resources.*` envelope, which carries a
+ * numeric `revision` as its concurrency token. Scripts do not: the `scripts`
+ * table has no `revision` column, so the `resources` provider cannot represent
+ * one, and its own router does the same job with `baseUpdatedAt`. Rather than
+ * migrate two schemas to unify the token, the store treats it as **opaque** —
+ * a backend hands one out on read and echoes it back on write, and only the
+ * backend knows whether it is a number or a timestamp.
+ *
+ * Both schemes are optimistic concurrency with the same contract: a write
+ * carrying a stale token is rejected rather than applied.
+ */
+
+import { createMobileTRPCClient } from '../trpc/client';
+import type { DocumentKind, ResourceDocumentKind } from './kinds';
+
+/** What a read or a write resolves to. `token` is only meaningful to the backend. */
+export interface LoadedDocument<Doc = unknown> {
+  doc: Doc;
+  name: string;
+  token: unknown;
+  updatedAt: string | null;
+}
+
+export interface SaveInput<Doc = unknown> {
+  doc: Doc;
+  name: string;
+  /** The token the caller read. A stale one must make the server reject. */
+  token: unknown;
+}
+
+/** One row in the browser's list. */
+export interface DocumentSummary {
+  id: string;
+  name: string;
+  updatedAt: string;
+  /** Kind-specific detail, e.g. "12 lines". Absent when the router has none. */
+  detail?: string;
+}
+
+export interface DocumentBackend<Doc = unknown> {
+  read: (id: string) => Promise<LoadedDocument<Doc>>;
+  save: (id: string, input: SaveInput<Doc>) => Promise<LoadedDocument<Doc>>;
+  list: (limit: number) => Promise<DocumentSummary[]>;
+  create: (name: string) => Promise<DocumentSummary>;
+  rename: (id: string, name: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  /** Whether this kind can be written at all. */
+  writable: boolean;
+}
+
+/** The `resources.*` envelope: token is the row's numeric revision. */
+function resourcesBackend(kind: ResourceDocumentKind): DocumentBackend {
+  return {
+    writable: true,
+    list: async (limit) => {
+      const summaries = await createMobileTRPCClient().resources.list.query({
+        kind,
+        limit,
+      });
+      return summaries.map((summary) => ({
+        id: summary.ref.id,
+        name: summary.name,
+        updatedAt: summary.updatedAt,
+      }));
+    },
+    create: async (name) => {
+      const detail = await createMobileTRPCClient().resources.create.mutate({
+        kind,
+        name,
+        projectId: 'default',
+      });
+      return {
+        id: detail.ref.id,
+        name: detail.name,
+        updatedAt: detail.updatedAt,
+      };
+    },
+    rename: async (id, name) => {
+      // No revision: a rename from the browser has no local body to clobber,
+      // and the list row does not carry one to echo back.
+      await createMobileTRPCClient().resources.update.mutate({
+        ref: { kind, id },
+        name,
+      });
+    },
+    remove: async (id) => {
+      await createMobileTRPCClient().resources.delete.mutate({
+        ref: { kind, id },
+      });
+    },
+    read: async (id) => {
+      const detail = await createMobileTRPCClient().resources.read.query({
+        ref: { kind, id },
+      });
+      return {
+        doc: detail.document,
+        name: detail.name,
+        token: detail.ref.revision,
+        updatedAt: detail.updatedAt,
+      };
+    },
+    save: async (id, { doc, name, token }) => {
+      const detail = await createMobileTRPCClient().resources.update.mutate({
+        ref: {
+          kind,
+          id,
+          revision: typeof token === 'number' ? token : undefined,
+        },
+        name,
+        document: doc,
+      });
+      return {
+        doc: detail.document,
+        name: detail.name,
+        token: detail.ref.revision,
+        updatedAt: detail.updatedAt,
+      };
+    },
+  };
+}
+
+/** The `scripts.*` router: token is `updated_at`, sent back as `baseUpdatedAt`. */
+function scriptsBackend(): DocumentBackend {
+  return {
+    writable: true,
+    list: async () => {
+      const scripts = await createMobileTRPCClient().scripts.list.query({});
+      return scripts.map((script) => ({
+        id: script.id,
+        name: script.name,
+        updatedAt: script.updatedAt,
+        detail: `${script.lineCount} ${script.lineCount === 1 ? 'line' : 'lines'}`,
+      }));
+    },
+    create: async (name) => {
+      const script = await createMobileTRPCClient().scripts.create.mutate({
+        name,
+        projectId: 'default',
+      });
+      return {
+        id: script.id,
+        name: script.name,
+        updatedAt: script.updatedAt,
+      };
+    },
+    rename: async (id, name) => {
+      await createMobileTRPCClient().scripts.update.mutate({ id, name });
+    },
+    remove: async (id) => {
+      await createMobileTRPCClient().scripts.delete.mutate({ id });
+    },
+    read: async (id) => {
+      const script = await createMobileTRPCClient().scripts.get.query({ id });
+      return {
+        doc: script.document,
+        name: script.name,
+        token: script.updatedAt,
+        updatedAt: script.updatedAt,
+      };
+    },
+    save: async (id, { doc, name, token }) => {
+      const script = await createMobileTRPCClient().scripts.update.mutate({
+        id,
+        name,
+        document: doc as Parameters<
+          ReturnType<typeof createMobileTRPCClient>['scripts']['update']['mutate']
+        >[0]['document'],
+        baseUpdatedAt: typeof token === 'string' ? token : undefined,
+      });
+      return {
+        doc: script.document,
+        name: script.name,
+        token: script.updatedAt,
+        updatedAt: script.updatedAt,
+      };
+    },
+  };
+}
+
+const backends: Record<DocumentKind, DocumentBackend> = {
+  timeline: resourcesBackend('timeline'),
+  storyboard: resourcesBackend('storyboard'),
+  sketch: resourcesBackend('sketch'),
+  script: scriptsBackend(),
+};
+
+export function documentBackend<Doc>(kind: DocumentKind): DocumentBackend<Doc> {
+  return backends[kind] as DocumentBackend<Doc>;
+}

--- a/mobile/src/documents/documentStore.ts
+++ b/mobile/src/documents/documentStore.ts
@@ -1,0 +1,208 @@
+/**
+ * Per-document store: load, local edits, dirty tracking, and revision-checked
+ * save.
+ *
+ * One store instance per open document, cached by kind + id and created on
+ * demand — the same factory-in-a-Map shape `WorkflowRunner` already uses. That
+ * matters here because the agent tools run outside React: they mutate the same
+ * store the screen renders from, so an agent edit repaints immediately, and a
+ * save triggered from a tool is the same code path as the user's Save button.
+ *
+ * Saving goes through the vanilla tRPC client rather than a mutation hook, for
+ * the same reason. `resources.update` carries the revision we read; the server
+ * rejects a stale write instead of applying it, which surfaces here as
+ * `status: 'conflict'` for the screen to offer a reload.
+ */
+
+import { create, type StoreApi, type UseBoundStore } from 'zustand';
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+import { createMobileTRPCClient } from '../trpc/client';
+
+export type DocumentStatus =
+  | 'idle'
+  | 'loading'
+  | 'saving'
+  | 'conflict'
+  | 'error';
+
+export interface DocumentState<Doc> {
+  kind: ResourceKind;
+  id: string;
+  /** The document body. Null until the first load resolves. */
+  doc: Doc | null;
+  name: string;
+  /** Revision echoed back on write; absent for kinds without one (assets). */
+  revision: number | undefined;
+  updatedAt: string | null;
+  dirty: boolean;
+  status: DocumentStatus;
+  error: string | null;
+
+  /** Fetch from the server, replacing any local state. */
+  load: () => Promise<void>;
+  /** Apply a local edit. Marks the document dirty; does not save. */
+  edit: (mutate: (doc: Doc) => Doc) => void;
+  /** Rename locally. Marks dirty. */
+  rename: (name: string) => void;
+  /** Persist the current body. No-op when clean. */
+  save: () => Promise<void>;
+  /** Discard local edits and re-read from the server. */
+  revert: () => Promise<void>;
+}
+
+type DocumentStore<Doc> = UseBoundStore<StoreApi<DocumentState<Doc>>>;
+
+const stores = new Map<string, DocumentStore<unknown>>();
+
+const storeKey = (kind: ResourceKind, id: string): string => `${kind}:${id}`;
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'Unknown error';
+
+/**
+ * A stale-write rejection comes back as the `ALREADY_EXISTS` code the resources
+ * router raises for an optimistic-concurrency conflict. Detecting it lets the
+ * screen offer "reload" instead of showing a generic failure the user can only
+ * retry into the same wall.
+ */
+const isConflict = (error: unknown): boolean => {
+  const message = errorMessage(error).toLowerCase();
+  return (
+    message.includes('optimistic concurrency') ||
+    message.includes('modified since')
+  );
+};
+
+function createDocumentStore<Doc>(
+  kind: ResourceKind,
+  id: string
+): DocumentStore<Doc> {
+  /**
+   * The write currently on the wire, if any.
+   *
+   * Saves must not overlap. The user's Save button and the agent's
+   * `ui_*_save` both land here, and two concurrent writes would carry the same
+   * revision — the server commits the first and rejects the second as a
+   * conflict, which would surface to the user as "someone else changed this"
+   * for two edits they made themselves.
+   */
+  let inFlight: Promise<void> | null = null;
+
+  return create<DocumentState<Doc>>((set, get) => ({
+    kind,
+    id,
+    doc: null,
+    name: '',
+    revision: undefined,
+    updatedAt: null,
+    dirty: false,
+    status: 'idle',
+    error: null,
+
+    load: async () => {
+      set({ status: 'loading', error: null });
+      try {
+        const detail = await createMobileTRPCClient().resources.read.query({
+          ref: { kind, id },
+        });
+        set({
+          doc: detail.document as Doc,
+          name: detail.name,
+          revision: detail.ref.revision,
+          updatedAt: detail.updatedAt,
+          dirty: false,
+          status: 'idle',
+          error: null,
+        });
+      } catch (error) {
+        set({ status: 'error', error: errorMessage(error) });
+      }
+    },
+
+    edit: (mutate) => {
+      const current = get().doc;
+      if (current === null) {
+        return;
+      }
+      set({ doc: mutate(current), dirty: true });
+    },
+
+    rename: (name) => set({ name, dirty: true }),
+
+    save: async () => {
+      // Wait out any write already on the wire, then re-check: the earlier save
+      // may well have persisted what this call was going to send.
+      while (inFlight) {
+        await inFlight;
+      }
+      const { doc, name, revision, dirty } = get();
+      if (doc === null || !dirty) {
+        return;
+      }
+
+      set({ status: 'saving', error: null });
+      const write = (async () => {
+        try {
+          const detail = await createMobileTRPCClient().resources.update.mutate({
+            ref: { kind, id, revision },
+            name,
+            document: doc,
+          });
+          const after = get();
+          // Only call the document clean if nothing changed while the write was
+          // in flight. An agent edit landing mid-save would otherwise be marked
+          // saved, disabling the Save button and losing the edit on reload.
+          const settled = after.doc === doc && after.name === name;
+          set({
+            // Adopt the server's revision either way, so the follow-up save is
+            // checked against the row we just wrote.
+            revision: detail.ref.revision,
+            updatedAt: detail.updatedAt,
+            status: 'idle',
+            ...(settled ? { name: detail.name, dirty: false } : {}),
+          });
+        } catch (error) {
+          set({
+            status: isConflict(error) ? 'conflict' : 'error',
+            error: errorMessage(error),
+          });
+        }
+      })();
+
+      inFlight = write.finally(() => {
+        inFlight = null;
+      });
+      await inFlight;
+    },
+
+    revert: async () => {
+      await get().load();
+    },
+  }));
+}
+
+/** The store for one document, created on first use and reused after. */
+export function documentStore<Doc>(
+  kind: ResourceKind,
+  id: string
+): DocumentStore<Doc> {
+  const key = storeKey(kind, id);
+  const existing = stores.get(key);
+  if (existing) {
+    return existing as DocumentStore<Doc>;
+  }
+  const created = createDocumentStore<Doc>(kind, id);
+  stores.set(key, created as DocumentStore<unknown>);
+  return created;
+}
+
+/** Drop a cached store — call when a document is deleted. */
+export function disposeDocumentStore(kind: ResourceKind, id: string): void {
+  stores.delete(storeKey(kind, id));
+}
+
+/** Test seam. */
+export function resetDocumentStores(): void {
+  stores.clear();
+}

--- a/mobile/src/documents/documentStore.ts
+++ b/mobile/src/documents/documentStore.ts
@@ -1,5 +1,5 @@
 /**
- * Per-document store: load, local edits, dirty tracking, and revision-checked
+ * Per-document store: load, local edits, dirty tracking, and concurrency-checked
  * save.
  *
  * One store instance per open document, cached by kind + id and created on
@@ -8,16 +8,17 @@
  * store the screen renders from, so an agent edit repaints immediately, and a
  * save triggered from a tool is the same code path as the user's Save button.
  *
- * Saving goes through the vanilla tRPC client rather than a mutation hook, for
- * the same reason. `resources.update` carries the revision we read; the server
- * rejects a stale write instead of applying it, which surfaces here as
+ * Transport is a per-kind backend (`backends.ts`) rather than a mutation hook,
+ * for the same reason. Every write echoes back the concurrency token it read —
+ * a revision for the `resources` kinds, `baseUpdatedAt` for scripts — and the
+ * server rejects a stale write instead of applying it, which surfaces here as
  * `status: 'conflict'` for the screen to offer a reload.
  */
 
 import { create, type StoreApi, type UseBoundStore } from 'zustand';
-import type { ResourceKind } from '@nodetool-ai/app-runtime';
 
-import { createMobileTRPCClient } from '../trpc/client';
+import { documentBackend } from './backends';
+import type { DocumentKind } from './kinds';
 
 export type DocumentStatus =
   | 'idle'
@@ -27,13 +28,16 @@ export type DocumentStatus =
   | 'error';
 
 export interface DocumentState<Doc> {
-  kind: ResourceKind;
+  kind: DocumentKind;
   id: string;
   /** The document body. Null until the first load resolves. */
   doc: Doc | null;
   name: string;
-  /** Revision echoed back on write; absent for kinds without one (assets). */
-  revision: number | undefined;
+  /**
+   * The concurrency token from the last read or write, echoed back on the next
+   * write. Opaque here: only the kind's backend knows its shape.
+   */
+  token: unknown;
   updatedAt: string | null;
   dirty: boolean;
   status: DocumentStatus;
@@ -55,37 +59,39 @@ type DocumentStore<Doc> = UseBoundStore<StoreApi<DocumentState<Doc>>>;
 
 const stores = new Map<string, DocumentStore<unknown>>();
 
-const storeKey = (kind: ResourceKind, id: string): string => `${kind}:${id}`;
+const storeKey = (kind: DocumentKind, id: string): string => `${kind}:${id}`;
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : 'Unknown error';
 
 /**
- * A stale-write rejection comes back as the `ALREADY_EXISTS` code the resources
- * router raises for an optimistic-concurrency conflict. Detecting it lets the
- * screen offer "reload" instead of showing a generic failure the user can only
- * retry into the same wall.
+ * A stale-write rejection. Both routers raise `ALREADY_EXISTS` with a message
+ * naming the conflict; matching it lets the screen offer "reload" instead of a
+ * generic failure the user can only retry into the same wall.
  */
 const isConflict = (error: unknown): boolean => {
   const message = errorMessage(error).toLowerCase();
   return (
     message.includes('optimistic concurrency') ||
-    message.includes('modified since')
+    message.includes('modified since') ||
+    message.includes('modified concurrently')
   );
 };
 
 function createDocumentStore<Doc>(
-  kind: ResourceKind,
+  kind: DocumentKind,
   id: string
 ): DocumentStore<Doc> {
+  const backend = documentBackend<Doc>(kind);
+
   /**
    * The write currently on the wire, if any.
    *
    * Saves must not overlap. The user's Save button and the agent's
    * `ui_*_save` both land here, and two concurrent writes would carry the same
-   * revision — the server commits the first and rejects the second as a
-   * conflict, which would surface to the user as "someone else changed this"
-   * for two edits they made themselves.
+   * token — the server commits the first and rejects the second as a conflict,
+   * which would surface to the user as "someone else changed this" for two
+   * edits they made themselves.
    */
   let inFlight: Promise<void> | null = null;
 
@@ -94,7 +100,7 @@ function createDocumentStore<Doc>(
     id,
     doc: null,
     name: '',
-    revision: undefined,
+    token: undefined,
     updatedAt: null,
     dirty: false,
     status: 'idle',
@@ -103,14 +109,12 @@ function createDocumentStore<Doc>(
     load: async () => {
       set({ status: 'loading', error: null });
       try {
-        const detail = await createMobileTRPCClient().resources.read.query({
-          ref: { kind, id },
-        });
+        const loaded = await backend.read(id);
         set({
-          doc: detail.document as Doc,
-          name: detail.name,
-          revision: detail.ref.revision,
-          updatedAt: detail.updatedAt,
+          doc: loaded.doc,
+          name: loaded.name,
+          token: loaded.token,
+          updatedAt: loaded.updatedAt,
           dirty: false,
           status: 'idle',
           error: null,
@@ -136,31 +140,30 @@ function createDocumentStore<Doc>(
       while (inFlight) {
         await inFlight;
       }
-      const { doc, name, revision, dirty } = get();
+      const { doc, name, token, dirty } = get();
       if (doc === null || !dirty) {
         return;
+      }
+      if (!backend.writable) {
+        throw new Error(`${kind} documents are read-only`);
       }
 
       set({ status: 'saving', error: null });
       const write = (async () => {
         try {
-          const detail = await createMobileTRPCClient().resources.update.mutate({
-            ref: { kind, id, revision },
-            name,
-            document: doc,
-          });
+          const saved = await backend.save(id, { doc, name, token });
           const after = get();
           // Only call the document clean if nothing changed while the write was
           // in flight. An agent edit landing mid-save would otherwise be marked
           // saved, disabling the Save button and losing the edit on reload.
           const settled = after.doc === doc && after.name === name;
           set({
-            // Adopt the server's revision either way, so the follow-up save is
+            // Adopt the server's token either way, so the follow-up save is
             // checked against the row we just wrote.
-            revision: detail.ref.revision,
-            updatedAt: detail.updatedAt,
+            token: saved.token,
+            updatedAt: saved.updatedAt,
             status: 'idle',
-            ...(settled ? { name: detail.name, dirty: false } : {}),
+            ...(settled ? { name: saved.name, dirty: false } : {}),
           });
         } catch (error) {
           set({
@@ -184,7 +187,7 @@ function createDocumentStore<Doc>(
 
 /** The store for one document, created on first use and reused after. */
 export function documentStore<Doc>(
-  kind: ResourceKind,
+  kind: DocumentKind,
   id: string
 ): DocumentStore<Doc> {
   const key = storeKey(kind, id);
@@ -198,7 +201,7 @@ export function documentStore<Doc>(
 }
 
 /** Drop a cached store — call when a document is deleted. */
-export function disposeDocumentStore(kind: ResourceKind, id: string): void {
+export function disposeDocumentStore(kind: DocumentKind, id: string): void {
   stores.delete(storeKey(kind, id));
 }
 

--- a/mobile/src/documents/kinds.ts
+++ b/mobile/src/documents/kinds.ts
@@ -1,0 +1,94 @@
+/**
+ * The document kinds mobile can open, and how each one is presented.
+ *
+ * Web keys this off `WorkspaceTabType` because every document lives in a tab.
+ * Mobile has no tabs: a document is a pushed screen, so the registry only has
+ * to answer three questions — what to call the kind, which icon to draw, and
+ * which screen to push. The kind ids themselves are the server's
+ * `ResourceKind`, so `trpc.resources.*` can address any of them.
+ */
+
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+/**
+ * Whether the surface can write the document back. `viewer` kinds are opened
+ * read-only — the timeline is far too dense to edit on a phone, and an asset
+ * is not a document at all.
+ */
+export type DocumentSurface = 'editor' | 'viewer';
+
+export interface DocumentKindInfo {
+  kind: ResourceKind;
+  /** Singular label, e.g. "Storyboard". */
+  label: string;
+  /** Plural label for section headers, e.g. "Storyboards". */
+  plural: string;
+  /** Ionicons name (outline variant, per mobile convention). */
+  icon: string;
+  surface: DocumentSurface;
+  /** Route pushed to open one. */
+  route: 'StoryboardEditor' | 'TimelineViewer' | 'DocumentViewer';
+  /** Whether the browser offers a "new document" action for this kind. */
+  creatable: boolean;
+}
+
+export const DOCUMENT_KINDS: readonly DocumentKindInfo[] = [
+  {
+    kind: 'storyboard',
+    label: 'Storyboard',
+    plural: 'Storyboards',
+    icon: 'albums-outline',
+    surface: 'editor',
+    route: 'StoryboardEditor',
+    creatable: true,
+  },
+  {
+    kind: 'timeline',
+    label: 'Timeline',
+    plural: 'Timelines',
+    icon: 'film-outline',
+    surface: 'viewer',
+    route: 'TimelineViewer',
+    creatable: false,
+  },
+  {
+    kind: 'sketch',
+    label: 'Sketch',
+    plural: 'Sketches',
+    icon: 'brush-outline',
+    surface: 'viewer',
+    route: 'DocumentViewer',
+    creatable: false,
+  },
+] as const;
+
+const BY_KIND = new Map<string, DocumentKindInfo>(
+  DOCUMENT_KINDS.map((entry) => [entry.kind, entry])
+);
+
+export function documentKindInfo(kind: ResourceKind): DocumentKindInfo {
+  const info = BY_KIND.get(kind);
+  if (!info) {
+    throw new Error(`Unknown document kind: ${kind}`);
+  }
+  return info;
+}
+
+/**
+ * The agent-facing surface name for a kind. Mirrors web's
+ * `TAB_TYPE_TO_SURFACE` — the ids handed to the agent in `ui_context` must use
+ * the protocol's `UiSurfaceType` spelling, not our route names.
+ */
+export function uiSurfaceForKind(kind: ResourceKind): string | null {
+  switch (kind) {
+    case 'storyboard':
+      return 'storyboard';
+    case 'timeline':
+      return 'timeline';
+    case 'sketch':
+      return 'sketch';
+    default:
+      // An asset has no ui_* tools; naming it would only invite bad calls.
+      return null;
+  }
+}

--- a/mobile/src/documents/kinds.ts
+++ b/mobile/src/documents/kinds.ts
@@ -11,14 +11,31 @@
 import type { ResourceKind } from '@nodetool-ai/app-runtime';
 
 /**
- * Whether the surface can write the document back. `viewer` kinds are opened
- * read-only — the timeline is far too dense to edit on a phone, and an asset
- * is not a document at all.
+ * The kinds mobile opens as documents.
+ *
+ * Not the same set as the server's `ResourceKind`: `asset` is a library entry
+ * with its own screen rather than a document, and `script` is a document the
+ * `resources` envelope cannot carry (its table has no `revision` column), so it
+ * travels over `scripts.*` instead. `backends.ts` maps each kind to its
+ * transport.
+ */
+export type DocumentKind = Exclude<ResourceKind, 'asset'> | 'script';
+
+/** The kinds the `resources.*` envelope can list and write. */
+export type ResourceDocumentKind = Exclude<DocumentKind, 'script'>;
+
+/**
+ * How much the surface lets a person do directly.
+ *
+ * `editor` means direct manipulation is available. `viewer` means the screen
+ * shows the document but does not edit it — the agent still can, through the
+ * `ui_*` tools, which is the point: a timeline is far too dense to arrange with
+ * fingers, but "move the title card two seconds later" is a sentence.
  */
 export type DocumentSurface = 'editor' | 'viewer';
 
 export interface DocumentKindInfo {
-  kind: ResourceKind;
+  kind: DocumentKind;
   /** Singular label, e.g. "Storyboard". */
   label: string;
   /** Plural label for section headers, e.g. "Storyboards". */
@@ -27,9 +44,19 @@ export interface DocumentKindInfo {
   icon: string;
   surface: DocumentSurface;
   /** Route pushed to open one. */
-  route: 'StoryboardEditor' | 'TimelineViewer' | 'DocumentViewer';
+  route:
+    | 'StoryboardEditor'
+    | 'TimelineViewer'
+    | 'ScriptEditor'
+    | 'DocumentViewer';
   /** Whether the browser offers a "new document" action for this kind. */
   creatable: boolean;
+  /**
+   * Whether the agent's `ui_*` tools can write this kind. Independent of
+   * `surface`: the timeline is agent-editable but has no direct-manipulation
+   * editor, which is exactly the split the browser needs to communicate.
+   */
+  agentEditable: boolean;
 }
 
 export const DOCUMENT_KINDS: readonly DocumentKindInfo[] = [
@@ -41,15 +68,29 @@ export const DOCUMENT_KINDS: readonly DocumentKindInfo[] = [
     surface: 'editor',
     route: 'StoryboardEditor',
     creatable: true,
+    agentEditable: true,
+  },
+  {
+    kind: 'script',
+    label: 'Script',
+    plural: 'Scripts',
+    icon: 'document-text-outline',
+    surface: 'editor',
+    route: 'ScriptEditor',
+    creatable: true,
+    agentEditable: true,
   },
   {
     kind: 'timeline',
     label: 'Timeline',
     plural: 'Timelines',
     icon: 'film-outline',
+    // No direct-manipulation editor — arranging clips by touch is not viable at
+    // phone width — but the agent edits it through `ui_timeline_*`.
     surface: 'viewer',
     route: 'TimelineViewer',
     creatable: false,
+    agentEditable: true,
   },
   {
     kind: 'sketch',
@@ -59,6 +100,7 @@ export const DOCUMENT_KINDS: readonly DocumentKindInfo[] = [
     surface: 'viewer',
     route: 'DocumentViewer',
     creatable: false,
+    agentEditable: false,
   },
 ] as const;
 
@@ -66,7 +108,7 @@ const BY_KIND = new Map<string, DocumentKindInfo>(
   DOCUMENT_KINDS.map((entry) => [entry.kind, entry])
 );
 
-export function documentKindInfo(kind: ResourceKind): DocumentKindInfo {
+export function documentKindInfo(kind: DocumentKind): DocumentKindInfo {
   const info = BY_KIND.get(kind);
   if (!info) {
     throw new Error(`Unknown document kind: ${kind}`);
@@ -79,12 +121,14 @@ export function documentKindInfo(kind: ResourceKind): DocumentKindInfo {
  * `TAB_TYPE_TO_SURFACE` — the ids handed to the agent in `ui_context` must use
  * the protocol's `UiSurfaceType` spelling, not our route names.
  */
-export function uiSurfaceForKind(kind: ResourceKind): string | null {
+export function uiSurfaceForKind(kind: DocumentKind): string | null {
   switch (kind) {
     case 'storyboard':
       return 'storyboard';
     case 'timeline':
       return 'timeline';
+    case 'script':
+      return 'script';
     case 'sketch':
       return 'sketch';
     default:

--- a/mobile/src/documents/scriptTypes.ts
+++ b/mobile/src/documents/scriptTypes.ts
@@ -1,0 +1,435 @@
+/**
+ * The agent-facing script contract on mobile.
+ *
+ * Ported from web's `scriptAgentBridge`, trimmed to what a phone should do:
+ * text, structure, and cast. Voicing (TTS), subtitle export, and timeline
+ * assembly are deliberately absent — voicing is N paid provider calls whose
+ * progress a phone screen cannot supervise, which is the same line the
+ * storyboard surface already draws around generation.
+ *
+ * Everything crossing the bridge is a plain serializable value, so the tool
+ * layer never touches a Zustand handle.
+ */
+
+/**
+ * The script document body — the wire shape of `scriptDocument` in
+ * `@nodetool-ai/protocol/api-schemas/scripts`. Declared structurally because
+ * that schema module is zod and is not re-exported from the package root, and
+ * mobile has no zod. Same rationale as `storyboardTypes.ts`.
+ */
+
+/** A provider/model/voice selection. Mobile reads these through, never writes them. */
+export interface VoiceBinding {
+  provider: string;
+  model: string;
+  voice: string;
+  settings?: Record<string, unknown>;
+}
+
+/** One word of a take's timing track. */
+export interface ScriptTakeWord {
+  word: string;
+  startMs: number;
+  endMs: number;
+}
+
+/**
+ * One voiced rendering of a line: an audio asset plus the text and voice it was
+ * voiced from. Those two snapshots are what make staleness derivable, so nothing
+ * on this surface may drop them.
+ */
+export interface ScriptTake {
+  id: string;
+  assetId: string;
+  durationMs: number;
+  words: ScriptTakeWord[];
+  textSnapshot: string;
+  voiceSnapshot: VoiceBinding | null;
+  createdAt: string;
+  favorite?: boolean;
+  costCredits?: number;
+}
+
+export interface ScriptSpeaker {
+  id: string;
+  name: string;
+  color?: string;
+  voice?: VoiceBinding | null;
+}
+
+export interface ScriptLine {
+  id: string;
+  speakerId?: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  voiceOverride?: VoiceBinding | null;
+  takes: ScriptTake[];
+  currentTakeId?: string | null;
+}
+
+export interface ScriptSection {
+  id: string;
+  title?: string;
+  lines: ScriptLine[];
+}
+
+export interface ScriptDocument {
+  cast: ScriptSpeaker[];
+  sections: ScriptSection[];
+}
+
+// ── Agent-facing projections ────────────────────────────────────────────────
+
+/** Whether a line's audio is missing, current, or behind its text. */
+export type ScriptLineStatus = 'draft' | 'voiced' | 'stale';
+
+/** Serializable view of one line the agent reads and edits. */
+export interface ScriptLineNode {
+  id: string;
+  /** 0-based position across the whole document, counting every section. */
+  index: number;
+  sectionId: string;
+  speakerId: string | null;
+  speakerName: string | null;
+  text: string;
+  direction?: string;
+  pauseAfterMs?: number;
+  status: ScriptLineStatus;
+  /** How many takes are recorded on the line. */
+  takeCount: number;
+}
+
+/** Serializable view of a cast member. */
+export interface ScriptSpeakerNode {
+  id: string;
+  name: string;
+  color?: string;
+  /** Whether a TTS voice is bound. Bindings are set on desktop, not here. */
+  hasVoice: boolean;
+}
+
+/** Serializable view of a section: its own fields plus the lines it holds. */
+export interface ScriptSectionNode {
+  id: string;
+  title?: string;
+  lineIds: string[];
+}
+
+/** Snapshot of the open script the agent reads before deciding what to change. */
+export interface ScriptSnapshot {
+  scriptId: string;
+  title: string;
+  cast: ScriptSpeakerNode[];
+  sections: ScriptSectionNode[];
+  lines: ScriptLineNode[];
+  selectedLineId: string | null;
+}
+
+/** Fields the agent can supply when adding a line. */
+export interface ScriptAddLineInput {
+  text: string;
+  speakerId?: string;
+  direction?: string;
+  /** Section to add into; the last section when omitted. */
+  sectionId?: string;
+  /** 0-based position within that section; appended when omitted. */
+  index?: number;
+}
+
+/** Fields the agent can patch on an existing line. */
+export interface ScriptLinePatch {
+  direction?: string;
+  pauseAfterMs?: number;
+}
+
+/**
+ * Operations the mounted ScriptEditorScreen exposes to the tool layer.
+ *
+ * Lines are addressed by id, 0-based document index as a string, or
+ * `"selected"`. Speakers and sections by id or 0-based index as a string.
+ */
+export interface ScriptAgentHandler {
+  getSnapshot: () => ScriptSnapshot;
+  addSpeaker: (name: string, color?: string) => ScriptSpeakerNode;
+  renameSpeaker: (target: string, name: string) => ScriptSpeakerNode;
+  /** Removes the cast member and clears `speakerId` on every line that used it. */
+  removeSpeaker: (target: string) => ScriptSpeakerNode;
+  addSection: (title?: string, index?: number) => ScriptSectionNode;
+  setSectionTitle: (target: string, title: string) => ScriptSectionNode;
+  /** Removes the section and every line inside it. */
+  removeSection: (target: string) => ScriptSectionNode;
+  addLine: (input: ScriptAddLineInput) => ScriptLineNode;
+  setLineText: (target: string, text: string) => ScriptLineNode;
+  setLineSpeaker: (target: string, speakerId: string | null) => ScriptLineNode;
+  patchLine: (target: string, patch: ScriptLinePatch) => ScriptLineNode;
+  removeLine: (target: string) => ScriptLineNode;
+  moveLine: (target: string, toIndex: number) => ScriptLineNode;
+  selectLine: (target: string | null) => ScriptLineNode | null;
+  /** Persist the script. Resolves with the server's new `updatedAt`. */
+  save: () => Promise<{ ok: true; updatedAt: string | null }>;
+}
+
+// ── Derivations ─────────────────────────────────────────────────────────────
+
+/**
+ * Derive a line's voicing status. Not stored: the take carries the text it was
+ * voiced from, so comparing the two is always right, while a stored flag drifts.
+ *
+ * Web also compares the take's voice snapshot against the line's effective
+ * voice. Mobile cannot change a voice binding, so text is the only thing that
+ * can go stale here.
+ */
+export function lineStatus(line: ScriptLine): ScriptLineStatus {
+  const current = line.takes.find((take) => take.id === line.currentTakeId);
+  if (!current) {
+    return 'draft';
+  }
+  return current.textSnapshot === line.text ? 'voiced' : 'stale';
+}
+
+/** Project a stored line into the agent's view of it. */
+export function lineToNode(
+  line: ScriptLine,
+  sectionId: string,
+  index: number,
+  cast: readonly ScriptSpeaker[]
+): ScriptLineNode {
+  const speaker = cast.find((member) => member.id === line.speakerId);
+  return {
+    id: line.id,
+    index,
+    sectionId,
+    speakerId: line.speakerId ?? null,
+    speakerName: speaker?.name ?? null,
+    text: line.text,
+    direction: line.direction,
+    pauseAfterMs: line.pauseAfterMs,
+    status: lineStatus(line),
+    takeCount: line.takes.length,
+  };
+}
+
+export function speakerToNode(speaker: ScriptSpeaker): ScriptSpeakerNode {
+  return {
+    id: speaker.id,
+    name: speaker.name,
+    color: speaker.color,
+    hasVoice: speaker.voice !== null && speaker.voice !== undefined,
+  };
+}
+
+export function sectionToNode(section: ScriptSection): ScriptSectionNode {
+  return {
+    id: section.id,
+    title: section.title,
+    lineIds: section.lines.map((line) => line.id),
+  };
+}
+
+/** One line with everywhere it lives, so a caller can both read and splice it. */
+export interface FlatScriptLine {
+  line: ScriptLine;
+  sectionId: string;
+  /** Position of the owning section in `doc.sections`. */
+  sectionIndex: number;
+  /** Position of the line within its section. */
+  lineIndex: number;
+  /** 0-based position across the whole document. */
+  index: number;
+}
+
+/** Every line in document order, with its section and document index. */
+export function flattenLines(doc: ScriptDocument): FlatScriptLine[] {
+  const flat: FlatScriptLine[] = [];
+  doc.sections.forEach((section, sectionIndex) => {
+    section.lines.forEach((line, lineIndex) => {
+      flat.push({
+        line,
+        sectionId: section.id,
+        sectionIndex,
+        lineIndex,
+        index: flat.length,
+      });
+    });
+  });
+  return flat;
+}
+
+/**
+ * Resolve an agent-supplied line address.
+ *
+ * Accepts a line id, a 0-based document index written as a string, or
+ * `"selected"`. Throws naming the valid ids, because that message is the agent's
+ * only way to recover from a bad guess.
+ */
+export function resolveLine(
+  doc: ScriptDocument,
+  target: string,
+  selectedLineId: string | null
+): FlatScriptLine {
+  const flat = flattenLines(doc);
+  const wanted = target === 'selected' ? selectedLineId : target;
+  if (wanted === null || wanted === '') {
+    throw new Error(
+      'No line is selected. Pass a line id or a 0-based index instead of "selected".'
+    );
+  }
+
+  const byId = flat.find((entry) => entry.line.id === wanted);
+  if (byId) {
+    return byId;
+  }
+
+  if (/^\d+$/.test(wanted)) {
+    const byIndex = flat[Number(wanted)];
+    if (byIndex) {
+      return byIndex;
+    }
+  }
+
+  const ids = flat.map((entry) => entry.line.id).join(', ');
+  throw new Error(
+    `No line matches "${target}". Use a line id, a 0-based index below ${flat.length}, or "selected". ` +
+      (ids.length > 0 ? `Line ids: ${ids}.` : 'This script has no lines yet.')
+  );
+}
+
+/** Resolve a speaker address (id or 0-based index) to a position in the cast. */
+export function resolveSpeakerIndex(
+  cast: readonly ScriptSpeaker[],
+  target: string
+): number {
+  const byId = cast.findIndex((speaker) => speaker.id === target);
+  if (byId >= 0) {
+    return byId;
+  }
+
+  if (/^\d+$/.test(target) && Number(target) < cast.length) {
+    return Number(target);
+  }
+
+  const ids = cast.map((speaker) => speaker.id).join(', ');
+  throw new Error(
+    `No cast member matches "${target}". Use a speaker id or a 0-based index below ${cast.length}. ` +
+      (ids.length > 0 ? `Speaker ids: ${ids}.` : 'This script has no cast yet.')
+  );
+}
+
+/** Resolve a section address (id or 0-based index) to a position in the script. */
+export function resolveSectionIndex(
+  sections: readonly ScriptSection[],
+  target: string
+): number {
+  const byId = sections.findIndex((section) => section.id === target);
+  if (byId >= 0) {
+    return byId;
+  }
+
+  if (/^\d+$/.test(target) && Number(target) < sections.length) {
+    return Number(target);
+  }
+
+  const ids = sections.map((section) => section.id).join(', ');
+  throw new Error(
+    `No section matches "${target}". Use a section id or a 0-based index below ${sections.length}. ` +
+      (ids.length > 0 ? `Section ids: ${ids}.` : 'This script has no sections yet.')
+  );
+}
+
+// ── Edits ───────────────────────────────────────────────────────────────────
+
+/** What `applyLinePatch` can change. `speakerId: null` clears the speaker. */
+export interface ScriptLineFields {
+  text?: string;
+  speakerId?: string | null;
+  direction?: string;
+  pauseAfterMs?: number;
+}
+
+/**
+ * Apply a patch to one line, carrying `takes` and `currentTakeId` across
+ * untouched.
+ *
+ * Every line edit on this surface goes through here. Takes are the line's
+ * derived-audio history and `lineStatus` compares against their `textSnapshot`,
+ * so dropping them on a text edit would both lose recorded audio and turn a
+ * stale line back into a draft.
+ */
+export function applyLinePatch(
+  line: ScriptLine,
+  patch: ScriptLineFields
+): ScriptLine {
+  return {
+    ...line,
+    text: patch.text ?? line.text,
+    speakerId: 'speakerId' in patch ? patch.speakerId : line.speakerId,
+    direction: patch.direction ?? line.direction,
+    pauseAfterMs: patch.pauseAfterMs ?? line.pauseAfterMs,
+  };
+}
+
+/** Replace one line in place, addressed by the flattened entry that found it. */
+export function replaceLine(
+  doc: ScriptDocument,
+  at: FlatScriptLine,
+  next: ScriptLine
+): ScriptDocument {
+  return {
+    ...doc,
+    sections: doc.sections.map((section, sectionIndex) =>
+      sectionIndex === at.sectionIndex
+        ? {
+            ...section,
+            lines: section.lines.map((line, lineIndex) =>
+              lineIndex === at.lineIndex ? next : line
+            ),
+          }
+        : section
+    ),
+  };
+}
+
+/**
+ * Drop a cast member and clear every line that pointed at it.
+ *
+ * Nothing in the schema enforces that `speakerId` names a real cast member, so
+ * leaving the references behind would give lines a speaker the UI cannot draw
+ * and the agent cannot resolve.
+ */
+export function withoutSpeaker(
+  doc: ScriptDocument,
+  speakerId: string
+): ScriptDocument {
+  return {
+    cast: doc.cast.filter((speaker) => speaker.id !== speakerId),
+    sections: doc.sections.map((section) => ({
+      ...section,
+      lines: section.lines.map((line) =>
+        line.speakerId === speakerId ? { ...line, speakerId: null } : line
+      ),
+    })),
+  };
+}
+
+/** Short ids, unique enough within one document. */
+const newId = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const newLineId = (): string => newId('line');
+export const newSectionId = (): string => newId('section');
+export const newSpeakerId = (): string => newId('speaker');
+
+/** An empty line, ready to type into. */
+export function emptyLine(text = '', speakerId?: string | null): ScriptLine {
+  return {
+    id: newLineId(),
+    speakerId: speakerId ?? null,
+    text,
+    takes: [],
+    currentTakeId: null,
+  };
+}
+
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);

--- a/mobile/src/documents/storyboardTypes.ts
+++ b/mobile/src/documents/storyboardTypes.ts
@@ -1,0 +1,177 @@
+/**
+ * The agent-facing storyboard contract on mobile.
+ *
+ * Ported from web's `storyboardAgentBridge`, trimmed to what a phone can
+ * actually do: read the board, write shots and board settings, select, save.
+ * Generation and timeline assembly are deliberately absent — both are long,
+ * expensive jobs that need the desktop surface to supervise, and offering them
+ * here would let an agent spend money from a screen that cannot show progress.
+ *
+ * Everything crossing the bridge is a plain serializable value, so the tool
+ * layer never touches a Zustand handle.
+ */
+
+import type {
+  CameraDirection,
+  ImageRef,
+  Screenplay,
+  Shot,
+  ShotStatus,
+  VideoRef,
+} from '@nodetool-ai/protocol';
+
+/** A model pick as the web pickers emit it. Mobile only reads these through. */
+export interface StoryboardModelSelection {
+  type: string;
+  id: string;
+  provider: string;
+  name?: string;
+}
+
+/**
+ * The storyboard document body — the wire shape of `storyboardDocument` in
+ * `@nodetool-ai/protocol/api-schemas/storyboards`. Declared structurally
+ * because the schema module is zod and is not re-exported from the package
+ * root, and mobile has no zod. Note the snake_case shot fields: that is the
+ * stored shape, not a slip.
+ */
+export interface StoryboardDocument {
+  screenplay: Screenplay | null;
+  shots: Shot[];
+  brief: string;
+  style: string;
+  entityIds: string[];
+  aspectRatio: string;
+  directorModel: StoryboardModelSelection | null;
+  imageModel: StoryboardModelSelection | null;
+  videoModel: StoryboardModelSelection | null;
+}
+
+/** Serializable view of one shot the agent reads and edits. */
+export interface StoryboardShotNode {
+  id: string;
+  index: number;
+  slug?: string;
+  action: string;
+  camera?: CameraDirection;
+  motion?: string;
+  durationSeconds?: number;
+  status: ShotStatus;
+  hasKeyframe: boolean;
+  hasClip: boolean;
+}
+
+/** Snapshot of the open board the agent reads before deciding what to change. */
+export interface StoryboardSnapshot {
+  boardId: string;
+  title: string;
+  brief: string;
+  style: string;
+  aspectRatio: string;
+  hasScreenplay: boolean;
+  selectedShotId: string | null;
+  shots: StoryboardShotNode[];
+}
+
+/** Fields the agent can supply when adding a shot. */
+export interface StoryboardAddShotInput {
+  action: string;
+  camera?: CameraDirection;
+  motion?: string;
+  durationSeconds?: number;
+  /** 0-based insertion index; appended when omitted. */
+  index?: number;
+}
+
+/** Fields the agent can patch on an existing shot. */
+export interface StoryboardUpdateShotPatch {
+  action?: string;
+  camera?: CameraDirection;
+  motion?: string;
+  status?: ShotStatus;
+  slug?: string;
+  durationSeconds?: number;
+}
+
+/**
+ * Operations the mounted StoryboardEditorScreen exposes to the tool layer.
+ * Shots are addressed by id, 0-based index as a string, or `"selected"`.
+ */
+export interface StoryboardAgentHandler {
+  getSnapshot: () => StoryboardSnapshot;
+  addShot: (input: StoryboardAddShotInput) => StoryboardShotNode;
+  updateShot: (
+    target: string,
+    patch: StoryboardUpdateShotPatch
+  ) => StoryboardShotNode;
+  removeShot: (target: string) => StoryboardShotNode;
+  reorderShot: (target: string, toIndex: number) => StoryboardShotNode;
+  setBrief: (brief: string) => StoryboardSnapshot;
+  setStyle: (style: string) => StoryboardSnapshot;
+  setAspectRatio: (ratio: string) => StoryboardSnapshot;
+  selectShot: (target: string | null) => StoryboardShotNode | null;
+  /** Persist the board. Resolves with the server's new `updatedAt`. */
+  save: () => Promise<{ ok: true; updatedAt: string | null }>;
+}
+
+const hasUri = (ref: ImageRef | VideoRef | null | undefined): boolean =>
+  typeof ref?.uri === 'string' && ref.uri.length > 0;
+
+/** Project a stored shot into the agent's view of it. */
+export function shotToNode(shot: Shot, index: number): StoryboardShotNode {
+  return {
+    id: shot.id,
+    index,
+    slug: shot.slug,
+    action: shot.action,
+    camera: shot.camera,
+    motion: shot.motion,
+    durationSeconds: shot.duration_seconds,
+    status: shot.status,
+    hasKeyframe: hasUri(shot.keyframe),
+    hasClip: hasUri(shot.clip),
+  };
+}
+
+/**
+ * Resolve an agent-supplied shot address to an array position.
+ *
+ * Accepts a shot id, a 0-based index written as a string, or `"selected"`.
+ * Throws naming the valid ids, because the message is the agent's only way to
+ * recover from a bad guess.
+ */
+export function resolveShotIndex(
+  shots: readonly Shot[],
+  target: string,
+  selectedShotId: string | null
+): number {
+  const wanted = target === 'selected' ? selectedShotId : target;
+  if (wanted === null || wanted === undefined || wanted === '') {
+    throw new Error(
+      'No shot is selected. Pass a shot id or 0-based index instead of "selected".'
+    );
+  }
+
+  const byId = shots.findIndex((shot) => shot.id === wanted);
+  if (byId >= 0) {
+    return byId;
+  }
+
+  if (/^\d+$/.test(wanted)) {
+    const position = Number(wanted);
+    if (position < shots.length) {
+      return position;
+    }
+  }
+
+  const ids = shots.map((shot) => shot.id).join(', ');
+  throw new Error(
+    `No shot matches "${target}". Use a shot id, a 0-based index below ${shots.length}, or "selected". ` +
+      (ids.length > 0 ? `Shot ids: ${ids}.` : 'This board has no shots yet.')
+  );
+}
+
+/** Renumber `index` after an insert, delete, or move. */
+export function reindexShots(shots: readonly Shot[]): Shot[] {
+  return shots.map((shot, index) => (shot.index === index ? shot : { ...shot, index }));
+}

--- a/mobile/src/documents/timelineEdits.ts
+++ b/mobile/src/documents/timelineEdits.ts
@@ -1,0 +1,696 @@
+/**
+ * Link-aware, pure timeline edits.
+ *
+ * Every function takes a `TimelineDocument` and returns a new one — no React, no
+ * Zustand, no ids minted outside the engine — so the invariants below can be
+ * tested directly. The screen's agent handler is a thin wrapper that feeds these
+ * into `documentStore.edit()`.
+ *
+ * The invariants exist because a timeline is not a list of independent rows:
+ *
+ * - **`linkId`** ties a video clip to the audio extracted from it. They must
+ *   move, trim, split, and duplicate as one, or the cut goes out of sync and
+ *   nothing on screen says why. Web's *agent* handlers take a `patchClip`
+ *   shortcut that desyncs them; the logic here follows web's `TimelineStore`
+ *   (`moveClip`, `trimClipStart`/`End`, `splitClipsLinkAware`, `deleteClip`,
+ *   `duplicateSelected`) instead, which is the code the desktop UI actually
+ *   runs.
+ * - **Staleness**: changing a generation input (prompt, provider, model, or any
+ *   other binding field) marks an already-generated clip `stale`. Otherwise the
+ *   clip reads "generated" while showing an asset that no longer matches its
+ *   prompt.
+ * - **Transcript integrity**: `transcript[].clipIds` points at clips. Web
+ *   re-flows the transcript on every structural edit (795 lines of it); mobile
+ *   refuses the edit instead, naming the line. A clear refusal beats a dangling
+ *   reference the user cannot see.
+ * - **Protocol schema**: only fields present in `timelineDocument`
+ *   (`packages/protocol/src/api-schemas/timeline.ts`) survive a PATCH. Notably
+ *   `aspectRatio` and `resolution` are *not* in that schema, so nothing here
+ *   writes them — they would be stripped on save.
+ *
+ * `splitClip` and `trimClip` come from the engine rather than being hand-rolled:
+ * they partition animations by role, rebase clip-local caption words, map
+ * timeline deltas through `sourceRate`, and clear the fades/transitions that an
+ * interior cut invalidates.
+ */
+
+import {
+  DEFAULT_SHAPE_FILL_COLOR,
+  DEFAULT_SHAPE_STROKE_COLOR,
+  DEFAULT_SHAPE_STROKE_WIDTH_PX,
+  DEFAULT_TEXT_CLIP_COLOR,
+  DEFAULT_TEXT_CLIP_DURATION_MS,
+  DEFAULT_TEXT_CLIP_FONT_SIZE_PX,
+  createTimeOrderedUuid,
+  makeClip,
+  makeMarker,
+  makeTrack,
+  splitClip as engineSplitClip,
+  trimClip as engineTrimClip,
+  type BlendMode,
+  type ClipShapeStyle,
+  type ClipTextStyle,
+  type TimelineClip,
+  type TimelineMarker,
+  type TimelineTrack,
+} from '@nodetool-ai/timeline';
+
+import {
+  resolveClip,
+  resolveTrack,
+  type TimelineAddMarkerInput,
+  type TimelineAddShapeClipInput,
+  type TimelineAddTextClipInput,
+  type TimelineClipParamsPatch,
+  type TimelineDocument,
+  type TimelineMovePatch,
+  type TimelineTrimPatch,
+} from './timelineTypes';
+
+/** Tracks a text or shape clip may be drawn on. */
+const AUTHORED_TRACK_TYPES: readonly TimelineTrack['type'][] = [
+  'video',
+  'overlay',
+];
+
+/** The binding fields whose change invalidates an existing render. */
+const BINDING_FIELDS = [
+  'prompt',
+  'negativePrompt',
+  'provider',
+  'model',
+  'voice',
+  'width',
+  'height',
+  'strength',
+  'numInferenceSteps',
+  'seed',
+] as const;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+/** Every member of the clip's link group, including the clip itself. */
+function linkGroup(
+  clips: readonly TimelineClip[],
+  clip: TimelineClip
+): TimelineClip[] {
+  if (clip.linkId === undefined) {
+    return [clip];
+  }
+  return clips.filter((other) => other.linkId === clip.linkId);
+}
+
+/**
+ * Refuse a structural edit to a clip the transcript owns. `clipIds` is a plain
+ * reference list with no repair path on mobile, so breaking it would leave the
+ * transcript pointing at clips that no longer exist.
+ */
+function assertNotTranscribed(
+  doc: TimelineDocument,
+  clips: readonly TimelineClip[],
+  verb: string
+): void {
+  const ids = new Set(clips.map((clip) => clip.id));
+  for (const line of doc.transcript ?? []) {
+    const hit = line.clipIds.find((clipId) => ids.has(clipId));
+    if (hit !== undefined) {
+      throw new Error(
+        `Cannot ${verb} clip ${hit}: transcript line "${line.text}" (${line.id}) ` +
+          'owns it. Transcript-backed clips can only be restructured on desktop, ' +
+          'which re-flows the transcript with them.'
+      );
+    }
+  }
+}
+
+/** Drop keys whose value is undefined, so a PATCH cannot carry empty slots. */
+function pruned(clip: TimelineClip): TimelineClip {
+  const out = { ...clip } as Record<string, unknown>;
+  for (const key of Object.keys(out)) {
+    if (out[key] === undefined) {
+      delete out[key];
+    }
+  }
+  return out as unknown as TimelineClip;
+}
+
+/** End of the last clip on a track, or 0 when it is empty. */
+function trackEndMs(clips: readonly TimelineClip[], trackId: string): number {
+  return clips
+    .filter((clip) => clip.trackId === trackId)
+    .reduce((end, clip) => Math.max(end, clip.startMs + clip.durationMs), 0);
+}
+
+/**
+ * Unlink survivors of a link group that has dropped below two members, so no
+ * clip keeps a `linkId` nothing else shares.
+ */
+function unlinkOrphans(
+  clips: readonly TimelineClip[],
+  affected: ReadonlySet<string>
+): TimelineClip[] {
+  if (affected.size === 0) {
+    return [...clips];
+  }
+  const counts = new Map<string, number>();
+  for (const clip of clips) {
+    if (clip.linkId !== undefined && affected.has(clip.linkId)) {
+      counts.set(clip.linkId, (counts.get(clip.linkId) ?? 0) + 1);
+    }
+  }
+  return clips.map((clip) => {
+    if (
+      clip.linkId !== undefined &&
+      affected.has(clip.linkId) &&
+      (counts.get(clip.linkId) ?? 0) < 2
+    ) {
+      const next = { ...clip };
+      delete next.linkId;
+      return next;
+    }
+    return clip;
+  });
+}
+
+const withClips = (
+  doc: TimelineDocument,
+  clips: TimelineClip[]
+): TimelineDocument => ({ ...doc, clips });
+
+// ── Tracks ──────────────────────────────────────────────────────────────────
+
+export function addTrack(
+  doc: TimelineDocument,
+  type: TimelineTrack['type'],
+  name?: string
+): { doc: TimelineDocument; track: TimelineTrack } {
+  const track = makeTrack({
+    type,
+    name: name ?? `${type} ${doc.tracks.length + 1}`,
+    index: doc.tracks.length,
+  });
+  return { doc: { ...doc, tracks: [...doc.tracks, track] }, track };
+}
+
+/**
+ * Resolve the target track for an authored (text/shape) clip, creating an
+ * overlay track when the sequence has none. Mirrors web's throw: text and
+ * shapes are drawn, so an audio or subtitle track cannot hold them.
+ */
+function authoredTrack(
+  doc: TimelineDocument,
+  trackId: string | undefined,
+  fallbackName: string
+): { doc: TimelineDocument; trackId: string } {
+  if (trackId !== undefined) {
+    const track = resolveTrack(doc.tracks, trackId);
+    if (!AUTHORED_TRACK_TYPES.includes(track.type)) {
+      throw new Error(
+        `Text and shape clips require a video or overlay track; "${track.name}" is ${track.type}.`
+      );
+    }
+    return { doc, trackId: track.id };
+  }
+  const overlay = doc.tracks.find((track) => track.type === 'overlay');
+  if (overlay) {
+    return { doc, trackId: overlay.id };
+  }
+  const created = addTrack(doc, 'overlay', fallbackName);
+  return { doc: created.doc, trackId: created.track.id };
+}
+
+// ── Authored clips ──────────────────────────────────────────────────────────
+
+function textStyleWithDefaults(input: TimelineAddTextClipInput): ClipTextStyle {
+  return {
+    text: input.text,
+    fontSizePx: input.style?.fontSizePx ?? DEFAULT_TEXT_CLIP_FONT_SIZE_PX,
+    color: input.style?.color ?? DEFAULT_TEXT_CLIP_COLOR,
+    fontFamily: input.style?.fontFamily,
+    fontWeight: input.style?.fontWeight,
+    align: input.style?.align,
+    maxWidthFrac: input.style?.maxWidthFrac,
+  };
+}
+
+/**
+ * Fill in a visible colour. An omitted fill on a rectangle (or stroke on a line)
+ * would render nothing, which reads to the user as a failed edit.
+ */
+export function shapeStyleWithDefaults(shape: ClipShapeStyle): ClipShapeStyle {
+  return {
+    ...shape,
+    ...(shape.kind === 'line'
+      ? {
+          stroke: shape.stroke ?? DEFAULT_SHAPE_STROKE_COLOR,
+          strokeWidthPx: shape.strokeWidthPx ?? DEFAULT_SHAPE_STROKE_WIDTH_PX,
+        }
+      : { fill: shape.fill ?? DEFAULT_SHAPE_FILL_COLOR }),
+  };
+}
+
+export function addTextClip(
+  doc: TimelineDocument,
+  input: TimelineAddTextClipInput
+): { doc: TimelineDocument; clip: TimelineClip } {
+  const text = input.text.trim();
+  if (text.length === 0) {
+    throw new Error('A text clip needs non-empty text.');
+  }
+  const target = authoredTrack(doc, input.trackId, 'Text');
+  const clip = makeClip({
+    trackId: target.trackId,
+    name: text.slice(0, 40),
+    startMs: Math.max(0, input.startMs ?? trackEndMs(doc.clips, target.trackId)),
+    durationMs: Math.max(
+      1,
+      input.durationMs ?? DEFAULT_TEXT_CLIP_DURATION_MS
+    ),
+    mediaType: 'text',
+    sourceType: 'imported',
+    status: 'generated',
+    textStyle: textStyleWithDefaults({ ...input, text }),
+  });
+  return {
+    doc: withClips(target.doc, [...target.doc.clips, pruned(clip)]),
+    clip,
+  };
+}
+
+export function addShapeClip(
+  doc: TimelineDocument,
+  input: TimelineAddShapeClipInput
+): { doc: TimelineDocument; clip: TimelineClip } {
+  const target = authoredTrack(doc, input.trackId, 'Shapes');
+  const clip = makeClip({
+    trackId: target.trackId,
+    name: input.shape.kind,
+    startMs: Math.max(0, input.startMs ?? trackEndMs(doc.clips, target.trackId)),
+    durationMs: Math.max(
+      1,
+      input.durationMs ?? DEFAULT_TEXT_CLIP_DURATION_MS
+    ),
+    mediaType: 'shape',
+    sourceType: 'imported',
+    status: 'generated',
+    shapeStyle: shapeStyleWithDefaults(input.shape),
+  });
+  return {
+    doc: withClips(target.doc, [...target.doc.clips, pruned(clip)]),
+    clip,
+  };
+}
+
+// ── Move ────────────────────────────────────────────────────────────────────
+
+/**
+ * Move a clip, and every link sibling with it, by one shared delta. Siblings
+ * keep their own `trackId` — extracted audio stays on the audio track.
+ *
+ * The delta is clamped once for the whole group so a move against t=0 preserves
+ * the group's internal spacing instead of piling members onto zero. That can
+ * land the primary later than requested; the returned clips say where it went.
+ */
+export function moveClip(
+  doc: TimelineDocument,
+  target: string,
+  patch: TimelineMovePatch,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; clips: TimelineClip[] } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  const toTrackId =
+    patch.trackId === undefined
+      ? undefined
+      : resolveTrack(doc.tracks, patch.trackId).id;
+
+  const requested =
+    patch.startMs === undefined ? clip.startMs : Math.max(0, patch.startMs);
+  const group = linkGroup(doc.clips, clip);
+  const minStartMs = group.reduce(
+    (min, member) => Math.min(min, member.startMs),
+    clip.startMs
+  );
+  const delta = Math.max(requested - clip.startMs, -minStartMs);
+
+  const groupIds = new Set(group.map((member) => member.id));
+  const moved: TimelineClip[] = [];
+  const clips = doc.clips.map((member) => {
+    if (!groupIds.has(member.id)) {
+      return member;
+    }
+    const next: TimelineClip = {
+      ...member,
+      startMs: member.startMs + delta,
+      trackId: member.id === clip.id ? (toTrackId ?? member.trackId) : member.trackId,
+    };
+    moved.push(next);
+    return next;
+  });
+
+  return { doc: withClips(doc, clips), clips: moved };
+}
+
+// ── Trim ────────────────────────────────────────────────────────────────────
+
+/**
+ * Trim a clip's timeline length and/or its source window.
+ *
+ * `durationMs` is applied as an end-edge delta through the engine, and the same
+ * delta is applied to every link sibling. All-or-nothing: the primary and every
+ * sibling are computed first, and the whole edit is abandoned if any is invalid,
+ * so a link can never end up half-trimmed.
+ *
+ * `inPointMs`/`outPointMs` address the clip's own source media, which siblings
+ * do not share, so they apply to the primary only.
+ */
+export function trimClip(
+  doc: TimelineDocument,
+  target: string,
+  patch: TimelineTrimPatch,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; clips: TimelineClip[] } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  const next = new Map<string, TimelineClip>();
+
+  if (patch.durationMs !== undefined) {
+    if (patch.durationMs < 1) {
+      throw new Error(
+        `durationMs must be at least 1ms; got ${patch.durationMs}.`
+      );
+    }
+    const delta = patch.durationMs - clip.durationMs;
+    for (const member of linkGroup(doc.clips, clip)) {
+      // Any invalid member throws out of the whole call, leaving `doc` untouched.
+      next.set(member.id, engineTrimClip(member, 'end', delta));
+    }
+  }
+
+  if (patch.inPointMs !== undefined || patch.outPointMs !== undefined) {
+    const base = next.get(clip.id) ?? clip;
+    const inPointMs = patch.inPointMs ?? base.inPointMs ?? 0;
+    const outPointMs =
+      patch.outPointMs ?? base.outPointMs ?? inPointMs + base.durationMs;
+    if (inPointMs < 0) {
+      throw new Error(`inPointMs cannot be negative; got ${inPointMs}.`);
+    }
+    if (outPointMs <= inPointMs) {
+      throw new Error(
+        `outPointMs (${outPointMs}) must be greater than inPointMs (${inPointMs}).`
+      );
+    }
+    next.set(clip.id, { ...base, inPointMs, outPointMs });
+  }
+
+  if (next.size === 0) {
+    throw new Error(
+      'Nothing to trim: pass durationMs, inPointMs, or outPointMs.'
+    );
+  }
+
+  const clips = doc.clips.map((member) => next.get(member.id) ?? member);
+  return { doc: withClips(doc, clips), clips: [...next.values()] };
+}
+
+// ── Split ───────────────────────────────────────────────────────────────────
+
+/**
+ * Split a clip at an absolute timeline time, together with every link sibling
+ * that spans that time.
+ *
+ * Each side of the cut gets **one fresh `linkId` shared by all its halves** — the
+ * left halves share one, the right halves another. Leaving the original id on all
+ * four would produce a single 4-member group in which nothing is paired.
+ */
+export function splitClipAt(
+  doc: TimelineDocument,
+  target: string,
+  atMs: number,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; clips: TimelineClip[] } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  const clipEndMs = clip.startMs + clip.durationMs;
+  if (atMs <= clip.startMs || atMs >= clipEndMs) {
+    throw new Error(
+      `Split time ${atMs}ms is outside clip "${clip.name}" (${clip.startMs}–${clipEndMs}ms).`
+    );
+  }
+
+  const spans = (member: TimelineClip): boolean =>
+    atMs > member.startMs && atMs < member.startMs + member.durationMs;
+  // A sibling that does not span the cut (rare — links stay time-aligned) is
+  // left alone and joins neither new group.
+  const toSplit = linkGroup(doc.clips, clip).filter(spans);
+  assertNotTranscribed(doc, toSplit, 'split');
+
+  const leftLinkId = clip.linkId === undefined ? undefined : createTimeOrderedUuid();
+  const rightLinkId = clip.linkId === undefined ? undefined : createTimeOrderedUuid();
+  const splitIds = new Set(toSplit.map((member) => member.id));
+
+  const halves: TimelineClip[] = [];
+  const clips: TimelineClip[] = [];
+  for (const member of doc.clips) {
+    if (!splitIds.has(member.id)) {
+      clips.push(member);
+      continue;
+    }
+    const [left, right] = engineSplitClip(member, atMs);
+    if (leftLinkId !== undefined && rightLinkId !== undefined) {
+      left.linkId = leftLinkId;
+      right.linkId = rightLinkId;
+    } else {
+      delete left.linkId;
+      delete right.linkId;
+    }
+    halves.push(left, right);
+    clips.push(pruned(left), pruned(right));
+  }
+
+  return { doc: withClips(doc, clips), clips: halves };
+}
+
+// ── Delete ──────────────────────────────────────────────────────────────────
+
+/**
+ * Remove one clip. A link group left with a single member is unlinked, so no
+ * clip keeps a `linkId` that pairs it with nothing.
+ */
+export function deleteClip(
+  doc: TimelineDocument,
+  target: string,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; deleted: TimelineClip } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  assertNotTranscribed(doc, [clip], 'delete');
+
+  const affected = new Set(clip.linkId === undefined ? [] : [clip.linkId]);
+  const remaining = doc.clips.filter((member) => member.id !== clip.id);
+  return {
+    doc: withClips(doc, unlinkOrphans(remaining, affected)),
+    deleted: clip,
+  };
+}
+
+// ── Duplicate ───────────────────────────────────────────────────────────────
+
+/**
+ * Duplicate a clip — or its whole link group, so the copies stay in sync rather
+ * than producing a lone half whose sibling is somewhere else.
+ *
+ * A fully-duplicated group gets a fresh shared `linkId` (its own group, not a
+ * member of the source's); an unlinked clip's copy has none. Every member shifts
+ * by the *primary's* offset so the group's internal alignment survives.
+ *
+ * Derived state is reset: the copy is a `draft` with no asset, no
+ * `lastGeneratedHash`, and no version history — it has never been generated.
+ */
+export function duplicateClip(
+  doc: TimelineDocument,
+  target: string,
+  gapMs = 0,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; clips: TimelineClip[] } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  const group = linkGroup(doc.clips, clip);
+  const offsetMs = clip.durationMs + gapMs;
+  const freshLinkId = group.length >= 2 ? createTimeOrderedUuid() : undefined;
+
+  const copies = group.map((member) => {
+    const copy = makeClip({
+      ...member,
+      id: createTimeOrderedUuid(),
+      startMs: member.startMs + offsetMs,
+      status: 'draft',
+      locked: false,
+      currentAssetId: undefined,
+      lastGeneratedHash: undefined,
+      linkId: freshLinkId,
+      // Fresh animation ids so the two clips are edited independently.
+      animations: member.animations?.map((animation) => ({
+        ...animation,
+        id: createTimeOrderedUuid(),
+      })),
+      versions: [],
+    });
+    return pruned(copy);
+  });
+
+  return {
+    doc: withClips(doc, [...doc.clips, ...copies]),
+    clips: copies,
+  };
+}
+
+// ── Params + binding ────────────────────────────────────────────────────────
+
+/**
+ * Patch a clip's render/audio params and generation binding.
+ *
+ * Only the fields present in the patch are written, so an omitted key never
+ * wipes an existing prompt or model. Touching any binding field marks a clip
+ * that has a render (`lastGeneratedHash` or `currentAssetId`) as `stale` — the
+ * asset on screen no longer matches the settings that produced it.
+ */
+export function setClipParams(
+  doc: TimelineDocument,
+  target: string,
+  patch: TimelineClipParamsPatch,
+  selectedClipIds: readonly string[] = []
+): { doc: TimelineDocument; clip: TimelineClip } {
+  const clip = resolveClip(doc.clips, target, selectedClipIds);
+  const next: TimelineClip = { ...clip };
+
+  if (patch.name !== undefined) {
+    next.name = patch.name;
+  }
+  if (patch.opacity !== undefined) {
+    next.opacity = clamp(patch.opacity, 0, 1);
+  }
+  if (patch.speedMultiplier !== undefined) {
+    next.speedMultiplier = clamp(patch.speedMultiplier, 0.1, 8);
+  }
+  if (patch.volumeDb !== undefined) {
+    next.volumeDb = patch.volumeDb;
+  }
+  if (patch.fadeInMs !== undefined) {
+    next.fadeInMs = Math.max(0, patch.fadeInMs);
+  }
+  if (patch.fadeOutMs !== undefined) {
+    next.fadeOutMs = Math.max(0, patch.fadeOutMs);
+  }
+  if (patch.blendMode !== undefined) {
+    next.blendMode = patch.blendMode as BlendMode;
+  }
+  if (patch.borderRadius !== undefined) {
+    next.borderRadius = Math.max(0, patch.borderRadius);
+  }
+  if (patch.hidden !== undefined) {
+    next.hidden = patch.hidden;
+  }
+  if (patch.muted !== undefined) {
+    next.muted = patch.muted;
+  }
+  if (patch.locked !== undefined) {
+    next.locked = patch.locked;
+  }
+  if (patch.textStyle !== undefined) {
+    if (clip.mediaType !== 'text') {
+      throw new Error(
+        `textStyle applies only to text clips; "${clip.name}" is a ${clip.mediaType} clip.`
+      );
+    }
+    next.textStyle = patch.textStyle;
+  }
+  if (patch.shapeStyle !== undefined) {
+    if (clip.mediaType !== 'shape') {
+      throw new Error(
+        `shapeStyle applies only to shape clips; "${clip.name}" is a ${clip.mediaType} clip.`
+      );
+    }
+    next.shapeStyle = shapeStyleWithDefaults(patch.shapeStyle);
+  }
+
+  let bindingChanged = false;
+  for (const field of BINDING_FIELDS) {
+    const value = patch[field];
+    if (value === undefined) {
+      continue;
+    }
+    if (clip.sourceType !== 'generated') {
+      throw new Error(
+        `Clip "${clip.name}" is imported and has no generation binding, so ${field} cannot be set.`
+      );
+    }
+    // Each field is assigned individually because the patch and the clip share
+    // names but not types (the clip's are narrowed).
+    Object.assign(next, { [field]: value });
+    bindingChanged = true;
+  }
+  if (bindingChanged && (clip.lastGeneratedHash || clip.currentAssetId)) {
+    next.status = 'stale';
+  }
+
+  const clips = doc.clips.map((member) =>
+    member.id === clip.id ? pruned(next) : member
+  );
+  return { doc: withClips(doc, clips), clip: next };
+}
+
+// ── Markers ─────────────────────────────────────────────────────────────────
+
+export function addMarker(
+  doc: TimelineDocument,
+  input: TimelineAddMarkerInput
+): { doc: TimelineDocument; marker: TimelineMarker } {
+  if (input.timeMs < 0) {
+    throw new Error(`A marker cannot sit before zero; got ${input.timeMs}ms.`);
+  }
+  const marker = makeMarker({
+    timeMs: input.timeMs,
+    label: input.label ?? '',
+    color: input.color,
+    note: input.note,
+  });
+  const stored = { ...marker } as Record<string, unknown>;
+  for (const key of Object.keys(stored)) {
+    if (stored[key] === undefined) {
+      delete stored[key];
+    }
+  }
+  return {
+    doc: {
+      ...doc,
+      markers: [...doc.markers, stored as unknown as TimelineMarker],
+    },
+    marker,
+  };
+}
+
+/** Resolve a marker by id or case-insensitive label, then remove it. */
+export function deleteMarker(
+  doc: TimelineDocument,
+  target: string
+): { doc: TimelineDocument; deleted: TimelineMarker } {
+  const lowered = target.toLowerCase();
+  const marker =
+    doc.markers.find((entry) => entry.id === target) ??
+    doc.markers.find((entry) => entry.label.toLowerCase() === lowered);
+  if (marker === undefined) {
+    const known = doc.markers
+      .map((entry) => `${entry.id} ("${entry.label}")`)
+      .join(', ');
+    throw new Error(
+      `No marker matches "${target}". Use a marker id or its label. ` +
+        (known.length > 0
+          ? `Markers: ${known}.`
+          : 'This sequence has no markers yet.')
+    );
+  }
+  return {
+    doc: {
+      ...doc,
+      markers: doc.markers.filter((entry) => entry.id !== marker.id),
+    },
+    deleted: marker,
+  };
+}

--- a/mobile/src/documents/timelineTypes.ts
+++ b/mobile/src/documents/timelineTypes.ts
@@ -1,85 +1,45 @@
 /**
  * The agent-facing timeline contract on mobile.
  *
- * Ported from web's `timelineAgentBridge`, trimmed to reads: snapshot, clip
- * lookup, selection, seek. Editing, generation, and rendering are deliberately
- * absent — a phone screen cannot supervise a render job, and a timeline is too
- * dense to cut accurately with a thumb, so mobile opens sequences read-only
- * (`kinds.ts` marks the surface `viewer`).
+ * The human-facing screen is a viewer — a timeline is too dense to cut with a
+ * thumb, so `kinds.ts` marks the surface `viewer` — but the document is fully
+ * agent-editable (`agentEditable: true`): "move the title card two seconds
+ * later" is a sentence, and that is what a phone is good at. The read tools
+ * answer questions about a sequence; the write tools apply the edit and the user
+ * presses Save.
+ *
+ * Document types come straight from `@nodetool-ai/timeline` rather than being
+ * re-declared here. That package is the same engine the desktop editor uses, so
+ * `splitClip`/`trimClip` apply to these values directly and the two surfaces
+ * cannot drift.
  *
  * Everything crossing the bridge is a plain serializable value, so the tool
  * layer never touches a Zustand handle.
  */
 
-export type TimelineTrackType = 'video' | 'audio' | 'overlay' | 'subtitle';
+import type {
+  ClipShapeStyle,
+  ClipTextStyle,
+  TimelineClip,
+  TimelineMarker,
+  TimelineTrack,
+  TranscriptLine,
+} from '@nodetool-ai/timeline';
 
-export type TimelineMediaType =
-  | 'image'
-  | 'video'
-  | 'audio'
-  | 'overlay'
-  | 'text'
-  | 'shape';
+export type TimelineTrackType = TimelineTrack['type'];
+export type TimelineMediaType = TimelineClip['mediaType'];
+export type TimelineClipStatus = TimelineClip['status'];
 
-export type TimelineClipStatus =
-  | 'draft'
-  | 'queued'
-  | 'generating'
-  | 'generated'
-  | 'stale'
-  | 'failed'
-  | 'locked'
-  | 'missing';
-
-export interface TimelineTrackData {
-  id: string;
-  name: string;
-  type: TimelineTrackType;
-  index: number;
-  visible: boolean;
-  locked: boolean;
-  muted?: boolean;
-  solo?: boolean;
-  heightPx?: number;
-}
-
-export interface TimelineClipData {
-  id: string;
-  trackId: string;
-  name: string;
-  startMs: number;
-  durationMs: number;
-  inPointMs?: number;
-  outPointMs?: number;
-  mediaType: TimelineMediaType;
-  sourceType: 'imported' | 'generated';
-  status: TimelineClipStatus;
-  locked: boolean;
-  muted?: boolean;
-  hidden?: boolean;
-  prompt?: string;
-  provider?: string;
-  model?: string;
-  currentAssetId?: string;
-  thumbnailAssetId?: string;
-  /** Generation history. The viewer only shows how many there are. */
-  versions: unknown[];
-}
-
-export interface TimelineMarkerData {
-  id: string;
-  timeMs: number;
-  label: string;
-  color?: string;
-  note?: string;
-}
+/** Document-shaped aliases, kept so existing call sites read unchanged. */
+export type TimelineTrackData = TimelineTrack;
+export type TimelineClipData = TimelineClip;
+export type TimelineMarkerData = TimelineMarker;
 
 /**
  * The timeline document body — the wire shape of `timelineDocument` in
- * `@nodetool-ai/protocol/api-schemas/timeline`. Declared structurally because
- * that module is zod and is not re-exported from the package root, and mobile
- * has no zod. Only the fields the viewer reads are named; the rest ride along
- * untouched.
+ * `@nodetool-ai/protocol/api-schemas/timeline`, expressed with the engine's
+ * types (the protocol module is zod, is not re-exported from the package root,
+ * and mobile has no zod).
  *
  * `fps`, `width`, and `height` live on the resource row, not in the body, so
  * they are unavailable here — duration comes from the clips.
@@ -88,7 +48,7 @@ export interface TimelineDocument {
   tracks: TimelineTrackData[];
   clips: TimelineClipData[];
   markers: TimelineMarkerData[];
-  transcript?: unknown[];
+  transcript?: TranscriptLine[];
   scriptEnabled?: boolean;
 }
 
@@ -109,6 +69,8 @@ export interface TimelineClipNode {
   prompt?: string;
   model?: string;
   provider?: string;
+  /** Set when the clip travels with a sibling (video + its extracted audio). */
+  linkId?: string;
   /** Whether a rendered asset is attached, so the agent can tell empty from done. */
   hasAsset: boolean;
 }
@@ -134,14 +96,88 @@ export interface TimelineSnapshot {
   clipCount: number;
   playheadMs: number;
   selectedClipIds: string[];
+  /** Whether the document has unsaved edits the user still has to save. */
+  dirty: boolean;
   tracks: TimelineTrackNode[];
   clips: TimelineClipNode[];
   markers: { id: string; timeMs: number; label: string }[];
+  /**
+   * Transcript lines and the clips they own. Clips a line references cannot be
+   * deleted or split, so the agent needs to see the constraint before it plans.
+   */
+  transcript: { id: string; text: string; clipIds: string[] }[];
+}
+
+// ── Edit inputs ─────────────────────────────────────────────────────────────
+
+export interface TimelineAddTextClipInput {
+  text: string;
+  trackId?: string;
+  startMs?: number;
+  durationMs?: number;
+  style?: Partial<Omit<ClipTextStyle, 'text'>>;
+}
+
+export interface TimelineAddShapeClipInput {
+  shape: ClipShapeStyle;
+  trackId?: string;
+  startMs?: number;
+  durationMs?: number;
+}
+
+export interface TimelineMovePatch {
+  startMs?: number;
+  trackId?: string;
+}
+
+export interface TimelineTrimPatch {
+  durationMs?: number;
+  inPointMs?: number;
+  outPointMs?: number;
+}
+
+/**
+ * Render/audio params plus the generation binding. Changing any binding field
+ * marks a generated clip `stale` (see `timelineEdits.ts`), so the user is never
+ * shown "generated" over an asset that no longer matches its prompt.
+ */
+export interface TimelineClipParamsPatch {
+  name?: string;
+  opacity?: number;
+  speedMultiplier?: number;
+  volumeDb?: number;
+  fadeInMs?: number;
+  fadeOutMs?: number;
+  blendMode?: string;
+  borderRadius?: number;
+  hidden?: boolean;
+  muted?: boolean;
+  locked?: boolean;
+  textStyle?: ClipTextStyle;
+  shapeStyle?: ClipShapeStyle;
+  prompt?: string;
+  negativePrompt?: string;
+  provider?: string;
+  model?: string;
+  voice?: string;
+  width?: number;
+  height?: number;
+  strength?: number;
+  numInferenceSteps?: number;
+  seed?: number;
+}
+
+export interface TimelineAddMarkerInput {
+  timeMs: number;
+  label?: string;
+  color?: string;
+  note?: string;
 }
 
 /**
  * Operations the mounted TimelineViewerScreen exposes to the tool layer. Clips
- * are addressed by id, case-insensitive name, or the literal `"selected"`.
+ * and tracks are addressed by id, case-insensitive name, or the literal
+ * `"selected"` (clips only).
  */
 export interface TimelineAgentHandler {
   getSnapshot: () => TimelineSnapshot;
@@ -150,6 +186,27 @@ export interface TimelineAgentHandler {
   selectClip: (target: string | null) => TimelineClipNode | null;
   /** Move the playhead and return the resulting position (ms). */
   seek: (timeMs: number) => number;
+
+  addTrack: (type: TimelineTrackType, name?: string) => TimelineTrackNode;
+  addTextClip: (input: TimelineAddTextClipInput) => TimelineClipNode;
+  addShapeClip: (input: TimelineAddShapeClipInput) => TimelineClipNode;
+  /** Moves the whole link group by one delta; returns every clip that moved. */
+  moveClip: (target: string, patch: TimelineMovePatch) => TimelineClipNode[];
+  /** All-or-nothing across the link group. */
+  trimClip: (target: string, patch: TimelineTrimPatch) => TimelineClipNode[];
+  /** Splits the clip and every link sibling at the same point. */
+  splitClip: (target: string, atMs?: number) => TimelineClipNode[];
+  deleteClip: (target: string) => TimelineClipNode;
+  /** Duplicates the clip, or the whole link group when it has one. */
+  duplicateClip: (target: string, gapMs?: number) => TimelineClipNode[];
+  setClipParams: (
+    target: string,
+    patch: TimelineClipParamsPatch
+  ) => TimelineClipNode;
+  addMarker: (input: TimelineAddMarkerInput) => TimelineMarkerData;
+  deleteMarker: (target: string) => TimelineMarkerData;
+  rename: (name: string) => { title: string };
+  save: () => Promise<{ ok: true; updatedAt: string | null }>;
 }
 
 /** Sequence length: the end of the last clip. Zero when there are none. */
@@ -179,6 +236,7 @@ export function clipToNode(
     prompt: clip.prompt,
     model: clip.model,
     provider: clip.provider,
+    linkId: clip.linkId,
     hasAsset: typeof clip.currentAssetId === 'string' && clip.currentAssetId.length > 0,
   };
 }
@@ -235,5 +293,33 @@ export function resolveClip(
       (known.length > 0
         ? `Clips: ${known}.`
         : 'This sequence has no clips yet.')
+  );
+}
+
+/**
+ * Resolve a track address: an id or a case-insensitive name. Never returns the
+ * raw string — writing a track *name* into `clip.trackId` would orphan the clip.
+ */
+export function resolveTrack(
+  tracks: readonly TimelineTrackData[],
+  target: string
+): TimelineTrackData {
+  const byId = tracks.find((track) => track.id === target);
+  if (byId) {
+    return byId;
+  }
+
+  const lowered = target.toLowerCase();
+  const byName = tracks.find((track) => track.name.toLowerCase() === lowered);
+  if (byName) {
+    return byName;
+  }
+
+  const known = tracks.map((track) => `${track.id} ("${track.name}")`).join(', ');
+  throw new Error(
+    `No track matches "${target}". Use a track id or a track name. ` +
+      (known.length > 0
+        ? `Tracks: ${known}.`
+        : 'This sequence has no tracks yet.')
   );
 }

--- a/mobile/src/documents/timelineTypes.ts
+++ b/mobile/src/documents/timelineTypes.ts
@@ -1,0 +1,239 @@
+/**
+ * The agent-facing timeline contract on mobile.
+ *
+ * Ported from web's `timelineAgentBridge`, trimmed to reads: snapshot, clip
+ * lookup, selection, seek. Editing, generation, and rendering are deliberately
+ * absent — a phone screen cannot supervise a render job, and a timeline is too
+ * dense to cut accurately with a thumb, so mobile opens sequences read-only
+ * (`kinds.ts` marks the surface `viewer`).
+ *
+ * Everything crossing the bridge is a plain serializable value, so the tool
+ * layer never touches a Zustand handle.
+ */
+
+export type TimelineTrackType = 'video' | 'audio' | 'overlay' | 'subtitle';
+
+export type TimelineMediaType =
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'overlay'
+  | 'text'
+  | 'shape';
+
+export type TimelineClipStatus =
+  | 'draft'
+  | 'queued'
+  | 'generating'
+  | 'generated'
+  | 'stale'
+  | 'failed'
+  | 'locked'
+  | 'missing';
+
+export interface TimelineTrackData {
+  id: string;
+  name: string;
+  type: TimelineTrackType;
+  index: number;
+  visible: boolean;
+  locked: boolean;
+  muted?: boolean;
+  solo?: boolean;
+  heightPx?: number;
+}
+
+export interface TimelineClipData {
+  id: string;
+  trackId: string;
+  name: string;
+  startMs: number;
+  durationMs: number;
+  inPointMs?: number;
+  outPointMs?: number;
+  mediaType: TimelineMediaType;
+  sourceType: 'imported' | 'generated';
+  status: TimelineClipStatus;
+  locked: boolean;
+  muted?: boolean;
+  hidden?: boolean;
+  prompt?: string;
+  provider?: string;
+  model?: string;
+  currentAssetId?: string;
+  thumbnailAssetId?: string;
+  /** Generation history. The viewer only shows how many there are. */
+  versions: unknown[];
+}
+
+export interface TimelineMarkerData {
+  id: string;
+  timeMs: number;
+  label: string;
+  color?: string;
+  note?: string;
+}
+
+/**
+ * The timeline document body — the wire shape of `timelineDocument` in
+ * `@nodetool-ai/protocol/api-schemas/timeline`. Declared structurally because
+ * that module is zod and is not re-exported from the package root, and mobile
+ * has no zod. Only the fields the viewer reads are named; the rest ride along
+ * untouched.
+ *
+ * `fps`, `width`, and `height` live on the resource row, not in the body, so
+ * they are unavailable here — duration comes from the clips.
+ */
+export interface TimelineDocument {
+  tracks: TimelineTrackData[];
+  clips: TimelineClipData[];
+  markers: TimelineMarkerData[];
+  transcript?: unknown[];
+  scriptEnabled?: boolean;
+}
+
+/** Serializable view of one clip. */
+export interface TimelineClipNode {
+  id: string;
+  trackId: string;
+  /** Name of the clip's track, or null when the track is gone. */
+  trackName: string | null;
+  name: string;
+  startMs: number;
+  durationMs: number;
+  mediaType: TimelineMediaType;
+  status: TimelineClipStatus;
+  locked: boolean;
+  muted?: boolean;
+  hidden?: boolean;
+  prompt?: string;
+  model?: string;
+  provider?: string;
+  /** Whether a rendered asset is attached, so the agent can tell empty from done. */
+  hasAsset: boolean;
+}
+
+/** Serializable view of one track. */
+export interface TimelineTrackNode {
+  id: string;
+  name: string;
+  type: TimelineTrackType;
+  index: number;
+  visible: boolean;
+  locked: boolean;
+  muted?: boolean;
+  clipCount: number;
+}
+
+/** What the agent reads to answer questions about the sequence. */
+export interface TimelineSnapshot {
+  sequenceId: string;
+  title: string;
+  durationMs: number;
+  trackCount: number;
+  clipCount: number;
+  playheadMs: number;
+  selectedClipIds: string[];
+  tracks: TimelineTrackNode[];
+  clips: TimelineClipNode[];
+  markers: { id: string; timeMs: number; label: string }[];
+}
+
+/**
+ * Operations the mounted TimelineViewerScreen exposes to the tool layer. Clips
+ * are addressed by id, case-insensitive name, or the literal `"selected"`.
+ */
+export interface TimelineAgentHandler {
+  getSnapshot: () => TimelineSnapshot;
+  getClip: (target: string) => TimelineClipNode;
+  /** Select a clip, or clear the selection with null. */
+  selectClip: (target: string | null) => TimelineClipNode | null;
+  /** Move the playhead and return the resulting position (ms). */
+  seek: (timeMs: number) => number;
+}
+
+/** Sequence length: the end of the last clip. Zero when there are none. */
+export function timelineDurationMs(clips: readonly TimelineClipData[]): number {
+  return clips.reduce(
+    (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+    0
+  );
+}
+
+export function clipToNode(
+  clip: TimelineClipData,
+  trackName: string | null
+): TimelineClipNode {
+  return {
+    id: clip.id,
+    trackId: clip.trackId,
+    trackName,
+    name: clip.name,
+    startMs: clip.startMs,
+    durationMs: clip.durationMs,
+    mediaType: clip.mediaType,
+    status: clip.status,
+    locked: clip.locked,
+    muted: clip.muted,
+    hidden: clip.hidden,
+    prompt: clip.prompt,
+    model: clip.model,
+    provider: clip.provider,
+    hasAsset: typeof clip.currentAssetId === 'string' && clip.currentAssetId.length > 0,
+  };
+}
+
+export function trackToNode(
+  track: TimelineTrackData,
+  clipCount: number
+): TimelineTrackNode {
+  return {
+    id: track.id,
+    name: track.name,
+    type: track.type,
+    index: track.index,
+    visible: track.visible,
+    locked: track.locked,
+    muted: track.muted,
+    clipCount,
+  };
+}
+
+/**
+ * Resolve an agent-supplied clip address: a clip id, a clip name
+ * (case-insensitive), or `"selected"`.
+ *
+ * Throws naming the clips that do exist — the message is the agent's only way
+ * to recover from a bad guess.
+ */
+export function resolveClip(
+  clips: readonly TimelineClipData[],
+  target: string,
+  selectedClipIds: readonly string[]
+): TimelineClipData {
+  const wanted = target === 'selected' ? (selectedClipIds[0] ?? '') : target;
+  if (wanted === '') {
+    throw new Error(
+      'No clip is selected. Pass a clip id or clip name instead of "selected".'
+    );
+  }
+
+  const byId = clips.find((clip) => clip.id === wanted);
+  if (byId) {
+    return byId;
+  }
+
+  const lowered = wanted.toLowerCase();
+  const byName = clips.find((clip) => clip.name.toLowerCase() === lowered);
+  if (byName) {
+    return byName;
+  }
+
+  const known = clips.map((clip) => `${clip.id} ("${clip.name}")`).join(', ');
+  throw new Error(
+    `No clip matches "${target}". Use a clip id, a clip name, or "selected". ` +
+      (known.length > 0
+        ? `Clips: ${known}.`
+        : 'This sequence has no clips yet.')
+  );
+}

--- a/mobile/src/documents/tools/__tests__/executeToolCall.test.ts
+++ b/mobile/src/documents/tools/__tests__/executeToolCall.test.ts
@@ -1,0 +1,223 @@
+import { executeToolCall, isToolCallMessage } from '../executeToolCall';
+import { MobileToolRegistry } from '../registry';
+
+describe('isToolCallMessage', () => {
+  it('accepts a well-formed tool call', () => {
+    expect(
+      isToolCallMessage({
+        type: 'tool_call',
+        tool_call_id: 'call-1',
+        name: 'ui_storyboard_get_state',
+        args: {},
+        thread_id: 'thread-1',
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    ['a chunk', { type: 'chunk', content: 'hi' }],
+    ['a missing id', { type: 'tool_call', name: 'ui_x' }],
+    ['a missing name', { type: 'tool_call', tool_call_id: 'call-1' }],
+    ['null', null],
+    ['a string', 'tool_call'],
+  ])('rejects %s', (_label, value) => {
+    expect(isToolCallMessage(value)).toBe(false);
+  });
+});
+
+describe('executeToolCall', () => {
+  const sender = { send: jest.fn() };
+
+  beforeEach(() => {
+    MobileToolRegistry.reset();
+    sender.send.mockReset();
+  });
+
+  const call = (name: string, args: Record<string, unknown> = {}) => ({
+    type: 'tool_call' as const,
+    tool_call_id: 'call-1',
+    name,
+    args,
+    thread_id: 'thread-1',
+  });
+
+  it('runs the tool and returns its result', async () => {
+    MobileToolRegistry.register({
+      name: 'ui_test_ok',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => ({ ok: true, shots: 2 }),
+    });
+
+    await executeToolCall(call('ui_test_ok'), sender);
+
+    const payload = sender.send.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      type: 'tool_result',
+      tool_call_id: 'call-1',
+      thread_id: 'thread-1',
+      ok: true,
+      result: { ok: true, shots: 2 },
+    });
+    expect(typeof payload.elapsed_ms).toBe('number');
+  });
+
+  it('passes the args through to the tool', async () => {
+    const execute = jest.fn().mockResolvedValue({ ok: true });
+    MobileToolRegistry.register({
+      name: 'ui_test_args',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute,
+    });
+
+    await executeToolCall(call('ui_test_args', { storyboard_id: 'sb1' }), sender);
+
+    expect(execute).toHaveBeenCalledWith(
+      { storyboard_id: 'sb1' },
+      expect.objectContaining({ abortSignal: expect.anything() })
+    );
+  });
+
+  it('still answers an unknown tool, so the agent is not left waiting', async () => {
+    await executeToolCall(call('ui_does_not_exist'), sender);
+
+    expect(sender.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool_result',
+        tool_call_id: 'call-1',
+        ok: false,
+        error: 'Unsupported tool: ui_does_not_exist',
+      })
+    );
+  });
+
+  it('relays a thrown message verbatim, so a bad id can be corrected', async () => {
+    MobileToolRegistry.register({
+      name: 'ui_test_throws',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => {
+        throw new Error('No storyboard "sb9" is open. Open storyboard ids: sb1.');
+      },
+    });
+
+    await executeToolCall(call('ui_test_throws'), sender);
+
+    expect(sender.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        error: 'No storyboard "sb9" is open. Open storyboard ids: sb1.',
+        result: {
+          error: 'No storyboard "sb9" is open. Open storyboard ids: sb1.',
+        },
+      })
+    );
+  });
+
+  it('does not throw when the socket send fails', async () => {
+    MobileToolRegistry.register({
+      name: 'ui_test_ok',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => ({ ok: true }),
+    });
+    const failing = {
+      send: jest.fn(() => {
+        throw new Error('socket closed');
+      }),
+    };
+
+    await expect(
+      executeToolCall(call('ui_test_ok'), failing)
+    ).resolves.toBeUndefined();
+  });
+
+  it('treats missing args as an empty object', async () => {
+    const execute = jest.fn().mockResolvedValue({ ok: true });
+    MobileToolRegistry.register({
+      name: 'ui_test_noargs',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute,
+    });
+
+    await executeToolCall(
+      {
+        type: 'tool_call',
+        tool_call_id: 'call-1',
+        name: 'ui_test_noargs',
+        args: undefined as unknown as Record<string, unknown>,
+        thread_id: 'thread-1',
+      },
+      sender
+    );
+
+    expect(execute).toHaveBeenCalledWith({}, expect.anything());
+  });
+});
+
+describe('MobileToolRegistry', () => {
+  beforeEach(() => {
+    MobileToolRegistry.reset();
+  });
+
+  it('exposes registered tools in the manifest the server reads', () => {
+    const parameters = {
+      type: 'object' as const,
+      properties: { storyboard_id: { type: 'string' } },
+      required: ['storyboard_id'],
+    };
+    MobileToolRegistry.register({
+      name: 'ui_manifest_check',
+      description: 'Read the board.',
+      parameters,
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(MobileToolRegistry.getManifest()).toEqual([
+      {
+        name: 'ui_manifest_check',
+        description: 'Read the board.',
+        parameters,
+      },
+    ]);
+  });
+
+  it('unregisters via the returned function', () => {
+    const unregister = MobileToolRegistry.register({
+      name: 'ui_temp',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => ({ ok: true }),
+    });
+
+    unregister();
+
+    expect(MobileToolRegistry.has('ui_temp')).toBe(false);
+  });
+
+  it('aborts in-flight calls', async () => {
+    const observed: { signal?: AbortSignal } = {};
+    MobileToolRegistry.register({
+      name: 'ui_slow',
+      description: 'test',
+      parameters: { type: 'object', properties: {} },
+      execute: async (_args, ctx) => {
+        observed.signal = ctx.abortSignal;
+        MobileToolRegistry.abortAll();
+        return { ok: true };
+      },
+    });
+
+    await MobileToolRegistry.call('ui_slow', {}, 'call-1');
+
+    expect(observed.signal?.aborted).toBe(true);
+  });
+
+  it('throws for an unknown tool', async () => {
+    await expect(MobileToolRegistry.call('ui_nope', {}, 'c1')).rejects.toThrow(
+      'Unknown tool: ui_nope'
+    );
+  });
+});

--- a/mobile/src/documents/tools/__tests__/scriptTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/scriptTools.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the ui_script_* tools.
+ *
+ * The tools are thin: they resolve a handler off the agent bridge and forward.
+ * So these tests check the forwarding contract — argument names, shapes, and the
+ * payload envelope — plus the failure the agent will actually hit most often,
+ * naming a script that is not open.
+ */
+
+import { MobileToolRegistry } from '../registry';
+import '../scriptTools';
+import {
+  registerDocumentHandler,
+  resetDocumentHandlers,
+} from '../../agentBridge';
+import type {
+  ScriptAgentHandler,
+  ScriptLineNode,
+  ScriptSectionNode,
+  ScriptSnapshot,
+  ScriptSpeakerNode,
+} from '../../scriptTypes';
+
+const lineNode = (id: string, index: number): ScriptLineNode => ({
+  id,
+  index,
+  sectionId: 'section-1',
+  speakerId: 'speaker-a',
+  speakerName: 'Ada',
+  text: 'Hello there',
+  status: 'draft',
+  takeCount: 0,
+});
+
+const speakerNode = (id: string): ScriptSpeakerNode => ({
+  id,
+  name: 'Ada',
+  hasVoice: false,
+});
+
+const sectionNode = (id: string): ScriptSectionNode => ({
+  id,
+  title: 'Cold open',
+  lineIds: ['line-a'],
+});
+
+const snapshot = (): ScriptSnapshot => ({
+  scriptId: 'sc-1',
+  title: 'Test script',
+  cast: [speakerNode('speaker-a')],
+  sections: [sectionNode('section-1')],
+  lines: [lineNode('line-a', 0)],
+  selectedLineId: null,
+});
+
+type MockHandler = {
+  [K in keyof ScriptAgentHandler]: jest.Mock;
+};
+
+const makeHandler = (): MockHandler => ({
+  getSnapshot: jest.fn(() => snapshot()),
+  addSpeaker: jest.fn(() => speakerNode('speaker-b')),
+  renameSpeaker: jest.fn(() => speakerNode('speaker-a')),
+  removeSpeaker: jest.fn(() => speakerNode('speaker-a')),
+  addSection: jest.fn(() => sectionNode('section-2')),
+  setSectionTitle: jest.fn(() => sectionNode('section-1')),
+  removeSection: jest.fn(() => sectionNode('section-1')),
+  addLine: jest.fn(() => lineNode('line-b', 1)),
+  setLineText: jest.fn(() => lineNode('line-a', 0)),
+  setLineSpeaker: jest.fn(() => lineNode('line-a', 0)),
+  patchLine: jest.fn(() => lineNode('line-a', 0)),
+  removeLine: jest.fn(() => lineNode('line-a', 0)),
+  moveLine: jest.fn(() => lineNode('line-a', 2)),
+  selectLine: jest.fn(() => lineNode('line-a', 0)),
+  save: jest.fn(async () => ({ ok: true, updatedAt: '2026-07-26T00:00:00Z' })),
+});
+
+const call = (name: string, args: Record<string, unknown>): Promise<unknown> =>
+  MobileToolRegistry.call(name, args, `${name}-call`);
+
+describe('script tools', () => {
+  let handler: MockHandler;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    resetDocumentHandlers();
+    handler = makeHandler();
+    unregister = registerDocumentHandler(
+      'script',
+      'sc-1',
+      'Test script',
+      handler as unknown as ScriptAgentHandler
+    );
+  });
+
+  afterEach(() => {
+    unregister();
+  });
+
+  it('registers every script tool in the manifest', () => {
+    expect(MobileToolRegistry.names()).toEqual(
+      expect.arrayContaining([
+        'ui_script_get_state',
+        'ui_script_add_speaker',
+        'ui_script_rename_speaker',
+        'ui_script_remove_speaker',
+        'ui_script_add_section',
+        'ui_script_set_section_title',
+        'ui_script_remove_section',
+        'ui_script_add_line',
+        'ui_script_set_line_text',
+        'ui_script_set_line_speaker',
+        'ui_script_patch_line',
+        'ui_script_remove_line',
+        'ui_script_move_line',
+        'ui_script_select_line',
+        'ui_script_save',
+      ])
+    );
+  });
+
+  it('registers no voicing, subtitle, or timeline tool — those are desktop-only', () => {
+    const names = MobileToolRegistry.names().filter((name) =>
+      name.startsWith('ui_script_')
+    );
+    expect(names).toHaveLength(15);
+    for (const name of names) {
+      expect(name).not.toMatch(/voice|subtitle|timeline/);
+    }
+  });
+
+  it('every script tool requires script_id and documents itself', () => {
+    const entries = MobileToolRegistry.getManifest().filter((entry) =>
+      entry.name.startsWith('ui_script_')
+    );
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.parameters.required).toContain('script_id');
+      expect(entry.description.length).toBeGreaterThan(40);
+    }
+  });
+
+  it('get_state returns the snapshot under an ok envelope', async () => {
+    const result = await call('ui_script_get_state', { script_id: 'sc-1' });
+
+    expect(handler.getSnapshot).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, ...snapshot() });
+  });
+
+  it('get_state says voicing and export are desktop-only', () => {
+    const entry = MobileToolRegistry.getManifest().find(
+      (it) => it.name === 'ui_script_get_state'
+    );
+    expect(entry?.description).toMatch(/desktop-only/);
+  });
+
+  it('cast tools forward name, color, and target', async () => {
+    const added = await call('ui_script_add_speaker', {
+      script_id: 'sc-1',
+      name: 'Grace',
+      color: '#6DB3F8',
+    });
+    await call('ui_script_rename_speaker', {
+      script_id: 'sc-1',
+      target: '0',
+      name: 'Ada Lovelace',
+    });
+    const removed = await call('ui_script_remove_speaker', {
+      script_id: 'sc-1',
+      target: 'speaker-a',
+    });
+
+    expect(handler.addSpeaker).toHaveBeenCalledWith('Grace', '#6DB3F8');
+    expect(handler.renameSpeaker).toHaveBeenCalledWith('0', 'Ada Lovelace');
+    expect(handler.removeSpeaker).toHaveBeenCalledWith('speaker-a');
+    expect(added).toEqual({ ok: true, speaker: speakerNode('speaker-b') });
+    expect(removed).toEqual({ ok: true, speaker: speakerNode('speaker-a') });
+  });
+
+  it('section tools forward title, index, and target', async () => {
+    const added = await call('ui_script_add_section', {
+      script_id: 'sc-1',
+      title: 'Act 2',
+      index: 1,
+    });
+    await call('ui_script_set_section_title', {
+      script_id: 'sc-1',
+      target: 'section-1',
+      title: 'Cold open',
+    });
+    await call('ui_script_remove_section', {
+      script_id: 'sc-1',
+      target: '0',
+    });
+
+    expect(handler.addSection).toHaveBeenCalledWith('Act 2', 1);
+    expect(handler.setSectionTitle).toHaveBeenCalledWith('section-1', 'Cold open');
+    expect(handler.removeSection).toHaveBeenCalledWith('0');
+    expect(added).toEqual({ ok: true, section: sectionNode('section-2') });
+  });
+
+  it('remove_section warns that it deletes the lines inside', () => {
+    const entry = MobileToolRegistry.getManifest().find(
+      (it) => it.name === 'ui_script_remove_section'
+    );
+    expect(entry?.description).toMatch(/every line inside it/);
+  });
+
+  it('add_line forwards text, speaker, direction, section and index', async () => {
+    const result = await call('ui_script_add_line', {
+      script_id: 'sc-1',
+      text: 'Over here',
+      speakerId: 'speaker-a',
+      direction: 'whispering',
+      sectionId: 'section-1',
+      index: 1,
+    });
+
+    expect(handler.addLine).toHaveBeenCalledWith({
+      text: 'Over here',
+      speakerId: 'speaker-a',
+      direction: 'whispering',
+      sectionId: 'section-1',
+      index: 1,
+    });
+    expect(result).toEqual({ ok: true, line: lineNode('line-b', 1) });
+  });
+
+  it('set_line_text forwards the target and the new text', async () => {
+    const result = await call('ui_script_set_line_text', {
+      script_id: 'sc-1',
+      target: 'selected',
+      text: 'Hello again',
+    });
+
+    expect(handler.setLineText).toHaveBeenCalledWith('selected', 'Hello again');
+    expect(result).toEqual({ ok: true, line: lineNode('line-a', 0) });
+  });
+
+  it('set_line_speaker forwards null to unassign the line', async () => {
+    await call('ui_script_set_line_speaker', {
+      script_id: 'sc-1',
+      target: '0',
+      speakerId: null,
+    });
+
+    expect(handler.setLineSpeaker).toHaveBeenCalledWith('0', null);
+  });
+
+  it('patch_line forwards only the delivery fields', async () => {
+    await call('ui_script_patch_line', {
+      script_id: 'sc-1',
+      target: 'line-a',
+      pauseAfterMs: 500,
+    });
+
+    expect(handler.patchLine).toHaveBeenCalledWith('line-a', {
+      direction: undefined,
+      pauseAfterMs: 500,
+    });
+  });
+
+  it('remove_line and move_line forward the target and destination', async () => {
+    const removed = await call('ui_script_remove_line', {
+      script_id: 'sc-1',
+      target: '0',
+    });
+    await call('ui_script_move_line', {
+      script_id: 'sc-1',
+      target: 'line-a',
+      to_index: 2,
+    });
+
+    expect(handler.removeLine).toHaveBeenCalledWith('0');
+    expect(handler.moveLine).toHaveBeenCalledWith('line-a', 2);
+    expect(removed).toEqual({ ok: true, line: lineNode('line-a', 0) });
+  });
+
+  it('select_line forwards null to clear the selection', async () => {
+    handler.selectLine.mockReturnValueOnce(null);
+
+    const result = await call('ui_script_select_line', {
+      script_id: 'sc-1',
+      target: null,
+    });
+
+    expect(handler.selectLine).toHaveBeenCalledWith(null);
+    expect(result).toEqual({ ok: true, selected: null });
+  });
+
+  it('save returns the handler result unchanged', async () => {
+    const result = await call('ui_script_save', { script_id: 'sc-1' });
+
+    expect(handler.save).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, updatedAt: '2026-07-26T00:00:00Z' });
+  });
+
+  it('fails with the open-script list when the id is not open', async () => {
+    await expect(
+      call('ui_script_get_state', { script_id: 'nope' })
+    ).rejects.toThrow(/No script "nope" is open.*Open script ids: sc-1/s);
+  });
+
+  it('fails naming no open scripts when nothing is open', async () => {
+    unregister();
+
+    await expect(
+      call('ui_script_add_line', { script_id: 'sc-1', text: 'x' })
+    ).rejects.toThrow(/No script documents are currently open/);
+  });
+});

--- a/mobile/src/documents/tools/__tests__/storyboardTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/storyboardTools.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the ui_storyboard_* tools.
+ *
+ * The tools are thin: they resolve a handler off the agent bridge and forward.
+ * So these tests check the forwarding contract — argument names, shapes, and the
+ * payload envelope — plus the failure the agent will actually hit most often,
+ * naming a board that is not open.
+ */
+
+import { MobileToolRegistry } from '../registry';
+import '../storyboardTools';
+import {
+  registerDocumentHandler,
+  resetDocumentHandlers,
+} from '../../agentBridge';
+import type {
+  StoryboardAgentHandler,
+  StoryboardShotNode,
+  StoryboardSnapshot,
+} from '../../storyboardTypes';
+
+const shotNode = (id: string, index: number): StoryboardShotNode => ({
+  id,
+  index,
+  action: 'A lighthouse at dusk',
+  status: 'planned',
+  hasKeyframe: false,
+  hasClip: false,
+});
+
+const snapshot = (): StoryboardSnapshot => ({
+  boardId: 'sb-1',
+  title: 'Test board',
+  brief: 'A brief',
+  style: 'grainy 16mm',
+  aspectRatio: '16:9',
+  hasScreenplay: false,
+  selectedShotId: null,
+  shots: [shotNode('shot-a', 0)],
+});
+
+type MockHandler = {
+  [K in keyof StoryboardAgentHandler]: jest.Mock;
+};
+
+const makeHandler = (): MockHandler => ({
+  getSnapshot: jest.fn(() => snapshot()),
+  addShot: jest.fn(() => shotNode('shot-b', 1)),
+  updateShot: jest.fn(() => shotNode('shot-a', 0)),
+  removeShot: jest.fn(() => shotNode('shot-a', 0)),
+  reorderShot: jest.fn(() => shotNode('shot-a', 2)),
+  setBrief: jest.fn(() => snapshot()),
+  setStyle: jest.fn(() => snapshot()),
+  setAspectRatio: jest.fn(() => snapshot()),
+  selectShot: jest.fn(() => shotNode('shot-a', 0)),
+  save: jest.fn(async () => ({ ok: true, updatedAt: '2026-07-26T00:00:00Z' })),
+});
+
+const call = (name: string, args: Record<string, unknown>): Promise<unknown> =>
+  MobileToolRegistry.call(name, args, `${name}-call`);
+
+describe('storyboard tools', () => {
+  let handler: MockHandler;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    resetDocumentHandlers();
+    handler = makeHandler();
+    unregister = registerDocumentHandler(
+      'storyboard',
+      'sb-1',
+      'Test board',
+      handler as unknown as StoryboardAgentHandler
+    );
+  });
+
+  afterEach(() => {
+    unregister();
+  });
+
+  it('registers every storyboard tool in the manifest', () => {
+    const names = MobileToolRegistry.names();
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'ui_storyboard_get_state',
+        'ui_storyboard_add_shot',
+        'ui_storyboard_update_shot',
+        'ui_storyboard_remove_shot',
+        'ui_storyboard_reorder_shot',
+        'ui_storyboard_set_brief',
+        'ui_storyboard_set_style',
+        'ui_storyboard_set_aspect_ratio',
+        'ui_storyboard_select_shot',
+        'ui_storyboard_save',
+      ])
+    );
+  });
+
+  it('every storyboard tool requires storyboard_id', () => {
+    const entries = MobileToolRegistry.getManifest().filter((entry) =>
+      entry.name.startsWith('ui_storyboard_')
+    );
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.parameters.required).toContain('storyboard_id');
+      expect(entry.description.length).toBeGreaterThan(40);
+    }
+  });
+
+  it('get_state returns the snapshot under an ok envelope', async () => {
+    const result = await call('ui_storyboard_get_state', {
+      storyboard_id: 'sb-1',
+    });
+
+    expect(handler.getSnapshot).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, ...snapshot() });
+  });
+
+  it('add_shot forwards action, camera, motion, duration and index', async () => {
+    const result = await call('ui_storyboard_add_shot', {
+      storyboard_id: 'sb-1',
+      action: 'Waves break on the rocks',
+      camera: { framing: 'wide' },
+      motion: 'slow push in',
+      durationSeconds: 4,
+      index: 1,
+    });
+
+    expect(handler.addShot).toHaveBeenCalledWith({
+      action: 'Waves break on the rocks',
+      camera: { framing: 'wide' },
+      motion: 'slow push in',
+      durationSeconds: 4,
+      index: 1,
+    });
+    expect(result).toEqual({ ok: true, shot: shotNode('shot-b', 1) });
+  });
+
+  it('update_shot forwards the target and the patch', async () => {
+    await call('ui_storyboard_update_shot', {
+      storyboard_id: 'sb-1',
+      target: 'selected',
+      action: 'Tighter on the lamp',
+      status: 'keyframe_ready',
+    });
+
+    expect(handler.updateShot).toHaveBeenCalledWith('selected', {
+      action: 'Tighter on the lamp',
+      camera: undefined,
+      motion: undefined,
+      slug: undefined,
+      durationSeconds: undefined,
+      status: 'keyframe_ready',
+    });
+  });
+
+  it('remove_shot forwards the target', async () => {
+    const result = await call('ui_storyboard_remove_shot', {
+      storyboard_id: 'sb-1',
+      target: '0',
+    });
+
+    expect(handler.removeShot).toHaveBeenCalledWith('0');
+    expect(result).toEqual({ ok: true, shot: shotNode('shot-a', 0) });
+  });
+
+  it('reorder_shot forwards the destination index', async () => {
+    await call('ui_storyboard_reorder_shot', {
+      storyboard_id: 'sb-1',
+      target: 'shot-a',
+      to_index: 2,
+    });
+
+    expect(handler.reorderShot).toHaveBeenCalledWith('shot-a', 2);
+  });
+
+  it('board setters forward their value and return a snapshot', async () => {
+    await call('ui_storyboard_set_brief', {
+      storyboard_id: 'sb-1',
+      brief: 'A storm rolls in',
+    });
+    await call('ui_storyboard_set_style', {
+      storyboard_id: 'sb-1',
+      style: 'muted teal',
+    });
+    const ratio = await call('ui_storyboard_set_aspect_ratio', {
+      storyboard_id: 'sb-1',
+      aspect_ratio: '9:16',
+    });
+
+    expect(handler.setBrief).toHaveBeenCalledWith('A storm rolls in');
+    expect(handler.setStyle).toHaveBeenCalledWith('muted teal');
+    expect(handler.setAspectRatio).toHaveBeenCalledWith('9:16');
+    expect(ratio).toEqual({ ok: true, ...snapshot() });
+  });
+
+  it('select_shot forwards null to clear the selection', async () => {
+    handler.selectShot.mockReturnValueOnce(null);
+
+    const result = await call('ui_storyboard_select_shot', {
+      storyboard_id: 'sb-1',
+      target: null,
+    });
+
+    expect(handler.selectShot).toHaveBeenCalledWith(null);
+    expect(result).toEqual({ ok: true, selected: null });
+  });
+
+  it('save returns the handler result unchanged', async () => {
+    const result = await call('ui_storyboard_save', { storyboard_id: 'sb-1' });
+
+    expect(handler.save).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, updatedAt: '2026-07-26T00:00:00Z' });
+  });
+
+  it('fails with the open-board list when the id is not open', async () => {
+    await expect(
+      call('ui_storyboard_get_state', { storyboard_id: 'nope' })
+    ).rejects.toThrow(/No storyboard "nope" is open.*Open storyboard ids: sb-1/s);
+  });
+
+  it('fails naming no open boards when nothing is open', async () => {
+    unregister();
+
+    await expect(
+      call('ui_storyboard_add_shot', { storyboard_id: 'sb-1', action: 'x' })
+    ).rejects.toThrow(/No storyboard documents are currently open/);
+  });
+});

--- a/mobile/src/documents/tools/__tests__/timelineTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/timelineTools.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Tests for the `ui_timeline_*` tool layer.
+ *
+ * The tools are thin: they validate nothing themselves, they delegate through
+ * the agent bridge. So these check the contract — every tool requires
+ * `timeline_id`, arguments arrive at the handler in the shape it expects, and
+ * results come back under `ok: true` — plus the two things the descriptions must
+ * say: that editing is available here, and that generation and rendering are not.
+ */
+
 import { MobileToolRegistry } from '../registry';
 import { registerDocumentHandler, resetDocumentHandlers } from '../../agentBridge';
 import {
@@ -10,7 +20,7 @@ import {
   type TimelineTrackData,
 } from '../../timelineTypes';
 
-// Registers the four ui_timeline_* tools as a side effect.
+// Registers the ui_timeline_* tools as a side effect.
 import '../timelineTools';
 
 const SEQ_ID = 'seq-1';
@@ -35,7 +45,7 @@ const clips: TimelineClipData[] = [
     provider: 'fal',
     model: 'flux',
     currentAssetId: 'asset-1',
-    versions: [{ id: 'v1' }],
+    versions: [],
   },
   {
     id: 'c2',
@@ -51,15 +61,27 @@ const clips: TimelineClipData[] = [
   },
 ];
 
+const trackNameOf = (trackId: string): string | null =>
+  tracks.find((track) => track.id === trackId)?.name ?? null;
+
+const node = (clip: TimelineClipData) => clipToNode(clip, trackNameOf(clip.trackId));
+
+/** Every write call, in order, so the tests can assert what reached the handler. */
+let calls: { name: string; args: unknown[] }[] = [];
+
+const record = <T>(name: string, args: unknown[], value: T): T => {
+  calls.push({ name, args });
+  return value;
+};
+
 /**
- * A handler built from the same helpers the screen uses, so the tests exercise
- * real target resolution rather than a stub that always succeeds.
+ * A handler built from the same helpers the screen uses, so target resolution is
+ * really exercised rather than stubbed into always succeeding.
  */
-function fakeHandler(selectedClipIds: string[]) {
-  const trackNameOf = (trackId: string): string | null =>
-    tracks.find((track) => track.id === trackId)?.name ?? null;
+function fakeHandler(selectedClipIds: string[]): TimelineAgentHandler {
   const durationMs = timelineDurationMs(clips);
-  const handler: TimelineAgentHandler = {
+  const resolve = (target: string) => resolveClip(clips, target, selectedClipIds);
+  return {
     getSnapshot: () => ({
       sequenceId: SEQ_ID,
       title: 'My Sequence',
@@ -68,26 +90,52 @@ function fakeHandler(selectedClipIds: string[]) {
       clipCount: clips.length,
       playheadMs: 500,
       selectedClipIds,
+      dirty: false,
       tracks: tracks.map((track) =>
         trackToNode(track, clips.filter((clip) => clip.trackId === track.id).length)
       ),
-      clips: clips.map((clip) => clipToNode(clip, trackNameOf(clip.trackId))),
+      clips: clips.map(node),
       markers: [{ id: 'm1', timeMs: 2000, label: 'Cut' }],
+      transcript: [{ id: 'line-1', text: 'Spoken line.', clipIds: ['c2'] }],
     }),
-    getClip: (target) => {
-      const clip = resolveClip(clips, target, selectedClipIds);
-      return clipToNode(clip, trackNameOf(clip.trackId));
-    },
-    selectClip: (target) => {
-      if (target === null) {
-        return null;
-      }
-      const clip = resolveClip(clips, target, selectedClipIds);
-      return clipToNode(clip, trackNameOf(clip.trackId));
-    },
+    getClip: (target) => node(resolve(target)),
+    selectClip: (target) => (target === null ? null : node(resolve(target))),
     seek: (timeMs) => Math.max(0, Math.min(timeMs, durationMs)),
+
+    addTrack: (type, name) =>
+      record('addTrack', [type, name], {
+        id: 't3',
+        name: name ?? 'overlay 3',
+        type,
+        index: 2,
+        visible: true,
+        locked: false,
+        clipCount: 0,
+      }),
+    addTextClip: (input) => record('addTextClip', [input], node(clips[0])),
+    addShapeClip: (input) => record('addShapeClip', [input], node(clips[0])),
+    moveClip: (target, patch) =>
+      record('moveClip', [target, patch], [node(resolve(target))]),
+    trimClip: (target, patch) =>
+      record('trimClip', [target, patch], [node(resolve(target))]),
+    splitClip: (target, atMs) =>
+      record('splitClip', [target, atMs], [node(clips[0]), node(clips[1])]),
+    deleteClip: (target) => record('deleteClip', [target], node(resolve(target))),
+    duplicateClip: (target, gapMs) =>
+      record('duplicateClip', [target, gapMs], [node(resolve(target))]),
+    setClipParams: (target, patch) =>
+      record('setClipParams', [target, patch], node(resolve(target))),
+    addMarker: (input) =>
+      record('addMarker', [input], {
+        id: 'm2',
+        timeMs: input.timeMs,
+        label: input.label ?? '',
+      }),
+    deleteMarker: (target) =>
+      record('deleteMarker', [target], { id: 'm1', timeMs: 2000, label: 'Cut' }),
+    rename: (name) => record('rename', [name], { title: name }),
+    save: async () => record('save', [], { ok: true as const, updatedAt: 'now' }),
   };
-  return handler;
 }
 
 const call = async (
@@ -99,36 +147,77 @@ const call = async (
     unknown
   >;
 
+const WRITE_TOOLS = [
+  'ui_timeline_add_track',
+  'ui_timeline_add_text_clip',
+  'ui_timeline_add_shape_clip',
+  'ui_timeline_move_clip',
+  'ui_timeline_trim_clip',
+  'ui_timeline_split_clip',
+  'ui_timeline_delete_clip',
+  'ui_timeline_duplicate_clip',
+  'ui_timeline_set_clip_params',
+  'ui_timeline_add_marker',
+  'ui_timeline_delete_marker',
+  'ui_timeline_rename',
+  'ui_timeline_save',
+];
+
 describe('timelineTools', () => {
   beforeEach(() => {
+    calls = [];
     resetDocumentHandlers();
     registerDocumentHandler('timeline', SEQ_ID, 'My Sequence', fakeHandler(['c2']));
   });
 
-  it('registers the read-only timeline tools', () => {
+  it('registers the read and the write tools', () => {
     expect(MobileToolRegistry.names()).toEqual(
       expect.arrayContaining([
         'ui_timeline_get_state',
         'ui_timeline_get_clip',
         'ui_timeline_select_clip',
         'ui_timeline_seek',
+        ...WRITE_TOOLS,
       ])
     );
   });
 
-  it('says in every description that the mobile timeline is read-only', () => {
+  it('does not offer generation or frame inspection, which are desktop-only', () => {
+    expect(MobileToolRegistry.has('ui_timeline_generate_clip')).toBe(false);
+    expect(MobileToolRegistry.has('ui_timeline_get_clip_frames')).toBe(false);
+  });
+
+  it('never claims the timeline is read-only, and always requires timeline_id', () => {
     const timelineTools = MobileToolRegistry.getManifest().filter((entry) =>
       entry.name.startsWith('ui_timeline_')
     );
 
-    expect(timelineTools).toHaveLength(4);
+    expect(timelineTools).toHaveLength(4 + WRITE_TOOLS.length);
     for (const tool of timelineTools) {
-      expect(tool.description).toMatch(/read-only/);
+      expect(tool.description).not.toMatch(/read-only/);
       expect(tool.parameters.required).toContain('timeline_id');
     }
   });
 
-  it('ui_timeline_get_state returns the snapshot', async () => {
+  it('tells the agent that generation and rendering are desktop-only', () => {
+    const state = MobileToolRegistry.getManifest().find(
+      (entry) => entry.name === 'ui_timeline_get_state'
+    );
+
+    expect(state?.description).toMatch(/desktop-only/);
+  });
+
+  it('tells the agent an edit still has to be saved', () => {
+    const move = MobileToolRegistry.getManifest().find(
+      (entry) => entry.name === 'ui_timeline_move_clip'
+    );
+
+    expect(move?.description).toMatch(/ui_timeline_save/);
+  });
+
+  // ── Reads ────────────────────────────────────────────────────────────────
+
+  it('ui_timeline_get_state returns the snapshot, including the transcript', async () => {
     const result = await call('ui_timeline_get_state', { timeline_id: SEQ_ID });
 
     expect(result).toMatchObject({
@@ -140,6 +229,8 @@ describe('timelineTools', () => {
       clipCount: 2,
       playheadMs: 500,
       selectedClipIds: ['c2'],
+      dirty: false,
+      transcript: [{ id: 'line-1', clipIds: ['c2'] }],
     });
   });
 
@@ -207,6 +298,174 @@ describe('timelineTools', () => {
     ).resolves.toEqual({ ok: true, playheadMs: 9000 });
   });
 
+  // ── Writes ───────────────────────────────────────────────────────────────
+
+  it('ui_timeline_add_track forwards the type and name', async () => {
+    const result = await call('ui_timeline_add_track', {
+      timeline_id: SEQ_ID,
+      type: 'overlay',
+      name: 'Titles',
+    });
+
+    expect(calls).toEqual([{ name: 'addTrack', args: ['overlay', 'Titles'] }]);
+    expect(result).toMatchObject({ ok: true, track: { name: 'Titles' } });
+  });
+
+  it('ui_timeline_add_text_clip forwards the text, placement, and style', async () => {
+    await call('ui_timeline_add_text_clip', {
+      timeline_id: SEQ_ID,
+      text: 'Chapter One',
+      trackId: 'Titles',
+      startMs: 1200,
+      durationMs: 2500,
+      style: { fontSizePx: 64, color: '#ff0000' },
+    });
+
+    expect(calls[0]).toEqual({
+      name: 'addTextClip',
+      args: [
+        {
+          text: 'Chapter One',
+          trackId: 'Titles',
+          startMs: 1200,
+          durationMs: 2500,
+          style: { fontSizePx: 64, color: '#ff0000' },
+        },
+      ],
+    });
+  });
+
+  it('ui_timeline_add_shape_clip forwards the shape', async () => {
+    await call('ui_timeline_add_shape_clip', {
+      timeline_id: SEQ_ID,
+      shape: { kind: 'rect', x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+    });
+
+    expect(calls[0].args[0]).toMatchObject({
+      shape: { kind: 'rect', width: 0.3 },
+    });
+  });
+
+  it('ui_timeline_move_clip forwards the patch and returns every clip that moved', async () => {
+    const result = await call('ui_timeline_move_clip', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+      startMs: 2000,
+      trackId: 't2',
+    });
+
+    expect(calls).toEqual([
+      { name: 'moveClip', args: ['c1', { startMs: 2000, trackId: 't2' }] },
+    ]);
+    expect(result).toMatchObject({ ok: true, clips: [{ id: 'c1' }] });
+  });
+
+  it('ui_timeline_trim_clip forwards all three fields', async () => {
+    await call('ui_timeline_trim_clip', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+      durationMs: 3000,
+    });
+
+    expect(calls[0]).toEqual({
+      name: 'trimClip',
+      args: [
+        'c1',
+        { durationMs: 3000, inPointMs: undefined, outPointMs: undefined },
+      ],
+    });
+  });
+
+  it('ui_timeline_split_clip passes atMs through, and undefined when omitted', async () => {
+    await call('ui_timeline_split_clip', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+      atMs: 1500,
+    });
+    await call('ui_timeline_split_clip', { timeline_id: SEQ_ID, target: 'c1' });
+
+    expect(calls.map((entry) => entry.args)).toEqual([
+      ['c1', 1500],
+      ['c1', undefined],
+    ]);
+  });
+
+  it('ui_timeline_delete_clip reports what it removed', async () => {
+    const result = await call('ui_timeline_delete_clip', {
+      timeline_id: SEQ_ID,
+      target: 'Theme',
+    });
+
+    expect(result).toMatchObject({ ok: true, deleted: { id: 'c2' } });
+  });
+
+  it('ui_timeline_duplicate_clip forwards the gap', async () => {
+    await call('ui_timeline_duplicate_clip', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+      gapMs: 500,
+    });
+
+    expect(calls[0].args).toEqual(['c1', 500]);
+  });
+
+  it('ui_timeline_set_clip_params forwards params and binding fields together', async () => {
+    await call('ui_timeline_set_clip_params', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+      opacity: 0.5,
+      prompt: 'a fox at dusk',
+    });
+
+    expect(calls[0]).toEqual({
+      name: 'setClipParams',
+      args: ['c1', { opacity: 0.5, prompt: 'a fox at dusk' }],
+    });
+  });
+
+  it('ui_timeline_set_clip_params documents the staleness rule', () => {
+    const tool = MobileToolRegistry.getManifest().find(
+      (entry) => entry.name === 'ui_timeline_set_clip_params'
+    );
+
+    expect(tool?.description).toMatch(/marks an already-generated clip `stale`/);
+  });
+
+  it('ui_timeline_add_marker and delete_marker round-trip', async () => {
+    const added = await call('ui_timeline_add_marker', {
+      timeline_id: SEQ_ID,
+      timeMs: 4500,
+      label: 'Beat',
+    });
+    expect(added).toMatchObject({
+      ok: true,
+      marker: { timeMs: 4500, label: 'Beat' },
+    });
+
+    const deleted = await call('ui_timeline_delete_marker', {
+      timeline_id: SEQ_ID,
+      target: 'Cut',
+    });
+    expect(deleted).toMatchObject({ ok: true, deleted: { id: 'm1' } });
+  });
+
+  it('ui_timeline_rename returns the new title', async () => {
+    const result = await call('ui_timeline_rename', {
+      timeline_id: SEQ_ID,
+      name: 'Trailer v2',
+    });
+
+    expect(result).toEqual({ ok: true, title: 'Trailer v2' });
+  });
+
+  it('ui_timeline_save reports the persisted timestamp', async () => {
+    const result = await call('ui_timeline_save', { timeline_id: SEQ_ID });
+
+    expect(result).toEqual({ ok: true, updatedAt: 'now' });
+  });
+
+  // ── Bridge failures ──────────────────────────────────────────────────────
+
   it('fails with the open ids when the timeline is not open', async () => {
     await expect(
       call('ui_timeline_get_state', { timeline_id: 'not-open' })
@@ -221,5 +480,23 @@ describe('timelineTools', () => {
     await expect(
       call('ui_timeline_get_state', { timeline_id: SEQ_ID })
     ).rejects.toThrow(/No timeline documents are currently open/);
+  });
+
+  it('every write tool fails through the bridge when nothing is open', async () => {
+    resetDocumentHandlers();
+
+    for (const toolName of WRITE_TOOLS) {
+      await expect(
+        call(toolName, {
+          timeline_id: SEQ_ID,
+          target: 'c1',
+          type: 'video',
+          text: 'x',
+          name: 'x',
+          timeMs: 0,
+          shape: { kind: 'rect' },
+        })
+      ).rejects.toThrow(/No timeline documents are currently open/);
+    }
   });
 });

--- a/mobile/src/documents/tools/__tests__/timelineTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/timelineTools.test.ts
@@ -1,0 +1,225 @@
+import { MobileToolRegistry } from '../registry';
+import { registerDocumentHandler, resetDocumentHandlers } from '../../agentBridge';
+import {
+  clipToNode,
+  resolveClip,
+  timelineDurationMs,
+  trackToNode,
+  type TimelineAgentHandler,
+  type TimelineClipData,
+  type TimelineTrackData,
+} from '../../timelineTypes';
+
+// Registers the four ui_timeline_* tools as a side effect.
+import '../timelineTools';
+
+const SEQ_ID = 'seq-1';
+
+const tracks: TimelineTrackData[] = [
+  { id: 't1', name: 'Video 1', type: 'video', index: 0, visible: true, locked: false },
+  { id: 't2', name: 'Music', type: 'audio', index: 1, visible: true, locked: false },
+];
+
+const clips: TimelineClipData[] = [
+  {
+    id: 'c1',
+    trackId: 't1',
+    name: 'Opening shot',
+    startMs: 0,
+    durationMs: 4000,
+    mediaType: 'video',
+    sourceType: 'generated',
+    status: 'generated',
+    locked: false,
+    prompt: 'a fox in snow',
+    provider: 'fal',
+    model: 'flux',
+    currentAssetId: 'asset-1',
+    versions: [{ id: 'v1' }],
+  },
+  {
+    id: 'c2',
+    trackId: 't2',
+    name: 'Theme',
+    startMs: 1000,
+    durationMs: 8000,
+    mediaType: 'audio',
+    sourceType: 'imported',
+    status: 'draft',
+    locked: false,
+    versions: [],
+  },
+];
+
+/**
+ * A handler built from the same helpers the screen uses, so the tests exercise
+ * real target resolution rather than a stub that always succeeds.
+ */
+function fakeHandler(selectedClipIds: string[]) {
+  const trackNameOf = (trackId: string): string | null =>
+    tracks.find((track) => track.id === trackId)?.name ?? null;
+  const durationMs = timelineDurationMs(clips);
+  const handler: TimelineAgentHandler = {
+    getSnapshot: () => ({
+      sequenceId: SEQ_ID,
+      title: 'My Sequence',
+      durationMs,
+      trackCount: tracks.length,
+      clipCount: clips.length,
+      playheadMs: 500,
+      selectedClipIds,
+      tracks: tracks.map((track) =>
+        trackToNode(track, clips.filter((clip) => clip.trackId === track.id).length)
+      ),
+      clips: clips.map((clip) => clipToNode(clip, trackNameOf(clip.trackId))),
+      markers: [{ id: 'm1', timeMs: 2000, label: 'Cut' }],
+    }),
+    getClip: (target) => {
+      const clip = resolveClip(clips, target, selectedClipIds);
+      return clipToNode(clip, trackNameOf(clip.trackId));
+    },
+    selectClip: (target) => {
+      if (target === null) {
+        return null;
+      }
+      const clip = resolveClip(clips, target, selectedClipIds);
+      return clipToNode(clip, trackNameOf(clip.trackId));
+    },
+    seek: (timeMs) => Math.max(0, Math.min(timeMs, durationMs)),
+  };
+  return handler;
+}
+
+const call = async (
+  name: string,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> =>
+  (await MobileToolRegistry.call(name, args, `${name}-call`)) as Record<
+    string,
+    unknown
+  >;
+
+describe('timelineTools', () => {
+  beforeEach(() => {
+    resetDocumentHandlers();
+    registerDocumentHandler('timeline', SEQ_ID, 'My Sequence', fakeHandler(['c2']));
+  });
+
+  it('registers the read-only timeline tools', () => {
+    expect(MobileToolRegistry.names()).toEqual(
+      expect.arrayContaining([
+        'ui_timeline_get_state',
+        'ui_timeline_get_clip',
+        'ui_timeline_select_clip',
+        'ui_timeline_seek',
+      ])
+    );
+  });
+
+  it('says in every description that the mobile timeline is read-only', () => {
+    const timelineTools = MobileToolRegistry.getManifest().filter((entry) =>
+      entry.name.startsWith('ui_timeline_')
+    );
+
+    expect(timelineTools).toHaveLength(4);
+    for (const tool of timelineTools) {
+      expect(tool.description).toMatch(/read-only/);
+      expect(tool.parameters.required).toContain('timeline_id');
+    }
+  });
+
+  it('ui_timeline_get_state returns the snapshot', async () => {
+    const result = await call('ui_timeline_get_state', { timeline_id: SEQ_ID });
+
+    expect(result).toMatchObject({
+      ok: true,
+      sequenceId: SEQ_ID,
+      title: 'My Sequence',
+      durationMs: 9000,
+      trackCount: 2,
+      clipCount: 2,
+      playheadMs: 500,
+      selectedClipIds: ['c2'],
+    });
+  });
+
+  it('ui_timeline_get_clip resolves a clip by id', async () => {
+    const result = await call('ui_timeline_get_clip', {
+      timeline_id: SEQ_ID,
+      target: 'c1',
+    });
+
+    expect(result.clip).toMatchObject({
+      id: 'c1',
+      trackName: 'Video 1',
+      mediaType: 'video',
+      hasAsset: true,
+      model: 'flux',
+    });
+  });
+
+  it('ui_timeline_get_clip resolves a clip by case-insensitive name', async () => {
+    const result = await call('ui_timeline_get_clip', {
+      timeline_id: SEQ_ID,
+      target: 'opening SHOT',
+    });
+
+    expect(result.clip).toMatchObject({ id: 'c1' });
+  });
+
+  it('ui_timeline_get_clip resolves "selected"', async () => {
+    const result = await call('ui_timeline_get_clip', {
+      timeline_id: SEQ_ID,
+      target: 'selected',
+    });
+
+    expect(result.clip).toMatchObject({ id: 'c2', trackName: 'Music' });
+  });
+
+  it('ui_timeline_get_clip names the existing clips when the target misses', async () => {
+    await expect(
+      call('ui_timeline_get_clip', { timeline_id: SEQ_ID, target: 'nope' })
+    ).rejects.toThrow(/No clip matches "nope".*c1 \("Opening shot"\)/s);
+  });
+
+  it('ui_timeline_select_clip delegates and reports the selection', async () => {
+    const selected = await call('ui_timeline_select_clip', {
+      timeline_id: SEQ_ID,
+      target: 'Theme',
+    });
+
+    expect(selected).toMatchObject({ ok: true, selected: { id: 'c2' } });
+  });
+
+  it('ui_timeline_select_clip clears the selection when target is omitted', async () => {
+    const result = await call('ui_timeline_select_clip', { timeline_id: SEQ_ID });
+
+    expect(result).toEqual({ ok: true, selected: null });
+  });
+
+  it('ui_timeline_seek returns the resulting playhead, clamped to the duration', async () => {
+    await expect(
+      call('ui_timeline_seek', { timeline_id: SEQ_ID, timeMs: 3000 })
+    ).resolves.toEqual({ ok: true, playheadMs: 3000 });
+
+    await expect(
+      call('ui_timeline_seek', { timeline_id: SEQ_ID, timeMs: 99_000 })
+    ).resolves.toEqual({ ok: true, playheadMs: 9000 });
+  });
+
+  it('fails with the open ids when the timeline is not open', async () => {
+    await expect(
+      call('ui_timeline_get_state', { timeline_id: 'not-open' })
+    ).rejects.toThrow(
+      /No timeline "not-open" is open\. Open timeline ids: seq-1\./
+    );
+  });
+
+  it('tells the agent to ask the user when no timeline is open at all', async () => {
+    resetDocumentHandlers();
+
+    await expect(
+      call('ui_timeline_get_state', { timeline_id: SEQ_ID })
+    ).rejects.toThrow(/No timeline documents are currently open/);
+  });
+});

--- a/mobile/src/documents/tools/executeToolCall.ts
+++ b/mobile/src/documents/tools/executeToolCall.ts
@@ -1,0 +1,79 @@
+/**
+ * The `tool_call` → `tool_result` round trip.
+ *
+ * Kept out of `ChatStore` so the chat store stays a state container and this
+ * stays testable without a socket. Mirrors web's `executeToolCall`: an unknown
+ * name still gets a `tool_result`, because a silent drop leaves the agent
+ * waiting on a call that will never come back.
+ */
+
+import { MobileToolRegistry } from './registry';
+
+/** Server → client request to run a client-side tool. */
+export interface ToolCallMessage {
+  type: 'tool_call';
+  tool_call_id: string;
+  name: string;
+  args: Record<string, unknown>;
+  thread_id: string;
+}
+
+/**
+ * The subset of the socket this needs. Shaped to match `WebSocketManager.send`,
+ * whose constraint is a tagged object.
+ */
+export interface ToolResultSender {
+  send: (message: { type: string; [key: string]: unknown }) => void;
+}
+
+export function isToolCallMessage(data: unknown): data is ToolCallMessage {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const candidate = data as Partial<ToolCallMessage>;
+  return (
+    candidate.type === 'tool_call' &&
+    typeof candidate.tool_call_id === 'string' &&
+    typeof candidate.name === 'string'
+  );
+}
+
+export async function executeToolCall(
+  message: ToolCallMessage,
+  sender: ToolResultSender
+): Promise<void> {
+  const { tool_call_id, name, args, thread_id } = message;
+
+  const reply = (payload: Record<string, unknown>): void => {
+    try {
+      sender.send({ type: 'tool_result', tool_call_id, thread_id, ...payload });
+    } catch (error) {
+      console.error('Failed to send tool_result:', error);
+    }
+  };
+
+  if (!MobileToolRegistry.has(name)) {
+    reply({
+      ok: false,
+      error: `Unsupported tool: ${name}`,
+      result: { error: `Unsupported tool: ${name}` },
+    });
+    return;
+  }
+
+  const startedAt = Date.now();
+  try {
+    const result = await MobileToolRegistry.call(name, args ?? {}, tool_call_id);
+    reply({ ok: true, result, elapsed_ms: Date.now() - startedAt });
+  } catch (error) {
+    // The bridge's "no such document is open, here are the open ids" message
+    // travels back verbatim — that is how the agent recovers from a bad id.
+    const errorText = error instanceof Error ? error.message : 'Unknown error';
+    reply({
+      ok: false,
+      error: errorText,
+      result: { error: errorText },
+      elapsed_ms: Date.now() - startedAt,
+    });
+  }
+}

--- a/mobile/src/documents/tools/index.ts
+++ b/mobile/src/documents/tools/index.ts
@@ -1,0 +1,21 @@
+/**
+ * The one list of client-side tool modules. Importing this registers all of
+ * them with the `MobileToolRegistry` as a side effect — the same
+ * registration-by-import shape web's `builtin/index.ts` uses, and for the same
+ * reason: one list means the manifest can't drift by entry point.
+ *
+ * Registration is not availability. Every tool takes a required document id and
+ * resolves it against the documents actually open, so registering a tool the
+ * user can't currently use is harmless — it fails naming the open ids.
+ */
+
+import './storyboardTools';
+import './timelineTools';
+
+export { MobileToolRegistry } from './registry';
+export type {
+  MobileToolDefinition,
+  ToolManifestEntry,
+  ToolParameterSchema,
+} from './registry';
+export { executeToolCall, isToolCallMessage } from './executeToolCall';

--- a/mobile/src/documents/tools/index.ts
+++ b/mobile/src/documents/tools/index.ts
@@ -9,6 +9,7 @@
  * user can't currently use is harmless — it fails naming the open ids.
  */
 
+import './scriptTools';
 import './storyboardTools';
 import './timelineTools';
 

--- a/mobile/src/documents/tools/registry.ts
+++ b/mobile/src/documents/tools/registry.ts
@@ -1,0 +1,102 @@
+/**
+ * The mobile frontend-tool registry.
+ *
+ * A slim port of web's `FrontendToolRegistry`. Two deliberate differences:
+ *
+ * - **Parameters are plain JSON Schema.** Web declares them with zod and
+ *   converts; mobile has no zod dependency, and the server only ever sees the
+ *   converted JSON Schema anyway, so we write that directly.
+ * - **No workflow runtime state.** Web's `FrontendToolContext` carries the
+ *   whole graph-editor state. Mobile tools act on documents through the agent
+ *   bridge, so the context only needs an abort signal.
+ *
+ * The wire contract is unchanged, which is what matters: the client pushes
+ * `client_tools_manifest` on connect, the server sends `tool_call`, the client
+ * answers `tool_result`.
+ */
+
+/** JSON Schema for a tool's arguments. Object schemas only, as providers require. */
+export interface ToolParameterSchema {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface MobileToolContext {
+  abortSignal: AbortSignal;
+}
+
+export interface MobileToolDefinition<Args = Record<string, unknown>> {
+  name: `ui_${string}`;
+  description: string;
+  parameters: ToolParameterSchema;
+  execute: (args: Args, ctx: MobileToolContext) => Promise<unknown>;
+}
+
+/** One manifest entry, exactly as the server's `clientToolsManifest` reads it. */
+export interface ToolManifestEntry {
+  name: string;
+  description: string;
+  parameters: ToolParameterSchema;
+}
+
+const registry = new Map<string, MobileToolDefinition<never>>();
+const active = new Map<string, AbortController>();
+
+export const MobileToolRegistry = {
+  register<Args>(tool: MobileToolDefinition<Args>): () => void {
+    registry.set(tool.name, tool as unknown as MobileToolDefinition<never>);
+    return () => registry.delete(tool.name);
+  },
+
+  getManifest(): ToolManifestEntry[] {
+    return [...registry.values()].map(({ name, description, parameters }) => ({
+      name,
+      description,
+      parameters,
+    }));
+  },
+
+  has(name: string): boolean {
+    return registry.has(name);
+  },
+
+  names(): string[] {
+    return [...registry.keys()];
+  },
+
+  async call(
+    name: string,
+    args: unknown,
+    toolCallId: string
+  ): Promise<unknown> {
+    const tool = registry.get(name);
+    if (!tool) {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+    const controller = new AbortController();
+    active.set(toolCallId, controller);
+    try {
+      return await tool.execute(args as never, {
+        abortSignal: controller.signal,
+      });
+    } finally {
+      active.delete(toolCallId);
+    }
+  },
+
+  /** Abort every in-flight call — used when the user stops generation. */
+  abortAll(): void {
+    for (const controller of active.values()) {
+      controller.abort();
+    }
+    active.clear();
+  },
+
+  /** Test seam. */
+  reset(): void {
+    registry.clear();
+    active.clear();
+  },
+};

--- a/mobile/src/documents/tools/scriptTools.ts
+++ b/mobile/src/documents/tools/scriptTools.ts
@@ -1,0 +1,425 @@
+/**
+ * `ui_script_*` — the tools that let the agent write an open script.
+ *
+ * A port of web's `builtin/script.ts` with the voicing, subtitle, and timeline
+ * tools removed (see `scriptTypes.ts` for why) and zod swapped for plain JSON
+ * Schema. Every tool takes an explicit `script_id` and delegates to the handler
+ * the mounted ScriptEditorScreen registered; when that script is not open the
+ * getter throws naming the open ids, and the tool layer hands that message to
+ * the agent verbatim.
+ */
+
+import { getDocumentHandler } from '../agentBridge';
+import { MobileToolRegistry } from './registry';
+import type { ScriptAgentHandler } from '../scriptTypes';
+
+const handlerFor = (scriptId: string): ScriptAgentHandler =>
+  getDocumentHandler<ScriptAgentHandler>('script', scriptId);
+
+const scriptIdProperty = {
+  type: 'string',
+  description:
+    'Id of the script to act on. Valid ids are listed in the ui_context block of the system prompt; there is no "current script" fallback.',
+} as const;
+
+const lineTargetProperty = {
+  type: 'string',
+  description:
+    'Which line: its id, its 0-based index across the whole script written as a string, or the literal "selected" for the line the user has selected on screen.',
+} as const;
+
+const speakerTargetProperty = {
+  type: 'string',
+  description:
+    'Which cast member: its speaker id, or its 0-based index in the cast written as a string.',
+} as const;
+
+const sectionTargetProperty = {
+  type: 'string',
+  description:
+    'Which section: its section id, or its 0-based index written as a string.',
+} as const;
+
+interface ScriptIdArgs {
+  script_id: string;
+}
+
+/** Every targeted tool: a script id plus one line, speaker, or section address. */
+interface TargetArgs extends ScriptIdArgs {
+  target: string;
+}
+
+MobileToolRegistry.register<ScriptIdArgs>({
+  name: 'ui_script_get_state',
+  description:
+    'Read a script: its title, the cast (each speaker id, name, chip color, and whether a TTS voice is bound), the sections in order with the line ids each holds, and every line in document order with its id, document index, section, speaker, text, direction, pause, voicing status (draft / voiced / stale) and take count. Call this first — every other tool addresses lines, speakers, and sections by the ids and indexes it returns. Note what this surface cannot do: voicing lines with TTS, exporting subtitles, and assembling the script into a timeline are desktop-only, so do not offer them here.',
+  parameters: {
+    type: 'object',
+    properties: { script_id: scriptIdProperty },
+    required: ['script_id'],
+  },
+  async execute({ script_id }) {
+    return { ok: true, ...handlerFor(script_id).getSnapshot() };
+  },
+});
+
+interface AddSpeakerArgs extends ScriptIdArgs {
+  name: string;
+  color?: string;
+}
+
+MobileToolRegistry.register<AddSpeakerArgs>({
+  name: 'ui_script_add_speaker',
+  description:
+    'Add a cast member. `name` is how the speaker is labelled in the script; `color` is an optional hex chip color that tells their lines apart at a glance. Returns the new speaker with the id you then pass to ui_script_add_line or ui_script_set_line_speaker. Binding a TTS voice to a speaker happens on the desktop app.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      name: {
+        type: 'string',
+        description: 'Speaker name, e.g. "Narrator" or "Ada".',
+      },
+      color: {
+        type: 'string',
+        description: 'Optional chip color as a hex string, e.g. "#6DB3F8".',
+      },
+    },
+    required: ['script_id', 'name'],
+  },
+  async execute({ script_id, name, color }) {
+    const speaker = handlerFor(script_id).addSpeaker(name, color);
+    return { ok: true, speaker };
+  },
+});
+
+interface RenameSpeakerArgs extends ScriptIdArgs {
+  target: string;
+  name: string;
+}
+
+MobileToolRegistry.register<RenameSpeakerArgs>({
+  name: 'ui_script_rename_speaker',
+  description:
+    'Rename a cast member. Their lines keep pointing at the same speaker id, so this changes the label everywhere at once. Returns the updated speaker.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: speakerTargetProperty,
+      name: { type: 'string', description: 'The new name.' },
+    },
+    required: ['script_id', 'target', 'name'],
+  },
+  async execute({ script_id, target, name }) {
+    const speaker = handlerFor(script_id).renameSpeaker(target, name);
+    return { ok: true, speaker };
+  },
+});
+
+MobileToolRegistry.register<TargetArgs>({
+  name: 'ui_script_remove_speaker',
+  description:
+    'Remove a cast member. Their lines stay in the script and become unassigned — nothing is deleted, so reassign them with ui_script_set_line_speaker afterwards. Returns the removed speaker.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: speakerTargetProperty,
+    },
+    required: ['script_id', 'target'],
+  },
+  async execute({ script_id, target }) {
+    const speaker = handlerFor(script_id).removeSpeaker(target);
+    return { ok: true, speaker };
+  },
+});
+
+interface AddSectionArgs extends ScriptIdArgs {
+  title?: string;
+  index?: number;
+}
+
+MobileToolRegistry.register<AddSectionArgs>({
+  name: 'ui_script_add_section',
+  description:
+    'Add a section — the chapter or beat that groups lines, e.g. "Cold open" or "Act 2". Pass `index` to insert at a 0-based position instead of appending. The section starts empty; add lines to it with ui_script_add_line and its returned id. Returns the new section.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      title: {
+        type: 'string',
+        description: 'Section title. Left untitled when omitted.',
+      },
+      index: {
+        type: 'number',
+        description: '0-based position to insert at. Appended when omitted.',
+      },
+    },
+    required: ['script_id'],
+  },
+  async execute({ script_id, title, index }) {
+    const section = handlerFor(script_id).addSection(title, index);
+    return { ok: true, section };
+  },
+});
+
+interface SetSectionTitleArgs extends ScriptIdArgs {
+  target: string;
+  title: string;
+}
+
+MobileToolRegistry.register<SetSectionTitleArgs>({
+  name: 'ui_script_set_section_title',
+  description:
+    "Replace a section's title. Its lines are untouched. Returns the updated section.",
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: sectionTargetProperty,
+      title: { type: 'string', description: 'The new title.' },
+    },
+    required: ['script_id', 'target', 'title'],
+  },
+  async execute({ script_id, target, title }) {
+    const section = handlerFor(script_id).setSectionTitle(target, title);
+    return { ok: true, section };
+  },
+});
+
+MobileToolRegistry.register<TargetArgs>({
+  name: 'ui_script_remove_section',
+  description:
+    'Delete a section **and every line inside it**, including any recorded takes on those lines. Move lines out first if you mean to keep them. Line indexes shift, so re-read with ui_script_get_state before addressing lines by index again. Returns the removed section with the line ids it held.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: sectionTargetProperty,
+    },
+    required: ['script_id', 'target'],
+  },
+  async execute({ script_id, target }) {
+    const section = handlerFor(script_id).removeSection(target);
+    return { ok: true, section };
+  },
+});
+
+interface AddLineArgs extends ScriptIdArgs {
+  text: string;
+  speakerId?: string;
+  direction?: string;
+  sectionId?: string;
+  index?: number;
+}
+
+MobileToolRegistry.register<AddLineArgs>({
+  name: 'ui_script_add_line',
+  description:
+    'Add a spoken line. `text` is what is said, written to be read aloud. Optionally set `speakerId` (from the cast — pass one that exists, an unknown id is rejected), `direction` (a free-form performance note like "whispering, tired"), `sectionId` to choose the section (the last section otherwise; one is created if the script has none), and `index` to insert at a 0-based position within that section instead of appending. The line starts as a draft; voicing it happens on the desktop app.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      text: { type: 'string', description: 'The spoken text of the line.' },
+      speakerId: {
+        type: 'string',
+        description: 'Id of the cast member who says it, from ui_script_get_state.',
+      },
+      direction: {
+        type: 'string',
+        description: 'Performance note, e.g. "whispering, tired".',
+      },
+      sectionId: {
+        type: 'string',
+        description: 'Section to add into. The last section when omitted.',
+      },
+      index: {
+        type: 'number',
+        description:
+          '0-based position within the section. Appended when omitted.',
+      },
+    },
+    required: ['script_id', 'text'],
+  },
+  async execute({ script_id, text, speakerId, direction, sectionId, index }) {
+    const line = handlerFor(script_id).addLine({
+      text,
+      speakerId,
+      direction,
+      sectionId,
+      index,
+    });
+    return { ok: true, line };
+  },
+});
+
+interface SetLineTextArgs extends TargetArgs {
+  text: string;
+}
+
+MobileToolRegistry.register<SetLineTextArgs>({
+  name: 'ui_script_set_line_text',
+  description:
+    "Replace a line's spoken text. Any takes already recorded on the line are kept, but a voiced line becomes stale because its audio no longer matches the words — re-voicing it is a desktop job. Returns the updated line with its new status.",
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: lineTargetProperty,
+      text: { type: 'string', description: 'The new spoken text.' },
+    },
+    required: ['script_id', 'target', 'text'],
+  },
+  async execute({ script_id, target, text }) {
+    const line = handlerFor(script_id).setLineText(target, text);
+    return { ok: true, line };
+  },
+});
+
+interface SetLineSpeakerArgs extends TargetArgs {
+  speakerId: string | null;
+}
+
+MobileToolRegistry.register<SetLineSpeakerArgs>({
+  name: 'ui_script_set_line_speaker',
+  description:
+    'Assign a line to a cast member, or pass null for `speakerId` to leave it unassigned. The id must be one from the cast in ui_script_get_state. Returns the updated line.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: lineTargetProperty,
+      speakerId: {
+        type: ['string', 'null'],
+        description:
+          'Id of an existing cast member, or null to clear the assignment.',
+      },
+    },
+    required: ['script_id', 'target', 'speakerId'],
+  },
+  async execute({ script_id, target, speakerId }) {
+    const line = handlerFor(script_id).setLineSpeaker(target, speakerId);
+    return { ok: true, line };
+  },
+});
+
+interface PatchLineArgs extends TargetArgs {
+  direction?: string;
+  pauseAfterMs?: number;
+}
+
+MobileToolRegistry.register<PatchLineArgs>({
+  name: 'ui_script_patch_line',
+  description:
+    "Edit a line's delivery without touching its words: `direction` is the performance note, `pauseAfterMs` the authored silence that follows the line in milliseconds. Omitted fields keep their current value. Use ui_script_set_line_text for the words themselves. Returns the updated line.",
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: lineTargetProperty,
+      direction: {
+        type: 'string',
+        description: 'Performance note, e.g. "flat, matter-of-fact".',
+      },
+      pauseAfterMs: {
+        type: 'number',
+        description: 'Silence after this line, in milliseconds.',
+      },
+    },
+    required: ['script_id', 'target'],
+  },
+  async execute({ script_id, target, direction, pauseAfterMs }) {
+    const line = handlerFor(script_id).patchLine(target, {
+      direction,
+      pauseAfterMs,
+    });
+    return { ok: true, line };
+  },
+});
+
+MobileToolRegistry.register<TargetArgs>({
+  name: 'ui_script_remove_line',
+  description:
+    'Delete one line, along with any takes recorded on it. The remaining lines are renumbered, so indexes you read earlier are stale after this call — re-read with ui_script_get_state before addressing lines by index again. Returns the removed line.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: lineTargetProperty,
+    },
+    required: ['script_id', 'target'],
+  },
+  async execute({ script_id, target }) {
+    const line = handlerFor(script_id).removeLine(target);
+    return { ok: true, line };
+  },
+});
+
+interface MoveLineArgs extends TargetArgs {
+  to_index: number;
+}
+
+MobileToolRegistry.register<MoveLineArgs>({
+  name: 'ui_script_move_line',
+  description:
+    'Move a line to a different position in the script. `to_index` is the 0-based document position it should end up at, counted after the line is lifted out, and it can land the line in another section. Its takes travel with it. Every line is renumbered, so re-read the script before using indexes again. Returns the moved line.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: lineTargetProperty,
+      to_index: {
+        type: 'number',
+        description:
+          '0-based destination position across the whole script. Clamped to the line count.',
+      },
+    },
+    required: ['script_id', 'target', 'to_index'],
+  },
+  async execute({ script_id, target, to_index }) {
+    const line = handlerFor(script_id).moveLine(target, to_index);
+    return { ok: true, line };
+  },
+});
+
+interface SelectLineArgs extends ScriptIdArgs {
+  target: string | null;
+}
+
+MobileToolRegistry.register<SelectLineArgs>({
+  name: 'ui_script_select_line',
+  description:
+    'Select a line on screen, so the user is looking at the line you are about to discuss. Pass null to clear the selection. The selected line is what "selected" resolves to in the other tools.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      target: {
+        type: ['string', 'null'],
+        description: `${lineTargetProperty.description} Pass null to clear the selection.`,
+      },
+    },
+    required: ['script_id', 'target'],
+  },
+  async execute({ script_id, target }) {
+    const selected = handlerFor(script_id).selectLine(target);
+    return { ok: true, selected };
+  },
+});
+
+MobileToolRegistry.register<ScriptIdArgs>({
+  name: 'ui_script_save',
+  description:
+    'Persist the script to the server. Edits from the other tools are local until this runs, so call it once after a batch of changes. Fails when someone else has saved the script since it was opened — the user then has to reload it.',
+  parameters: {
+    type: 'object',
+    properties: { script_id: scriptIdProperty },
+    required: ['script_id'],
+  },
+  async execute({ script_id }) {
+    return await handlerFor(script_id).save();
+  },
+});

--- a/mobile/src/documents/tools/storyboardTools.ts
+++ b/mobile/src/documents/tools/storyboardTools.ts
@@ -1,0 +1,328 @@
+/**
+ * `ui_storyboard_*` — the tools that let the agent direct an open storyboard.
+ *
+ * A port of web's `builtin/storyboard.ts` with the generation and assembly
+ * tools removed (see `storyboardTypes.ts` for why) and zod swapped for plain
+ * JSON Schema. Every tool takes an explicit `storyboard_id` and delegates to the
+ * handler the mounted StoryboardEditorScreen registered; when that board is not
+ * open the getter throws naming the open ids, and the tool layer hands that
+ * message to the agent verbatim.
+ */
+
+import { getDocumentHandler } from '../agentBridge';
+import { MobileToolRegistry } from './registry';
+import type {
+  StoryboardAgentHandler,
+  StoryboardUpdateShotPatch,
+} from '../storyboardTypes';
+import type { CameraDirection, ShotStatus } from '@nodetool-ai/protocol';
+
+const handlerFor = (storyboardId: string): StoryboardAgentHandler =>
+  getDocumentHandler<StoryboardAgentHandler>('storyboard', storyboardId);
+
+const storyboardIdProperty = {
+  type: 'string',
+  description:
+    'Id of the storyboard to act on. Valid ids are listed in the ui_context block of the system prompt; there is no "current board" fallback.',
+} as const;
+
+const targetProperty = {
+  type: 'string',
+  description:
+    'Which shot: its id, its 0-based index written as a string, or the literal "selected" for the shot the user has selected on screen.',
+} as const;
+
+const cameraProperty = {
+  type: 'object',
+  description:
+    'Structured camera direction. All fields optional: framing ("wide", "close-up"), lens ("35mm"), angle ("low angle"), movement ("slow push in").',
+  properties: {
+    framing: { type: 'string' },
+    lens: { type: 'string' },
+    angle: { type: 'string' },
+    movement: { type: 'string' },
+  },
+} as const;
+
+const SHOT_STATUSES: readonly ShotStatus[] = [
+  'planned',
+  'keyframe_generating',
+  'keyframe_ready',
+  'approved',
+  'clip_generating',
+  'rendered',
+  'failed',
+];
+
+interface StoryboardIdArgs {
+  storyboard_id: string;
+}
+
+interface TargetArgs extends StoryboardIdArgs {
+  target: string;
+}
+
+MobileToolRegistry.register<StoryboardIdArgs>({
+  name: 'ui_storyboard_get_state',
+  description:
+    'Read a storyboard: title, brief, style, aspect ratio, whether a screenplay is loaded, the selected shot, and every shot with its index, slug, action, camera, motion, duration, status, and whether it already has a keyframe still or a rendered clip. Call this first — the other tools address shots by the ids and indexes it returns.',
+  parameters: {
+    type: 'object',
+    properties: { storyboard_id: storyboardIdProperty },
+    required: ['storyboard_id'],
+  },
+  async execute({ storyboard_id }) {
+    return { ok: true, ...handlerFor(storyboard_id).getSnapshot() };
+  },
+});
+
+interface AddShotArgs extends StoryboardIdArgs {
+  action: string;
+  camera?: CameraDirection;
+  motion?: string;
+  durationSeconds?: number;
+  index?: number;
+}
+
+MobileToolRegistry.register<AddShotArgs>({
+  name: 'ui_storyboard_add_shot',
+  description:
+    'Add a shot to a storyboard. `action` is the concrete visual — subject and setting, written as an image prompt. Optionally set `camera`, `motion` (what moves in frame), `durationSeconds`, and `index` to insert at a position instead of appending. The new shot starts in the "planned" status; rendering it happens on the desktop app.',
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      action: {
+        type: 'string',
+        description: 'The concrete visual for this shot, phrased as an image prompt.',
+      },
+      camera: cameraProperty,
+      motion: {
+        type: 'string',
+        description: 'What moves in the shot, and how the camera moves with it.',
+      },
+      durationSeconds: {
+        type: 'number',
+        description: 'Target clip length in seconds.',
+      },
+      index: {
+        type: 'number',
+        description: '0-based position to insert at. Appended when omitted.',
+      },
+    },
+    required: ['storyboard_id', 'action'],
+  },
+  async execute({ storyboard_id, action, camera, motion, durationSeconds, index }) {
+    const shot = handlerFor(storyboard_id).addShot({
+      action,
+      camera,
+      motion,
+      durationSeconds,
+      index,
+    });
+    return { ok: true, shot };
+  },
+});
+
+interface UpdateShotArgs extends TargetArgs, StoryboardUpdateShotPatch {}
+
+MobileToolRegistry.register<UpdateShotArgs>({
+  name: 'ui_storyboard_update_shot',
+  description:
+    "Edit one existing shot in place. Set only the fields you want to change — `action`, `camera`, `motion`, `slug` (a short human label), `durationSeconds`, or `status`. Omitted fields keep their current value; there is no way to clear a field.",
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      target: targetProperty,
+      action: { type: 'string' },
+      camera: cameraProperty,
+      motion: { type: 'string' },
+      slug: {
+        type: 'string',
+        description: 'Short human label for the shot, e.g. "Lighthouse at dusk".',
+      },
+      durationSeconds: { type: 'number' },
+      status: {
+        type: 'string',
+        enum: [...SHOT_STATUSES],
+        description:
+          'Lifecycle status. Only set this to correct a stale value — the generation pipeline owns it.',
+      },
+    },
+    required: ['storyboard_id', 'target'],
+  },
+  async execute({
+    storyboard_id,
+    target,
+    action,
+    camera,
+    motion,
+    slug,
+    durationSeconds,
+    status,
+  }) {
+    const shot = handlerFor(storyboard_id).updateShot(target, {
+      action,
+      camera,
+      motion,
+      slug,
+      durationSeconds,
+      status,
+    });
+    return { ok: true, shot };
+  },
+});
+
+MobileToolRegistry.register<TargetArgs>({
+  name: 'ui_storyboard_remove_shot',
+  description:
+    'Delete one shot from a storyboard. The remaining shots are renumbered so indexes stay contiguous, which means indexes you read earlier are stale after this call — re-read with ui_storyboard_get_state before addressing shots by index again. Returns the removed shot.',
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      target: targetProperty,
+    },
+    required: ['storyboard_id', 'target'],
+  },
+  async execute({ storyboard_id, target }) {
+    const shot = handlerFor(storyboard_id).removeShot(target);
+    return { ok: true, shot };
+  },
+});
+
+interface ReorderShotArgs extends TargetArgs {
+  to_index: number;
+}
+
+MobileToolRegistry.register<ReorderShotArgs>({
+  name: 'ui_storyboard_reorder_shot',
+  description:
+    'Move one shot to a different position in the running order. `to_index` is the 0-based position it should end up at, counted after the shot is lifted out. Every shot is renumbered, so re-read the board before using indexes again. Returns the moved shot.',
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      target: targetProperty,
+      to_index: {
+        type: 'number',
+        description: '0-based destination position. Clamped to the board length.',
+      },
+    },
+    required: ['storyboard_id', 'target', 'to_index'],
+  },
+  async execute({ storyboard_id, target, to_index }) {
+    const shot = handlerFor(storyboard_id).reorderShot(target, to_index);
+    return { ok: true, shot };
+  },
+});
+
+interface SetBriefArgs extends StoryboardIdArgs {
+  brief: string;
+}
+
+MobileToolRegistry.register<SetBriefArgs>({
+  name: 'ui_storyboard_set_brief',
+  description:
+    "Replace the board's brief — the one-paragraph description of what the piece is about. Returns the updated board snapshot.",
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      brief: { type: 'string', description: 'The new brief. Replaces the old one.' },
+    },
+    required: ['storyboard_id', 'brief'],
+  },
+  async execute({ storyboard_id, brief }) {
+    return { ok: true, ...handlerFor(storyboard_id).setBrief(brief) };
+  },
+});
+
+interface SetStyleArgs extends StoryboardIdArgs {
+  style: string;
+}
+
+MobileToolRegistry.register<SetStyleArgs>({
+  name: 'ui_storyboard_set_style',
+  description:
+    "Replace the board's style — palette, light, lens, and texture, appended to every shot prompt to hold the look consistent. Returns the updated board snapshot.",
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      style: {
+        type: 'string',
+        description:
+          'The look applied to every shot, e.g. "grainy 16mm, muted teal palette, low sun".',
+      },
+    },
+    required: ['storyboard_id', 'style'],
+  },
+  async execute({ storyboard_id, style }) {
+    return { ok: true, ...handlerFor(storyboard_id).setStyle(style) };
+  },
+});
+
+interface SetAspectRatioArgs extends StoryboardIdArgs {
+  aspect_ratio: string;
+}
+
+MobileToolRegistry.register<SetAspectRatioArgs>({
+  name: 'ui_storyboard_set_aspect_ratio',
+  description:
+    'Set the frame shape every shot is generated at, as a ratio string like "16:9", "9:16", or "1:1". Returns the updated board snapshot.',
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      aspect_ratio: {
+        type: 'string',
+        description: 'Ratio string, e.g. "16:9" for landscape or "9:16" for vertical.',
+      },
+    },
+    required: ['storyboard_id', 'aspect_ratio'],
+  },
+  async execute({ storyboard_id, aspect_ratio }) {
+    return { ok: true, ...handlerFor(storyboard_id).setAspectRatio(aspect_ratio) };
+  },
+});
+
+interface SelectShotArgs extends StoryboardIdArgs {
+  target: string | null;
+}
+
+MobileToolRegistry.register<SelectShotArgs>({
+  name: 'ui_storyboard_select_shot',
+  description:
+    'Select a shot on screen, scrolling the user to it. Pass null to clear the selection. The selected shot is what "selected" resolves to in the other tools, so use this to show the user the shot you are about to discuss.',
+  parameters: {
+    type: 'object',
+    properties: {
+      storyboard_id: storyboardIdProperty,
+      target: {
+        ...targetProperty,
+        description: `${targetProperty.description} Pass null to clear the selection.`,
+      },
+    },
+    required: ['storyboard_id', 'target'],
+  },
+  async execute({ storyboard_id, target }) {
+    const selected = handlerFor(storyboard_id).selectShot(target);
+    return { ok: true, selected };
+  },
+});
+
+MobileToolRegistry.register<StoryboardIdArgs>({
+  name: 'ui_storyboard_save',
+  description:
+    'Persist the board to the server. Edits from the other tools are local until this runs, so call it once after a batch of changes. Fails when someone else has saved the board since it was opened — the user then has to reload it.',
+  parameters: {
+    type: 'object',
+    properties: { storyboard_id: storyboardIdProperty },
+    required: ['storyboard_id'],
+  },
+  async execute({ storyboard_id }) {
+    return await handlerFor(storyboard_id).save();
+  },
+});

--- a/mobile/src/documents/tools/timelineTools.ts
+++ b/mobile/src/documents/tools/timelineTools.ts
@@ -1,11 +1,17 @@
 /**
- * `ui_timeline_*` — the agent's read access to an open timeline sequence.
+ * `ui_timeline_*` — the agent's hands on an open timeline sequence.
  *
- * Web's timeline tools cut, arrange, generate, and render. Mobile's do none of
- * that: the phone surface is a viewer, so only the four read/navigate tools are
- * registered. The descriptions say so explicitly — an agent that knows editing
- * is unavailable answers questions about the sequence instead of attempting an
- * edit and reporting a failure to the user.
+ * The screen stays a viewer (arranging clips by touch is not viable at phone
+ * width), so the agent is the only way to change a sequence here: it reads the
+ * state, applies the edit, and the user presses Save. Every write goes through
+ * `documentStore.edit()`, so the screen the user is holding repaints
+ * immediately, and `ui_timeline_save` is the same code path as the Save button.
+ *
+ * Two desktop capabilities are deliberately absent, and every description says
+ * so: **generation** (`ui_timeline_generate_clip`) needs a running generation
+ * job to supervise, and **frame inspection** (`ui_timeline_get_clip_frames`)
+ * needs canvas and video decode. Promising either here would produce a failure
+ * the user has to interpret.
  *
  * Every tool names its target with `timeline_id` and resolves it through the
  * agent bridge, which throws listing the open ids when the sequence is not
@@ -14,7 +20,16 @@
 
 import { getDocumentHandler } from '../agentBridge';
 import { MobileToolRegistry } from './registry';
-import type { TimelineAgentHandler } from '../timelineTypes';
+import type {
+  TimelineAddMarkerInput,
+  TimelineAddShapeClipInput,
+  TimelineAddTextClipInput,
+  TimelineAgentHandler,
+  TimelineClipParamsPatch,
+  TimelineMovePatch,
+  TimelineTrackType,
+  TimelineTrimPatch,
+} from '../timelineTypes';
 
 const handlerFor = (timelineId: string): TimelineAgentHandler =>
   getDocumentHandler<TimelineAgentHandler>('timeline', timelineId);
@@ -31,14 +46,57 @@ const targetParam = {
     'Clip id, clip name (case-insensitive), or the literal "selected" for the currently-selected clip.',
 } as const;
 
-const READ_ONLY_NOTE =
-  'The mobile timeline is read-only: clips cannot be added, edited, trimmed, moved, generated, or deleted here. Tell the user to open the sequence on desktop for edits.';
+const DESKTOP_ONLY_NOTE =
+  'Generating clip media and rendering or inspecting frames are desktop-only; this surface edits the sequence document, and the user then saves it.';
+
+const SAVE_NOTE =
+  'This edits the open document but does not persist it — call ui_timeline_save, or tell the user to press Save.';
+
+const LINK_NOTE =
+  'Linked clips (a video clip and the audio extracted from it share a linkId) are kept in sync automatically.';
+
+const numberParam = (description: string) =>
+  ({ type: 'number', description }) as const;
+
+const textStyleSchema = {
+  type: 'object',
+  properties: {
+    fontFamily: { type: 'string' },
+    fontSizePx: { type: 'number' },
+    fontWeight: { type: 'number' },
+    color: { type: 'string', description: 'CSS colour, e.g. "#FFFFFF".' },
+    align: { type: 'string', enum: ['left', 'center', 'right'] },
+    maxWidthFrac: {
+      type: 'number',
+      description: 'Maximum text width as a fraction of the frame width, 0..1.',
+    },
+  },
+} as const;
+
+const shapeSchema = {
+  type: 'object',
+  properties: {
+    kind: { type: 'string', enum: ['rect', 'ellipse', 'line'] },
+    fill: { type: 'string' },
+    stroke: { type: 'string' },
+    strokeWidthPx: { type: 'number' },
+    x: { type: 'number', description: 'Normalized canvas coordinate, 0..1.' },
+    y: { type: 'number', description: 'Normalized canvas coordinate, 0..1.' },
+    width: { type: 'number', description: 'Normalized width, 0..1.' },
+    height: { type: 'number', description: 'Normalized height, 0..1.' },
+    x2: { type: 'number', description: 'Line end point, normalized.' },
+    y2: { type: 'number', description: 'Line end point, normalized.' },
+  },
+  required: ['kind'],
+} as const;
+
+// ── Reads ───────────────────────────────────────────────────────────────────
 
 MobileToolRegistry.register<{ timeline_id: string }>({
   name: 'ui_timeline_get_state',
   description:
-    'Read an open timeline sequence: duration, playhead, selection, every track, and every clip with its timing, media type, status, and generation binding (prompt/provider/model). Call this first — the other timeline tools need the clip ids and names it returns. ' +
-    READ_ONLY_NOTE,
+    'Read an open timeline sequence: duration, playhead, selection, whether it has unsaved edits, every track, every clip with its timing, media type, status, link id, and generation binding (prompt/provider/model), and the transcript lines with the clips they own. Call this first — the other timeline tools need the clip ids and names it returns. ' +
+    DESKTOP_ONLY_NOTE,
   parameters: {
     type: 'object',
     properties: { timeline_id: timelineIdParam },
@@ -54,7 +112,7 @@ MobileToolRegistry.register<{ timeline_id: string; target: string }>({
   name: 'ui_timeline_get_clip',
   description:
     'Read one clip of an open timeline sequence — its track, timing, media type, status, prompt/model, and whether a rendered asset is attached. Use it to answer a question about a specific clip after ui_timeline_get_state. ' +
-    READ_ONLY_NOTE,
+    DESKTOP_ONLY_NOTE,
   parameters: {
     type: 'object',
     properties: { timeline_id: timelineIdParam, target: targetParam },
@@ -72,8 +130,7 @@ MobileToolRegistry.register<{
 }>({
   name: 'ui_timeline_select_clip',
   description:
-    'Select a clip on screen, opening its detail panel for the user. Omit `target` (or pass null) to clear the selection. Selecting only changes what is shown; it changes nothing in the document. ' +
-    READ_ONLY_NOTE,
+    'Select a clip on screen, opening its detail panel for the user. Omit `target` (or pass null) to clear the selection. Selecting only changes what is shown; it changes nothing in the document — but it does set what "selected" resolves to for the other tools.',
   parameters: {
     type: 'object',
     properties: {
@@ -94,17 +151,14 @@ MobileToolRegistry.register<{
 MobileToolRegistry.register<{ timeline_id: string; timeMs: number }>({
   name: 'ui_timeline_seek',
   description:
-    'Move the playhead of an open timeline sequence to an absolute time in milliseconds, clamped to the sequence duration. Use it to point the user at a moment you are describing. ' +
-    READ_ONLY_NOTE,
+    'Move the playhead of an open timeline sequence to an absolute time in milliseconds, clamped to the sequence duration. Use it to point the user at a moment you are describing, or before ui_timeline_split_clip to cut at the playhead.',
   parameters: {
     type: 'object',
     properties: {
       timeline_id: timelineIdParam,
-      timeMs: {
-        type: 'number',
-        description:
-          'Absolute position on the sequence timeline, in milliseconds from the start.',
-      },
+      timeMs: numberParam(
+        'Absolute position on the sequence timeline, in milliseconds from the start.'
+      ),
     },
     required: ['timeline_id', 'timeMs'],
   },
@@ -112,4 +166,356 @@ MobileToolRegistry.register<{ timeline_id: string; timeMs: number }>({
     ok: true,
     playheadMs: handlerFor(timeline_id).seek(timeMs),
   }),
+});
+
+// ── Structure ───────────────────────────────────────────────────────────────
+
+MobileToolRegistry.register<{
+  timeline_id: string;
+  type: TimelineTrackType;
+  name?: string;
+}>({
+  name: 'ui_timeline_add_track',
+  description:
+    'Add a track to an open timeline sequence. `type` is one of video, audio, overlay, subtitle. Optionally provide a name. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      type: {
+        type: 'string',
+        enum: ['video', 'audio', 'overlay', 'subtitle'],
+        description: 'Kind of track to create.',
+      },
+      name: { type: 'string', description: 'Track name. Defaults to "<type> <n>".' },
+    },
+    required: ['timeline_id', 'type'],
+  },
+  execute: async ({ timeline_id, type, name }) => ({
+    ok: true,
+    track: handlerFor(timeline_id).addTrack(type, name),
+  }),
+});
+
+MobileToolRegistry.register<
+  { timeline_id: string } & TimelineAddTextClipInput
+>({
+  name: 'ui_timeline_add_text_clip',
+  description:
+    'Add authored text to an open timeline sequence. It goes on an overlay track, creating one when needed, and lasts 3000ms by default. Text and shapes require a video or overlay track — an audio or subtitle track is rejected. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      text: { type: 'string', description: 'The text to draw. Must not be empty.' },
+      trackId: {
+        type: 'string',
+        description:
+          'Target track id or name. Omit to use (or create) an overlay track.',
+      },
+      startMs: numberParam(
+        'Absolute start on the timeline in ms. Omit to append after the track\'s existing content.'
+      ),
+      durationMs: numberParam('On-timeline length in ms. Default 3000, minimum 1.'),
+      style: textStyleSchema,
+    },
+    required: ['timeline_id', 'text'],
+  },
+  execute: async ({ timeline_id, ...input }) => ({
+    ok: true,
+    clip: handlerFor(timeline_id).addTextClip(input),
+  }),
+});
+
+MobileToolRegistry.register<
+  { timeline_id: string } & TimelineAddShapeClipInput
+>({
+  name: 'ui_timeline_add_shape_clip',
+  description:
+    'Add a rectangle, ellipse, or line on an overlay track of an open timeline sequence. Omitted colours use a visible white fill (rect/ellipse) or a visible white stroke (line). Shapes require a video or overlay track. Preview and export rasterization happen on desktop. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      shape: shapeSchema,
+      trackId: {
+        type: 'string',
+        description:
+          'Target track id or name. Omit to use (or create) an overlay track.',
+      },
+      startMs: numberParam(
+        'Absolute start on the timeline in ms. Omit to append after the track\'s existing content.'
+      ),
+      durationMs: numberParam('On-timeline length in ms. Default 3000, minimum 1.'),
+    },
+    required: ['timeline_id', 'shape'],
+  },
+  execute: async ({ timeline_id, ...input }) => ({
+    ok: true,
+    clip: handlerFor(timeline_id).addShapeClip(input),
+  }),
+});
+
+// ── Arranging ───────────────────────────────────────────────────────────────
+
+MobileToolRegistry.register<
+  { timeline_id: string; target: string } & TimelineMovePatch
+>({
+  name: 'ui_timeline_move_clip',
+  description:
+    'Move a clip to a new absolute start time and/or onto a different track. Omit a field to leave it unchanged. ' +
+    LINK_NOTE +
+    ' Siblings shift by the same delta and keep their own track, and the delta is clamped so no member of the group is pushed before zero — check the returned clips for where they landed. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: targetParam,
+      startMs: numberParam('New absolute start on the timeline in ms, clamped to >= 0.'),
+      trackId: {
+        type: 'string',
+        description:
+          'Track id or name to move onto. Rejected when no such track exists.',
+      },
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target, startMs, trackId }) => ({
+    ok: true,
+    clips: handlerFor(timeline_id).moveClip(target, { startMs, trackId }),
+  }),
+});
+
+MobileToolRegistry.register<
+  { timeline_id: string; target: string } & TimelineTrimPatch
+>({
+  name: 'ui_timeline_trim_clip',
+  description:
+    "Trim a clip's length or its source in/out points. `durationMs` sets the on-timeline length (minimum 1); `inPointMs`/`outPointMs` set the trimmed source window (ms into the source media). Omit a field to leave it unchanged. " +
+    LINK_NOTE +
+    ' A length change applies the same delta to every sibling and is all-or-nothing: if it would be invalid for any of them, nothing changes. Source in/out points belong to one clip\'s own media, so they apply to the target only. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: targetParam,
+      durationMs: numberParam('New on-timeline length in ms. Minimum 1.'),
+      inPointMs: numberParam('Start of the source window, ms into the source media.'),
+      outPointMs: numberParam('End of the source window, ms into the source media.'),
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target, durationMs, inPointMs, outPointMs }) => ({
+    ok: true,
+    clips: handlerFor(timeline_id).trimClip(target, {
+      durationMs,
+      inPointMs,
+      outPointMs,
+    }),
+  }),
+});
+
+MobileToolRegistry.register<{
+  timeline_id: string;
+  target: string;
+  atMs?: number;
+}>({
+  name: 'ui_timeline_split_clip',
+  description:
+    'Cut a clip in two at the given time (the razor tool). `atMs` is an absolute time on the timeline and must fall strictly inside the clip; omit it to split at the playhead. Returns the two halves. ' +
+    LINK_NOTE +
+    ' Every sibling spanning the cut is split at the same point, and each side becomes its own link pair. A clip owned by a transcript line is refused: the transcript can only be re-flowed on desktop. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: targetParam,
+      atMs: numberParam(
+        'Absolute split time on the timeline in ms. Omit to split at the playhead.'
+      ),
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target, atMs }) => ({
+    ok: true,
+    clips: handlerFor(timeline_id).splitClip(target, atMs),
+  }),
+});
+
+MobileToolRegistry.register<{ timeline_id: string; target: string }>({
+  name: 'ui_timeline_delete_clip',
+  description:
+    'Remove a clip from an open timeline sequence. A link group left with one member is unlinked. A clip owned by a transcript line is refused: the transcript can only be re-flowed on desktop. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: { timeline_id: timelineIdParam, target: targetParam },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target }) => ({
+    ok: true,
+    deleted: handlerFor(timeline_id).deleteClip(target),
+  }),
+});
+
+MobileToolRegistry.register<{
+  timeline_id: string;
+  target: string;
+  gapMs?: number;
+}>({
+  name: 'ui_timeline_duplicate_clip',
+  description:
+    'Duplicate a clip. The copy is placed immediately after the source (add `gapMs` for a gap) and keeps its generation binding, so you can tweak the copy for a variation. The copy is a draft with no asset and no version history — it has not been generated, and generating it is desktop-only. ' +
+    LINK_NOTE +
+    ' A linked clip duplicates together with its siblings, and the copies form their own link group. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: targetParam,
+      gapMs: numberParam('Extra gap in ms between the source and the copy. Default 0.'),
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target, gapMs }) => ({
+    ok: true,
+    clips: handlerFor(timeline_id).duplicateClip(target, gapMs),
+  }),
+});
+
+MobileToolRegistry.register<
+  { timeline_id: string; target: string } & TimelineClipParamsPatch
+>({
+  name: 'ui_timeline_set_clip_params',
+  description:
+    "Change a clip's render/audio params — `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle` — or its generation binding: `prompt`, `negativePrompt`, `provider`, `model`, TTS `voice`, `width`/`height`, `strength`, `numInferenceSteps`, `seed`. Omit a field to leave it unchanged. Changing any binding field marks an already-generated clip `stale`, because its asset no longer matches its settings; re-generating it is desktop-only. Binding fields are rejected on imported clips. " +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: targetParam,
+      name: { type: 'string' },
+      opacity: numberParam('Opacity, 0..1.'),
+      speedMultiplier: numberParam('Playback speed, 0.1..8.'),
+      volumeDb: numberParam('Audio volume in dB. 0 is unchanged.'),
+      fadeInMs: numberParam('Fade-in length in ms.'),
+      fadeOutMs: numberParam('Fade-out length in ms.'),
+      blendMode: { type: 'string', description: 'GPU blend mode, e.g. "normal".' },
+      borderRadius: numberParam('Rounded-corner radius in source pixels.'),
+      hidden: { type: 'boolean' },
+      muted: { type: 'boolean' },
+      locked: { type: 'boolean' },
+      textStyle: {
+        ...textStyleSchema,
+        properties: {
+          ...textStyleSchema.properties,
+          text: { type: 'string' },
+        },
+        required: ['text', 'fontSizePx', 'color'],
+        description: 'Replacement text style. Text clips only.',
+      },
+      shapeStyle: {
+        ...shapeSchema,
+        description: 'Replacement shape geometry. Shape clips only.',
+      },
+      prompt: { type: 'string' },
+      negativePrompt: { type: 'string' },
+      provider: { type: 'string' },
+      model: { type: 'string' },
+      voice: { type: 'string', description: 'TTS voice id for text-to-audio clips.' },
+      width: numberParam('Generation width in pixels.'),
+      height: numberParam('Generation height in pixels.'),
+      strength: numberParam('Image-to-image strength, 0..1.'),
+      numInferenceSteps: numberParam('Sampler steps.'),
+      seed: numberParam('Generation seed.'),
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target, ...patch }) => ({
+    ok: true,
+    clip: handlerFor(timeline_id).setClipParams(target, patch),
+  }),
+});
+
+// ── Markers ─────────────────────────────────────────────────────────────────
+
+MobileToolRegistry.register<{ timeline_id: string } & TimelineAddMarkerInput>({
+  name: 'ui_timeline_add_marker',
+  description:
+    'Drop a marker at an absolute time on an open timeline sequence, to flag a moment for the user. ' +
+    SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      timeMs: numberParam('Absolute position on the timeline in ms. Must be >= 0.'),
+      label: { type: 'string', description: 'Short label shown on the ruler.' },
+      color: { type: 'string', description: 'CSS colour for the marker dot.' },
+      note: { type: 'string', description: 'Longer note attached to the marker.' },
+    },
+    required: ['timeline_id', 'timeMs'],
+  },
+  execute: async ({ timeline_id, ...input }) => ({
+    ok: true,
+    marker: handlerFor(timeline_id).addMarker(input),
+  }),
+});
+
+MobileToolRegistry.register<{ timeline_id: string; target: string }>({
+  name: 'ui_timeline_delete_marker',
+  description: 'Remove a marker by id or by its label (case-insensitive). ' + SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: {
+        type: 'string',
+        description: 'Marker id or label (case-insensitive).',
+      },
+    },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target }) => ({
+    ok: true,
+    deleted: handlerFor(timeline_id).deleteMarker(target),
+  }),
+});
+
+// ── Document ────────────────────────────────────────────────────────────────
+
+MobileToolRegistry.register<{ timeline_id: string; name: string }>({
+  name: 'ui_timeline_rename',
+  description: 'Rename an open timeline sequence. ' + SAVE_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      name: { type: 'string', description: 'New sequence name.' },
+    },
+    required: ['timeline_id', 'name'],
+  },
+  execute: async ({ timeline_id, name }) => ({
+    ok: true,
+    ...handlerFor(timeline_id).rename(name),
+  }),
+});
+
+MobileToolRegistry.register<{ timeline_id: string }>({
+  name: 'ui_timeline_save',
+  description:
+    'Persist the open timeline sequence — the same action as the user pressing Save. Call it once after a batch of edits. Fails if someone else saved the sequence in the meantime; tell the user to reload from the banner on screen.',
+  parameters: {
+    type: 'object',
+    properties: { timeline_id: timelineIdParam },
+    required: ['timeline_id'],
+  },
+  execute: async ({ timeline_id }) => handlerFor(timeline_id).save(),
 });

--- a/mobile/src/documents/tools/timelineTools.ts
+++ b/mobile/src/documents/tools/timelineTools.ts
@@ -1,0 +1,115 @@
+/**
+ * `ui_timeline_*` — the agent's read access to an open timeline sequence.
+ *
+ * Web's timeline tools cut, arrange, generate, and render. Mobile's do none of
+ * that: the phone surface is a viewer, so only the four read/navigate tools are
+ * registered. The descriptions say so explicitly — an agent that knows editing
+ * is unavailable answers questions about the sequence instead of attempting an
+ * edit and reporting a failure to the user.
+ *
+ * Every tool names its target with `timeline_id` and resolves it through the
+ * agent bridge, which throws listing the open ids when the sequence is not
+ * mounted.
+ */
+
+import { getDocumentHandler } from '../agentBridge';
+import { MobileToolRegistry } from './registry';
+import type { TimelineAgentHandler } from '../timelineTypes';
+
+const handlerFor = (timelineId: string): TimelineAgentHandler =>
+  getDocumentHandler<TimelineAgentHandler>('timeline', timelineId);
+
+const timelineIdParam = {
+  type: 'string',
+  description:
+    'Id of the target timeline sequence. The ids currently open are listed in the ui_context block of the system prompt.',
+} as const;
+
+const targetParam = {
+  type: 'string',
+  description:
+    'Clip id, clip name (case-insensitive), or the literal "selected" for the currently-selected clip.',
+} as const;
+
+const READ_ONLY_NOTE =
+  'The mobile timeline is read-only: clips cannot be added, edited, trimmed, moved, generated, or deleted here. Tell the user to open the sequence on desktop for edits.';
+
+MobileToolRegistry.register<{ timeline_id: string }>({
+  name: 'ui_timeline_get_state',
+  description:
+    'Read an open timeline sequence: duration, playhead, selection, every track, and every clip with its timing, media type, status, and generation binding (prompt/provider/model). Call this first — the other timeline tools need the clip ids and names it returns. ' +
+    READ_ONLY_NOTE,
+  parameters: {
+    type: 'object',
+    properties: { timeline_id: timelineIdParam },
+    required: ['timeline_id'],
+  },
+  execute: async ({ timeline_id }) => ({
+    ok: true,
+    ...handlerFor(timeline_id).getSnapshot(),
+  }),
+});
+
+MobileToolRegistry.register<{ timeline_id: string; target: string }>({
+  name: 'ui_timeline_get_clip',
+  description:
+    'Read one clip of an open timeline sequence — its track, timing, media type, status, prompt/model, and whether a rendered asset is attached. Use it to answer a question about a specific clip after ui_timeline_get_state. ' +
+    READ_ONLY_NOTE,
+  parameters: {
+    type: 'object',
+    properties: { timeline_id: timelineIdParam, target: targetParam },
+    required: ['timeline_id', 'target'],
+  },
+  execute: async ({ timeline_id, target }) => ({
+    ok: true,
+    clip: handlerFor(timeline_id).getClip(target),
+  }),
+});
+
+MobileToolRegistry.register<{
+  timeline_id: string;
+  target?: string | null;
+}>({
+  name: 'ui_timeline_select_clip',
+  description:
+    'Select a clip on screen, opening its detail panel for the user. Omit `target` (or pass null) to clear the selection. Selecting only changes what is shown; it changes nothing in the document. ' +
+    READ_ONLY_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      target: {
+        ...targetParam,
+        description: `${targetParam.description} Omit or pass null to clear the selection.`,
+      },
+    },
+    required: ['timeline_id'],
+  },
+  execute: async ({ timeline_id, target }) => ({
+    ok: true,
+    selected: handlerFor(timeline_id).selectClip(target ?? null),
+  }),
+});
+
+MobileToolRegistry.register<{ timeline_id: string; timeMs: number }>({
+  name: 'ui_timeline_seek',
+  description:
+    'Move the playhead of an open timeline sequence to an absolute time in milliseconds, clamped to the sequence duration. Use it to point the user at a moment you are describing. ' +
+    READ_ONLY_NOTE,
+  parameters: {
+    type: 'object',
+    properties: {
+      timeline_id: timelineIdParam,
+      timeMs: {
+        type: 'number',
+        description:
+          'Absolute position on the sequence timeline, in milliseconds from the start.',
+      },
+    },
+    required: ['timeline_id', 'timeMs'],
+  },
+  execute: async ({ timeline_id, timeMs }) => ({
+    ok: true,
+    playheadMs: handlerFor(timeline_id).seek(timeMs),
+  }),
+});

--- a/mobile/src/documents/uiContext.ts
+++ b/mobile/src/documents/uiContext.ts
@@ -1,0 +1,87 @@
+/**
+ * `ui_context` — the block that tells the agent which document ids are valid.
+ *
+ * Every `ui_*` tool takes a required document id and there is no "act on
+ * whatever is mounted" fallback, so this is part of the tool contract rather
+ * than decoration: without it the agent has no way to learn an id and every
+ * call is a guess.
+ *
+ * Web builds this from the tab store. Mobile builds it from the agent bridge —
+ * the mounted screens *are* the open documents, and the top of the navigation
+ * stack is the focused one.
+ */
+
+import { focusedDocument, listOpenDocuments } from './agentBridge';
+import { uiSurfaceForKind } from './kinds';
+import type { OpenDocument } from './agentBridge';
+
+export interface UiDocumentRef {
+  type: string;
+  id: string;
+  title?: string | null;
+}
+
+export interface UiContextPayload {
+  focused?: UiDocumentRef | null;
+  open?: UiDocumentRef[] | null;
+  selection?: {
+    clip_ids?: string[] | null;
+    shot_ids?: string[] | null;
+    layer_ids?: string[] | null;
+  } | null;
+}
+
+/** Selection the focused screen reports, so the agent can act on "this shot". */
+export interface UiSelection {
+  clipIds?: string[];
+  shotIds?: string[];
+  layerIds?: string[];
+}
+
+let selection: UiSelection = {};
+
+/** Screens publish their current selection here; cleared on unmount. */
+export function setUiSelection(next: UiSelection): void {
+  selection = next;
+}
+
+export function clearUiSelection(): void {
+  selection = {};
+}
+
+const toRef = (doc: OpenDocument): UiDocumentRef | null => {
+  const type = uiSurfaceForKind(doc.kind);
+  return type ? { type, id: doc.id, title: doc.title } : null;
+};
+
+const isRef = (ref: UiDocumentRef | null): ref is UiDocumentRef => ref !== null;
+
+/**
+ * Snapshot the open documents for an outgoing chat turn. Returns undefined when
+ * nothing addressable is open, so the field is omitted rather than sent empty.
+ */
+export function buildUiContext(): UiContextPayload | undefined {
+  const open = listOpenDocuments().map(toRef).filter(isRef);
+  if (open.length === 0) {
+    return undefined;
+  }
+  const focused = focusedDocument();
+  const focusedRef = focused ? toRef(focused) : null;
+
+  const hasSelection =
+    (selection.clipIds?.length ?? 0) > 0 ||
+    (selection.shotIds?.length ?? 0) > 0 ||
+    (selection.layerIds?.length ?? 0) > 0;
+
+  return {
+    open,
+    focused: focusedRef,
+    selection: hasSelection
+      ? {
+          clip_ids: selection.clipIds ?? null,
+          shot_ids: selection.shotIds ?? null,
+          layer_ids: selection.layerIds ?? null,
+        }
+      : null,
+  };
+}

--- a/mobile/src/documents/useDocuments.ts
+++ b/mobile/src/documents/useDocuments.ts
@@ -1,41 +1,57 @@
 /**
- * TanStack Query bindings for the documents browser.
+ * React Query bindings for the documents browser.
  *
- * Browsing is server state, so it stays in tRPC + React Query. Only the *open*
+ * Browsing is server state, so it stays in React Query. Only the *open*
  * document moves into a Zustand store (see `documentStore.ts`), because that is
  * the one thing agent tools must reach from outside React.
+ *
+ * Queries go through the kind's `DocumentBackend` rather than a tRPC hook: the
+ * four kinds do not share one router (scripts have their own), and routing that
+ * choice through the backend keeps it in the one place that already knows.
  */
 
-import { useMemo } from 'react';
-import type { ResourceKind } from '@nodetool-ai/app-runtime';
+import { useCallback, useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
 
-import { trpc } from '../trpc/client';
+import { documentBackend } from './backends';
 import { disposeDocumentStore } from './documentStore';
+import { DOCUMENT_KINDS, type DocumentKind } from './kinds';
 
 export interface DocumentListEntry {
-  kind: ResourceKind;
+  kind: DocumentKind;
   id: string;
   name: string;
   updatedAt: string;
+  /** Kind-specific detail, e.g. "12 lines". */
+  detail?: string;
 }
 
-/** One kind's documents, newest first. */
-export function useDocumentsOfKind(kind: ResourceKind, limit = 50) {
-  const query = trpc.resources.list.useQuery(
-    { kind, limit },
-    {
-      select: (summaries) =>
-        summaries.map(
-          (summary): DocumentListEntry => ({
-            kind: summary.ref.kind,
-            id: summary.ref.id,
-            name: summary.name || `Untitled ${kind}`,
-            updatedAt: summary.updatedAt,
-          })
-        ),
-    }
-  );
-  return query;
+const listKey = (kind: DocumentKind, limit: number): QueryKey => [
+  'documents',
+  kind,
+  limit,
+];
+
+/** One kind's documents. */
+export function useDocumentsOfKind(kind: DocumentKind, limit = 50) {
+  return useQuery({
+    queryKey: listKey(kind, limit),
+    queryFn: async (): Promise<DocumentListEntry[]> => {
+      const summaries = await documentBackend(kind).list(limit);
+      return summaries.map((summary) => ({
+        kind,
+        id: summary.id,
+        name: summary.name || `Untitled ${kind}`,
+        updatedAt: summary.updatedAt,
+        detail: summary.detail,
+      }));
+    },
+  });
 }
 
 /**
@@ -46,6 +62,7 @@ export function useDocumentsOfKind(kind: ResourceKind, limit = 50) {
  */
 export function useAllDocuments(limit = 50) {
   const storyboards = useDocumentsOfKind('storyboard', limit);
+  const scripts = useDocumentsOfKind('script', limit);
   const timelines = useDocumentsOfKind('timeline', limit);
   const sketches = useDocumentsOfKind('sketch', limit);
 
@@ -53,19 +70,20 @@ export function useAllDocuments(limit = 50) {
     () =>
       [
         ...(storyboards.data ?? []),
+        ...(scripts.data ?? []),
         ...(timelines.data ?? []),
         ...(sketches.data ?? []),
       ].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
-    [storyboards.data, timelines.data, sketches.data]
+    [storyboards.data, scripts.data, timelines.data, sketches.data]
   );
 
-  const queries = [storyboards, timelines, sketches];
+  const queries = [storyboards, scripts, timelines, sketches];
 
   return {
     documents,
     isLoading: queries.some((query) => query.isLoading),
     isRefetching: queries.some((query) => query.isRefetching),
-    // Surface the first failure; the browser shows one banner, not three.
+    // Surface the first failure; the browser shows one banner, not four.
     error: queries.find((query) => query.error)?.error ?? null,
     refetch: () => {
       for (const query of queries) {
@@ -75,34 +93,65 @@ export function useAllDocuments(limit = 50) {
   };
 }
 
-/** Create a document of a kind and invalidate that kind's list. */
+/** Invalidate one kind's list, whatever page size it was fetched with. */
+function useInvalidateKind() {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (kind: DocumentKind) =>
+      queryClient.invalidateQueries({ queryKey: ['documents', kind] }),
+    [queryClient]
+  );
+}
+
 export function useCreateDocument() {
-  const utils = trpc.useUtils();
-  return trpc.resources.create.useMutation({
-    onSuccess: (detail) => {
-      void utils.resources.list.invalidate({ kind: detail.ref.kind });
+  const invalidate = useInvalidateKind();
+  return useMutation({
+    mutationFn: async ({ kind, name }: { kind: DocumentKind; name: string }) => {
+      const created = await documentBackend(kind).create(name);
+      return { kind, ...created };
+    },
+    onSuccess: ({ kind }) => {
+      void invalidate(kind);
     },
   });
 }
 
 export function useRenameDocument() {
-  const utils = trpc.useUtils();
-  return trpc.resources.update.useMutation({
-    onSuccess: (detail) => {
-      void utils.resources.list.invalidate({ kind: detail.ref.kind });
-      void utils.resources.read.invalidate({ ref: { kind: detail.ref.kind, id: detail.ref.id } });
+  const invalidate = useInvalidateKind();
+  return useMutation({
+    mutationFn: async ({
+      kind,
+      id,
+      name,
+    }: {
+      kind: DocumentKind;
+      id: string;
+      name: string;
+    }) => {
+      await documentBackend(kind).rename(id, name);
+      return { kind, id, name };
+    },
+    onSuccess: ({ kind }) => {
+      void invalidate(kind);
     },
   });
 }
 
 export function useDeleteDocument() {
-  const utils = trpc.useUtils();
-  return trpc.resources.delete.useMutation({
-    onSuccess: (_result, variables) => {
+  const invalidate = useInvalidateKind();
+  return useMutation({
+    mutationFn: async ({ kind, id }: { kind: DocumentKind; id: string }) => {
+      await documentBackend(kind).remove(id);
+      return { kind, id };
+    },
+    onSuccess: ({ kind, id }) => {
       // The cached store would otherwise keep serving a document that no
       // longer exists if the same id were somehow reopened.
-      disposeDocumentStore(variables.ref.kind, variables.ref.id);
-      void utils.resources.list.invalidate({ kind: variables.ref.kind });
+      disposeDocumentStore(kind, id);
+      void invalidate(kind);
     },
   });
 }
+
+/** The kinds the browser offers a "new document" action for. */
+export const CREATABLE_KINDS = DOCUMENT_KINDS.filter((entry) => entry.creatable);

--- a/mobile/src/documents/useDocuments.ts
+++ b/mobile/src/documents/useDocuments.ts
@@ -1,0 +1,108 @@
+/**
+ * TanStack Query bindings for the documents browser.
+ *
+ * Browsing is server state, so it stays in tRPC + React Query. Only the *open*
+ * document moves into a Zustand store (see `documentStore.ts`), because that is
+ * the one thing agent tools must reach from outside React.
+ */
+
+import { useMemo } from 'react';
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+import { trpc } from '../trpc/client';
+import { disposeDocumentStore } from './documentStore';
+
+export interface DocumentListEntry {
+  kind: ResourceKind;
+  id: string;
+  name: string;
+  updatedAt: string;
+}
+
+/** One kind's documents, newest first. */
+export function useDocumentsOfKind(kind: ResourceKind, limit = 50) {
+  const query = trpc.resources.list.useQuery(
+    { kind, limit },
+    {
+      select: (summaries) =>
+        summaries.map(
+          (summary): DocumentListEntry => ({
+            kind: summary.ref.kind,
+            id: summary.ref.id,
+            name: summary.name || `Untitled ${kind}`,
+            updatedAt: summary.updatedAt,
+          })
+        ),
+    }
+  );
+  return query;
+}
+
+/**
+ * Every browsable kind in one list, newest first across kinds.
+ *
+ * One hook call per kind rather than a loop, so the hook order is fixed and the
+ * memo's dependencies can name the exact values it reads.
+ */
+export function useAllDocuments(limit = 50) {
+  const storyboards = useDocumentsOfKind('storyboard', limit);
+  const timelines = useDocumentsOfKind('timeline', limit);
+  const sketches = useDocumentsOfKind('sketch', limit);
+
+  const documents = useMemo(
+    () =>
+      [
+        ...(storyboards.data ?? []),
+        ...(timelines.data ?? []),
+        ...(sketches.data ?? []),
+      ].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    [storyboards.data, timelines.data, sketches.data]
+  );
+
+  const queries = [storyboards, timelines, sketches];
+
+  return {
+    documents,
+    isLoading: queries.some((query) => query.isLoading),
+    isRefetching: queries.some((query) => query.isRefetching),
+    // Surface the first failure; the browser shows one banner, not three.
+    error: queries.find((query) => query.error)?.error ?? null,
+    refetch: () => {
+      for (const query of queries) {
+        void query.refetch();
+      }
+    },
+  };
+}
+
+/** Create a document of a kind and invalidate that kind's list. */
+export function useCreateDocument() {
+  const utils = trpc.useUtils();
+  return trpc.resources.create.useMutation({
+    onSuccess: (detail) => {
+      void utils.resources.list.invalidate({ kind: detail.ref.kind });
+    },
+  });
+}
+
+export function useRenameDocument() {
+  const utils = trpc.useUtils();
+  return trpc.resources.update.useMutation({
+    onSuccess: (detail) => {
+      void utils.resources.list.invalidate({ kind: detail.ref.kind });
+      void utils.resources.read.invalidate({ ref: { kind: detail.ref.kind, id: detail.ref.id } });
+    },
+  });
+}
+
+export function useDeleteDocument() {
+  const utils = trpc.useUtils();
+  return trpc.resources.delete.useMutation({
+    onSuccess: (_result, variables) => {
+      // The cached store would otherwise keep serving a document that no
+      // longer exists if the same id were somehow reopened.
+      disposeDocumentStore(variables.ref.kind, variables.ref.id);
+      void utils.resources.list.invalidate({ kind: variables.ref.kind });
+    },
+  });
+}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -14,6 +14,24 @@ export type RootStackParamList = {
   AssetViewer: {
     assetId: string;
   };
+  /** Browse every document, all kinds in one list. */
+  Documents: undefined;
+  /** Storyboard editor. `name` seeds the header before the load resolves. */
+  StoryboardEditor: {
+    id: string;
+    name?: string;
+  };
+  /** Read-only timeline. */
+  TimelineViewer: {
+    id: string;
+    name?: string;
+  };
+  /** Fallback surface for document kinds with no dedicated screen yet. */
+  DocumentViewer: {
+    kind: string;
+    id: string;
+    name?: string;
+  };
   Secrets: undefined;
   Collections: undefined;
   Jobs: undefined;

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -21,6 +21,11 @@ export type RootStackParamList = {
     id: string;
     name?: string;
   };
+  /** Script editor. `name` seeds the header before the load resolves. */
+  ScriptEditor: {
+    id: string;
+    name?: string;
+  };
   /** Read-only timeline. */
   TimelineViewer: {
     id: string;

--- a/mobile/src/polyfills/__tests__/randomUuid.test.ts
+++ b/mobile/src/polyfills/__tests__/randomUuid.test.ts
@@ -1,0 +1,55 @@
+import { createTimeOrderedUuid } from '@nodetool-ai/timeline';
+import { v4 as uuidv4 } from 'uuid';
+
+import { installRandomUuid } from '../randomUuid';
+
+type CryptoHost = { crypto?: { randomUUID?: () => string } };
+
+const host = globalThis as CryptoHost;
+
+describe('installRandomUuid', () => {
+  const original = host.crypto;
+
+  afterEach(() => {
+    host.crypto = original;
+  });
+
+  it('supplies randomUUID when the runtime has none (Hermes)', () => {
+    host.crypto = {};
+
+    installRandomUuid();
+
+    expect(typeof host.crypto.randomUUID).toBe('function');
+    // `uuid` is mocked in jest.setup.js, so this asserts the delegation rather
+    // than the id format.
+    expect(host.crypto.randomUUID?.()).toBe(uuidv4());
+  });
+
+  it('creates the crypto object when it is missing entirely', () => {
+    delete host.crypto;
+
+    installRandomUuid();
+
+    // Read through a fresh reference: the `delete` above narrows `host.crypto`
+    // to undefined, so TS would not admit that the install put it back.
+    const patched = (globalThis as CryptoHost).crypto;
+    expect(typeof patched?.randomUUID).toBe('function');
+  });
+
+  it('leaves an existing randomUUID alone', () => {
+    const existing = () => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    host.crypto = { randomUUID: existing };
+
+    installRandomUuid();
+
+    expect(host.crypto.randomUUID).toBe(existing);
+  });
+
+  it('is what makes the timeline engine able to mint ids', () => {
+    host.crypto = {};
+    installRandomUuid();
+
+    // createTimeOrderedUuid strips the hyphens off whatever randomUUID returns.
+    expect(createTimeOrderedUuid()).toBe(uuidv4().replace(/-/g, ''));
+  });
+});

--- a/mobile/src/polyfills/randomUuid.ts
+++ b/mobile/src/polyfills/randomUuid.ts
@@ -1,0 +1,24 @@
+/**
+ * `crypto.randomUUID` for Hermes.
+ *
+ * `react-native-get-random-values` supplies `crypto.getRandomValues` only, and
+ * Hermes ships no `randomUUID` at all. `@nodetool-ai/timeline` mints every clip,
+ * track, marker, and animation id through `globalThis.crypto.randomUUID()`, so
+ * an unpolyfilled runtime throws on the first edit rather than degrading.
+ *
+ * `crypto` itself may be missing (bare Hermes, or a test environment that
+ * stubbed globals), so the object is created when absent.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+/** Idempotent: an existing `randomUUID` (JSC, a newer Hermes) is left alone. */
+export function installRandomUuid(): void {
+  const target = globalThis as {
+    crypto?: { randomUUID?: () => string };
+  };
+  if (target.crypto === undefined) {
+    target.crypto = {};
+  }
+  target.crypto.randomUUID ??= () => uuidv4();
+}

--- a/mobile/src/screens/DocumentViewerScreen.tsx
+++ b/mobile/src/screens/DocumentViewerScreen.tsx
@@ -20,7 +20,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { ResourceKind } from '@nodetool-ai/app-runtime';
+import type { DocumentKind } from '../documents/kinds';
 
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../hooks/useTheme';
@@ -73,7 +73,7 @@ export default function DocumentViewerScreen({
   const insets = useSafeAreaInsets();
 
   const useStore = useMemo(
-    () => documentStore<unknown>(kind as ResourceKind, id),
+    () => documentStore<unknown>(kind as DocumentKind, id),
     [kind, id]
   );
   const doc = useStore((state) => state.doc);
@@ -94,7 +94,7 @@ export default function DocumentViewerScreen({
 
   const kindLabel = useMemo(() => {
     try {
-      return documentKindInfo(kind as ResourceKind).label;
+      return documentKindInfo(kind as DocumentKind).label;
     } catch {
       // An unregistered kind can still be opened by id; name it as-is.
       return kind;

--- a/mobile/src/screens/DocumentViewerScreen.tsx
+++ b/mobile/src/screens/DocumentViewerScreen.tsx
@@ -1,0 +1,341 @@
+/**
+ * Fallback viewer for document kinds that have no dedicated screen yet.
+ *
+ * A kind reaches this screen because the registry points it here (sketch,
+ * today). Rather than leave those documents unopenable, this renders a shape
+ * summary plus the raw JSON — enough to confirm what the agent wrote.
+ */
+
+import React, { useEffect, useLayoutEffect, useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { documentStore } from '../documents/documentStore';
+import { documentKindInfo } from '../documents/kinds';
+
+type DocumentViewerScreenProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'DocumentViewer'>;
+  route: RouteProp<RootStackParamList, 'DocumentViewer'>;
+};
+
+interface FieldSummary {
+  key: string;
+  value: string;
+}
+
+/** One line per top-level field: length for collections, the value for scalars. */
+function summarizeFields(doc: unknown): FieldSummary[] {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    return [];
+  }
+  return Object.entries(doc as Record<string, unknown>).map(([key, value]) => ({
+    key,
+    value: describeValue(value),
+  }));
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `${value.length} item${value.length === 1 ? '' : 's'}`;
+  }
+  if (typeof value === 'object') {
+    return `${Object.keys(value as Record<string, unknown>).length} field(s)`;
+  }
+  if (typeof value === 'string') {
+    return value.length > 60 ? `${value.slice(0, 60)}…` : value;
+  }
+  return String(value);
+}
+
+export default function DocumentViewerScreen({
+  navigation,
+  route,
+}: DocumentViewerScreenProps) {
+  const { kind, id, name: seedName } = route.params;
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const useStore = useMemo(
+    () => documentStore<unknown>(kind as ResourceKind, id),
+    [kind, id]
+  );
+  const doc = useStore((state) => state.doc);
+  const name = useStore((state) => state.name);
+  const status = useStore((state) => state.status);
+  const error = useStore((state) => state.error);
+  const updatedAt = useStore((state) => state.updatedAt);
+  const load = useStore((state) => state.load);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const headerTitle = name || seedName || 'Document';
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: headerTitle });
+  }, [navigation, headerTitle]);
+
+  const kindLabel = useMemo(() => {
+    try {
+      return documentKindInfo(kind as ResourceKind).label;
+    } catch {
+      // An unregistered kind can still be opened by id; name it as-is.
+      return kind;
+    }
+  }, [kind]);
+
+  const fields = useMemo(() => summarizeFields(doc), [doc]);
+  const json = useMemo(
+    () => (doc === null ? '' : JSON.stringify(doc, null, 2)),
+    [doc]
+  );
+
+  if (status === 'loading' && doc === null) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.centerText, { color: colors.textSecondary }]}>
+          Loading {kindLabel}...
+        </Text>
+      </View>
+    );
+  }
+
+  if (doc === null) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        <View style={[styles.errorIcon, { backgroundColor: colors.primaryMuted }]}>
+          <Ionicons name="alert-circle-outline" size={36} color={colors.error} />
+        </View>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>
+          Could not load {kindLabel}
+        </Text>
+        {error ? (
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>{error}</Text>
+        ) : null}
+        <TouchableOpacity
+          style={[styles.retryButton, shadows.small, { backgroundColor: colors.primary }]}
+          onPress={() => {
+            void load();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading document"
+          activeOpacity={0.7}
+        >
+          <Ionicons name="refresh-outline" size={16} color={colors.textOnPrimary} />
+          <Text style={[styles.retryText, { color: colors.textOnPrimary }]}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
+    >
+      <View style={styles.headerSection}>
+        <Text style={[styles.name, { color: colors.text }]} numberOfLines={2}>
+          {headerTitle}
+        </Text>
+        <Text style={[styles.meta, { color: colors.textSecondary }]}>
+          {kindLabel}
+          {updatedAt ? ` · updated ${new Date(updatedAt).toLocaleString()}` : ''}
+        </Text>
+      </View>
+
+      <View
+        style={[
+          styles.note,
+          { backgroundColor: colors.primaryMuted, borderColor: colors.borderLight },
+        ]}
+      >
+        <Ionicons name="information-circle-outline" size={16} color={colors.primary} />
+        <Text style={[styles.noteText, { color: colors.textSecondary }]}>
+          A {kindLabel} has no dedicated mobile screen yet. This generic view shows the
+          document read-only so every kind can still be opened and inspected.
+        </Text>
+      </View>
+
+      {fields.length > 0 ? (
+        <View
+          style={[
+            styles.card,
+            shadows.small,
+            { backgroundColor: colors.cardBg, borderColor: colors.borderLight },
+          ]}
+        >
+          {fields.map((field, index) => (
+            <View
+              key={field.key}
+              style={[
+                styles.fieldRow,
+                index < fields.length - 1 && {
+                  borderBottomColor: colors.borderLight,
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                },
+              ]}
+            >
+              <Text style={[styles.fieldKey, { color: colors.textSecondary }]}>
+                {field.key}
+              </Text>
+              <Text
+                style={[styles.fieldValue, { color: colors.text }]}
+                numberOfLines={2}
+                ellipsizeMode="tail"
+              >
+                {field.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>JSON</Text>
+      <ScrollView
+        horizontal
+        style={[
+          styles.jsonBlock,
+          { backgroundColor: colors.inputBg, borderColor: colors.borderLight },
+        ]}
+        contentContainerStyle={styles.jsonContent}
+      >
+        <Text style={[styles.jsonText, { color: colors.text }]} selectable>
+          {json}
+        </Text>
+      </ScrollView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  centerText: {
+    fontSize: 15,
+  },
+  errorIcon: {
+    width: 72,
+    height: 72,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  errorText: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  retryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  retryText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  headerSection: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 12,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginBottom: 6,
+  },
+  meta: {
+    fontSize: 14,
+  },
+  note: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginHorizontal: 16,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  noteText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  card: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    paddingVertical: 10,
+    alignItems: 'flex-start',
+  },
+  fieldKey: {
+    fontSize: 13,
+    width: 110,
+    marginRight: 8,
+  },
+  fieldValue: {
+    flex: 1,
+    fontSize: 14,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    marginHorizontal: 20,
+    marginTop: 20,
+    marginBottom: 8,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  jsonBlock: {
+    marginHorizontal: 16,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    maxHeight: 420,
+  },
+  jsonContent: {
+    padding: 12,
+  },
+  jsonText: {
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    fontSize: 12,
+    lineHeight: 17,
+  },
+});

--- a/mobile/src/screens/DocumentsScreen.tsx
+++ b/mobile/src/screens/DocumentsScreen.tsx
@@ -1,0 +1,742 @@
+/**
+ * The documents browser: every kind in one list.
+ *
+ * Web puts each open document in a workspace tab with a left rail of sections.
+ * A phone has no room for either, so the rail collapses into filter chips and
+ * opening a document pushes a screen. Which screen is decided by the kind
+ * registry, not by this file.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { ResourceKind } from '@nodetool-ai/app-runtime';
+
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { DOCUMENT_KINDS, documentKindInfo } from '../documents/kinds';
+import {
+  useAllDocuments,
+  useCreateDocument,
+  useDeleteDocument,
+  useRenameDocument,
+  type DocumentListEntry,
+} from '../documents/useDocuments';
+
+type DocumentsScreenProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'Documents'>;
+};
+
+type IconName = keyof typeof Ionicons.glyphMap;
+
+const icon = (name: string): IconName => name as IconName;
+
+/** Coarse "2h ago" stamp. Rows only need recency, so no date library. */
+export function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) {
+    return '';
+  }
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) {
+    return 'just now';
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.round(hours / 24);
+  if (days < 7) {
+    return `${days}d ago`;
+  }
+  const weeks = Math.round(days / 7);
+  if (weeks < 5) {
+    return `${weeks}w ago`;
+  }
+  const months = Math.round(days / 30);
+  if (months < 12) {
+    return `${months}mo ago`;
+  }
+  return `${Math.round(days / 365)}y ago`;
+}
+
+const CREATABLE_KINDS = DOCUMENT_KINDS.filter((entry) => entry.creatable);
+
+export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const [activeKind, setActiveKind] = useState<ResourceKind | null>(null);
+  const [renameTarget, setRenameTarget] = useState<DocumentListEntry | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+
+  const { documents, isLoading, isRefetching, error, refetch } = useAllDocuments();
+  const createDocument = useCreateDocument();
+  const renameDocument = useRenameDocument();
+  const deleteDocument = useDeleteDocument();
+
+  const visibleDocuments = useMemo(
+    () =>
+      activeKind === null
+        ? documents
+        : documents.filter((entry) => entry.kind === activeKind),
+    [documents, activeKind]
+  );
+
+  /**
+   * The registry says which route opens a kind; the param shapes differ, so the
+   * switch is over the three routes rather than over every kind.
+   */
+  const openDocument = useCallback(
+    (entry: DocumentListEntry) => {
+      const info = documentKindInfo(entry.kind);
+      switch (info.route) {
+        case 'StoryboardEditor':
+          navigation.navigate('StoryboardEditor', { id: entry.id, name: entry.name });
+          break;
+        case 'TimelineViewer':
+          navigation.navigate('TimelineViewer', { id: entry.id, name: entry.name });
+          break;
+        case 'DocumentViewer':
+          navigation.navigate('DocumentViewer', {
+            kind: entry.kind,
+            id: entry.id,
+            name: entry.name,
+          });
+          break;
+      }
+    },
+    [navigation]
+  );
+
+  const handleCreate = useCallback(
+    async (kind: ResourceKind, label: string) => {
+      try {
+        const detail = await createDocument.mutateAsync({
+          kind,
+          name: `New ${label}`,
+          projectId: 'default',
+        });
+        openDocument({
+          kind: detail.ref.kind,
+          id: detail.ref.id,
+          name: detail.name,
+          updatedAt: detail.updatedAt,
+        });
+      } catch (createError: unknown) {
+        const message =
+          createError instanceof Error ? createError.message : `Could not create ${label}`;
+        Alert.alert('Error', message);
+      }
+    },
+    [createDocument, openDocument]
+  );
+
+  const handleDelete = useCallback(
+    (entry: DocumentListEntry) => {
+      Alert.alert(
+        'Delete document?',
+        `This will permanently delete "${entry.name}".`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              deleteDocument.mutate(
+                { ref: { kind: entry.kind, id: entry.id } },
+                {
+                  onError: (deleteError) => {
+                    Alert.alert('Error', deleteError.message);
+                  },
+                }
+              );
+            },
+          },
+        ]
+      );
+    },
+    [deleteDocument]
+  );
+
+  const handleRenameSubmit = useCallback(async () => {
+    const target = renameTarget;
+    if (!target) {
+      return;
+    }
+    const name = renameValue.trim();
+    if (!name || name === target.name) {
+      setRenameTarget(null);
+      return;
+    }
+    try {
+      await renameDocument.mutateAsync({
+        ref: { kind: target.kind, id: target.id },
+        name,
+      });
+      setRenameTarget(null);
+    } catch (renameError: unknown) {
+      const message =
+        renameError instanceof Error ? renameError.message : 'Could not rename document';
+      Alert.alert('Error', message);
+    }
+  }, [renameTarget, renameValue, renameDocument]);
+
+  const showRowActions = useCallback(
+    (entry: DocumentListEntry) => {
+      Alert.alert(entry.name, undefined, [
+        {
+          text: 'Rename',
+          onPress: () => {
+            setRenameValue(entry.name);
+            setRenameTarget(entry);
+          },
+        },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => handleDelete(entry),
+        },
+        { text: 'Cancel', style: 'cancel' },
+      ]);
+    },
+    [handleDelete]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: DocumentListEntry }) => {
+      const info = documentKindInfo(item.kind);
+      const isReadOnly = info.surface === 'viewer';
+      return (
+        <View
+          style={[
+            styles.row,
+            shadows.small,
+            { backgroundColor: colors.cardBg, borderColor: colors.borderLight },
+          ]}
+        >
+          <TouchableOpacity
+            style={styles.rowMain}
+            onPress={() => openDocument(item)}
+            onLongPress={() => showRowActions(item)}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${item.name}, ${info.label}`}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.rowIcon, { backgroundColor: colors.primaryMuted }]}>
+              <Ionicons name={icon(info.icon)} size={20} color={colors.primary} />
+            </View>
+            <View style={styles.rowText}>
+              <Text style={[styles.rowName, { color: colors.text }]} numberOfLines={1}>
+                {item.name}
+              </Text>
+              <View style={styles.rowMetaLine}>
+                <Text style={[styles.rowMeta, { color: colors.textSecondary }]}>
+                  {info.label} · {formatRelativeTime(item.updatedAt)}
+                </Text>
+                {isReadOnly ? (
+                  <View style={[styles.badge, { backgroundColor: colors.primaryLight }]}>
+                    <Ionicons name="eye-outline" size={11} color={colors.textSecondary} />
+                    <Text style={[styles.badgeText, { color: colors.textSecondary }]}>
+                      Read-only
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.rowAction}
+            onPress={() => showRowActions(item)}
+            accessibilityRole="button"
+            accessibilityLabel={`Actions for ${item.name}`}
+            activeOpacity={0.7}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="ellipsis-horizontal" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+      );
+    },
+    [colors, shadows, openDocument, showRowActions]
+  );
+
+  if (isLoading) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.centerText, { color: colors.textSecondary }]}>
+          Loading documents...
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {error ? (
+        <View
+          style={[
+            styles.errorBanner,
+            { backgroundColor: colors.primaryMuted, borderColor: colors.border },
+          ]}
+        >
+          <Ionicons name="alert-circle-outline" size={16} color={colors.error} />
+          <Text style={[styles.errorText, { color: colors.error }]} numberOfLines={2}>
+            {error.message || 'Could not load documents'}
+          </Text>
+          <TouchableOpacity
+            onPress={() => refetch()}
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading documents"
+            activeOpacity={0.7}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="refresh-outline" size={18} color={colors.error} />
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+      >
+        <FilterChip
+          label="All"
+          isActive={activeKind === null}
+          onPress={() => setActiveKind(null)}
+          colors={colors}
+        />
+        {DOCUMENT_KINDS.map((entry) => (
+          <FilterChip
+            key={entry.kind}
+            label={entry.plural}
+            iconName={entry.icon}
+            isActive={activeKind === entry.kind}
+            onPress={() => setActiveKind(entry.kind)}
+            colors={colors}
+          />
+        ))}
+      </ScrollView>
+
+      {CREATABLE_KINDS.length > 0 ? (
+        <View style={styles.createRow}>
+          {CREATABLE_KINDS.map((entry) => (
+            <TouchableOpacity
+              key={entry.kind}
+              style={[styles.createButton, { backgroundColor: colors.primary }]}
+              onPress={() => {
+                void handleCreate(entry.kind, entry.label);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`New ${entry.label}`}
+              activeOpacity={0.7}
+              disabled={createDocument.isPending}
+            >
+              <Ionicons name="add" size={16} color={colors.textOnPrimary} />
+              <Text style={[styles.createButtonText, { color: colors.textOnPrimary }]}>
+                New {entry.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ) : null}
+
+      <FlatList
+        data={visibleDocuments}
+        renderItem={renderItem}
+        keyExtractor={(item) => `${item.kind}:${item.id}`}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefetching}
+            onRefresh={() => refetch()}
+            tintColor={colors.primary}
+            colors={[colors.primary]}
+          />
+        }
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <View style={[styles.emptyIcon, { backgroundColor: colors.primaryMuted }]}>
+              <Ionicons name="documents-outline" size={36} color={colors.primary} />
+            </View>
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>
+              {activeKind === null ? 'No documents yet' : 'Nothing of this kind'}
+            </Text>
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              Storyboards, timelines, and sketches are usually built by asking the
+              assistant. Describe what you want and it writes the document for you.
+            </Text>
+            <TouchableOpacity
+              style={[styles.emptyButton, shadows.small, { backgroundColor: colors.primary }]}
+              onPress={() => navigation.navigate('Chat')}
+              accessibilityRole="button"
+              accessibilityLabel="Open chat with the assistant"
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name="chatbubble-ellipses-outline"
+                size={16}
+                color={colors.textOnPrimary}
+              />
+              <Text style={[styles.emptyButtonText, { color: colors.textOnPrimary }]}>
+                Ask the assistant
+              </Text>
+            </TouchableOpacity>
+          </View>
+        }
+      />
+
+      <Modal
+        visible={renameTarget !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setRenameTarget(null)}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.modalBackdrop}
+        >
+          <View style={[styles.modalCard, shadows.large, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Rename document</Text>
+            <TextInput
+              style={[
+                styles.modalInput,
+                {
+                  color: colors.text,
+                  borderColor: colors.border,
+                  backgroundColor: colors.inputBg,
+                },
+              ]}
+              value={renameValue}
+              onChangeText={setRenameValue}
+              placeholder="Document name"
+              placeholderTextColor={colors.textTertiary}
+              accessibilityLabel="Document name"
+              autoFocus
+              autoCorrect={false}
+              selectTextOnFocus
+            />
+            <View style={styles.modalActions}>
+              <TouchableOpacity
+                style={[
+                  styles.modalButtonOutline,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                ]}
+                onPress={() => setRenameTarget(null)}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel rename"
+                activeOpacity={0.7}
+                disabled={renameDocument.isPending}
+              >
+                <Text style={[styles.modalButtonText, { color: colors.text }]}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalButton, { backgroundColor: colors.primary }]}
+                onPress={() => {
+                  void handleRenameSubmit();
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Save rename"
+                activeOpacity={0.7}
+                disabled={renameDocument.isPending}
+              >
+                {renameDocument.isPending ? (
+                  <ActivityIndicator color={colors.textOnPrimary} />
+                ) : (
+                  <Text style={[styles.modalButtonText, { color: colors.textOnPrimary }]}>
+                    Save
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+}
+
+type FilterChipProps = {
+  label: string;
+  iconName?: string;
+  isActive: boolean;
+  onPress: () => void;
+  colors: {
+    primary: string;
+    primaryMuted: string;
+    text: string;
+    textSecondary: string;
+    border: string;
+    surface: string;
+  };
+};
+
+function FilterChip({ label, iconName, isActive, onPress, colors }: FilterChipProps) {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.chip,
+        {
+          backgroundColor: isActive ? colors.primaryMuted : colors.surface,
+          borderColor: isActive ? colors.primary : colors.border,
+        },
+      ]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Filter by ${label}`}
+      accessibilityState={{ selected: isActive }}
+      activeOpacity={0.7}
+    >
+      {iconName ? (
+        <Ionicons
+          name={icon(iconName)}
+          size={14}
+          color={isActive ? colors.primary : colors.textSecondary}
+        />
+      ) : null}
+      <Text
+        style={[
+          styles.chipText,
+          { color: isActive ? colors.primary : colors.textSecondary },
+        ]}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  centerText: {
+    fontSize: 15,
+  },
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginHorizontal: 16,
+    marginTop: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  errorText: {
+    flex: 1,
+    fontSize: 13,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  createRow: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 10,
+  },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 12,
+  },
+  createButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 12,
+    flexGrow: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 10,
+  },
+  rowMain: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+  },
+  rowIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 11,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  rowText: {
+    flex: 1,
+  },
+  rowName: {
+    fontSize: 16,
+    fontWeight: '600',
+    letterSpacing: -0.2,
+    marginBottom: 3,
+  },
+  rowMetaLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  rowMeta: {
+    fontSize: 13,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  rowAction: {
+    paddingHorizontal: 14,
+    paddingVertical: 18,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingTop: 48,
+  },
+  emptyIcon: {
+    width: 72,
+    height: 72,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 18,
+  },
+  emptyTitle: {
+    fontSize: 19,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  emptyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  emptyButtonText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  modalBackdrop: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  modalCard: {
+    width: '100%',
+    maxWidth: 420,
+    borderRadius: 16,
+    padding: 20,
+  },
+  modalTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    marginBottom: 16,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+  },
+  modalButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  modalButtonOutline: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  modalButtonText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/screens/DocumentsScreen.tsx
+++ b/mobile/src/screens/DocumentsScreen.tsx
@@ -26,7 +26,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { ResourceKind } from '@nodetool-ai/app-runtime';
+import type { DocumentKind } from '../documents/kinds';
 
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../hooks/useTheme';
@@ -86,7 +86,7 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
   const { colors, shadows } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const [activeKind, setActiveKind] = useState<ResourceKind | null>(null);
+  const [activeKind, setActiveKind] = useState<DocumentKind | null>(null);
   const [renameTarget, setRenameTarget] = useState<DocumentListEntry | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
@@ -114,6 +114,9 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
         case 'StoryboardEditor':
           navigation.navigate('StoryboardEditor', { id: entry.id, name: entry.name });
           break;
+        case 'ScriptEditor':
+          navigation.navigate('ScriptEditor', { id: entry.id, name: entry.name });
+          break;
         case 'TimelineViewer':
           navigation.navigate('TimelineViewer', { id: entry.id, name: entry.name });
           break;
@@ -130,19 +133,13 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
   );
 
   const handleCreate = useCallback(
-    async (kind: ResourceKind, label: string) => {
+    async (kind: DocumentKind, label: string) => {
       try {
-        const detail = await createDocument.mutateAsync({
+        const created = await createDocument.mutateAsync({
           kind,
           name: `New ${label}`,
-          projectId: 'default',
         });
-        openDocument({
-          kind: detail.ref.kind,
-          id: detail.ref.id,
-          name: detail.name,
-          updatedAt: detail.updatedAt,
-        });
+        openDocument(created);
       } catch (createError: unknown) {
         const message =
           createError instanceof Error ? createError.message : `Could not create ${label}`;
@@ -164,7 +161,7 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
             style: 'destructive',
             onPress: () => {
               deleteDocument.mutate(
-                { ref: { kind: entry.kind, id: entry.id } },
+                { kind: entry.kind, id: entry.id },
                 {
                   onError: (deleteError) => {
                     Alert.alert('Error', deleteError.message);
@@ -191,7 +188,8 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
     }
     try {
       await renameDocument.mutateAsync({
-        ref: { kind: target.kind, id: target.id },
+        kind: target.kind,
+        id: target.id,
         name,
       });
       setRenameTarget(null);
@@ -385,8 +383,9 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
               {activeKind === null ? 'No documents yet' : 'Nothing of this kind'}
             </Text>
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              Storyboards, timelines, and sketches are usually built by asking the
-              assistant. Describe what you want and it writes the document for you.
+              Storyboards, scripts, timelines, and sketches are usually built by
+              asking the assistant. Describe what you want and it writes the
+              document for you.
             </Text>
             <TouchableOpacity
               style={[styles.emptyButton, shadows.small, { backgroundColor: colors.primary }]}

--- a/mobile/src/screens/ScriptEditorScreen.tsx
+++ b/mobile/src/screens/ScriptEditorScreen.tsx
@@ -1,0 +1,1125 @@
+/**
+ * Script editor.
+ *
+ * The phone half of the script surface: read a script, write its cast, sections,
+ * and lines, reorder, save. Voicing lines with TTS, exporting subtitles, and
+ * assembling takes into a timeline stay on the desktop app — those are long, paid
+ * jobs a phone screen cannot supervise — so this screen is a text editor that
+ * shows, but never touches, the audio history each line carries.
+ *
+ * It is also the agent's hands on the script. The handler registered here mutates
+ * the same `documentStore` the render reads, so a `ui_script_*` call repaints the
+ * screen the user is holding, and `ui_script_save` is the same code path as the
+ * Save button.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { RouteProp, useFocusEffect } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useShallow } from 'zustand/react/shallow';
+
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { documentStore } from '../documents/documentStore';
+import {
+  registerDocumentHandler,
+  setDocumentTitle,
+  setFocusedDocument,
+} from '../documents/agentBridge';
+import {
+  applyLinePatch,
+  clamp,
+  emptyLine,
+  flattenLines,
+  lineStatus,
+  lineToNode,
+  newSectionId,
+  newSpeakerId,
+  replaceLine,
+  resolveLine,
+  resolveSectionIndex,
+  resolveSpeakerIndex,
+  sectionToNode,
+  speakerToNode,
+  withoutSpeaker,
+  type ScriptAddLineInput,
+  type ScriptAgentHandler,
+  type ScriptDocument,
+  type ScriptLine,
+  type ScriptLineFields,
+  type ScriptLineNode,
+  type ScriptLinePatch,
+  type ScriptLineStatus,
+  type ScriptSection,
+  type ScriptSectionNode,
+  type ScriptSpeakerNode,
+  type ScriptSnapshot,
+} from '../documents/scriptTypes';
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'ScriptEditor'>;
+  route: RouteProp<RootStackParamList, 'ScriptEditor'>;
+};
+
+const STATUS_LABELS: Record<ScriptLineStatus, string> = {
+  draft: 'Draft',
+  voiced: 'Voiced',
+  stale: 'Stale',
+};
+
+export default function ScriptEditorScreen({ navigation, route }: Props) {
+  const { id, name: initialName } = route.params;
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const store = documentStore<ScriptDocument>('script', id);
+  const { doc, name, dirty, status, error } = store(
+    useShallow((state) => ({
+      doc: state.doc,
+      name: state.name,
+      dirty: state.dirty,
+      status: state.status,
+      error: state.error,
+    }))
+  );
+
+  const [selectedLineId, setSelectedLineId] = useState<string | null>(null);
+  // The agent handler runs outside React, so it reads selection from a ref.
+  const selectedRef = useRef<string | null>(null);
+  const select = useCallback((next: string | null) => {
+    selectedRef.current = next;
+    setSelectedLineId(next);
+  }, []);
+
+  // The store's actions live in its state, so every caller goes through
+  // getState() — including the agent handler, which runs outside React.
+  const edit = useCallback(
+    (mutate: (script: ScriptDocument) => ScriptDocument) => {
+      store.getState().edit(mutate);
+    },
+    [store]
+  );
+  const runLoad = useCallback(() => void store.getState().load(), [store]);
+  const runSave = useCallback(() => store.getState().save(), [store]);
+  const runRevert = useCallback(() => void store.getState().revert(), [store]);
+
+  useEffect(() => {
+    // Re-read on every open. The store is cached for the app's lifetime, so a
+    // script reopened after an edit elsewhere would otherwise render stale text
+    // and save against an `updatedAt` the server has already moved past.
+    // Unsaved local edits are the one thing worth keeping over a fresh read.
+    if (!store.getState().dirty) {
+      runLoad();
+    }
+  }, [store, runLoad]);
+
+  // ── Agent handler ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const requireDoc = (): ScriptDocument => {
+      const current = store.getState().doc;
+      if (current === null) {
+        throw new Error(
+          `Script "${id}" has not finished loading. Retry in a moment.`
+        );
+      }
+      return current;
+    };
+
+    const snapshot = (): ScriptSnapshot => {
+      const state = store.getState();
+      const script = state.doc;
+      return {
+        scriptId: id,
+        title: state.name || initialName || 'Untitled script',
+        cast: (script?.cast ?? []).map(speakerToNode),
+        sections: (script?.sections ?? []).map(sectionToNode),
+        lines: script
+          ? flattenLines(script).map((entry) =>
+              lineToNode(entry.line, entry.sectionId, entry.index, script.cast)
+            )
+          : [],
+        selectedLineId: selectedRef.current,
+      };
+    };
+
+    /** Re-read a line after an edit, so the returned node reflects the write. */
+    const nodeFor = (lineId: string): ScriptLineNode => {
+      const script = requireDoc();
+      const entry = flattenLines(script).find((it) => it.line.id === lineId);
+      if (!entry) {
+        throw new Error(`Line "${lineId}" disappeared after the edit.`);
+      }
+      return lineToNode(entry.line, entry.sectionId, entry.index, script.cast);
+    };
+
+    const requireSpeaker = (script: ScriptDocument, speakerId: string): void => {
+      if (!script.cast.some((speaker) => speaker.id === speakerId)) {
+        const ids = script.cast.map((speaker) => speaker.id).join(', ');
+        throw new Error(
+          `No cast member "${speakerId}" exists. ` +
+            (ids.length > 0
+              ? `Speaker ids: ${ids}.`
+              : 'Add one with ui_script_add_speaker first.')
+        );
+      }
+    };
+
+    const patchLineAt = (
+      target: string,
+      patch: ScriptLineFields
+    ): ScriptLineNode => {
+      const at = resolveLine(requireDoc(), target, selectedRef.current);
+      const next = applyLinePatch(at.line, patch);
+      edit((script) => replaceLine(script, at, next));
+      return nodeFor(next.id);
+    };
+
+    const handler: ScriptAgentHandler = {
+      getSnapshot: snapshot,
+
+      addSpeaker: (speakerName: string, color?: string): ScriptSpeakerNode => {
+        requireDoc();
+        const speaker = { id: newSpeakerId(), name: speakerName, color };
+        edit((script) => ({ ...script, cast: [...script.cast, speaker] }));
+        return speakerToNode(speaker);
+      },
+
+      renameSpeaker: (target: string, speakerName: string): ScriptSpeakerNode => {
+        const script = requireDoc();
+        const at = resolveSpeakerIndex(script.cast, target);
+        const updated = { ...script.cast[at], name: speakerName };
+        edit((current) => ({
+          ...current,
+          cast: current.cast.map((speaker, index) =>
+            index === at ? updated : speaker
+          ),
+        }));
+        return speakerToNode(updated);
+      },
+
+      removeSpeaker: (target: string): ScriptSpeakerNode => {
+        const script = requireDoc();
+        const at = resolveSpeakerIndex(script.cast, target);
+        const removed = script.cast[at];
+        edit((current) => withoutSpeaker(current, removed.id));
+        return speakerToNode(removed);
+      },
+
+      addSection: (title?: string, index?: number): ScriptSectionNode => {
+        const sections = requireDoc().sections;
+        const at =
+          index === undefined
+            ? sections.length
+            : clamp(Math.trunc(index), 0, sections.length);
+        const section: ScriptSection = { id: newSectionId(), title, lines: [] };
+        edit((script) => ({
+          ...script,
+          sections: [
+            ...script.sections.slice(0, at),
+            section,
+            ...script.sections.slice(at),
+          ],
+        }));
+        return sectionToNode(section);
+      },
+
+      setSectionTitle: (target: string, title: string): ScriptSectionNode => {
+        const script = requireDoc();
+        const at = resolveSectionIndex(script.sections, target);
+        const updated = { ...script.sections[at], title };
+        edit((current) => ({
+          ...current,
+          sections: current.sections.map((section, index) =>
+            index === at ? updated : section
+          ),
+        }));
+        return sectionToNode(updated);
+      },
+
+      removeSection: (target: string): ScriptSectionNode => {
+        const script = requireDoc();
+        const at = resolveSectionIndex(script.sections, target);
+        const removed = script.sections[at];
+        edit((current) => ({
+          ...current,
+          sections: current.sections.filter((_, index) => index !== at),
+        }));
+        if (removed.lines.some((line) => line.id === selectedRef.current)) {
+          select(null);
+        }
+        return sectionToNode(removed);
+      },
+
+      addLine: (input: ScriptAddLineInput): ScriptLineNode => {
+        const script = requireDoc();
+        if (input.speakerId !== undefined) {
+          requireSpeaker(script, input.speakerId);
+        }
+        const line: ScriptLine = {
+          ...emptyLine(input.text, input.speakerId ?? null),
+          direction: input.direction,
+        };
+
+        // No section to write into: give the script one rather than refuse, so
+        // an agent writing a fresh script does not need a setup call first.
+        if (script.sections.length === 0) {
+          const section: ScriptSection = {
+            id: newSectionId(),
+            lines: [line],
+          };
+          edit((current) => ({ ...current, sections: [section] }));
+          return nodeFor(line.id);
+        }
+
+        const sectionIndex =
+          input.sectionId === undefined
+            ? script.sections.length - 1
+            : resolveSectionIndex(script.sections, input.sectionId);
+        const target = script.sections[sectionIndex];
+        const at =
+          input.index === undefined
+            ? target.lines.length
+            : clamp(Math.trunc(input.index), 0, target.lines.length);
+        edit((current) => ({
+          ...current,
+          sections: current.sections.map((section, index) =>
+            index === sectionIndex
+              ? {
+                  ...section,
+                  lines: [
+                    ...section.lines.slice(0, at),
+                    line,
+                    ...section.lines.slice(at),
+                  ],
+                }
+              : section
+          ),
+        }));
+        return nodeFor(line.id);
+      },
+
+      setLineText: (target: string, text: string): ScriptLineNode =>
+        patchLineAt(target, { text }),
+
+      setLineSpeaker: (
+        target: string,
+        speakerId: string | null
+      ): ScriptLineNode => {
+        if (speakerId !== null) {
+          requireSpeaker(requireDoc(), speakerId);
+        }
+        return patchLineAt(target, { speakerId });
+      },
+
+      patchLine: (target: string, patch: ScriptLinePatch): ScriptLineNode =>
+        patchLineAt(target, patch),
+
+      removeLine: (target: string): ScriptLineNode => {
+        const script = requireDoc();
+        const at = resolveLine(script, target, selectedRef.current);
+        const removed = lineToNode(at.line, at.sectionId, at.index, script.cast);
+        edit((current) => ({
+          ...current,
+          sections: current.sections.map((section, index) =>
+            index === at.sectionIndex
+              ? {
+                  ...section,
+                  lines: section.lines.filter(
+                    (line) => line.id !== at.line.id
+                  ),
+                }
+              : section
+          ),
+        }));
+        if (selectedRef.current === at.line.id) {
+          select(null);
+        }
+        return removed;
+      },
+
+      moveLine: (target: string, toIndex: number): ScriptLineNode => {
+        const script = requireDoc();
+        const at = resolveLine(script, target, selectedRef.current);
+        edit((current) => moveLineTo(current, at.line.id, toIndex));
+        return nodeFor(at.line.id);
+      },
+
+      selectLine: (target: string | null): ScriptLineNode | null => {
+        if (target === null) {
+          select(null);
+          return null;
+        }
+        const script = requireDoc();
+        const at = resolveLine(script, target, selectedRef.current);
+        select(at.line.id);
+        return lineToNode(at.line, at.sectionId, at.index, script.cast);
+      },
+
+      save: async (): Promise<{ ok: true; updatedAt: string | null }> => {
+        await runSave();
+        const state = store.getState();
+        if (state.status === 'conflict' || state.status === 'error') {
+          throw new Error(state.error ?? 'Failed to save the script.');
+        }
+        return { ok: true, updatedAt: state.updatedAt };
+      },
+    };
+
+    return registerDocumentHandler(
+      'script',
+      id,
+      store.getState().name || initialName || 'Script',
+      handler
+    );
+  }, [store, id, initialName, select, edit, runSave]);
+
+  // Keep the id the agent addresses tied to the screen the user is looking at.
+  // Claim focus on focus, but do not release it on blur. Navigating to Chat
+  // blurs this screen, and the chat turn is the one moment `ui_context.focused`
+  // is read — releasing here would tell the agent nothing is focused precisely
+  // when the user is asking about this script. Unmount drops the registration,
+  // which is what actually makes the claim stale.
+  useFocusEffect(
+    useCallback(() => {
+      setFocusedDocument('script', id);
+    }, [id])
+  );
+
+  // No `setUiSelection` call: that payload carries clip, shot, and layer ids,
+  // none of which a line is. The selected line reaches the agent through the
+  // script snapshot instead.
+
+  useEffect(() => {
+    if (name) {
+      setDocumentTitle('script', id, name);
+    }
+  }, [name, id]);
+
+  const handleSave = useCallback(() => {
+    void runSave();
+  }, [runSave]);
+
+  const openChat = useCallback(() => {
+    navigation.navigate('Chat');
+  }, [navigation]);
+
+  useLayoutEffect(() => {
+    const saving = status === 'saving';
+    navigation.setOptions({
+      title: name || initialName || 'Script',
+      headerRight: () => (
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={openChat}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Write this script by chat"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons
+              name="chatbubble-ellipses-outline"
+              size={22}
+              color={colors.primary}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSave}
+            activeOpacity={0.7}
+            disabled={!dirty || saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save script"
+            accessibilityState={{ disabled: !dirty || saving }}
+          >
+            {saving ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <Text
+                style={[
+                  styles.saveText,
+                  { color: dirty ? colors.primary : colors.textTertiary },
+                ]}
+              >
+                Save
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      ),
+    });
+  }, [
+    navigation,
+    name,
+    initialName,
+    dirty,
+    status,
+    colors.primary,
+    colors.textTertiary,
+    handleSave,
+    openChat,
+  ]);
+
+  // ── Local edits ──────────────────────────────────────────────────────────
+  const patchLine = useCallback(
+    (lineId: string, patch: ScriptLineFields) => {
+      edit((script) => ({
+        ...script,
+        sections: script.sections.map((section) => ({
+          ...section,
+          lines: section.lines.map((line) =>
+            line.id === lineId ? applyLinePatch(line, patch) : line
+          ),
+        })),
+      }));
+    },
+    [edit]
+  );
+
+  const addLine = useCallback(
+    (sectionId: string) => {
+      const line = emptyLine();
+      edit((script) => ({
+        ...script,
+        sections: script.sections.map((section) =>
+          section.id === sectionId
+            ? { ...section, lines: [...section.lines, line] }
+            : section
+        ),
+      }));
+      select(line.id);
+    },
+    [edit, select]
+  );
+
+  const removeLine = useCallback(
+    (lineId: string) => {
+      edit((script) => ({
+        ...script,
+        sections: script.sections.map((section) => ({
+          ...section,
+          lines: section.lines.filter((line) => line.id !== lineId),
+        })),
+      }));
+      if (selectedRef.current === lineId) {
+        select(null);
+      }
+    },
+    [edit, select]
+  );
+
+  const moveLine = useCallback(
+    (lineId: string, delta: number) => {
+      edit((script) => {
+        const entry = flattenLines(script).find((it) => it.line.id === lineId);
+        if (!entry) {
+          return script;
+        }
+        return moveLineTo(script, lineId, entry.index + delta);
+      });
+    },
+    [edit]
+  );
+
+  const addSection = useCallback(() => {
+    edit((script) => ({
+      ...script,
+      sections: [
+        ...script.sections,
+        { id: newSectionId(), title: '', lines: [] },
+      ],
+    }));
+  }, [edit]);
+
+  const removeSection = useCallback(
+    (sectionId: string) => {
+      edit((script) => ({
+        ...script,
+        sections: script.sections.filter((section) => section.id !== sectionId),
+      }));
+      select(null);
+    },
+    [edit, select]
+  );
+
+  const addSpeaker = useCallback(() => {
+    edit((script) => ({
+      ...script,
+      cast: [
+        ...script.cast,
+        { id: newSpeakerId(), name: `Speaker ${script.cast.length + 1}` },
+      ],
+    }));
+  }, [edit]);
+
+  const renameSpeaker = useCallback(
+    (speakerId: string, speakerName: string) => {
+      edit((script) => ({
+        ...script,
+        cast: script.cast.map((speaker) =>
+          speaker.id === speakerId ? { ...speaker, name: speakerName } : speaker
+        ),
+      }));
+    },
+    [edit]
+  );
+
+  const removeSpeaker = useCallback(
+    (speakerId: string) => {
+      edit((script) => withoutSpeaker(script, speakerId));
+    },
+    [edit]
+  );
+
+  const assignSpeaker = useCallback(
+    (speakerId: string) => {
+      const lineId = selectedRef.current;
+      if (lineId === null) {
+        return;
+      }
+      patchLine(lineId, { speakerId });
+    },
+    [patchLine]
+  );
+
+  if (doc === null) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        {status === 'error' ? (
+          <>
+            <Ionicons name="alert-circle-outline" size={36} color={colors.error} />
+            <Text style={[styles.centerText, { color: colors.textSecondary }]}>
+              {error ?? 'Failed to load this script.'}
+            </Text>
+            <TouchableOpacity
+              onPress={runLoad}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading script"
+              style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            >
+              <Text
+                style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}
+              >
+                Retry
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <ActivityIndicator size="large" color={colors.primary} />
+        )}
+      </View>
+    );
+  }
+
+  const flat = flattenLines(doc);
+  const lineNumber = new Map(flat.map((entry) => [entry.line.id, entry.index]));
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {status === 'conflict' && (
+        <View
+          style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
+          accessibilityLabel="Script changed elsewhere"
+        >
+          <Ionicons name="git-compare-outline" size={16} color={colors.warning} />
+          <Text style={[styles.bannerText, { color: colors.text }]}>
+            Someone else saved this script. Reload to get their version — your
+            unsaved edits here will be lost.
+          </Text>
+          <TouchableOpacity
+            onPress={runRevert}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Reload script"
+            style={[styles.bannerButton, { backgroundColor: colors.warning }]}
+          >
+            <Text style={styles.bannerButtonText}>Reload</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {status === 'error' && error !== null && (
+        <View style={[styles.banner, { backgroundColor: colors.error + '18' }]}>
+          <Ionicons name="warning-outline" size={16} color={colors.error} />
+          <Text style={[styles.bannerText, { color: colors.error }]}>{error}</Text>
+        </View>
+      )}
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.scroll,
+          { paddingBottom: insets.bottom + 40 },
+        ]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.metaRow}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            {`Cast (${doc.cast.length})`}
+          </Text>
+          {dirty && (
+            <View style={styles.dirtyRow} accessibilityLabel="Unsaved changes">
+              <View style={[styles.dirtyDot, { backgroundColor: colors.warning }]} />
+              <Text style={[styles.dirtyText, { color: colors.textSecondary }]}>
+                Unsaved
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {doc.cast.map((speaker, index) => (
+          <View key={speaker.id} style={styles.castRow}>
+            <View
+              style={[
+                styles.colorChip,
+                { backgroundColor: speaker.color || colors.primaryMuted },
+              ]}
+            />
+            <TextInput
+              style={[
+                styles.input,
+                styles.castInput,
+                {
+                  backgroundColor: colors.inputBg,
+                  borderColor: colors.borderLight,
+                  color: colors.text,
+                },
+              ]}
+              value={speaker.name}
+              onChangeText={(next) => renameSpeaker(speaker.id, next)}
+              placeholder="Speaker name"
+              placeholderTextColor={colors.textTertiary}
+              accessibilityLabel={`Speaker ${index + 1} name`}
+            />
+            <TouchableOpacity
+              onPress={() => assignSpeaker(speaker.id)}
+              activeOpacity={0.7}
+              disabled={selectedLineId === null}
+              accessibilityRole="button"
+              accessibilityLabel={`Assign ${speaker.name} to the selected line`}
+              accessibilityState={{ disabled: selectedLineId === null }}
+              style={styles.iconButton}
+            >
+              <Ionicons
+                name="person-add-outline"
+                size={18}
+                color={selectedLineId === null ? colors.textTertiary : colors.primary}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => removeSpeaker(speaker.id)}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel={`Remove speaker ${index + 1}`}
+              style={styles.iconButton}
+            >
+              <Ionicons name="trash-outline" size={18} color={colors.error} />
+            </TouchableOpacity>
+          </View>
+        ))}
+
+        <TouchableOpacity
+          onPress={addSpeaker}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Add speaker"
+          style={styles.addButton}
+        >
+          <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+          <Text style={[styles.addButtonText, { color: colors.primary }]}>
+            Add speaker
+          </Text>
+        </TouchableOpacity>
+
+        <View style={styles.metaRow}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            {`Script (${flat.length} ${flat.length === 1 ? 'line' : 'lines'})`}
+          </Text>
+          <TouchableOpacity
+            onPress={addSection}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Add section"
+            style={styles.addButton}
+          >
+            <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+            <Text style={[styles.addButtonText, { color: colors.primary }]}>
+              Section
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {doc.sections.length === 0 ? (
+          <View style={styles.empty}>
+            <Ionicons
+              name="document-text-outline"
+              size={36}
+              color={colors.textTertiary}
+            />
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              No lines yet. Scripts are usually written by asking the assistant
+              for the dialogue you want — then fix the wording here. Voicing them
+              happens in the desktop app.
+            </Text>
+            <TouchableOpacity
+              onPress={openChat}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Ask the assistant"
+              style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            >
+              <Text
+                style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}
+              >
+                Ask the assistant
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          doc.sections.map((section, sectionIndex) => (
+            <View key={section.id} style={styles.sectionBlock}>
+              <View style={styles.sectionHeader}>
+                <TextInput
+                  style={[
+                    styles.input,
+                    styles.sectionInput,
+                    {
+                      backgroundColor: colors.inputBg,
+                      borderColor: colors.borderLight,
+                      color: colors.text,
+                    },
+                  ]}
+                  value={section.title ?? ''}
+                  onChangeText={(title) =>
+                    edit((script) => ({
+                      ...script,
+                      sections: script.sections.map((it) =>
+                        it.id === section.id ? { ...it, title } : it
+                      ),
+                    }))
+                  }
+                  placeholder={`Section ${sectionIndex + 1} title`}
+                  placeholderTextColor={colors.textTertiary}
+                  accessibilityLabel={`Section ${sectionIndex + 1} title`}
+                />
+                <TouchableOpacity
+                  onPress={() => removeSection(section.id)}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Delete section ${sectionIndex + 1}`}
+                  style={styles.iconButton}
+                >
+                  <Ionicons name="trash-outline" size={18} color={colors.error} />
+                </TouchableOpacity>
+              </View>
+
+              {section.lines.map((line) => {
+                const index = lineNumber.get(line.id) ?? 0;
+                const isSelected = line.id === selectedLineId;
+                const speaker = doc.cast.find(
+                  (member) => member.id === line.speakerId
+                );
+                const derived = lineStatus(line);
+                return (
+                  <View
+                    key={line.id}
+                    style={[
+                      styles.card,
+                      shadows.small,
+                      {
+                        backgroundColor: colors.cardBg,
+                        borderColor: isSelected
+                          ? colors.primary
+                          : colors.borderLight,
+                      },
+                    ]}
+                  >
+                    <TouchableOpacity
+                      onPress={() => select(isSelected ? null : line.id)}
+                      activeOpacity={0.7}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Select line ${index + 1}`}
+                      accessibilityState={{ selected: isSelected }}
+                      style={styles.cardHeader}
+                    >
+                      <View
+                        style={[
+                          styles.colorChip,
+                          {
+                            backgroundColor:
+                              speaker?.color || colors.primaryMuted,
+                          },
+                        ]}
+                      />
+                      <Text
+                        style={[styles.speakerName, { color: colors.text }]}
+                        numberOfLines={1}
+                      >
+                        {speaker?.name || 'Unassigned'}
+                      </Text>
+                      <View
+                        style={[
+                          styles.statusPill,
+                          { backgroundColor: colors.accentMuted },
+                        ]}
+                        accessibilityLabel={`Line ${index + 1} status ${STATUS_LABELS[derived]}, ${line.takes.length} takes`}
+                      >
+                        <Text
+                          style={[styles.statusPillText, { color: colors.accent }]}
+                        >
+                          {line.takes.length > 0
+                            ? `${STATUS_LABELS[derived]} · ${line.takes.length}`
+                            : STATUS_LABELS[derived]}
+                        </Text>
+                      </View>
+                    </TouchableOpacity>
+
+                    <TextInput
+                      style={[
+                        styles.input,
+                        styles.inputMulti,
+                        {
+                          backgroundColor: colors.inputBg,
+                          borderColor: colors.borderLight,
+                          color: colors.text,
+                        },
+                      ]}
+                      value={line.text}
+                      onChangeText={(text) => patchLine(line.id, { text })}
+                      placeholder="What is said"
+                      placeholderTextColor={colors.textTertiary}
+                      multiline
+                      accessibilityLabel={`Line ${index + 1} text`}
+                    />
+
+                    <TextInput
+                      style={[
+                        styles.input,
+                        {
+                          backgroundColor: colors.inputBg,
+                          borderColor: colors.borderLight,
+                          color: colors.text,
+                        },
+                      ]}
+                      value={line.direction ?? ''}
+                      onChangeText={(direction) =>
+                        patchLine(line.id, { direction })
+                      }
+                      placeholder="Direction, e.g. whispering, tired"
+                      placeholderTextColor={colors.textTertiary}
+                      accessibilityLabel={`Line ${index + 1} direction`}
+                    />
+
+                    <View style={styles.cardActions}>
+                      <TouchableOpacity
+                        onPress={() => moveLine(line.id, -1)}
+                        activeOpacity={0.7}
+                        disabled={index === 0}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Move line ${index + 1} up`}
+                        accessibilityState={{ disabled: index === 0 }}
+                        style={styles.iconButton}
+                      >
+                        <Ionicons
+                          name="arrow-up-outline"
+                          size={18}
+                          color={index === 0 ? colors.textTertiary : colors.text}
+                        />
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        onPress={() => moveLine(line.id, 1)}
+                        activeOpacity={0.7}
+                        disabled={index === flat.length - 1}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Move line ${index + 1} down`}
+                        accessibilityState={{ disabled: index === flat.length - 1 }}
+                        style={styles.iconButton}
+                      >
+                        <Ionicons
+                          name="arrow-down-outline"
+                          size={18}
+                          color={
+                            index === flat.length - 1
+                              ? colors.textTertiary
+                              : colors.text
+                          }
+                        />
+                      </TouchableOpacity>
+                      <View style={styles.spacer} />
+                      <TouchableOpacity
+                        onPress={() => removeLine(line.id)}
+                        activeOpacity={0.7}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Delete line ${index + 1}`}
+                        style={styles.iconButton}
+                      >
+                        <Ionicons name="trash-outline" size={18} color={colors.error} />
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                );
+              })}
+
+              <TouchableOpacity
+                onPress={() => addLine(section.id)}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={`Add line to section ${sectionIndex + 1}`}
+                style={styles.addButton}
+              >
+                <Ionicons
+                  name="add-circle-outline"
+                  size={22}
+                  color={colors.primary}
+                />
+                <Text style={[styles.addButtonText, { color: colors.primary }]}>
+                  Add line
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+/**
+ * Move one line to a 0-based position counted across the whole script.
+ *
+ * Lines live inside sections, so the destination decides the section too: the
+ * line lands in whichever section already owns the line now at that position.
+ * The line object is carried across unchanged, which is what keeps its takes.
+ */
+function moveLineTo(
+  script: ScriptDocument,
+  lineId: string,
+  toIndex: number
+): ScriptDocument {
+  const entries: Array<{ sectionIndex: number; line: ScriptLine }> = [];
+  let moved: ScriptLine | undefined;
+  for (let sectionIndex = 0; sectionIndex < script.sections.length; sectionIndex += 1) {
+    for (const line of script.sections[sectionIndex].lines) {
+      if (line.id === lineId) {
+        moved = line;
+      } else {
+        entries.push({ sectionIndex, line });
+      }
+    }
+  }
+  if (moved === undefined) {
+    return script;
+  }
+
+  const to = clamp(Math.trunc(toIndex), 0, entries.length);
+  const sectionIndex =
+    entries[to]?.sectionIndex ??
+    entries[entries.length - 1]?.sectionIndex ??
+    0;
+  entries.splice(to, 0, { sectionIndex, line: moved });
+
+  return {
+    ...script,
+    sections: script.sections.map((section, index) => ({
+      ...section,
+      lines: entries
+        .filter((entry) => entry.sectionIndex === index)
+        .map((entry) => entry.line),
+    })),
+  };
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  centerText: { fontSize: 14, textAlign: 'center' },
+  headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
+  saveText: { fontSize: 16, fontWeight: '600' },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  bannerText: { flex: 1, fontSize: 13 },
+  bannerButton: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
+  bannerButtonText: { fontSize: 13, fontWeight: '600', color: '#fff' },
+  scroll: { padding: 16 },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  sectionTitle: { fontSize: 17, fontWeight: '700', letterSpacing: -0.3 },
+  dirtyRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dirtyDot: { width: 8, height: 8, borderRadius: 4 },
+  dirtyText: { fontSize: 12, fontWeight: '600' },
+  input: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 15,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 8,
+  },
+  inputMulti: { minHeight: 68, textAlignVertical: 'top' },
+  castRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  castInput: { flex: 1, marginBottom: 0 },
+  colorChip: { width: 14, height: 14, borderRadius: 7 },
+  addButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginTop: 10,
+  },
+  addButtonText: { fontSize: 15, fontWeight: '600' },
+  empty: { alignItems: 'center', paddingVertical: 40, gap: 12 },
+  emptyText: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  primaryButton: { paddingHorizontal: 18, paddingVertical: 10, borderRadius: 10 },
+  primaryButtonText: { fontSize: 15, fontWeight: '600' },
+  sectionBlock: { marginTop: 14 },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  sectionInput: { flex: 1, marginBottom: 0, fontWeight: '600' },
+  card: { borderRadius: 14, borderWidth: 1, padding: 12, marginTop: 10 },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 10,
+  },
+  speakerName: { flex: 1, fontSize: 15, fontWeight: '600' },
+  statusPill: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8 },
+  statusPillText: { fontSize: 11, fontWeight: '600' },
+  cardActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 2,
+  },
+  iconButton: { padding: 6 },
+  spacer: { flex: 1 },
+});

--- a/mobile/src/screens/StoryboardEditorScreen.tsx
+++ b/mobile/src/screens/StoryboardEditorScreen.tsx
@@ -1,0 +1,833 @@
+/**
+ * Storyboard editor.
+ *
+ * The phone half of the storyboard surface: read a board, fix its brief, style,
+ * and shot list, reorder, save. Generation stays on the desktop app, so this
+ * screen is deliberately a text-and-thumbnails editor.
+ *
+ * It is also the agent's hands on the board. The handler registered here mutates
+ * the same `documentStore` the render reads, so a `ui_storyboard_*` call repaints
+ * the screen the user is holding, and `ui_storyboard_save` is the same code path
+ * as the Save button.
+ */
+
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { RouteProp, useFocusEffect } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useShallow } from 'zustand/react/shallow';
+import type { Shot, ShotStatus } from '@nodetool-ai/protocol';
+
+import { RootStackParamList } from '../navigation/types';
+import { apiService } from '../services/api';
+import { useTheme } from '../hooks/useTheme';
+import { documentStore } from '../documents/documentStore';
+import {
+  registerDocumentHandler,
+  setDocumentTitle,
+  setFocusedDocument,
+} from '../documents/agentBridge';
+import { clearUiSelection, setUiSelection } from '../documents/uiContext';
+import {
+  reindexShots,
+  resolveShotIndex,
+  shotToNode,
+  type StoryboardAddShotInput,
+  type StoryboardAgentHandler,
+  type StoryboardDocument,
+  type StoryboardShotNode,
+  type StoryboardSnapshot,
+  type StoryboardUpdateShotPatch,
+} from '../documents/storyboardTypes';
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'StoryboardEditor'>;
+  route: RouteProp<RootStackParamList, 'StoryboardEditor'>;
+};
+
+const DEFAULT_ASPECT_RATIO = '16:9';
+
+/** Short, collision-resistant enough for ids that only have to be unique in one board. */
+const newShotId = (): string =>
+  `shot-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const STATUS_LABELS: Record<ShotStatus, string> = {
+  planned: 'Planned',
+  keyframe_generating: 'Still…',
+  keyframe_ready: 'Still ready',
+  approved: 'Still ready',
+  clip_generating: 'Rendering…',
+  rendered: 'Rendered',
+  failed: 'Failed',
+};
+
+export default function StoryboardEditorScreen({ navigation, route }: Props) {
+  const { id, name: initialName } = route.params;
+  const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const store = documentStore<StoryboardDocument>('storyboard', id);
+  const { doc, name, dirty, status, error } = store(
+    useShallow((state) => ({
+      doc: state.doc,
+      name: state.name,
+      dirty: state.dirty,
+      status: state.status,
+      error: state.error,
+    }))
+  );
+
+  const [selectedShotId, setSelectedShotId] = useState<string | null>(null);
+  // The agent handler runs outside React, so it reads selection from a ref.
+  const selectedRef = useRef<string | null>(null);
+  const select = useCallback((next: string | null) => {
+    selectedRef.current = next;
+    setSelectedShotId(next);
+  }, []);
+
+  // The store's actions live in its state, so every caller goes through
+  // getState() — including the agent handler, which runs outside React.
+  const edit = useCallback(
+    (mutate: (board: StoryboardDocument) => StoryboardDocument) => {
+      store.getState().edit(mutate);
+    },
+    [store]
+  );
+  const runLoad = useCallback(() => void store.getState().load(), [store]);
+  const runSave = useCallback(() => store.getState().save(), [store]);
+  const runRevert = useCallback(() => void store.getState().revert(), [store]);
+
+  useEffect(() => {
+    // Re-read on every open. The store is cached for the app's lifetime, so a
+    // board reopened after a rename elsewhere would otherwise render the old
+    // name and save against a revision the server has already moved past.
+    // Unsaved local edits are the one thing worth keeping over a fresh read.
+    if (!store.getState().dirty) {
+      runLoad();
+    }
+  }, [store, runLoad]);
+
+  // ── Agent handler ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const requireDoc = (): StoryboardDocument => {
+      const current = store.getState().doc;
+      if (current === null) {
+        throw new Error(
+          `Storyboard "${id}" has not finished loading. Retry in a moment.`
+        );
+      }
+      return current;
+    };
+
+    const snapshot = (): StoryboardSnapshot => {
+      const state = store.getState();
+      const board = state.doc;
+      return {
+        boardId: id,
+        title: state.name || initialName || 'Untitled storyboard',
+        brief: board?.brief ?? '',
+        style: board?.style ?? '',
+        aspectRatio: board?.aspectRatio ?? DEFAULT_ASPECT_RATIO,
+        hasScreenplay: board?.screenplay != null,
+        selectedShotId: selectedRef.current,
+        shots: (board?.shots ?? []).map(shotToNode),
+      };
+    };
+
+    const writeShots = (shots: Shot[]): void => {
+      edit((board) => ({ ...board, shots: reindexShots(shots) }));
+    };
+
+    const handler: StoryboardAgentHandler = {
+      getSnapshot: snapshot,
+
+      addShot: (input: StoryboardAddShotInput): StoryboardShotNode => {
+        const shots = requireDoc().shots;
+        const at =
+          input.index === undefined
+            ? shots.length
+            : clamp(Math.trunc(input.index), 0, shots.length);
+        const shot: Shot = {
+          type: 'shot',
+          id: newShotId(),
+          index: at,
+          action: input.action,
+          camera: input.camera,
+          motion: input.motion,
+          duration_seconds: input.durationSeconds,
+          status: 'planned',
+        };
+        writeShots([...shots.slice(0, at), shot, ...shots.slice(at)]);
+        return shotToNode(shot, at);
+      },
+
+      updateShot: (
+        target: string,
+        patch: StoryboardUpdateShotPatch
+      ): StoryboardShotNode => {
+        const shots = requireDoc().shots;
+        const at = resolveShotIndex(shots, target, selectedRef.current);
+        const updated: Shot = {
+          ...shots[at],
+          action: patch.action ?? shots[at].action,
+          camera: patch.camera ?? shots[at].camera,
+          motion: patch.motion ?? shots[at].motion,
+          slug: patch.slug ?? shots[at].slug,
+          duration_seconds: patch.durationSeconds ?? shots[at].duration_seconds,
+          status: patch.status ?? shots[at].status,
+        };
+        writeShots(shots.map((shot, index) => (index === at ? updated : shot)));
+        return shotToNode(updated, at);
+      },
+
+      removeShot: (target: string): StoryboardShotNode => {
+        const shots = requireDoc().shots;
+        const at = resolveShotIndex(shots, target, selectedRef.current);
+        const removed = shots[at];
+        writeShots(shots.filter((_, index) => index !== at));
+        if (selectedRef.current === removed.id) {
+          select(null);
+        }
+        return shotToNode(removed, at);
+      },
+
+      reorderShot: (target: string, toIndex: number): StoryboardShotNode => {
+        const shots = requireDoc().shots;
+        const from = resolveShotIndex(shots, target, selectedRef.current);
+        const rest = shots.filter((_, index) => index !== from);
+        const to = clamp(Math.trunc(toIndex), 0, rest.length);
+        const moved = shots[from];
+        writeShots([...rest.slice(0, to), moved, ...rest.slice(to)]);
+        return shotToNode(moved, to);
+      },
+
+      setBrief: (brief: string): StoryboardSnapshot => {
+        requireDoc();
+        edit((board) => ({ ...board, brief }));
+        return snapshot();
+      },
+
+      setStyle: (style: string): StoryboardSnapshot => {
+        requireDoc();
+        edit((board) => ({ ...board, style }));
+        return snapshot();
+      },
+
+      setAspectRatio: (aspectRatio: string): StoryboardSnapshot => {
+        requireDoc();
+        edit((board) => ({ ...board, aspectRatio }));
+        return snapshot();
+      },
+
+      selectShot: (target: string | null): StoryboardShotNode | null => {
+        if (target === null) {
+          select(null);
+          return null;
+        }
+        const shots = requireDoc().shots;
+        const at = resolveShotIndex(shots, target, selectedRef.current);
+        select(shots[at].id);
+        return shotToNode(shots[at], at);
+      },
+
+      save: async (): Promise<{ ok: true; updatedAt: string | null }> => {
+        await runSave();
+        const state = store.getState();
+        if (state.status === 'conflict' || state.status === 'error') {
+          throw new Error(state.error ?? 'Failed to save the storyboard.');
+        }
+        return { ok: true, updatedAt: state.updatedAt };
+      },
+    };
+
+    return registerDocumentHandler(
+      'storyboard',
+      id,
+      store.getState().name || initialName || 'Storyboard',
+      handler
+    );
+  }, [store, id, initialName, select, edit, runSave]);
+
+  // Keep the id the agent addresses tied to the screen the user is looking at.
+  // Claim focus on focus, but do not release it on blur. Navigating to Chat
+  // blurs this screen, and the chat turn is the one moment `ui_context.focused`
+  // is read — releasing here would tell the agent nothing is focused precisely
+  // when the user is asking about this board. Unmount drops the registration,
+  // which is what actually makes the claim stale.
+  useFocusEffect(
+    useCallback(() => {
+      setFocusedDocument('storyboard', id);
+    }, [id])
+  );
+
+  useEffect(() => {
+    setUiSelection({ shotIds: selectedShotId ? [selectedShotId] : [] });
+  }, [selectedShotId]);
+
+  useEffect(() => () => clearUiSelection(), []);
+
+  useEffect(() => {
+    if (name) {
+      setDocumentTitle('storyboard', id, name);
+    }
+  }, [name, id]);
+
+  const handleSave = useCallback(() => {
+    void runSave();
+  }, [runSave]);
+
+  const openChat = useCallback(() => {
+    navigation.navigate('Chat');
+  }, [navigation]);
+
+  useLayoutEffect(() => {
+    const saving = status === 'saving';
+    navigation.setOptions({
+      title: name || initialName || 'Storyboard',
+      headerRight: () => (
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={openChat}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Direct this storyboard by chat"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="chatbubble-ellipses-outline" size={22} color={colors.primary} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSave}
+            activeOpacity={0.7}
+            disabled={!dirty || saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save storyboard"
+            accessibilityState={{ disabled: !dirty || saving }}
+          >
+            {saving ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <Text
+                style={[
+                  styles.saveText,
+                  { color: dirty ? colors.primary : colors.textTertiary },
+                ]}
+              >
+                Save
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      ),
+    });
+  }, [
+    navigation,
+    name,
+    initialName,
+    dirty,
+    status,
+    colors.primary,
+    colors.textTertiary,
+    handleSave,
+    openChat,
+  ]);
+
+  // ── Local edits ──────────────────────────────────────────────────────────
+  const patchShot = useCallback(
+    (shotId: string, patch: Partial<Shot>) => {
+      edit((board) => ({
+        ...board,
+        shots: board.shots.map((shot) =>
+          shot.id === shotId ? { ...shot, ...patch } : shot
+        ),
+      }));
+    },
+    [edit]
+  );
+
+  const addShot = useCallback(() => {
+    const shot: Shot = {
+      type: 'shot',
+      id: newShotId(),
+      index: 0,
+      action: '',
+      status: 'planned',
+    };
+    edit((board) => ({
+      ...board,
+      shots: reindexShots([...board.shots, shot]),
+    }));
+    select(shot.id);
+  }, [edit, select]);
+
+  const removeShot = useCallback(
+    (shotId: string) => {
+      edit((board) => ({
+        ...board,
+        shots: reindexShots(board.shots.filter((shot) => shot.id !== shotId)),
+      }));
+      if (selectedRef.current === shotId) {
+        select(null);
+      }
+    },
+    [edit, select]
+  );
+
+  const moveShot = useCallback(
+    (shotId: string, delta: number) => {
+      edit((board) => {
+        const from = board.shots.findIndex((shot) => shot.id === shotId);
+        const to = from + delta;
+        if (from < 0 || to < 0 || to >= board.shots.length) {
+          return board;
+        }
+        const shots = [...board.shots];
+        const [moved] = shots.splice(from, 1);
+        shots.splice(to, 0, moved);
+        return { ...board, shots: reindexShots(shots) };
+      });
+    },
+    [edit]
+  );
+
+  if (doc === null) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        {status === 'error' ? (
+          <>
+            <Ionicons name="alert-circle-outline" size={36} color={colors.error} />
+            <Text style={[styles.centerText, { color: colors.textSecondary }]}>
+              {error ?? 'Failed to load this storyboard.'}
+            </Text>
+            <TouchableOpacity
+              onPress={runLoad}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading storyboard"
+              style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            >
+              <Text style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}>
+                Retry
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <ActivityIndicator size="large" color={colors.primary} />
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {status === 'conflict' && (
+        <View
+          style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
+          accessibilityLabel="Storyboard changed elsewhere"
+        >
+          <Ionicons name="git-compare-outline" size={16} color={colors.warning} />
+          <Text style={[styles.bannerText, { color: colors.text }]}>
+            Someone else saved this storyboard. Reload to get their version — your
+            unsaved edits here will be lost.
+          </Text>
+          <TouchableOpacity
+            onPress={runRevert}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Reload storyboard"
+            style={[styles.bannerButton, { backgroundColor: colors.warning }]}
+          >
+            <Text style={styles.bannerButtonText}>Reload</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {status === 'error' && error !== null && (
+        <View style={[styles.banner, { backgroundColor: colors.error + '18' }]}>
+          <Ionicons name="warning-outline" size={16} color={colors.error} />
+          <Text style={[styles.bannerText, { color: colors.error }]}>{error}</Text>
+        </View>
+      )}
+
+      <ScrollView
+        contentContainerStyle={[styles.scroll, { paddingBottom: insets.bottom + 40 }]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.metaRow}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>Board</Text>
+          {dirty && (
+            <View style={styles.dirtyRow} accessibilityLabel="Unsaved changes">
+              <View style={[styles.dirtyDot, { backgroundColor: colors.warning }]} />
+              <Text style={[styles.dirtyText, { color: colors.textSecondary }]}>
+                Unsaved
+              </Text>
+            </View>
+          )}
+        </View>
+
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Brief</Text>
+        <TextInput
+          style={[
+            styles.input,
+            styles.inputMulti,
+            { backgroundColor: colors.inputBg, borderColor: colors.borderLight, color: colors.text },
+          ]}
+          value={doc.brief}
+          onChangeText={(brief) => edit((board) => ({ ...board, brief }))}
+          placeholder="What is this piece about?"
+          placeholderTextColor={colors.textTertiary}
+          multiline
+          accessibilityLabel="Board brief"
+        />
+
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Style</Text>
+        <TextInput
+          style={[
+            styles.input,
+            styles.inputMulti,
+            { backgroundColor: colors.inputBg, borderColor: colors.borderLight, color: colors.text },
+          ]}
+          value={doc.style}
+          onChangeText={(style) => edit((board) => ({ ...board, style }))}
+          placeholder="Grainy 16mm, muted teal palette, low sun"
+          placeholderTextColor={colors.textTertiary}
+          multiline
+          accessibilityLabel="Board style"
+        />
+
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
+          Aspect ratio
+        </Text>
+        <TextInput
+          style={[
+            styles.input,
+            { backgroundColor: colors.inputBg, borderColor: colors.borderLight, color: colors.text },
+          ]}
+          value={doc.aspectRatio}
+          onChangeText={(aspectRatio) =>
+            edit((board) => ({ ...board, aspectRatio }))
+          }
+          placeholder={DEFAULT_ASPECT_RATIO}
+          placeholderTextColor={colors.textTertiary}
+          autoCapitalize="none"
+          autoCorrect={false}
+          accessibilityLabel="Board aspect ratio"
+        />
+
+        <View style={styles.metaRow}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            {`Shots (${doc.shots.length})`}
+          </Text>
+          <TouchableOpacity
+            onPress={addShot}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Add shot"
+            style={styles.addButton}
+          >
+            <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+            <Text style={[styles.addButtonText, { color: colors.primary }]}>Add</Text>
+          </TouchableOpacity>
+        </View>
+
+        {doc.shots.length === 0 ? (
+          <View style={styles.empty}>
+            <Ionicons name="albums-outline" size={36} color={colors.textTertiary} />
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              No shots yet. Shots are usually created by asking the assistant to
+              break your brief into a shot list — then fix them up here.
+            </Text>
+            <TouchableOpacity
+              onPress={openChat}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Ask the assistant"
+              style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            >
+              <Text style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}>
+                Ask the assistant
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          doc.shots.map((shot, index) => {
+            const isSelected = shot.id === selectedShotId;
+            const thumbnail = apiService.resolveUrl(shot.keyframe?.uri);
+            return (
+              <View
+                key={shot.id}
+                style={[
+                  styles.card,
+                  shadows.small,
+                  {
+                    backgroundColor: colors.cardBg,
+                    borderColor: isSelected ? colors.primary : colors.borderLight,
+                  },
+                ]}
+              >
+                <TouchableOpacity
+                  onPress={() => select(isSelected ? null : shot.id)}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Select shot ${index + 1}`}
+                  accessibilityState={{ selected: isSelected }}
+                  style={styles.cardHeader}
+                >
+                  <View
+                    style={[
+                      styles.indexBadge,
+                      {
+                        backgroundColor: isSelected ? colors.primary : colors.primaryMuted,
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.indexBadgeText,
+                        { color: isSelected ? colors.textOnPrimary : colors.primary },
+                      ]}
+                    >
+                      {index + 1}
+                    </Text>
+                  </View>
+                  <Text
+                    style={[styles.slugPreview, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {shot.slug || 'Untitled shot'}
+                  </Text>
+                  <View
+                    style={[styles.statusPill, { backgroundColor: colors.accentMuted }]}
+                    accessibilityLabel={`Shot ${index + 1} status ${STATUS_LABELS[shot.status]}`}
+                  >
+                    <Text style={[styles.statusPillText, { color: colors.accent }]}>
+                      {STATUS_LABELS[shot.status]}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+
+                {thumbnail !== null && (
+                  <Image
+                    source={{ uri: thumbnail }}
+                    style={styles.thumbnail}
+                    resizeMode="cover"
+                    accessibilityLabel={`Keyframe for shot ${index + 1}`}
+                  />
+                )}
+
+                <TextInput
+                  style={[
+                    styles.input,
+                    styles.inputMulti,
+                    {
+                      backgroundColor: colors.inputBg,
+                      borderColor: colors.borderLight,
+                      color: colors.text,
+                    },
+                  ]}
+                  value={shot.action}
+                  onChangeText={(action) => patchShot(shot.id, { action })}
+                  placeholder="What we see in this shot"
+                  placeholderTextColor={colors.textTertiary}
+                  multiline
+                  accessibilityLabel={`Shot ${index + 1} action`}
+                />
+
+                <TextInput
+                  style={[
+                    styles.input,
+                    {
+                      backgroundColor: colors.inputBg,
+                      borderColor: colors.borderLight,
+                      color: colors.text,
+                    },
+                  ]}
+                  value={shot.slug ?? ''}
+                  onChangeText={(slug) => patchShot(shot.id, { slug })}
+                  placeholder="Label, e.g. Lighthouse at dusk"
+                  placeholderTextColor={colors.textTertiary}
+                  accessibilityLabel={`Shot ${index + 1} slug`}
+                />
+
+                <TextInput
+                  style={[
+                    styles.input,
+                    {
+                      backgroundColor: colors.inputBg,
+                      borderColor: colors.borderLight,
+                      color: colors.text,
+                    },
+                  ]}
+                  value={shot.motion ?? ''}
+                  onChangeText={(motion) => patchShot(shot.id, { motion })}
+                  placeholder="Motion, e.g. slow push in"
+                  placeholderTextColor={colors.textTertiary}
+                  accessibilityLabel={`Shot ${index + 1} motion`}
+                />
+
+                <TextInput
+                  style={[
+                    styles.input,
+                    {
+                      backgroundColor: colors.inputBg,
+                      borderColor: colors.borderLight,
+                      color: colors.text,
+                    },
+                  ]}
+                  value={
+                    shot.duration_seconds === undefined
+                      ? ''
+                      : String(shot.duration_seconds)
+                  }
+                  onChangeText={(text) => {
+                    const parsed = Number.parseFloat(text);
+                    patchShot(shot.id, {
+                      duration_seconds: Number.isFinite(parsed) ? parsed : undefined,
+                    });
+                  }}
+                  placeholder="Duration in seconds"
+                  placeholderTextColor={colors.textTertiary}
+                  keyboardType="numeric"
+                  accessibilityLabel={`Shot ${index + 1} duration in seconds`}
+                />
+
+                <View style={styles.cardActions}>
+                  <TouchableOpacity
+                    onPress={() => moveShot(shot.id, -1)}
+                    activeOpacity={0.7}
+                    disabled={index === 0}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Move shot ${index + 1} up`}
+                    accessibilityState={{ disabled: index === 0 }}
+                    style={styles.iconButton}
+                  >
+                    <Ionicons
+                      name="arrow-up-outline"
+                      size={18}
+                      color={index === 0 ? colors.textTertiary : colors.text}
+                    />
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() => moveShot(shot.id, 1)}
+                    activeOpacity={0.7}
+                    disabled={index === doc.shots.length - 1}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Move shot ${index + 1} down`}
+                    accessibilityState={{ disabled: index === doc.shots.length - 1 }}
+                    style={styles.iconButton}
+                  >
+                    <Ionicons
+                      name="arrow-down-outline"
+                      size={18}
+                      color={
+                        index === doc.shots.length - 1 ? colors.textTertiary : colors.text
+                      }
+                    />
+                  </TouchableOpacity>
+                  <View style={styles.spacer} />
+                  <TouchableOpacity
+                    onPress={() => removeShot(shot.id)}
+                    activeOpacity={0.7}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Delete shot ${index + 1}`}
+                    style={styles.iconButton}
+                  >
+                    <Ionicons name="trash-outline" size={18} color={colors.error} />
+                  </TouchableOpacity>
+                </View>
+              </View>
+            );
+          })
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
+  centerText: { fontSize: 14, textAlign: 'center' },
+  headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
+  saveText: { fontSize: 16, fontWeight: '600' },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  bannerText: { flex: 1, fontSize: 13 },
+  bannerButton: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
+  bannerButtonText: { fontSize: 13, fontWeight: '600', color: '#fff' },
+  scroll: { padding: 16 },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  sectionTitle: { fontSize: 17, fontWeight: '700', letterSpacing: -0.3 },
+  dirtyRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dirtyDot: { width: 8, height: 8, borderRadius: 4 },
+  dirtyText: { fontSize: 12, fontWeight: '600' },
+  fieldLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    marginTop: 12,
+    marginBottom: 6,
+  },
+  input: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 15,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 8,
+  },
+  inputMulti: { minHeight: 68, textAlignVertical: 'top' },
+  addButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  addButtonText: { fontSize: 15, fontWeight: '600' },
+  empty: { alignItems: 'center', paddingVertical: 40, gap: 12 },
+  emptyText: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  primaryButton: { paddingHorizontal: 18, paddingVertical: 10, borderRadius: 10 },
+  primaryButtonText: { fontSize: 15, fontWeight: '600' },
+  card: {
+    borderRadius: 14,
+    borderWidth: 1,
+    padding: 12,
+    marginTop: 10,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 10 },
+  indexBadge: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  indexBadgeText: { fontSize: 13, fontWeight: '700' },
+  slugPreview: { flex: 1, fontSize: 15, fontWeight: '600' },
+  statusPill: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8 },
+  statusPillText: { fontSize: 11, fontWeight: '600' },
+  thumbnail: { width: '100%', height: 150, borderRadius: 10, marginBottom: 10 },
+  cardActions: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 2 },
+  iconButton: { padding: 6 },
+  spacer: { flex: 1 },
+});

--- a/mobile/src/screens/TimelineViewerScreen.tsx
+++ b/mobile/src/screens/TimelineViewerScreen.tsx
@@ -1,12 +1,16 @@
 /**
- * Read-only timeline viewer.
+ * Timeline viewer, edited by the agent.
  *
- * The sequence is shown, never edited: a phone cannot place a cut accurately
- * and cannot supervise a render, so `kinds.ts` opens timelines as a `viewer`
- * surface and this screen never calls `save()`. What it does offer is the two
- * things a phone is good for — looking at what a sequence contains, and asking
- * the assistant about it, which is why the header links to Chat and why the
- * screen registers an agent handler for the `ui_timeline_*` tools.
+ * Direct manipulation stays off: placing a cut accurately with a thumb is not
+ * possible at phone width, so `kinds.ts` opens timelines as a `viewer` surface —
+ * no drag, no trim handles, no clip editing by touch. What the phone is good at
+ * is the other half: looking at what a sequence contains, and saying "move the
+ * title card two seconds later". So this screen registers the agent handler the
+ * `ui_timeline_*` tools write through, and owns the Save button for the result.
+ *
+ * The handler mutates the same `documentStore` the render reads, so an agent edit
+ * repaints the screen the user is holding, and `ui_timeline_save` is the same
+ * code path as pressing Save.
  */
 
 import React, {
@@ -14,6 +18,7 @@ import React, {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -29,12 +34,18 @@ import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useShallow } from 'zustand/react/shallow';
 
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../hooks/useTheme';
 import { documentStore } from '../documents/documentStore';
-import { registerDocumentHandler, setFocusedDocument } from '../documents/agentBridge';
+import {
+  registerDocumentHandler,
+  setDocumentTitle,
+  setFocusedDocument,
+} from '../documents/agentBridge';
 import { clearUiSelection, setUiSelection } from '../documents/uiContext';
+import * as edits from '../documents/timelineEdits';
 import {
   clipToNode,
   resolveClip,
@@ -42,9 +53,11 @@ import {
   trackToNode,
   type TimelineAgentHandler,
   type TimelineClipData,
+  type TimelineClipNode,
   type TimelineClipStatus,
   type TimelineDocument,
   type TimelineMediaType,
+  type TimelineSnapshot,
   type TimelineTrackData,
   type TimelineTrackType,
 } from '../documents/timelineTypes';
@@ -130,24 +143,50 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
   const insets = useSafeAreaInsets();
 
   const store = useMemo(() => documentStore<TimelineDocument>('timeline', id), [id]);
-  const doc = store((state) => state.doc);
-  const docName = store((state) => state.name);
-  const status = store((state) => state.status);
-  const error = store((state) => state.error);
-  const load = store((state) => state.load);
+  const { doc, docName, dirty, status, error } = store(
+    useShallow((state) => ({
+      doc: state.doc,
+      docName: state.name,
+      dirty: state.dirty,
+      status: state.status,
+      error: state.error,
+    }))
+  );
 
   const [pxPerSecond, setPxPerSecond] = useState(DEFAULT_PX_PER_SECOND);
   const [playheadMs, setPlayheadMs] = useState(0);
   const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+
+  // The agent handler runs outside React, so it reads live selection and
+  // playhead from refs rather than a stale render closure.
+  const selectedRef = useRef<string | null>(null);
+  const playheadRef = useRef(0);
+  const select = useCallback((next: string | null) => {
+    selectedRef.current = next;
+    setSelectedClipId(next);
+  }, []);
+  const movePlayhead = useCallback((next: number) => {
+    playheadRef.current = next;
+    setPlayheadMs(next);
+  }, []);
+
+  // The store's actions live in its state, so every caller goes through
+  // getState() — including the agent handler.
+  const runLoad = useCallback(() => void store.getState().load(), [store]);
+  const runSave = useCallback(() => store.getState().save(), [store]);
+  const runRevert = useCallback(() => void store.getState().revert(), [store]);
 
   const title = docName || name || 'Timeline';
 
   useEffect(() => {
     // Re-read on every open: the store is cached for the app's lifetime, so a
     // sequence edited on desktop since it was last viewed here would otherwise
-    // keep showing the stale cut. Nothing local can be lost — this is a viewer.
-    void load();
-  }, [store, load]);
+    // keep showing a stale cut. Unsaved agent edits are the one thing worth
+    // keeping over a fresh read.
+    if (!store.getState().dirty) {
+      runLoad();
+    }
+  }, [store, runLoad]);
 
   const tracks = useMemo<TimelineTrackData[]>(
     () => [...(doc?.tracks ?? [])].sort((a, b) => a.index - b.index),
@@ -163,53 +202,221 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
     [tracks]
   );
 
-  const handler = useMemo<TimelineAgentHandler>(() => {
-    const selectedClipIds = selectedClipId ? [selectedClipId] : [];
-    const node = (clip: TimelineClipData) => clipToNode(clip, trackNameOf(clip.trackId));
-    return {
-      getSnapshot: () => ({
+  // ── Agent handler ────────────────────────────────────────────────────────
+  useEffect(() => {
+    /** The live document. Reading it per call keeps a batch of edits coherent. */
+    const requireDoc = (): TimelineDocument => {
+      const current = store.getState().doc;
+      if (current === null) {
+        throw new Error(
+          `Timeline "${id}" has not finished loading. Retry in a moment.`
+        );
+      }
+      return current;
+    };
+
+    const selectedIds = (): string[] =>
+      selectedRef.current ? [selectedRef.current] : [];
+
+    const trackNameIn = (
+      current: TimelineDocument,
+      trackId: string
+    ): string | null =>
+      current.tracks.find((track) => track.id === trackId)?.name ?? null;
+
+    const node = (
+      current: TimelineDocument,
+      clip: TimelineClipData
+    ): TimelineClipNode => clipToNode(clip, trackNameIn(current, clip.trackId));
+
+    /** Apply a pure edit, write it to the store, and project the result. */
+    const apply = <T,>(
+      run: (current: TimelineDocument) => {
+        doc: TimelineDocument;
+        result: T;
+      }
+    ): T => {
+      const outcome = run(requireDoc());
+      store.getState().edit(() => outcome.doc);
+      return outcome.result;
+    };
+
+    const applyClips = (
+      run: (current: TimelineDocument) => {
+        doc: TimelineDocument;
+        clips: TimelineClipData[];
+      }
+    ): TimelineClipNode[] =>
+      apply((current) => {
+        const next = run(current);
+        return {
+          doc: next.doc,
+          result: next.clips.map((clip) => node(next.doc, clip)),
+        };
+      });
+
+    const snapshot = (): TimelineSnapshot => {
+      const state = store.getState();
+      const current = state.doc;
+      const currentTracks = [...(current?.tracks ?? [])].sort(
+        (a, b) => a.index - b.index
+      );
+      const currentClips = current?.clips ?? [];
+      return {
         sequenceId: id,
-        title,
-        durationMs,
-        trackCount: tracks.length,
-        clipCount: clips.length,
-        playheadMs,
-        selectedClipIds,
-        tracks: tracks.map((track) =>
+        title: state.name || name || 'Timeline',
+        durationMs: timelineDurationMs(currentClips),
+        trackCount: currentTracks.length,
+        clipCount: currentClips.length,
+        playheadMs: playheadRef.current,
+        selectedClipIds: selectedIds(),
+        dirty: state.dirty,
+        tracks: currentTracks.map((track) =>
           trackToNode(
             track,
-            clips.filter((clip) => clip.trackId === track.id).length
+            currentClips.filter((clip) => clip.trackId === track.id).length
           )
         ),
-        clips: clips.map(node),
-        markers: markers.map((marker) => ({
+        clips: currentClips.map((clip) =>
+          clipToNode(
+            clip,
+            currentTracks.find((track) => track.id === clip.trackId)?.name ?? null
+          )
+        ),
+        markers: (current?.markers ?? []).map((marker) => ({
           id: marker.id,
           timeMs: marker.timeMs,
           label: marker.label,
         })),
-      }),
-      getClip: (target) => node(resolveClip(clips, target, selectedClipIds)),
+        transcript: (current?.transcript ?? []).map((line) => ({
+          id: line.id,
+          text: line.text,
+          clipIds: line.clipIds,
+        })),
+      };
+    };
+
+    const handler: TimelineAgentHandler = {
+      getSnapshot: snapshot,
+
+      getClip: (target) => {
+        const current = requireDoc();
+        return node(current, resolveClip(current.clips, target, selectedIds()));
+      },
+
       selectClip: (target) => {
         if (target === null || target === '') {
-          setSelectedClipId(null);
+          select(null);
           return null;
         }
-        const clip = resolveClip(clips, target, selectedClipIds);
-        setSelectedClipId(clip.id);
-        return node(clip);
+        const current = requireDoc();
+        const clip = resolveClip(current.clips, target, selectedIds());
+        select(clip.id);
+        return node(current, clip);
       },
+
       seek: (timeMs) => {
-        const clamped = Math.max(0, Math.min(timeMs, durationMs));
-        setPlayheadMs(clamped);
+        const clamped = Math.max(
+          0,
+          Math.min(timeMs, timelineDurationMs(requireDoc().clips))
+        );
+        movePlayhead(clamped);
         return clamped;
       },
-    };
-  }, [clips, durationMs, id, markers, playheadMs, selectedClipId, title, trackNameOf, tracks]);
 
-  useEffect(
-    () => registerDocumentHandler('timeline', id, title, handler),
-    [handler, id, title]
-  );
+      addTrack: (type, trackName) =>
+        apply((current) => {
+          const next = edits.addTrack(current, type, trackName);
+          return { doc: next.doc, result: trackToNode(next.track, 0) };
+        }),
+
+      addTextClip: (input) =>
+        apply((current) => {
+          const next = edits.addTextClip(current, input);
+          return { doc: next.doc, result: node(next.doc, next.clip) };
+        }),
+
+      addShapeClip: (input) =>
+        apply((current) => {
+          const next = edits.addShapeClip(current, input);
+          return { doc: next.doc, result: node(next.doc, next.clip) };
+        }),
+
+      moveClip: (target, patch) =>
+        applyClips((current) => edits.moveClip(current, target, patch, selectedIds())),
+
+      trimClip: (target, patch) =>
+        applyClips((current) => edits.trimClip(current, target, patch, selectedIds())),
+
+      splitClip: (target, atMs) =>
+        applyClips((current) =>
+          edits.splitClipAt(
+            current,
+            target,
+            atMs ?? Math.round(playheadRef.current),
+            selectedIds()
+          )
+        ),
+
+      deleteClip: (target) =>
+        apply((current) => {
+          const next = edits.deleteClip(current, target, selectedIds());
+          if (selectedRef.current === next.deleted.id) {
+            select(null);
+          }
+          return { doc: next.doc, result: node(next.doc, next.deleted) };
+        }),
+
+      duplicateClip: (target, gapMs) =>
+        applyClips((current) =>
+          edits.duplicateClip(current, target, gapMs ?? 0, selectedIds())
+        ),
+
+      setClipParams: (target, patch) =>
+        apply((current) => {
+          const next = edits.setClipParams(current, target, patch, selectedIds());
+          return { doc: next.doc, result: node(next.doc, next.clip) };
+        }),
+
+      addMarker: (input) =>
+        apply((current) => {
+          const next = edits.addMarker(current, input);
+          return { doc: next.doc, result: next.marker };
+        }),
+
+      deleteMarker: (target) =>
+        apply((current) => {
+          const next = edits.deleteMarker(current, target);
+          return { doc: next.doc, result: next.deleted };
+        }),
+
+      rename: (nextName) => {
+        store.getState().rename(nextName);
+        return { title: nextName };
+      },
+
+      save: async () => {
+        await runSave();
+        const state = store.getState();
+        if (state.status === 'conflict' || state.status === 'error') {
+          throw new Error(state.error ?? 'Failed to save the timeline.');
+        }
+        return { ok: true, updatedAt: state.updatedAt };
+      },
+    };
+
+    return registerDocumentHandler('timeline', id, title, handler);
+    // `title` is intentionally excluded: it changes on rename, and
+    // re-registering the handler mid-turn is churn the bridge does not need.
+    // `setDocumentTitle` below keeps the agent-visible title current instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store, id, name, select, movePlayhead, runSave]);
+
+  useEffect(() => {
+    if (docName) {
+      setDocumentTitle('timeline', id, docName);
+    }
+  }, [docName, id]);
 
   // Claim focus and publish the selection on focus, but release neither on
   // blur. Navigating to Chat blurs this screen, and the chat turn is the one
@@ -226,24 +433,58 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
   useEffect(() => clearUiSelection, []);
 
   const openChat = useCallback(() => navigation.navigate('Chat'), [navigation]);
+  const handleSave = useCallback(() => void runSave(), [runSave]);
 
   useLayoutEffect(() => {
+    const saving = status === 'saving';
     navigation.setOptions({
       title,
       headerRight: () => (
-        <TouchableOpacity
-          onPress={openChat}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel="Ask the assistant about this sequence"
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          style={styles.headerButton}
-        >
-          <Ionicons name="chatbubble-ellipses-outline" size={22} color={colors.text} />
-        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={openChat}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Ask the assistant to change this sequence"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="chatbubble-ellipses-outline" size={22} color={colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSave}
+            activeOpacity={0.7}
+            disabled={!dirty || saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save timeline"
+            accessibilityState={{ disabled: !dirty || saving }}
+          >
+            {saving ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <Text
+                style={[
+                  styles.saveText,
+                  { color: dirty ? colors.primary : colors.textTertiary },
+                ]}
+              >
+                Save
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
       ),
     });
-  }, [colors.text, navigation, openChat, title]);
+  }, [
+    colors.primary,
+    colors.text,
+    colors.textTertiary,
+    dirty,
+    handleSave,
+    navigation,
+    openChat,
+    status,
+    title,
+  ]);
 
   const msToPx = useCallback(
     (ms: number): number => (ms / 1000) * pxPerSecond,
@@ -264,9 +505,9 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
   const seekAt = useCallback(
     (event: GestureResponderEvent) => {
       const x = event.nativeEvent.locationX;
-      setPlayheadMs(Math.max(0, Math.min((x / pxPerSecond) * 1000, durationMs)));
+      movePlayhead(Math.max(0, Math.min((x / pxPerSecond) * 1000, durationMs)));
     },
-    [durationMs, pxPerSecond]
+    [durationMs, movePlayhead, pxPerSecond]
   );
 
   const zoomOut = useCallback(
@@ -291,7 +532,10 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
     );
   }
 
-  if (status === 'error') {
+  // A failure with nothing loaded blocks the screen; a failure with a document
+  // in hand (a rejected save) must not hide the edits it failed to persist, so
+  // that case falls through to the banner below.
+  if (doc === null && status === 'error') {
     return (
       <View style={[styles.centered, { backgroundColor: colors.background }]}>
         <Ionicons name="alert-circle-outline" size={32} color={colors.error} />
@@ -299,7 +543,7 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
           {error ?? 'Failed to load this timeline.'}
         </Text>
         <TouchableOpacity
-          onPress={() => void load()}
+          onPress={runLoad}
           activeOpacity={0.7}
           accessibilityRole="button"
           accessibilityLabel="Retry loading timeline"
@@ -318,11 +562,48 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
         { backgroundColor: colors.background, paddingBottom: insets.bottom },
       ]}
     >
+      {status === 'conflict' && (
+        <View
+          style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
+          accessibilityLabel="Timeline changed elsewhere"
+        >
+          <Ionicons name="git-compare-outline" size={16} color={colors.warning} />
+          <Text style={[styles.bannerText, { color: colors.text }]}>
+            Someone else saved this sequence. Reload to get their version — the
+            unsaved edits here will be lost.
+          </Text>
+          <TouchableOpacity
+            onPress={runRevert}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Reload timeline"
+            style={[styles.bannerButton, { backgroundColor: colors.warning }]}
+          >
+            <Text style={styles.bannerButtonText}>Reload</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {status === 'error' && error !== null && (
+        <View style={[styles.banner, { backgroundColor: colors.error + '18' }]}>
+          <Ionicons name="warning-outline" size={16} color={colors.error} />
+          <Text style={[styles.bannerText, { color: colors.error }]}>{error}</Text>
+        </View>
+      )}
+
       <View style={[styles.toolbar, { borderBottomColor: colors.borderLight }]}>
         <Text style={[styles.toolbarText, { color: colors.textSecondary }]}>
           {`${formatTime(durationMs)} · ${tracks.length} tracks · ${clips.length} clips`}
         </Text>
         <View style={styles.toolbarActions}>
+          {dirty && (
+            <View style={styles.dirtyRow} accessibilityLabel="Unsaved changes">
+              <View style={[styles.dirtyDot, { backgroundColor: colors.warning }]} />
+              <Text style={[styles.dirtyText, { color: colors.textSecondary }]}>
+                Unsaved
+              </Text>
+            </View>
+          )}
           <Text style={[styles.playheadReadout, { color: colors.text }]}>
             {formatTime(playheadMs)}
           </Text>
@@ -351,8 +632,20 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
         <View style={styles.centered}>
           <Ionicons name="film-outline" size={36} color={colors.textTertiary} />
           <Text style={[styles.centeredText, { color: colors.textSecondary }]}>
-            This sequence has no clips yet.
+            This sequence has no clips yet. Clips cannot be arranged by touch at
+            this width — ask the assistant to change the sequence, then save.
           </Text>
+          <TouchableOpacity
+            onPress={openChat}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Ask the assistant"
+            style={[styles.retryButton, { backgroundColor: colors.primaryMuted }]}
+          >
+            <Text style={[styles.retryText, { color: colors.primary }]}>
+              Ask the assistant
+            </Text>
+          </TouchableOpacity>
         </View>
       ) : (
         <ScrollView contentContainerStyle={styles.verticalContent}>
@@ -433,7 +726,7 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
                           activeOpacity={0.7}
                           accessibilityRole="button"
                           accessibilityLabel={`Clip ${clip.name}, ${clip.mediaType}, ${formatTime(clip.startMs)} to ${formatTime(clip.startMs + clip.durationMs)}`}
-                          onPress={() => setSelectedClipId(clip.id)}
+                          onPress={() => select(clip.id)}
                           style={[
                             styles.clip,
                             {
@@ -488,7 +781,7 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
               {selectedClip.name}
             </Text>
             <TouchableOpacity
-              onPress={() => setSelectedClipId(null)}
+              onPress={() => select(null)}
               activeOpacity={0.7}
               accessibilityRole="button"
               accessibilityLabel="Close clip details"
@@ -575,9 +868,50 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
   },
-  headerButton: {
-    paddingHorizontal: 10,
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  saveText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  bannerText: {
+    flex: 1,
+    fontSize: 13,
+  },
+  bannerButton: {
+    paddingHorizontal: 12,
     paddingVertical: 6,
+    borderRadius: 8,
+  },
+  bannerButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#fff',
+  },
+  dirtyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginRight: 6,
+  },
+  dirtyDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  dirtyText: {
+    fontSize: 11,
+    fontWeight: '600',
   },
   toolbar: {
     flexDirection: 'row',

--- a/mobile/src/screens/TimelineViewerScreen.tsx
+++ b/mobile/src/screens/TimelineViewerScreen.tsx
@@ -1,0 +1,707 @@
+/**
+ * Read-only timeline viewer.
+ *
+ * The sequence is shown, never edited: a phone cannot place a cut accurately
+ * and cannot supervise a render, so `kinds.ts` opens timelines as a `viewer`
+ * surface and this screen never calls `save()`. What it does offer is the two
+ * things a phone is good for — looking at what a sequence contains, and asking
+ * the assistant about it, which is why the header links to Chat and why the
+ * screen registers an agent handler for the `ui_timeline_*` tools.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type GestureResponderEvent,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { documentStore } from '../documents/documentStore';
+import { registerDocumentHandler, setFocusedDocument } from '../documents/agentBridge';
+import { clearUiSelection, setUiSelection } from '../documents/uiContext';
+import {
+  clipToNode,
+  resolveClip,
+  timelineDurationMs,
+  trackToNode,
+  type TimelineAgentHandler,
+  type TimelineClipData,
+  type TimelineClipStatus,
+  type TimelineDocument,
+  type TimelineMediaType,
+  type TimelineTrackData,
+  type TimelineTrackType,
+} from '../documents/timelineTypes';
+import type { ThemeColors } from '../utils/theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'TimelineViewer'>;
+
+const TRACK_HEADER_WIDTH = 108;
+const RULER_HEIGHT = 34;
+const LANE_HEIGHT = 56;
+const MIN_PX_PER_SECOND = 2;
+const MAX_PX_PER_SECOND = 240;
+const DEFAULT_PX_PER_SECOND = 20;
+const ZOOM_FACTOR = 2;
+/** Empty room after the last clip, so the sequence end is reachable. */
+const TAIL_MS = 2000;
+
+/** Tick spacings, coarsest that still leaves ~64px between labels wins. */
+const TICK_STEPS_MS = [
+  250, 500, 1000, 2000, 5000, 10_000, 15_000, 30_000, 60_000, 120_000, 300_000,
+  600_000,
+];
+
+const TRACK_ICONS: Record<TimelineTrackType, keyof typeof Ionicons.glyphMap> = {
+  video: 'videocam-outline',
+  audio: 'musical-notes-outline',
+  overlay: 'layers-outline',
+  subtitle: 'text-outline',
+};
+
+function formatTime(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const mmss = `${minutes.toString().padStart(hours > 0 ? 2 : 1, '0')}:${seconds
+    .toString()
+    .padStart(2, '0')}`;
+  return hours > 0 ? `${hours}:${mmss}` : mmss;
+}
+
+function chooseTickMs(pxPerSecond: number): number {
+  const step = TICK_STEPS_MS.find((candidate) => (candidate / 1000) * pxPerSecond >= 64);
+  return step ?? TICK_STEPS_MS[TICK_STEPS_MS.length - 1];
+}
+
+function mediaColor(mediaType: TimelineMediaType, colors: ThemeColors): string {
+  switch (mediaType) {
+    case 'video':
+      return colors.primaryMuted;
+    case 'audio':
+      return colors.accentMuted;
+    case 'image':
+      return colors.primaryLight;
+    case 'text':
+    case 'overlay':
+    case 'shape':
+    default:
+      return colors.surfaceElevated;
+  }
+}
+
+function statusColor(status: TimelineClipStatus, colors: ThemeColors): string {
+  switch (status) {
+    case 'failed':
+    case 'missing':
+      return colors.error;
+    case 'queued':
+    case 'generating':
+      return colors.warning;
+    case 'generated':
+      return colors.success;
+    case 'stale':
+      return colors.info;
+    default:
+      return colors.border;
+  }
+}
+
+export default function TimelineViewerScreen({ navigation, route }: Props) {
+  const { id, name } = route.params;
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const store = useMemo(() => documentStore<TimelineDocument>('timeline', id), [id]);
+  const doc = store((state) => state.doc);
+  const docName = store((state) => state.name);
+  const status = store((state) => state.status);
+  const error = store((state) => state.error);
+  const load = store((state) => state.load);
+
+  const [pxPerSecond, setPxPerSecond] = useState(DEFAULT_PX_PER_SECOND);
+  const [playheadMs, setPlayheadMs] = useState(0);
+  const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+
+  const title = docName || name || 'Timeline';
+
+  useEffect(() => {
+    // Re-read on every open: the store is cached for the app's lifetime, so a
+    // sequence edited on desktop since it was last viewed here would otherwise
+    // keep showing the stale cut. Nothing local can be lost — this is a viewer.
+    void load();
+  }, [store, load]);
+
+  const tracks = useMemo<TimelineTrackData[]>(
+    () => [...(doc?.tracks ?? [])].sort((a, b) => a.index - b.index),
+    [doc]
+  );
+  const clips = useMemo<TimelineClipData[]>(() => doc?.clips ?? [], [doc]);
+  const markers = useMemo(() => doc?.markers ?? [], [doc]);
+  const durationMs = useMemo(() => timelineDurationMs(clips), [clips]);
+
+  const trackNameOf = useCallback(
+    (trackId: string): string | null =>
+      tracks.find((track) => track.id === trackId)?.name ?? null,
+    [tracks]
+  );
+
+  const handler = useMemo<TimelineAgentHandler>(() => {
+    const selectedClipIds = selectedClipId ? [selectedClipId] : [];
+    const node = (clip: TimelineClipData) => clipToNode(clip, trackNameOf(clip.trackId));
+    return {
+      getSnapshot: () => ({
+        sequenceId: id,
+        title,
+        durationMs,
+        trackCount: tracks.length,
+        clipCount: clips.length,
+        playheadMs,
+        selectedClipIds,
+        tracks: tracks.map((track) =>
+          trackToNode(
+            track,
+            clips.filter((clip) => clip.trackId === track.id).length
+          )
+        ),
+        clips: clips.map(node),
+        markers: markers.map((marker) => ({
+          id: marker.id,
+          timeMs: marker.timeMs,
+          label: marker.label,
+        })),
+      }),
+      getClip: (target) => node(resolveClip(clips, target, selectedClipIds)),
+      selectClip: (target) => {
+        if (target === null || target === '') {
+          setSelectedClipId(null);
+          return null;
+        }
+        const clip = resolveClip(clips, target, selectedClipIds);
+        setSelectedClipId(clip.id);
+        return node(clip);
+      },
+      seek: (timeMs) => {
+        const clamped = Math.max(0, Math.min(timeMs, durationMs));
+        setPlayheadMs(clamped);
+        return clamped;
+      },
+    };
+  }, [clips, durationMs, id, markers, playheadMs, selectedClipId, title, trackNameOf, tracks]);
+
+  useEffect(
+    () => registerDocumentHandler('timeline', id, title, handler),
+    [handler, id, title]
+  );
+
+  // Claim focus and publish the selection on focus, but release neither on
+  // blur. Navigating to Chat blurs this screen, and the chat turn is the one
+  // moment `ui_context` is read — clearing here would drop both the focused
+  // document and the selected clip exactly when the user asks about them.
+  useFocusEffect(
+    useCallback(() => {
+      setFocusedDocument('timeline', id);
+      setUiSelection({ clipIds: selectedClipId ? [selectedClipId] : [] });
+    }, [id, selectedClipId])
+  );
+
+  // Unmount is what makes the claim stale, so the release belongs here.
+  useEffect(() => clearUiSelection, []);
+
+  const openChat = useCallback(() => navigation.navigate('Chat'), [navigation]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title,
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={openChat}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Ask the assistant about this sequence"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          style={styles.headerButton}
+        >
+          <Ionicons name="chatbubble-ellipses-outline" size={22} color={colors.text} />
+        </TouchableOpacity>
+      ),
+    });
+  }, [colors.text, navigation, openChat, title]);
+
+  const msToPx = useCallback(
+    (ms: number): number => (ms / 1000) * pxPerSecond,
+    [pxPerSecond]
+  );
+
+  const contentWidth = Math.max(msToPx(durationMs + TAIL_MS), 320);
+  const tickMs = chooseTickMs(pxPerSecond);
+  const ticks = useMemo(() => {
+    const out: number[] = [];
+    const end = durationMs + TAIL_MS;
+    for (let at = 0; at <= end; at += tickMs) {
+      out.push(at);
+    }
+    return out;
+  }, [durationMs, tickMs]);
+
+  const seekAt = useCallback(
+    (event: GestureResponderEvent) => {
+      const x = event.nativeEvent.locationX;
+      setPlayheadMs(Math.max(0, Math.min((x / pxPerSecond) * 1000, durationMs)));
+    },
+    [durationMs, pxPerSecond]
+  );
+
+  const zoomOut = useCallback(
+    () => setPxPerSecond((current) => Math.max(current / ZOOM_FACTOR, MIN_PX_PER_SECOND)),
+    []
+  );
+  const zoomIn = useCallback(
+    () => setPxPerSecond((current) => Math.min(current * ZOOM_FACTOR, MAX_PX_PER_SECOND)),
+    []
+  );
+
+  const selectedClip = clips.find((clip) => clip.id === selectedClipId) ?? null;
+
+  if (doc === null && status === 'loading') {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator color={colors.primary} />
+        <Text style={[styles.centeredText, { color: colors.textSecondary }]}>
+          Loading timeline…
+        </Text>
+      </View>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <Ionicons name="alert-circle-outline" size={32} color={colors.error} />
+        <Text style={[styles.centeredText, { color: colors.text }]}>
+          {error ?? 'Failed to load this timeline.'}
+        </Text>
+        <TouchableOpacity
+          onPress={() => void load()}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading timeline"
+          style={[styles.retryButton, { backgroundColor: colors.primaryMuted }]}
+        >
+          <Text style={[styles.retryText, { color: colors.primary }]}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingBottom: insets.bottom },
+      ]}
+    >
+      <View style={[styles.toolbar, { borderBottomColor: colors.borderLight }]}>
+        <Text style={[styles.toolbarText, { color: colors.textSecondary }]}>
+          {`${formatTime(durationMs)} · ${tracks.length} tracks · ${clips.length} clips`}
+        </Text>
+        <View style={styles.toolbarActions}>
+          <Text style={[styles.playheadReadout, { color: colors.text }]}>
+            {formatTime(playheadMs)}
+          </Text>
+          <TouchableOpacity
+            onPress={zoomOut}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Zoom out"
+            style={styles.zoomButton}
+          >
+            <Ionicons name="remove-outline" size={20} color={colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={zoomIn}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Zoom in"
+            style={styles.zoomButton}
+          >
+            <Ionicons name="add-outline" size={20} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {clips.length === 0 ? (
+        <View style={styles.centered}>
+          <Ionicons name="film-outline" size={36} color={colors.textTertiary} />
+          <Text style={[styles.centeredText, { color: colors.textSecondary }]}>
+            This sequence has no clips yet.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.verticalContent}>
+          <View style={styles.lanesRow}>
+            {/* Track headers stay put while the lanes scroll. */}
+            <View
+              style={[
+                styles.trackHeaderColumn,
+                { borderRightColor: colors.border, backgroundColor: colors.surface },
+              ]}
+            >
+              <View style={styles.rulerSpacer} />
+              {tracks.map((track) => (
+                <View
+                  key={track.id}
+                  style={[styles.trackHeader, { borderTopColor: colors.borderLight }]}
+                >
+                  <Ionicons
+                    name={TRACK_ICONS[track.type]}
+                    size={15}
+                    color={colors.textSecondary}
+                  />
+                  <Text
+                    style={[styles.trackHeaderText, { color: colors.text }]}
+                    numberOfLines={1}
+                  >
+                    {track.name}
+                  </Text>
+                  {track.muted === true && (
+                    <Ionicons
+                      name="volume-mute-outline"
+                      size={13}
+                      color={colors.textTertiary}
+                    />
+                  )}
+                </View>
+              ))}
+            </View>
+
+            {/* Ruler and lanes share one scroller so they cannot desync. */}
+            <ScrollView horizontal showsHorizontalScrollIndicator>
+              <View style={{ width: contentWidth }}>
+                <View style={[styles.ruler, { borderBottomColor: colors.border }]}>
+                  {ticks.map((at) => (
+                    <View key={at} style={[styles.tick, { left: msToPx(at) }]}>
+                      <View style={[styles.tickMark, { backgroundColor: colors.border }]} />
+                      <Text style={[styles.tickLabel, { color: colors.textTertiary }]}>
+                        {formatTime(at)}
+                      </Text>
+                    </View>
+                  ))}
+                  {markers.map((marker) => (
+                    <View
+                      key={marker.id}
+                      accessibilityLabel={`Marker ${marker.label} at ${formatTime(marker.timeMs)}`}
+                      style={[
+                        styles.marker,
+                        { left: msToPx(marker.timeMs), backgroundColor: marker.color ?? colors.warning },
+                      ]}
+                    />
+                  ))}
+                </View>
+
+                {tracks.map((track) => (
+                  <TouchableOpacity
+                    key={track.id}
+                    activeOpacity={0.7}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Seek on track ${track.name}`}
+                    onPress={seekAt}
+                    style={[styles.lane, { borderTopColor: colors.borderLight }]}
+                  >
+                    {clips
+                      .filter((clip) => clip.trackId === track.id)
+                      .map((clip) => (
+                        <TouchableOpacity
+                          key={clip.id}
+                          activeOpacity={0.7}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Clip ${clip.name}, ${clip.mediaType}, ${formatTime(clip.startMs)} to ${formatTime(clip.startMs + clip.durationMs)}`}
+                          onPress={() => setSelectedClipId(clip.id)}
+                          style={[
+                            styles.clip,
+                            {
+                              left: msToPx(clip.startMs),
+                              width: Math.max(msToPx(clip.durationMs), 8),
+                              backgroundColor: mediaColor(clip.mediaType, colors),
+                              borderColor:
+                                clip.id === selectedClipId
+                                  ? colors.primary
+                                  : statusColor(clip.status, colors),
+                              borderWidth: clip.id === selectedClipId ? 2 : 1,
+                            },
+                          ]}
+                        >
+                          <Text
+                            style={[styles.clipText, { color: colors.text }]}
+                            numberOfLines={1}
+                          >
+                            {clip.name}
+                          </Text>
+                        </TouchableOpacity>
+                      ))}
+                  </TouchableOpacity>
+                ))}
+
+                <View
+                  pointerEvents="none"
+                  style={[
+                    styles.playhead,
+                    {
+                      left: msToPx(playheadMs),
+                      height: RULER_HEIGHT + tracks.length * LANE_HEIGHT,
+                      backgroundColor: colors.primary,
+                    },
+                  ]}
+                />
+              </View>
+            </ScrollView>
+          </View>
+        </ScrollView>
+      )}
+
+      {selectedClip && (
+        <View
+          style={[
+            styles.detailPanel,
+            { backgroundColor: colors.surface, borderTopColor: colors.border },
+          ]}
+        >
+          <View style={styles.detailHeader}>
+            <Text style={[styles.detailTitle, { color: colors.text }]} numberOfLines={1}>
+              {selectedClip.name}
+            </Text>
+            <TouchableOpacity
+              onPress={() => setSelectedClipId(null)}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Close clip details"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons name="close-outline" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+          <DetailRow
+            label="Time"
+            value={`${formatTime(selectedClip.startMs)} – ${formatTime(
+              selectedClip.startMs + selectedClip.durationMs
+            )} (${formatTime(selectedClip.durationMs)})`}
+            colors={colors}
+          />
+          <DetailRow label="Media" value={selectedClip.mediaType} colors={colors} />
+          <DetailRow label="Status" value={selectedClip.status} colors={colors} />
+          <DetailRow
+            label="Track"
+            value={trackNameOf(selectedClip.trackId) ?? selectedClip.trackId}
+            colors={colors}
+          />
+          {selectedClip.model !== undefined && (
+            <DetailRow
+              label="Model"
+              value={
+                selectedClip.provider !== undefined
+                  ? `${selectedClip.provider} / ${selectedClip.model}`
+                  : selectedClip.model
+              }
+              colors={colors}
+            />
+          )}
+          {selectedClip.prompt !== undefined && (
+            <DetailRow label="Prompt" value={selectedClip.prompt} colors={colors} />
+          )}
+          <DetailRow
+            label="Versions"
+            value={String(selectedClip.versions.length)}
+            colors={colors}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+  colors: ThemeColors;
+}
+
+function DetailRow({ label, value, colors }: DetailRowProps) {
+  return (
+    <View style={styles.detailRow}>
+      <Text style={[styles.detailLabel, { color: colors.textTertiary }]}>{label}</Text>
+      <Text style={[styles.detailValue, { color: colors.text }]}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  centeredText: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  retryText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  headerButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  toolbarText: {
+    fontSize: 12,
+  },
+  toolbarActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  playheadReadout: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+    marginRight: 4,
+  },
+  zoomButton: {
+    padding: 6,
+  },
+  verticalContent: {
+    paddingBottom: 12,
+  },
+  lanesRow: {
+    flexDirection: 'row',
+  },
+  trackHeaderColumn: {
+    width: TRACK_HEADER_WIDTH,
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  rulerSpacer: {
+    height: RULER_HEIGHT,
+  },
+  trackHeader: {
+    height: LANE_HEIGHT,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  trackHeaderText: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  ruler: {
+    height: RULER_HEIGHT,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  tick: {
+    position: 'absolute',
+    top: 0,
+    alignItems: 'flex-start',
+  },
+  tickMark: {
+    width: StyleSheet.hairlineWidth,
+    height: 8,
+  },
+  tickLabel: {
+    fontSize: 10,
+    paddingLeft: 2,
+  },
+  marker: {
+    position: 'absolute',
+    bottom: 2,
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  lane: {
+    height: LANE_HEIGHT,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  clip: {
+    position: 'absolute',
+    top: 6,
+    bottom: 6,
+    borderRadius: 6,
+    justifyContent: 'center',
+    paddingHorizontal: 6,
+    overflow: 'hidden',
+  },
+  clipText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  playhead: {
+    position: 'absolute',
+    top: 0,
+    width: 2,
+  },
+  detailPanel: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    gap: 6,
+  },
+  detailHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  detailTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  detailRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  detailLabel: {
+    width: 72,
+    fontSize: 12,
+  },
+  detailValue: {
+    flex: 1,
+    fontSize: 12,
+  },
+});

--- a/mobile/src/screens/WorkflowsListScreen.tsx
+++ b/mobile/src/screens/WorkflowsListScreen.tsx
@@ -159,6 +159,16 @@ export default function WorkflowsListScreen({ navigation }: WorkflowsListScreenP
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.headerButton, { backgroundColor: colors.primaryMuted }]}
+            onPress={() => navigation.navigate('Documents')}
+            accessibilityRole="button"
+            accessibilityLabel="Open documents"
+            activeOpacity={0.7}
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+          >
+            <Ionicons name="documents-outline" size={20} color={colors.primary} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.headerButton, { backgroundColor: colors.primaryMuted }]}
             onPress={() => navigation.navigate('Assets')}
             accessibilityRole="button"
             accessibilityLabel="Open assets"

--- a/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for DocumentViewerScreen — the generic fallback surface.
+ *
+ * The per-document Zustand store is mocked, so the screen's three states
+ * (loading, loaded summary, failure) can be driven directly.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import DocumentViewerScreen from '../DocumentViewerScreen';
+import type { DocumentStatus } from '../../documents/documentStore';
+
+interface MockState {
+  doc: unknown;
+  name: string;
+  status: DocumentStatus;
+  error: string | null;
+  updatedAt: string | null;
+  load: () => Promise<void>;
+}
+
+let mockState: MockState;
+
+jest.mock('../../documents/documentStore', () => ({
+  documentStore: () => (selector: (state: MockState) => unknown) => selector(mockState),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const load = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const route = {
+  key: 'DocumentViewer-1',
+  name: 'DocumentViewer' as const,
+  params: { kind: 'sketch', id: 'sk-1', name: 'Doodle' },
+};
+
+function renderScreen() {
+  return render(
+    <DocumentViewerScreen navigation={navigation as never} route={route as never} />
+  );
+}
+
+describe('DocumentViewerScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockState = {
+      doc: {
+        strokes: [{ id: 's1' }, { id: 's2' }],
+        background: '#FFFFFF',
+        meta: { author: 'agent' },
+      },
+      name: 'Doodle',
+      status: 'idle',
+      error: null,
+      updatedAt: '2026-07-26T10:00:00.000Z',
+      load,
+    };
+  });
+
+  it('loads the document on mount and titles the header', () => {
+    renderScreen();
+
+    expect(load).toHaveBeenCalled();
+    expect(navigation.setOptions).toHaveBeenCalledWith({ title: 'Doodle' });
+  });
+
+  it('summarizes top-level fields and shows the raw JSON', () => {
+    renderScreen();
+
+    expect(screen.getByText('strokes')).toBeTruthy();
+    expect(screen.getByText('2 items')).toBeTruthy();
+    expect(screen.getByText('#FFFFFF')).toBeTruthy();
+    expect(screen.getByText('1 field(s)')).toBeTruthy();
+    expect(screen.getByText(/"strokes"/)).toBeTruthy();
+  });
+
+  it('explains that the kind has no dedicated screen', () => {
+    renderScreen();
+
+    expect(screen.getByText(/no dedicated mobile screen yet/)).toBeTruthy();
+  });
+
+  it('shows a spinner while the first load is in flight', () => {
+    mockState = { ...mockState, doc: null, status: 'loading' };
+    renderScreen();
+
+    expect(screen.getByText('Loading Sketch...')).toBeTruthy();
+  });
+
+  it('offers a retry when the load failed', () => {
+    mockState = { ...mockState, doc: null, status: 'error', error: 'boom' };
+    renderScreen();
+
+    expect(screen.getByText('Could not load Sketch')).toBeTruthy();
+    expect(screen.getByText('boom')).toBeTruthy();
+
+    load.mockClear();
+    fireEvent.press(screen.getByLabelText('Retry loading document'));
+    expect(load).toHaveBeenCalled();
+  });
+});

--- a/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
@@ -182,14 +182,15 @@ describe('DocumentsScreen', () => {
     alertButton(1, 'Delete').onPress?.();
 
     expect(deleteMutate).toHaveBeenCalledWith(
-      { ref: { kind: 'storyboard', id: 'sb-1' } },
+      { kind: 'storyboard', id: 'sb-1' },
       expect.objectContaining({ onError: expect.any(Function) })
     );
   });
 
   it('renames through the modal', async () => {
     renameMutateAsync.mockResolvedValue({
-      ref: { kind: 'storyboard', id: 'sb-1' },
+      kind: 'storyboard',
+      id: 'sb-1',
       name: 'Board B',
     });
     renderScreen();
@@ -205,7 +206,8 @@ describe('DocumentsScreen', () => {
 
     await waitFor(() => {
       expect(renameMutateAsync).toHaveBeenCalledWith({
-        ref: { kind: 'storyboard', id: 'sb-1' },
+        kind: 'storyboard',
+        id: 'sb-1',
         name: 'Board B',
       });
     });
@@ -213,7 +215,8 @@ describe('DocumentsScreen', () => {
 
   it('creates a storyboard and opens it', async () => {
     createMutateAsync.mockResolvedValue({
-      ref: { kind: 'storyboard', id: 'sb-new' },
+      kind: 'storyboard',
+      id: 'sb-new',
       name: 'New Storyboard',
       updatedAt: '2026-07-26T00:00:00.000Z',
     });
@@ -225,7 +228,6 @@ describe('DocumentsScreen', () => {
       expect(createMutateAsync).toHaveBeenCalledWith({
         kind: 'storyboard',
         name: 'New Storyboard',
-        projectId: 'default',
       });
     });
     expect(navigation.navigate).toHaveBeenCalledWith('StoryboardEditor', {

--- a/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for DocumentsScreen — the tabless documents browser.
+ *
+ * The document hooks are mocked so the list, the kind filter, and the
+ * registry-driven navigation can be exercised without a server.
+ */
+
+import React from 'react';
+import { Alert, type AlertButton } from 'react-native';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react-native';
+
+import DocumentsScreen from '../DocumentsScreen';
+import {
+  useAllDocuments,
+  useCreateDocument,
+  useDeleteDocument,
+  useRenameDocument,
+  type DocumentListEntry,
+} from '../../documents/useDocuments';
+
+jest.mock('../../documents/useDocuments', () => ({
+  useAllDocuments: jest.fn(),
+  useCreateDocument: jest.fn(),
+  useRenameDocument: jest.fn(),
+  useDeleteDocument: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const mockedUseAllDocuments = useAllDocuments as jest.MockedFunction<
+  typeof useAllDocuments
+>;
+const mockedUseCreateDocument = useCreateDocument as jest.Mock;
+const mockedUseRenameDocument = useRenameDocument as jest.Mock;
+const mockedUseDeleteDocument = useDeleteDocument as jest.Mock;
+
+const DOCUMENTS: DocumentListEntry[] = [
+  {
+    kind: 'storyboard',
+    id: 'sb-1',
+    name: 'Board A',
+    updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    kind: 'timeline',
+    id: 'tl-1',
+    name: 'Cut One',
+    updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    kind: 'sketch',
+    id: 'sk-1',
+    name: 'Doodle',
+    updatedAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const refetch = jest.fn();
+const createMutateAsync = jest.fn();
+const renameMutateAsync = jest.fn();
+const deleteMutate = jest.fn();
+
+type ListResult = ReturnType<typeof useAllDocuments>;
+
+function listResult(overrides: Partial<ListResult> = {}): ListResult {
+  return {
+    documents: DOCUMENTS,
+    isLoading: false,
+    isRefetching: false,
+    error: null,
+    refetch,
+    ...overrides,
+  } as ListResult;
+}
+
+function renderScreen() {
+  return render(<DocumentsScreen navigation={navigation as never} />);
+}
+
+/** Pull a button out of the last Alert.alert call by its label. */
+function alertButton(callIndex: number, text: string): AlertButton {
+  const spy = Alert.alert as unknown as jest.Mock;
+  const buttons = spy.mock.calls[callIndex][2] as AlertButton[];
+  const button = buttons.find((candidate) => candidate.text === text);
+  if (!button) {
+    throw new Error(`No "${text}" button in alert ${callIndex}`);
+  }
+  return button;
+}
+
+describe('DocumentsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    mockedUseAllDocuments.mockReturnValue(listResult());
+    mockedUseCreateDocument.mockReturnValue({
+      mutateAsync: createMutateAsync,
+      isPending: false,
+    });
+    mockedUseRenameDocument.mockReturnValue({
+      mutateAsync: renameMutateAsync,
+      isPending: false,
+    });
+    mockedUseDeleteDocument.mockReturnValue({
+      mutate: deleteMutate,
+      isPending: false,
+    });
+  });
+
+  it('renders documents of every kind', () => {
+    renderScreen();
+
+    expect(screen.getByLabelText('Open Board A, Storyboard')).toBeTruthy();
+    expect(screen.getByLabelText('Open Cut One, Timeline')).toBeTruthy();
+    expect(screen.getByLabelText('Open Doodle, Sketch')).toBeTruthy();
+  });
+
+  it('shows a relative updated-at stamp and a read-only hint for viewer kinds', () => {
+    renderScreen();
+
+    expect(screen.getByText('Storyboard · 2h ago')).toBeTruthy();
+    // Timeline and sketch both open read-only.
+    expect(screen.getAllByText('Read-only')).toHaveLength(2);
+  });
+
+  it('narrows the list to the selected kind', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Filter by Timelines'));
+
+    expect(screen.getByLabelText('Open Cut One, Timeline')).toBeTruthy();
+    expect(screen.queryByLabelText('Open Board A, Storyboard')).toBeNull();
+    expect(screen.queryByLabelText('Open Doodle, Sketch')).toBeNull();
+
+    fireEvent.press(screen.getByLabelText('Filter by All'));
+    expect(screen.getByLabelText('Open Board A, Storyboard')).toBeTruthy();
+  });
+
+  it('navigates to the route the kind registry maps', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Open Board A, Storyboard'));
+    expect(navigation.navigate).toHaveBeenCalledWith('StoryboardEditor', {
+      id: 'sb-1',
+      name: 'Board A',
+    });
+
+    fireEvent.press(screen.getByLabelText('Open Cut One, Timeline'));
+    expect(navigation.navigate).toHaveBeenCalledWith('TimelineViewer', {
+      id: 'tl-1',
+      name: 'Cut One',
+    });
+
+    fireEvent.press(screen.getByLabelText('Open Doodle, Sketch'));
+    expect(navigation.navigate).toHaveBeenCalledWith('DocumentViewer', {
+      kind: 'sketch',
+      id: 'sk-1',
+      name: 'Doodle',
+    });
+  });
+
+  it('confirms before deleting', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Actions for Board A'));
+    alertButton(0, 'Delete').onPress?.();
+
+    // The action menu only opens the confirmation; nothing is deleted yet.
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect((Alert.alert as unknown as jest.Mock).mock.calls[1][0]).toBe(
+      'Delete document?'
+    );
+
+    alertButton(1, 'Delete').onPress?.();
+
+    expect(deleteMutate).toHaveBeenCalledWith(
+      { ref: { kind: 'storyboard', id: 'sb-1' } },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('renames through the modal', async () => {
+    renameMutateAsync.mockResolvedValue({
+      ref: { kind: 'storyboard', id: 'sb-1' },
+      name: 'Board B',
+    });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Actions for Board A'));
+    act(() => {
+      alertButton(0, 'Rename').onPress?.();
+    });
+
+    const input = await screen.findByLabelText('Document name');
+    fireEvent.changeText(input, 'Board B');
+    fireEvent.press(screen.getByLabelText('Save rename'));
+
+    await waitFor(() => {
+      expect(renameMutateAsync).toHaveBeenCalledWith({
+        ref: { kind: 'storyboard', id: 'sb-1' },
+        name: 'Board B',
+      });
+    });
+  });
+
+  it('creates a storyboard and opens it', async () => {
+    createMutateAsync.mockResolvedValue({
+      ref: { kind: 'storyboard', id: 'sb-new' },
+      name: 'New Storyboard',
+      updatedAt: '2026-07-26T00:00:00.000Z',
+    });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('New Storyboard'));
+
+    await waitFor(() => {
+      expect(createMutateAsync).toHaveBeenCalledWith({
+        kind: 'storyboard',
+        name: 'New Storyboard',
+        projectId: 'default',
+      });
+    });
+    expect(navigation.navigate).toHaveBeenCalledWith('StoryboardEditor', {
+      id: 'sb-new',
+      name: 'New Storyboard',
+    });
+  });
+
+  it('points an empty library at the assistant', () => {
+    mockedUseAllDocuments.mockReturnValue(listResult({ documents: [] }));
+    renderScreen();
+
+    expect(screen.getByText('No documents yet')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Open chat with the assistant'));
+    expect(navigation.navigate).toHaveBeenCalledWith('Chat');
+  });
+
+  it('shows a spinner while loading', () => {
+    mockedUseAllDocuments.mockReturnValue(
+      listResult({ documents: [], isLoading: true })
+    );
+    renderScreen();
+
+    expect(screen.getByText('Loading documents...')).toBeTruthy();
+  });
+
+  it('banners a load error and retries', () => {
+    mockedUseAllDocuments.mockReturnValue(
+      listResult({ error: new Error('offline') as unknown as ListResult['error'] })
+    );
+    renderScreen();
+
+    expect(screen.getByText('offline')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Retry loading documents'));
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/mobile/src/screens/__tests__/ScriptEditorScreen.test.tsx
+++ b/mobile/src/screens/__tests__/ScriptEditorScreen.test.tsx
@@ -1,0 +1,575 @@
+/**
+ * Tests for ScriptEditorScreen.
+ *
+ * The document store is replaced with a real (but network-free) Zustand store, so
+ * the screen exercises the same read/edit/save paths it does in the app without
+ * a tRPC client. The agent handler is reached through the real bridge, which is
+ * the contract the ui_script_* tools depend on.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { create } from 'zustand';
+
+import ScriptEditorScreen from '../ScriptEditorScreen';
+import {
+  getDocumentHandler,
+  resetDocumentHandlers,
+} from '../../documents/agentBridge';
+import {
+  flattenLines,
+  type ScriptAgentHandler,
+  type ScriptDocument,
+  type ScriptTake,
+} from '../../documents/scriptTypes';
+import type { DocumentState } from '../../documents/documentStore';
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const ReactModule = require('react');
+    ReactModule.useEffect(callback, [callback]);
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      surface: '#111',
+      primary: '#6DB3F8',
+      primaryMuted: '#123',
+      text: '#fff',
+      textSecondary: '#aaa',
+      textTertiary: '#777',
+      textOnPrimary: '#fff',
+      border: '#222',
+      borderLight: '#333',
+      error: '#f00',
+      warning: '#fc0',
+      inputBg: '#222',
+      cardBg: '#111',
+      accent: '#a7f',
+      accentMuted: '#334',
+    },
+    shadows: { small: {}, medium: {}, large: {} },
+  }),
+}));
+
+const saveMock = jest.fn(async () => {});
+const loadMock = jest.fn(async () => {});
+const revertMock = jest.fn(async () => {});
+
+type TestState = DocumentState<ScriptDocument>;
+
+const take = (id: string, textSnapshot: string): ScriptTake => ({
+  id,
+  assetId: `asset-${id}`,
+  durationMs: 900,
+  words: [],
+  textSnapshot,
+  voiceSnapshot: null,
+  createdAt: '2026-07-26T00:00:00Z',
+});
+
+const makeDocument = (
+  overrides: Partial<ScriptDocument> = {}
+): ScriptDocument => ({
+  cast: [
+    { id: 'speaker-a', name: 'Ada', color: '#6DB3F8' },
+    { id: 'speaker-b', name: 'Grace' },
+  ],
+  sections: [
+    {
+      id: 'section-1',
+      title: 'Cold open',
+      lines: [
+        {
+          id: 'line-a',
+          speakerId: 'speaker-a',
+          text: 'The lamp still turns',
+          takes: [take('take-1', 'The lamp still turns')],
+          currentTakeId: 'take-1',
+        },
+        {
+          id: 'line-b',
+          speakerId: 'speaker-b',
+          text: 'Not for much longer',
+          direction: 'flat',
+          takes: [],
+          currentTakeId: null,
+        },
+      ],
+    },
+    {
+      id: 'section-2',
+      title: 'Act 2',
+      lines: [
+        {
+          id: 'line-c',
+          speakerId: null,
+          text: 'Rain on the glass',
+          takes: [],
+          currentTakeId: null,
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+let mockStore: ReturnType<typeof makeStore>;
+
+function makeStore(overrides: Partial<TestState> = {}) {
+  return create<TestState>((set, get) => ({
+    kind: 'script',
+    id: 'sc-1',
+    doc: makeDocument(),
+    name: 'Test script',
+    token: '2026-07-26T00:00:00Z',
+    updatedAt: '2026-07-26T00:00:00Z',
+    dirty: false,
+    status: 'idle',
+    error: null,
+    load: loadMock,
+    edit: (mutate) => {
+      const current = get().doc;
+      if (current === null) {
+        return;
+      }
+      set({ doc: mutate(current), dirty: true });
+    },
+    rename: (name) => set({ name, dirty: true }),
+    save: saveMock,
+    revert: revertMock,
+    ...overrides,
+  }));
+}
+
+jest.mock('../../documents/documentStore', () => ({
+  documentStore: () => mockStore,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const route = { params: { id: 'sc-1', name: 'Test script' } };
+
+const renderScreen = () =>
+  render(
+    <ScriptEditorScreen
+      navigation={navigation as never}
+      route={route as never}
+    />
+  );
+
+/** The header component the screen last handed to the navigator. */
+const renderHeaderRight = () => {
+  const calls = navigation.setOptions.mock.calls;
+  const options = calls[calls.length - 1][0] as {
+    headerRight: () => React.ReactElement;
+  };
+  const HeaderRight = options.headerRight;
+  return render(<HeaderRight />);
+};
+
+const lineIds = (): string[] =>
+  flattenLines(mockStore.getState().doc as ScriptDocument).map(
+    (entry) => entry.line.id
+  );
+
+describe('ScriptEditorScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDocumentHandlers();
+    mockStore = makeStore();
+  });
+
+  it('renders every section, line, and cast member', () => {
+    renderScreen();
+
+    expect(screen.getByDisplayValue('Cold open')).toBeTruthy();
+    expect(screen.getByDisplayValue('Act 2')).toBeTruthy();
+    expect(screen.getByDisplayValue('The lamp still turns')).toBeTruthy();
+    expect(screen.getByDisplayValue('Not for much longer')).toBeTruthy();
+    expect(screen.getByDisplayValue('Rain on the glass')).toBeTruthy();
+    expect(screen.getByLabelText('Speaker 1 name')).toBeTruthy();
+    expect(screen.getByLabelText('Line 3 text')).toBeTruthy();
+  });
+
+  it('shows each line status with its take count', () => {
+    renderScreen();
+
+    expect(
+      screen.getByLabelText('Line 1 status Voiced, 1 takes')
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Line 2 status Draft, 0 takes')).toBeTruthy();
+  });
+
+  it('marks a voiced line stale once its text is edited, keeping the take', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Line 1 text'), 'The lamp is out');
+
+    const line = mockStore.getState().doc?.sections[0].lines[0];
+    expect(line?.text).toBe('The lamp is out');
+    expect(line?.takes).toHaveLength(1);
+    expect(line?.currentTakeId).toBe('take-1');
+    expect(screen.getByLabelText('Line 1 status Stale, 1 takes')).toBeTruthy();
+    expect(screen.getByLabelText('Unsaved changes')).toBeTruthy();
+  });
+
+  it('loads the document when it is not in the store yet', () => {
+    mockStore = makeStore({ doc: null, status: 'loading' });
+
+    renderScreen();
+
+    expect(loadMock).toHaveBeenCalled();
+  });
+
+  it('does not reload over unsaved edits', () => {
+    mockStore = makeStore({ dirty: true });
+
+    renderScreen();
+
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+
+  it('edits a line direction in place', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Line 3 direction'), 'urgent');
+
+    expect(mockStore.getState().doc?.sections[1].lines[0].direction).toBe('urgent');
+  });
+
+  it('moves a line up across a section boundary', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Move line 3 up'));
+
+    expect(lineIds()).toEqual(['line-a', 'line-c', 'line-b']);
+    expect(mockStore.getState().doc?.sections[1].lines).toHaveLength(0);
+  });
+
+  it('adds and deletes lines', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Add line to section 1'));
+    expect(mockStore.getState().doc?.sections[0].lines).toHaveLength(3);
+
+    fireEvent.press(screen.getByLabelText('Delete line 1'));
+    expect(lineIds()).not.toContain('line-a');
+  });
+
+  it('adds and deletes sections', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Add section'));
+    expect(mockStore.getState().doc?.sections).toHaveLength(3);
+
+    fireEvent.press(screen.getByLabelText('Delete section 2'));
+    expect(
+      mockStore.getState().doc?.sections.map((section) => section.id)
+    ).not.toContain('section-2');
+  });
+
+  it('adds a speaker, renames one, and removes one without orphaning lines', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Add speaker'));
+    expect(mockStore.getState().doc?.cast).toHaveLength(3);
+
+    fireEvent.changeText(screen.getByLabelText('Speaker 1 name'), 'Ada L');
+    expect(mockStore.getState().doc?.cast[0].name).toBe('Ada L');
+
+    fireEvent.press(screen.getByLabelText('Remove speaker 1'));
+    expect(
+      mockStore.getState().doc?.cast.map((speaker) => speaker.id)
+    ).not.toContain('speaker-a');
+    expect(mockStore.getState().doc?.sections[0].lines[0].speakerId).toBeNull();
+  });
+
+  it('assigns a speaker to the selected line', () => {
+    renderScreen();
+
+    const assign = screen.getByLabelText('Assign Grace to the selected line');
+    expect(assign.props.accessibilityState.disabled).toBe(true);
+
+    fireEvent.press(screen.getByLabelText('Select line 3'));
+    fireEvent.press(screen.getByLabelText('Assign Grace to the selected line'));
+
+    expect(mockStore.getState().doc?.sections[1].lines[0].speakerId).toBe(
+      'speaker-b'
+    );
+  });
+
+  it('saves through the store when the header button is pressed', () => {
+    mockStore = makeStore({ dirty: true });
+    renderScreen();
+
+    fireEvent.press(renderHeaderRight().getByLabelText('Save script'));
+
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('disables the save button while the document is clean', () => {
+    renderScreen();
+
+    const button = renderHeaderRight().getByLabelText('Save script');
+    fireEvent.press(button);
+
+    expect(button.props.accessibilityState.disabled).toBe(true);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a spinner on the save button while saving', () => {
+    mockStore = makeStore({ dirty: true, status: 'saving' });
+    renderScreen();
+
+    const header = renderHeaderRight();
+    expect(header.queryByText('Save')).toBeNull();
+    expect(
+      header.getByLabelText('Save script').props.accessibilityState.disabled
+    ).toBe(true);
+  });
+
+  it('offers a reload on a save conflict', () => {
+    mockStore = makeStore({
+      dirty: true,
+      status: 'conflict',
+      error: 'Row was modified since it was read',
+    });
+    renderScreen();
+
+    expect(screen.getByLabelText('Script changed elsewhere')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Reload script'));
+
+    expect(revertMock).toHaveBeenCalled();
+  });
+
+  it('retries a failed load', () => {
+    mockStore = makeStore({ doc: null, status: 'error', error: 'Network down' });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Retry loading script'));
+
+    expect(loadMock).toHaveBeenCalled();
+  });
+
+  it('shows the agent-first empty state and routes to chat', () => {
+    mockStore = makeStore({ doc: makeDocument({ sections: [] }) });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Ask the assistant'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('Chat');
+  });
+
+  describe('agent handler', () => {
+    const handler = (): ScriptAgentHandler =>
+      getDocumentHandler<ScriptAgentHandler>('script', 'sc-1');
+
+    it('registers on mount and unregisters on unmount', () => {
+      const view = renderScreen();
+
+      expect(handler().getSnapshot().lines).toHaveLength(3);
+
+      view.unmount();
+      expect(() => handler()).toThrow(/No script "sc-1" is open/);
+    });
+
+    it('snapshots the script the way the tools report it', () => {
+      renderScreen();
+
+      const snapshot = handler().getSnapshot();
+      expect(snapshot).toMatchObject({
+        scriptId: 'sc-1',
+        title: 'Test script',
+        selectedLineId: null,
+      });
+      expect(snapshot.cast).toEqual([
+        { id: 'speaker-a', name: 'Ada', color: '#6DB3F8', hasVoice: false },
+        { id: 'speaker-b', name: 'Grace', color: undefined, hasVoice: false },
+      ]);
+      expect(snapshot.sections).toEqual([
+        { id: 'section-1', title: 'Cold open', lineIds: ['line-a', 'line-b'] },
+        { id: 'section-2', title: 'Act 2', lineIds: ['line-c'] },
+      ]);
+      expect(snapshot.lines[0]).toMatchObject({
+        id: 'line-a',
+        index: 0,
+        sectionId: 'section-1',
+        speakerName: 'Ada',
+        status: 'voiced',
+        takeCount: 1,
+      });
+    });
+
+    it('repaints the screen when the agent adds a line', () => {
+      renderScreen();
+
+      act(() => {
+        handler().addLine({
+          text: 'A gull crosses the beam',
+          speakerId: 'speaker-a',
+          sectionId: 'section-1',
+          index: 0,
+        });
+      });
+
+      expect(screen.getByDisplayValue('A gull crosses the beam')).toBeTruthy();
+      expect(lineIds()[0]).not.toBe('line-a');
+    });
+
+    it('refuses a line for a speaker that is not in the cast', () => {
+      renderScreen();
+
+      expect(() => handler().addLine({ text: 'x', speakerId: 'ghost' })).toThrow(
+        /No cast member "ghost" exists.*speaker-a, speaker-b/s
+      );
+    });
+
+    it('creates a section when the script has none', () => {
+      mockStore = makeStore({ doc: makeDocument({ sections: [] }) });
+      renderScreen();
+
+      act(() => {
+        handler().addLine({ text: 'First words' });
+      });
+
+      expect(mockStore.getState().doc?.sections).toHaveLength(1);
+      expect(handler().getSnapshot().lines[0].text).toBe('First words');
+    });
+
+    it('resolves line targets by id, index, and "selected"', () => {
+      renderScreen();
+
+      act(() => {
+        handler().selectLine('1');
+      });
+      expect(handler().getSnapshot().selectedLineId).toBe('line-b');
+
+      act(() => {
+        handler().patchLine('selected', { pauseAfterMs: 400 });
+      });
+      expect(mockStore.getState().doc?.sections[0].lines[1].pauseAfterMs).toBe(400);
+
+      act(() => {
+        handler().setLineText('line-c', 'Hail on the glass');
+      });
+      expect(mockStore.getState().doc?.sections[1].lines[0].text).toBe(
+        'Hail on the glass'
+      );
+    });
+
+    it('throws a recoverable message for an unknown line target', () => {
+      renderScreen();
+
+      expect(() => handler().setLineText('line-zzz', 'x')).toThrow(
+        /No line matches "line-zzz".*Line ids: line-a, line-b, line-c/s
+      );
+    });
+
+    it('keeps the takes when the agent rewrites a voiced line', () => {
+      renderScreen();
+
+      let node = handler().getSnapshot().lines[0];
+      expect(node.status).toBe('voiced');
+
+      act(() => {
+        node = handler().setLineText('line-a', 'The lamp is out');
+      });
+
+      expect(node).toMatchObject({ status: 'stale', takeCount: 1 });
+      expect(mockStore.getState().doc?.sections[0].lines[0].takes).toHaveLength(1);
+    });
+
+    it('moves, removes, and reassigns lines through the bridge', () => {
+      renderScreen();
+
+      act(() => {
+        handler().moveLine('line-c', 0);
+      });
+      expect(lineIds()).toEqual(['line-c', 'line-a', 'line-b']);
+
+      act(() => {
+        handler().setLineSpeaker('line-c', 'speaker-b');
+      });
+      expect(mockStore.getState().doc?.sections[0].lines[0].speakerId).toBe(
+        'speaker-b'
+      );
+
+      act(() => {
+        handler().removeLine('0');
+      });
+      expect(lineIds()).toEqual(['line-a', 'line-b']);
+    });
+
+    it('manages cast and sections through the bridge', () => {
+      renderScreen();
+
+      let speaker = { id: '', name: '', hasVoice: false };
+      act(() => {
+        speaker = handler().addSpeaker('Hopper', '#f0f');
+      });
+      expect(mockStore.getState().doc?.cast).toHaveLength(3);
+
+      act(() => {
+        handler().renameSpeaker(speaker.id, 'Grace Hopper');
+      });
+      expect(mockStore.getState().doc?.cast[2].name).toBe('Grace Hopper');
+
+      act(() => {
+        handler().removeSpeaker('speaker-a');
+      });
+      expect(mockStore.getState().doc?.sections[0].lines[0].speakerId).toBeNull();
+
+      act(() => {
+        handler().addSection('Act 3', 0);
+      });
+      expect(mockStore.getState().doc?.sections[0].title).toBe('Act 3');
+
+      act(() => {
+        handler().setSectionTitle('section-1', 'Opening');
+      });
+      expect(mockStore.getState().doc?.sections[1].title).toBe('Opening');
+
+      act(() => {
+        handler().removeSection('section-2');
+      });
+      expect(lineIds()).toEqual(['line-a', 'line-b']);
+    });
+
+    it('saves through the store and reports the new updatedAt', async () => {
+      renderScreen();
+
+      await expect(handler().save()).resolves.toEqual({
+        ok: true,
+        updatedAt: '2026-07-26T00:00:00Z',
+      });
+      expect(saveMock).toHaveBeenCalled();
+    });
+
+    it('surfaces a conflict as a thrown error the agent can report', async () => {
+      mockStore = makeStore({
+        dirty: true,
+        status: 'conflict',
+        error: 'Row was modified since it was read',
+      });
+      renderScreen();
+
+      await expect(handler().save()).rejects.toThrow(/modified since/);
+    });
+  });
+});

--- a/mobile/src/screens/__tests__/StoryboardEditorScreen.test.tsx
+++ b/mobile/src/screens/__tests__/StoryboardEditorScreen.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * Tests for StoryboardEditorScreen.
+ *
+ * The document store is replaced with a real (but network-free) Zustand store, so
+ * the screen exercises the same read/edit/save paths it does in the app without
+ * a tRPC client. The agent handler is reached through the real bridge, which is
+ * the contract the ui_storyboard_* tools depend on.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { create } from 'zustand';
+
+import StoryboardEditorScreen from '../StoryboardEditorScreen';
+import {
+  getDocumentHandler,
+  resetDocumentHandlers,
+} from '../../documents/agentBridge';
+import type {
+  StoryboardAgentHandler,
+  StoryboardDocument,
+} from '../../documents/storyboardTypes';
+import type { DocumentState } from '../../documents/documentStore';
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const ReactModule = require('react');
+    ReactModule.useEffect(callback, [callback]);
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../services/api', () => ({
+  apiService: {
+    resolveUrl: (path?: string | null) =>
+      path ? `https://example.test${path}` : null,
+  },
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      surface: '#111',
+      primary: '#6DB3F8',
+      primaryMuted: '#123',
+      text: '#fff',
+      textSecondary: '#aaa',
+      textTertiary: '#777',
+      textOnPrimary: '#fff',
+      border: '#222',
+      borderLight: '#333',
+      error: '#f00',
+      warning: '#fc0',
+      inputBg: '#222',
+      cardBg: '#111',
+      accent: '#a7f',
+      accentMuted: '#334',
+    },
+    shadows: { small: {}, medium: {}, large: {} },
+  }),
+}));
+
+const saveMock = jest.fn(async () => {});
+const loadMock = jest.fn(async () => {});
+const revertMock = jest.fn(async () => {});
+
+type TestState = DocumentState<StoryboardDocument>;
+
+const makeDocument = (
+  overrides: Partial<StoryboardDocument> = {}
+): StoryboardDocument => ({
+  screenplay: null,
+  shots: [
+    {
+      type: 'shot',
+      id: 'shot-a',
+      index: 0,
+      action: 'A lighthouse at dusk',
+      slug: 'Lighthouse',
+      status: 'planned',
+      keyframe: { type: 'image', uri: '/api/assets/key.png' },
+    },
+    {
+      type: 'shot',
+      id: 'shot-b',
+      index: 1,
+      action: 'Waves break on the rocks',
+      status: 'keyframe_ready',
+    },
+  ],
+  brief: 'A storm rolls in',
+  style: 'grainy 16mm',
+  entityIds: [],
+  aspectRatio: '16:9',
+  directorModel: null,
+  imageModel: null,
+  videoModel: null,
+  ...overrides,
+});
+
+let mockStore: ReturnType<typeof makeStore>;
+
+function makeStore(overrides: Partial<TestState> = {}) {
+  return create<TestState>((set, get) => ({
+    kind: 'storyboard',
+    id: 'sb-1',
+    doc: makeDocument(),
+    name: 'Test board',
+    revision: 3,
+    updatedAt: '2026-07-26T00:00:00Z',
+    dirty: false,
+    status: 'idle',
+    error: null,
+    load: loadMock,
+    edit: (mutate) => {
+      const current = get().doc;
+      if (current === null) {
+        return;
+      }
+      set({ doc: mutate(current), dirty: true });
+    },
+    rename: (name) => set({ name, dirty: true }),
+    save: saveMock,
+    revert: revertMock,
+    ...overrides,
+  }));
+}
+
+jest.mock('../../documents/documentStore', () => ({
+  documentStore: () => mockStore,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const route = { params: { id: 'sb-1', name: 'Test board' } };
+
+const renderScreen = () =>
+  render(
+    <StoryboardEditorScreen
+      navigation={navigation as never}
+      route={route as never}
+    />
+  );
+
+/** The header component the screen last handed to the navigator. */
+const renderHeaderRight = () => {
+  const calls = navigation.setOptions.mock.calls;
+  const options = calls[calls.length - 1][0] as {
+    headerRight: () => React.ReactElement;
+  };
+  const HeaderRight = options.headerRight;
+  return render(<HeaderRight />);
+};
+
+describe('StoryboardEditorScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDocumentHandlers();
+    mockStore = makeStore();
+  });
+
+  it('renders every shot from the loaded document', () => {
+    renderScreen();
+
+    expect(screen.getByDisplayValue('A lighthouse at dusk')).toBeTruthy();
+    expect(screen.getByDisplayValue('Waves break on the rocks')).toBeTruthy();
+    expect(screen.getByLabelText('Shot 1 action')).toBeTruthy();
+    expect(screen.getByLabelText('Shot 2 action')).toBeTruthy();
+  });
+
+  it('renders the board fields and the keyframe thumbnail', () => {
+    renderScreen();
+
+    expect(screen.getByDisplayValue('A storm rolls in')).toBeTruthy();
+    expect(screen.getByDisplayValue('grainy 16mm')).toBeTruthy();
+    expect(screen.getByDisplayValue('16:9')).toBeTruthy();
+    expect(screen.getByLabelText('Keyframe for shot 1').props.source).toEqual({
+      uri: 'https://example.test/api/assets/key.png',
+    });
+  });
+
+  it('loads the document when it is not in the store yet', () => {
+    mockStore = makeStore({ doc: null, status: 'loading' });
+
+    renderScreen();
+
+    expect(loadMock).toHaveBeenCalled();
+  });
+
+  it('marks the document dirty when a field is edited', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Board brief'), 'A calm morning');
+
+    expect(mockStore.getState().doc?.brief).toBe('A calm morning');
+    expect(mockStore.getState().dirty).toBe(true);
+    expect(screen.getByLabelText('Unsaved changes')).toBeTruthy();
+  });
+
+  it('edits a shot action in place', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Shot 2 action'), 'Rain on glass');
+
+    expect(mockStore.getState().doc?.shots[1].action).toBe('Rain on glass');
+  });
+
+  it('reorders shots with the move buttons and renumbers them', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Move shot 2 up'));
+
+    const shots = mockStore.getState().doc?.shots ?? [];
+    expect(shots.map((shot) => shot.id)).toEqual(['shot-b', 'shot-a']);
+    expect(shots.map((shot) => shot.index)).toEqual([0, 1]);
+  });
+
+  it('deletes a shot', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Delete shot 1'));
+
+    expect(mockStore.getState().doc?.shots.map((shot) => shot.id)).toEqual([
+      'shot-b',
+    ]);
+  });
+
+  it('adds a shot', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Add shot'));
+
+    expect(mockStore.getState().doc?.shots).toHaveLength(3);
+  });
+
+  it('saves through the store when the header button is pressed', () => {
+    mockStore = makeStore({ dirty: true });
+    renderScreen();
+
+    fireEvent.press(renderHeaderRight().getByLabelText('Save storyboard'));
+
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('disables the save button while the document is clean', () => {
+    renderScreen();
+
+    const button = renderHeaderRight().getByLabelText('Save storyboard');
+    fireEvent.press(button);
+
+    expect(button.props.accessibilityState.disabled).toBe(true);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a spinner on the save button while saving', () => {
+    mockStore = makeStore({ dirty: true, status: 'saving' });
+    renderScreen();
+
+    const header = renderHeaderRight();
+    expect(header.queryByText('Save')).toBeNull();
+    expect(
+      header.getByLabelText('Save storyboard').props.accessibilityState.disabled
+    ).toBe(true);
+  });
+
+  it('offers a reload on a save conflict', () => {
+    mockStore = makeStore({
+      dirty: true,
+      status: 'conflict',
+      error: 'Row was modified since it was read',
+    });
+    renderScreen();
+
+    expect(screen.getByLabelText('Storyboard changed elsewhere')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Reload storyboard'));
+
+    expect(revertMock).toHaveBeenCalled();
+  });
+
+  it('shows the agent-first empty state and routes to chat', () => {
+    mockStore = makeStore({ doc: makeDocument({ shots: [] }) });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Ask the assistant'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('Chat');
+  });
+
+  describe('agent handler', () => {
+    const handler = (): StoryboardAgentHandler =>
+      getDocumentHandler<StoryboardAgentHandler>('storyboard', 'sb-1');
+
+    it('registers on mount and unregisters on unmount', () => {
+      const view = renderScreen();
+
+      expect(handler().getSnapshot().shots).toHaveLength(2);
+
+      view.unmount();
+      expect(() => handler()).toThrow(/No storyboard "sb-1" is open/);
+    });
+
+    it('snapshots the board the way the tools report it', () => {
+      renderScreen();
+
+      const snapshot = handler().getSnapshot();
+      expect(snapshot).toMatchObject({
+        boardId: 'sb-1',
+        title: 'Test board',
+        brief: 'A storm rolls in',
+        style: 'grainy 16mm',
+        aspectRatio: '16:9',
+        hasScreenplay: false,
+        selectedShotId: null,
+      });
+      expect(snapshot.shots[0]).toMatchObject({
+        id: 'shot-a',
+        index: 0,
+        hasKeyframe: true,
+        hasClip: false,
+      });
+    });
+
+    it('repaints the screen when the agent adds a shot', () => {
+      renderScreen();
+
+      act(() => {
+        handler().addShot({ action: 'A gull crosses the beam', index: 0 });
+      });
+
+      expect(screen.getByDisplayValue('A gull crosses the beam')).toBeTruthy();
+      expect(mockStore.getState().doc?.shots[0].action).toBe(
+        'A gull crosses the beam'
+      );
+    });
+
+    it('resolves shot targets by id, index, and "selected"', () => {
+      renderScreen();
+
+      act(() => {
+        handler().selectShot('1');
+      });
+      expect(handler().getSnapshot().selectedShotId).toBe('shot-b');
+
+      act(() => {
+        handler().updateShot('selected', { slug: 'Rocks' });
+      });
+      expect(mockStore.getState().doc?.shots[1].slug).toBe('Rocks');
+
+      act(() => {
+        handler().updateShot('shot-a', { motion: 'slow push in' });
+      });
+      expect(mockStore.getState().doc?.shots[0].motion).toBe('slow push in');
+    });
+
+    it('throws a recoverable message for an unknown shot target', () => {
+      renderScreen();
+
+      expect(() => handler().updateShot('shot-zzz', { slug: 'x' })).toThrow(
+        /No shot matches "shot-zzz".*Shot ids: shot-a, shot-b/s
+      );
+    });
+
+    it('reorders and removes shots through the bridge', () => {
+      renderScreen();
+
+      act(() => {
+        handler().reorderShot('shot-b', 0);
+      });
+      expect(mockStore.getState().doc?.shots.map((shot) => shot.id)).toEqual([
+        'shot-b',
+        'shot-a',
+      ]);
+
+      act(() => {
+        handler().removeShot('0');
+      });
+      expect(mockStore.getState().doc?.shots.map((shot) => shot.id)).toEqual([
+        'shot-a',
+      ]);
+    });
+
+    it('saves through the store and reports the new updatedAt', async () => {
+      renderScreen();
+
+      await expect(handler().save()).resolves.toEqual({
+        ok: true,
+        updatedAt: '2026-07-26T00:00:00Z',
+      });
+      expect(saveMock).toHaveBeenCalled();
+    });
+
+    it('surfaces a conflict as a thrown error the agent can report', async () => {
+      mockStore = makeStore({
+        dirty: true,
+        status: 'conflict',
+        error: 'Row was modified since it was read',
+      });
+      renderScreen();
+
+      await expect(handler().save()).rejects.toThrow(/modified since/);
+    });
+  });
+});

--- a/mobile/src/screens/__tests__/StoryboardEditorScreen.test.tsx
+++ b/mobile/src/screens/__tests__/StoryboardEditorScreen.test.tsx
@@ -112,7 +112,7 @@ function makeStore(overrides: Partial<TestState> = {}) {
     id: 'sb-1',
     doc: makeDocument(),
     name: 'Test board',
-    revision: 3,
+    token: 3,
     updatedAt: '2026-07-26T00:00:00Z',
     dirty: false,
     status: 'idle',

--- a/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
@@ -3,6 +3,8 @@ import { StyleSheet } from 'react-native';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
+import { makeClipVersion } from '@nodetool-ai/timeline';
+
 import TimelineViewerScreen from '../TimelineViewerScreen';
 import type { RootStackParamList } from '../../navigation/types';
 import { resetDocumentStores } from '../../documents/documentStore';
@@ -25,10 +27,14 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockRead = jest.fn();
+const mockUpdate = jest.fn();
 
 jest.mock('../../trpc/client', () => ({
   createMobileTRPCClient: () => ({
-    resources: { read: { query: (input: unknown) => mockRead(input) } },
+    resources: {
+      read: { query: (input: unknown) => mockRead(input) },
+      update: { mutate: (input: unknown) => mockUpdate(input) },
+    },
   }),
 }));
 
@@ -54,7 +60,25 @@ const sequence: TimelineDocument = {
       provider: 'fal',
       model: 'flux',
       currentAssetId: 'asset-1',
-      versions: [{ id: 'v1' }, { id: 'v2' }],
+      versions: [{
+        id: 'v1',
+        createdAt: '2026-07-01T00:00:00Z',
+        jobId: 'job-v1',
+        assetId: 'asset-1',
+        workflowUpdatedAt: '2026-07-01T00:00:00Z',
+        dependencyHash: 'hash-v1',
+        paramOverridesSnapshot: {},
+        status: 'success',
+      }, {
+        id: 'v2',
+        createdAt: '2026-07-01T00:00:00Z',
+        jobId: 'job-v2',
+        assetId: 'asset-2',
+        workflowUpdatedAt: '2026-07-01T00:00:00Z',
+        dependencyHash: 'hash-v2',
+        paramOverridesSnapshot: {},
+        status: 'success',
+      }],
     },
     {
       id: 'c2',
@@ -100,6 +124,51 @@ const widthOf = (label: string): number | undefined => {
   const style = StyleSheet.flatten(screen.getByLabelText(label).props.style);
   return typeof style.width === 'number' ? style.width : undefined;
 };
+
+/**
+ * The header lives in navigation options rather than in the screen's own tree,
+ * so the Save button is read off the last `setOptions` call. The element is
+ * walked instead of rendered: a second `render()` would unmount the screen the
+ * assertions are about.
+ */
+const findByLabel = (
+  node: React.ReactNode,
+  label: string
+): React.ReactElement<Record<string, unknown>> | null => {
+  if (!React.isValidElement(node)) {
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        const hit = findByLabel(child as React.ReactNode, label);
+        if (hit) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+  const props = node.props as Record<string, unknown>;
+  if (props.accessibilityLabel === label) {
+    return node as React.ReactElement<Record<string, unknown>>;
+  }
+  return findByLabel(props.children as React.ReactNode, label);
+};
+
+const headerButton = (label: string): Record<string, unknown> => {
+  const calls = (navigation.setOptions as jest.Mock).mock.calls as [
+    { headerRight?: () => React.ReactElement },
+  ][];
+  const headerRight = calls[calls.length - 1][0].headerRight;
+  if (headerRight === undefined) {
+    throw new Error('the screen set no headerRight');
+  }
+  const found = findByLabel(headerRight(), label);
+  if (found === null) {
+    throw new Error(`no header button labelled "${label}"`);
+  }
+  return found.props;
+};
+
+const saveButton = () => headerButton('Save timeline');
 
 describe('TimelineViewerScreen', () => {
   beforeEach(() => {
@@ -196,7 +265,11 @@ describe('TimelineViewerScreen', () => {
 
     renderScreen();
 
-    expect(await screen.findByText('This sequence has no clips yet.')).toBeTruthy();
+    expect(await screen.findByText(/This sequence has no clips yet/)).toBeTruthy();
+    // The empty state has to say the screen is not touch-editable, and point at
+    // the thing that is.
+    expect(screen.getByText(/ask the assistant to change the sequence/)).toBeTruthy();
+    expect(screen.getByLabelText('Ask the assistant')).toBeTruthy();
   });
 
   it('shows the error with a retry that reloads', async () => {
@@ -208,5 +281,157 @@ describe('TimelineViewerScreen', () => {
 
     await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('Video 1')).toBeTruthy();
+  });
+  // ── Agent edits and saving ───────────────────────────────────────────────
+
+  it('starts clean with Save disabled, and enables it after an agent edit', async () => {
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    expect(saveButton().accessibilityState).toEqual({ disabled: true });
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.moveClip('Opening shot', { startMs: 3000 });
+    });
+
+    // The edit repaints the screen the user is holding.
+    expect(screen.getByLabelText(/^Clip Opening shot, video, 0:03/)).toBeTruthy();
+    expect(screen.getByLabelText('Unsaved changes')).toBeTruthy();
+    expect(saveButton().accessibilityState).toEqual({ disabled: false });
+    expect(handler.getSnapshot().dirty).toBe(true);
+  });
+
+  it('saves through the same path as the Save button', async () => {
+    mockUpdate.mockResolvedValue(detail(sequence));
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.addMarker({ timeMs: 5000, label: 'Beat' });
+    });
+
+    await act(async () => {
+      (saveButton().onPress as () => void)();
+    });
+
+    // The revision read on load is echoed back so a stale write is rejected.
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: { kind: 'timeline', id: SEQ_ID, revision: 3 } })
+    );
+    const written = mockUpdate.mock.calls[0][0] as {
+      document: TimelineDocument;
+    };
+    expect(written.document.markers).toHaveLength(2);
+    expect(screen.queryByLabelText('Unsaved changes')).toBeNull();
+  });
+
+  it('ui_timeline_save rethrows when the write is rejected', async () => {
+    mockUpdate.mockRejectedValue(new Error('Sequence was modified concurrently'));
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.addMarker({ timeMs: 5000, label: 'Beat' });
+    });
+
+    await expect(handler.save()).rejects.toThrow(/modified concurrently/);
+
+    // And the user gets a way out that does not just retry into the same wall.
+    expect(await screen.findByLabelText('Timeline changed elsewhere')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Reload timeline'));
+    await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not reload over unsaved edits when the screen remounts', async () => {
+    const view = renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    act(() => {
+      getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID).addMarker({
+        timeMs: 5000,
+      });
+    });
+    view.unmount();
+
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    // Still one read: a fresh fetch would have discarded the agent's edit.
+    expect(mockRead).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Unsaved changes')).toBeTruthy();
+  });
+
+  it('keeps the failed edits on screen when a save fails', async () => {
+    mockUpdate.mockRejectedValue(new Error('Disk full'));
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.addTextClip({ text: 'Chapter One' });
+    });
+    await act(async () => {
+      await expect(handler.save()).rejects.toThrow(/Disk full/);
+    });
+
+    // The banner reports it; the timeline (and the new clip) stay visible.
+    expect(screen.getByText('Disk full')).toBeTruthy();
+    expect(screen.getByLabelText(/^Clip Chapter One, text/)).toBeTruthy();
+  });
+
+  it('refuses to split a transcript-owned clip, naming the line', async () => {
+    mockRead.mockResolvedValue(
+      detail({
+        ...sequence,
+        transcript: [
+          {
+            id: 'line-1',
+            text: 'And then we cut away.',
+            beatStartMs: 0,
+            clipIds: ['c1'],
+          },
+        ],
+      })
+    );
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+
+    expect(() => handler.splitClip('c1', 2000)).toThrow(
+      /transcript line "And then we cut away\." \(line-1\)/
+    );
+    expect(handler.getSnapshot().dirty).toBe(false);
+  });
+
+  it('splits at the playhead when no time is given', async () => {
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.seek(2500);
+    });
+    const halves = handler.splitClip('c1');
+
+    expect(halves.map((clip) => [clip.startMs, clip.durationMs])).toEqual([
+      [0, 2500],
+      [2500, 1500],
+    ]);
+  });
+
+  it('renames the document', async () => {
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    act(() => {
+      handler.rename('Trailer v2');
+    });
+
+    expect(handler.getSnapshot()).toMatchObject({ title: 'Trailer v2', dirty: true });
   });
 });

--- a/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import TimelineViewerScreen from '../TimelineViewerScreen';
+import type { RootStackParamList } from '../../navigation/types';
+import { resetDocumentStores } from '../../documents/documentStore';
+import { getDocumentHandler, resetDocumentHandlers } from '../../documents/agentBridge';
+import type {
+  TimelineAgentHandler,
+  TimelineDocument,
+} from '../../documents/timelineTypes';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// The stack's focus effect reduces to a plain effect in tests.
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    const react = require('react');
+    react.useEffect(effect, [effect]);
+  },
+}));
+
+const mockRead = jest.fn();
+
+jest.mock('../../trpc/client', () => ({
+  createMobileTRPCClient: () => ({
+    resources: { read: { query: (input: unknown) => mockRead(input) } },
+  }),
+}));
+
+const SEQ_ID = 'seq-1';
+
+const sequence: TimelineDocument = {
+  tracks: [
+    { id: 't1', name: 'Video 1', type: 'video', index: 0, visible: true, locked: false },
+    { id: 't2', name: 'Music', type: 'audio', index: 1, visible: true, locked: false },
+  ],
+  clips: [
+    {
+      id: 'c1',
+      trackId: 't1',
+      name: 'Opening shot',
+      startMs: 0,
+      durationMs: 4000,
+      mediaType: 'video',
+      sourceType: 'generated',
+      status: 'generated',
+      locked: false,
+      prompt: 'a fox in snow',
+      provider: 'fal',
+      model: 'flux',
+      currentAssetId: 'asset-1',
+      versions: [{ id: 'v1' }, { id: 'v2' }],
+    },
+    {
+      id: 'c2',
+      trackId: 't2',
+      name: 'Theme',
+      startMs: 1000,
+      durationMs: 8000,
+      mediaType: 'audio',
+      sourceType: 'imported',
+      status: 'draft',
+      locked: false,
+      versions: [],
+    },
+  ],
+  markers: [{ id: 'm1', timeMs: 2000, label: 'Cut' }],
+};
+
+const detail = (doc: TimelineDocument) => ({
+  ref: { kind: 'timeline', id: SEQ_ID, revision: 3 },
+  name: 'My Sequence',
+  document: doc,
+  updatedAt: '2026-07-01T00:00:00.000Z',
+});
+
+type Props = NativeStackScreenProps<RootStackParamList, 'TimelineViewer'>;
+
+const navigation = {
+  setOptions: jest.fn(),
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+} as unknown as Props['navigation'];
+
+const route = {
+  key: 'TimelineViewer-1',
+  name: 'TimelineViewer',
+  params: { id: SEQ_ID, name: 'Seed name' },
+} as Props['route'];
+
+const renderScreen = () =>
+  render(<TimelineViewerScreen navigation={navigation} route={route} />);
+
+const widthOf = (label: string): number | undefined => {
+  const style = StyleSheet.flatten(screen.getByLabelText(label).props.style);
+  return typeof style.width === 'number' ? style.width : undefined;
+};
+
+describe('TimelineViewerScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDocumentStores();
+    resetDocumentHandlers();
+    mockRead.mockResolvedValue(detail(sequence));
+  });
+
+  it('loads the document and renders a lane per track with its clips', async () => {
+    renderScreen();
+
+    await waitFor(() => expect(mockRead).toHaveBeenCalledWith({
+      ref: { kind: 'timeline', id: SEQ_ID },
+    }));
+
+    expect(await screen.findByText('Video 1')).toBeTruthy();
+    expect(screen.getByText('Music')).toBeTruthy();
+    expect(screen.getByLabelText('Seek on track Video 1')).toBeTruthy();
+    expect(screen.getByLabelText(/^Clip Opening shot, video/)).toBeTruthy();
+    expect(screen.getByLabelText(/^Clip Theme, audio/)).toBeTruthy();
+    expect(screen.getByLabelText('Marker Cut at 0:02')).toBeTruthy();
+    // Duration comes from the clips: 1000 + 8000.
+    expect(screen.getByText('0:09 · 2 tracks · 2 clips')).toBeTruthy();
+  });
+
+  it('shows the clip detail panel when a clip is tapped', async () => {
+    renderScreen();
+
+    fireEvent.press(await screen.findByLabelText(/^Clip Opening shot/));
+
+    expect(screen.getByLabelText('Close clip details')).toBeTruthy();
+    expect(screen.getByText('a fox in snow')).toBeTruthy();
+    expect(screen.getByText('fal / flux')).toBeTruthy();
+    expect(screen.getByText('0:00 – 0:04 (0:04)')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Close clip details'));
+
+    expect(screen.queryByLabelText('Close clip details')).toBeNull();
+  });
+
+  it('zooming changes the pixel width of a clip', async () => {
+    renderScreen();
+
+    await screen.findByLabelText(/^Clip Opening shot/);
+    const initial = widthOf('Clip Opening shot, video, 0:00 to 0:04');
+    expect(initial).toBe(80);
+
+    fireEvent.press(screen.getByLabelText('Zoom in'));
+    expect(widthOf('Clip Opening shot, video, 0:00 to 0:04')).toBe(160);
+
+    fireEvent.press(screen.getByLabelText('Zoom out'));
+    fireEvent.press(screen.getByLabelText('Zoom out'));
+    expect(widthOf('Clip Opening shot, video, 0:00 to 0:04')).toBe(40);
+  });
+
+  it('tapping a lane moves the playhead', async () => {
+    renderScreen();
+
+    fireEvent.press(await screen.findByLabelText('Seek on track Video 1'), {
+      nativeEvent: { locationX: 40 },
+    });
+
+    // 40px at the default 20px/s is 2s.
+    expect(screen.getByText('0:02')).toBeTruthy();
+  });
+
+  it('exposes an agent handler while mounted and removes it on unmount', async () => {
+    const view = renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    expect(handler.getSnapshot()).toMatchObject({
+      sequenceId: SEQ_ID,
+      title: 'My Sequence',
+      durationMs: 9000,
+      trackCount: 2,
+      clipCount: 2,
+      markers: [{ id: 'm1', timeMs: 2000, label: 'Cut' }],
+    });
+
+    act(() => {
+      handler.selectClip('Theme');
+    });
+    expect(screen.getByLabelText('Close clip details')).toBeTruthy();
+
+    view.unmount();
+    expect(() => getDocumentHandler('timeline', SEQ_ID)).toThrow(/is open/);
+  });
+
+  it('shows an empty state when the sequence has no clips', async () => {
+    mockRead.mockResolvedValue(detail({ tracks: sequence.tracks, clips: [], markers: [] }));
+
+    renderScreen();
+
+    expect(await screen.findByText('This sequence has no clips yet.')).toBeTruthy();
+  });
+
+  it('shows the error with a retry that reloads', async () => {
+    mockRead.mockRejectedValueOnce(new Error('Sequence not found'));
+
+    renderScreen();
+
+    fireEvent.press(await screen.findByLabelText('Retry loading timeline'));
+
+    await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Video 1')).toBeTruthy();
+  });
+});

--- a/mobile/src/stores/ChatStore.ts
+++ b/mobile/src/stores/ChatStore.ts
@@ -26,6 +26,13 @@ import {
   LanguageModel,
 } from '../types';
 import type { MediaGenerationRequest } from './MediaGenerationStore';
+import { buildUiContext } from '../documents/uiContext';
+import { MobileToolRegistry } from '../documents/tools/registry';
+import {
+  executeToolCall,
+  isToolCallMessage,
+} from '../documents/tools/executeToolCall';
+import '../documents/tools';
 
 interface ChatState {
   // Connection state
@@ -93,6 +100,21 @@ function handleWebSocketMessage(
     if (!['generation_stopped', 'error', 'job_update'].includes(msgType)) {
       return;
     }
+  }
+
+  // Client-side tool call. Handled before the switch because `tool_call` is a
+  // request/response exchange rather than a state update, and because the
+  // result must go back even for a tool we don't have.
+  // `data` is typed as the set of state-update messages, which `tool_call` is
+  // deliberately not part of — widen before narrowing.
+  const incoming: unknown = data;
+  if (isToolCallMessage(incoming)) {
+    const { wsManager } = state;
+    if (wsManager) {
+      set({ statusMessage: `Running ${incoming.name}` });
+      void executeToolCall(incoming, wsManager);
+    }
+    return;
   }
 
   switch (data.type) {
@@ -298,8 +320,24 @@ export const useChatStore = create<ChatState>((set, get) => ({
       timeoutInterval: 30000,
     });
 
+    // Advertise the client-side `ui_*` tools. The server exposes whatever the
+    // manifest lists for the life of the connection, so it has to be re-sent on
+    // every reconnect — not just the first open.
+    const sendToolManifest = (): void => {
+      const tools = MobileToolRegistry.getManifest();
+      if (tools.length === 0) {
+        return;
+      }
+      try {
+        wsManager.send({ type: 'client_tools_manifest', tools });
+      } catch (error) {
+        console.error('Failed to send tool manifest:', error);
+      }
+    };
+
     // Set up callbacks
     wsManager.setCallbacks({
+      onOpen: sendToolManifest,
       onStateChange: (newState: ConnectionState) => {
         const currentState = get();
         // Don't override loading/streaming status when WebSocket events occur
@@ -422,6 +460,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         ? stateForSend.selectedTools
         : undefined,
       media_generation: mediaGeneration,
+      // Which document ids the `ui_*` tools may address. Omitted when nothing
+      // is open, so a plain chat turn stays unchanged.
+      ui_context: buildUiContext(),
     };
 
     // Cancel any prior safety timeout — otherwise rapid sends accumulate

--- a/mobile/src/stores/__tests__/ChatStore.agentTools.test.ts
+++ b/mobile/src/stores/__tests__/ChatStore.agentTools.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The chat store's half of the agent tool contract: advertise the client tools
+ * on every open, dispatch an incoming `tool_call`, and attach `ui_context` to
+ * outgoing turns.
+ */
+
+import { useChatStore } from '../ChatStore';
+import { WebSocketManager } from '../../services/WebSocketManager';
+import {
+  registerDocumentHandler,
+  resetDocumentHandlers,
+  setFocusedDocument,
+} from '../../documents/agentBridge';
+import { MobileToolRegistry } from '../../documents/tools/registry';
+
+jest.mock('../../services/WebSocketManager', () => ({
+  WebSocketManager: jest.fn(),
+}));
+
+jest.mock('../../services/api', () => ({
+  apiService: {
+    getWebSocketUrl: jest.fn().mockReturnValue('ws://localhost:7777/ws'),
+  },
+}));
+
+interface Callbacks {
+  onOpen?: () => void;
+  onMessage?: (data: unknown) => void;
+}
+
+describe('ChatStore agent tool wiring', () => {
+  let socket: {
+    connect: jest.Mock;
+    disconnect: jest.Mock;
+    destroy: jest.Mock;
+    send: jest.Mock;
+    isConnected: jest.Mock;
+    setCallbacks: jest.Mock;
+    getState: jest.Mock;
+  };
+  let callbacks: Callbacks;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDocumentHandlers();
+
+    useChatStore.setState({
+      status: 'disconnected',
+      statusMessage: null,
+      error: null,
+      wsManager: null,
+      threads: {},
+      currentThreadId: null,
+      messageCache: {},
+      isLoadingMessages: false,
+    });
+
+    callbacks = {};
+    socket = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn(),
+      destroy: jest.fn(),
+      send: jest.fn(),
+      isConnected: jest.fn().mockReturnValue(true),
+      setCallbacks: jest.fn((next: Callbacks) => {
+        callbacks = next;
+      }),
+      getState: jest.fn().mockReturnValue('connected'),
+    };
+    (WebSocketManager as unknown as jest.Mock).mockImplementation(() => socket);
+  });
+
+  afterEach(() => {
+    // `sendMessage` arms a five-minute response timeout. Disconnecting clears
+    // it; left running it holds the Jest process open after the suite passes.
+    useChatStore.getState().disconnect();
+  });
+
+  /** The messages of one type the store pushed onto the socket. */
+  const sentOfType = <T,>(type: string): T[] =>
+    socket.send.mock.calls
+      .map((call) => call[0] as { type: string })
+      .filter((message) => message.type === type) as T[];
+
+  it('advertises the ui_* tools when the socket opens', async () => {
+    await useChatStore.getState().connect();
+
+    callbacks.onOpen?.();
+
+    const [manifest] = sentOfType<{ tools: { name: string }[] }>(
+      'client_tools_manifest'
+    );
+    expect(manifest).toBeDefined();
+    const names = manifest.tools.map((tool) => tool.name);
+    expect(names).toContain('ui_storyboard_get_state');
+    expect(names).toContain('ui_timeline_get_state');
+  });
+
+  it('re-advertises on every open, so a reconnect does not lose the tools', async () => {
+    await useChatStore.getState().connect();
+
+    callbacks.onOpen?.();
+    callbacks.onOpen?.();
+
+    expect(sentOfType('client_tools_manifest')).toHaveLength(2);
+  });
+
+  it('answers a tool_call with a tool_result on the same id', async () => {
+    await useChatStore.getState().connect();
+    registerDocumentHandler('storyboard', 'sb1', 'Board', {
+      getSnapshot: () => ({ boardId: 'sb1', shots: [] }),
+    });
+
+    callbacks.onMessage?.({
+      type: 'tool_call',
+      tool_call_id: 'call-7',
+      name: 'ui_storyboard_get_state',
+      args: { storyboard_id: 'sb1' },
+      thread_id: 'thread-1',
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const [result] = sentOfType<{ tool_call_id: string; ok: boolean }>(
+      'tool_result'
+    );
+    expect(result).toMatchObject({ tool_call_id: 'call-7', ok: true });
+  });
+
+  it('reports the failure when the addressed document is not open', async () => {
+    await useChatStore.getState().connect();
+
+    callbacks.onMessage?.({
+      type: 'tool_call',
+      tool_call_id: 'call-8',
+      name: 'ui_storyboard_get_state',
+      args: { storyboard_id: 'missing' },
+      thread_id: 'thread-1',
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const [result] = sentOfType<{ ok: boolean; error: string }>('tool_result');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/No storyboard "missing" is open/);
+  });
+
+  it('does not treat a tool_call as a chat message', async () => {
+    await useChatStore.getState().connect();
+    useChatStore.setState({ currentThreadId: 'thread-1' });
+
+    callbacks.onMessage?.({
+      type: 'tool_call',
+      tool_call_id: 'call-9',
+      name: 'ui_unknown',
+      args: {},
+      thread_id: 'thread-1',
+    });
+    await Promise.resolve();
+
+    expect(useChatStore.getState().messageCache['thread-1']).toBeUndefined();
+  });
+
+  it('attaches the open documents to an outgoing turn', async () => {
+    await useChatStore.getState().connect();
+    useChatStore.setState({ currentThreadId: 'thread-1' });
+    registerDocumentHandler('storyboard', 'sb1', 'Chase scene', {});
+    setFocusedDocument('storyboard', 'sb1');
+
+    await useChatStore
+      .getState()
+      .sendMessage([{ type: 'text', text: 'add a shot' }], 'add a shot');
+
+    const [turn] = sentOfType<{
+      ui_context?: {
+        open: { type: string; id: string; title: string }[];
+        focused: { id: string } | null;
+      };
+    }>('message');
+    expect(turn.ui_context?.open).toEqual([
+      { type: 'storyboard', id: 'sb1', title: 'Chase scene' },
+    ]);
+    expect(turn.ui_context?.focused).toMatchObject({ id: 'sb1' });
+  });
+
+  it('omits ui_context when no document is open', async () => {
+    await useChatStore.getState().connect();
+    useChatStore.setState({ currentThreadId: 'thread-1' });
+
+    await useChatStore
+      .getState()
+      .sendMessage([{ type: 'text', text: 'hello' }], 'hello');
+
+    const [turn] = sentOfType<{ ui_context?: unknown }>('message');
+    expect(turn.ui_context).toBeUndefined();
+  });
+
+  it('registers no tool outside the ui_ namespace', () => {
+    for (const name of MobileToolRegistry.names()) {
+      expect(name.startsWith('ui_')).toBe(true);
+    }
+  });
+});

--- a/mobile/src/types/chat.ts
+++ b/mobile/src/types/chat.ts
@@ -5,6 +5,7 @@
 
 import { Message, MessageContent, LanguageModel, Thread, Chunk, JobUpdate, NodeUpdate, NodeProgress, OutputUpdate } from './ApiTypes';
 import type { MediaGenerationRequest } from '../stores/MediaGenerationStore';
+import type { UiContextPayload } from '../documents/uiContext';
 
 // Re-export types we use directly
 export type { Message, LanguageModel, Thread, Chunk };
@@ -104,6 +105,8 @@ export interface ChatMessageRequest {
   agent_mode?: boolean;
   help_mode?: boolean;
   media_generation?: MediaGenerationRequest;
+  /** Open/focused document ids the agent's `ui_*` tools may address. */
+  ui_context?: UiContextPayload;
 }
 
 /**

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -24,6 +24,12 @@
       ],
       "@nodetool-ai/app-runtime": [
         "../packages/app-runtime/src/index.ts"
+      ],
+      "@nodetool-ai/timeline": [
+        "../packages/timeline/src/index.ts"
+      ],
+      "@nodetool-ai/gpu": [
+        "../packages/gpu/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
Ports the document UX from web to `mobile/`: users can browse and open every document kind, load and save them, and drive edits through the chat agent.

## No tabs

Web keys its whole document surface off `WorkspaceTabType` and keeps every tab mounted at once. On a phone the navigation stack *is* the tab model — one document per pushed screen, the top of the stack is the focused one. That drops the tab store, the `openTab` indirection, and the per-surface `active` prop, and keeps the parts that never depended on focus (the agent bridge keys by document id, so it ports unchanged).

## Surfaces

| Kind | Touch surface | Agent-editable |
|---|---|---|
| Storyboard | Editor — brief/style/aspect ratio, shot list with keyframe thumbnails, reorder, add/delete | yes |
| Script | Editor — cast, sections, lines, derived draft/voiced/stale status | yes |
| Timeline | Viewer — track lanes on a zoomable axis, playhead, markers, clip detail | yes |
| Sketch (and any future kind) | Fallback viewer, so every document can be opened | no |

`surface` and `agentEditable` are tracked separately because they are genuinely different questions. The timeline has no touch editor — placing a cut accurately with a thumb is not possible at phone width — but "move the title card two seconds later" is a sentence, so the agent gets the full set of structural edits and the user gets a Save button for the result.

Reordering uses move up/down buttons: `mobile/` has no `react-native-gesture-handler` or `reanimated`, and this adds no dependencies.

## Load and save

`documentStore` holds one store per open document, cached by kind + id, with the body, name, concurrency token, and dirty flag. A save echoes back the token it read, so the server rejects a stale write instead of applying it; that surfaces as a Reload banner rather than a generic failure.

**Two transports, one interface.** Three kinds ride the `resources.*` envelope, whose token is a numeric `revision`. Scripts cannot: the `scripts` table has no `revision` column, so the provider's conflict check would compare `undefined` to `undefined`, pass, and silently clobber concurrent writes. Adding the column means migrating two schemas, and the same one-line enum edit would also make `{kind:"script"}` a legal resource binding in every app document — a product-surface expansion. Their own router already does the job with `baseUpdatedAt`, so `backends.ts` makes the token **opaque**: a backend hands one out on read and echoes it back on write, and only it knows the shape.

Two races the store handles, because the user's Save button and an agent's `ui_*_save` land in the same place:

- **Writes are serialized.** Two concurrent saves would carry the same token, the server would commit the first and reject the second, and the user would be told "someone else changed this" about two of their own edits.
- **A save only marks the document clean if nothing changed while it was in flight.** Otherwise an agent edit arriving mid-save would be marked saved, disabling Save and losing the edit on reload.

## Agent-first

1. On every socket open — including reconnects — the chat store sends `client_tools_manifest`.
2. Each turn carries `ui_context` (open documents, focused one, selection). Every tool takes a **required** document id with no "act on whatever is mounted" fallback, so this block is the only thing that tells the agent which ids are valid.
3. The server sends `tool_call`; `executeToolCall` runs it against the handler the mounted screen registered and replies `tool_result` — always, including for unknown tools, so the agent is never left waiting.
4. Handlers mutate the same store the screen renders from, so an agent edit repaints immediately and `ui_*_save` is the Save button's code path.

Tools are scoped by one rule: pure document edits ship, anything that dispatches a long paid job or needs a browser stays on desktop where its progress can be supervised. So storyboards get shot editing but not generation or timeline assembly; scripts get cast/section/line editing but not TTS voicing, subtitle export, or send-to-timeline; timelines get structural edits but not clip generation or frame extraction. Each description says which side of that line it is on, so the agent doesn't promise what it can't do.

## Timeline edits are link-aware

A video clip and the audio extracted from it share a `linkId` and must move, trim, split, and delete together. Web's own agent handlers take a `patchClip` shortcut that bypasses the link-aware store methods and **desyncs the pair** — so `timelineEdits.ts` ports the logic from web's store rather than its bridge. A split mints a fresh `linkId` per side so neither becomes a three-member group; a delete unlinks survivors below two members; a group move clamps the delta once for the group so a move against t=0 preserves internal spacing.

Anything touching a generation input marks the clip `stale`. An edit that would orphan a `transcript[].clipIds` reference is **refused** naming the line — web re-flows the transcript in 795 lines of code, and a clear refusal beats a dangling pointer.

`splitClip`/`trimClip` come from `@nodetool-ai/timeline`, now compiled from source like `app-runtime` (metro/tsconfig/jest all updated together). Split also partitions animations by role, rebases clip-local caption words, and clears the fades and transition the halves must not inherit; hand-rolling that would get it wrong. Its id factory calls `crypto.randomUUID`, which Hermes lacks, so a polyfill over `uuid` is installed in `index.ts`.

One trap worth recording: `aspectRatio` and `resolution` exist on the engine's clip type but not in `packages/protocol/src/api-schemas/timeline.ts`, so writing them would be silently stripped on PATCH. They are deliberately excluded.

## Testing

- `npx tsc --noEmit` clean.
- `npx oxlint src` clean (one pre-existing `curly` warning in `ChatStore.ts`, unrelated).
- `npx jest` — 45 suites / 710 tests pass, 275 of them new: the store's load/save/conflict/serialization behaviour, both transports, the bridge and `ui_context`, the `tool_call` round trip, the link-aware timeline edits (63 cases) and their invariants, script status derivation and target resolution, every `ui_*` tool's delegation, and all five screens.

No dependencies added; no changes outside `mobile/` except the `CLAUDE.md` pointer.