### PR TITLE
Fix AtlasCloud "Cannot resolve image asset" on empty and non-URL image refs

### DIFF
--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -16,9 +16,11 @@ import {
   registerDeclaredProperty
 } from "@nodetool-ai/node-sdk";
 import type { NodeClass, PropOptions } from "@nodetool-ai/node-sdk";
-import { mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
+import { loadMediaRefBytes, mapPromptAssetsToInputs } from "@nodetool-ai/runtime";
 import type {
   AssetMediaKind,
+  MediaRefValue,
+  ProcessingContext,
   PromptAssetInputField,
   PromptAssetTextField
 } from "@nodetool-ai/runtime";
@@ -76,6 +78,13 @@ export interface AtlasManifestEntry {
 
 const ASSET_TYPES = new Set<AtlasFieldType>(["image", "video", "audio"]);
 const LIST_ASSET_RE = /^list\[(image|video|audio)\]$/;
+
+/**
+ * In-flight raw-RGBA images (protocol `RAW_RGBA_MIME`) carry straight-alpha
+ * pixels in `data`, not an encoded file. `loadMediaRefBytes` PNG-encodes them,
+ * so the outgoing data URI must say `image/png` rather than the ref's mime.
+ */
+const RAW_RGBA_MIME = "image/x-raw-rgba";
 
 type AssetRef = {
   uri?: string;
@@ -261,6 +270,40 @@ function defaultMimeFor(fieldType: "image" | "video" | "audio"): string {
   return "image/png";
 }
 
+/** Mime for bytes we resolved ourselves, with the raw-RGBA case mapped to PNG. */
+function resolvedMime(
+  ref: AssetRef,
+  fieldType: "image" | "video" | "audio"
+): string {
+  const mime = guessMime(ref, defaultMimeFor(fieldType));
+  return mime === RAW_RGBA_MIME ? "image/png" : mime;
+}
+
+/** True for a raw-RGBA in-flight image: pixels in `data`, no encoded file. */
+function isRawRgba(ref: AssetRef): boolean {
+  return (
+    (ref.mime_type ?? ref.mimeType) === RAW_RGBA_MIME &&
+    ref.data instanceof Uint8Array
+  );
+}
+
+/**
+ * True when a ref carries no source at all: every slot blank. The UI sends a
+ * fully-shaped ref for an asset input the user left empty
+ * (`{ type: "image", uri: "", asset_id: null, data: null }`), which is an
+ * absent optional input — not something to fail the node over.
+ */
+function isEmptyAssetRef(ref: AssetRef): boolean {
+  if (typeof ref.uri === "string" && ref.uri.trim() !== "") return false;
+  if (typeof ref.data === "string" && ref.data.length > 0) return false;
+  if (ref.data instanceof Uint8Array && ref.data.byteLength > 0) return false;
+  return ref.asset_id == null || ref.asset_id === "";
+}
+
+function isHttpUri(uri: unknown): boolean {
+  return typeof uri === "string" && /^https?:\/\//i.test(uri);
+}
+
 /**
  * Resolve a NodeTool asset ref (ImageRef/VideoRef/AudioRef) to something the
  * AtlasCloud API accepts: either a public HTTPS URL or a `data:<mime>;base64,...`
@@ -273,21 +316,36 @@ export async function resolveAssetForAtlas(
 ): Promise<string | null> {
   if (!ref) return null;
 
-  // Bare URL string the user pasted in.
+  // Bare string the user pasted in: a public URL, or a data: URI which is
+  // already the exact shape the API wants.
   if (typeof ref === "string") {
+    if (ref.startsWith("data:")) return ref;
     return looksLikePublicUrl(ref) ? ref : null;
   }
 
   if (typeof ref !== "object") return null;
   const r = ref as AssetRef;
 
-  if (looksLikePublicUrl(r.uri)) return r.uri as string;
+  // An asset input left empty is an absent optional input, not a broken one.
+  if (isEmptyAssetRef(r)) return null;
 
-  if (typeof r.data === "string" && r.data.length > 0) {
-    return `data:${guessMime(r, defaultMimeFor(fieldType))};base64,${r.data}`;
-  }
-  if (r.data instanceof Uint8Array && r.data.byteLength > 0) {
-    return bytesToDataUri(r.data, guessMime(r, defaultMimeFor(fieldType)));
+  if (looksLikePublicUrl(r.uri)) return r.uri as string;
+  // Read uri fresh from ref: the looksLikePublicUrl predicate above narrowed
+  // r.uri away, so a typeof check re-establishes the string type here.
+  const rawUri = (ref as AssetRef).uri;
+  if (typeof rawUri === "string" && rawUri.startsWith("data:")) return rawUri;
+
+  // Inline bytes, except raw-RGBA pixels — those are not an encoded image and
+  // must go through the canonical resolver's PNG encoder below.
+  if (!isRawRgba(r)) {
+    if (typeof r.data === "string" && r.data.length > 0) {
+      return r.data.startsWith("data:")
+        ? r.data
+        : `data:${resolvedMime(r, fieldType)};base64,${r.data}`;
+    }
+    if (r.data instanceof Uint8Array && r.data.byteLength > 0) {
+      return bytesToDataUri(r.data, resolvedMime(r, fieldType));
+    }
   }
 
   // Internal references the canonical resolver understands but a raw
@@ -303,9 +361,7 @@ export async function resolveAssetForAtlas(
   // asset_id). Arbitrary http(s) URIs stay on the isSafeHttpUrl-guarded fetch
   // path below and are never routed through it.
   //
-  // Read uri fresh from ref: the looksLikePublicUrl predicate above narrowed
-  // r.uri away, so a typeof check re-establishes the string type here.
-  const uri = (ref as AssetRef).uri;
+  const uri = rawUri;
   const assetId =
     typeof r.asset_id === "string" && r.asset_id.trim() !== ""
       ? r.asset_id.trim()
@@ -356,6 +412,25 @@ export async function resolveAssetForAtlas(
       }
     } catch {
       /* fall through to direct fetch */
+    }
+  }
+
+  // Canonical resolver fallback — it understands ref shapes the bespoke
+  // branches above miss: `file://` URIs and absolute local paths, raw-RGBA
+  // in-flight images (PNG-encoded on the way out), and `asset_id` →
+  // `/api/storage/<id>.<ext>` storage candidates.
+  //
+  // Skipped for http(s) URIs: a safe one already passed through at the top, so
+  // anything still here is a private/loopback/metadata host, and
+  // loadMediaRefBytes downloads http(s) unguarded. Routing those through it
+  // would hand back the SSRF hole isSafeHttpUrl exists to close.
+  if (!isHttpUri(r.uri)) {
+    const bytes = await loadMediaRefBytes(
+      ref as MediaRefValue,
+      context as unknown as ProcessingContext | undefined
+    );
+    if (bytes && bytes.byteLength > 0) {
+      return bytesToDataUri(bytes, resolvedMime(r, fieldType));
     }
   }
 
@@ -515,16 +590,22 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
 
       for (const f of specRef.fields) {
         const v = readValue(f.name);
-        if (v === undefined || v === null) continue;
 
         if (ASSET_TYPES.has(f.type)) {
           const inner = f.type as "image" | "video" | "audio";
-          const resolved = await resolveAssetForAtlas(v, context, inner);
+          const resolved =
+            v == null ? null : await resolveAssetForAtlas(v, context, inner);
           if (resolved !== null) {
             input[f.name] = f.array ? [resolved] : resolved;
+          } else if (f.required) {
+            throw new Error(
+              `${specRef.title}: the ${inner} input "${f.title ?? f.name}" is empty — connect or upload a${inner === "image" ? "n" : ""} ${inner}`
+            );
           }
           continue;
         }
+
+        if (v === undefined || v === null) continue;
 
         const listMatch = LIST_ASSET_RE.exec(f.type);
         if (listMatch) {

--- a/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
@@ -221,6 +221,84 @@ describe("resolveAssetForAtlas", () => {
     expect(out).toBe("https://cdn.example.org/secret.png");
   });
 
+  // An asset input the user left empty still arrives as a fully-shaped ref
+  // with every slot blank. That's an absent optional input — resolving it must
+  // yield null (field omitted) instead of failing the node with
+  // "Cannot resolve image asset for AtlasCloud — no usable uri or inline data".
+  it("returns null for a blank-but-shaped ref (unset optional input)", async () => {
+    const resolveAssetBytes = vi.fn();
+    const retrieve = vi.fn();
+    for (const blank of [
+      { type: "image", uri: "", asset_id: null, data: null, metadata: null },
+      { type: "image", uri: "   " },
+      { type: "video", uri: "", asset_id: "", data: "" },
+      { type: "image", data: new Uint8Array(0) }
+    ]) {
+      expect(
+        await resolveAssetForAtlas(
+          blank,
+          { storage: { retrieve }, resolveAssetBytes } as unknown as never,
+          "image"
+        )
+      ).toBeNull();
+    }
+    expect(resolveAssetBytes).not.toHaveBeenCalled();
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it("passes a data: URI through unchanged", async () => {
+    const uri = "data:image/png;base64,AQID";
+    expect(await resolveAssetForAtlas({ uri }, undefined, "image")).toBe(uri);
+    expect(await resolveAssetForAtlas(uri, undefined, "image")).toBe(uri);
+    expect(
+      await resolveAssetForAtlas({ data: uri }, undefined, "image")
+    ).toBe(uri);
+  });
+
+  // Refs produced by local file nodes carry a file:// URI or an absolute path;
+  // neither is a public URL nor a storage key, so only the canonical resolver
+  // can materialize them.
+  it("resolves a file:// ref via the canonical resolver", async () => {
+    const { mkdtemp, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { pathToFileURL } = await import("node:url");
+    const dir = await mkdtemp(join(tmpdir(), "atlas-"));
+    const file = join(dir, "pic.png");
+    await writeFile(file, Buffer.from([1, 2, 3]));
+
+    expect(
+      await resolveAssetForAtlas(
+        { type: "image", uri: pathToFileURL(file).href },
+        undefined,
+        "image"
+      )
+    ).toBe("data:image/png;base64,AQID");
+    expect(
+      await resolveAssetForAtlas({ type: "image", uri: file }, undefined, "image")
+    ).toBe("data:image/png;base64,AQID");
+  });
+
+  // Raw-RGBA in-flight images hold straight-alpha pixels, not an encoded file.
+  // Base64-ing them as-is would ship garbage labeled image/x-raw-rgba; they
+  // must be PNG-encoded and labeled image/png.
+  it("PNG-encodes a raw-RGBA in-flight image", async () => {
+    const out = await resolveAssetForAtlas(
+      {
+        type: "image",
+        mimeType: "image/x-raw-rgba",
+        width: 1,
+        height: 1,
+        data: Uint8Array.from([255, 0, 0, 255])
+      },
+      undefined,
+      "image"
+    );
+    expect(out).toMatch(/^data:image\/png;base64,/);
+    const bytes = Buffer.from(out!.split(",")[1], "base64");
+    // PNG magic — proof it went through the encoder, not a raw passthrough.
+    expect([...bytes.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
   it("returns null for an empty/null ref", async () => {
     expect(await resolveAssetForAtlas(null, undefined, "image")).toBeNull();
     expect(await resolveAssetForAtlas(undefined, undefined, "image")).toBeNull();
@@ -630,6 +708,88 @@ describe("createAtlasNodeClass.process", () => {
       prompt: "restyle now",
       video: "https://input/wired.mp4"
     });
+  });
+
+  // An empty optional image (Seedance's `last_image`) must not fail the node —
+  // it is simply omitted — while an empty *required* image fails locally with
+  // a message naming the input instead of a resolver-internal one.
+  it("omits an empty optional asset input and names an empty required one", async () => {
+    const submitted: { body: unknown } = { body: null };
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/generateVideo")) {
+        submitted.body = JSON.parse(init!.body as string);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "v" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/v")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.mp4"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.mp4") {
+        return {
+          ok: true,
+          arrayBuffer: async () => Uint8Array.from([1]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const spec = makeSpec({
+      title: "Seedance 2.0 — Image to Video",
+      modality: "video",
+      outputType: "video",
+      fields: [
+        { name: "prompt", type: "str", default: "" },
+        { name: "image", type: "image", default: null, required: true },
+        { name: "last_image", type: "image", default: null }
+      ]
+    });
+    const Cls = createAtlasNodeClass(spec) as unknown as new () => {
+      prompt: string;
+      image: unknown;
+      last_image: unknown;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "animate";
+    node.image = { type: "image", uri: "https://input/first.png" };
+    // The UI sends this shape for an image input the user never filled in.
+    node.last_image = {
+      type: "image",
+      uri: "",
+      asset_id: null,
+      data: null,
+      metadata: null
+    };
+
+    await node.process({ storage: null });
+    expect(submitted.body).toEqual({
+      model: "test/model/t2i",
+      prompt: "animate",
+      image: "https://input/first.png"
+    });
+
+    const missing = new Cls();
+    missing.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    missing.prompt = "animate";
+    missing.image = { type: "image", uri: "", asset_id: null, data: null };
+    await expect(missing.process({ storage: null })).rejects.toThrow(
+      'Seedance 2.0 — Image to Video: the image input "image" is empty'
+    );
   });
 
   it("propagates structured AtlasCloud job failures", async () => {


### PR DESCRIPTION
## The bug

Running **Seedance 2.0 — Image to Video** failed after ~2s with:

> Cannot resolve image asset for AtlasCloud — no usable uri or inline data

An asset input the user leaves empty does not arrive as `null`. The UI sends a
fully-shaped ref with every slot blank:

```json
{ "type": "image", "uri": "", "asset_id": null, "data": null, "metadata": null }
```

That object is truthy, so the factory's `v === undefined || v === null` skip
didn't catch it, and `resolveAssetForAtlas` ran out of resolution paths and
threw. Seedance's optional `last_image` triggers it on every run where it is
left unset.

## Changes (`packages/atlascloud-nodes/src/atlascloud-factory.ts`)

- **Blank-but-shaped refs resolve to `null`** — an absent optional input, so the
  field is simply omitted from the request.
- **Required asset inputs fail with a message naming the input**
  (`Seedance 2.0 — Image to Video: the image input "image" is empty — connect or
  upload an image`) instead of a resolver-internal one.
- **`data:` URIs pass through unchanged**, whether they arrive as a bare string,
  in `uri`, or in `data`.
- **Fall back to the canonical `loadMediaRefBytes`** for shapes the bespoke
  branches miss: `file://` URIs, absolute local paths, raw-RGBA in-flight images,
  and `asset_id` → `/api/storage/<id>.<ext>` storage candidates. This mirrors the
  same fix already made in `kie-nodes`.
- **Raw-RGBA images are PNG-encoded.** They previously matched the
  `data instanceof Uint8Array` branch and were shipped as raw pixel bytes
  labeled `image/x-raw-rgba` — a silent bad upload rather than an error.

### SSRF guard preserved

`loadMediaRefBytes` downloads http(s) unguarded, so the new fallback is skipped
for http(s) URIs. A *safe* public URL already passed through at the top of the
resolver, meaning anything still reaching that point is private/loopback/metadata
and stays behind `isSafeHttpUrl`. The existing SSRF test suite (loopback, RFC1918,
`169.254.169.254`, inet_aton numeric forms, IPv4-mapped IPv6) still passes
unchanged.

## Tests

Added to `packages/atlascloud-nodes/tests/atlascloud-factory.test.ts`:

- blank-but-shaped refs resolve to `null` without touching storage or
  `resolveAssetBytes`
- `data:` URI pass-through in all three positions
- `file://` and absolute-path refs resolve through the canonical resolver
- raw-RGBA input comes out as a real PNG (magic-byte assertion)
- end-to-end: empty optional `last_image` is omitted; empty required `image`
  throws the named error

`npm run test --workspace=packages/atlascloud-nodes` — 78 passed.
`npm run lint` and `npm run typecheck` pass (mobile typecheck fails only because
Expo deps aren't installed in this container; unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzyppGjrnah7McMEUMZJv3)_