### PR TITLE
Mini apps: implement the semantics the document schema already declares

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,18 +325,37 @@ npm run dev:nodetool -- app debug <id> --no-run       # static wiring check only
 npm run dev:nodetool -- app debug <id> --json         # full AppDebugReport for agents
 
 # Scripted interactions: set values, change inputs, click widgets (by
-# component id, unique type, or unique label)
+# component id, unique type, or unique label), and run or cancel an
+# operation by id
 npm run dev:nodetool -- app debug <id> --interact \
   '[{"set":{"key":"prompt","value":"hi"}},{"click":"Button-1"}]'
+npm run dev:nodetool -- app debug <id> --interact \
+  '[{"set":{"key":"tone","value":"terse","operationId":"draft"}},{"run":"draft"},{"cancel":"draft"}]'
 ```
+
+The harness runs **every** declared operation, not just the first: each resolves
+its own graph, and state is keyed per operation.
 
 The verdict catches app-level failures a workflow-only run can't: bindings that
 reference missing inputs/outputs/variables, apps with no run trigger, and
-display widgets that never receive a value from a completed run. The bundle
-(`nodetool-debug/app-<id>-<ts>/`) contains `report.json`/`report.md`,
+display widgets that never receive a value from a completed run. It also catches
+what the operation/variable layer makes mis-configurable — an output mapped to
+an undeclared variable, a mapping keyed on a node the workflow lacks, an event
+naming an operation the document never declares, a widget showing execution
+state of an operation nothing can run, and an elapsed `timeoutMs`. A
+`persist: true` variable that is `instance`-scoped warns rather than being
+silently downgraded.
+
+The bundle (`nodetool-debug/app-<id>-<ts>/`) contains `report.json`/`report.md`,
 `app.json` (the app document), `workflow.json`, and
-`server/run-N.messages.jsonl` per triggered run. Harness code:
-`packages/cli/src/app-debug/`.
+`server/run-N.messages.jsonl` per triggered run. The report carries final
+variable values, the activity label stream, and each invocation's policy
+decision, so an agent can see why a run was replaced, queued, or timed out.
+Harness code: `packages/cli/src/app-debug/`.
+
+Not simulated headlessly: `visibleWhen`/`disabledWhen`/`format`, so a widget
+hidden by a condition is reported as if visible; and `from: "resource"` params,
+which have no provider outside the browser.
 
 Every shipped workflow template carries a generated mini app on its `app_doc`
 (`node scripts/generate-template-apps.mjs` — curation table + Output-node

--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -136,6 +136,24 @@ WorkflowAppView      # resolves the document, renders the widget tree
 - **Run identity**: the runtime claims the job id of the run it dispatched and
   drops messages from any other job, so a run started in the chain editor never
   folds into what the app shows.
+- **Run policy and timeout** are enforced, not just parsed: `decideRun` decides
+  what a run colliding with a live one does (`replace` cancels first, `queue`
+  waits, `parallel` starts), and an operation's `timeoutMs` cancels the run and
+  fails the invocation with a timeout error.
+- **Variables**: declared defaults seed the instance at open, and `scope: "user"`
+  + `persist: true` variables survive a restart — stored in AsyncStorage by
+  `variablePersistence.ts` under `app-runtime:variables:app:<workflowId>`, so two
+  apps never share a slot. Restoring runs before defaults are seeded (seeding
+  never clobbers), and instance-scoped and view values are never written.
+- **Outputs can write variables**: an operation output mapped `to: "variable"`
+  lands in that variable as well as in its display slot, streamed chunks
+  accumulating in both.
+- **Activity**: a streaming agent's tool/phase/step label shows in the `Progress`
+  widget and reads through `op:<id>/exec#activity`, instead of a bare spinner.
+- **Operations** are dispatched by id, so an event naming a second operation runs
+  that one. Mobile holds one workflow per app screen: when a document's
+  operations name several workflows, the ones bound elsewhere refuse to run with
+  a visible error rather than running the loaded graph under another name.
 - **No app document?** `generateAppDoc` builds one in memory from the graph's
   Input/Output nodes, so every workflow is runnable. Mobile never writes it
   back — authoring is the web builder's job.

--- a/mobile/src/components/app_runtime/AppRuntimeContext.ts
+++ b/mobile/src/components/app_runtime/AppRuntimeContext.ts
@@ -12,6 +12,7 @@ import {
   evaluateCondition,
   formatTemplate,
   parseCondition,
+  readRef,
   resolveBinding,
   stateKey,
   type AppAction,
@@ -32,8 +33,10 @@ export interface AppRuntimeContextValue {
   io: WorkflowIO;
   /** Everything a stored binding string can resolve against. */
   scope: BindingScope;
-  /** The operation a widget's `run` targets. */
+  /** The operation a widget's `run` targets when its event names none. */
   operation: OperationBinding;
+  /** Every operation the document declares, in document order. */
+  operations: OperationBinding[];
   /** The document's resource bindings, by declaration order. */
   resources: ResourceBinding[];
   dispatch: (action: AppAction) => void;
@@ -83,6 +86,13 @@ export const useBindingValue = (ref: BindingRef | null): unknown => {
         return s.variables[key];
       case "view":
         return s.view[key];
+      // `op:<id>/exec#<field>` reads the run itself rather than a value slot.
+      case "execution":
+        return readRef(s, {
+          source: "execution",
+          operationId: ref.operationId,
+          field: ref.field,
+        });
       default:
         return s.inputs[key]?.value;
     }

--- a/mobile/src/components/app_runtime/WorkflowAppView.tsx
+++ b/mobile/src/components/app_runtime/WorkflowAppView.tsx
@@ -41,9 +41,18 @@ export const resolveAppDocument = (
  */
 const RuntimeError: React.FC = () => {
   const { colors } = useTheme();
+  // With several operations the banner belongs to whichever of their active
+  // runs failed most recently.
   const error = useRuntimeSelector((s) => {
-    const invocationId = Object.values(s.activeInvocation)[0];
-    return invocationId ? s.invocations[invocationId]?.error : undefined;
+    let latest: { startedAt: number; error: string } | undefined;
+    for (const invocationId of Object.values(s.activeInvocation)) {
+      const invocation = s.invocations[invocationId];
+      if (!invocation?.error) {continue;}
+      if (!latest || invocation.startedAt > latest.startedAt) {
+        latest = { startedAt: invocation.startedAt, error: invocation.error };
+      }
+    }
+    return latest?.error;
   });
   if (!error) {return null;}
   return (

--- a/mobile/src/components/app_runtime/__tests__/tableWidget.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/tableWidget.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The Table widget: an array of objects becomes columns from the rows' keys, an
+ * array of primitives becomes one column, and an empty value says so instead of
+ * rendering an empty frame.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+import WorkflowAppView from "../WorkflowAppView";
+
+const appDoc = (rows: unknown, placeholder?: string) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Report" } },
+    content: [
+      {
+        type: "Table",
+        props: {
+          id: "table-1",
+          binding: "var:rows",
+          ...(placeholder ? { placeholder } : {}),
+        },
+      },
+    ],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-table",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    {
+      id: "rows",
+      name: "rows",
+      scope: "instance",
+      persist: false,
+      default: rows,
+    },
+  ],
+});
+
+const makeWorkflow = (id: string, doc: unknown): Workflow =>
+  ({
+    id,
+    name: "Report",
+    description: "",
+    app_doc: doc,
+    graph: { nodes: [], edges: [] },
+  }) as unknown as Workflow;
+
+describe("Table widget", () => {
+  it("renders one column per key of an array of objects", async () => {
+    render(
+      <WorkflowAppView
+        workflow={makeWorkflow(
+          "wf-table-objects",
+          appDoc([
+            { city: "Berlin", score: 7 },
+            { city: "Lisbon", extra: true },
+          ])
+        )}
+      />
+    );
+
+    // Columns are the union of the rows' keys, in first-seen order.
+    expect(await screen.findByText("city")).toBeTruthy();
+    expect(screen.getByText("score")).toBeTruthy();
+    expect(screen.getByText("extra")).toBeTruthy();
+    expect(screen.getByText("Berlin")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.getByText("true")).toBeTruthy();
+  });
+
+  it("renders an array of primitives as a single unnamed column", async () => {
+    render(
+      <WorkflowAppView
+        workflow={makeWorkflow("wf-table-primitives", appDoc(["red", "green"]))}
+      />
+    );
+
+    expect(await screen.findByText("red")).toBeTruthy();
+    expect(screen.getByText("green")).toBeTruthy();
+  });
+
+  it("shows the placeholder for an empty value", () => {
+    render(
+      <WorkflowAppView
+        workflow={makeWorkflow("wf-table-empty", appDoc([], "Nothing yet"))}
+      />
+    );
+
+    expect(screen.getByText("Nothing yet")).toBeTruthy();
+    expect(screen.queryByText(/not available on mobile/)).toBeNull();
+  });
+});

--- a/mobile/src/components/app_runtime/__tests__/useAppRuntime.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/useAppRuntime.test.tsx
@@ -1,0 +1,416 @@
+/**
+ * The parts of the runtime that are pure wiring: where a run's output lands,
+ * what a variable starts as and whether it survives a restart, what happens
+ * when a run collides with a live one, and what a timeout does.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const mockRun = jest.fn().mockResolvedValue(undefined);
+const mockCancel = jest.fn().mockResolvedValue(undefined);
+const mockRunnerState = {
+  job_id: null as string | null,
+  run: mockRun,
+  cancel: mockCancel,
+};
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => mockRunnerState,
+    subscribe: () => () => {},
+  }),
+}));
+
+const mockHandlers = new Map<
+  string,
+  (message: Record<string, unknown>) => void
+>();
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: {
+    subscribe: (key: string, handler: (m: Record<string, unknown>) => void) => {
+      mockHandlers.set(key, handler);
+      return () => mockHandlers.delete(key);
+    },
+  },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+import { useAppRuntime } from "../useAppRuntime";
+import { disposeAppRuntimeStore, workflowInstanceId } from "../appRuntimeStore";
+import { variableStorageKey } from "../variablePersistence";
+
+const makeWorkflow = (id: string): Workflow =>
+  ({
+    id,
+    name: "Greeter",
+    description: "",
+    graph: {
+      nodes: [
+        {
+          id: "n1",
+          type: "nodetool.input.StringInput",
+          data: { name: "prompt" },
+        },
+        {
+          id: "o1",
+          type: "nodetool.output.StringOutput",
+          data: { name: "result" },
+        },
+      ],
+      edges: [],
+    },
+  }) as unknown as Workflow;
+
+const emit = (message: Record<string, unknown>) => {
+  act(() => {
+    mockHandlers.forEach((handler) => handler(message));
+  });
+};
+
+const doc = (
+  overrides: Partial<ApplicationDocument> = {}
+): ApplicationDocument => ({
+  schemaVersion: 3,
+  ui: { root: { props: {} }, content: [], zones: {} },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [],
+  ...overrides,
+});
+
+const renderRuntime = (workflowId: string, document: ApplicationDocument) => {
+  disposeAppRuntimeStore(workflowInstanceId(workflowId));
+  return renderHook(() =>
+    useAppRuntime(makeWorkflow(workflowId), { document })
+  );
+};
+
+/** Start a run and let the server answer with a job id. */
+const startRun = async (
+  runtime: { dispatch: (action: { kind: "run"; operationId: string }) => void },
+  operationId: string,
+  jobId: string
+) => {
+  await act(async () => {
+    runtime.dispatch({ kind: "run", operationId });
+  });
+  emit({ type: "job_update", job_id: jobId, status: "running" });
+};
+
+beforeEach(async () => {
+  mockHandlers.clear();
+  mockRun.mockClear();
+  mockCancel.mockClear();
+  mockRunnerState.job_id = null;
+  await AsyncStorage.clear();
+});
+
+describe("output → variable", () => {
+  it("writes a node's streamed value into the variable it maps to", async () => {
+    const document = doc({
+      operations: [
+        {
+          id: "main",
+          name: "Run",
+          workflowId: "wf",
+          inputs: {},
+          outputs: { o1: { to: "variable", variableId: "answer" } },
+          policy: "replace",
+        },
+      ],
+      variables: [
+        { id: "answer", name: "answer", scope: "instance", persist: false },
+      ],
+    });
+    const { result } = renderRuntime("wf-out-var", document);
+
+    await startRun(result.current, "main", "job-1");
+    emit({ type: "output_update", job_id: "job-1", node_id: "o1", value: "Hi " });
+    emit({
+      type: "output_update",
+      job_id: "job-1",
+      node_id: "o1",
+      value: "there",
+    });
+
+    // Streamed chunks accumulate in the variable the same way they do in the
+    // display slot.
+    expect(result.current.store.getState().variables.answer).toBe("Hi there");
+  });
+
+  it("leaves variables alone when the output only displays", async () => {
+    const { result } = renderRuntime("wf-no-var", doc());
+
+    await startRun(result.current, "main", "job-1");
+    emit({ type: "output_update", job_id: "job-1", node_id: "o1", value: "hi" });
+
+    expect(result.current.store.getState().variables).toEqual({});
+  });
+});
+
+describe("variable defaults and persistence", () => {
+  const persistedDoc = doc({
+    variables: [
+      {
+        id: "tone",
+        name: "tone",
+        scope: "user",
+        persist: true,
+        default: "formal",
+      },
+      {
+        id: "draft",
+        name: "draft",
+        scope: "instance",
+        persist: false,
+        default: "empty",
+      },
+    ],
+  });
+
+  it("seeds the declared defaults", async () => {
+    const { result } = renderRuntime("wf-defaults", persistedDoc);
+
+    await waitFor(() =>
+      expect(result.current.store.getState().variables.tone).toBe("formal")
+    );
+    expect(result.current.store.getState().variables.draft).toBe("empty");
+  });
+
+  it("restores a persisted value over the default and never stores the rest", async () => {
+    const first = renderRuntime("wf-persist", persistedDoc);
+    await waitFor(() =>
+      expect(first.result.current.store.getState().variables.tone).toBe("formal")
+    );
+
+    act(() => {
+      first.result.current.store.getState().dispatchEvent({
+        type: "setVariable",
+        variableId: "tone",
+        value: "casual",
+      });
+      first.result.current.store.getState().dispatchEvent({
+        type: "setVariable",
+        variableId: "draft",
+        value: "secret",
+      });
+    });
+
+    const key = variableStorageKey(workflowInstanceId("wf-persist"));
+    await waitFor(async () =>
+      expect(JSON.parse((await AsyncStorage.getItem(key)) ?? "{}")).toEqual({
+        tone: "casual",
+      })
+    );
+
+    first.unmount();
+    const second = renderRuntime("wf-persist", persistedDoc);
+    await waitFor(() =>
+      expect(second.result.current.store.getState().variables.tone).toBe("casual")
+    );
+    // Instance scope dies with the app: the second run starts on the default.
+    expect(second.result.current.store.getState().variables.draft).toBe("empty");
+  });
+});
+
+describe("run policy", () => {
+  const policyDoc = (policy: "replace" | "queue" | "parallel") =>
+    doc({
+      operations: [
+        {
+          id: "main",
+          name: "Run",
+          workflowId: "wf",
+          inputs: {},
+          outputs: {},
+          policy,
+        },
+      ],
+    });
+
+  it("replace cancels the live run before starting", async () => {
+    const { result } = renderRuntime("wf-replace", policyDoc("replace"));
+
+    await startRun(result.current, "main", "job-1");
+    await startRun(result.current, "main", "job-2");
+
+    expect(mockCancel).toHaveBeenCalledWith("job-1");
+    expect(mockRun).toHaveBeenCalledTimes(2);
+    expect(result.current.store.getState().invocations["job-1"].status).toBe(
+      "cancelled"
+    );
+  });
+
+  it("queue waits for the live run to settle", async () => {
+    const { result } = renderRuntime("wf-queue", policyDoc("queue"));
+
+    await startRun(result.current, "main", "job-1");
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+
+    // Still queued behind the first run.
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockCancel).not.toHaveBeenCalled();
+
+    emit({ type: "job_update", job_id: "job-1", status: "completed" });
+    await waitFor(() => expect(mockRun).toHaveBeenCalledTimes(2));
+  });
+
+  it("parallel starts immediately and keeps both runs", async () => {
+    const { result } = renderRuntime("wf-parallel", policyDoc("parallel"));
+
+    await startRun(result.current, "main", "job-1");
+    await startRun(result.current, "main", "job-2");
+
+    expect(mockCancel).not.toHaveBeenCalled();
+    const { invocations } = result.current.store.getState();
+    expect(invocations["job-1"].status).toBe("running");
+    expect(invocations["job-2"].status).toBe("running");
+  });
+});
+
+describe("timeoutMs", () => {
+  const timeoutDoc = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf",
+        inputs: {},
+        outputs: {},
+        policy: "replace",
+        timeoutMs: 30,
+      },
+    ],
+  });
+
+  it("cancels and fails the run when the limit elapses", async () => {
+    const { result } = renderRuntime("wf-timeout", timeoutDoc);
+
+    await startRun(result.current, "main", "job-1");
+
+    await waitFor(() => {
+      const invocation = result.current.store.getState().invocations["job-1"];
+      expect(invocation.status).toBe("failed");
+      expect(invocation.error).toContain("timed out");
+    });
+    expect(mockCancel).toHaveBeenCalledWith("job-1");
+  });
+
+  it("clears the timer when the run finishes in time", async () => {
+    const { result } = renderRuntime("wf-timeout-ok", timeoutDoc);
+
+    await startRun(result.current, "main", "job-1");
+    emit({ type: "job_update", job_id: "job-1", status: "completed" });
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(result.current.store.getState().invocations["job-1"].status).toBe(
+      "completed"
+    );
+    expect(mockCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe("multiple operations", () => {
+  const multiDoc = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf-multi",
+        inputs: {},
+        outputs: {},
+        policy: "replace",
+      },
+      {
+        id: "second",
+        name: "Second",
+        workflowId: "wf-multi",
+        inputs: { n1: { from: "constant", value: "fixed" } },
+        outputs: { o1: { to: "variable", variableId: "second_out" } },
+        policy: "replace",
+      },
+      {
+        id: "foreign",
+        name: "Foreign",
+        workflowId: "wf-elsewhere",
+        inputs: {},
+        outputs: {},
+        policy: "replace",
+      },
+    ],
+    variables: [
+      { id: "second_out", name: "second_out", scope: "instance", persist: false },
+    ],
+  });
+
+  it("runs the operation the action names, not the first one", async () => {
+    const { result } = renderRuntime("wf-multi", multiDoc);
+
+    await startRun(result.current, "second", "job-2");
+    emit({ type: "output_update", job_id: "job-2", node_id: "o1", value: "ok" });
+
+    expect(mockRun.mock.calls[0][0]).toEqual({ prompt: "fixed" });
+    const state = result.current.store.getState();
+    expect(state.invocations["job-2"].operationId).toBe("second");
+    expect(state.variables.second_out).toBe("ok");
+  });
+
+  it("refuses an operation bound to a workflow this screen does not hold", async () => {
+    const { result } = renderRuntime("wf-multi-foreign", multiDoc);
+
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "foreign" });
+    });
+
+    expect(mockRun).not.toHaveBeenCalled();
+    const state = result.current.store.getState();
+    const failed = Object.values(state.invocations).find(
+      (invocation) => invocation.operationId === "foreign"
+    );
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toContain("wf-elsewhere");
+  });
+});
+
+describe("streaming activity", () => {
+  it("records what the run says it is doing", async () => {
+    const { result } = renderRuntime("wf-activity", doc());
+
+    await startRun(result.current, "main", "job-1");
+    emit({
+      type: "tool_call_update",
+      job_id: "job-1",
+      name: "search",
+      message: "Searching the web",
+    });
+
+    expect(result.current.store.getState().activity["job-1"]).toBe(
+      "Searching the web"
+    );
+  });
+});

--- a/mobile/src/components/app_runtime/useAppRuntime.ts
+++ b/mobile/src/components/app_runtime/useAppRuntime.ts
@@ -4,8 +4,9 @@
  * Binds an app-instance store to the shared per-workflow runner, folds the
  * run's streaming messages into namespaced state, and turns widget actions into
  * runs. All the semantics — what a message does to a value, which invocation
- * owns a slot, how an action reads — live in `@nodetool-ai/app-runtime`; this
- * hook is the React Native adapter around them.
+ * owns a slot, how an action reads, what a policy means when a run collides
+ * with a live one — live in `@nodetool-ai/app-runtime`; this hook is the React
+ * Native adapter around them.
  *
  * Run identity is the load-bearing part: every invocation this app starts is
  * registered by its `job_id`, and a streaming message for any other job is
@@ -13,13 +14,20 @@
  * shows.
  *
  * Unlike web there is no reactive subgraph path — mobile has no browser worker
- * — so every `run` action runs the whole workflow on the server.
+ * — so every `run` action runs the whole workflow on the server. A document may
+ * declare several operations over that workflow and each is dispatched by id;
+ * an operation bound to a *different* workflow cannot run on a screen that
+ * holds only this one, and says so instead of running the wrong graph.
  */
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
+  decideRun,
   implicitOperation,
+  initialVariableValues,
+  isLiveInvocation,
   mergeVariables,
   messageToEvents,
+  outputVariableTargets,
   resolveOperationParams,
   stateKey,
   type AppAction,
@@ -46,8 +54,30 @@ import {
   seedInputValue,
 } from "./workflowIO";
 import { useOpenResource } from "./useOpenResource";
+import {
+  loadPersistedVariables,
+  persistableValues,
+  persistableVariableIds,
+  savePersistedVariables,
+} from "./variablePersistence";
 
 type RawMessage = Record<string, unknown>;
+
+/** Trailing window before a variable change is written to storage. */
+const PERSIST_DEBOUNCE_MS = 300;
+
+/**
+ * A run that has been dispatched but whose `job_id` has not come back yet.
+ * Starts are claimed in dispatch order, which is what lets two parallel
+ * invocations of one operation each find their own job.
+ */
+interface PendingStart {
+  operationId: string;
+  timeoutMs?: number;
+  /** Set once the run's job id arrives. */
+  invocationId?: string;
+  timer?: ReturnType<typeof setTimeout>;
+}
 
 export interface AppRuntimeOptions {
   /**
@@ -66,11 +96,44 @@ export const useAppRuntime = (
   const workflowId = workflow?.id;
   const io = useMemo(() => extractWorkflowIO(workflow), [workflow]);
 
-  // The operation a widget's run targets. Multi-operation apps arrive with the
-  // application entity; until then every app has exactly one.
-  const operation: OperationBinding = useMemo(
-    () => document?.operations[0] ?? implicitOperation(workflowId ?? ""),
+  // Every operation a widget's run/cancel can name. A legacy app running
+  // straight off a workflow gets the one implicit operation.
+  const operations: OperationBinding[] = useMemo(
+    () =>
+      document?.operations.length
+        ? document.operations
+        : [implicitOperation(workflowId ?? "")],
     [document, workflowId]
+  );
+  const operation = operations[0];
+
+  /**
+   * Mobile holds exactly one workflow per app screen.
+   *
+   * A document whose operations all name one workflow *is* this screen's app —
+   * it is stored on the workflow it was opened from — so it runs the loaded
+   * graph even when the id it carries is stale (a copied workflow keeps the
+   * original's app document). Only a document that mixes several workflows can
+   * name one this screen does not hold, and that operation refuses to run
+   * rather than running the loaded graph under another operation's name.
+   */
+  const isRunnable = useMemo(() => {
+    const workflowIds = new Set(
+      operations.map((op) => op.workflowId).filter((id) => id !== "")
+    );
+    return (candidate: OperationBinding) =>
+      workflowIds.size <= 1 ||
+      candidate.workflowId === "" ||
+      candidate.workflowId === workflowId;
+  }, [operations, workflowId]);
+
+  const variables = useMemo(
+    () =>
+      mergeVariables(
+        document?.variables ?? [],
+        extractVariableNames(workflow)
+      ),
+    [document, workflow]
   );
 
   // Everything a stored binding string can resolve against. Legacy documents
@@ -79,23 +142,24 @@ export const useAppRuntime = (
   const scope: BindingScope = useMemo(
     () => ({
       defaultOperationId: operation.id,
-      operations: [
-        {
-          operationId: operation.id,
-          inputs: io.inputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          outputs: io.outputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          nodeIds: (workflow?.graph?.nodes ?? []).map(
-            (node: { id: string }) => node.id
-          ),
-          variableNames: extractVariableNames(workflow),
-        },
-      ],
-      variables: mergeVariables(
-        document?.variables ?? [],
-        extractVariableNames(workflow)
-      ),
+      operations: operations.map((op) => ({
+        operationId: op.id,
+        inputs: isRunnable(op)
+          ? io.inputs.map(({ nodeId, name }) => ({ nodeId, name }))
+          : [],
+        outputs: isRunnable(op)
+          ? io.outputs.map(({ nodeId, name }) => ({ nodeId, name }))
+          : [],
+        nodeIds: isRunnable(op)
+          ? (workflow?.graph?.nodes ?? []).map(
+              (node: { id: string }) => node.id
+            )
+          : [],
+        variableNames: extractVariableNames(workflow),
+      })),
+      variables,
     }),
-    [document, io, operation.id, workflow]
+    [io, isRunnable, operation.id, operations, variables, workflow]
   );
 
   const resources = useMemo(() => document?.resources ?? [], [document]);
@@ -116,30 +180,70 @@ export const useAppRuntime = (
 
   const openResource = useOpenResource();
 
-  const inputKey = useCallback(
-    (nodeId: string) =>
-      stateKey({ kind: "input", operationId: operation.id, nodeId }),
-    [operation.id]
-  );
   const outputKey = useCallback(
-    (nodeId: string) =>
-      stateKey({ kind: "output", operationId: operation.id, nodeId }),
-    [operation.id]
+    (operationId: string, nodeId: string) =>
+      stateKey({ kind: "output", operationId, nodeId }),
+    []
   );
+
+  const instanceId = workflowInstanceId(workflowId ?? "__app_runtime__");
 
   // Kept in the instance registry so values survive an editor↔app toggle.
   const store: AppRuntimeStore = useMemo(() => {
-    const target = getAppRuntimeStore(
-      workflowInstanceId(workflowId ?? "__app_runtime__")
-    );
+    const target = getAppRuntimeStore(instanceId);
     const values: Record<string, unknown> = {};
-    for (const input of io.inputs) {
-      const seed = seedInputValue(input);
-      if (seed !== undefined) {values[inputKey(input.nodeId)] = seed;}
+    for (const op of operations) {
+      for (const input of io.inputs) {
+        const seed = seedInputValue(input);
+        if (seed !== undefined) {
+          values[stateKey({ kind: "input", operationId: op.id, nodeId: input.nodeId })] =
+            seed;
+        }
+      }
     }
     target.getState().dispatchEvent({ type: "seedInputs", values });
     return target;
-  }, [inputKey, io.inputs, workflowId]);
+  }, [instanceId, io.inputs, operations]);
+
+  // Restore first, then seed the declared defaults: `seedVariables` never
+  // clobbers, so a value the user set last session outranks the default.
+  useEffect(() => {
+    let cancelled = false;
+    const defaults = initialVariableValues(variables);
+    void loadPersistedVariables(instanceId, variables).then((restored) => {
+      if (cancelled) {return;}
+      const { dispatchEvent } = store.getState();
+      dispatchEvent({ type: "seedVariables", values: restored });
+      dispatchEvent({ type: "seedVariables", values: defaults });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceId, store, variables]);
+
+  // Write back whatever the document declared persistent. Instance-scoped and
+  // view values never reach storage — that is what their scope means.
+  useEffect(() => {
+    const ids = persistableVariableIds(variables);
+    if (ids.size === 0) {return undefined;}
+    let last = JSON.stringify(persistableValues(store.getState().variables, ids));
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = store.subscribe((state) => {
+      const values = persistableValues(state.variables, ids);
+      const encoded = JSON.stringify(values);
+      if (encoded === last) {return;}
+      last = encoded;
+      if (timer) {clearTimeout(timer);}
+      timer = setTimeout(() => {
+        timer = null;
+        void savePersistedVariables(instanceId, values);
+      }, PERSIST_DEBOUNCE_MS);
+    });
+    return () => {
+      unsubscribe();
+      if (timer) {clearTimeout(timer);}
+    };
+  }, [instanceId, store, variables]);
 
   const runnerStore = useWorkflowRunner(workflowId ?? "__app_runtime__");
 
@@ -149,33 +253,62 @@ export const useAppRuntime = (
     [io.outputs]
   );
 
+  // Operation id → (output node id → the variable that output writes).
+  const outputVariablesRef = useRef(new Map<string, Map<string, string>>());
+  outputVariablesRef.current = useMemo(() => {
+    const byOperation = new Map<string, Map<string, string>>();
+    for (const op of operations) {
+      const targets = outputVariableTargets(op);
+      if (targets.length === 0) {continue;}
+      byOperation.set(
+        op.id,
+        new Map(targets.map(({ nodeId, variableId }) => [nodeId, variableId]))
+      );
+    }
+    return byOperation;
+  }, [operations]);
+
   // Invocations this app started, by job id. A streaming message for anything
   // else is not ours — that is the cross-run contamination fix.
   const ownedRef = useRef(new Map<string, InvocationState>());
-  // Messages that arrived between dispatching a run and learning its job id.
-  const pendingRef = useRef<RawMessage[]>([]);
-  // True from the moment a run is dispatched until its job id comes back. The
-  // runner resolves as soon as the request is sent, well before the server
-  // answers, so this cannot be tied to the run promise.
-  const expectingJobRef = useRef(false);
+  // Runs dispatched but not yet matched to a job id, oldest first.
+  const pendingStartsRef = useRef<PendingStart[]>([]);
+  // Claimed runs that still hold a timeout timer, by invocation id.
+  const startsByInvocationRef = useRef(new Map<string, PendingStart>());
+
+  const clearTimer = useCallback((start: PendingStart | undefined) => {
+    if (start?.timer) {
+      clearTimeout(start.timer);
+      start.timer = undefined;
+    }
+  }, []);
 
   const fold = useCallback(
     (message: RawMessage) => {
       const events = messageToEvents(message, {
         resolveInvocation: (jobId) =>
           jobId ? ownedRef.current.get(jobId) ?? null : null,
-        outputKey: (_operationId, nodeId) =>
-          outputNodeIdsRef.current.has(nodeId) ? outputKey(nodeId) : null,
+        outputKey: (operationId, nodeId) =>
+          outputNodeIdsRef.current.has(nodeId)
+            ? outputKey(operationId, nodeId)
+            : null,
+        outputVariable: (operationId, nodeId) =>
+          outputVariablesRef.current.get(operationId)?.get(nodeId) ?? null,
       });
       for (const event of events) {
         store.getState().dispatchEvent(event);
         if (event.type === "invocationStatus") {
           const invocation = ownedRef.current.get(event.invocationId);
           if (invocation) {invocation.status = event.status;}
+          if (event.status !== "pending" && event.status !== "running") {
+            const start = startsByInvocationRef.current.get(event.invocationId);
+            clearTimer(start);
+            startsByInvocationRef.current.delete(event.invocationId);
+          }
         }
       }
     },
-    [outputKey, store]
+    [clearTimer, outputKey, store]
   );
   const foldRef = useRef(fold);
   foldRef.current = fold;
@@ -183,12 +316,38 @@ export const useAppRuntime = (
   const outputsRef = useRef(io.outputs);
   outputsRef.current = io.outputs;
 
-  /** Register a run this app started and flush anything buffered for it. */
+  /** Report a run that could not start, so the failure is visible in the app. */
+  const failRun = useCallback(
+    (operationId: string, error: string) => {
+      const failed: InvocationState = {
+        id: `failed-${operationId}-${Date.now()}`,
+        operationId,
+        status: "failed",
+        error,
+        startedAt: Date.now(),
+      };
+      ownedRef.current.set(failed.id, failed);
+      store.getState().dispatchEvent({
+        type: "runStarted",
+        invocation: failed,
+        outputKeys: [],
+      });
+    },
+    [store]
+  );
+  const failRunRef = useRef(failRun);
+  failRunRef.current = failRun;
+
+  /** Register a run this app started against the start that is waiting for it. */
   const claimInvocation = useCallback(
     (jobId: string) => {
+      const start = pendingStartsRef.current.shift();
+      if (!start) {return;}
+      start.invocationId = jobId;
+      startsByInvocationRef.current.set(jobId, start);
       const invocation: InvocationState = {
         id: jobId,
-        operationId: operation.id,
+        operationId: start.operationId,
         status: "running",
         startedAt: Date.now(),
       };
@@ -197,14 +356,11 @@ export const useAppRuntime = (
         type: "runStarted",
         invocation,
         outputKeys: outputsRef.current.map((output) =>
-          outputKey(output.nodeId)
+          outputKey(start.operationId, output.nodeId)
         ),
       });
-      const buffered = pendingRef.current;
-      pendingRef.current = [];
-      for (const message of buffered) {foldRef.current(message);}
     },
-    [operation.id, outputKey, store]
+    [outputKey, store]
   );
   const claimRef = useRef(claimInvocation);
   claimRef.current = claimInvocation;
@@ -214,19 +370,15 @@ export const useAppRuntime = (
 
     const handler = (message: RawMessage) => {
       const jobId = message.job_id;
-      if (typeof jobId === "string") {
+      // A message with no job id cannot be attributed to one of this app's
+      // invocations, so it is not folded.
+      if (typeof jobId !== "string") {return;}
+      if (!ownedRef.current.has(jobId)) {
         // The first job id to arrive after we dispatched a run is that run.
-        if (!ownedRef.current.has(jobId)) {
-          if (!expectingJobRef.current) {return;}
-          expectingJobRef.current = false;
-          claimRef.current(jobId);
-        }
-        foldRef.current(message);
-        return;
+        if (pendingStartsRef.current.length === 0) {return;}
+        claimRef.current(jobId);
       }
-      // A run we started whose job id has not come back yet: buffer rather than
-      // drop, then replay once the id is known.
-      if (expectingJobRef.current) {pendingRef.current.push(message);}
+      foldRef.current(message);
     };
 
     const unsubscribeWorkflow = webSocketService.subscribe(
@@ -253,58 +405,180 @@ export const useAppRuntime = (
     };
   }, [runnerStore, workflowId]);
 
-  const run = useCallback(async () => {
-    if (!workflow) {return;}
-    // Bindings key on node IDs; the run protocol wants names. That translation
-    // happens here, at the execution boundary, which is why a graph rename
-    // never touches the app document.
-    const params = resolveOperationParams({
-      operation,
-      state: store.getState(),
-      inputNodeIds: io.inputs.map((input) => input.nodeId),
-      inputName: (nodeId) =>
-        io.inputs.find((input) => input.nodeId === nodeId)?.name,
-      resourceRef: (resourceBindingId) =>
-        resourceRefsRef.current.get(resourceBindingId),
-    });
-
-    expectingJobRef.current = true;
-    pendingRef.current = [];
-    try {
-      await runnerStore.getState().run(params, workflow);
-    } catch (error) {
-      expectingJobRef.current = false;
-      pendingRef.current = [];
-      const failed: InvocationState = {
-        id: `failed-${Date.now()}`,
-        operationId: operation.id,
-        status: "failed",
-        error: error instanceof Error ? error.message : "Run failed",
-        startedAt: Date.now(),
-      };
-      ownedRef.current.set(failed.id, failed);
-      store.getState().dispatchEvent({
-        type: "runStarted",
-        invocation: failed,
-        outputKeys: [],
-      });
-    }
-  }, [io.inputs, operation, runnerStore, store, workflow]);
-
-  const cancel = useCallback(async () => {
-    await runnerStore.getState().cancel();
-    for (const [id, invocation] of ownedRef.current) {
-      if (invocation.status !== "running" && invocation.status !== "pending") {
-        continue;
+  /**
+   * Cancel invocations this app owns. `error` turns the cancellation into a
+   * failure, which is what a timeout is: the run stops and the app says why.
+   */
+  const cancelInvocations = useCallback(
+    async (invocationIds: ReadonlyArray<string>, error?: string) => {
+      for (const id of invocationIds) {
+        const invocation = ownedRef.current.get(id);
+        if (invocation && !isLiveInvocation(invocation)) {continue;}
+        clearTimer(startsByInvocationRef.current.get(id));
+        startsByInvocationRef.current.delete(id);
+        await runnerStore.getState().cancel(id);
+        if (invocation) {invocation.status = error ? "failed" : "cancelled";}
+        store.getState().dispatchEvent({
+          type: "invocationStatus",
+          invocationId: id,
+          status: error ? "failed" : "cancelled",
+          ...(error ? { error } : {}),
+        });
       }
-      invocation.status = "cancelled";
-      store.getState().dispatchEvent({
-        type: "invocationStatus",
-        invocationId: id,
-        status: "cancelled",
+    },
+    [clearTimer, runnerStore, store]
+  );
+
+  /** Resolve once none of the given invocations is live any more. */
+  const waitForSettled = useCallback(
+    (invocationIds: ReadonlyArray<string>) =>
+      new Promise<void>((resolve) => {
+        const settled = () =>
+          invocationIds.every((id) => {
+            const invocation = store.getState().invocations[id];
+            return !invocation || !isLiveInvocation(invocation);
+          });
+        if (settled()) {
+          resolve();
+          return;
+        }
+        const unsubscribe = store.subscribe(() => {
+          if (!settled()) {return;}
+          unsubscribe();
+          resolve();
+        });
+      }),
+    [store]
+  );
+
+  const startTimeout = useCallback(
+    (start: PendingStart) => {
+      if (!start.timeoutMs || start.timeoutMs <= 0) {return;}
+      const limit = start.timeoutMs;
+      start.timer = setTimeout(() => {
+        start.timer = undefined;
+        const message = `Run timed out after ${limit}ms`;
+        if (start.invocationId) {
+          void cancelInvocations([start.invocationId], message);
+          return;
+        }
+        // The run never reported a job id, so there is nothing to cancel — the
+        // failure is all the app can show.
+        pendingStartsRef.current = pendingStartsRef.current.filter(
+          (pending) => pending !== start
+        );
+        failRunRef.current(start.operationId, message);
+      }, limit);
+    },
+    [cancelInvocations]
+  );
+
+  const run = useCallback(
+    async (operationId: string) => {
+      const target = operations.find((op) => op.id === operationId);
+      if (!target) {
+        failRun(
+          operation.id,
+          `This app has no operation "${operationId}".`
+        );
+        return;
+      }
+      if (!workflow || !isRunnable(target)) {
+        failRun(
+          target.id,
+          `"${target.name}" runs workflow ${target.workflowId}, which this screen does not have open.`
+        );
+        return;
+      }
+
+      const decision = decideRun(store.getState(), target);
+      if (decision.kind === "replace") {
+        await cancelInvocations(decision.cancel);
+      } else if (decision.kind === "queue") {
+        await waitForSettled(decision.after);
+      }
+
+      // Bindings key on node IDs; the run protocol wants names. That
+      // translation happens here, at the execution boundary, which is why a
+      // graph rename never touches the app document.
+      const params = resolveOperationParams({
+        operation: target,
+        state: store.getState(),
+        inputNodeIds: io.inputs.map((input) => input.nodeId),
+        inputName: (nodeId) =>
+          io.inputs.find((input) => input.nodeId === nodeId)?.name,
+        resourceRef: (resourceBindingId) =>
+          resourceRefsRef.current.get(resourceBindingId),
       });
-    }
-  }, [runnerStore, store]);
+
+      const start: PendingStart = {
+        operationId: target.id,
+        timeoutMs: target.timeoutMs,
+      };
+      pendingStartsRef.current.push(start);
+      startTimeout(start);
+      try {
+        await runnerStore.getState().run(params, workflow);
+      } catch (error) {
+        pendingStartsRef.current = pendingStartsRef.current.filter(
+          (pending) => pending !== start
+        );
+        clearTimer(start);
+        failRun(
+          target.id,
+          error instanceof Error ? error.message : "Run failed"
+        );
+      }
+    },
+    [
+      cancelInvocations,
+      clearTimer,
+      failRun,
+      io.inputs,
+      isRunnable,
+      operation.id,
+      operations,
+      runnerStore,
+      startTimeout,
+      store,
+      waitForSettled,
+      workflow,
+    ]
+  );
+
+  const cancel = useCallback(
+    async (operationId: string, invocationId?: string) => {
+      if (invocationId) {
+        await cancelInvocations([invocationId]);
+        return;
+      }
+      const live = Object.values(store.getState().invocations)
+        .filter((i) => i.operationId === operationId && isLiveInvocation(i))
+        .map((i) => i.id);
+      // A run dispatched but not yet claimed has no job to cancel; dropping its
+      // start keeps a late job id from being adopted as a live run.
+      pendingStartsRef.current = pendingStartsRef.current.filter((start) => {
+        if (start.operationId !== operationId) {return true;}
+        clearTimer(start);
+        return false;
+      });
+      await cancelInvocations(live);
+    },
+    [cancelInvocations, clearTimer, store]
+  );
+
+  // A screen that goes away leaves no timer behind to fail a run nobody sees.
+  useEffect(
+    () => () => {
+      for (const start of pendingStartsRef.current) {
+        if (start.timer) {clearTimeout(start.timer);}
+      }
+      for (const start of startsByInvocationRef.current.values()) {
+        if (start.timer) {clearTimeout(start.timer);}
+      }
+    },
+    []
+  );
 
   const write = useCallback(
     (ref: BindingRef, value: unknown) => {
@@ -332,10 +606,13 @@ export const useAppRuntime = (
     (action: AppAction) => {
       switch (action.kind) {
         case "run":
-          void run();
+          void run(action.operationId);
           break;
         case "cancel":
-          void cancel();
+          void cancel(
+            action.operationId ?? operation.id,
+            action.invocationId
+          );
           break;
         case "setVariable":
           store.getState().dispatchEvent({
@@ -366,7 +643,7 @@ export const useAppRuntime = (
           break;
       }
     },
-    [cancel, openResource, run, store]
+    [cancel, openResource, operation.id, run, store]
   );
 
   return useMemo(
@@ -375,6 +652,7 @@ export const useAppRuntime = (
       io,
       scope,
       operation,
+      operations,
       resources,
       dispatch,
       write,
@@ -384,6 +662,7 @@ export const useAppRuntime = (
       dispatch,
       io,
       operation,
+      operations,
       resources,
       scope,
       selectResource,

--- a/mobile/src/components/app_runtime/useWidgetRuntime.ts
+++ b/mobile/src/components/app_runtime/useWidgetRuntime.ts
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   eventToAction,
   isOperationRunning,
+  operationActivity,
   operationProgress,
   resolveBinding,
   type AppEvent,
@@ -43,6 +44,8 @@ export interface WidgetRuntime {
   running: boolean;
   /** Fractional progress of the app's active run, when it reports any. */
   progress: number | undefined;
+  /** What that run last reported it was doing — the agent's tool, phase, step. */
+  activity: string | undefined;
 }
 
 interface UseWidgetRuntimeParams {
@@ -75,12 +78,19 @@ export const useWidgetRuntime = ({
 
   const value = useBindingValue(ref);
 
-  const operationId = scope.defaultOperationId;
+  // A widget reports on the operation its own events drive; only a widget with
+  // no run/cancel event of its own falls back to the app's default operation.
+  const operationId =
+    events?.find((event) => event.operationId)?.operationId ??
+    scope.defaultOperationId;
   const running = useRuntimeSelector((s) =>
     isOperationRunning(s, operationId)
   );
   const progress = useRuntimeSelector((s) =>
     operationProgress(s, operationId)
+  );
+  const activity = useRuntimeSelector((s) =>
+    operationActivity(s, operationId)
   );
 
   const setValue = useCallback(
@@ -150,5 +160,5 @@ export const useWidgetRuntime = ({
     [dispatch, events, scope]
   );
 
-  return { value, setValue, emit, running, progress };
+  return { value, setValue, emit, running, progress, activity };
 };

--- a/mobile/src/components/app_runtime/variablePersistence.ts
+++ b/mobile/src/components/app_runtime/variablePersistence.ts
@@ -1,0 +1,91 @@
+/**
+ * Storage for the app variables a document declares as persistent.
+ *
+ * Only `scope: "user"` variables with `persist: true` are written — instance
+ * variables and widget-local view state die with the open app, which is what
+ * their scope means. The record is keyed by app identity, so two apps that both
+ * declare a `theme` variable never read each other's value.
+ *
+ * Restoring runs before the document's defaults are seeded: `seedVariables`
+ * never clobbers, so whichever value lands first wins, and a value the user set
+ * last session must beat the declared default.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { VariableDeclaration } from "@nodetool-ai/app-runtime";
+
+const STORAGE_PREFIX = "app-runtime:variables:";
+
+export const variableStorageKey = (appId: string): string =>
+  `${STORAGE_PREFIX}${appId}`;
+
+/** Ids of the variables a document is allowed to persist. */
+export const persistableVariableIds = (
+  variables: ReadonlyArray<VariableDeclaration>
+): Set<string> =>
+  new Set(
+    variables
+      .filter((variable) => variable.scope === "user" && variable.persist)
+      .map((variable) => variable.id)
+  );
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * The stored values for this app, filtered to what the document still declares
+ * as persistent. A variable that lost its `persist` flag — or vanished from the
+ * document — is not restored.
+ */
+export const loadPersistedVariables = async (
+  appId: string,
+  variables: ReadonlyArray<VariableDeclaration>
+): Promise<Record<string, unknown>> => {
+  const ids = persistableVariableIds(variables);
+  if (ids.size === 0) {return {};}
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(variableStorageKey(appId));
+  } catch {
+    // Storage is unavailable on this device; the app still runs on defaults.
+    return {};
+  }
+  if (!raw) {return {};}
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // A corrupt record is not worth failing an app over.
+    return {};
+  }
+  if (!isRecord(parsed)) {return {};}
+  const restored: Record<string, unknown> = {};
+  for (const [id, value] of Object.entries(parsed)) {
+    if (ids.has(id) && value !== undefined) {restored[id] = value;}
+  }
+  return restored;
+};
+
+/** Write the persistable subset of the instance's variables. */
+export const savePersistedVariables = async (
+  appId: string,
+  values: Record<string, unknown>
+): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(variableStorageKey(appId), JSON.stringify(values));
+  } catch {
+    // Same as reading: a device that cannot store still runs the app.
+  }
+};
+
+/** The subset of instance variables that may be written, in a stable shape. */
+export const persistableValues = (
+  variables: Record<string, unknown>,
+  ids: ReadonlySet<string>
+): Record<string, unknown> => {
+  const values: Record<string, unknown> = {};
+  for (const id of [...ids].sort()) {
+    const value = variables[id];
+    if (value !== undefined) {values[id] = value;}
+  }
+  return values;
+};

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -172,20 +172,119 @@ const MediaOutputWidget: React.FC<WidgetProps> = (widget) => {
   );
 };
 
+/** A cell's text: primitives print, anything structured falls back to JSON. */
+const cellText = (value: unknown): string => {
+  if (value == null) {return "";}
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+const isRow = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Columns of a bound array: the union of the rows' keys, in first-seen order.
+ * An array of primitives has none — it renders as a single unnamed column.
+ */
+export const tableColumns = (rows: ReadonlyArray<unknown>): string[] => {
+  const columns: string[] = [];
+  for (const row of rows) {
+    if (!isRow(row)) {continue;}
+    for (const key of Object.keys(row)) {
+      if (!columns.includes(key)) {columns.push(key);}
+    }
+  }
+  return columns;
+};
+
+/** Lays an array value out as rows — what a run that emits N results needs. */
+const TableWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const rows = asItems(value);
+  const columns = useMemo(() => tableColumns(rows), [rows]);
+
+  if (rows.length === 0) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "No rows"}
+        colors={colors}
+      />
+    );
+  }
+
+  const cells = (row: unknown): string[] =>
+    columns.length === 0
+      ? [cellText(row)]
+      : columns.map((column) => (isRow(row) ? cellText(row[column]) : ""));
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <View style={[styles.table, { borderColor: colors.border }]}>
+        {columns.length > 0 ? (
+          <View style={[styles.tableRow, { backgroundColor: colors.inputBg }]}>
+            {columns.map((column) => (
+              <Text
+                key={column}
+                numberOfLines={1}
+                style={[styles.tableCell, styles.tableHeader, { color: colors.text }]}
+              >
+                {column}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+        {rows.map((row, index) => (
+          <View
+            key={index}
+            style={[
+              styles.tableRow,
+              index > 0 || columns.length > 0
+                ? { borderTopColor: colors.border, borderTopWidth: StyleSheet.hairlineWidth }
+                : null,
+            ]}
+          >
+            {cells(row).map((text, cellIndex) => (
+              <Text
+                key={cellIndex}
+                numberOfLines={3}
+                style={[styles.tableCell, { color: colors.textSecondary }]}
+              >
+                {text}
+              </Text>
+            ))}
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
 const ProgressWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
-  const { value, running, progress } = useWidgetRuntime({
+  const { value, running, progress, activity } = useWidgetRuntime({
     ...widget,
     bindingMode: "read",
   });
   const bound = typeof value === "number" ? value : undefined;
   const ratio = bound ?? progress;
-  const label = str(widget.props.label);
+  // What the run says it is doing outranks the author's static label: an app
+  // over an agent workflow otherwise shows a bare spinner for minutes.
+  const label = (running ? activity : undefined) ?? str(widget.props.label);
   if (!running && ratio === undefined) {return null;}
   return (
     <View style={styles.stack}>
       {label ? (
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
+        <Text
+          numberOfLines={2}
+          style={[styles.label, { color: colors.textSecondary }]}
+        >
           {label}
         </Text>
       ) : null}
@@ -708,6 +807,7 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Video: MediaOutputWidget,
   Json: MediaOutputWidget,
   Output: MediaOutputWidget,
+  Table: TableWidget,
   Progress: ProgressWidget,
   WorkflowInput: WorkflowInputWidget,
   TextInput: TextInputWidget,
@@ -852,6 +952,24 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     fontSize: 13,
+  },
+  table: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: "hidden",
+  },
+  tableRow: {
+    flexDirection: "row",
+  },
+  tableCell: {
+    minWidth: 120,
+    maxWidth: 240,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+  },
+  tableHeader: {
+    fontWeight: "700",
   },
   progressTrack: {
     height: 6,

--- a/mobile/src/stores/WorkflowRunner.ts
+++ b/mobile/src/stores/WorkflowRunner.ts
@@ -61,7 +61,11 @@ export type WorkflowRunner = {
 
   ensureConnection: () => Promise<void>;
   cleanup: () => void;
-  cancel: () => Promise<void>;
+  /**
+   * Cancel a run. Defaults to the runner's current job; an app that keeps
+   * several invocations of one workflow in flight passes the job it means.
+   */
+  cancel: (jobId?: string) => Promise<void>;
   resume: () => Promise<void>;
 };
 
@@ -213,22 +217,26 @@ export const createWorkflowRunnerStore = (
       );
     },
 
-    cancel: async () => {
-      const { job_id } = get();
-      if (job_id && workflowId) {
+    cancel: async (jobId?: string) => {
+      const target = jobId ?? get().job_id;
+      if (target && workflowId) {
         await webSocketService.send(
           {
             type: "cancel_job",
             command: "cancel_job",
             data: {
-              job_id,
+              job_id: target,
               workflow_id: workflowId,
             },
           },
           "/ws"
         );
       }
-      set({ state: "cancelled", statusMessage: "Cancelled" });
+      // Only the run the store is tracking changes its state; cancelling one of
+      // several app invocations must not report the whole runner as cancelled.
+      if (!jobId || jobId === get().job_id) {
+        set({ state: "cancelled", statusMessage: "Cancelled" });
+      }
     },
 
     resume: async () => {

--- a/packages/agents/src/evals/surfaces/app.ts
+++ b/packages/agents/src/evals/surfaces/app.ts
@@ -876,7 +876,8 @@ export function createAppToolBridge(
       "List everything a widget can bind to, with the exact token to store in " +
         "its `binding` prop: each operation's input and output nodes " +
         "(op:<opId>/in:<nodeId>, op:<opId>/out:<nodeId>), its execution fields " +
-        "(op:<opId>/exec#running|progress|error), and every variable (var:<id>). " +
+        "(op:<opId>/exec#running|progress|error|activity), and every variable " +
+        "(var:<id>). " +
         "Call this before binding a widget instead of guessing a name. An " +
         "operation over a workflow this editor has not loaded reports " +
         "ioAvailable: false and no node lists.",
@@ -916,7 +917,7 @@ The app is a tree of widgets bound to a workflow. Use the ui_app_* tools:
 - Set the page title with ui_app_set_title.
 
 Widgets are wired to workflow runs through the document's operations, variables, and resources:
-- ui_app_get_binding_targets lists every slot a widget can bind to and the exact token to put in its \`binding\` prop (op:<opId>/in:<nodeId>, op:<opId>/out:<nodeId>, op:<opId>/exec#running|progress|error, var:<id>). Call it before binding instead of guessing.
+- ui_app_get_binding_targets lists every slot a widget can bind to and the exact token to put in its \`binding\` prop (op:<opId>/in:<nodeId>, op:<opId>/out:<nodeId>, op:<opId>/exec#running|progress|error|activity, var:<id>). Call it before binding instead of guessing.
 - ui_app_list_operations / ui_app_add_operation / ui_app_update_operation / ui_app_remove_operation manage which workflows the app runs and how their inputs and outputs are mapped.
 - ui_app_list_variables / ui_app_declare_variable / ui_app_update_variable / ui_app_remove_variable manage app state. Only user-scoped variables may persist.
 - ui_app_list_resources / ui_app_add_resource / ui_app_remove_resource manage the document collections the app may reach.

--- a/packages/app-runtime/src/actions.ts
+++ b/packages/app-runtime/src/actions.ts
@@ -53,6 +53,8 @@ export interface AppEvent {
   value?: string;
   /** Which operation a run/cancel targets; defaults to the app's main one. */
   operationId?: string;
+  /** Cancel one specific run rather than the operation's latest. */
+  invocationId?: string;
   /** Resource binding id for resourceCommand/openResource. */
   resourceBindingId?: string;
   /** Command name for resourceCommand. */
@@ -101,7 +103,8 @@ export const eventToAction = (
     case "cancel":
       return {
         kind: "cancel",
-        operationId: event.operationId ?? ctx.defaultOperationId
+        operationId: event.operationId ?? ctx.defaultOperationId,
+        ...(event.invocationId ? { invocationId: event.invocationId } : {})
       };
     case "resourceCommand": {
       const command = event.command ?? "";

--- a/packages/app-runtime/src/bindings.ts
+++ b/packages/app-runtime/src/bindings.ts
@@ -10,7 +10,7 @@
  *   op:<opId>/in:<nodeId>              operation input
  *   op:<opId>/out:<nodeId>             operation output
  *   op:<opId>/prop:<nodeId>#<prop>     node property driven by a widget
- *   op:<opId>/exec#<field>             running | progress | error
+ *   op:<opId>/exec#<field>             running | progress | error | activity
  *   var:<variableId>                   declared app variable
  *   view:<componentId>#<prop>          widget-local state, never persisted
  *   node:<nodeId>#<prop>               legacy node property (default operation)
@@ -18,7 +18,7 @@
  */
 import type { VariableDeclaration } from "./document.js";
 
-export type ExecutionField = "running" | "progress" | "error";
+export type ExecutionField = "running" | "progress" | "error" | "activity";
 
 export type BindingRef =
   | { kind: "input"; operationId: string; nodeId: string }
@@ -148,7 +148,10 @@ export interface BindingScope {
 }
 
 const isExecutionField = (value: string): value is ExecutionField =>
-  value === "running" || value === "progress" || value === "error";
+  value === "running" ||
+  value === "progress" ||
+  value === "error" ||
+  value === "activity";
 
 /** Parse an explicit (already ID-based) binding token. Legacy names return null. */
 export const parseBinding = (binding?: string | null): BindingRef | null => {

--- a/packages/app-runtime/src/conditions.ts
+++ b/packages/app-runtime/src/conditions.ts
@@ -8,10 +8,20 @@
  * revision path is to adopt CEL or JSONLogic in the `Condition` and `format`
  * slots — not to grow a language in this file.
  */
-import type { BindingRef, BindingScope, BindingMode } from "./bindings.js";
+import type {
+  BindingRef,
+  BindingScope,
+  BindingMode,
+  ExecutionField
+} from "./bindings.js";
 import { resolveBinding, stateKey } from "./bindings.js";
 import type { AppInstanceState } from "./state.js";
-import { isOperationRunning, operationError, operationProgress } from "./state.js";
+import {
+  isOperationRunning,
+  operationActivity,
+  operationError,
+  operationProgress
+} from "./state.js";
 
 export type StateRef =
   | { source: "variable"; variableId: string }
@@ -20,7 +30,7 @@ export type StateRef =
   | {
       source: "execution";
       operationId: string;
-      field: "running" | "progress" | "error";
+      field: ExecutionField;
     };
 
 export type ConditionOp =
@@ -28,6 +38,9 @@ export type ConditionOp =
   | "neq"
   | "gt"
   | "lt"
+  | "gte"
+  | "lte"
+  | "contains"
   | "empty"
   | "notEmpty";
 
@@ -49,6 +62,9 @@ const CONDITION_OPS: ReadonlySet<string> = new Set([
   "neq",
   "gt",
   "lt",
+  "gte",
+  "lte",
+  "contains",
   "empty",
   "notEmpty"
 ]);
@@ -132,6 +148,8 @@ export const readRef = (
           return operationProgress(state, ref.operationId);
         case "error":
           return operationError(state, ref.operationId);
+        case "activity":
+          return operationActivity(state, ref.operationId);
       }
   }
 };
@@ -161,6 +179,20 @@ const coerceLike = (value: unknown, sample: unknown): unknown => {
   return value;
 };
 
+/**
+ * The numeric comparisons all read the same: a non-numeric actual value never
+ * satisfies one, and the stored literal is coerced from its Puck string form.
+ */
+const compareNumeric = (
+  actual: unknown,
+  value: unknown,
+  compare: (a: number, b: number) => boolean
+): boolean => {
+  const expected = Number(coerceLike(value, 0));
+  if (typeof actual !== "number" || Number.isNaN(expected)) return false;
+  return compare(actual, expected);
+};
+
 export const evaluateCondition = (
   state: AppInstanceState,
   condition: Condition
@@ -175,17 +207,24 @@ export const evaluateCondition = (
       return actual === coerceLike(condition.value, actual);
     case "neq":
       return actual !== coerceLike(condition.value, actual);
-    case "gt": {
-      const expected = Number(coerceLike(condition.value, 0));
-      return typeof actual === "number" && !Number.isNaN(expected)
-        ? actual > expected
-        : false;
-    }
-    case "lt": {
-      const expected = Number(coerceLike(condition.value, 0));
-      return typeof actual === "number" && !Number.isNaN(expected)
-        ? actual < expected
-        : false;
+    case "gt":
+      return compareNumeric(actual, condition.value, (a, b) => a > b);
+    case "lt":
+      return compareNumeric(actual, condition.value, (a, b) => a < b);
+    case "gte":
+      return compareNumeric(actual, condition.value, (a, b) => a >= b);
+    case "lte":
+      return compareNumeric(actual, condition.value, (a, b) => a <= b);
+    case "contains": {
+      if (typeof actual === "string") {
+        return actual.includes(
+          condition.value == null ? "" : String(condition.value)
+        );
+      }
+      if (Array.isArray(actual)) {
+        return actual.some((item) => item === coerceLike(condition.value, item));
+      }
+      return false;
     }
   }
 };
@@ -208,6 +247,13 @@ const FILTERS: Record<string, (value: unknown, arg?: string) => string> = {
     return arg === "short" ? date.toLocaleDateString() : date.toLocaleString();
   },
   upper: (value) => String(value ?? "").toUpperCase(),
+  lower: (value) => String(value ?? "").toLowerCase(),
+  join: (value, arg) => {
+    const separator = arg === undefined ? ", " : arg;
+    return Array.isArray(value)
+      ? value.map((item) => (item == null ? "" : String(item))).join(separator)
+      : String(value ?? "");
+  },
   truncate: (value, arg) => {
     const text = String(value ?? "");
     const limit = Number(arg);

--- a/packages/app-runtime/src/doc-ops.ts
+++ b/packages/app-runtime/src/doc-ops.ts
@@ -268,7 +268,12 @@ export const removeResource = (
 
 /* ----------------------------------------------------------- binding targets */
 
-const EXECUTION_FIELDS: ExecutionField[] = ["running", "progress", "error"];
+const EXECUTION_FIELDS: ExecutionField[] = [
+  "running",
+  "progress",
+  "error",
+  "activity"
+];
 
 /**
  * The bindable surface of a workflow graph, as much of it as

--- a/packages/app-runtime/src/fold.ts
+++ b/packages/app-runtime/src/fold.ts
@@ -10,8 +10,13 @@
  * instance did not start is dropped: that is how a second tab, an overlapping
  * run, or a run started in the graph editor stops contaminating the app's
  * values.
+ *
+ * A node's value can land in two places at once: the output slot a display
+ * widget reads, and — when the operation maps that output `to: "variable"` —
+ * an app variable. Both get the same value, streamed chunks accumulating the
+ * same way in each.
  */
-import type { AppStateEvent, InvocationState } from "./state.js";
+import type { AppStateEvent, Disposition, InvocationState } from "./state.js";
 
 export interface FoldContext {
   /**
@@ -24,6 +29,11 @@ export interface FoldContext {
   ) => InvocationState | null;
   /** The output state key for a node within an operation, or null if unbound. */
   outputKey: (operationId: string, nodeId: string) => string | null;
+  /**
+   * The variable a node's output writes, or null when it writes none. Built
+   * from `outputVariableTargets` of the running operation.
+   */
+  outputVariable?: (operationId: string, nodeId: string) => string | null;
 }
 
 const str = (value: unknown): string =>
@@ -46,6 +56,72 @@ export const errorText = (value: unknown): string => {
   return "";
 };
 
+/**
+ * Fan one node value out to whatever it is wired to: the display slot, the
+ * variable, or both. Neither wired means the message carries nothing this app
+ * shows.
+ */
+const valueEvents = (
+  ctx: FoldContext,
+  invocation: InvocationState,
+  nodeId: string,
+  value: unknown,
+  disposition: Disposition,
+  done: boolean
+): AppStateEvent[] => {
+  const key = ctx.outputKey(invocation.operationId, nodeId);
+  const variableId = ctx.outputVariable?.(invocation.operationId, nodeId) ?? null;
+  const events: AppStateEvent[] = [];
+  if (key) {
+    events.push({
+      type: "outputValue",
+      key,
+      invocationId: invocation.id,
+      value,
+      disposition,
+      done
+    });
+  }
+  if (variableId) {
+    events.push({
+      type: "setVariable",
+      variableId,
+      value,
+      disposition,
+      invocationId: invocation.id
+    });
+  }
+  return events;
+};
+
+/** A short human-readable label for what a streaming run is doing right now. */
+const activityLabel = (
+  type: string,
+  message: Record<string, unknown>
+): string => {
+  switch (type) {
+    case "tool_call_update": {
+      const note = str(message.message).trim();
+      return note || str(message.name).trim();
+    }
+    case "planning_update": {
+      const phase = str(message.phase).trim();
+      const status = str(message.status).trim();
+      return phase && status ? `${phase}: ${status}` : phase || status;
+    }
+    case "task_update": {
+      const step = message.step as Record<string, unknown> | null | undefined;
+      const task = message.task as Record<string, unknown> | null | undefined;
+      const stepName = str(step?.name).trim();
+      const taskTitle = str(task?.title).trim() || str(task?.name).trim();
+      if (stepName && taskTitle) return `${taskTitle}: ${stepName}`;
+      return stepName || taskTitle || str(message.event).replace(/_/g, " ");
+    }
+    default:
+      return "";
+  }
+};
+
 const TERMINAL_JOB_STATUS: Record<string, InvocationState["status"]> = {
   completed: "completed",
   failed: "failed",
@@ -60,6 +136,10 @@ const TERMINAL_JOB_STATUS: Record<string, InvocationState["status"]> = {
  * `output_update` follows the protocol default: an absent `disposition`
  * appends (older servers omit it on streamed chunks); only an explicit
  * `"replace"` replaces.
+ *
+ * `tool_call_update`, `planning_update`, and `task_update` carry no value —
+ * they become the invocation's activity label, which is all an app can show of
+ * an agent's work in progress.
  */
 export const messageToEvents = (
   message: Record<string, unknown>,
@@ -74,39 +154,28 @@ export const messageToEvents = (
   if (!invocation) return [];
 
   switch (type) {
-    case "output_update": {
-      const nodeId = str(message.node_id);
-      const key = ctx.outputKey(invocation.operationId, nodeId);
-      if (!key) return [];
-      return [
-        {
-          type: "outputValue",
-          key,
-          invocationId: invocation.id,
-          value: message.value,
-          disposition: message.disposition === "replace" ? "replace" : "append",
-          done: message.done === true
-        }
-      ];
-    }
+    case "output_update":
+      return valueEvents(
+        ctx,
+        invocation,
+        str(message.node_id),
+        message.value,
+        message.disposition === "replace" ? "replace" : "append",
+        message.done === true
+      );
 
     case "chunk": {
       // Only text chunks fold into a display value; audio/video chunks are
       // consumed by their own players.
       if (message.content_type && message.content_type !== "text") return [];
-      const nodeId = str(message.node_id);
-      const key = ctx.outputKey(invocation.operationId, nodeId);
-      if (!key) return [];
-      return [
-        {
-          type: "outputValue",
-          key,
-          invocationId: invocation.id,
-          value: str(message.content),
-          disposition: "append",
-          done: message.done === true
-        }
-      ];
+      return valueEvents(
+        ctx,
+        invocation,
+        str(message.node_id),
+        str(message.content),
+        "append",
+        message.done === true
+      );
     }
 
     case "node_progress": {
@@ -127,6 +196,24 @@ export const messageToEvents = (
       if (!error) return [];
       return [
         { type: "invocationError", invocationId: invocation.id, error }
+      ];
+    }
+
+    case "error": {
+      const error = errorText(message.message) || errorText(message.error);
+      if (!error) return [];
+      return [
+        { type: "invocationError", invocationId: invocation.id, error }
+      ];
+    }
+
+    case "tool_call_update":
+    case "planning_update":
+    case "task_update": {
+      const label = activityLabel(type, message);
+      if (!label) return [];
+      return [
+        { type: "invocationActivity", invocationId: invocation.id, label }
       ];
     }
 

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -5,14 +5,15 @@
  * and resources. All computation stays in workflow graphs; the only logic this
  * layer holds is a closed vocabulary of widget props. This package owns the
  * shared semantics — document parsing, binding resolution, instance state, the
- * streaming fold, conditions, and the widget catalog — so the web runtime, the
- * CLI `app debug` harness, and the eval suites cannot drift apart.
+ * streaming fold, run policy, conditions, and the widget catalog — so the web
+ * runtime, the CLI `app debug` harness, and the eval suites cannot drift apart.
  */
 export * from "./document.js";
 export * from "./bindings.js";
 export * from "./state.js";
 export * from "./operations.js";
 export * from "./fold.js";
+export * from "./policy.js";
 export * from "./conditions.js";
 export * from "./actions.js";
 export * from "./widgets.js";

--- a/packages/app-runtime/src/operations.ts
+++ b/packages/app-runtime/src/operations.ts
@@ -85,6 +85,23 @@ export const outputVariableTargets = (
   );
 
 /**
+ * The declared defaults an instance starts from: variable id → `default`, for
+ * every variable that declares one. Feed it to the `seedVariables` event, which
+ * never clobbers — so a restored user-scoped value, seeded first, wins over the
+ * document's default.
+ */
+export const initialVariableValues = (
+  variables: ReadonlyArray<VariableDeclaration>
+): Record<string, unknown> => {
+  const values: Record<string, unknown> = {};
+  for (const variable of variables) {
+    if (variable.default === undefined) continue;
+    values[variable.id] = variable.default;
+  }
+  return values;
+};
+
+/**
  * The operation a legacy single-workflow app runs: every input takes its bound
  * widget's value, every output displays. Lets one code path serve both a
  * document with explicit operations and one imported from `workflow.app_doc`.

--- a/packages/app-runtime/src/policy.ts
+++ b/packages/app-runtime/src/policy.ts
@@ -1,0 +1,36 @@
+/**
+ * What to do when an operation is asked to run while it is already running.
+ *
+ * The document declares the intent (`OperationPolicy`); this decides, against
+ * the live invocations, what the caller must do first. It stays pure: the
+ * runtime owns cancelling and awaiting, this only says which invocations those
+ * verbs apply to.
+ */
+import type { OperationBinding } from "./document.js";
+import type { AppInstanceState } from "./state.js";
+import { liveInvocations } from "./state.js";
+
+export type RunDecision =
+  | { kind: "start" }
+  /** Cancel these invocations, then start. */
+  | { kind: "replace"; cancel: string[] }
+  /** Wait for these invocations to settle, then start. */
+  | { kind: "queue"; after: string[] };
+
+/**
+ * With nothing in flight every policy starts immediately — the policy only
+ * describes the collision.
+ */
+export const decideRun = (
+  state: AppInstanceState,
+  operation: OperationBinding
+): RunDecision => {
+  if (operation.policy === "parallel") return { kind: "start" };
+
+  const live = liveInvocations(state, operation.id).map((i) => i.id);
+  if (live.length === 0) return { kind: "start" };
+
+  return operation.policy === "queue"
+    ? { kind: "queue", after: live }
+    : { kind: "replace", cancel: live };
+};

--- a/packages/app-runtime/src/state.ts
+++ b/packages/app-runtime/src/state.ts
@@ -11,6 +11,12 @@
  *
  * Every function here is pure. The React store, the CLI harness, and the eval
  * suites all drive the same reducer.
+ *
+ * Beside the four value namespaces the state carries what a run reports about
+ * itself: invocation status/progress/error, and `activity` — the latest
+ * human-readable label a streaming agent emitted (the tool it is calling, the
+ * planning phase it is in, the task step it is on). Without it an app over an
+ * agent workflow shows a spinner and nothing else.
  */
 
 export type InvocationStatus =
@@ -59,6 +65,14 @@ export interface AppInstanceState {
   invocations: Record<string, InvocationState>;
   /** Most recent invocation per operation id. */
   activeInvocation: Record<string, string>;
+  /** Keyed by invocation id: the latest activity label the run reported. */
+  activity: Record<string, string>;
+  /**
+   * Keyed by variable id: the invocation whose stream last appended to it.
+   * Bookkeeping for streamed output→variable writes, so a second run starts a
+   * fresh value instead of appending to the previous run's.
+   */
+  variableWriters: Record<string, string>;
 }
 
 export const createInstanceState = (): AppInstanceState => ({
@@ -67,7 +81,9 @@ export const createInstanceState = (): AppInstanceState => ({
   variables: {},
   view: {},
   invocations: {},
-  activeInvocation: {}
+  activeInvocation: {},
+  activity: {},
+  variableWriters: {}
 });
 
 /** How a streamed value combines with what the slot already holds. */
@@ -76,8 +92,25 @@ export type Disposition = "append" | "replace";
 export type AppStateEvent =
   /** Seed values that have not been set yet (defaults); never clobbers. */
   | { type: "seedInputs"; values: Record<string, unknown> }
+  /**
+   * Seed declared variable defaults (or a restored user-scoped value) into any
+   * variable that has none yet; never clobbers, same as `seedInputs`.
+   */
+  | { type: "seedVariables"; values: Record<string, unknown> }
   | { type: "setInput"; key: string; value: unknown; dirty?: boolean }
-  | { type: "setVariable"; variableId: string; value: unknown }
+  | {
+      type: "setVariable";
+      variableId: string;
+      value: unknown;
+      /**
+       * "append" accumulates the way an output slot does, so a streamed output
+       * mapped to a variable builds up instead of flickering one chunk at a
+       * time. Defaults to "replace" — a widget writing a variable overwrites.
+       */
+      disposition?: Disposition;
+      /** The run doing the appending; a new run restarts the accumulation. */
+      invocationId?: string;
+    }
   | { type: "toggleVariable"; variableId: string }
   | { type: "setView"; key: string; value: unknown }
   /** Validate → snapshot → create invocation → mark outputs pending, atomically. */
@@ -95,6 +128,8 @@ export type AppStateEvent =
   | { type: "invocationProgress"; invocationId: string; progress?: number }
   /** A node reported an error; the run may still be in flight. */
   | { type: "invocationError"; invocationId: string; error: string }
+  /** The run reported what it is doing right now (tool, phase, step). */
+  | { type: "invocationActivity"; invocationId: string; label: string }
   | {
       type: "outputValue";
       key: string;
@@ -113,7 +148,7 @@ const asString = (value: unknown): string =>
  * streamed string must render as one Markdown block, not N), while structured
  * items collect into a list — one entry per emitted item.
  */
-const appendValue = (previous: unknown, next: unknown): unknown => {
+export const appendValue = (previous: unknown, next: unknown): unknown => {
   if (typeof next === "string") return asString(previous) + next;
   if (previous === undefined) return next;
   if (Array.isArray(previous)) return [...previous, next];
@@ -136,6 +171,17 @@ export const applyEvent = (
       return changed ? { ...state, inputs } : state;
     }
 
+    case "seedVariables": {
+      let changed = false;
+      const variables = { ...state.variables };
+      for (const [id, value] of Object.entries(event.values)) {
+        if (value === undefined || variables[id] !== undefined) continue;
+        variables[id] = value;
+        changed = true;
+      }
+      return changed ? { ...state, variables } : state;
+    }
+
     case "setInput": {
       const previous = state.inputs[event.key];
       return {
@@ -151,11 +197,34 @@ export const applyEvent = (
       };
     }
 
-    case "setVariable":
+    case "setVariable": {
+      if (event.disposition !== "append") {
+        const { [event.variableId]: _dropped, ...variableWriters } =
+          state.variableWriters;
+        return {
+          ...state,
+          variables: { ...state.variables, [event.variableId]: event.value },
+          variableWriters
+        };
+      }
+      const writer = state.variableWriters[event.variableId];
+      const sameRun = event.invocationId !== undefined && writer === event.invocationId;
+      const previous = sameRun ? state.variables[event.variableId] : undefined;
       return {
         ...state,
-        variables: { ...state.variables, [event.variableId]: event.value }
+        variables: {
+          ...state.variables,
+          [event.variableId]: appendValue(previous, event.value)
+        },
+        variableWriters:
+          event.invocationId === undefined
+            ? state.variableWriters
+            : {
+                ...state.variableWriters,
+                [event.variableId]: event.invocationId
+              }
       };
+    }
 
     case "toggleVariable":
       return {
@@ -238,6 +307,15 @@ export const applyEvent = (
       };
     }
 
+    case "invocationActivity": {
+      if (!state.invocations[event.invocationId]) return state;
+      if (state.activity[event.invocationId] === event.label) return state;
+      return {
+        ...state,
+        activity: { ...state.activity, [event.invocationId]: event.label }
+      };
+    }
+
     case "outputValue": {
       // Run identity is the whole point: a message from an invocation this
       // instance did not start, or from one superseded by a newer run on the
@@ -285,13 +363,19 @@ export const invocationsOf = (
     .filter((i) => i.operationId === operationId)
     .sort((a, b) => b.startedAt - a.startedAt);
 
+export const isLiveInvocation = (invocation: InvocationState): boolean =>
+  invocation.status === "pending" || invocation.status === "running";
+
+/** Invocations of an operation that have not settled yet, newest first. */
+export const liveInvocations = (
+  state: AppInstanceState,
+  operationId: string
+): InvocationState[] => invocationsOf(state, operationId).filter(isLiveInvocation);
+
 export const isOperationRunning = (
   state: AppInstanceState,
   operationId: string
-): boolean =>
-  invocationsOf(state, operationId).some(
-    (i) => i.status === "pending" || i.status === "running"
-  );
+): boolean => liveInvocations(state, operationId).length > 0;
 
 /** Aggregate progress of the operation's active invocation, if any. */
 export const operationProgress = (
@@ -308,4 +392,13 @@ export const operationError = (
 ): string | undefined => {
   const id = state.activeInvocation[operationId];
   return id ? state.invocations[id]?.error : undefined;
+};
+
+/** What the operation's active invocation last reported it was doing. */
+export const operationActivity = (
+  state: AppInstanceState,
+  operationId: string
+): string | undefined => {
+  const id = state.activeInvocation[operationId];
+  return id ? state.activity[id] : undefined;
 };

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -34,6 +34,8 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   Audio: { label: "Audio", mode: "read" },
   Video: { label: "Video", mode: "read" },
   Json: { label: "JSON", mode: "read" },
+  // Lays out an array value as rows — what a run that emits N results needs.
+  Table: { label: "Table", mode: "read" },
   Output: { label: "Output", mode: "read" },
   Progress: { label: "Progress", mode: "read" },
   // Inputs

--- a/packages/app-runtime/tests/conditions.test.ts
+++ b/packages/app-runtime/tests/conditions.test.ts
@@ -143,3 +143,122 @@ describe("event to action", () => {
     ).toEqual({ kind: "resourceCommand", resourceBindingId: "r1", command: "upload" });
   });
 });
+
+describe("added condition ops", () => {
+  const listState = applyEvents(createInstanceState(), [
+    { type: "setVariable", variableId: "dark", value: ["red", "blue"] }
+  ]);
+
+  it("mirrors gt/lt with inclusive bounds", () => {
+    const gte = parseCondition({ binding: "count", op: "gte", value: "5" }, scope, "write");
+    expect(gte && evaluateCondition(state, gte)).toBe(true);
+    const lte = parseCondition({ binding: "count", op: "lte", value: "5" }, scope, "write");
+    expect(lte && evaluateCondition(state, lte)).toBe(true);
+    const tooHigh = parseCondition({ binding: "count", op: "lte", value: "4" }, scope, "write");
+    expect(tooHigh && evaluateCondition(state, tooHigh)).toBe(false);
+  });
+
+  it("refuses a numeric comparison against a non-number", () => {
+    const gte = parseCondition({ binding: "result", op: "gte", value: "1" }, scope);
+    expect(gte && evaluateCondition(state, gte)).toBe(false);
+  });
+
+  it("matches a substring of a string value", () => {
+    const yes = parseCondition({ binding: "result", op: "contains", value: "streamed" }, scope);
+    expect(yes && evaluateCondition(state, yes)).toBe(true);
+    const no = parseCondition({ binding: "result", op: "contains", value: "absent" }, scope);
+    expect(no && evaluateCondition(state, no)).toBe(false);
+  });
+
+  it("matches a member of an array value", () => {
+    const yes = parseCondition({ binding: "dark", op: "contains", value: "blue" }, scope);
+    expect(yes && evaluateCondition(listState, yes)).toBe(true);
+    const no = parseCondition({ binding: "dark", op: "contains", value: "green" }, scope);
+    expect(no && evaluateCondition(listState, no)).toBe(false);
+  });
+
+  it("keeps the operators a closed vocabulary", () => {
+    expect(parseCondition({ binding: "result", op: "gte" }, scope)?.op).toBe("gte");
+    expect(parseCondition({ binding: "result", op: "regex" }, scope)?.op).toBe("notEmpty");
+  });
+});
+
+describe("added format filters", () => {
+  const listState = applyEvents(createInstanceState(), [
+    { type: "setVariable", variableId: "dark", value: ["red", "blue"] }
+  ]);
+
+  it("lowercases", () => {
+    expect(formatTemplate("{result|lower}", state, scope)).toBe(
+      "a long piece of streamed text"
+    );
+  });
+
+  it("joins an array, comma-separated by default", () => {
+    expect(formatTemplate("{dark|join}", listState, scope)).toBe("red, blue");
+    expect(formatTemplate("{dark|join:/}", listState, scope)).toBe("red/blue");
+  });
+
+  it("renders a non-array join as the value itself", () => {
+    expect(formatTemplate("{result|join}", state, scope)).toBe(
+      "a long piece of streamed text"
+    );
+  });
+});
+
+describe("activity binding", () => {
+  const runningState = applyEvents(createInstanceState(), [
+    {
+      type: "runStarted",
+      invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+      outputKeys: []
+    },
+    { type: "invocationActivity", invocationId: "j1", label: "web_search" }
+  ]);
+
+  it("resolves op:main/exec#activity and reads the label", () => {
+    const condition = parseCondition(
+      { binding: "op:main/exec#activity", op: "notEmpty" },
+      scope
+    );
+    expect(condition?.ref).toEqual({
+      source: "execution",
+      operationId: "main",
+      field: "activity"
+    });
+    expect(condition && evaluateCondition(runningState, condition)).toBe(true);
+    expect(
+      readRef(runningState, {
+        source: "execution",
+        operationId: "main",
+        field: "activity"
+      })
+    ).toBe("web_search");
+  });
+
+  it("interpolates the activity label into a format template", () => {
+    expect(
+      formatTemplate("{op:main/exec#activity}", runningState, scope)
+    ).toBe("web_search");
+  });
+});
+
+describe("cancel by invocation", () => {
+  it("passes an explicit invocation through", () => {
+    expect(
+      eventToAction(
+        { trigger: "click", kind: "cancel", invocationId: "j7" },
+        { defaultOperationId: "main", resolveVariableId: () => null }
+      )
+    ).toEqual({ kind: "cancel", operationId: "main", invocationId: "j7" });
+  });
+
+  it("omits it when the event names none, so the latest run is cancelled", () => {
+    expect(
+      eventToAction(
+        { trigger: "click", kind: "cancel" },
+        { defaultOperationId: "main", resolveVariableId: () => null }
+      )
+    ).toEqual({ kind: "cancel", operationId: "main" });
+  });
+});

--- a/packages/app-runtime/tests/doc-ops.test.ts
+++ b/packages/app-runtime/tests/doc-ops.test.ts
@@ -203,7 +203,8 @@ describe("bindingTargets", () => {
     expect(targets.operations[0].execution.map((e) => e.binding)).toEqual([
       "op:main/exec#running",
       "op:main/exec#progress",
-      "op:main/exec#error"
+      "op:main/exec#error",
+      "op:main/exec#activity"
     ]);
   });
 

--- a/packages/app-runtime/tests/fold.test.ts
+++ b/packages/app-runtime/tests/fold.test.ts
@@ -162,3 +162,124 @@ describe("errorText", () => {
     expect(errorText({ message: "  " })).toBe("");
   });
 });
+
+describe("output → variable", () => {
+  const varCtx = (state: AppInstanceState) => ({
+    ...ctx(state),
+    outputVariable: (_operationId: string, nodeId: string) =>
+      nodeId === "n9" || nodeId === "n8" ? "analysis" : null
+  });
+
+  const foldVar = (
+    state: AppInstanceState,
+    messages: Record<string, unknown>[]
+  ): AppInstanceState => applyEvents(state, messagesToEvents(messages, varCtx(state)));
+
+  it("writes both the display slot and the variable", () => {
+    const state = foldVar(started("job-1"), [
+      {
+        type: "output_update",
+        job_id: "job-1",
+        node_id: "n9",
+        value: "done",
+        disposition: "replace"
+      }
+    ]);
+    expect(state.outputs["main:n9"].value).toBe("done");
+    expect(state.variables.analysis).toBe("done");
+  });
+
+  it("writes the variable for a node no display is bound to", () => {
+    // n8 has no output key, only a variable target.
+    const state = foldVar(started("job-1"), [
+      { type: "output_update", job_id: "job-1", node_id: "n8", value: 42, disposition: "replace" }
+    ]);
+    expect(state.variables.analysis).toBe(42);
+    expect(state.outputs["main:n8"]).toBeUndefined();
+  });
+
+  it("accumulates streamed chunks into the variable", () => {
+    const state = foldVar(started("job-1"), [
+      { type: "chunk", job_id: "job-1", node_id: "n9", content: "Hel" },
+      { type: "chunk", job_id: "job-1", node_id: "n9", content: "lo", done: true }
+    ]);
+    expect(state.variables.analysis).toBe("Hello");
+    expect(state.outputs["main:n9"].value).toBe("Hello");
+  });
+
+  it("emits nothing when neither a display nor a variable is bound", () => {
+    const state = started("job-1");
+    expect(
+      messagesToEvents(
+        [{ type: "output_update", job_id: "job-1", node_id: "nX", value: "x" }],
+        varCtx(state)
+      )
+    ).toEqual([]);
+  });
+
+  it("drops a variable write from a job this instance did not start", () => {
+    const state = foldVar(started("job-1"), [
+      { type: "output_update", job_id: "job-other", node_id: "n9", value: "leak" }
+    ]);
+    expect(state.variables.analysis).toBeUndefined();
+  });
+});
+
+describe("streaming activity", () => {
+  it("labels a tool call by its message, falling back to the tool name", () => {
+    let state = fold(started("job-1"), [
+      { type: "tool_call_update", job_id: "job-1", name: "web_search", args: {} }
+    ]);
+    expect(state.activity["job-1"]).toBe("web_search");
+
+    state = fold(state, [
+      {
+        type: "tool_call_update",
+        job_id: "job-1",
+        name: "web_search",
+        args: {},
+        message: "Searching for hammocks"
+      }
+    ]);
+    expect(state.activity["job-1"]).toBe("Searching for hammocks");
+  });
+
+  it("labels a planning update with its phase and status", () => {
+    const state = fold(started("job-1"), [
+      { type: "planning_update", job_id: "job-1", phase: "Analysis", status: "Success" }
+    ]);
+    expect(state.activity["job-1"]).toBe("Analysis: Success");
+  });
+
+  it("labels a task update by its task title and step", () => {
+    let state = fold(started("job-1"), [
+      {
+        type: "task_update",
+        job_id: "job-1",
+        task: { title: "Research" },
+        step: { name: "Fetch sources" },
+        event: "step_started"
+      }
+    ]);
+    expect(state.activity["job-1"]).toBe("Research: Fetch sources");
+
+    state = fold(state, [
+      { type: "task_update", job_id: "job-1", task: {}, event: "task_completed" }
+    ]);
+    expect(state.activity["job-1"]).toBe("task completed");
+  });
+
+  it("ignores an activity message with nothing to say", () => {
+    const state = fold(started("job-1"), [
+      { type: "planning_update", job_id: "job-1", phase: "", status: "" }
+    ]);
+    expect(state.activity["job-1"]).toBeUndefined();
+  });
+
+  it("folds a top-level error onto the invocation", () => {
+    const state = fold(started("job-1"), [
+      { type: "error", job_id: "job-1", message: "provider refused" }
+    ]);
+    expect(state.invocations["job-1"].error).toBe("provider refused");
+  });
+});

--- a/packages/app-runtime/tests/operations.test.ts
+++ b/packages/app-runtime/tests/operations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   implicitOperation,
+  initialVariableValues,
   mergeVariables,
   outputVariableTargets,
   resolveOperationParams
@@ -93,5 +94,25 @@ describe("mergeVariables", () => {
     expect(merged).toHaveLength(2);
     expect(merged[0]).toMatchObject({ id: "v1", persist: true });
     expect(merged[1]).toMatchObject({ id: "dark", scope: "instance" });
+  });
+});
+
+describe("initialVariableValues", () => {
+  it("returns only the variables that declare a default", () => {
+    expect(
+      initialVariableValues([
+        { id: "v1", name: "tone", scope: "instance", persist: false, default: "warm" },
+        { id: "v2", name: "count", scope: "instance", persist: false, default: 0 },
+        { id: "v3", name: "note", scope: "instance", persist: false }
+      ])
+    ).toEqual({ v1: "warm", v2: 0 });
+  });
+
+  it("is empty when nothing declares one", () => {
+    expect(
+      initialVariableValues([
+        { id: "v1", name: "tone", scope: "instance", persist: false }
+      ])
+    ).toEqual({});
   });
 });

--- a/packages/app-runtime/tests/policy.test.ts
+++ b/packages/app-runtime/tests/policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import type { OperationBinding, OperationPolicy } from "../src/document.js";
+import { implicitOperation } from "../src/operations.js";
+import { decideRun } from "../src/policy.js";
+import {
+  applyEvent,
+  applyEvents,
+  createInstanceState,
+  type AppInstanceState
+} from "../src/state.js";
+
+const operation = (policy: OperationPolicy): OperationBinding => ({
+  ...implicitOperation("wf1"),
+  policy
+});
+
+const withRuns = (): AppInstanceState =>
+  applyEvents(createInstanceState(), [
+    {
+      type: "runStarted",
+      invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+      outputKeys: []
+    },
+    {
+      type: "runStarted",
+      invocation: { id: "j2", operationId: "main", status: "pending", startedAt: 2 },
+      outputKeys: []
+    },
+    {
+      type: "runStarted",
+      invocation: { id: "j3", operationId: "other", status: "running", startedAt: 3 },
+      outputKeys: []
+    }
+  ]);
+
+describe("decideRun", () => {
+  it("starts under every policy when nothing is in flight", () => {
+    const idle = createInstanceState();
+    for (const policy of ["parallel", "replace", "queue"] as const) {
+      expect(decideRun(idle, operation(policy))).toEqual({ kind: "start" });
+    }
+  });
+
+  it("starts a parallel operation even while it is running", () => {
+    expect(decideRun(withRuns(), operation("parallel"))).toEqual({ kind: "start" });
+  });
+
+  it("cancels every live run of the operation under replace", () => {
+    expect(decideRun(withRuns(), operation("replace"))).toEqual({
+      kind: "replace",
+      cancel: ["j2", "j1"]
+    });
+  });
+
+  it("awaits every live run of the operation under queue", () => {
+    expect(decideRun(withRuns(), operation("queue"))).toEqual({
+      kind: "queue",
+      after: ["j2", "j1"]
+    });
+  });
+
+  it("ignores other operations' runs", () => {
+    const state = applyEvent(createInstanceState(), {
+      type: "runStarted",
+      invocation: { id: "j3", operationId: "other", status: "running", startedAt: 3 },
+      outputKeys: []
+    });
+    expect(decideRun(state, operation("replace"))).toEqual({ kind: "start" });
+  });
+
+  it("starts again once the previous run settled", () => {
+    const state = applyEvent(withRuns(), {
+      type: "invocationStatus",
+      invocationId: "j1",
+      status: "completed"
+    });
+    expect(decideRun(state, operation("queue"))).toEqual({
+      kind: "queue",
+      after: ["j2"]
+    });
+  });
+});

--- a/packages/app-runtime/tests/state.test.ts
+++ b/packages/app-runtime/tests/state.test.ts
@@ -6,6 +6,8 @@ import {
   createInstanceState,
   invocationsOf,
   isOperationRunning,
+  liveInvocations,
+  operationActivity,
   operationError,
   operationProgress
 } from "../src/state.js";
@@ -106,5 +108,162 @@ describe("invocations", () => {
         status: "failed"
       })
     ).toBe(state);
+  });
+});
+
+describe("seedVariables", () => {
+  it("seeds only variables that have no value yet", () => {
+    let state = applyEvent(createInstanceState(), {
+      type: "setVariable",
+      variableId: "tone",
+      value: "user picked"
+    });
+    state = applyEvent(state, {
+      type: "seedVariables",
+      values: { tone: "default", count: 3 }
+    });
+    expect(state.variables.tone).toBe("user picked");
+    expect(state.variables.count).toBe(3);
+  });
+
+  it("skips undefined defaults and returns the same object when nothing changes", () => {
+    const state = applyEvent(createInstanceState(), {
+      type: "seedVariables",
+      values: { tone: undefined }
+    });
+    expect(state.variables).toEqual({});
+    expect(applyEvent(state, { type: "seedVariables", values: {} })).toBe(state);
+  });
+
+  it("keeps a value seeded first, which is how a restored user value wins", () => {
+    let state = applyEvent(createInstanceState(), {
+      type: "seedVariables",
+      values: { tone: "restored" }
+    });
+    state = applyEvent(state, {
+      type: "seedVariables",
+      values: { tone: "document default" }
+    });
+    expect(state.variables.tone).toBe("restored");
+  });
+});
+
+describe("appended variables", () => {
+  const running = (id: string) =>
+    applyEvent(createInstanceState(), {
+      type: "runStarted",
+      invocation: { id, operationId: "main", status: "running", startedAt: 1 },
+      outputKeys: []
+    });
+
+  it("accumulates chunks of one run and restarts on the next", () => {
+    let state = applyEvents(running("j1"), [
+      { type: "setVariable", variableId: "draft", value: "Hel", disposition: "append", invocationId: "j1" },
+      { type: "setVariable", variableId: "draft", value: "lo", disposition: "append", invocationId: "j1" }
+    ]);
+    expect(state.variables.draft).toBe("Hello");
+
+    state = applyEvent(state, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "Bye",
+      disposition: "append",
+      invocationId: "j2"
+    });
+    expect(state.variables.draft).toBe("Bye");
+  });
+
+  it("collects structured items into a list", () => {
+    const state = applyEvents(running("j1"), [
+      { type: "setVariable", variableId: "rows", value: { a: 1 }, disposition: "append", invocationId: "j1" },
+      { type: "setVariable", variableId: "rows", value: { a: 2 }, disposition: "append", invocationId: "j1" }
+    ]);
+    expect(state.variables.rows).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("lets a plain write replace an accumulated value", () => {
+    let state = applyEvent(running("j1"), {
+      type: "setVariable",
+      variableId: "draft",
+      value: "streamed",
+      disposition: "append",
+      invocationId: "j1"
+    });
+    state = applyEvent(state, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "typed"
+    });
+    expect(state.variables.draft).toBe("typed");
+    expect(state.variableWriters.draft).toBeUndefined();
+  });
+});
+
+describe("activity", () => {
+  const running = applyEvent(createInstanceState(), {
+    type: "runStarted",
+    invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+    outputKeys: []
+  });
+
+  it("records the latest label per invocation", () => {
+    const state = applyEvents(running, [
+      { type: "invocationActivity", invocationId: "j1", label: "Planning" },
+      { type: "invocationActivity", invocationId: "j1", label: "web_search" }
+    ]);
+    expect(state.activity.j1).toBe("web_search");
+    expect(operationActivity(state, "main")).toBe("web_search");
+  });
+
+  it("ignores an invocation this instance did not start", () => {
+    expect(
+      applyEvent(running, {
+        type: "invocationActivity",
+        invocationId: "other",
+        label: "leak"
+      })
+    ).toBe(running);
+  });
+
+  it("clears on reset", () => {
+    const state = applyEvents(running, [
+      { type: "invocationActivity", invocationId: "j1", label: "Planning" },
+      { type: "reset" }
+    ]);
+    expect(state.activity).toEqual({});
+    expect(state.variableWriters).toEqual({});
+  });
+});
+
+describe("liveInvocations", () => {
+  const withRuns = applyEvents(createInstanceState(), [
+    {
+      type: "runStarted",
+      invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+      outputKeys: []
+    },
+    {
+      type: "runStarted",
+      invocation: { id: "j2", operationId: "main", status: "pending", startedAt: 2 },
+      outputKeys: []
+    },
+    {
+      type: "runStarted",
+      invocation: { id: "j3", operationId: "other", status: "running", startedAt: 3 },
+      outputKeys: []
+    }
+  ]);
+
+  it("returns an operation's unsettled runs, newest first", () => {
+    expect(liveInvocations(withRuns, "main").map((i) => i.id)).toEqual(["j2", "j1"]);
+  });
+
+  it("drops settled runs", () => {
+    const state = applyEvents(withRuns, [
+      { type: "invocationStatus", invocationId: "j1", status: "completed" },
+      { type: "invocationStatus", invocationId: "j2", status: "cancelled" }
+    ]);
+    expect(liveInvocations(state, "main")).toEqual([]);
+    expect(isOperationRunning(state, "main")).toBe(false);
   });
 });

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -49,3 +49,11 @@ describe("widget catalog", () => {
     expect(WIDGET_CATALOG.Divider.slots).toBeUndefined();
   });
 });
+
+describe("Table", () => {
+  it("is a read widget, so it binds an output slot", () => {
+    expect(WIDGET_CATALOG.Table).toEqual({ label: "Table", mode: "read" });
+    expect(widgetMode("Table")).toBe("read");
+    expect(isKnownWidget("Table")).toBe(true);
+  });
+});

--- a/packages/cli/src/app-debug/app-spec.ts
+++ b/packages/cli/src/app-debug/app-spec.ts
@@ -11,19 +11,24 @@ import {
   DEFAULT_OPERATION_ID,
   encodeBinding,
   parseApplicationDocument,
+  parseBinding,
   resolveBinding,
   stateKey,
   widgetMode,
   WIDGET_CATALOG,
+  type ApplicationDocument,
   type BindingMode,
   type BindingRef,
-  type BindingScope
+  type BindingScope,
+  type OperationBinding,
+  type VariableDeclaration
 } from "@nodetool-ai/app-runtime";
 
 import type { DebugGraph } from "../debug/types.js";
 import type {
   AppEventSpec,
   AppIO,
+  AppOperationSpec,
   AppSpec,
   AppValidation,
   AppWidgetSpec
@@ -44,6 +49,18 @@ interface PuckNode {
 const isPuckNode = (v: unknown): v is PuckNode =>
   isRecord(v) && typeof v.type === "string" && isRecord(v.props);
 
+/**
+ * The app's operations resolved against real graphs, plus the declared
+ * variables and resources. Built by the harness (resolving an operation's
+ * workflow may need a database read) and handed to the pure layer here.
+ */
+export interface AppContext {
+  defaultOperationId: string;
+  operations: AppOperationSpec[];
+  variables: VariableDeclaration[];
+  resources: Array<{ id: string; name: string; kind: string }>;
+}
+
 const parseEvents = (raw: unknown): AppEventSpec[] => {
   if (!Array.isArray(raw)) return [];
   const events: AppEventSpec[] = [];
@@ -57,6 +74,7 @@ const parseEvents = (raw: unknown): AppEventSpec[] => {
       key: str(item.key) || undefined,
       value: str(item.value) || undefined,
       operationId: str(item.operationId) || undefined,
+      invocationId: str(item.invocationId) || undefined,
       resourceBindingId: str(item.resourceBindingId) || undefined,
       command: str(item.command) || undefined
     });
@@ -64,25 +82,106 @@ const parseEvents = (raw: unknown): AppEventSpec[] => {
   return events;
 };
 
-/** The binding scope a single-workflow app resolves against. */
-export function bindingScopeFor(io: AppIO): BindingScope {
+/**
+ * The binding scope an app resolves against: every declared operation with the
+ * surface of the workflow it runs, plus the declared variables. Without a
+ * context this is the single-operation shape a legacy `app_doc` has.
+ */
+export function bindingScopeFor(io: AppIO, context?: AppContext): BindingScope {
+  const operationIO = (id: string, own: AppIO | null) => ({
+    operationId: id,
+    inputs: (own ?? io).inputs.map(({ nodeId, name }) => ({ nodeId, name })),
+    outputs: (own ?? io).outputs.map(({ nodeId, name }) => ({ nodeId, name })),
+    nodeIds: (own ?? io).nodeIds,
+    variableNames: (own ?? io).variables
+  });
+  if (!context) {
+    return {
+      defaultOperationId: DEFAULT_OPERATION_ID,
+      operations: [operationIO(DEFAULT_OPERATION_ID, io)],
+      variables: []
+    };
+  }
   return {
-    defaultOperationId: DEFAULT_OPERATION_ID,
-    operations: [
-      {
-        operationId: DEFAULT_OPERATION_ID,
-        inputs: io.inputs.map(({ nodeId, name }) => ({ nodeId, name })),
-        outputs: io.outputs.map(({ nodeId, name }) => ({ nodeId, name })),
-        nodeIds: io.nodeIds,
-        variableNames: io.variables
-      }
-    ],
-    variables: []
+    defaultOperationId: context.defaultOperationId,
+    operations: context.operations.map((op) => operationIO(op.id, op.io)),
+    variables: context.variables
   };
 }
 
 const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
   mode === "write" ? "write" : mode === "read" ? "read" : "none";
+
+/**
+ * The operations a parsed document declares, as report specs. A document with
+ * none gets the implicit single operation a legacy `app_doc` runs.
+ */
+export function documentOperations(
+  document: ApplicationDocument
+): OperationBinding[] {
+  if (document.operations.length > 0) return document.operations;
+  return [
+    {
+      id: DEFAULT_OPERATION_ID,
+      name: "Run",
+      workflowId: "",
+      inputs: {},
+      outputs: {},
+      policy: "replace"
+    }
+  ];
+}
+
+/** Parse an app document (object or JSON string), or explain why it will not. */
+export function parseAppDocument(
+  appDoc: unknown
+): { document: ApplicationDocument | null; issue: string | null } {
+  if (appDoc == null) {
+    return {
+      document: null,
+      issue: "Workflow has no app_doc — build the app in the App Builder first."
+    };
+  }
+  let raw: unknown = appDoc;
+  if (typeof raw === "string") {
+    try {
+      raw = JSON.parse(raw);
+    } catch {
+      return { document: null, issue: "app_doc is a string but not valid JSON." };
+    }
+  }
+  const document = parseApplicationDocument(raw, { hostWorkflowId: "self" });
+  return document
+    ? { document, issue: null }
+    : {
+        document: null,
+        issue: "app_doc is not a valid application document (no `ui`/`data`)."
+      };
+}
+
+/**
+ * Variables the document declared as persisted but that the parser downgraded:
+ * only user-scoped variables may persist, and the parser applies that silently.
+ */
+function persistDowngrades(appDoc: unknown): string[] {
+  const raw = typeof appDoc === "string" ? safeParse(appDoc) : appDoc;
+  if (!isRecord(raw) || !Array.isArray(raw.variables)) return [];
+  const names: string[] = [];
+  for (const entry of raw.variables) {
+    if (!isRecord(entry) || entry.persist !== true) continue;
+    if (entry.scope === "user") continue;
+    names.push(str(entry.name) ?? str(entry.id) ?? "(unnamed)");
+  }
+  return names;
+}
+
+const safeParse = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
 
 /**
  * Parse an app document (object or JSON string) into an {@link AppSpec},
@@ -93,32 +192,20 @@ const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
  */
 export function parseAppSpec(
   appDoc: unknown,
-  io: AppIO
-): { spec: AppSpec | null; issues: string[] } {
-  if (appDoc == null) {
-    return {
-      spec: null,
-      issues: ["Workflow has no app_doc — build the app in the App Builder first."]
-    };
-  }
-  let raw: unknown = appDoc;
-  if (typeof raw === "string") {
-    try {
-      raw = JSON.parse(raw);
-    } catch {
-      return { spec: null, issues: ["app_doc is a string but not valid JSON."] };
-    }
-  }
-  const document = parseApplicationDocument(raw, { hostWorkflowId: "self" });
-  if (!document) {
-    return {
-      spec: null,
-      issues: ["app_doc is not a valid application document (no `ui`/`data`)."]
-    };
-  }
+  io: AppIO,
+  context?: AppContext
+): { spec: AppSpec | null; issues: string[]; warnings: string[] } {
+  const { document, issue } = parseAppDocument(appDoc);
+  if (!document) return { spec: null, issues: [issue ?? ""], warnings: [] };
 
   const issues: string[] = [];
-  const scope = bindingScopeFor(io);
+  const warnings: string[] = [];
+  for (const name of persistDowngrades(appDoc)) {
+    warnings.push(
+      `Variable "${name}" declares persist: true with scope: "instance" — only user-scoped variables persist, so it was downgraded to in-memory.`
+    );
+  }
+  const scope = bindingScopeFor(io, context);
   const rootProps = isRecord(document.ui.root.props) ? document.ui.root.props : {};
   const title = str(rootProps.title);
 
@@ -164,7 +251,41 @@ export function parseAppSpec(
     issues.push("The app document has no widgets — nothing to render or run.");
   }
 
-  return { spec: { version: document.schemaVersion, title, widgets }, issues };
+  const operations =
+    context?.operations ??
+    documentOperations(document).map((binding) => operationSpec(binding, null, null));
+
+  return {
+    spec: {
+      version: document.schemaVersion,
+      title,
+      widgets,
+      operations,
+      variables: context?.variables ?? document.variables,
+      resources: document.resources.map(({ id, name, kind }) => ({ id, name, kind }))
+    },
+    issues,
+    warnings
+  };
+}
+
+/** An operation binding plus the surface it resolved against, for the report. */
+export function operationSpec(
+  binding: OperationBinding,
+  io: AppIO | null,
+  unavailable: string | null
+): AppOperationSpec {
+  return {
+    id: binding.id,
+    name: binding.name,
+    workflowId: binding.workflowId,
+    policy: binding.policy,
+    timeoutMs: binding.timeoutMs ?? null,
+    inputs: binding.inputs,
+    outputs: binding.outputs,
+    io,
+    unavailable
+  };
 }
 
 /** Read a node property from the kernel graph shape (`properties`, not `data`). */
@@ -218,14 +339,45 @@ const VARIABLE_EVENT_KINDS = new Set([
   "toggleState"
 ]);
 
+/** Every id a variable binding may name: declared ids/names + graph channels. */
+function knownVariableIds(io: AppIO, context?: AppContext): Set<string> {
+  const known = new Set<string>(io.variables);
+  for (const variable of context?.variables ?? []) {
+    known.add(variable.id);
+    known.add(variable.name);
+  }
+  for (const operation of context?.operations ?? []) {
+    for (const name of operation.io?.variables ?? []) known.add(name);
+  }
+  return known;
+}
+
 /** Statically check the app's wiring against the workflow's bindable surface. */
-export function validateApp(spec: AppSpec, io: AppIO): AppValidation {
+export function validateApp(
+  spec: AppSpec,
+  io: AppIO,
+  context?: AppContext
+): AppValidation {
   const errors: string[] = [];
   const warnings: string[] = [];
-  const scope = bindingScopeFor(io);
+  const scope = bindingScopeFor(io, context);
+  const defaultOperationId = context?.defaultOperationId ?? DEFAULT_OPERATION_ID;
+  // Without a context there is one operation over the host workflow, so the
+  // host surface is its surface.
+  const operations = spec.operations.map((op) =>
+    op.io || op.id !== defaultOperationId ? op : { ...op, io }
+  );
+  const operationIds = new Set(operations.map((op) => op.id));
+  const variableIds = knownVariableIds(io, context);
+  const resourceIds = new Set(spec.resources.map((r) => r.id));
 
   let hasRunTrigger = false;
+  /** `opId:nodeId` of every output a widget displays. */
   const displayedOutputs = new Set<string>();
+  /** Operations some widget event can run. */
+  const runnableOperations = new Set<string>();
+  /** Operation ids whose execution state a widget shows. */
+  const execBindings = new Map<string, string[]>();
 
   for (const w of spec.widgets) {
     const where = `${w.type} "${w.id}"`;
@@ -242,10 +394,36 @@ export function validateApp(spec: AppSpec, io: AppIO): AppValidation {
     } else if (!w.binding && w.bindingMode === "write") {
       warnings.push(`${where}: not bound to an input — its value stays local UI state.`);
     }
-    if (w.ref?.kind === "output") displayedOutputs.add(w.ref.nodeId);
+    // An explicit `op:<id>/…` token resolves on its own syntax, so a token
+    // naming an operation the document never declared has to be caught here.
+    const explicit = parseBinding(w.binding);
+    if (explicit && "operationId" in explicit && explicit.operationId) {
+      if (!operationIds.has(explicit.operationId)) {
+        errors.push(
+          `${where}: bound to "${w.binding}" but the app declares no operation "${explicit.operationId}".`
+        );
+      }
+    }
+    if (w.ref?.kind === "output") {
+      displayedOutputs.add(`${w.ref.operationId}:${w.ref.nodeId}`);
+    }
+    if (w.ref?.kind === "execution") {
+      const list = execBindings.get(w.ref.operationId) ?? [];
+      list.push(`${where} (${w.ref.field})`);
+      execBindings.set(w.ref.operationId, list);
+    }
 
     for (const event of w.events) {
-      if (event.kind === "run") hasRunTrigger = true;
+      const target = event.operationId ?? defaultOperationId;
+      if (event.kind === "run") {
+        hasRunTrigger = true;
+        runnableOperations.add(target);
+      }
+      if ((event.kind === "run" || event.kind === "cancel") && !operationIds.has(target)) {
+        errors.push(
+          `${where}: ${event.kind} targets operation "${target}" but the app declares no such operation.`
+        );
+      }
       if (
         VARIABLE_EVENT_KINDS.has(event.kind) &&
         !resolveBinding(event.key, scope, "read")
@@ -253,6 +431,13 @@ export function validateApp(spec: AppSpec, io: AppIO): AppValidation {
         errors.push(
           `${where}: ${event.kind} targets variable "${event.key ?? ""}" but the workflow has no SetVariable node with that name.`
         );
+      }
+      if (event.kind === "resourceCommand" || event.kind === "openResource") {
+        if (!event.resourceBindingId || !resourceIds.has(event.resourceBindingId)) {
+          errors.push(
+            `${where}: ${event.kind} targets resource "${event.resourceBindingId ?? ""}" but the app declares no such resource binding.`
+          );
+        }
       }
     }
   }
@@ -262,11 +447,98 @@ export function validateApp(spec: AppSpec, io: AppIO): AppValidation {
       'No widget has a "run" event — the app can never execute the workflow. Add a Run button or an on-change run.'
     );
   }
-  for (const output of io.outputs) {
-    if (!displayedOutputs.has(output.nodeId)) {
+
+  for (const operation of operations) {
+    const label = `Operation "${operation.id}"`;
+    if (operation.unavailable) {
+      errors.push(`${label}: ${operation.unavailable}`);
+    }
+    validateMappings(operation, variableIds, resourceIds, errors, warnings);
+
+    const mappedToVariable = new Set(
+      Object.entries(operation.outputs)
+        .filter(([, mapping]) => mapping.to === "variable")
+        .map(([nodeId]) => nodeId)
+    );
+    for (const output of operation.io?.outputs ?? []) {
+      if (displayedOutputs.has(`${operation.id}:${output.nodeId}`)) continue;
+      if (mappedToVariable.has(output.nodeId)) continue;
       warnings.push(`Workflow output "${output.name}" is not displayed by any widget.`);
+    }
+
+    if (spec.widgets.length > 0 && !runnableOperations.has(operation.id)) {
+      const shown = execBindings.get(operation.id);
+      // A display of an operation nothing can start shows nothing, ever.
+      if (shown) {
+        errors.push(
+          `${label} is never run by any widget, but ${shown.join(", ")} shows its execution state.`
+        );
+      } else {
+        warnings.push(`${label} is declared but no widget event runs it.`);
+      }
     }
   }
 
   return { errors, warnings };
+}
+
+/** Check one operation's input/output mappings against what the app declares. */
+function validateMappings(
+  operation: AppOperationSpec,
+  variableIds: ReadonlySet<string>,
+  resourceIds: ReadonlySet<string>,
+  errors: string[],
+  warnings: string[]
+): void {
+  const label = `Operation "${operation.id}"`;
+  const inputNodeIds = new Set((operation.io?.inputs ?? []).map((i) => i.nodeId));
+  const outputNodeIds = new Set((operation.io?.outputs ?? []).map((o) => o.nodeId));
+
+  for (const [nodeId, mapping] of Object.entries(operation.inputs)) {
+    if (operation.io && !inputNodeIds.has(nodeId)) {
+      errors.push(`${label}: input mapping for node "${nodeId}", which the workflow has no input node for.`);
+    }
+    switch (mapping.from) {
+      case "variable":
+        if (!variableIds.has(mapping.variableId)) {
+          errors.push(
+            `${label}: input "${nodeId}" reads variable "${mapping.variableId}", which the app does not declare.`
+          );
+        }
+        break;
+      case "constant":
+        if (mapping.value === undefined) {
+          warnings.push(
+            `${label}: input "${nodeId}" is mapped to a constant with no value — the run sends nothing for it.`
+          );
+        }
+        break;
+      case "resource":
+        if (!resourceIds.has(mapping.resourceBindingId)) {
+          errors.push(
+            `${label}: input "${nodeId}" reads resource binding "${mapping.resourceBindingId}", which the app does not declare.`
+          );
+        } else {
+          warnings.push(
+            `${label}: input "${nodeId}" comes from a resource — headless runs have no resource provider, so it stays unset.`
+          );
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  for (const [nodeId, mapping] of Object.entries(operation.outputs)) {
+    if (operation.io && !outputNodeIds.has(nodeId)) {
+      errors.push(
+        `${label}: output mapping for node "${nodeId}", which the workflow has no output node for.`
+      );
+    }
+    if (mapping.to === "variable" && !variableIds.has(mapping.variableId)) {
+      errors.push(
+        `${label}: output "${nodeId}" writes variable "${mapping.variableId}", which the app does not declare.`
+      );
+    }
+  }
 }

--- a/packages/cli/src/app-debug/harness.ts
+++ b/packages/cli/src/app-debug/harness.ts
@@ -1,12 +1,14 @@
 /**
  * The app-builder debug harness orchestrator.
  *
- * Resolves a workflow target, parses its `app_doc` into a widget spec,
- * statically validates the wiring, then simulates the app headlessly: seed
- * input defaults, apply params, execute the interaction script (each `run`
- * action is a full workflow run on the kernel server runner), and fold the
- * message stream into the app's reactive values. Writes a self-contained
- * bundle and returns the `AppDebugReport` so an agent can iterate directly.
+ * Resolves a workflow target, parses its `app_doc` into a widget spec and a set
+ * of operations, statically validates the wiring, then simulates the app
+ * headlessly the way the web and mobile runtimes do: seed input and variable
+ * defaults, apply params, execute the interaction script (each `run` action is
+ * a full workflow run on the kernel server runner, subject to the operation's
+ * policy and timeout), and fold the message stream into the app's reactive
+ * values. Writes a self-contained bundle and returns the `AppDebugReport` so an
+ * agent can iterate directly.
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -23,14 +25,29 @@ import {
   eventToAction,
   parseBinding,
   resolveBinding,
-  stateKey
+  stateKey,
+  type OperationBinding
 } from "@nodetool-ai/app-runtime";
-import { bindingScopeFor, extractAppIO, parseAppSpec, validateApp } from "./app-spec.js";
-import { HeadlessAppRuntime } from "./runtime.js";
+import {
+  bindingScopeFor,
+  documentOperations,
+  extractAppIO,
+  operationSpec,
+  parseAppDocument,
+  parseAppSpec,
+  validateApp,
+  type AppContext
+} from "./app-spec.js";
+import {
+  effectiveTimeoutMs,
+  HeadlessAppRuntime,
+  type HeadlessOperationInit
+} from "./runtime.js";
 import { renderAppReportMarkdown } from "./markdown.js";
 import type {
   AppDebugOptions,
   AppDebugReport,
+  AppIO,
   AppSpec,
   AppWidgetSpec,
   InteractionRecord,
@@ -95,6 +112,8 @@ export function defaultInteractions(spec: AppSpec): InteractionStep[] {
 function describeStep(step: InteractionStep): string {
   if ("set" in step) return `set ${step.set.key}`;
   if ("click" in step) return `click ${step.click}`;
+  if ("run" in step) return `run ${step.run}`;
+  if ("cancel" in step) return `cancel ${step.cancel}`;
   return `change ${step.change}`;
 }
 
@@ -156,7 +175,10 @@ function nodeIdsByName(graph: DebugGraph): Map<string, string> {
 }
 
 function buildAppVerdict(
-  report: Pick<AppDebugReport, "validation" | "interactions" | "runs" | "widgets" | "spec">,
+  report: Pick<
+    AppDebugReport,
+    "validation" | "interactions" | "runs" | "widgets" | "spec" | "invocations"
+  >,
   ranWorkflow: boolean,
   graph: DebugGraph
 ): DebugVerdict {
@@ -177,6 +199,13 @@ function buildAppVerdict(
       issues.push(`Node ${where}: ${e.message.replace(/\s+/g, " ").slice(0, 200)}`);
     }
   }
+  for (const invocation of report.invocations) {
+    if (invocation.timedOutMs == null) continue;
+    issues.push(
+      `Operation "${invocation.operationId}" did not finish within its ${invocation.timedOutMs}ms timeout — the app would show it still running.`
+    );
+  }
+  const ranOperations = new Set(report.invocations.map((i) => i.operationId));
   if (ranWorkflow && report.runs.length > 0 && report.runs.every((r) => r.ok)) {
     const conditional = conditionalNodeIds(graph);
     const byName = nodeIdsByName(graph);
@@ -186,6 +215,20 @@ function buildAppVerdict(
     for (const w of report.widgets) {
       if (w.bindingMode !== "read" || !w.binding || w.hasValue) continue;
       const ref = parseBinding(w.binding);
+      if (ref?.kind === "execution") {
+        // Execution state is not a value the graph emits — an empty one only
+        // means the operation never ran, or reported no activity.
+        if (!ranOperations.has(ref.operationId)) {
+          issues.push(
+            `${w.type} "${w.id}" shows operation "${ref.operationId}" ${ref.field}, but that operation never ran.`
+          );
+        } else if (ref.field === "activity") {
+          warnings.push(
+            `${w.type} "${w.id}" shows activity, but the run reported none — only streaming agent nodes emit activity labels.`
+          );
+        }
+        continue;
+      }
       // A legacy document binds by node name, and `parseBinding` hands the name
       // back in the `nodeId` slot, so an unrecognised id is retried as a name.
       const parsed = (ref && "nodeId" in ref ? ref.nodeId : null) ?? w.binding;
@@ -204,7 +247,13 @@ function buildAppVerdict(
       );
     }
   }
-  if (ranWorkflow && report.runs.length === 0 && report.spec && report.spec.widgets.length > 0) {
+  if (
+    ranWorkflow &&
+    report.runs.length === 0 &&
+    report.invocations.length === 0 &&
+    report.spec &&
+    report.spec.widgets.length > 0
+  ) {
     issues.push("No interaction triggered a workflow run — the app was never executed.");
   }
 
@@ -215,6 +264,33 @@ function buildAppVerdict(
       : "App wiring is valid (static check only — no run executed)."
     : `App has issues — ${issues[0]}`;
   return { ok, headline, issues, warnings };
+}
+
+/** The graph an operation runs, resolved against the host or the database. */
+async function resolveOperationGraph(
+  operation: OperationBinding,
+  host: { workflowId: string | null; graph: DebugGraph },
+  loadFromDb: AppDebugDeps["loadFromDb"]
+): Promise<{ graph: DebugGraph | null; unavailable: string | null }> {
+  const target = operation.workflowId;
+  if (!target || target === "self" || target === host.workflowId) {
+    return { graph: host.graph, unavailable: null };
+  }
+  try {
+    const workflow = await loadFromDb(target);
+    if (!workflow?.graph) {
+      return {
+        graph: null,
+        unavailable: `runs workflow "${target}", which is not in the local database.`
+      };
+    }
+    return { graph: workflow.graph, unavailable: null };
+  } catch (error) {
+    return {
+      graph: null,
+      unavailable: `runs workflow "${target}", which could not be loaded: ${String(error)}`
+    };
+  }
 }
 
 export async function runAppDebug(
@@ -242,11 +318,49 @@ export async function runAppDebug(
   }
 
   const io = extractAppIO(resolved.graph);
-  const { spec, issues: parseIssues } = parseAppSpec(resolved.appDoc, io);
+  // Parsed up front to resolve operations; `parseAppSpec` reports any issue.
+  const { document } = parseAppDocument(resolved.appDoc);
+
+  // Resolve every declared operation against a real graph before parsing the
+  // widgets: a binding into a second operation resolves against that
+  // operation's surface, not the host's.
+  const graphByOperation = new Map<string, DebugGraph>();
+  const context: AppContext = {
+    defaultOperationId: DEFAULT_OPERATION_ID,
+    operations: [],
+    variables: document?.variables ?? [],
+    resources: document?.resources.map(({ id, name, kind }) => ({ id, name, kind })) ?? []
+  };
+  const bindingByOperation = new Map<string, OperationBinding>();
+  if (document) {
+    for (const binding of documentOperations(document)) {
+      const { graph, unavailable } = await resolveOperationGraph(
+        binding,
+        { workflowId: resolved.info.workflowId, graph: resolved.graph },
+        deps.loadFromDb
+      );
+      const operationIO: AppIO | null =
+        graph === resolved.graph ? io : graph ? extractAppIO(graph) : null;
+      if (graph) graphByOperation.set(binding.id, graph);
+      bindingByOperation.set(binding.id, binding);
+      context.operations.push(operationSpec(binding, operationIO, unavailable));
+    }
+    context.defaultOperationId =
+      context.operations.find((op) => op.id === DEFAULT_OPERATION_ID)?.id ??
+      context.operations[0]?.id ??
+      DEFAULT_OPERATION_ID;
+  }
+
+  const { spec, issues: parseIssues, warnings: parseWarnings } = parseAppSpec(
+    resolved.appDoc,
+    io,
+    document ? context : undefined
+  );
   const validation = spec
-    ? validateApp(spec, io)
+    ? validateApp(spec, io, context)
     : { errors: [], warnings: [] };
   validation.errors = [...parseIssues, ...validation.errors];
+  validation.warnings = [...parseWarnings, ...validation.warnings];
 
   const report: AppDebugReport = {
     generatedAt: new Date().toISOString(),
@@ -264,6 +378,9 @@ export async function runAppDebug(
     interactions: [],
     runs: [],
     values: {},
+    variables: {},
+    invocations: [],
+    activity: [],
     widgets: [],
     verdict: { ok: false, headline: "", issues: [] },
     bundleDir: outDir
@@ -272,19 +389,26 @@ export async function runAppDebug(
   if (spec) {
     const runs: ServerRunReport[] = report.runs;
     const runWorkflow = async (
+      operationId: string,
+      graph: DebugGraph,
+      workflowId: string | null,
+      timeoutMs: number | null,
       params: Record<string, unknown>
-    ): Promise<ReadonlyArray<Record<string, unknown>>> => {
+    ) => {
       const runServer =
         deps.runOnServer ??
         (await import("../debug/server-runner.js")).runOnServer;
-      log(`Running workflow (run ${runs.length + 1})…`);
+      log(`Running operation "${operationId}"…`);
       const outcome = await runServer({
-        graph: resolved.graph,
-        workflowId: resolved.info.workflowId,
+        graph,
+        workflowId,
         params,
-        timeoutMs: options.timeoutMs
+        ...(timeoutMs != null ? { timeoutMs } : {})
       });
-      const messagesFile = `server/run-${runs.length + 1}.messages.jsonl`;
+      // The slot is claimed only once the run settles, so a run the harness
+      // timed out on never takes an index from the one that follows it.
+      const runIndex = runs.length;
+      const messagesFile = `server/run-${runIndex + 1}.messages.jsonl`;
       await writeFile(
         join(outDir, messagesFile),
         outcome.rawMessages.map((m) => JSON.stringify(m)).join("\n") + "\n",
@@ -293,46 +417,70 @@ export async function runAppDebug(
       outcome.report.messagesFile = messagesFile;
       runs.push(outcome.report);
       log(
-        `Run ${runs.length}: ${outcome.report.status} · ${outcome.report.summary.counts.errored} node error(s)`
+        `Run ${runIndex + 1}: ${outcome.report.status} · ${outcome.report.summary.counts.errored} node error(s)`
       );
-      return outcome.rawMessages as unknown as ReadonlyArray<Record<string, unknown>>;
+      return {
+        messages: outcome.rawMessages as unknown as ReadonlyArray<
+          Record<string, unknown>
+        >,
+        runIndex
+      };
     };
 
-    const scope = bindingScopeFor(io);
-    const inputKey = (nodeId: string) =>
-      stateKey({ kind: "input", operationId: DEFAULT_OPERATION_ID, nodeId });
-    const outputKeyByNodeId = new Map(
-      io.outputs.map((o) => [
-        o.nodeId,
-        stateKey({
-          kind: "output",
-          operationId: DEFAULT_OPERATION_ID,
-          nodeId: o.nodeId
-        })
-      ])
-    );
-    const paramNameByInputKey = new Map(
-      io.inputs.map((i) => [inputKey(i.nodeId), i.name])
-    );
-    const defaults: Record<string, unknown> = {};
-    for (const input of io.inputs) {
-      if (input.defaultValue !== undefined) {
-        defaults[inputKey(input.nodeId)] = input.defaultValue;
+    const scope = bindingScopeFor(io, context);
+    const operations: HeadlessOperationInit[] = context.operations.map((op) => {
+      const binding = bindingByOperation.get(op.id) as OperationBinding;
+      const graph = graphByOperation.get(op.id) ?? null;
+      const operationIO = op.io ?? { inputs: [], outputs: [], variables: [], nodeIds: [] };
+      const defaults: Record<string, unknown> = {};
+      for (const input of operationIO.inputs) {
+        if (input.defaultValue === undefined) continue;
+        defaults[stateKey({ kind: "input", operationId: op.id, nodeId: input.nodeId })] =
+          input.defaultValue;
       }
-    }
+      const timeoutMs = effectiveTimeoutMs(op.timeoutMs, options.timeoutMs);
+      return {
+        binding,
+        outputKeyByNodeId: new Map(
+          operationIO.outputs.map((o) => [
+            o.nodeId,
+            stateKey({ kind: "output", operationId: op.id, nodeId: o.nodeId })
+          ])
+        ),
+        inputNodeIds: operationIO.inputs.map((i) => i.nodeId),
+        inputNameByNodeId: new Map(operationIO.inputs.map((i) => [i.nodeId, i.name])),
+        defaults,
+        ...(graph
+          ? {
+              runWorkflow: (params: Record<string, unknown>) =>
+                runWorkflow(
+                  op.id,
+                  graph,
+                  graph === resolved.graph ? resolved.info.workflowId : op.workflowId,
+                  timeoutMs,
+                  params
+                )
+            }
+          : {})
+      };
+    });
 
     const runtime = new HeadlessAppRuntime({
-      operationId: DEFAULT_OPERATION_ID,
-      outputKeyByNodeId,
-      paramNameByInputKey,
-      defaults,
-      runWorkflow
+      operations,
+      defaultOperationId: context.defaultOperationId,
+      variables: context.variables,
+      ...(options.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {})
     });
 
     /** Write a value addressed by name (a param, or an `--interact` set step). */
-    const writeByName = (name: string, value: unknown): boolean => {
+    const writeByName = (
+      name: string,
+      value: unknown,
+      operationId = context.defaultOperationId
+    ): boolean => {
       const ref =
-        resolveBinding(name, scope, "write") ?? resolveBinding(name, scope, "read");
+        resolveBinding(name, scope, "write", operationId) ??
+        resolveBinding(name, scope, "read", operationId);
       if (!ref) return false;
       runtime.write(ref, value);
       return true;
@@ -349,6 +497,26 @@ export async function runAppDebug(
       }
     }
 
+    /** Dispatch one action, tracking which run it produced. */
+    const dispatch = async (
+      record: InteractionRecord,
+      action: Parameters<HeadlessAppRuntime["dispatch"]>[0]
+    ): Promise<void> => {
+      const before = runtime.invocations.length;
+      try {
+        await runtime.dispatch(action);
+      } catch (error) {
+        record.error = record.error ?? (error as Error).message;
+        return;
+      }
+      const started = runtime.invocations.slice(before);
+      const withRun = started.find((i) => i.runIndex !== null);
+      if (withRun) record.runIndex = withRun.runIndex;
+      if (action.kind === "run") {
+        record.error = record.error ?? runtime.errorFor(action.operationId);
+      }
+    };
+
     const steps = options.interact ?? defaultInteractions(spec);
     for (const step of steps) {
       const record: InteractionRecord = {
@@ -360,11 +528,31 @@ export async function runAppDebug(
       report.interactions.push(record);
 
       if ("set" in step) {
-        if (writeByName(step.set.key, step.set.value)) {
+        if (writeByName(step.set.key, step.set.value, step.set.operationId)) {
           record.actions.push(`set ${step.set.key}`);
         } else {
           record.error = `"${step.set.key}" matches no input, output, or variable.`;
         }
+        continue;
+      }
+
+      if ("run" in step) {
+        if (!allowRuns) {
+          record.actions.push("run (skipped — --no-run)");
+          continue;
+        }
+        record.actions.push(`run ${step.run}`);
+        await dispatch(record, { kind: "run", operationId: step.run });
+        continue;
+      }
+
+      if ("cancel" in step) {
+        const cancelled = runtime.cancel(step.cancel);
+        record.actions.push(
+          cancelled.length > 0
+            ? `cancel ${step.cancel} (${cancelled.join(", ")})`
+            : `cancel ${step.cancel} (nothing running)`
+        );
         continue;
       }
 
@@ -384,7 +572,7 @@ export async function runAppDebug(
       const from =
         found.bindingMode === "write" ? found.canonicalBinding ?? undefined : undefined;
       const eventCtx = {
-        defaultOperationId: DEFAULT_OPERATION_ID,
+        defaultOperationId: context.defaultOperationId,
         resolveVariableId: (key: string | undefined) => {
           const ref = resolveBinding(key, scope, "read");
           return ref?.kind === "variable" ? ref.variableId : null;
@@ -403,43 +591,65 @@ export async function runAppDebug(
           record.actions.push("run (skipped — --no-run)");
           continue;
         }
-        if (action.kind === "run") record.runIndex = report.runs.length;
         record.actions.push(
           action.kind === "setVariable" || action.kind === "toggleVariable"
             ? `${action.kind} ${action.variableId}`
-            : action.kind
+            : action.kind === "run" || action.kind === "cancel"
+              ? `${action.kind} ${action.operationId ?? context.defaultOperationId}`
+              : action.kind
         );
-        await runtime.dispatch(action);
+        await dispatch(record, action);
       }
       if (record.actions.length === 0) {
         record.error = `widget has no "${trigger}" events to fire.`;
       }
-      if (runtime.error) record.error = record.error ?? runtime.error;
     }
 
     // The report reads better keyed by the names an author recognizes than by
-    // the runtime's namespaced state keys.
+    // the runtime's namespaced state keys. A second operation prefixes its
+    // names so two operations over one workflow stay apart.
     const values: Record<string, unknown> = {};
-    for (const input of io.inputs) {
-      const value = runtime.read({
-        kind: "input",
-        operationId: DEFAULT_OPERATION_ID,
-        nodeId: input.nodeId
-      });
-      if (value !== undefined) values[input.name] = value;
+    for (const operation of context.operations) {
+      const prefix =
+        operation.id === context.defaultOperationId ? "" : `${operation.id}.`;
+      for (const input of operation.io?.inputs ?? []) {
+        const value = runtime.read({
+          kind: "input",
+          operationId: operation.id,
+          nodeId: input.nodeId
+        });
+        if (value !== undefined) values[`${prefix}${input.name}`] = value;
+      }
+      for (const output of operation.io?.outputs ?? []) {
+        const value = runtime.read({
+          kind: "output",
+          operationId: operation.id,
+          nodeId: output.nodeId
+        });
+        if (value !== undefined) values[`${prefix}${output.name}`] = value;
+      }
     }
-    for (const output of io.outputs) {
-      const value = runtime.read({
-        kind: "output",
-        operationId: DEFAULT_OPERATION_ID,
-        nodeId: output.nodeId
-      });
-      if (value !== undefined) values[output.name] = value;
-    }
+    const variables: Record<string, unknown> = {};
     for (const [variableId, value] of Object.entries(runtime.state.variables)) {
-      if (value !== undefined) values[variableId] = value;
+      if (value === undefined) continue;
+      values[variableId] = value;
+      variables[variableId] = value;
     }
     report.values = previewValue(values) as Record<string, unknown>;
+    report.variables = previewValue(variables) as Record<string, unknown>;
+
+    report.invocations = runtime.invocations.map((invocation) => ({
+      id: invocation.id,
+      operationId: invocation.operationId,
+      status: runtime.state.invocations[invocation.id]?.status ?? "unknown",
+      decision: invocation.decision,
+      decisionTargets: invocation.decisionTargets,
+      runIndex: invocation.runIndex,
+      timedOutMs: invocation.timedOutMs,
+      error: runtime.state.invocations[invocation.id]?.error ?? null,
+      activity: invocation.activity
+    }));
+    report.activity = [...runtime.activity];
 
     report.widgets = spec.widgets
       .filter((w) => w.bindingMode !== "layout")

--- a/packages/cli/src/app-debug/index.ts
+++ b/packages/cli/src/app-debug/index.ts
@@ -2,10 +2,14 @@ export { runAppDebug, defaultInteractions } from "./harness.js";
 export type { AppDebugDeps } from "./harness.js";
 export {
   parseAppSpec,
+  parseAppDocument,
+  documentOperations,
+  operationSpec,
   extractAppIO,
   validateApp,
   bindingScopeFor
 } from "./app-spec.js";
-export { HeadlessAppRuntime } from "./runtime.js";
+export type { AppContext } from "./app-spec.js";
+export { HeadlessAppRuntime, effectiveTimeoutMs } from "./runtime.js";
 export { renderAppReportMarkdown } from "./markdown.js";
 export type * from "./types.js";

--- a/packages/cli/src/app-debug/markdown.ts
+++ b/packages/cli/src/app-debug/markdown.ts
@@ -68,6 +68,45 @@ export function renderAppReportMarkdown(report: AppDebugReport): string {
     });
   }
 
+  const operations = report.spec?.operations ?? [];
+  if (operations.length > 0) {
+    lines.push("", "## Operations", "");
+    for (const op of operations) {
+      const timeout = op.timeoutMs != null ? `, timeout ${op.timeoutMs}ms` : "";
+      const state = op.unavailable ? ` — ⚠ ${op.unavailable}` : "";
+      lines.push(
+        `- \`${op.id}\` → workflow \`${op.workflowId || "(host)"}\` (policy ${op.policy}${timeout})${state}`
+      );
+    }
+  }
+
+  if (report.invocations.length > 0) {
+    lines.push("", "## Invocations", "");
+    lines.push("| Invocation | Operation | Decision | Status | Run |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const inv of report.invocations) {
+      const decision =
+        inv.decisionTargets.length > 0
+          ? `${inv.decision} (${inv.decisionTargets.join(", ")})`
+          : inv.decision;
+      const status = inv.timedOutMs != null
+        ? `timed out after ${inv.timedOutMs}ms`
+        : inv.status;
+      lines.push(
+        `| ${inv.id} | ${inv.operationId} | ${decision} | ${status} | ${
+          inv.runIndex != null ? inv.runIndex + 1 : "—"
+        } |`
+      );
+    }
+  }
+
+  if (report.activity.length > 0) {
+    lines.push("", "## Activity", "");
+    for (const entry of report.activity) {
+      lines.push(`- ${entry.operationId} (${entry.invocationId}): ${short(entry.label)}`);
+    }
+  }
+
   if (report.widgets.length > 0) {
     lines.push("", "## Widget state", "");
     lines.push("| Widget | Mode | Binding | Value |");
@@ -83,6 +122,14 @@ export function renderAppReportMarkdown(report: AppDebugReport): string {
   if (values.length > 0) {
     lines.push("", "## Final values", "");
     for (const [key, value] of values) {
+      lines.push(`- \`${key}\`: ${short(value, 300)}`);
+    }
+  }
+
+  const variables = Object.entries(report.variables);
+  if (variables.length > 0) {
+    lines.push("", "## Variables", "");
+    for (const [key, value] of variables) {
       lines.push(`- \`${key}\`: ${short(value, 300)}`);
     }
   }

--- a/packages/cli/src/app-debug/runtime.ts
+++ b/packages/cli/src/app-debug/runtime.ts
@@ -1,10 +1,11 @@
 /**
  * Headless driver for the shared app runtime core.
  *
- * The fold rules, the state namespaces, and the action vocabulary all live in
- * `@nodetool-ai/app-runtime` — the same code the web runtime runs. This file
- * only supplies what a headless run needs: a workflow executor and the
- * bookkeeping that turns an awaited run into an invocation.
+ * The fold rules, the state namespaces, the run policy, and the action
+ * vocabulary all live in `@nodetool-ai/app-runtime` — the same code the web and
+ * mobile runtimes run. This file only supplies what a headless run needs: a
+ * workflow executor per operation and the bookkeeping that turns an awaited run
+ * into an invocation.
  *
  * The web engine's reactive subgraph runs collapse to full workflow runs here
  * (the headless kernel has no browser worker), which the report notes rather
@@ -14,51 +15,143 @@ import {
   applyEvent,
   applyEvents,
   createInstanceState,
+  decideRun,
+  initialVariableValues,
+  liveInvocations,
   messagesToEvents,
   operationError,
+  outputVariableTargets,
   readRef,
+  resolveOperationParams,
   stateKey,
   type AppAction,
   type AppInstanceState,
+  type AppStateEvent,
   type BindingRef,
-  type InvocationState
+  type InvocationState,
+  type OperationBinding,
+  type RunDecision,
+  type VariableDeclaration
 } from "@nodetool-ai/app-runtime";
 
-export interface HeadlessRuntimeInit {
-  operationId: string;
+/** What one run returned: its messages plus where its report landed. */
+export interface HeadlessRunResult {
+  messages: ReadonlyArray<Record<string, unknown>>;
+  /** Index into the harness's `runs` array. */
+  runIndex: number;
+}
+
+export interface HeadlessOperationInit {
+  binding: OperationBinding;
   /** Output node id → the state key its value lands in. */
   outputKeyByNodeId: ReadonlyMap<string, string>;
-  /** Input state key → the param name the run protocol expects. */
-  paramNameByInputKey: ReadonlyMap<string, string>;
+  /** Input node ids, in graph order. */
+  inputNodeIds: ReadonlyArray<string>;
+  /** Input node id → the param name the run protocol expects. */
+  inputNameByNodeId: ReadonlyMap<string, string>;
   /** Input defaults, keyed by input state key. */
   defaults: Record<string, unknown>;
   /**
-   * Execute the workflow with the given params and return its processing
-   * messages. Called once per dispatched `run` action.
+   * Execute the operation's workflow. Absent when the workflow could not be
+   * loaded — dispatching a run then records why instead of throwing.
    */
-  runWorkflow: (
-    params: Record<string, unknown>
-  ) => Promise<ReadonlyArray<Record<string, unknown>>>;
+  runWorkflow?: (params: Record<string, unknown>) => Promise<HeadlessRunResult>;
 }
+
+export interface HeadlessRuntimeInit {
+  operations: ReadonlyArray<HeadlessOperationInit>;
+  /** The operation a bare `run`/`cancel` targets. */
+  defaultOperationId: string;
+  /** Declared variables, for `seedVariables`. */
+  variables?: ReadonlyArray<VariableDeclaration>;
+  /** Ceiling on every run, on top of each operation's own `timeoutMs`. */
+  timeoutMs?: number;
+}
+
+/** One simulated invocation, as the report shows it. */
+export interface HeadlessInvocationRecord {
+  id: string;
+  operationId: string;
+  decision: RunDecision["kind"];
+  decisionTargets: string[];
+  runIndex: number | null;
+  timedOutMs: number | null;
+  activity: string[];
+}
+
+/**
+ * The timeout a run actually gets: the operation's own `timeoutMs` capped by
+ * the harness-wide ceiling, so `--timeout` always shortens and never extends.
+ */
+export const effectiveTimeoutMs = (
+  operationTimeoutMs: number | null | undefined,
+  ceilingMs: number | null | undefined
+): number | null => {
+  const candidates = [operationTimeoutMs, ceilingMs].filter(
+    (value): value is number => typeof value === "number" && value > 0
+  );
+  return candidates.length > 0 ? Math.min(...candidates) : null;
+};
+
+const TIMED_OUT = Symbol("timed-out");
+
+/** Resolve, or hand back {@link TIMED_OUT} once `ms` elapses. */
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number | null
+): Promise<T | typeof TIMED_OUT> => {
+  if (ms == null) return promise;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<typeof TIMED_OUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMED_OUT), ms);
+  });
+  try {
+    return await Promise.race([promise, expiry]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
 
 export class HeadlessAppRuntime {
   state: AppInstanceState = createInstanceState();
   runCount = 0;
+  /** Every invocation started, in order. */
+  readonly invocations: HeadlessInvocationRecord[] = [];
+  /** Every activity label reported, in order. */
+  readonly activity: Array<{
+    invocationId: string;
+    operationId: string;
+    label: string;
+  }> = [];
 
   private readonly init: HeadlessRuntimeInit;
+  private readonly byId = new Map<string, HeadlessOperationInit>();
+  /** Runs the harness stopped waiting for, still settling in the background. */
+  private readonly inFlight = new Map<string, Promise<unknown>>();
   private invocationSeq = 0;
 
   constructor(init: HeadlessRuntimeInit) {
     this.init = init;
+    for (const operation of init.operations) {
+      this.byId.set(operation.binding.id, operation);
+      this.state = applyEvent(this.state, {
+        type: "seedInputs",
+        values: operation.defaults
+      });
+    }
     this.state = applyEvent(this.state, {
-      type: "seedInputs",
-      values: init.defaults
+      type: "seedVariables",
+      values: initialVariableValues(init.variables ?? [])
     });
   }
 
-  /** Last error reported against the operation's active invocation. */
+  /** Last error reported against an operation's active invocation. */
+  errorFor(operationId: string): string | null {
+    return operationError(this.state, operationId) ?? null;
+  }
+
   get error(): string | null {
-    return operationError(this.state, this.init.operationId) ?? null;
+    return this.errorFor(this.init.defaultOperationId);
   }
 
   /** Write a value through its resolved binding. */
@@ -101,60 +194,30 @@ export class HeadlessAppRuntime {
     }
   }
 
-  /** Params for a run: every bound input's current value, keyed by node name. */
-  collectParams(): Record<string, unknown> {
-    const params: Record<string, unknown> = {};
-    for (const [key, name] of this.init.paramNameByInputKey) {
-      const value = this.state.inputs[key]?.value;
-      if (value !== undefined) params[name] = value;
-    }
-    return params;
+  /**
+   * Params for one operation's run: every input resolved through its mapping
+   * (widget value, variable, constant, or resource), keyed by node name.
+   */
+  collectParams(operationId: string): Record<string, unknown> {
+    const operation = this.byId.get(operationId);
+    if (!operation) return {};
+    return resolveOperationParams({
+      operation: operation.binding,
+      state: this.state,
+      inputName: (nodeId) => operation.inputNameByNodeId.get(nodeId),
+      inputNodeIds: operation.inputNodeIds
+    });
   }
 
   /** Dispatch one action; a `run` executes the workflow and folds its stream. */
   async dispatch(action: AppAction): Promise<void> {
     switch (action.kind) {
-      case "run": {
-        this.invocationSeq += 1;
-        const invocation: InvocationState = {
-          id: `headless-${this.invocationSeq}`,
-          operationId: action.operationId,
-          status: "running",
-          // Deterministic, so two harness runs produce identical reports.
-          startedAt: this.invocationSeq
-        };
-        this.state = applyEvent(this.state, {
-          type: "runStarted",
-          invocation,
-          outputKeys: [...this.init.outputKeyByNodeId.values()]
-        });
-        this.runCount += 1;
-        const messages = await this.init.runWorkflow(this.collectParams());
-        // The headless runner awaits the whole stream, so every message belongs
-        // to the invocation just started; stamp it where the server did not.
-        const stamped = messages.map((message) => ({
-          ...message,
-          job_id: message.job_id ?? invocation.id
-        }));
-        this.state = applyEvents(
-          this.state,
-          messagesToEvents(stamped, {
-            resolveInvocation: (jobId: string | null | undefined) =>
-              jobId ? this.state.invocations[jobId] ?? null : null,
-            outputKey: (_operationId: string, nodeId: string) =>
-              this.init.outputKeyByNodeId.get(nodeId) ?? null
-          })
-        );
-        this.state = applyEvent(this.state, {
-          type: "invocationStatus",
-          invocationId: invocation.id,
-          status:
-            this.state.invocations[invocation.id]?.status === "failed"
-              ? "failed"
-              : "completed"
-        });
+      case "run":
+        await this.run(action.operationId);
         break;
-      }
+      case "cancel":
+        this.cancel(action.operationId ?? this.init.defaultOperationId, action.invocationId);
+        break;
       case "setVariable":
         this.state = applyEvent(this.state, {
           type: "setVariable",
@@ -168,12 +231,162 @@ export class HeadlessAppRuntime {
           variableId: action.variableId
         });
         break;
-      case "cancel":
       case "resourceCommand":
       case "openResource":
-        // Headless runs are awaited to completion and have no resource
-        // providers attached; the harness records the action and moves on.
+        // Headless runs have no resource providers attached; the harness
+        // records the action and moves on.
         break;
+    }
+  }
+
+  /** Cancel an operation's live invocations (or one named invocation). */
+  cancel(operationId: string, invocationId?: string): string[] {
+    const targets = invocationId
+      ? [invocationId].filter((id) => this.state.invocations[id])
+      : liveInvocations(this.state, operationId).map((i) => i.id);
+    for (const id of targets) {
+      this.state = applyEvent(this.state, {
+        type: "invocationStatus",
+        invocationId: id,
+        status: "cancelled"
+      });
+    }
+    return targets;
+  }
+
+  private timeoutFor(operation: OperationBinding): number | null {
+    return effectiveTimeoutMs(operation.timeoutMs, this.init.timeoutMs);
+  }
+
+  /**
+   * Start one run, after `decideRun` says what the operation's policy makes of
+   * whatever is already in flight.
+   */
+  private async run(operationId: string): Promise<void> {
+    const operation = this.byId.get(operationId);
+    if (!operation) {
+      throw new Error(`No operation "${operationId}" is declared by this app.`);
+    }
+    if (!operation.runWorkflow) {
+      throw new Error(
+        `Operation "${operationId}" has no runnable workflow — its binding could not be resolved.`
+      );
+    }
+
+    const decision = decideRun(this.state, operation.binding);
+    const targets =
+      decision.kind === "replace"
+        ? decision.cancel
+        : decision.kind === "queue"
+          ? decision.after
+          : [];
+    const timeoutMs = this.timeoutFor(operation.binding);
+    if (decision.kind === "replace") {
+      for (const id of targets) this.cancel(operationId, id);
+    } else if (decision.kind === "queue") {
+      // Wait for what is ahead. A run the harness already gave up on is bounded
+      // by the same timeout, so queueing cannot hang the report.
+      for (const id of targets) {
+        const pending = this.inFlight.get(id);
+        if (pending) await withTimeout(pending, timeoutMs);
+        this.cancel(operationId, id);
+      }
+    }
+
+    this.invocationSeq += 1;
+    const invocation: InvocationState = {
+      id: `headless-${this.invocationSeq}`,
+      operationId,
+      status: "running",
+      // Deterministic, so two harness runs produce identical reports.
+      startedAt: this.invocationSeq
+    };
+    const record: HeadlessInvocationRecord = {
+      id: invocation.id,
+      operationId,
+      decision: decision.kind,
+      decisionTargets: targets,
+      runIndex: null,
+      timedOutMs: null,
+      activity: []
+    };
+    this.invocations.push(record);
+
+    this.state = applyEvent(this.state, {
+      type: "runStarted",
+      invocation,
+      outputKeys: [...operation.outputKeyByNodeId.values()]
+    });
+    this.runCount += 1;
+
+    const pending = operation.runWorkflow(this.collectParams(operationId));
+    // A run the harness never sees the end of must not take the process with
+    // it: swallow its eventual settlement and keep it for a queued successor.
+    this.inFlight.set(
+      invocation.id,
+      pending.then(
+        () => undefined,
+        () => undefined
+      )
+    );
+    const outcome = await withTimeout(pending, timeoutMs);
+    if (outcome === TIMED_OUT) {
+      // The invocation stays live: the job is still running on the server, the
+      // harness simply stopped waiting. A later run of the same operation
+      // collides with it, which is exactly what the policy is for.
+      record.timedOutMs = timeoutMs;
+      this.state = applyEvent(this.state, {
+        type: "invocationError",
+        invocationId: invocation.id,
+        error: `timed out after ${timeoutMs}ms`
+      });
+      return;
+    }
+    this.inFlight.delete(invocation.id);
+    record.runIndex = outcome.runIndex;
+
+    // The headless runner awaits the whole stream, so every message belongs to
+    // the invocation just started; stamp it where the server did not.
+    const stamped = outcome.messages.map((message) => ({
+      ...message,
+      job_id: message.job_id ?? invocation.id
+    }));
+    const outputVariables = new Map(
+      outputVariableTargets(operation.binding).map((t) => [t.nodeId, t.variableId])
+    );
+    const events = messagesToEvents(stamped, {
+      resolveInvocation: (jobId: string | null | undefined) =>
+        jobId ? this.state.invocations[jobId] ?? null : null,
+      outputKey: (_operationId: string, nodeId: string) =>
+        operation.outputKeyByNodeId.get(nodeId) ?? null,
+      outputVariable: (_operationId: string, nodeId: string) =>
+        outputVariables.get(nodeId) ?? null
+    });
+    this.recordActivity(record, events);
+    this.state = applyEvents(this.state, events);
+    this.state = applyEvent(this.state, {
+      type: "invocationStatus",
+      invocationId: invocation.id,
+      status:
+        this.state.invocations[invocation.id]?.status === "failed"
+          ? "failed"
+          : "completed"
+    });
+  }
+
+  private recordActivity(
+    record: HeadlessInvocationRecord,
+    events: ReadonlyArray<AppStateEvent>
+  ): void {
+    for (const event of events) {
+      if (event.type !== "invocationActivity") continue;
+      if (record.activity.at(-1) === event.label) continue;
+      record.activity.push(event.label);
+      this.activity.push({
+        invocationId: record.id,
+        operationId: record.operationId,
+        label: event.label
+      });
     }
   }
 }

--- a/packages/cli/src/app-debug/types.ts
+++ b/packages/cli/src/app-debug/types.ts
@@ -12,6 +12,12 @@
 import type {
   AppEvent,
   BindingRef,
+  InputMapping,
+  OperationPolicy,
+  OutputMapping,
+  ResourceKind,
+  RunDecision,
+  VariableDeclaration,
   WidgetBindingMode as SharedWidgetBindingMode
 } from "@nodetool-ai/app-runtime";
 
@@ -50,10 +56,36 @@ export interface AppWidgetSpec {
   slot: string | null;
 }
 
+/** One declared operation, with the workflow surface it resolved against. */
+export interface AppOperationSpec {
+  id: string;
+  name: string;
+  workflowId: string;
+  policy: OperationPolicy;
+  timeoutMs: number | null;
+  /** Input node id → where its value comes from. */
+  inputs: Record<string, InputMapping>;
+  /** Output node id → where its value lands. */
+  outputs: Record<string, OutputMapping>;
+  /** The operation's bindable surface, or null when its workflow is missing. */
+  io: AppIO | null;
+  /** Why the operation cannot run (workflow not found), else null. */
+  unavailable: string | null;
+}
+
+export interface AppResourceSpec {
+  id: string;
+  name: string;
+  kind: ResourceKind;
+}
+
 export interface AppSpec {
   version: number;
   title: string | null;
   widgets: AppWidgetSpec[];
+  operations: AppOperationSpec[];
+  variables: VariableDeclaration[];
+  resources: AppResourceSpec[];
 }
 
 /** The bindable surface of the workflow graph (kernel shape). */
@@ -92,12 +124,18 @@ export interface AppValidation {
  *  - `set`    — write a reactive value directly (no events fire)
  *  - `change` — set a write widget's value, then fire its `change` events
  *  - `click`  — fire a widget's `click` events
+ *  - `run`    — run one operation by id, without going through a widget
+ *  - `cancel` — cancel an operation's live invocations
  * Widgets are referenced by component id, unique type, or unique label.
+ * `set` resolves against the default operation unless `operationId` says
+ * otherwise.
  */
 export type InteractionStep =
-  | { set: { key: string; value: unknown } }
+  | { set: { key: string; value: unknown; operationId?: string } }
   | { click: string }
-  | { change: string; value: unknown };
+  | { change: string; value: unknown }
+  | { run: string }
+  | { cancel: string };
 
 /** What actually happened when a step executed. */
 export interface InteractionRecord {
@@ -107,6 +145,24 @@ export interface InteractionRecord {
   /** Index into `runs` when the step triggered a workflow run. */
   runIndex: number | null;
   error: string | null;
+}
+
+/** One simulated invocation: what policy said, what the run did. */
+export interface AppInvocationReport {
+  id: string;
+  operationId: string;
+  status: string;
+  /** What `decideRun` said about starting this invocation. */
+  decision: RunDecision["kind"];
+  /** Invocations the decision named — cancelled (replace) or waited on (queue). */
+  decisionTargets: string[];
+  /** Index into `runs`, or null when the run never started. */
+  runIndex: number | null;
+  /** The timeout that elapsed, when the harness stopped waiting. */
+  timedOutMs: number | null;
+  error: string | null;
+  /** Every activity label the run reported, in order. */
+  activity: string[];
 }
 
 /** A widget's resolved value after the simulation settled. */
@@ -133,6 +189,15 @@ export interface AppDebugReport {
   runs: ServerRunReport[];
   /** Final reactive values (preview-safe), keyed by input/output/variable name. */
   values: Record<string, unknown>;
+  /**
+   * Final variable values (preview-safe), keyed by variable id — including the
+   * ones an operation output wrote.
+   */
+  variables: Record<string, unknown>;
+  /** Every invocation the simulation started, in order. */
+  invocations: AppInvocationReport[];
+  /** The activity labels the runs reported, in order. */
+  activity: Array<{ invocationId: string; operationId: string; label: string }>;
   widgets: AppWidgetState[];
   verdict: DebugVerdict;
   bundleDir: string | null;
@@ -152,6 +217,9 @@ export interface AppDebugOptions {
   run?: boolean;
   /** Bundle output directory. When omitted a timestamped dir is generated. */
   outDir?: string;
-  /** Per-run timeout, ms. */
+  /**
+   * Per-run timeout, ms. An operation's own `timeoutMs` also applies; when both
+   * are set the shorter one wins, so `--timeout` is always a ceiling.
+   */
   timeoutMs?: number;
 }

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -33,7 +33,7 @@ export function registerAppCommands(program: Command): void {
     .option("--params <json>", "Reactive values applied before interactions, keyed by input name")
     .option(
       "--interact <json>",
-      'Scripted interaction steps, e.g. \'[{"set":{"key":"prompt","value":"hi"}},{"click":"Button-1"}]\''
+      'Scripted interaction steps: set, change, click, run (by operation id), cancel — e.g. \'[{"set":{"key":"prompt","value":"hi"}},{"run":"main"}]\''
     )
     .option("--no-run", "Static wiring check only — never execute the workflow")
     .option(
@@ -104,6 +104,14 @@ function printAppSummary(report: {
   validation: { warnings: string[] };
   app: { title: string | null; widgetCount: number } | null;
   runs: Array<{ status: string; summary: { counts: { errored: number } } }>;
+  invocations: Array<{
+    id: string;
+    operationId: string;
+    status: string;
+    decision: string;
+    timedOutMs: number | null;
+  }>;
+  variables: Record<string, unknown>;
   widgets: Array<{
     id: string;
     type: string;
@@ -125,6 +133,15 @@ function printAppSummary(report: {
       `  run ${i + 1}: ${run.status} (${run.summary.counts.errored} node error(s))`
     );
   });
+  for (const inv of report.invocations) {
+    const state =
+      inv.timedOutMs != null ? `timed out after ${inv.timedOutMs}ms` : inv.status;
+    console.log(`  ${inv.operationId} (${inv.decision}): ${state}`);
+  }
+  const variables = Object.keys(report.variables);
+  if (variables.length > 0) {
+    console.log(`  variables: ${variables.join(", ")}`);
+  }
   const bound = report.widgets.filter((w) => w.bindingMode === "read" && w.binding);
   if (bound.length > 0) {
     const filled = bound.filter((w) => w.hasValue).length;

--- a/packages/cli/tests/app-debug-harness.test.ts
+++ b/packages/cli/tests/app-debug-harness.test.ts
@@ -108,7 +108,7 @@ describe("runAppDebug", () => {
     expect(report.interactions).toHaveLength(1);
     expect(report.interactions[0]).toMatchObject({
       step: "click Button-1",
-      actions: ["run"],
+      actions: ["run main"],
       runIndex: 0,
       error: null
     });
@@ -250,6 +250,415 @@ describe("runAppDebug", () => {
     expect(report.spec).toBeNull();
     expect(report.verdict.ok).toBe(false);
     expect(report.verdict.issues.join("\n")).toMatch(/no app_doc/);
+  });
+});
+
+/** A v3 app document: explicit operations, variables, and ID-form bindings. */
+const v3File = (over: {
+  operations?: unknown[];
+  variables?: unknown[];
+  resources?: unknown[];
+  content?: unknown[];
+}): string => {
+  const dir = mkdtempSync(join(tmpdir(), "app-debug-v3-"));
+  const file = join(dir, "workflow.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      id: "wf1",
+      graph: {
+        nodes: [
+          {
+            id: "in1",
+            type: "nodetool.input.StringInput",
+            data: { name: "prompt", value: "hello" }
+          },
+          { id: "out1", type: "nodetool.output.StringOutput", data: { name: "result" } }
+        ],
+        edges: []
+      },
+      app_doc: {
+        schemaVersion: 3,
+        ui: {
+          root: { props: { title: "V3 App" } },
+          content: over.content ?? [
+            {
+              type: "Markdown",
+              props: { id: "Markdown-1", binding: "op:main/out:out1" }
+            },
+            {
+              type: "Button",
+              props: {
+                id: "Button-1",
+                label: "Run",
+                events: [{ trigger: "click", kind: "run" }]
+              }
+            }
+          ],
+          zones: {}
+        },
+        operations: over.operations ?? [
+          { id: "main", name: "Run", workflowId: "", inputs: {}, outputs: {}, policy: "replace" }
+        ],
+        variables: over.variables ?? [],
+        resources: over.resources ?? []
+      }
+    }),
+    "utf8"
+  );
+  return file;
+};
+
+const ANSWER = [
+  { type: "output_update", node_id: "out1", output_name: "output", value: "the answer" },
+  { type: "job_update", status: "completed" }
+];
+
+const outDir = () => mkdtempSync(join(tmpdir(), "app-bundle-"));
+
+describe("runAppDebug — operations", () => {
+  const twoOperations = [
+    { id: "main", name: "Run", workflowId: "", inputs: {}, outputs: {}, policy: "replace" },
+    { id: "polish", name: "Polish", workflowId: "", inputs: {}, outputs: {}, policy: "replace" }
+  ];
+
+  it("runs a named operation and keeps its values under its own key", async () => {
+    const runOnServer = stubRunner(ANSWER);
+    const dir = outDir();
+    const report = await runAppDebug(
+      v3File({
+        operations: twoOperations,
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:polish/out:out1" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          },
+          {
+            type: "Button",
+            props: {
+              id: "Button-2",
+              events: [{ trigger: "click", kind: "run", operationId: "polish" }]
+            }
+          }
+        ]
+      }),
+      { interact: [{ run: "polish" }], outDir: dir },
+      deps(runOnServer)
+    );
+
+    expect(report.verdict.ok).toBe(true);
+    expect(report.interactions[0]).toMatchObject({ step: "run polish", runIndex: 0 });
+    expect(report.invocations).toHaveLength(1);
+    expect(report.invocations[0]).toMatchObject({
+      operationId: "polish",
+      decision: "start",
+      status: "completed"
+    });
+    expect(report.values["polish.result"]).toBe("the answer");
+    expect(report.values.result).toBeUndefined();
+    expect(readFileSync(join(dir, "report.md"), "utf8")).toContain("## Invocations");
+  });
+
+  it("clicking a widget dispatches to the operation its event names", async () => {
+    const runOnServer = stubRunner(ANSWER);
+    const report = await runAppDebug(
+      v3File({
+        operations: twoOperations,
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:polish/out:out1" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          },
+          {
+            type: "Button",
+            props: {
+              id: "Button-2",
+              events: [{ trigger: "click", kind: "run", operationId: "polish" }]
+            }
+          }
+        ]
+      }),
+      { interact: [{ click: "Button-2" }], outDir: outDir() },
+      deps(runOnServer)
+    );
+    expect(report.interactions[0].actions).toEqual(["run polish"]);
+    expect(report.invocations[0].operationId).toBe("polish");
+  });
+
+  it("cancels an operation's live invocation", async () => {
+    const runOnServer = vi.fn(() => new Promise<ServerRunOutcome>(() => {}));
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: {},
+            outputs: {},
+            policy: "replace",
+            timeoutMs: 5
+          }
+        ]
+      }),
+      { interact: [{ click: "Button-1" }, { cancel: "main" }], outDir: outDir() },
+      deps(runOnServer as never)
+    );
+    expect(report.interactions[1].actions[0]).toMatch(/cancel main \(headless-1\)/);
+    expect(report.invocations[0].status).toBe("cancelled");
+  });
+
+  it("reports a run that outlived the operation's timeout", async () => {
+    const runOnServer = vi.fn(() => new Promise<ServerRunOutcome>(() => {}));
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: {},
+            outputs: {},
+            policy: "replace",
+            timeoutMs: 5
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(runOnServer as never)
+    );
+    expect(report.invocations[0].timedOutMs).toBe(5);
+    expect(report.verdict.issues.join("\n")).toMatch(
+      /did not finish within its 5ms timeout/
+    );
+    expect(report.verdict.issues.join("\n")).not.toMatch(/never executed/);
+  });
+
+  it("flags an operation whose workflow is not in the database", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          { id: "main", name: "Run", workflowId: "", inputs: {}, outputs: {}, policy: "replace" },
+          {
+            id: "other",
+            name: "Other",
+            workflowId: "missing-wf",
+            inputs: {},
+            outputs: {},
+            policy: "replace"
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(/not in the local database/);
+  });
+});
+
+describe("runAppDebug — variables", () => {
+  const draft = {
+    id: "draft",
+    name: "draft",
+    scope: "instance",
+    persist: false
+  };
+
+  it("fans an output mapped to a variable into the variable and reports it", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: {},
+            outputs: { out1: { to: "variable", variableId: "draft" } },
+            policy: "replace"
+          }
+        ],
+        variables: [draft],
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "var:draft" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.ok).toBe(true);
+    expect(report.variables).toEqual({ draft: "the answer" });
+    expect(report.widgets[0]).toMatchObject({ id: "Markdown-1", value: "the answer" });
+  });
+
+  it("seeds a declared variable default before the first run", async () => {
+    const report = await runAppDebug(
+      v3File({
+        variables: [{ ...draft, default: "seeded" }],
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:main/out:out1" } },
+          { type: "Text", props: { id: "Text-1", binding: "var:draft" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.variables.draft).toBe("seeded");
+  });
+
+  it("flags an output that writes a variable the app never declares", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: {},
+            outputs: { out1: { to: "variable", variableId: "ghost" } },
+            policy: "replace"
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(
+      /writes variable "ghost", which the app does not declare/
+    );
+  });
+
+  it("flags an input that reads a variable the app never declares", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: { in1: { from: "variable", variableId: "ghost" } },
+            outputs: {},
+            policy: "replace"
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(
+      /reads variable "ghost", which the app does not declare/
+    );
+  });
+
+  it("flags an input that reads a resource binding the app never declares", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "",
+            inputs: { in1: { from: "resource", resourceBindingId: "ghost" } },
+            outputs: {},
+            policy: "replace"
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(
+      /reads resource binding "ghost", which the app does not declare/
+    );
+  });
+
+  it("warns that a persisted instance-scoped variable was downgraded", async () => {
+    const report = await runAppDebug(
+      v3File({ variables: [{ ...draft, persist: true }] }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.validation.warnings.join("\n")).toMatch(/downgraded to in-memory/);
+  });
+});
+
+describe("runAppDebug — execution bindings", () => {
+  it("flags a widget bound to an operation the app never declares", async () => {
+    const report = await runAppDebug(
+      v3File({
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:main/out:out1" } },
+          { type: "Text", props: { id: "Text-1", binding: "op:ghost/exec#activity" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(
+      /declares no operation "ghost"/
+    );
+  });
+
+  it("flags an activity display for an operation no widget can run", async () => {
+    const report = await runAppDebug(
+      v3File({
+        operations: [
+          { id: "main", name: "Run", workflowId: "", inputs: {}, outputs: {}, policy: "replace" },
+          { id: "polish", name: "Polish", workflowId: "", inputs: {}, outputs: {}, policy: "replace" }
+        ],
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:main/out:out1" } },
+          { type: "Text", props: { id: "Text-1", binding: "op:polish/exec#activity" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(stubRunner(ANSWER))
+    );
+    expect(report.verdict.issues.join("\n")).toMatch(/shows its execution state/);
+  });
+
+  it("reports the activity labels a streaming run emitted", async () => {
+    const report = await runAppDebug(
+      v3File({
+        content: [
+          { type: "Markdown", props: { id: "Markdown-1", binding: "op:main/out:out1" } },
+          { type: "Text", props: { id: "Text-1", binding: "op:main/exec#activity" } },
+          {
+            type: "Button",
+            props: { id: "Button-1", events: [{ trigger: "click", kind: "run" }] }
+          }
+        ]
+      }),
+      { outDir: outDir() },
+      deps(
+        stubRunner([
+          { type: "tool_call_update", name: "search", message: "searching the web" },
+          ...ANSWER
+        ])
+      )
+    );
+    expect(report.verdict.ok).toBe(true);
+    expect(report.activity.map((a) => a.label)).toEqual(["searching the web"]);
+    expect(report.widgets.find((w) => w.id === "Text-1")?.value).toBe(
+      "searching the web"
+    );
   });
 });
 

--- a/packages/cli/tests/app-debug-runtime.test.ts
+++ b/packages/cli/tests/app-debug-runtime.test.ts
@@ -1,65 +1,119 @@
 /**
  * Tests for the headless app runtime driver (src/app-debug/runtime.ts): value
- * seeding, param collection, and dispatch over the shared runtime core. The
- * fold rules themselves are tested in `@nodetool-ai/app-runtime`.
+ * seeding, param resolution, run policy, timeouts, and dispatch over the shared
+ * runtime core. The fold rules themselves are tested in
+ * `@nodetool-ai/app-runtime`.
  */
 import { describe, expect, it, vi } from "vitest";
-import { HeadlessAppRuntime } from "../src/app-debug/runtime.js";
+import type { OperationBinding } from "@nodetool-ai/app-runtime";
+import {
+  effectiveTimeoutMs,
+  HeadlessAppRuntime,
+  type HeadlessOperationInit,
+  type HeadlessRunResult
+} from "../src/app-debug/runtime.js";
 
 const IN_PROMPT = { kind: "input", operationId: "main", nodeId: "in1" } as const;
 const IN_COUNT = { kind: "input", operationId: "main", nodeId: "in2" } as const;
 const OUT_RESULT = { kind: "output", operationId: "main", nodeId: "out1" } as const;
 
+type Messages = ReadonlyArray<Record<string, unknown>>;
+
+const binding = (over: Partial<OperationBinding> = {}): OperationBinding => ({
+  id: "main",
+  name: "Run",
+  workflowId: "wf1",
+  inputs: {},
+  outputs: {},
+  policy: "replace",
+  ...over
+});
+
+/** One operation over a two-input, one-output workflow. */
+const operation = (
+  run: (params: Record<string, unknown>) => Promise<Messages>,
+  over: Partial<OperationBinding> = {},
+  runIndex = 0
+): HeadlessOperationInit => ({
+  binding: binding(over),
+  outputKeyByNodeId: new Map([["out1", `${over.id ?? "main"}:out1`]]),
+  inputNodeIds: ["in1", "in2"],
+  inputNameByNodeId: new Map([
+    ["in1", "prompt"],
+    ["in2", "count"]
+  ]),
+  defaults: { [`${over.id ?? "main"}:in1`]: "hi" },
+  runWorkflow: async (params): Promise<HeadlessRunResult> => ({
+    messages: await run(params),
+    runIndex
+  })
+});
+
 const runtime = (
-  runWorkflow: (
-    params: Record<string, unknown>
-  ) => Promise<ReadonlyArray<Record<string, unknown>>> = async () => []
+  run: (params: Record<string, unknown>) => Promise<Messages> = async () => [],
+  over: Partial<OperationBinding> = {}
 ) =>
   new HeadlessAppRuntime({
-    operationId: "main",
-    outputKeyByNodeId: new Map([["out1", "main:out1"]]),
-    paramNameByInputKey: new Map([
-      ["main:in1", "prompt"],
-      ["main:in2", "count"]
-    ]),
-    defaults: { "main:in1": "hi" },
-    runWorkflow
+    operations: [operation(run, over)],
+    defaultOperationId: "main"
   });
+
+/** A run that never settles — what a timeout has to save the harness from. */
+const hangs = () => new Promise<Messages>(() => {});
 
 describe("HeadlessAppRuntime", () => {
   it("seeds values from input defaults and collects only defined params", () => {
     const rt = runtime();
     expect(rt.read(IN_PROMPT)).toBe("hi");
-    expect(rt.collectParams()).toEqual({ prompt: "hi" });
+    expect(rt.collectParams("main")).toEqual({ prompt: "hi" });
     rt.write(IN_COUNT, 3);
-    expect(rt.collectParams()).toEqual({ prompt: "hi", count: 3 });
+    expect(rt.collectParams("main")).toEqual({ prompt: "hi", count: 3 });
+  });
+
+  it("seeds declared variable defaults without clobbering a written value", () => {
+    const rt = new HeadlessAppRuntime({
+      operations: [operation(async () => [])],
+      defaultOperationId: "main",
+      variables: [
+        { id: "tone", name: "tone", default: "formal", scope: "instance", persist: false },
+        { id: "empty", name: "empty", scope: "instance", persist: false }
+      ]
+    });
+    expect(rt.state.variables.tone).toBe("formal");
+    expect(rt.state.variables).not.toHaveProperty("empty");
   });
 
   it("folds a run's stream into the output slot", async () => {
-    const runWorkflow = vi.fn(async () => [
+    const run = vi.fn(async () => [
       { type: "output_update", node_id: "out1", output_name: "output", value: "a" },
       { type: "output_update", node_id: "out1", output_name: "output", value: "b" },
       { type: "chunk", node_id: "out1", content: "c" },
       { type: "job_update", status: "completed" }
     ]);
-    const rt = runtime(runWorkflow);
+    const rt = runtime(run);
     await rt.dispatch({ kind: "run", operationId: "main" });
     expect(rt.read(OUT_RESULT)).toBe("abc");
     expect(rt.runCount).toBe(1);
+    expect(rt.invocations[0]).toMatchObject({
+      operationId: "main",
+      decision: "start",
+      runIndex: 0,
+      timedOutMs: null
+    });
   });
 
   it("clears the previous run's output before folding the new one", async () => {
-    const runWorkflow = vi.fn(async (params: Record<string, unknown>) => {
+    const run = vi.fn(async (params: Record<string, unknown>) => {
       expect(params).toEqual({ prompt: "hello" });
       return [
         { type: "output_update", node_id: "out1", output_name: "output", value: "fresh" }
       ];
     });
-    const rt = runtime(runWorkflow);
+    const rt = runtime(run);
     rt.write(IN_PROMPT, "hello");
     await rt.dispatch({ kind: "run", operationId: "main" });
     await rt.dispatch({ kind: "run", operationId: "main" });
-    expect(runWorkflow).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledTimes(2);
     expect(rt.read(OUT_RESULT)).toBe("fresh");
   });
 
@@ -73,18 +127,150 @@ describe("HeadlessAppRuntime", () => {
   });
 
   it("mutates variables without running", async () => {
-    const runWorkflow = vi.fn(async () => []);
-    const rt = runtime(runWorkflow);
+    const run = vi.fn(async () => []);
+    const rt = runtime(run);
     await rt.dispatch({ kind: "setVariable", variableId: "dark", value: "yes" });
     await rt.dispatch({ kind: "toggleVariable", variableId: "dark" });
     expect(rt.state.variables.dark).toBe(false);
-    expect(runWorkflow).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("keeps an unbound write widget's value out of the run params", () => {
     const rt = runtime();
     rt.write({ kind: "view", componentId: "Slider-9", prop: "value" }, 42);
-    expect(rt.collectParams()).toEqual({ prompt: "hi" });
+    expect(rt.collectParams("main")).toEqual({ prompt: "hi" });
     expect(rt.state.view["Slider-9:value"]).toBe(42);
+  });
+
+  it("fans an output mapped to a variable into both the slot and the variable", async () => {
+    const rt = runtime(
+      async () => [
+        { type: "chunk", node_id: "out1", content: "half " },
+        { type: "chunk", node_id: "out1", content: "and half", done: true },
+        { type: "job_update", status: "completed" }
+      ],
+      { outputs: { out1: { to: "variable", variableId: "draft" } } }
+    );
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.read(OUT_RESULT)).toBe("half and half");
+    expect(rt.state.variables.draft).toBe("half and half");
+  });
+
+  it("resolves input mappings from variables and constants", async () => {
+    const run = vi.fn(async () => []);
+    const rt = runtime(run, {
+      inputs: {
+        in1: { from: "variable", variableId: "tone" },
+        in2: { from: "constant", value: 7 }
+      }
+    });
+    await rt.dispatch({ kind: "setVariable", variableId: "tone", value: "terse" });
+    expect(rt.collectParams("main")).toEqual({ prompt: "terse", count: 7 });
+  });
+
+  it("records every activity label the run reports, in order", async () => {
+    const rt = runtime(async () => [
+      { type: "tool_call_update", name: "search", message: "searching the web" },
+      { type: "planning_update", phase: "plan", status: "done" },
+      { type: "job_update", status: "completed" }
+    ]);
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.invocations[0].activity).toEqual([
+      "searching the web",
+      "plan: done"
+    ]);
+    expect(rt.activity.map((a) => a.operationId)).toEqual(["main", "main"]);
+    expect(rt.read({ kind: "execution", operationId: "main", field: "activity" })).toBe(
+      "plan: done"
+    );
+  });
+
+  it("gives up on a run that outlives its timeoutMs and leaves it live", async () => {
+    const rt = runtime(hangs, { timeoutMs: 5 });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.invocations[0].timedOutMs).toBe(5);
+    expect(rt.state.invocations["headless-1"].status).toBe("running");
+    expect(rt.error).toMatch(/timed out after 5ms/);
+  });
+
+  it("replaces a live invocation when the policy says so", async () => {
+    const rt = new HeadlessAppRuntime({
+      operations: [
+        operation(hangs, { policy: "replace", timeoutMs: 5 }),
+        // Second call resolves, so the replacement run settles normally.
+        operation(async () => [{ type: "job_update", status: "completed" }], {
+          id: "other"
+        })
+      ],
+      defaultOperationId: "main"
+    });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.invocations[1]).toMatchObject({
+      decision: "replace",
+      decisionTargets: ["headless-1"]
+    });
+    expect(rt.state.invocations["headless-1"].status).toBe("cancelled");
+  });
+
+  it("queues behind a live invocation when the policy says so", async () => {
+    const rt = runtime(hangs, { policy: "queue", timeoutMs: 5 });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.invocations[1]).toMatchObject({
+      decision: "queue",
+      decisionTargets: ["headless-1"]
+    });
+  });
+
+  it("starts immediately under the parallel policy", async () => {
+    const rt = runtime(hangs, { policy: "parallel", timeoutMs: 5 });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.invocations.map((i) => i.decision)).toEqual(["start", "start"]);
+    expect(rt.state.invocations["headless-1"].status).toBe("running");
+  });
+
+  it("cancels an operation's live invocations", async () => {
+    const rt = runtime(hangs, { timeoutMs: 5 });
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.cancel("main")).toEqual(["headless-1"]);
+    expect(rt.state.invocations["headless-1"].status).toBe("cancelled");
+    expect(rt.cancel("main")).toEqual([]);
+  });
+
+  it("runs a second operation with its own inputs, outputs, and defaults", async () => {
+    const first = vi.fn(async () => []);
+    const second = vi.fn(async () => [
+      { type: "output_update", node_id: "out1", value: "from other" },
+      { type: "job_update", status: "completed" }
+    ]);
+    const rt = new HeadlessAppRuntime({
+      operations: [operation(first), operation(second, { id: "other" }, 1)],
+      defaultOperationId: "main"
+    });
+    await rt.dispatch({ kind: "run", operationId: "other" });
+    expect(first).not.toHaveBeenCalled();
+    expect(rt.read({ kind: "output", operationId: "other", nodeId: "out1" })).toBe(
+      "from other"
+    );
+    expect(rt.read(OUT_RESULT)).toBeUndefined();
+  });
+
+  it("throws for an operation the app never declared", async () => {
+    const rt = runtime();
+    await expect(rt.dispatch({ kind: "run", operationId: "ghost" })).rejects.toThrow(
+      /No operation "ghost"/
+    );
+  });
+});
+
+describe("effectiveTimeoutMs", () => {
+  it("takes the shorter of the operation's timeout and the harness ceiling", () => {
+    expect(effectiveTimeoutMs(5000, 1000)).toBe(1000);
+    expect(effectiveTimeoutMs(500, 1000)).toBe(500);
+    expect(effectiveTimeoutMs(null, 1000)).toBe(1000);
+    expect(effectiveTimeoutMs(2000, undefined)).toBe(2000);
+    expect(effectiveTimeoutMs(null, null)).toBeNull();
   });
 });

--- a/packages/cli/tests/app-debug-spec.test.ts
+++ b/packages/cli/tests/app-debug-spec.test.ts
@@ -4,7 +4,13 @@
  * surface, and statically validating the wiring.
  */
 import { describe, expect, it } from "vitest";
-import { extractAppIO, parseAppSpec, validateApp } from "../src/app-debug/app-spec.js";
+import {
+  extractAppIO,
+  operationSpec,
+  parseAppSpec,
+  validateApp,
+  type AppContext
+} from "../src/app-debug/app-spec.js";
 import type { AppIO } from "../src/app-debug/types.js";
 import type { DebugGraph } from "../src/debug/types.js";
 
@@ -188,10 +194,56 @@ describe("validateApp", () => {
     expect(warnings.join("\n")).toMatch(/"result" is not displayed/);
   });
 
+  it("accepts every display widget in the shared catalog, including Table", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Table", "Table-1", { binding: "result" }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ]),
+      io
+    );
+    expect(spec?.widgets[0].bindingMode).toBe("read");
+    expect(validateApp(spec!, io).errors).toEqual([]);
+  });
+
   it("flags unknown widget types", () => {
     const { spec } = parseAppSpec(appDoc([widget("Bogus", "Bogus-1")]), io);
     const { errors } = validateApp(spec!, io);
     expect(errors.join("\n")).toMatch(/unknown widget type/);
+  });
+
+  it("flags operation mappings keyed on nodes the workflow does not have", () => {
+    const context: AppContext = {
+      defaultOperationId: "main",
+      variables: [],
+      resources: [],
+      operations: [
+        operationSpec(
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "wf1",
+            inputs: { ghostIn: { from: "widget" }, in1: { from: "constant", value: undefined } },
+            outputs: { ghostOut: { to: "display" } },
+            policy: "replace"
+          },
+          io,
+          null
+        )
+      ]
+    };
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ]),
+      io,
+      context
+    );
+    const { errors, warnings } = validateApp(spec!, io, context);
+    expect(errors.join("\n")).toMatch(/input mapping for node "ghostIn"/);
+    expect(errors.join("\n")).toMatch(/output mapping for node "ghostOut"/);
+    expect(warnings.join("\n")).toMatch(/constant with no value/);
   });
 
   it("warns on an unbound write widget (local-only state)", () => {

--- a/packages/models/src/application.ts
+++ b/packages/models/src/application.ts
@@ -7,6 +7,7 @@
  * operation and carry no history. An application row separates the two: the app
  * owns a UI document plus typed bindings, and each binding names a workflow.
  */
+import { createHash } from "node:crypto";
 import { eq, desc, and, max } from "drizzle-orm";
 import {
   APP_SCHEMA_VERSION,
@@ -25,6 +26,8 @@ import {
 } from "./base-model.js";
 import { getDb } from "./db.js";
 import { applications, applicationVersions } from "./schema/applications.js";
+import { Workflow, type WorkflowGraph } from "./workflow.js";
+import { WorkflowVersion } from "./workflow-version.js";
 
 /**
  * What a release is allowed to do, derived from its bindings at publish time
@@ -32,10 +35,38 @@ import { applications, applicationVersions } from "./schema/applications.js";
  * nothing else the app layer can do.
  */
 export interface ApplicationCapabilities {
-  /** Workflow ids the release may invoke, with the version each is pinned to. */
-  workflows: Array<{ workflowId: string; version?: number }>;
+  /**
+   * Workflow ids the release may invoke, with the version each is pinned to
+   * and the hash of the graph that version froze. The hash identifies the
+   * exact graph a release runs without carrying it.
+   */
+  workflows: Array<{
+    workflowId: string;
+    version?: number;
+    graphHash?: string;
+  }>;
   /** Resource kinds the release touches and the operations it uses on them. */
   resources: Array<{ kind: ResourceKind; operations: ResourceOperation[] }>;
+}
+
+/**
+ * A workflow graph as a release froze it.
+ *
+ * `version` is a row in `nodetool_workflow_versions` written at publish time,
+ * so the number means the same thing it means everywhere else in the app. The
+ * graph itself is copied onto the release as well: a release must stay
+ * reproducible even if that version row is later pruned or its workflow is
+ * deleted.
+ *
+ * Both are null on a snapshot published before releases pinned anything; a
+ * runtime that meets one has no frozen graph to run and falls back to the live
+ * workflow.
+ */
+export interface PinnedWorkflow {
+  workflowId: string;
+  version: number | null;
+  graphHash: string | null;
+  graph: WorkflowGraph | null;
 }
 
 export interface ApplicationResponse {
@@ -58,6 +89,14 @@ export interface ApplicationVersionResponse {
   createdAt: string;
 }
 
+/**
+ * Everything needed to *run* a release: the snapshot plus the frozen graph of
+ * every workflow its operations name.
+ */
+export interface ApplicationReleaseResponse extends ApplicationVersionResponse {
+  workflows: PinnedWorkflow[];
+}
+
 export class ApplicationConflictError extends Error {
   constructor(id: string) {
     super(`Application ${id} was modified concurrently`);
@@ -67,19 +106,25 @@ export class ApplicationConflictError extends Error {
 
 /** Derive a release's capability summary from the document's bindings. */
 export const deriveCapabilities = (
-  document: ApplicationDocument
+  document: ApplicationDocument,
+  graphHashes: ReadonlyMap<string, string> = new Map()
 ): ApplicationCapabilities => {
-  const workflows = new Map<string, { workflowId: string; version?: number }>();
+  const workflows = new Map<
+    string,
+    { workflowId: string; version?: number; graphHash?: string }
+  >();
   for (const operation of document.operations) {
     const key = `${operation.workflowId}@${operation.workflowVersion ?? ""}`;
     workflows.set(key, {
       workflowId: operation.workflowId,
-      version: operation.workflowVersion
+      version: operation.workflowVersion,
+      graphHash: graphHashes.get(operation.workflowId)
     });
   }
   const resources = new Map<ResourceKind, Set<ResourceOperation>>();
   for (const binding of document.resources) {
-    const existing = resources.get(binding.kind) ?? new Set<ResourceOperation>();
+    const existing =
+      resources.get(binding.kind) ?? new Set<ResourceOperation>();
     for (const op of binding.operations) existing.add(op);
     resources.set(binding.kind, existing);
   }
@@ -231,7 +276,9 @@ const toVersionResponse = (
   applicationId: String(row.application_id),
   version: Number(row.version),
   document: parseDocumentOrThrow(
-    typeof row.document === "string" ? row.document : JSON.stringify(row.document)
+    typeof row.document === "string"
+      ? row.document
+      : JSON.stringify(row.document)
   ),
   capabilities:
     typeof row.capabilities === "string"
@@ -241,20 +288,139 @@ const toVersionResponse = (
   createdAt: String(row.created_at)
 });
 
+/** Stable hash of a graph — the identity of the code a release runs. */
+const hashGraph = (graph: WorkflowGraph): string =>
+  createHash("sha256").update(JSON.stringify(graph)).digest("hex");
+
+const parsePinnedGraphs = (
+  raw: unknown
+): Map<
+  string,
+  { version: number | null; graphHash: string; graph: WorkflowGraph }
+> => {
+  if (raw == null) return new Map();
+  const parsed = (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<
+    string,
+    { version: number | null; graphHash: string; graph: WorkflowGraph }
+  >;
+  return new Map(Object.entries(parsed));
+};
+
+/**
+ * Freeze every workflow the document invokes.
+ *
+ * Each referenced workflow's live graph is written as a new row in the
+ * workflow's own version history (`save_type: "publish"`), so the number the
+ * release pins is a real workflow version, not one invented for apps. The
+ * graph is returned alongside it so the release can carry its own copy.
+ */
+async function pinWorkflows(
+  document: ApplicationDocument,
+  userId: string,
+  applicationVersion: number
+): Promise<
+  Map<
+    string,
+    { version: number | null; graphHash: string; graph: WorkflowGraph }
+  >
+> {
+  const pinned = new Map<
+    string,
+    { version: number | null; graphHash: string; graph: WorkflowGraph }
+  >();
+  for (const operation of document.operations) {
+    if (pinned.has(operation.workflowId)) continue;
+    const workflow = await Workflow.find(userId, operation.workflowId);
+    if (!workflow) {
+      throw new Error(
+        `Cannot publish: workflow ${operation.workflowId} bound to operation ` +
+          `${operation.id} was not found`
+      );
+    }
+    const graph = workflow.getGraph();
+    // Only the workflow's owner may add to its version history; publishing an
+    // app over someone else's shared workflow still pins the graph, it just
+    // has no version of theirs to name.
+    let version: number | null = null;
+    if (workflow.user_id === userId) {
+      version = await WorkflowVersion.nextVersion(operation.workflowId);
+      await WorkflowVersion.create<WorkflowVersion>({
+        workflow_id: operation.workflowId,
+        user_id: workflow.user_id,
+        name: workflow.name,
+        description: `Pinned by application release v${applicationVersion}`,
+        graph,
+        version,
+        save_type: "publish"
+      });
+    }
+    pinned.set(operation.workflowId, {
+      version,
+      graphHash: hashGraph(graph),
+      graph
+    });
+  }
+  return pinned;
+}
+
+/**
+ * A version plus the frozen graphs it runs. Snapshots published before pinning
+ * carry no graphs; their entries report null so the caller can tell "pinned to
+ * nothing" from "pinned to this".
+ */
+const toReleaseResponse = (
+  row: Record<string, unknown>
+): ApplicationReleaseResponse => {
+  const version = toVersionResponse(row);
+  const graphs = parsePinnedGraphs(row.workflow_graphs);
+  const workflowIds = new Set(
+    version.document.operations.map((operation) => operation.workflowId)
+  );
+  return {
+    ...version,
+    workflows: [...workflowIds].map((workflowId) => {
+      const pinned = graphs.get(workflowId);
+      return {
+        workflowId,
+        version: pinned?.version ?? null,
+        graphHash: pinned?.graphHash ?? null,
+        graph: pinned?.graph ?? null
+      };
+    })
+  };
+};
+
 /**
  * Publish the application's current draft as an immutable, released snapshot.
  * The release pointer moves to the new version; rollback is `release(id, n)`.
+ *
+ * Publishing pins: every operation's `workflowVersion` is set to a workflow
+ * version written now, and that version's graph is copied onto the snapshot.
+ * Editing the workflow afterwards changes the draft's runs, never the
+ * release's.
  */
 export async function publishApplication(
   application: Application
-): Promise<ApplicationVersionResponse> {
+): Promise<ApplicationReleaseResponse> {
   const db = getDb();
-  const document = application.toDocument();
+  const draft = application.toDocument();
   const highest = await db
     .select({ value: max(applicationVersions.version) })
     .from(applicationVersions)
     .where(eq(applicationVersions.application_id, application.id));
   const nextVersion = Number(highest[0]?.value ?? 0) + 1;
+
+  const pinned = await pinWorkflows(draft, application.user_id, nextVersion);
+  const document: ApplicationDocument = {
+    ...draft,
+    operations: draft.operations.map((operation) => ({
+      ...operation,
+      workflowVersion: pinned.get(operation.workflowId)?.version ?? undefined
+    }))
+  };
+  const graphHashes = new Map(
+    [...pinned].map(([workflowId, entry]) => [workflowId, entry.graphHash])
+  );
 
   await db
     .update(applicationVersions)
@@ -268,13 +434,14 @@ export async function publishApplication(
       application_id: application.id,
       version: nextVersion,
       document: JSON.stringify(document),
-      capabilities: JSON.stringify(deriveCapabilities(document)),
+      capabilities: JSON.stringify(deriveCapabilities(document, graphHashes)),
+      workflow_graphs: JSON.stringify(Object.fromEntries(pinned)),
       released: 1,
       created_at: new Date().toISOString()
     })
     .returning();
 
-  return toVersionResponse(rows[0] as Record<string, unknown>);
+  return toReleaseResponse(rows[0] as Record<string, unknown>);
 }
 
 export async function listApplicationVersions(
@@ -308,6 +475,28 @@ export async function releasedApplicationVersion(
     .limit(1);
   const row = rows[0] as Record<string, unknown> | undefined;
   return row ? toVersionResponse(row) : null;
+}
+
+/**
+ * The released snapshot plus the graphs it is pinned to — everything a client
+ * needs to run the release rather than the draft.
+ */
+export async function releasedApplicationRelease(
+  applicationId: string
+): Promise<ApplicationReleaseResponse | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(applicationVersions)
+    .where(
+      and(
+        eq(applicationVersions.application_id, applicationId),
+        eq(applicationVersions.released, 1)
+      )
+    )
+    .limit(1);
+  const row = rows[0] as Record<string, unknown> | undefined;
+  return row ? toReleaseResponse(row) : null;
 }
 
 /** Move the release pointer to an existing version (publish or rollback). */

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1028,6 +1028,7 @@ function getCreateSchemaSql(): string {
       "version" integer NOT NULL,
       "document" text NOT NULL,
       "capabilities" text NOT NULL,
+      "workflow_graphs" text,
       "released" integer NOT NULL DEFAULT 0,
       "created_at" text NOT NULL
     );

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -152,12 +152,15 @@ export {
   publishApplication,
   listApplicationVersions,
   releasedApplicationVersion,
+  releasedApplicationRelease,
   releaseApplicationVersion
 } from "./application.js";
 export type {
   ApplicationCapabilities,
+  ApplicationReleaseResponse,
   ApplicationResponse,
-  ApplicationVersionResponse
+  ApplicationVersionResponse,
+  PinnedWorkflow
 } from "./application.js";
 export {
   applicationUsage,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2098,5 +2098,27 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP TABLE IF EXISTS application_invocations");
       await db.execute("DROP TABLE IF EXISTS application_budgets");
     }
+  },
+
+  // ── Pin the graphs an application release runs ──────────────────────
+  // A release used to copy the draft document and nothing else, so it ran
+  // whatever the workflow happened to hold at run time. Publishing now freezes
+  // each referenced workflow's graph onto the snapshot.
+  {
+    version: "20260726_000000",
+    name: "add_workflow_graphs_to_application_versions",
+    createsTables: [],
+    modifiesTables: ["application_versions"],
+    async up(db) {
+      if (!(await db.columnExists("application_versions", "workflow_graphs"))) {
+        await db.execute(
+          "ALTER TABLE application_versions ADD COLUMN workflow_graphs TEXT"
+        );
+      }
+    },
+    async down() {
+      // SQLite cannot drop a column on older engines; the column is nullable
+      // and unread by prior code, so leaving it is harmless.
+    }
   }
 ];

--- a/packages/models/src/schema-pg/applications.ts
+++ b/packages/models/src/schema-pg/applications.ts
@@ -31,6 +31,7 @@ export const applicationVersions = pgTable(
     version: integer("version").notNull(),
     document: jsonText<ApplicationDocument>()("document").notNull(),
     capabilities: jsonText<ApplicationCapabilities>()("capabilities").notNull(),
+    workflow_graphs: text("workflow_graphs"),
     released: integer("released").notNull(),
     created_at: text("created_at").notNull()
   },

--- a/packages/models/src/schema/applications.ts
+++ b/packages/models/src/schema/applications.ts
@@ -40,6 +40,13 @@ export const applicationVersions = sqliteTable(
     document: text("document").notNull(),
     /** Workflows the release may invoke, derived at publish time. */
     capabilities: text("capabilities").notNull(),
+    /**
+     * The graph of every workflow the release invokes, as it stood at publish
+     * time, keyed by workflow id. The release runs these rather than the live
+     * graphs, so editing a workflow cannot change what shipped. Null on
+     * snapshots published before releases pinned anything.
+     */
+    workflow_graphs: text("workflow_graphs"),
     released: integer("released").notNull(),
     created_at: text("created_at").notNull()
   },

--- a/packages/models/tests/application.test.ts
+++ b/packages/models/tests/application.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createEmptyDocument } from "@nodetool-ai/app-runtime";
 
-import { initTestDb } from "../src/db.js";
+import { eq } from "drizzle-orm";
+
+import { getDb, initTestDb } from "../src/db.js";
+import { applicationVersions } from "../src/schema/applications.js";
 import {
   Application,
   deriveCapabilities,
   listApplicationVersions,
   publishApplication,
   releaseApplicationVersion,
+  releasedApplicationRelease,
   releasedApplicationVersion
 } from "../src/application.js";
+import { Workflow } from "../src/workflow.js";
+import { WorkflowVersion } from "../src/workflow-version.js";
 
 const documentWith = (workflowId = "wf1") => {
   const doc = createEmptyDocument("Demo");
@@ -36,6 +42,21 @@ const createApp = (
     project_id: projectId,
     name,
     document: JSON.stringify(documentWith())
+  });
+
+const nodeNamed = (id: string) => ({ id, type: "nodetool.text.Concat" });
+
+/** The workflow the app's operation names — publishing pins its graph. */
+const createWorkflow = (
+  id = "wf1",
+  userId = "u1",
+  nodeId = "n1"
+): Promise<Workflow> =>
+  Workflow.create<Workflow>({
+    id,
+    user_id: userId,
+    name: "Demo workflow",
+    graph: { nodes: [nodeNamed(nodeId)], edges: [] }
   });
 
 describe("Application model", () => {
@@ -85,8 +106,9 @@ describe("Application model", () => {
 });
 
 describe("application releases", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     initTestDb();
+    await createWorkflow();
   });
 
   it("publishes monotonic versions and moves the release pointer", async () => {
@@ -122,6 +144,102 @@ describe("application releases", () => {
   it("returns null when rolling back to a version that does not exist", async () => {
     const app = await createApp();
     expect(await releaseApplicationVersion(app.id, 7)).toBeNull();
+  });
+
+  it("pins each operation to a workflow version written at publish time", async () => {
+    const app = await createApp();
+
+    const release = await publishApplication(app);
+
+    const pinnedVersion = release.document.operations[0]!.workflowVersion;
+    expect(pinnedVersion).toBe(1);
+    expect(release.workflows).toEqual([
+      {
+        workflowId: "wf1",
+        version: 1,
+        graphHash: expect.any(String),
+        graph: { nodes: [nodeNamed("n1")], edges: [] }
+      }
+    ]);
+    expect(release.capabilities.workflows[0]).toMatchObject({
+      workflowId: "wf1",
+      version: 1
+    });
+    const stored = await WorkflowVersion.findByVersion("wf1", 1);
+    expect(stored?.save_type).toBe("publish");
+    expect(stored?.graph).toEqual({ nodes: [nodeNamed("n1")], edges: [] });
+  });
+
+  it("keeps the release unchanged when the workflow is edited afterwards", async () => {
+    const app = await createApp();
+    const release = await publishApplication(app);
+    const hashAtPublish = release.capabilities.workflows[0]!.graphHash;
+
+    const workflow = (await Workflow.get<Workflow>("wf1"))!;
+    workflow.graph = { nodes: [nodeNamed("edited")], edges: [] };
+    await workflow.save();
+
+    const served = await releasedApplicationRelease(app.id);
+    expect(served?.workflows[0]!.graph).toEqual({
+      nodes: [nodeNamed("n1")],
+      edges: []
+    });
+    expect(served?.workflows[0]!.graphHash).toBe(hashAtPublish);
+    expect(served?.document.operations[0]!.workflowVersion).toBe(1);
+
+    // Publishing again picks the edit up as a new pin, leaving v1 alone.
+    const next = await publishApplication(app);
+    expect(next.workflows[0]!.version).toBe(2);
+    expect(next.workflows[0]!.graph).toEqual({
+      nodes: [nodeNamed("edited")],
+      edges: []
+    });
+    const first = (await listApplicationVersions(app.id)).find(
+      (v) => v.version === 1
+    );
+    expect(first?.document.operations[0]!.workflowVersion).toBe(1);
+  });
+
+  it("pins a shared workflow's graph without writing to its history", async () => {
+    const workflow = (await Workflow.get<Workflow>("wf1"))!;
+    workflow.user_id = "someone-else";
+    workflow.access = "public";
+    await workflow.save();
+    const app = await createApp();
+
+    const release = await publishApplication(app);
+
+    expect(release.workflows[0]).toMatchObject({
+      workflowId: "wf1",
+      version: null,
+      graph: { nodes: [nodeNamed("n1")], edges: [] }
+    });
+    expect(await WorkflowVersion.listForWorkflow("wf1")).toEqual([]);
+  });
+
+  it("refuses to publish an operation whose workflow is gone", async () => {
+    const app = await createApp();
+    const workflow = (await Workflow.get<Workflow>("wf1"))!;
+    await workflow.delete();
+
+    await expect(publishApplication(app)).rejects.toThrow(
+      /workflow wf1 bound to operation main was not found/
+    );
+  });
+
+  it("reports no pinned graph on a snapshot published before pinning", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+    // Simulate a row written by the pre-pinning publish path.
+    await getDb()
+      .update(applicationVersions)
+      .set({ workflow_graphs: null })
+      .where(eq(applicationVersions.application_id, app.id));
+
+    const served = await releasedApplicationRelease(app.id);
+    expect(served?.workflows).toEqual([
+      { workflowId: "wf1", version: null, graphHash: null, graph: null }
+    ]);
   });
 });
 

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 51;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 52;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/protocol/src/api-schemas/applications.ts
+++ b/packages/protocol/src/api-schemas/applications.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { graph } from "./workflows.js";
+
 // ── Application document ────────────────────────────────────────────────────
 // Mirrors `ApplicationDocument` in `@nodetool-ai/app-runtime`. The UI document
 // is a client-owned Puck payload, so it travels loosely; the binding, variable,
@@ -110,7 +112,12 @@ export type ApplicationListItem = z.infer<typeof applicationListItem>;
 /** Derived at publish time from the release's bindings — never hand-written. */
 export const applicationCapabilities = z.object({
   workflows: z.array(
-    z.object({ workflowId: z.string(), version: z.number().optional() })
+    z.object({
+      workflowId: z.string(),
+      version: z.number().optional(),
+      /** sha256 of the graph the release froze for this workflow. */
+      graphHash: z.string().optional()
+    })
   ),
   resources: z.array(
     z.object({
@@ -131,6 +138,29 @@ export const applicationVersionResponse = z.object({
 });
 export type ApplicationVersionResponse = z.infer<
   typeof applicationVersionResponse
+>;
+
+/**
+ * A workflow graph as a release froze it. `version` is a row in the workflow's
+ * own version history written at publish time; `graph` is the copy the release
+ * carries, so it survives that row being pruned. Both are null on a snapshot
+ * published before releases pinned anything — a runtime that meets one has no
+ * frozen graph and falls back to the live workflow.
+ */
+export const pinnedWorkflow = z.object({
+  workflowId: z.string(),
+  version: z.number().nullable(),
+  graphHash: z.string().nullable(),
+  graph: graph.nullable()
+});
+export type PinnedWorkflowSchema = z.infer<typeof pinnedWorkflow>;
+
+/** The released snapshot plus everything needed to run it. */
+export const applicationReleaseResponse = applicationVersionResponse.extend({
+  workflows: z.array(pinnedWorkflow)
+});
+export type ApplicationReleaseResponse = z.infer<
+  typeof applicationReleaseResponse
 >;
 
 export const createApplicationInput = z.object({

--- a/packages/websocket/src/trpc/routers/applications.ts
+++ b/packages/websocket/src/trpc/routers/applications.ts
@@ -16,6 +16,8 @@
  *   versions (query)    — ApplicationVersionResponse[]
  *   release  (mutation) — ApplicationVersionResponse (publish or rollback)
  *   released (query)    — ApplicationVersionResponse | null
+ *   releasedDocument (query) — ApplicationReleaseResponse | null
+ *                              (the snapshot plus the graphs it is pinned to)
  *
  * Spend governance, for apps published to people other than their author:
  *   budget/setBudget       — the app-scoped ceiling
@@ -40,6 +42,7 @@ import {
   publishApplication,
   reserveInvocation,
   releaseApplicationVersion,
+  releasedApplicationRelease,
   releasedApplicationVersion,
   setApplicationBudget,
   settleInvocation
@@ -48,6 +51,7 @@ import { Workflow } from "@nodetool-ai/models";
 import {
   applicationBudget,
   applicationListItem,
+  applicationReleaseResponse,
   applicationResponse,
   applicationUsage as applicationUsageSchema,
   applicationVersionResponse,
@@ -252,6 +256,21 @@ export const applicationsRouter = router({
       await loadOwned(ctx.userId, input.id);
       const version = await releasedApplicationVersion(input.id);
       return version ? applicationVersionResponse.parse(version) : null;
+    }),
+
+  /**
+   * What a published app should run: the released snapshot's document, its
+   * version number and capabilities, plus the graph each operation is pinned
+   * to. A client that runs these graphs runs the release; a client that runs
+   * the app's `document` runs the draft.
+   */
+  releasedDocument: protectedProcedure
+    .input(idInput)
+    .output(applicationReleaseResponse.nullable())
+    .query(async ({ ctx, input }) => {
+      await loadOwned(ctx.userId, input.id);
+      const release = await releasedApplicationRelease(input.id);
+      return release ? applicationReleaseResponse.parse(release) : null;
     }),
 
   budget: protectedProcedure

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -35,6 +35,7 @@ import {
   Asset,
   ImageDocument,
   Job,
+  releasedApplicationVersion,
   reserveInvocation,
   settleInvocation,
   Message,
@@ -2229,12 +2230,20 @@ export class UnifiedWebSocketRunner {
     req.job_id = jobId;
     try {
       const estimatedUsd = this.estimateRunCost(req);
+      // The client says whether this is a release run or a draft run; the
+      // server says which release. Taking the number from the client would let
+      // a run bill itself to a version it never executed, and the ledger is
+      // also the release telemetry.
+      const version =
+        req.application_version == null
+          ? null
+          : ((await releasedApplicationVersion(applicationId))?.version ?? null);
       // Reserving claims the run against the budget in the same transaction
       // that checks it, so concurrent runs of one app cannot each read a total
       // that excludes the others and all be admitted.
       const decision = await reserveInvocation({
         applicationId,
-        version: req.application_version ?? null,
+        version,
         invocationId: jobId,
         estimatedUsd
       });

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -16,10 +16,14 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/unified-websocket-runner.js";
+import { createEmptyDocument } from "@nodetool-ai/app-runtime";
 import {
+  Application,
+  Workflow,
   applicationUsage,
   initTestDb,
   listInvocations,
+  publishApplication,
   recordInvocation,
   setApplicationBudget
 } from "@nodetool-ai/models";
@@ -107,9 +111,75 @@ describe("application budget gate", () => {
     expect(ledger).toHaveLength(1);
     expect(ledger[0]).toMatchObject({
       invocationId: "job-1",
-      version: 2,
+      // The app has no release, so there is no version to bill the run to —
+      // the client's claim of one does not create it.
+      version: null,
       status: "running"
     });
+  });
+
+  it("bills a release run to the released version, not the claimed one", async () => {
+    await Workflow.create<Workflow>({
+      id: "wf1",
+      user_id: "u1",
+      name: "Demo workflow",
+      graph: { nodes: [], edges: [] }
+    });
+    const document = createEmptyDocument("Demo");
+    document.operations = [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf1",
+        inputs: {},
+        outputs: {},
+        policy: "replace"
+      }
+    ];
+    const app = await Application.create<Application>({
+      id: APP,
+      user_id: "u1",
+      name: "Demo app",
+      document: JSON.stringify(document)
+    });
+    await publishApplication(app);
+
+    await run({ application_id: APP, application_version: 99 });
+
+    const [record] = await listInvocations(APP);
+    expect(record).toMatchObject({ invocationId: "job-1", version: 1 });
+  });
+
+  it("records a draft run against no version even when a release exists", async () => {
+    await Workflow.create<Workflow>({
+      id: "wf1",
+      user_id: "u1",
+      name: "Demo workflow",
+      graph: { nodes: [], edges: [] }
+    });
+    const document = createEmptyDocument("Demo");
+    document.operations = [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf1",
+        inputs: {},
+        outputs: {},
+        policy: "replace"
+      }
+    ];
+    const app = await Application.create<Application>({
+      id: APP,
+      user_id: "u1",
+      name: "Demo app",
+      document: JSON.stringify(document)
+    });
+    await publishApplication(app);
+
+    await run({ application_id: APP });
+
+    const [record] = await listInvocations(APP);
+    expect(record).toMatchObject({ invocationId: "job-1", version: null });
   });
 
   it("refuses a run that would cross the budget, before the job exists", async () => {

--- a/packages/websocket/tests/trpc-applications.test.ts
+++ b/packages/websocket/tests/trpc-applications.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createEmptyDocument } from "@nodetool-ai/app-runtime";
+import {
+  Application,
+  ModelObserver,
+  Workflow,
+  initTestDb
+} from "@nodetool-ai/models";
+
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+
+// Real DB, real resolvers: the release path is only worth testing end to end,
+// since the point of it is that what the server serves is not the draft.
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(userId: string): Context {
+  return {
+    userId,
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false
+  } as Context;
+}
+
+const node = (id: string) => ({ id, type: "nodetool.text.Concat" });
+
+async function seedApp(userId = "user-1") {
+  await Workflow.create<Workflow>({
+    id: "wf1",
+    user_id: userId,
+    name: "Demo workflow",
+    graph: { nodes: [node("n1")], edges: [] }
+  });
+  const document = createEmptyDocument("Demo");
+  document.operations = [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf1",
+      inputs: {},
+      outputs: {},
+      policy: "replace"
+    }
+  ];
+  return Application.create<Application>({
+    user_id: userId,
+    project_id: "p1",
+    name: "Demo app",
+    document: JSON.stringify(document)
+  });
+}
+
+describe("applications router releases", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("releasedDocument serves the pinned snapshot, not the draft", async () => {
+    const app = await seedApp();
+    const caller = createCaller(makeCtx("user-1"));
+    await caller.applications.publish({ id: app.id });
+
+    // Both the workflow and the app's draft move on after the release.
+    const workflow = (await Workflow.get<Workflow>("wf1"))!;
+    workflow.graph = { nodes: [node("edited")], edges: [] };
+    await workflow.save();
+    const draft = await caller.applications.get({ id: app.id });
+    await caller.applications.update({
+      id: app.id,
+      baseUpdatedAt: draft.updatedAt,
+      document: {
+        ...draft.document,
+        variables: [
+          {
+            id: "v1",
+            name: "added later",
+            scope: "instance",
+            persist: false
+          }
+        ]
+      }
+    });
+
+    const release = await caller.applications.releasedDocument({ id: app.id });
+    expect(release?.version).toBe(1);
+    expect(release?.released).toBe(true);
+    expect(release?.document.variables).toEqual([]);
+    expect(release?.document.operations[0]!.workflowVersion).toBe(1);
+    expect(release?.workflows).toEqual([
+      {
+        workflowId: "wf1",
+        version: 1,
+        graphHash: expect.any(String),
+        graph: { nodes: [expect.objectContaining({ id: "n1" })], edges: [] }
+      }
+    ]);
+    expect(release?.capabilities.workflows[0]).toMatchObject({
+      workflowId: "wf1",
+      version: 1
+    });
+  });
+
+  it("releasedDocument is null before the first publish", async () => {
+    const app = await seedApp();
+    const caller = createCaller(makeCtx("user-1"));
+    expect(
+      await caller.applications.releasedDocument({ id: app.id })
+    ).toBeNull();
+  });
+
+  it("releasedDocument does not serve another user's app", async () => {
+    const app = await seedApp();
+    const caller = createCaller(makeCtx("user-2"));
+    await expect(
+      caller.applications.releasedDocument({ id: app.id })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("rollback serves the earlier snapshot's graphs again", async () => {
+    const app = await seedApp();
+    const caller = createCaller(makeCtx("user-1"));
+    await caller.applications.publish({ id: app.id });
+
+    const workflow = (await Workflow.get<Workflow>("wf1"))!;
+    workflow.graph = { nodes: [node("edited")], edges: [] };
+    await workflow.save();
+    await caller.applications.publish({ id: app.id });
+    expect(
+      (await caller.applications.releasedDocument({ id: app.id }))
+        ?.workflows[0]!.graph?.nodes[0]
+    ).toMatchObject({ id: "edited" });
+
+    await caller.applications.release({ id: app.id, version: 1 });
+    const back = await caller.applications.releasedDocument({ id: app.id });
+    expect(back?.version).toBe(1);
+    expect(back?.workflows[0]!.graph?.nodes[0]).toMatchObject({ id: "n1" });
+  });
+});

--- a/web/src/__mocks__/themeMock.ts
+++ b/web/src/__mocks__/themeMock.ts
@@ -14,6 +14,17 @@ const mockTheme = createTheme({
     text: {
       primary: "#fff"
     },
+    // MUI derives these track colors when a real palette is built; the mock
+    // declares them so LinearProgress-based primitives render under Jest.
+    LinearProgress: {
+      primaryBg: "#3a5a72",
+      secondaryBg: "#3a3a3a",
+      errorBg: "#5a3a3a",
+      infoBg: "#3a4a5a",
+      successBg: "#3a5a3a",
+      warningBg: "#5a4a3a",
+      inheritBg: "#444444"
+    },
     // Add the custom palette properties
     c_hl1: "#77b4e6",
     c_white: "#FCFCFC",
@@ -235,6 +246,12 @@ const zIndexScale = {
 };
 (mockTheme as any).palette.Switch = {
   defaultColor: "#9e9e9e"
+};
+
+// LinearProgress track colors, which MUI reads off `vars.palette` in CSS
+// variables mode.
+(mockTheme as any).vars.palette.LinearProgress = {
+  ...(mockTheme as any).palette.LinearProgress
 };
 
 // Add theme.alpha() method for MUI v7 CSS variables mode

--- a/web/src/app_preview/AppPreviewApp.tsx
+++ b/web/src/app_preview/AppPreviewApp.tsx
@@ -223,6 +223,7 @@ const AppPreviewApp: React.FC = () => {
               variables: []
             },
             operation: implicitOperation(""),
+            operations: [implicitOperation("")],
             resources: [],
             designMode: false,
             dispatch: () => {},

--- a/web/src/components/appbuilder/AppBuilderShell.tsx
+++ b/web/src/components/appbuilder/AppBuilderShell.tsx
@@ -47,10 +47,20 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
   onClose
 }) => {
   const setCurrentWorkflowId = useWorkflowManager((s) => s.setCurrentWorkflowId);
-  // Puck owns the layout after mount, so this is the seed only.
-  const [data] = useState<Data>(
-    () => (document.ui as Data | undefined) ?? createEmptyData()
-  );
+  // Puck owns the layout after mount, so this is the seed only. The document's
+  // theme is seeded onto the root so the author edits it as a root field, and
+  // the save below writes the choice back to `document.theme`.
+  const [data] = useState<Data>(() => {
+    const seeded = (document.ui as Data | undefined) ?? createEmptyData();
+    if (!document.theme) return seeded;
+    return {
+      ...seeded,
+      root: {
+        ...seeded.root,
+        props: { theme: document.theme.id, ...(seeded.root?.props ?? {}) }
+      }
+    };
+  });
   const [meta, setMeta] = useState<AppDocMeta>(() => ({
     operations: document.operations,
     resources: document.resources,
@@ -66,12 +76,24 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
 
   const handleSave = useCallback(
     (nextData: Data) => {
+      const rootProps = nextData.root?.props as
+        | Record<string, unknown>
+        | undefined;
+      // The author's pick wins; a root that never carried the field at all
+      // (a surface that does not edit it) leaves the document's theme alone.
+      const themeId = rootProps && "theme" in rootProps ? rootProps.theme : null;
       onSave({
         ...document,
         ui: nextData,
         operations: meta.operations,
         resources: meta.resources,
-        variables: meta.variables
+        variables: meta.variables,
+        theme:
+          themeId === null
+            ? document.theme
+            : typeof themeId === "string" && themeId
+              ? { id: themeId }
+              : undefined
       });
     },
     [document, meta, onSave]

--- a/web/src/components/appbuilder/AppRuntimeView.tsx
+++ b/web/src/components/appbuilder/AppRuntimeView.tsx
@@ -24,6 +24,13 @@ interface AppRuntimeViewProps {
    * runtime synthesizes a single-operation document from the graph.
    */
   document?: ApplicationDocument;
+  /** The application record this app belongs to (budget + release metering). */
+  application?: { id: string; version?: number };
+  /**
+   * Workflow graphs the caller already has, by id — the graphs a release
+   * pinned. An operation whose workflow is here runs that exact graph.
+   */
+  workflowOverrides?: Record<string, Workflow>;
 }
 
 /**
@@ -72,9 +79,15 @@ const RuntimeErrorBanner: React.FC = () => {
 const AppRuntimeView: React.FC<AppRuntimeViewProps> = ({
   workflow,
   data,
-  document
+  document,
+  application,
+  workflowOverrides
 }) => {
-  const runtime = useAppRuntime(workflow, false, { document });
+  const runtime = useAppRuntime(workflow, false, {
+    document,
+    application,
+    workflowOverrides
+  });
   return (
     <AppRuntimeContext.Provider value={runtime}>
       <Box

--- a/web/src/components/appbuilder/ApplicationRunView.tsx
+++ b/web/src/components/appbuilder/ApplicationRunView.tsx
@@ -1,0 +1,132 @@
+/**
+ * Runs an app that has its own `applications` record.
+ *
+ * A released app runs its **release**, not the canvas: the server pins the
+ * document and every workflow graph at publish time, and this renders that
+ * snapshot. Editing the app afterwards changes what the Design view shows and
+ * nothing about what runs here until the next publish. With nothing released
+ * the draft runs instead, which is what makes an unpublished app testable.
+ */
+import React, { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { Data } from "@puckeditor/core";
+
+import { Workflow } from "../../stores/ApiTypes";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import {
+  useApplication,
+  useReleasedApplicationDocument
+} from "../../hooks/useApplications";
+import {
+  Caption,
+  EmptyState,
+  FlexColumn,
+  LoadingSpinner,
+  SPACING
+} from "../ui_primitives";
+import { parseApplicationDocument, type AppDocument } from "./appData";
+import AppRuntimeView from "./AppRuntimeView";
+
+export interface ApplicationRunViewProps {
+  applicationId: string;
+}
+
+/** A pinned graph, wrapped as the workflow shape the runtime and runner want. */
+const pinnedWorkflow = (
+  id: string,
+  name: string,
+  graph: Workflow["graph"]
+): Workflow => ({
+  id,
+  name,
+  description: "",
+  graph,
+  access: "private",
+  created_at: "",
+  updated_at: ""
+});
+
+const ApplicationRunView: React.FC<ApplicationRunViewProps> = ({
+  applicationId
+}) => {
+  const { data: application, isLoading } = useApplication(applicationId);
+  const { data: release, isLoading: releaseLoading } =
+    useReleasedApplicationDocument(applicationId);
+  const fetchWorkflow = useWorkflowManager((s) => s.fetchWorkflow);
+
+  const document = useMemo<AppDocument | null>(() => {
+    const source = release?.document ?? application?.document;
+    return source ? parseApplicationDocument(source) : null;
+  }, [application?.document, release?.document]);
+
+  // Graphs the release froze. A snapshot published before releases pinned
+  // anything carries none, and those operations fall back to the live workflow.
+  const workflowOverrides = useMemo<Record<string, Workflow>>(() => {
+    const overrides: Record<string, Workflow> = {};
+    for (const pinned of release?.workflows ?? []) {
+      if (!pinned.graph) continue;
+      overrides[pinned.workflowId] = pinnedWorkflow(
+        pinned.workflowId,
+        application?.name ?? pinned.workflowId,
+        pinned.graph as unknown as Workflow["graph"]
+      );
+    }
+    return overrides;
+  }, [application?.name, release?.workflows]);
+
+  // The host workflow: the first operation's, pinned when the release pinned it.
+  const hostWorkflowId = document?.operations[0]?.workflowId ?? "";
+  const pinnedHost = workflowOverrides[hostWorkflowId];
+  const { data: liveHost } = useQuery({
+    queryKey: ["app-run-workflow", hostWorkflowId],
+    queryFn: async () => await fetchWorkflow(hostWorkflowId),
+    enabled: Boolean(hostWorkflowId) && !pinnedHost,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    retry: false
+  });
+  const workflow = pinnedHost ?? liveHost;
+
+  if (isLoading || releaseLoading) {
+    return <LoadingSpinner size="large" text="Loading app" />;
+  }
+
+  if (!document || document.ui.content.length === 0) {
+    return (
+      <EmptyState
+        variant="empty"
+        title="Nothing to run yet"
+        description="Add widgets in the Design view, then run the app here."
+      />
+    );
+  }
+
+  if (!workflow) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Workflow unavailable"
+        description={`This app runs workflow ${hostWorkflowId || "(none)"}, which could not be loaded.`}
+      />
+    );
+  }
+
+  return (
+    <FlexColumn gap={0} fullWidth sx={{ height: "100%", minHeight: 0 }}>
+      <Caption color="secondary" sx={{ px: SPACING.lg, py: SPACING.xs }}>
+        {release
+          ? `Running released version ${release.version}`
+          : "Running the draft — this app has no released version"}
+      </Caption>
+      <AppRuntimeView
+        workflow={workflow}
+        data={document.ui as Data}
+        document={document}
+        application={{ id: applicationId, version: release?.version }}
+        workflowOverrides={workflowOverrides}
+      />
+    </FlexColumn>
+  );
+};
+
+export default ApplicationRunView;

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -26,7 +26,19 @@ framework-independent core the web runtime, the CLI `app debug` harness, and the
   that is the legacy `app_doc` form and the migration path.
 - **Widgets** bind one slot (read for displays, two-way for inputs) and emit
   **events** (`click` / `change`) that dispatch **actions** (`run`, `cancel`,
-  `setVariable`, `toggleVariable`, `resourceCommand`, `openResource`).
+  `setVariable`, `toggleVariable`, `resourceCommand`, `openResource`). A `run`
+  names its operation; the runtime runs **that** operation's workflow, fetching
+  it when it is not the one the view already holds.
+- **Operation outputs land in two places**: the display slot a widget reads and,
+  when the operation maps the output `to: "variable"`, an app variable. That is
+  how one operation hands a value to the next without a procedure language.
+- **Run policy** (`replace` / `queue` / `parallel`) decides what a second run
+  means while one is in flight: cancel the live one, wait for it, or ask the
+  server for a concurrent slot. `timeoutMs` fails the invocation when it
+  elapses.
+- **Variables** start from their declared `default`. A `user`-scoped variable
+  with `persist: true` survives a reload (`localStorage`, keyed by application
+  or workflow id); `instance` variables and widget-local `view` state do not.
 - **Resource bindings** name a collection (a kind plus a project or a pinned
   id) rather than a document. A picker chooses a member; the chosen
   `ResourceRef` carries the document's `revision`, and the server rejects a
@@ -58,9 +70,15 @@ the existing worker path.
   one implementation.
 - `workflowIO.ts` / `workflowState.ts` — a workflow's bindable surface
   (inputs, outputs, variables).
+- `appThemes.ts` — the named-theme registry `ApplicationDocument.theme`
+  resolves against. A theme decides how the page is presented (surface, content
+  width, framing); widget styling stays with the widgets and the design tokens.
+- `runtime/variablePersistence.ts` — `localStorage` for user-scoped variables
+  declared `persist: true`, keyed by application or workflow id.
 - `runtime/` — `appRuntimeStore` (a Zustand wrapper around the shared reducer,
-  one store per app instance), `useAppRuntime` (the engine: claims invocations,
-  folds the streaming runner into state, dispatches actions),
+  one store per app instance), `useAppRuntime` (the engine: resolves each
+  operation's workflow and runner, claims invocations, folds the streaming
+  runner into state, dispatches actions under the operation's run policy),
   `AppRuntimeContext` (binding resolution, conditions, formatting),
   `buildTriggerSubgraph` (reactive subgraph runs + the effect gate).
 - `puck/` — the Puck integration:
@@ -134,8 +152,11 @@ on top of the same `@nodetool-ai/app-runtime` core — it runs apps, it does not
 edit them.
 
 An app with its own record opens in the workspace: the app library's tab renders
-`ApplicationSurface`, whose **Design** view is the builder canvas and whose
-**Settings** view is publishing, budgets, and telemetry.
+`ApplicationSurface`, whose **Design** view is the builder canvas, whose **Run**
+view is `ApplicationRunView`, and whose **Settings** view is publishing,
+budgets, and telemetry. The Run view renders the **released** snapshot — its
+document and the workflow graphs the release pinned — falling back to the draft
+only while nothing is published.
 
 ## Publishing
 

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -165,6 +165,20 @@ immutable `application_versions` snapshot with a capability summary **derived**
 from its bindings — the workflows it may invoke and the resource kinds it
 touches. Rollback moves the release pointer.
 
+A release is **pinned**, not a copy of a moving target. Publishing freezes each
+operation's workflow twice over: it writes a row in that workflow's own version
+history and records the number on the snapshot's `workflowVersion`, and it
+copies the graph JSON plus a sha256 onto the release itself, so the snapshot
+survives the version row being pruned or the workflow deleted. Editing the
+workflow afterwards moves the draft only. Publishing an operation whose workflow
+is missing throws rather than shipping a release that references nothing.
+
+Running one is the **Run** view in `ApplicationSurface`, which reads
+`applications.releasedDocument` and hands the pinned graphs to the runtime as
+workflow overrides — a release runs the graphs it froze, not whatever the
+workflow says today. With nothing released the view falls back to the draft and
+says so.
+
 A released app runs on the creator's secrets, so runs are metered. An app run
 carries its `application_id` on the run request; the websocket runner checks the
 budget before the job is created — refusing with a typed `BUDGET_EXCEEDED` error

--- a/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
@@ -89,6 +89,17 @@ jest.mock("../puck/PuckAppEditor", () => ({
       <button type="button" onClick={() => onPublish(EDITED_UI)}>
         Save
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          onPublish({
+            ...EDITED_UI,
+            root: { props: { ...EDITED_UI.root.props, theme: "card" } }
+          } as unknown as Data)
+        }
+      >
+        Save with theme
+      </button>
       {onToggleAgent && (
         <button type="button" onClick={onToggleAgent}>
           Ask Agent
@@ -154,6 +165,17 @@ describe("AppBuilderShell", () => {
       resources: EDITED_META.resources,
       variables: EDITED_META.variables
     });
+  });
+
+  it("writes the theme the author picked on the root back to the document", async () => {
+    const user = userEvent.setup();
+    const onSave = renderShell();
+
+    await user.click(screen.getByRole("button", { name: "Save with theme" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: { id: "card" } })
+    );
   });
 
   it("points the agent's workflow tools at the bound workflow", () => {

--- a/web/src/components/appbuilder/__tests__/AppRuntimeView.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppRuntimeView.test.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Data } from "@puckeditor/core";
 
 import mockTheme from "../../../__mocks__/themeMock";
+import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
+
 import AppRuntimeView from "../AppRuntimeView";
 import { Workflow } from "../../../stores/ApiTypes";
 import { globalWebSocketManager } from "../../../lib/websocket/GlobalWebSocketManager";
@@ -42,11 +45,13 @@ const data: Data = {
 const instance = workflowInstanceId(workflow.id);
 const store = () => getAppRuntimeStore(instance);
 
-const renderView = () =>
+const renderView = (document?: ApplicationDocument) =>
   render(
-    <ThemeProvider theme={mockTheme}>
-      <AppRuntimeView workflow={workflow} data={data} />
-    </ThemeProvider>
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeProvider theme={mockTheme}>
+        <AppRuntimeView workflow={workflow} data={data} document={document} />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 
 /** Register a run and make it the operation's active invocation. */
@@ -113,6 +118,23 @@ describe("AppRuntimeView (Puck Render)", () => {
         screen.queryByText("Contamination from another tab")
       ).not.toBeInTheDocument()
     );
+  });
+
+  it("applies the theme the document selects", () => {
+    renderView({
+      schemaVersion: 3,
+      ui: data as unknown as ApplicationDocument["ui"],
+      operations: [],
+      resources: [],
+      variables: [],
+      theme: { id: "centered" }
+    });
+    // The "centered" theme caps the content column; the default does not.
+    const css = Array.from(document.querySelectorAll("style"))
+      .flatMap((el) => Array.from(el.sheet?.cssRules ?? []))
+      .map((rule) => rule.cssText)
+      .join("");
+    expect(css).toMatch(/max-width:\s*720px/);
   });
 
   it("surfaces the active invocation's error as a dismissible banner", async () => {

--- a/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
+++ b/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Running an app renders its release, not the canvas — and falls back to the
+ * draft only while nothing is published.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import type { Data } from "@puckeditor/core";
+
+import type { Workflow } from "../../../stores/ApiTypes";
+
+const fetchWorkflow = jest.fn();
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: (selector: (s: { fetchWorkflow: unknown }) => unknown) =>
+    selector({ fetchWorkflow })
+}));
+
+const useApplication = jest.fn();
+const useReleasedApplicationDocument = jest.fn();
+jest.mock("../../../hooks/useApplications", () => ({
+  useApplication: (id: string) => useApplication(id),
+  useReleasedApplicationDocument: (id: string) =>
+    useReleasedApplicationDocument(id)
+}));
+
+jest.mock("../AppRuntimeView", () => ({
+  __esModule: true,
+  default: ({
+    workflow,
+    data
+  }: {
+    workflow: Workflow;
+    data: Data;
+  }) => (
+    <div data-testid="runtime">
+      <span data-testid="workflow">{workflow.id}</span>
+      <span data-testid="title">{String(data.root?.props?.title ?? "")}</span>
+    </div>
+  )
+}));
+
+import ApplicationRunView from "../ApplicationRunView";
+
+const ui = (title: string) => ({
+  root: { props: { title } },
+  content: [{ type: "Text", props: { id: "t1" } }],
+  zones: {}
+});
+
+const appDocument = (title: string) => ({
+  schemaVersion: 3,
+  ui: ui(title),
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-1",
+      inputs: {},
+      outputs: {},
+      policy: "replace"
+    }
+  ],
+  resources: [],
+  variables: []
+});
+
+const liveWorkflow: Workflow = {
+  id: "wf-1",
+  name: "Workflow",
+  description: "",
+  graph: { nodes: [], edges: [] },
+  access: "private",
+  created_at: "",
+  updated_at: ""
+};
+
+const renderView = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeProvider theme={mockTheme}>
+        <ApplicationRunView applicationId="app-1" />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchWorkflow.mockResolvedValue(liveWorkflow);
+  useApplication.mockReturnValue({
+    data: { id: "app-1", name: "App", document: appDocument("Draft") },
+    isLoading: false
+  });
+  useReleasedApplicationDocument.mockReturnValue({
+    data: null,
+    isLoading: false
+  });
+});
+
+describe("ApplicationRunView", () => {
+  it("runs the released snapshot when one exists", async () => {
+    useReleasedApplicationDocument.mockReturnValue({
+      data: {
+        version: 3,
+        document: appDocument("Released"),
+        workflows: [
+          { workflowId: "wf-1", version: 2, graphHash: null, graph: { nodes: [], edges: [] } }
+        ]
+      },
+      isLoading: false
+    });
+
+    renderView();
+
+    expect(await screen.findByTestId("title")).toHaveTextContent("Released");
+    expect(screen.getByText(/Running released version 3/)).toBeInTheDocument();
+    // The pinned graph is used, so the live workflow is never fetched.
+    expect(fetchWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the draft when nothing is released", async () => {
+    renderView();
+
+    expect(await screen.findByTestId("title")).toHaveTextContent("Draft");
+    expect(screen.getByText(/no released version/)).toBeInTheDocument();
+    await waitFor(() => expect(fetchWorkflow).toHaveBeenCalledWith("wf-1"));
+  });
+
+  it("reports a workflow it cannot load rather than rendering an inert app", async () => {
+    fetchWorkflow.mockRejectedValue(new Error("gone"));
+    renderView();
+
+    expect(await screen.findByText(/Workflow unavailable/)).toBeInTheDocument();
+    expect(screen.queryByTestId("runtime")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/__tests__/appThemes.test.ts
+++ b/web/src/components/appbuilder/__tests__/appThemes.test.ts
@@ -1,0 +1,25 @@
+import { APP_THEMES, DEFAULT_APP_THEME, appThemeFrame, resolveAppTheme } from "../appThemes";
+
+describe("app themes", () => {
+  it("resolves a document's theme id to its registry entry", () => {
+    expect(resolveAppTheme("card").id).toBe("card");
+    expect(resolveAppTheme("centered").maxWidth).toBe(720);
+  });
+
+  it("falls back to the default for an unknown or absent id", () => {
+    expect(resolveAppTheme(undefined)).toBe(DEFAULT_APP_THEME);
+    expect(resolveAppTheme("no-such-theme")).toBe(DEFAULT_APP_THEME);
+  });
+
+  it("frames only the themes that ask for it", () => {
+    expect(appThemeFrame(resolveAppTheme("card"))).toHaveProperty(
+      "backgroundColor"
+    );
+    expect(appThemeFrame(DEFAULT_APP_THEME)).toEqual({});
+  });
+
+  it("has unique ids", () => {
+    const ids = APP_THEMES.map((theme) => theme.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/web/src/components/appbuilder/__tests__/buildTriggerSubgraph.test.ts
+++ b/web/src/components/appbuilder/__tests__/buildTriggerSubgraph.test.ts
@@ -64,6 +64,8 @@ const stateWith = (values: Record<string, unknown> = {}): AppRuntimeState =>
     view: {},
     invocations: {},
     activeInvocation: {},
+    activity: {},
+    variableWriters: {},
     dispatchEvent: () => {}
   }) as AppInstanceState as AppRuntimeState;
 

--- a/web/src/components/appbuilder/__tests__/fields.test.tsx
+++ b/web/src/components/appbuilder/__tests__/fields.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
 import mockTheme from "../../../__mocks__/themeMock";
-import { bindingField, variableField } from "../puck/fields";
+import { bindingField, conditionField, variableField } from "../puck/fields";
 import { BuilderWorkflowProvider } from "../puck/BuilderWorkflowContext";
 import { WorkflowState } from "../workflowState";
 
@@ -79,5 +80,58 @@ describe("binding fields", () => {
     expect(
       screen.getByText(/Add a Set Variable node/i)
     ).toBeInTheDocument();
+  });
+});
+
+describe("execution + logic vocabulary", () => {
+  const stateWithOutput: WorkflowState = {
+    inputs: [],
+    outputs: [
+      {
+        nodeId: "o1",
+        nodeType: "nodetool.output.StringOutput",
+        name: "result",
+        label: "Result"
+      }
+    ],
+    variables: [],
+    nodes: [],
+    resources: []
+  };
+
+  it("offers the run's activity field as a read binding", async () => {
+    const field = bindingField("read");
+    renderField(field.render(fieldProps), stateWithOutput);
+    await userEvent.click(screen.getByRole("combobox", { name: /Bind to/i }));
+    expect(
+      await screen.findByRole("option", { name: "run · activity" })
+    ).toBeInTheDocument();
+  });
+
+  it("still tells the user to add an Output node when there is nothing to bind", () => {
+    const field = bindingField("read");
+    renderField(field.render(fieldProps), emptyState);
+    expect(
+      screen.getByText(/Add an Output node or Set Variable node/i)
+    ).toBeInTheDocument();
+  });
+
+  it("offers the new condition operators once a binding is picked", async () => {
+    const field = conditionField("Visible when");
+    renderField(
+      field.render({
+        ...fieldProps,
+        value: { binding: "op:main/out:o1", op: "contains" }
+      }),
+      stateWithOutput
+    );
+    await userEvent.click(screen.getByRole("combobox", { name: /Condition/i }));
+    for (const label of ["contains", "is at least", "is at most"]) {
+      expect(
+        await screen.findByRole("option", { name: label })
+      ).toBeInTheDocument();
+    }
+    // `contains` compares against a literal, so the value box is offered.
+    expect(screen.getByLabelText("Value")).toBeInTheDocument();
   });
 });

--- a/web/src/components/appbuilder/__tests__/testRuntime.tsx
+++ b/web/src/components/appbuilder/__tests__/testRuntime.tsx
@@ -53,6 +53,7 @@ export const makeTestRuntime = (
     io: { inputs: [], outputs: [] },
     scope: TEST_SCOPE,
     operation: implicitOperation("wf1"),
+    operations: [implicitOperation("wf1")],
     resources: [],
     designMode: false,
     dispatch: jest.fn(),

--- a/web/src/components/appbuilder/appThemes.ts
+++ b/web/src/components/appbuilder/appThemes.ts
@@ -1,0 +1,69 @@
+/**
+ * The named themes an application document may select.
+ *
+ * `ApplicationDocument.theme` is a `ThemeRef` — a name, not a stylesheet — so
+ * this is the registry that name resolves against. A theme decides how the
+ * app's page is presented: the surface it sits on, how wide its content runs,
+ * and whether it reads as a page or as a card. Widget-level styling stays with
+ * the widgets and the design tokens; a theme is deliberately not a way to
+ * restyle every control.
+ */
+import { BORDER_RADIUS, SPACING } from "../ui_primitives";
+
+export interface AppTheme {
+  id: string;
+  label: string;
+  /** Palette slot the page sits on. */
+  surface: string;
+  /** Content width cap, or null for full width. */
+  maxWidth: number | null;
+  /** Outer padding, from the spacing scale. */
+  padding: number;
+  /** True when the content block is drawn as a bordered, rounded card. */
+  framed: boolean;
+}
+
+export const APP_THEMES: ReadonlyArray<AppTheme> = [
+  {
+    id: "default",
+    label: "Default",
+    surface: "background.default",
+    maxWidth: null,
+    padding: SPACING.xl,
+    framed: false
+  },
+  {
+    id: "centered",
+    label: "Centered",
+    surface: "background.default",
+    maxWidth: 720,
+    padding: SPACING.xl,
+    framed: false
+  },
+  {
+    id: "card",
+    label: "Card",
+    surface: "background.default",
+    maxWidth: 880,
+    padding: SPACING.xxl,
+    framed: true
+  }
+];
+
+export const DEFAULT_APP_THEME = APP_THEMES[0];
+
+/** The theme a document's `theme.id` names, or the default when it names none. */
+export const resolveAppTheme = (id: string | undefined | null): AppTheme =>
+  APP_THEMES.find((theme) => theme.id === id) ?? DEFAULT_APP_THEME;
+
+/** Card framing, applied only by themes that ask for it. */
+export const appThemeFrame = (theme: AppTheme) =>
+  theme.framed
+    ? {
+        backgroundColor: "background.paper",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: BORDER_RADIUS.lg,
+        p: SPACING.xl
+      }
+    : {};

--- a/web/src/components/appbuilder/puck/__tests__/displayWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/displayWidgets.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Display widgets that read the runtime beyond a plain value: the Table's
+ * shaping of an array binding, and the Progress widget's streaming activity
+ * label.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { ProgressWidget, TableWidget } from "../widgets";
+
+const OUTPUT_KEY = "main:out1";
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const { wrapper: Wrapper } = makeTestRuntime(initial);
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <Wrapper>{element}</Wrapper>
+    </ThemeProvider>
+  );
+};
+
+const withOutput = (value: unknown): Partial<AppInstanceState> => ({
+  outputs: {
+    [OUTPUT_KEY]: { value, invocationId: "j1", status: "done", revision: 1 }
+  }
+});
+
+const RUNNING: Partial<AppInstanceState> = {
+  invocations: {
+    j1: { id: "j1", operationId: "main", status: "running", startedAt: 1 }
+  },
+  activeInvocation: { main: "j1" }
+};
+
+describe("TableWidget", () => {
+  it("renders an array of objects as one column per key", () => {
+    renderWidget(
+      <TableWidget id="t1" binding="result" />,
+      withOutput([
+        { title: "First", score: 1 },
+        { title: "Second", score: 2 }
+      ])
+    );
+    expect(screen.getByRole("columnheader", { name: "title" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "score" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "First" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "2" })).toBeInTheDocument();
+  });
+
+  it("renders an array of primitives as a single column", () => {
+    renderWidget(
+      <TableWidget id="t1" binding="result" label="Results" />,
+      withOutput(["alpha", "beta"])
+    );
+    expect(
+      screen.getByRole("columnheader", { name: "Results" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+  });
+
+  it("shows the placeholder when the binding holds nothing", () => {
+    renderWidget(
+      <TableWidget id="t1" binding="result" placeholder="Nothing yet" />
+    );
+    expect(screen.getByText("Nothing yet")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});
+
+describe("ProgressWidget", () => {
+  it("shows what the run reports it is doing", () => {
+    renderWidget(<ProgressWidget id="p1" label="Working" />, {
+      ...RUNNING,
+      activity: { j1: "Calling search" }
+    });
+    expect(screen.getByText("Calling search")).toBeInTheDocument();
+  });
+
+  it("falls back to the configured label when the run reports nothing", () => {
+    renderWidget(<ProgressWidget id="p1" label="Working" />, RUNNING);
+    expect(screen.getByText("Working")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import type { Config, ArrayField } from "@puckeditor/core";
 
 import { Box, Text, FlexColumn, SPACING, SPACING_PX } from "../../ui_primitives";
+import { APP_THEMES, appThemeFrame, resolveAppTheme } from "../appThemes";
+import { useAppRuntimeContext } from "../runtime/AppRuntimeContext";
 import {
   bindingField,
   conditionField,
@@ -18,6 +20,7 @@ import {
   AudioWidget,
   VideoWidget,
   JsonWidget,
+  TableWidget,
   OutputWidget,
   ProgressWidget,
   TextInputWidget,
@@ -59,7 +62,8 @@ const conditionalFields = ({ format = true }: { format?: boolean } = {}) => ({
     ? {
         format: {
           type: "text" as const,
-          label: "Format ({binding} · number:2 · date:short · upper · truncate:80)"
+          label:
+            "Format ({binding} · number:2 · date:short · upper · lower · join:, · truncate:80)"
         }
       }
     : {})
@@ -133,54 +137,90 @@ const fixedInputEntry = (label: string, kind: FixedInputKind) => ({
   ))
 });
 
+/**
+ * The app page. Its theme comes from the root prop the author picked, falling
+ * back to what the document declares (`ApplicationDocument.theme`) — the shell
+ * keeps the two in step, and the fallback is what makes a document authored
+ * through the API render with its theme.
+ */
+const AppRoot: React.FC<{
+  title?: string;
+  theme?: string;
+  children?: React.ReactNode;
+}> = ({ title, theme, children }) => {
+  const { theme: documentTheme } = useAppRuntimeContext();
+  const appTheme = resolveAppTheme(theme ?? documentTheme);
+  return (
+    <Box
+      sx={{
+        p: appTheme.padding,
+        minHeight: "100%",
+        backgroundColor: appTheme.surface,
+        color: "text.primary",
+        // Width-responsive widgets (Columns) query this container, so the
+        // editor canvas and the published app share one layout per width.
+        containerType: "inline-size"
+      }}
+    >
+      <FlexColumn
+        gap={SPACING.xxl}
+        sx={{
+          width: "100%",
+          ...(appTheme.maxWidth
+            ? { maxWidth: appTheme.maxWidth, mx: "auto" }
+            : {}),
+          ...appThemeFrame(appTheme),
+          // The root zone renders as a single direct div in both the editor
+          // (Puck's DropZone) and the runtime (a plain wrapper div); style
+          // its children as a gapped flex column so top-level widgets get
+          // the same vertical rhythm as slot contents (see slotStack in
+          // widgets.tsx) in both surfaces.
+          "& > div": {
+            display: "flex",
+            flexDirection: "column",
+            gap: `${SPACING_PX.xxl}px`,
+            width: "100%"
+          }
+        }}
+      >
+        {title ? (
+          <Text size="big" weight={600}>
+            {title}
+          </Text>
+        ) : null}
+        {children}
+      </FlexColumn>
+    </Box>
+  );
+};
+
 // `Config` is intentionally loosely typed (DefaultComponents): Puck injects
 // `id`/`puck` into render props, and our widget components take optional props.
 export const appConfig: Config = {
   root: {
     fields: {
-      title: { type: "text", label: "App title" }
+      title: { type: "text", label: "App title" },
+      theme: {
+        type: "select",
+        label: "Theme",
+        options: APP_THEMES.map((theme) => ({
+          label: theme.label,
+          value: theme.id
+        }))
+      }
     },
     render: ({
       children,
-      title
+      title,
+      theme
     }: {
       children?: React.ReactNode;
       title?: string;
+      theme?: string;
     }) => (
-      <Box
-        sx={{
-          p: SPACING.xl,
-          minHeight: "100%",
-          backgroundColor: "background.default",
-          color: "text.primary",
-          // Width-responsive widgets (Columns) query this container, so the
-          // editor canvas and the published app share one layout per width.
-          containerType: "inline-size"
-        }}
-      >
-        <FlexColumn
-          gap={SPACING.xxl}
-          sx={{
-            width: "100%",
-            // The root zone renders as a single direct div in both the editor
-            // (Puck's DropZone) and the runtime (a plain wrapper div); style
-            // its children as a gapped flex column so top-level widgets get
-            // the same vertical rhythm as slot contents (see slotStack in
-            // widgets.tsx) in both surfaces.
-            "& > div": {
-              display: "flex",
-              flexDirection: "column",
-              gap: `${SPACING_PX.xxl}px`,
-              width: "100%"
-            }
-          }}
-        >
-          {title ? (
-            <Text size="big" weight={600}>{title}</Text>
-          ) : null}
-          {children}
-        </FlexColumn>
-      </Box>
+      <AppRoot title={title} theme={theme}>
+        {children}
+      </AppRoot>
     )
   },
   categories: {
@@ -214,6 +254,7 @@ export const appConfig: Config = {
         "Audio",
         "Video",
         "Json",
+        "Table",
         "Output",
         "Progress"
       ]
@@ -306,6 +347,18 @@ export const appConfig: Config = {
       fields: { binding: bindingField("read"), ...conditionalFields() },
       defaultProps: {},
       render: withConditions((props) => <JsonWidget {...props} />)
+    },
+    Table: {
+      label: "Table",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        maxHeight: { type: "number", label: "Max height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { label: "", placeholder: "No rows yet" },
+      render: withConditions((props) => <TableWidget {...props} />)
     },
     Output: {
       label: "Output",

--- a/web/src/components/appbuilder/puck/fields.tsx
+++ b/web/src/components/appbuilder/puck/fields.tsx
@@ -58,10 +58,13 @@ const Picker: React.FC<{
   value: string;
   options: Option[];
   emptyHint?: string;
+  /** Show the hint even though the picker has options (execution fields). */
+  hintVisible?: boolean;
   readOnly?: boolean;
   onChange: (value: string) => void;
-}> = ({ label, value, options, emptyHint, readOnly, onChange }) => {
+}> = ({ label, value, options, emptyHint, hintVisible, readOnly, onChange }) => {
   const hasOptions = options.length > 0;
+  const showHint = hintVisible ?? !hasOptions;
   return (
     <FlexColumn gap={0.5}>
       <SelectField
@@ -71,9 +74,7 @@ const Picker: React.FC<{
         disabled={readOnly || !hasOptions}
         onChange={onChange}
       />
-      {!hasOptions && emptyHint && (
-        <Caption color="secondary">{emptyHint}</Caption>
-      )}
+      {showHint && emptyHint && <Caption color="secondary">{emptyHint}</Caption>}
     </FlexColumn>
   );
 };
@@ -127,13 +128,17 @@ const ReadBindingPicker: React.FC<{
     ...variables.map((v) => ({
       label: `variable · ${v}`,
       value: encodeBinding({ kind: "variable", variableId: v })
-    }))
+    })),
+    ...EXECUTION_OPTIONS
   ];
   return (
     <Picker
       label={label}
       value={canonicalBinding(value, scope, "read")}
       options={options}
+      // Execution fields are always bindable, so "nothing to bind" is about
+      // the workflow's own outputs and variables.
+      hintVisible={outputs.length === 0 && variables.length === 0}
       emptyHint="Add an Output node or Set Variable node to the workflow."
       readOnly={readOnly}
       onChange={onChange}
@@ -388,11 +393,42 @@ const CONDITION_OPS: Option[] = [
   { label: "equals", value: "eq" },
   { label: "does not equal", value: "neq" },
   { label: "is greater than", value: "gt" },
-  { label: "is less than", value: "lt" }
+  { label: "is at least", value: "gte" },
+  { label: "is less than", value: "lt" },
+  { label: "is at most", value: "lte" },
+  { label: "contains", value: "contains" }
 ];
 
 /** Operators that compare against a literal, so the value box is meaningful. */
-const OPS_WITH_VALUE = new Set(["eq", "neq", "gt", "lt"]);
+const OPS_WITH_VALUE = new Set([
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "contains"
+]);
+
+/**
+ * What a run reports about itself. Bindable from any read widget (a Text
+ * showing the agent's current step) and from a condition.
+ */
+const EXECUTION_OPTIONS: Option[] = (
+  [
+    ["running", "is running"],
+    ["progress", "progress"],
+    ["error", "error"],
+    ["activity", "activity"]
+  ] as const
+).map(([field, label]) => ({
+  label: `run · ${label}`,
+  value: encodeBinding({
+    kind: "execution",
+    operationId: DEFAULT_OPERATION_ID,
+    field
+  })
+}));
 
 /**
  * Condition field: a state reference, an operator, and (for comparisons) a
@@ -443,22 +479,7 @@ const ConditionEditor: React.FC<{
       label: `variable · ${v}`,
       value: encodeBinding({ kind: "variable", variableId: v })
     })),
-    {
-      label: "run · is running",
-      value: encodeBinding({
-        kind: "execution",
-        operationId: DEFAULT_OPERATION_ID,
-        field: "running"
-      })
-    },
-    {
-      label: "run · error",
-      value: encodeBinding({
-        kind: "execution",
-        operationId: DEFAULT_OPERATION_ID,
-        field: "error"
-      })
-    }
+    ...EXECUTION_OPTIONS
   ];
   const op = value.op ?? "notEmpty";
   return (
@@ -467,6 +488,9 @@ const ConditionEditor: React.FC<{
         label={label}
         value={canonicalBinding(value.binding ?? "", scope, "none")}
         options={options}
+        hintVisible={
+          outputs.length === 0 && inputs.length === 0 && variables.length === 0
+        }
         emptyHint="Add an Input, Output, or Set Variable node to condition on."
         readOnly={readOnly}
         onChange={(binding) => onChange({ ...value, binding })}

--- a/web/src/components/appbuilder/puck/useWidgetRuntime.ts
+++ b/web/src/components/appbuilder/puck/useWidgetRuntime.ts
@@ -12,6 +12,7 @@ import {
   encodeBinding,
   eventToAction,
   isOperationRunning,
+  operationActivity,
   operationProgress,
   resolveBinding,
   type AppEvent,
@@ -49,6 +50,12 @@ export interface WidgetRuntime {
   runnerState: RuntimeRunnerState;
   /** Fractional progress of the app's active run, when it reports any. */
   progress: number | undefined;
+  /**
+   * What the run this widget watches last reported it was doing — the tool an
+   * agent is calling, the planning phase, the task step. Undefined when the run
+   * reports nothing but a spinner.
+   */
+  activity: string | undefined;
 }
 
 interface UseWidgetRuntimeParams {
@@ -65,7 +72,7 @@ export const useWidgetRuntime = ({
   binding,
   events
 }: UseWidgetRuntimeParams): WidgetRuntime => {
-  const { designMode, dispatch, write, getNodeProperty, scope } =
+  const { designMode, dispatch, write, getNodeProperty, operations, scope } =
     useAppRuntimeContext();
 
   const boundRef = useBindingRef(binding, bindingMode);
@@ -88,11 +95,22 @@ export const useWidgetRuntime = ({
       ? getNodeProperty(boundRef.nodeId, boundRef.property)
       : storedValue;
 
-  const operationId = scope.defaultOperationId;
+  // A widget reports on the operation its own events drive, so a button wired
+  // to the second operation shows that operation's run, not operation 0's.
+  const operationId = useMemo(() => {
+    const named = (events ?? []).find(
+      (event) =>
+        (event.kind === "run" || event.kind === "cancel") &&
+        event.operationId &&
+        operations.some((operation) => operation.id === event.operationId)
+    )?.operationId;
+    return named ?? scope.defaultOperationId;
+  }, [events, operations, scope.defaultOperationId]);
   const runnerState = useRuntimeSelector((s) =>
     isOperationRunning(s, operationId) ? "running" : "idle"
   );
   const progress = useRuntimeSelector((s) => operationProgress(s, operationId));
+  const activity = useRuntimeSelector((s) => operationActivity(s, operationId));
 
   const setValue = useCallback(
     (next: unknown) => {
@@ -166,5 +184,5 @@ export const useWidgetRuntime = ({
     [dispatch, events, from, scope]
   );
 
-  return { value, setValue, emit, designMode, runnerState, progress };
+  return { value, setValue, emit, designMode, runnerState, progress, activity };
 };

--- a/web/src/components/appbuilder/puck/widgets.tsx
+++ b/web/src/components/appbuilder/puck/widgets.tsx
@@ -14,6 +14,7 @@ import {
   Box,
   FlexColumn,
   Card,
+  DataTable,
   Divider,
   ProgressBar,
   Caption,
@@ -389,10 +390,83 @@ export const JsonWidget: React.FC<WidgetCommon> = (props) => {
   return <JsonBlock value={value} />;
 };
 
+/**
+ * Renders an array binding as rows: an array of objects becomes one column per
+ * key (union of the rows' keys, in first-seen order), an array of primitives a
+ * single "Value" column. Arrays are what an operation that emits N results —
+ * or a streamed output the runtime accumulated — actually holds.
+ */
+export const TableWidget: React.FC<WidgetCommon & {
+  label?: string;
+  placeholder?: string;
+  maxHeight?: number;
+}> = (props) => {
+  const { value } = useBinding(props, "read");
+  const items = asItems(value).filter((item) => item != null);
+
+  const { columns, rows } = React.useMemo(() => {
+    const objectRows = items.filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null && !Array.isArray(item)
+    );
+    if (objectRows.length === items.length && objectRows.length > 0) {
+      const keys: string[] = [];
+      for (const row of objectRows) {
+        for (const key of Object.keys(row)) {
+          if (!keys.includes(key)) keys.push(key);
+        }
+      }
+      return {
+        columns: keys.map((key) => ({ key, label: key })),
+        rows: objectRows.map((row) =>
+          Object.fromEntries(
+            keys.map((key) => [
+              key,
+              typeof row[key] === "object" && row[key] !== null
+                ? JSON.stringify(row[key])
+                : str(row[key])
+            ])
+          )
+        )
+      };
+    }
+    return {
+      columns: [{ key: "value", label: props.label || "Value" }],
+      rows: items.map((item) => ({
+        value:
+          typeof item === "object" ? JSON.stringify(item) : str(item)
+      }))
+    };
+  }, [items, props.label]);
+
+  if (rows.length === 0) {
+    return (
+      <Caption color="secondary">{props.placeholder ?? "No rows yet"}</Caption>
+    );
+  }
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <DataTable
+        compact
+        striped
+        stickyHeader={Boolean(props.maxHeight)}
+        maxHeight={props.maxHeight}
+        columns={columns}
+        rows={rows}
+        containerSx={{ borderRadius: BORDER_RADIUS.md }}
+      />
+    </FlexColumn>
+  );
+};
+
 export const ProgressWidget: React.FC<WidgetCommon & { label?: string }> = (
   props
 ) => {
-  const { value, runnerState, progress, designMode } = useBinding(props, "read");
+  const { value, runnerState, progress, activity, designMode } = useBinding(
+    props,
+    "read"
+  );
   const isRunning = runnerState === "running";
   // A widget bound to a numeric output shows that; otherwise the run's own
   // progress, which the runtime reports as a 0..1 fraction.
@@ -404,9 +478,12 @@ export const ProgressWidget: React.FC<WidgetCommon & { label?: string }> = (
   // progress field is cleared), so visibility hangs off the run state, not the
   // value. Keep it visible in the editor so the widget can be laid out.
   if (!designMode && !isRunning) return null;
+  // An agent run reports what it is doing; without it the app shows a spinner
+  // and nothing else. The label the run reports wins over the static one.
+  const caption = (isRunning && activity) || props.label;
   return (
     <FlexColumn gap={SPACING.micro} fullWidth>
-      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      {caption ? <Caption color="secondary">{caption}</Caption> : null}
       <ProgressBar
         value={hasValue ? bound : 0}
         progressVariant={!hasValue && isRunning ? "indeterminate" : "determinate"}

--- a/web/src/components/appbuilder/runtime/AppRuntimeContext.ts
+++ b/web/src/components/appbuilder/runtime/AppRuntimeContext.ts
@@ -32,8 +32,12 @@ export interface AppRuntimeContextValue {
   io: WorkflowIO;
   /** Everything a stored binding string can resolve against. */
   scope: BindingScope;
-  /** The operation a widget's `run` targets. */
+  /** The operation a widget's `run` targets when it names none. */
   operation: OperationBinding;
+  /** Every operation the app binds, in document order. */
+  operations: ReadonlyArray<OperationBinding>;
+  /** The named theme the document selects, when it selects one. */
+  theme?: string;
   /** Resource collections the app is bound to. */
   resources: ReadonlyArray<ResourceBinding>;
   /** In the builder's design surface, events are inert (no workflow runs). */

--- a/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
+++ b/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
@@ -1,0 +1,478 @@
+/**
+ * The web adapter around the shared runtime core: which operation a run
+ * targets, what a collision with a live run does, where an output lands, and
+ * what a declared timeout means.
+ */
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../../stores/ApiTypes";
+
+const fetchWorkflow = jest.fn();
+
+jest.mock("../../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: (selector: (s: { fetchWorkflow: unknown }) => unknown) =>
+    selector({ fetchWorkflow })
+}));
+
+jest.mock("../../../../stores/WorkflowRunner", () => ({
+  getWorkflowRunnerStore: jest.fn()
+}));
+
+const subscribers: Array<(message: Record<string, unknown>) => void> = [];
+jest.mock("../../../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    subscribe: (_id: string, handler: (message: Record<string, unknown>) => void) => {
+      subscribers.push(handler);
+      return () => {
+        const at = subscribers.indexOf(handler);
+        if (at >= 0) subscribers.splice(at, 1);
+      };
+    }
+  }
+}));
+
+jest.mock("../../../../lib/workflow/browserWorkflowRunner", () => ({
+  runBrowserGraphJob: jest.fn(async () => undefined)
+}));
+
+const cancelJob = jest.fn(async (_input: { id: string }) => ({ ok: true }));
+jest.mock("../../../../trpc/client", () => ({
+  trpcClient: { jobs: { cancel: { mutate: (input: { id: string }) => cancelJob(input) } } }
+}));
+
+import { getWorkflowRunnerStore } from "../../../../stores/WorkflowRunner";
+import { useAppRuntime } from "../useAppRuntime";
+import { disposeAppRuntimeStore, workflowInstanceId } from "../appRuntimeStore";
+import { variableStorageKey } from "../variablePersistence";
+
+interface FakeRunnerState {
+  job_id: string | null;
+  state: string;
+  isBrowserRun: boolean;
+  run: jest.Mock;
+  cancel: jest.Mock;
+  streamInput: jest.Mock;
+}
+
+const runners = new Map<string, { getState: () => FakeRunnerState; subscribe: jest.Mock }>();
+let jobCounter = 0;
+
+const makeRunner = (id: string) => {
+  const state: FakeRunnerState = {
+    job_id: null,
+    state: "idle",
+    isBrowserRun: false,
+    run: jest.fn(async () => {
+      jobCounter += 1;
+      return `job-${id}-${jobCounter}`;
+    }),
+    cancel: jest.fn(async () => undefined),
+    streamInput: jest.fn()
+  };
+  const store = { getState: () => state, subscribe: jest.fn(() => () => undefined) };
+  runners.set(id, store);
+  return store;
+};
+
+const runnerState = (id: string): FakeRunnerState => runners.get(id)!.getState();
+
+const graph = (nodeId: string, outputId: string) => ({
+  nodes: [
+    {
+      id: nodeId,
+      type: "nodetool.input.StringInput",
+      data: { name: "prompt", label: "Prompt" }
+    },
+    {
+      id: outputId,
+      type: "nodetool.output.StringOutput",
+      data: { name: "result", label: "Result" }
+    }
+  ],
+  edges: []
+});
+
+const workflowA = {
+  id: "wf-a",
+  name: "A",
+  access: "private",
+  graph: graph("in1", "out1")
+} as unknown as Workflow;
+
+const workflowB = {
+  id: "wf-b",
+  name: "B",
+  access: "private",
+  graph: graph("in2", "out2")
+} as unknown as Workflow;
+
+const emptyUi = { root: { props: {} }, content: [], zones: {} };
+
+const doc = (over: Partial<ApplicationDocument> = {}): ApplicationDocument => ({
+  schemaVersion: 3,
+  ui: emptyUi,
+  operations: [],
+  resources: [],
+  variables: [],
+  ...over
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    {children}
+  </QueryClientProvider>
+);
+
+const renderRuntime = (
+  workflow: Workflow | undefined,
+  document?: ApplicationDocument
+) =>
+  renderHook(() => useAppRuntime(workflow, false, { document }), { wrapper });
+
+/** Deliver a streaming message the way the websocket manager would. */
+const deliver = (message: Record<string, unknown>) =>
+  act(() => {
+    for (const handler of [...subscribers]) handler(message);
+  });
+
+beforeEach(() => {
+  jobCounter = 0;
+  runners.clear();
+  subscribers.length = 0;
+  cancelJob.mockClear();
+  window.localStorage.clear();
+  disposeAppRuntimeStore(workflowInstanceId("wf-a"));
+  (getWorkflowRunnerStore as jest.Mock).mockImplementation(
+    (id: string) => runners.get(id) ?? makeRunner(id)
+  );
+  fetchWorkflow.mockImplementation(async (id: string) =>
+    id === "wf-b" ? workflowB : workflowA
+  );
+});
+
+describe("useAppRuntime — outputs into variables", () => {
+  it("writes a node's streamed output to the variable the operation maps it to", async () => {
+    const document = doc({
+      operations: [
+        {
+          id: "main",
+          name: "Run",
+          workflowId: "wf-a",
+          inputs: {},
+          outputs: { out1: { to: "variable", variableId: "summary" } },
+          policy: "replace"
+        }
+      ],
+      variables: [
+        { id: "summary", name: "Summary", scope: "instance", persist: false }
+      ]
+    });
+    const { result } = renderRuntime(workflowA, document);
+
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const jobId = runnerState("wf-a").run.mock.results.length
+      ? await runnerState("wf-a").run.mock.results[0].value
+      : "";
+
+    deliver({
+      type: "output_update",
+      job_id: jobId,
+      node_id: "out1",
+      value: "Hello",
+      disposition: "replace"
+    });
+
+    await waitFor(() =>
+      expect(result.current.store.getState().variables.summary).toBe("Hello")
+    );
+    // The display slot still gets it — a mapped output lands in both places.
+    expect(result.current.store.getState().outputs["main:out1"]?.value).toBe(
+      "Hello"
+    );
+  });
+});
+
+describe("useAppRuntime — variable defaults and persistence", () => {
+  it("seeds declared defaults into the instance", () => {
+    const document = doc({
+      variables: [
+        {
+          id: "tone",
+          name: "Tone",
+          default: "warm",
+          scope: "instance",
+          persist: false
+        }
+      ]
+    });
+    const { result } = renderRuntime(workflowA, document);
+    expect(result.current.store.getState().variables.tone).toBe("warm");
+  });
+
+  it("restores a persisted user-scoped variable over its declared default", () => {
+    window.localStorage.setItem(
+      variableStorageKey("workflow:wf-a"),
+      JSON.stringify({ tone: "cool" })
+    );
+    const document = doc({
+      variables: [
+        {
+          id: "tone",
+          name: "Tone",
+          default: "warm",
+          scope: "user",
+          persist: true
+        }
+      ]
+    });
+    const { result } = renderRuntime(workflowA, document);
+    expect(result.current.store.getState().variables.tone).toBe("cool");
+  });
+
+  it("writes a persisting variable back, and never an instance one", async () => {
+    const document = doc({
+      variables: [
+        { id: "tone", name: "Tone", scope: "user", persist: true },
+        { id: "draft", name: "Draft", scope: "instance", persist: false }
+      ]
+    });
+    const { result } = renderRuntime(workflowA, document);
+
+    act(() => {
+      result.current.dispatch({
+        kind: "setVariable",
+        variableId: "tone",
+        value: "cool"
+      });
+      result.current.dispatch({
+        kind: "setVariable",
+        variableId: "draft",
+        value: "scratch"
+      });
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem(variableStorageKey("workflow:wf-a")) ?? "{}"
+      );
+      expect(stored).toEqual({ tone: "cool" });
+    });
+  });
+});
+
+describe("useAppRuntime — run policy", () => {
+  const operation = (policy: "replace" | "queue" | "parallel") =>
+    doc({
+      operations: [
+        {
+          id: "main",
+          name: "Run",
+          workflowId: "wf-a",
+          inputs: {},
+          outputs: {},
+          policy
+        }
+      ]
+    });
+
+  it("replace cancels the run in flight before starting the next", async () => {
+    const { result } = renderRuntime(workflowA, operation("replace"));
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const first = await runnerState("wf-a").run.mock.results[0].value;
+    runnerState("wf-a").job_id = first;
+
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+
+    expect(runnerState("wf-a").cancel).toHaveBeenCalled();
+    expect(
+      result.current.store.getState().invocations[first]?.status
+    ).toBe("cancelled");
+    expect(runnerState("wf-a").run).toHaveBeenCalledTimes(2);
+  });
+
+  it("queue waits for the run in flight to settle", async () => {
+    const { result } = renderRuntime(workflowA, operation("queue"));
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const first = await runnerState("wf-a").run.mock.results[0].value;
+
+    act(() => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    // Nothing new started while the first invocation is still live.
+    expect(runnerState("wf-a").run).toHaveBeenCalledTimes(1);
+
+    deliver({ type: "job_update", job_id: first, status: "completed" });
+
+    await waitFor(() =>
+      expect(runnerState("wf-a").run).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it("parallel starts immediately and asks the server for a concurrent slot", async () => {
+    const { result } = renderRuntime(workflowA, operation("parallel"));
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+
+    expect(runnerState("wf-a").cancel).not.toHaveBeenCalled();
+    expect(runnerState("wf-a").run).toHaveBeenCalledTimes(2);
+    // 7th argument is the runner's `concurrent` flag.
+    expect(runnerState("wf-a").run.mock.calls[0][6]).toBe(true);
+  });
+});
+
+describe("useAppRuntime — timeoutMs", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  const timedDoc = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Summarize",
+        workflowId: "wf-a",
+        inputs: {},
+        outputs: {},
+        policy: "replace",
+        timeoutMs: 5_000
+      }
+    ]
+  });
+
+  it("fails the invocation once the declared timeout elapses", async () => {
+    const { result } = renderRuntime(workflowA, timedDoc);
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const jobId = await runnerState("wf-a").run.mock.results[0].value;
+
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    const invocation = result.current.store.getState().invocations[jobId];
+    expect(invocation?.status).toBe("failed");
+    expect(invocation?.error).toMatch(/timed out after 5000 ms/);
+  });
+
+  it("does not fail a run that finished before the timeout", async () => {
+    const { result } = renderRuntime(workflowA, timedDoc);
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const jobId = await runnerState("wf-a").run.mock.results[0].value;
+
+    deliver({ type: "job_update", job_id: jobId, status: "completed" });
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    const invocation = result.current.store.getState().invocations[jobId];
+    expect(invocation?.status).toBe("completed");
+    expect(invocation?.error).toBeUndefined();
+  });
+});
+
+describe("useAppRuntime — multiple operations", () => {
+  const twoOperations = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Draft",
+        workflowId: "wf-a",
+        inputs: {},
+        outputs: {},
+        policy: "replace"
+      },
+      {
+        id: "publish",
+        name: "Publish",
+        workflowId: "wf-b",
+        inputs: {},
+        outputs: {},
+        policy: "replace"
+      }
+    ]
+  });
+
+  it("runs the named operation's own workflow, not operation 0's", async () => {
+    const { result } = renderRuntime(workflowA, twoOperations);
+    // The second operation's workflow is fetched; wait for its graph to land.
+    await waitFor(() =>
+      expect(
+        result.current.scope.operations.find((o) => o.operationId === "publish")
+          ?.nodeIds
+      ).toHaveLength(2)
+    );
+
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "publish" });
+    });
+
+    await waitFor(() => expect(runnerState("wf-b").run).toHaveBeenCalled());
+    expect(runnerState("wf-a").run).not.toHaveBeenCalled();
+    expect(runnerState("wf-b").run.mock.calls[0][1]).toMatchObject({
+      id: "wf-b"
+    });
+  });
+
+  it("covers every operation in the binding scope", async () => {
+    const { result } = renderRuntime(workflowA, twoOperations);
+    await waitFor(() =>
+      expect(result.current.scope.operations).toHaveLength(2)
+    );
+    expect(
+      result.current.scope.operations.map((o) => o.operationId).sort()
+    ).toEqual(["main", "publish"]);
+  });
+
+  it("refuses a run naming an operation the app does not have", async () => {
+    const { result } = renderRuntime(workflowA, twoOperations);
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "ghost" });
+    });
+
+    expect(runnerState("wf-a").run).not.toHaveBeenCalled();
+    const failed = Object.values(result.current.store.getState().invocations);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].status).toBe("failed");
+    expect(failed[0].error).toMatch(/no operation "ghost"/);
+  });
+});
+
+describe("useAppRuntime — activity", () => {
+  it("records what a streaming agent run reports it is doing", async () => {
+    const { result } = renderRuntime(workflowA, doc());
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const jobId = await runnerState("wf-a").run.mock.results[0].value;
+
+    deliver({
+      type: "tool_call_update",
+      job_id: jobId,
+      name: "search",
+      message: "Searching the web"
+    });
+
+    await waitFor(() =>
+      expect(result.current.store.getState().activity[jobId]).toBe(
+        "Searching the web"
+      )
+    );
+  });
+});

--- a/web/src/components/appbuilder/runtime/useAppRuntime.ts
+++ b/web/src/components/appbuilder/runtime/useAppRuntime.ts
@@ -1,22 +1,33 @@
 /**
  * The reactive engine.
  *
- * Binds an app-instance store to the shared per-workflow runner, folds the
- * run's streaming messages into namespaced state, and turns widget actions into
- * runs. All the semantics — what a message does to a value, which invocation
- * owns a slot, how an action reads — live in `@nodetool-ai/app-runtime`; this
- * hook is the web adapter around them.
+ * Binds an app-instance store to the workflow runners its operations target,
+ * folds each run's streaming messages into namespaced state, and turns widget
+ * actions into runs. All the semantics — what a message does to a value, which
+ * invocation owns a slot, what a collision with a live run means — live in
+ * `@nodetool-ai/app-runtime`; this hook is the web adapter around them.
  *
  * Run identity is the load-bearing part: every invocation this app starts is
  * registered by its `job_id`, and a streaming message for any other job is
  * dropped. Overlapping runs, a second tab, and runs started in the graph editor
  * no longer fold into what the app shows.
+ *
+ * An app may bind several operations, each over its own workflow. Every
+ * operation gets its own runner store, its own IO, and its own invocations, so
+ * a `run` action naming an operation runs that operation — never operation 0
+ * against the host workflow.
  */
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useQueries } from "@tanstack/react-query";
 import {
+  decideRun,
   implicitOperation,
+  initialVariableValues,
+  isLiveInvocation,
+  liveInvocations,
   mergeVariables,
   messageToEvents,
+  outputVariableTargets,
   resolveBinding,
   resolveOperationParams,
   stateKey,
@@ -32,14 +43,17 @@ import {
 import { Workflow } from "../../../stores/ApiTypes";
 import {
   getWorkflowRunnerStore,
-  MsgpackData
+  MsgpackData,
+  WorkflowRunnerStore
 } from "../../../stores/WorkflowRunner";
 import { globalWebSocketManager } from "../../../lib/websocket/GlobalWebSocketManager";
 import { graphNodeToReactFlowNode } from "../../../stores/graphNodeToReactFlowNode";
 import { graphEdgeToReactFlowEdge } from "../../../stores/graphEdgeToReactFlowEdge";
 import { runBrowserGraphJob } from "../../../lib/workflow/browserWorkflowRunner";
 import useMetadataStore from "../../../stores/MetadataStore";
-import { extractWorkflowIO } from "../workflowIO";
+import { useWorkflowManager } from "../../../contexts/WorkflowManagerContext";
+import { trpcClient } from "../../../trpc/client";
+import { extractWorkflowIO, WorkflowIO } from "../workflowIO";
 import { extractVariableNames } from "../workflowState";
 import { seedInputValue } from "../inputProperty";
 import { collectNodePropertyOverlays, withNodeProperties } from "../nodeBinding";
@@ -50,9 +64,33 @@ import {
   workflowInstanceId,
   AppRuntimeStore
 } from "./appRuntimeStore";
+import {
+  appVariableIdentity,
+  loadPersistedVariables,
+  savePersistedVariables
+} from "./variablePersistence";
 import { AppRuntimeContextValue } from "./AppRuntimeContext";
 
 const now = (): number => Date.now();
+
+const EMPTY_IO: WorkflowIO = { inputs: [], outputs: [] };
+
+/** Everything one bound operation needs to run: its graph, IO, and runner. */
+interface OperationRuntime {
+  operation: OperationBinding;
+  /** Undefined while the operation's workflow is still loading, or missing. */
+  workflow: Workflow | undefined;
+  io: WorkflowIO;
+  runnerStore: WorkflowRunnerStore;
+}
+
+/** Per-operation bookkeeping for coalesced reactive (subgraph) runs. */
+interface ReactiveRunState {
+  jobId: string;
+  inFlight: boolean;
+  pending: BindingRef | null;
+  hasRunFull: boolean;
+}
 
 export interface AppRuntimeOptions {
   /**
@@ -67,6 +105,12 @@ export interface AppRuntimeOptions {
    * the ledger afterwards. Absent for an app that has no record yet.
    */
   application?: { id: string; version?: number };
+  /**
+   * Workflow graphs supplied by the caller, by workflow id — the graphs a
+   * release pinned. An operation whose workflow is here runs that exact graph
+   * instead of fetching the live one.
+   */
+  workflowOverrides?: Record<string, Workflow>;
   /** Open a resource in its own editor. The runtime only knows which one. */
   onOpenResource?: (resourceBindingId: string, ref: ResourceRef) => void;
   /** Run a provider command (upload, delete, …) against a resource binding. */
@@ -82,83 +126,173 @@ export const useAppRuntime = (
   designMode: boolean,
   options: AppRuntimeOptions = {}
 ): AppRuntimeContextValue => {
-  const { application, document, onOpenResource, onResourceCommand } = options;
-  const io = useMemo(() => extractWorkflowIO(workflow), [workflow]);
+  const {
+    application,
+    document,
+    workflowOverrides,
+    onOpenResource,
+    onResourceCommand
+  } = options;
   const workflowId = workflow?.id;
+  const fetchWorkflow = useWorkflowManager((state) => state.fetchWorkflow);
 
-  // The operation a widget's run targets. Multi-operation apps arrive with the
-  // application entity; until then every app has exactly one.
-  const operation: OperationBinding = useMemo(
-    () => document?.operations[0] ?? implicitOperation(workflowId ?? ""),
-    [document, workflowId]
-  );
+  // Every operation the app binds. A legacy app running straight off a
+  // workflow has none declared, so it gets the implicit one.
+  const operations = useMemo<OperationBinding[]>(() => {
+    const declared = document?.operations ?? [];
+    return declared.length > 0 ? declared : [implicitOperation(workflowId ?? "")];
+  }, [document, workflowId]);
+
+  // Operations over a workflow this view did not already load. Fetched once
+  // each, so a two-operation app addresses two different graphs.
+  const extraWorkflowIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const operation of operations) {
+      const id = operation.workflowId;
+      if (!id || id === workflowId || workflowOverrides?.[id]) continue;
+      ids.add(id);
+    }
+    return [...ids].sort();
+  }, [operations, workflowId, workflowOverrides]);
+
+  const extraWorkflows = useQueries({
+    queries: extraWorkflowIds.map((id) => ({
+      queryKey: ["app-operation-workflow", id],
+      queryFn: async () => await fetchWorkflow(id),
+      enabled: !designMode,
+      staleTime: 60_000,
+      retry: false
+    }))
+  });
+
+  const fetched = new Map<string, Workflow>();
+  extraWorkflowIds.forEach((id, index) => {
+    const data = extraWorkflows[index]?.data;
+    if (data) fetched.set(id, data);
+  });
+  const fetchedRef = useRef(fetched);
+  fetchedRef.current = fetched;
+  const fetchedKey = [...fetched.keys()].join("|");
+
+  const operationRuntimes = useMemo(() => {
+    const map = new Map<string, OperationRuntime>();
+    for (const operation of operations) {
+      const targetId = operation.workflowId;
+      const target =
+        !targetId || targetId === workflowId
+          ? workflow
+          : workflowOverrides?.[targetId] ?? fetchedRef.current.get(targetId);
+      map.set(operation.id, {
+        operation,
+        workflow: target,
+        io: extractWorkflowIO(target),
+        runnerStore: getWorkflowRunnerStore(
+          targetId || workflowId || "__app_runtime__"
+        )
+      });
+    }
+    return map;
+    // `fetchedKey` tracks which operation workflows have arrived; the graphs
+    // themselves are read from the ref so the dep list stays fixed-length.
+  }, [fetchedKey, operations, workflow, workflowId, workflowOverrides]);
+
+  const operationRuntimesRef = useRef(operationRuntimes);
+  operationRuntimesRef.current = operationRuntimes;
+
+  const defaultOperation = operations[0];
+  // The host workflow's own surface, which the legacy single-operation
+  // contract (and every widget that does not name an operation) reads.
+  const io = operationRuntimes.get(defaultOperation.id)?.io ?? EMPTY_IO;
 
   // Everything a stored binding string can resolve against. Legacy documents
   // bind by name; the scope turns those names into node IDs once, here, so a
   // later rename in the graph editor is invisible to the app.
   const scope: BindingScope = useMemo(
     () => ({
-      defaultOperationId: operation.id,
-      operations: [
-        {
-          operationId: operation.id,
-          inputs: io.inputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          outputs: io.outputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          nodeIds: (workflow?.graph?.nodes ?? []).map((n) => n.id),
-          variableNames: extractVariableNames(workflow)
-        }
-      ],
+      defaultOperationId: defaultOperation.id,
+      operations: [...operationRuntimes.values()].map((entry) => ({
+        operationId: entry.operation.id,
+        inputs: entry.io.inputs.map(({ nodeId, name }) => ({ nodeId, name })),
+        outputs: entry.io.outputs.map(({ nodeId, name }) => ({ nodeId, name })),
+        nodeIds: (entry.workflow?.graph?.nodes ?? []).map((node) => node.id),
+        variableNames: extractVariableNames(entry.workflow)
+      })),
       variables: mergeVariables(
         document?.variables ?? [],
-        extractVariableNames(workflow)
+        [...operationRuntimes.values()].flatMap((entry) =>
+          extractVariableNames(entry.workflow)
+        )
       )
     }),
-    [document, io, workflow]
+    [defaultOperation.id, document, operationRuntimes]
   );
 
-  const inputKey = useCallback(
-    (nodeId: string) => stateKey({ kind: "input", operationId: operation.id, nodeId }),
-    [operation.id]
-  );
   const outputKey = useCallback(
-    (nodeId: string) => stateKey({ kind: "output", operationId: operation.id, nodeId }),
-    [operation.id]
+    (operationId: string, nodeId: string) =>
+      stateKey({ kind: "output", operationId, nodeId }),
+    []
   );
 
   // A design canvas gets an ephemeral store: widget writes there must not leak
   // into the published app's state. A live app keeps its store in the instance
   // registry so values survive View↔Edit tab switches and refetches.
+  const identity = appVariableIdentity(application?.id, workflowId);
   const store: AppRuntimeStore = useMemo(() => {
     const target =
       designMode || !workflowId
         ? createAppRuntimeStore()
         : getAppRuntimeStore(workflowInstanceId(workflowId));
+    const dispatchEvent = target.getState().dispatchEvent;
+
     // Seeding fills only slots that have no value: workflow input defaults plus
     // the select/boolean fallbacks the controls display, so an untouched form
     // runs with what it shows.
     const values: Record<string, unknown> = {};
-    for (const input of io.inputs) {
-      const seed = seedInputValue(input);
-      if (seed !== undefined) values[inputKey(input.nodeId)] = seed;
+    for (const entry of operationRuntimes.values()) {
+      for (const input of entry.io.inputs) {
+        const seed = seedInputValue(input);
+        if (seed === undefined) continue;
+        values[
+          stateKey({
+            kind: "input",
+            operationId: entry.operation.id,
+            nodeId: input.nodeId
+          })
+        ] = seed;
+      }
     }
-    target.getState().dispatchEvent({ type: "seedInputs", values });
+    dispatchEvent({ type: "seedInputs", values });
+
+    // Restored user-scoped values first, declared defaults second: seeding
+    // never clobbers, so what the user left behind wins over the default.
+    const variables = document?.variables ?? [];
+    if (!designMode) {
+      dispatchEvent({
+        type: "seedVariables",
+        values: loadPersistedVariables(identity, variables)
+      });
+    }
+    dispatchEvent({
+      type: "seedVariables",
+      values: initialVariableValues(variables)
+    });
     return target;
-  }, [designMode, workflowId, io, inputKey]);
+  }, [designMode, document, identity, operationRuntimes, workflowId]);
 
-  // The shared per-workflow runner (same instance the graph editor, jobs panel
-  // and frontend tools use), so busy/queue/cancel state is consistent across
-  // views.
-  const runnerStore = useMemo(
-    () => getWorkflowRunnerStore(workflowId ?? "__app_runtime__"),
-    [workflowId]
-  );
-
-  const outputNodeIds = useMemo(
-    () => new Set(io.outputs.map((o) => o.nodeId)),
-    [io.outputs]
-  );
-  const outputNodeIdsRef = useRef(outputNodeIds);
-  outputNodeIdsRef.current = outputNodeIds;
+  // Write persisting user-scoped variables back whenever they change. Instance
+  // variables and widget-local view state are deliberately not persisted.
+  useEffect(() => {
+    const variables = document?.variables ?? [];
+    if (designMode || !identity) return;
+    if (!variables.some((v) => v.scope === "user" && v.persist)) return;
+    let previous = store.getState().variables;
+    savePersistedVariables(identity, variables, previous);
+    return store.subscribe((state) => {
+      if (state.variables === previous) return;
+      previous = state.variables;
+      savePersistedVariables(identity, variables, previous);
+    });
+  }, [designMode, document, identity, store]);
 
   // Invocations this app started, by job id. A streaming message for anything
   // else is not ours — that is the whole cross-run contamination fix.
@@ -169,6 +303,23 @@ export const useAppRuntime = (
   // Messages that arrived between dispatching a run and learning its job id.
   const pendingRef = useRef<MsgpackData[]>([]);
   const awaitingJobRef = useRef(0);
+  // Timeout timers by invocation id, for operations that declare `timeoutMs`.
+  const timersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const clearTimeoutTimer = useCallback((invocationId: string) => {
+    const timer = timersRef.current.get(invocationId);
+    if (!timer) return;
+    clearTimeout(timer);
+    timersRef.current.delete(invocationId);
+  }, []);
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
 
   const foldRef = useRef<(message: MsgpackData) => void>(() => {});
 
@@ -177,27 +328,100 @@ export const useAppRuntime = (
       const events = messageToEvents(message as Record<string, unknown>, {
         resolveInvocation: (jobId) =>
           jobId ? ownedRef.current.get(jobId) ?? null : null,
-        outputKey: (_operationId, nodeId) =>
-          outputNodeIdsRef.current.has(nodeId) ? outputKey(nodeId) : null
+        outputKey: (operationId, nodeId) => {
+          const entry = operationRuntimesRef.current.get(operationId);
+          return entry?.io.outputs.some((output) => output.nodeId === nodeId)
+            ? outputKey(operationId, nodeId)
+            : null;
+        },
+        // An output mapped `to: "variable"` writes app state as well as its
+        // display slot — that is how one operation hands a value to the next.
+        outputVariable: (operationId, nodeId) => {
+          const entry = operationRuntimesRef.current.get(operationId);
+          if (!entry) return null;
+          const mapping = entry.operation.outputs[nodeId];
+          return mapping?.to === "variable" ? mapping.variableId : null;
+        }
       });
       for (const event of events) {
         store.getState().dispatchEvent(event);
-        if (event.type === "invocationStatus") {
-          const invocation = ownedRef.current.get(event.invocationId);
-          if (invocation) invocation.status = event.status;
-        }
+        if (event.type !== "invocationStatus") continue;
+        const invocation = ownedRef.current.get(event.invocationId);
+        if (invocation) invocation.status = event.status;
+        const settled = event.status !== "pending" && event.status !== "running";
+        if (settled) clearTimeoutTimer(event.invocationId);
       }
     },
-    [outputKey, store]
+    [clearTimeoutTimer, outputKey, store]
   );
   foldRef.current = fold;
 
+  /** Stop one run on the server (or in the browser, when it runs there). */
+  const stopJob = useCallback(async (invocationId: string) => {
+    const invocation = ownedRef.current.get(invocationId);
+    const entry = invocation
+      ? operationRuntimesRef.current.get(invocation.operationId)
+      : undefined;
+    const runner = entry?.runnerStore;
+    // The runner only knows how to cancel the run it currently displays;
+    // anything else (a queued or parallel sibling) is cancelled by job id.
+    if (runner && runner.getState().job_id === invocationId) {
+      await runner.getState().cancel();
+      return;
+    }
+    try {
+      await trpcClient.jobs.cancel.mutate({ id: invocationId });
+    } catch {
+      // The job may already be gone; the app still marks it cancelled.
+    }
+  }, []);
+
+  const cancelInvocations = useCallback(
+    async (invocationIds: ReadonlyArray<string>) => {
+      for (const invocationId of invocationIds) {
+        clearTimeoutTimer(invocationId);
+        const invocation = ownedRef.current.get(invocationId);
+        if (invocation) invocation.status = "cancelled";
+        await stopJob(invocationId);
+        store.getState().dispatchEvent({
+          type: "invocationStatus",
+          invocationId,
+          status: "cancelled"
+        });
+      }
+    },
+    [clearTimeoutTimer, stopJob, store]
+  );
+
+  /** Resolve once every listed invocation has settled. */
+  const awaitSettled = useCallback(
+    (invocationIds: ReadonlyArray<string>) =>
+      new Promise<void>((resolve) => {
+        const settled = () =>
+          invocationIds.every((id) => {
+            const invocation = store.getState().invocations[id];
+            return !invocation || !isLiveInvocation(invocation);
+          });
+        if (settled()) {
+          resolve();
+          return;
+        }
+        const unsubscribe = store.subscribe(() => {
+          if (!settled()) return;
+          unsubscribe();
+          resolve();
+        });
+      }),
+    [store]
+  );
+
   /** Register a run this app started and flush anything buffered for it. */
   const claimInvocation = useCallback(
-    (jobId: string, clearOutputs: boolean) => {
+    (operationId: string, jobId: string, clearOutputs: boolean) => {
+      const entry = operationRuntimesRef.current.get(operationId);
       const invocation: InvocationState = {
         id: jobId,
-        operationId: operation.id,
+        operationId,
         status: "running",
         startedAt: now()
       };
@@ -205,19 +429,75 @@ export const useAppRuntime = (
       store.getState().dispatchEvent({
         type: "runStarted",
         invocation,
-        outputKeys: clearOutputs
-          ? io.outputs.map((output) => outputKey(output.nodeId))
-          : []
+        outputKeys:
+          clearOutputs && entry
+            ? entry.io.outputs.map((output) =>
+                outputKey(operationId, output.nodeId)
+              )
+            : []
       });
+
+      // A declared timeout is a promise to the user that the app stops waiting.
+      const timeoutMs = entry?.operation.timeoutMs;
+      if (timeoutMs && timeoutMs > 0) {
+        timersRef.current.set(
+          jobId,
+          setTimeout(() => {
+            timersRef.current.delete(jobId);
+            const live = ownedRef.current.get(jobId);
+            if (!live || !isLiveInvocation(live)) return;
+            live.status = "failed";
+            void stopJob(jobId);
+            store.getState().dispatchEvent({
+              type: "invocationStatus",
+              invocationId: jobId,
+              status: "failed",
+              error: `"${entry.operation.name}" timed out after ${timeoutMs} ms`
+            });
+          }, timeoutMs)
+        );
+      }
+
       const buffered = pendingRef.current;
       pendingRef.current = [];
       for (const message of buffered) foldRef.current(message);
     },
-    [io.outputs, operation.id, outputKey, store]
+    [outputKey, stopJob, store]
   );
 
+  /** Record a run that never started as a failed invocation the app can show. */
+  const failInvocation = useCallback(
+    (operationId: string, error: string) => {
+      const failed: InvocationState = {
+        id: `failed-${now()}`,
+        operationId,
+        status: "failed",
+        error,
+        startedAt: now()
+      };
+      ownedRef.current.set(failed.id, failed);
+      store
+        .getState()
+        .dispatchEvent({ type: "runStarted", invocation: failed, outputKeys: [] });
+    },
+    [store]
+  );
+
+  const workflowIds = useMemo(
+    () =>
+      [
+        ...new Set(
+          [...operationRuntimes.values()]
+            .map((entry) => entry.workflow?.id)
+            .filter((id): id is string => Boolean(id))
+        )
+      ].sort(),
+    [operationRuntimes]
+  );
+  const workflowIdsKey = workflowIds.join("|");
+
   useEffect(() => {
-    if (!workflowId || designMode) return;
+    if (designMode || workflowIds.length === 0) return;
 
     // Protocol-level handling (runner state machine, ResultsStore, node stores)
     // already runs via the workflow-manager subscription installed when the
@@ -233,150 +513,192 @@ export const useAppRuntime = (
       if (awaitingJobRef.current > 0) pendingRef.current.push(message);
     };
 
-    const unsubscribeWorkflow = globalWebSocketManager.subscribe(
-      workflowId,
-      (message) => handler(message as MsgpackData)
+    const unsubscribes = workflowIds.map((id) =>
+      globalWebSocketManager.subscribe(id, (message) =>
+        handler(message as MsgpackData)
+      )
     );
 
-    let unsubscribeJob: (() => void) | null = null;
-    const updateJobSubscription = (jobId: string | null) => {
-      unsubscribeJob?.();
-      unsubscribeJob = null;
+    const jobUnsubscribes = new Map<string, () => void>();
+    const updateJobSubscription = (runnerKey: string, jobId: string | null) => {
+      jobUnsubscribes.get(runnerKey)?.();
+      jobUnsubscribes.delete(runnerKey);
       if (!jobId) return;
-      unsubscribeJob = globalWebSocketManager.subscribe(jobId, (message) => {
-        if (message?.workflow_id) return;
-        handler(message as MsgpackData);
-      });
+      jobUnsubscribes.set(
+        runnerKey,
+        globalWebSocketManager.subscribe(jobId, (message) => {
+          if (message?.workflow_id) return;
+          handler(message as MsgpackData);
+        })
+      );
     };
-    updateJobSubscription(runnerStore.getState().job_id);
 
-    const unsubscribeRunner = runnerStore.subscribe((state, prev) => {
-      if (state.job_id !== prev.job_id) updateJobSubscription(state.job_id);
+    const runners = new Map<string, WorkflowRunnerStore>();
+    for (const entry of operationRuntimesRef.current.values()) {
+      const key = entry.workflow?.id;
+      if (key) runners.set(key, entry.runnerStore);
+    }
+    const runnerUnsubscribes = [...runners.entries()].map(([key, runner]) => {
+      updateJobSubscription(key, runner.getState().job_id);
+      return runner.subscribe((state, prev) => {
+        if (state.job_id !== prev.job_id) updateJobSubscription(key, state.job_id);
+      });
     });
 
     return () => {
-      unsubscribeWorkflow();
-      unsubscribeRunner();
-      unsubscribeJob?.();
+      for (const unsubscribe of unsubscribes) unsubscribe();
+      for (const unsubscribe of runnerUnsubscribes) unsubscribe();
+      for (const unsubscribe of jobUnsubscribes.values()) unsubscribe();
     };
-  }, [designMode, runnerStore, workflowId]);
+    // `workflowIdsKey` stands in for the workflow id list; the runner stores
+    // themselves are read from the ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [designMode, workflowIdsKey]);
 
-  const run = useCallback(async () => {
-    if (!workflow || designMode) return;
-    const state = store.getState();
-    // Bindings key on node IDs; the run protocol wants names. That translation
-    // happens here, at the execution boundary, which is why a graph rename
-    // never touches the app document.
-    const params = resolveOperationParams({
-      operation,
-      state,
-      inputNodeIds: io.inputs.map((input) => input.nodeId),
-      inputName: (nodeId) =>
-        io.inputs.find((input) => input.nodeId === nodeId)?.name,
-      resourceRef: (resourceBindingId) =>
-        resourceRefsRef.current.get(resourceBindingId)
-    });
-
-    // Node-property bindings overlay their live widget values onto the graph
-    // before the run, so a slider bound to e.g. a model's `strength` drives the
-    // actual node property.
-    const overlays = collectNodePropertyOverlays(state.inputs);
-    const nodes = (workflow.graph?.nodes ?? []).map((node) => {
-      const rf = graphNodeToReactFlowNode(workflow, node);
-      const overlay = overlays.get(rf.id);
-      return overlay ? withNodeProperties(rf, overlay) : rf;
-    });
-    const edges = (workflow.graph?.edges ?? []).map((edge) =>
-      graphEdgeToReactFlowEdge(edge)
-    );
-
-    awaitingJobRef.current += 1;
-    try {
-      const jobId = await runnerStore
-        .getState()
-        .run(
-          params,
-          workflow,
-          nodes,
-          edges,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { application }
+  const run = useCallback(
+    async (operationId: string) => {
+      if (designMode) return;
+      const entry = operationRuntimesRef.current.get(operationId);
+      if (!entry) {
+        failInvocation(
+          operationId,
+          `This app has no operation "${operationId}".`
         );
-      claimInvocation(jobId, true);
-    } catch (error) {
-      pendingRef.current = [];
-      const message = error instanceof Error ? error.message : "Run failed";
-      const failed: InvocationState = {
-        id: `failed-${now()}`,
-        operationId: operation.id,
-        status: "failed",
-        error: message,
-        startedAt: now()
-      };
-      ownedRef.current.set(failed.id, failed);
-      store
-        .getState()
-        .dispatchEvent({ type: "runStarted", invocation: failed, outputKeys: [] });
-    } finally {
-      awaitingJobRef.current -= 1;
-    }
-  }, [
-    application,
-    claimInvocation,
-    designMode,
-    io.inputs,
-    operation,
-    runnerStore,
-    store,
-    workflow
-  ]);
-
-  const cancel = useCallback(async () => {
-    await runnerStore.getState().cancel();
-    for (const [id, invocation] of ownedRef.current) {
-      if (invocation.status !== "running" && invocation.status !== "pending") {
-        continue;
+        return;
       }
-      invocation.status = "cancelled";
+      const target = entry.workflow;
+      if (!target) {
+        failInvocation(
+          operationId,
+          `"${entry.operation.name}" runs workflow ${entry.operation.workflowId}, which could not be loaded.`
+        );
+        return;
+      }
+
+      // What a collision with a live run of this operation means: replace it,
+      // queue behind it, or start alongside it.
+      const decision = decideRun(store.getState(), entry.operation);
+      if (decision.kind === "replace") {
+        await cancelInvocations(decision.cancel);
+      } else if (decision.kind === "queue") {
+        await awaitSettled(decision.after);
+      }
+
+      const state = store.getState();
+      // Bindings key on node IDs; the run protocol wants names. That translation
+      // happens here, at the execution boundary, which is why a graph rename
+      // never touches the app document.
+      const params = resolveOperationParams({
+        operation: entry.operation,
+        state,
+        inputNodeIds: entry.io.inputs.map((input) => input.nodeId),
+        inputName: (nodeId) =>
+          entry.io.inputs.find((input) => input.nodeId === nodeId)?.name,
+        resourceRef: (resourceBindingId) =>
+          resourceRefsRef.current.get(resourceBindingId)
+      });
+
+      // Node-property bindings overlay their live widget values onto the graph
+      // before the run, so a slider bound to e.g. a model's `strength` drives the
+      // actual node property.
+      const overlays = collectNodePropertyOverlays(state.inputs);
+      const nodes = (target.graph?.nodes ?? []).map((node) => {
+        const rf = graphNodeToReactFlowNode(target, node);
+        const overlay = overlays.get(rf.id);
+        return overlay ? withNodeProperties(rf, overlay) : rf;
+      });
+      const edges = (target.graph?.edges ?? []).map((edge) =>
+        graphEdgeToReactFlowEdge(edge)
+      );
+
+      awaitingJobRef.current += 1;
+      try {
+        const jobId = await entry.runnerStore
+          .getState()
+          .run(
+            params,
+            target,
+            nodes,
+            edges,
+            undefined,
+            undefined,
+            // A parallel operation asks the server to lift the one-run-per-
+            // workflow limit rather than queue behind the run in flight.
+            entry.operation.policy === "parallel",
+            undefined,
+            { application }
+          );
+        claimInvocation(operationId, jobId, true);
+      } catch (error) {
+        pendingRef.current = [];
+        failInvocation(
+          operationId,
+          error instanceof Error ? error.message : "Run failed"
+        );
+      } finally {
+        awaitingJobRef.current -= 1;
+      }
+    },
+    [
+      application,
+      awaitSettled,
+      cancelInvocations,
+      claimInvocation,
+      designMode,
+      failInvocation,
       store
-        .getState()
-        .dispatchEvent({ type: "invocationStatus", invocationId: id, status: "cancelled" });
-    }
-  }, [runnerStore, store]);
+    ]
+  );
+
+  const cancel = useCallback(
+    async (operationId: string, invocationId?: string) => {
+      const ids = invocationId
+        ? [invocationId]
+        : liveInvocations(store.getState(), operationId).map((i) => i.id);
+      await cancelInvocations(ids);
+    },
+    [cancelInvocations, store]
+  );
 
   // Reactive trigger: recompute only the subgraph downstream of a bound input.
-  // Runs are coalesced — one in flight, latest value wins — and reuse a single
-  // job id so a scrub upserts one live result instead of flooding new ones. No
-  // runner-state toggling: a slider scrub is a live update, not a "run", so the
-  // UI never flashes "Running…".
-  const reactiveJobIdRef = useRef<string>("");
-  if (reactiveJobIdRef.current === "") {
-    reactiveJobIdRef.current = crypto.randomUUID();
-  }
-  const reactiveInFlightRef = useRef(false);
-  const reactivePendingRef = useRef<BindingRef | null>(null);
-  const reactiveRunRef = useRef<(trigger: BindingRef) => void>(() => {});
-  // The first trigger runs the whole graph, so computed upstreams (a generated
-  // image, a constant) populate their caches. Later triggers reuse those caches
-  // and only recompute the downstream subgraph.
-  const hasRunFullRef = useRef(false);
+  // Runs are coalesced per operation — one in flight, latest value wins — and
+  // reuse a single job id so a scrub upserts one live result instead of
+  // flooding new ones. No runner-state toggling: a slider scrub is a live
+  // update, not a "run", so the UI never flashes "Running…".
+  const reactiveRef = useRef(new Map<string, ReactiveRunState>());
+  const reactiveRunRef = useRef<
+    (operationId: string, trigger: BindingRef) => void
+  >(() => {});
   useEffect(() => {
-    hasRunFullRef.current = false;
-  }, [workflowId]);
+    reactiveRef.current.clear();
+  }, [workflowIdsKey]);
 
   const reactiveRun = useCallback(
-    (trigger: BindingRef) => {
-      if (!workflow || designMode) return;
+    (operationId: string, trigger: BindingRef) => {
+      if (designMode) return;
+      const entry = operationRuntimesRef.current.get(operationId);
+      const target = entry?.workflow;
+      if (!entry || !target) {
+        void run(operationId);
+        return;
+      }
+      let reactive = reactiveRef.current.get(operationId);
+      if (!reactive) {
+        reactive = {
+          jobId: crypto.randomUUID(),
+          inFlight: false,
+          pending: null,
+          hasRunFull: false
+        };
+        reactiveRef.current.set(operationId, reactive);
+      }
 
       // A graph is already running (a long-lived / streaming workflow): feed the
       // new value into the live job instead of starting a fresh subgraph run.
       // Its streaming input re-propagates downstream without a restart. Only
       // input-node bindings can stream — a node-property change falls through to
       // a subgraph run.
-      const runner = runnerStore.getState();
+      const runner = entry.runnerStore.getState();
       if (
         trigger.kind === "input" &&
         runner.job_id &&
@@ -385,29 +707,34 @@ export const useAppRuntime = (
           runner.state === "connecting" ||
           runner.state === "connected")
       ) {
-        const input = io.inputs.find((i) => i.nodeId === trigger.nodeId);
+        const input = entry.io.inputs.find((i) => i.nodeId === trigger.nodeId);
         if (input) {
           void runner.streamInput(
             input.name,
-            store.getState().inputs[inputKey(trigger.nodeId)]?.value
+            store.getState().inputs[
+              stateKey({ kind: "input", operationId, nodeId: trigger.nodeId })
+            ]?.value
           );
           return;
         }
       }
 
-      if (!hasRunFullRef.current) {
-        hasRunFullRef.current = true;
-        void run();
+      // The first trigger runs the whole graph, so computed upstreams (a
+      // generated image, a constant) populate their caches. Later triggers
+      // reuse those caches and only recompute the downstream subgraph.
+      if (!reactive.hasRunFull) {
+        reactive.hasRunFull = true;
+        void run(operationId);
         return;
       }
 
-      if (reactiveInFlightRef.current) {
-        reactivePendingRef.current = trigger;
+      if (reactive.inFlight) {
+        reactive.pending = trigger;
         return;
       }
       const sub = buildTriggerSubgraph(
-        workflow,
-        io,
+        target,
+        entry.io,
         store.getState(),
         trigger,
         (type) => useMetadataStore.getState().getMetadata(type)?.effect
@@ -416,36 +743,39 @@ export const useAppRuntime = (
       // server-only compute tail, an effectful node the reactive gate refuses)
       // — fall back to a full authoritative run.
       if (!sub) {
-        void run();
+        void run(operationId);
         return;
       }
-      reactiveInFlightRef.current = true;
-      if (!ownedRef.current.has(reactiveJobIdRef.current)) {
-        claimInvocation(reactiveJobIdRef.current, false);
+      reactive.inFlight = true;
+      if (!ownedRef.current.has(reactive.jobId)) {
+        claimInvocation(operationId, reactive.jobId, false);
       }
+      const jobId = reactive.jobId;
       void runBrowserGraphJob({
         graph: sub.graph,
-        workflowId: workflow.id,
-        jobId: reactiveJobIdRef.current
+        workflowId: target.id,
+        jobId
       })
         .catch((error) => {
           store.getState().dispatchEvent({
             type: "invocationError",
-            invocationId: reactiveJobIdRef.current,
+            invocationId: jobId,
             error: error instanceof Error ? error.message : "Run failed"
           });
         })
         .finally(() => {
-          reactiveInFlightRef.current = false;
-          const pending = reactivePendingRef.current;
+          const current = reactiveRef.current.get(operationId);
+          if (!current) return;
+          current.inFlight = false;
+          const pending = current.pending;
           if (pending !== null) {
-            reactivePendingRef.current = null;
+            current.pending = null;
             // Re-run from fresh store values — the slider has moved on.
-            reactiveRunRef.current(pending);
+            reactiveRunRef.current(operationId, pending);
           }
         });
     },
-    [claimInvocation, designMode, inputKey, io, run, runnerStore, store, workflow]
+    [claimInvocation, designMode, run, store]
   );
   reactiveRunRef.current = reactiveRun;
 
@@ -473,14 +803,22 @@ export const useAppRuntime = (
       switch (action.kind) {
         case "run": {
           // A run triggered from a bound input recomputes just its downstream
-          // subgraph; an unbound run (a button) runs the whole workflow.
+          // subgraph; an unbound run (a button) runs the whole workflow. A
+          // trigger belonging to another operation is not a subgraph of this
+          // one, so it runs whole.
           const trigger = resolveBinding(action.from, scope, "write");
-          if (trigger) reactiveRun(trigger);
-          else void run();
+          if (trigger && "operationId" in trigger && trigger.operationId === action.operationId) {
+            reactiveRun(action.operationId, trigger);
+          } else {
+            void run(action.operationId);
+          }
           break;
         }
         case "cancel":
-          void cancel();
+          void cancel(
+            action.operationId ?? defaultOperation.id,
+            action.invocationId
+          );
           break;
         case "setVariable":
           store.getState().dispatchEvent({
@@ -513,6 +851,7 @@ export const useAppRuntime = (
     },
     [
       cancel,
+      defaultOperation.id,
       designMode,
       onOpenResource,
       onResourceCommand,
@@ -525,14 +864,17 @@ export const useAppRuntime = (
 
   const getNodeProperty = useCallback(
     (nodeId: string, property: string): unknown => {
-      const node = workflow?.graph?.nodes?.find((n) => n.id === nodeId);
-      if (!node) return undefined;
-      const data = (node.data ?? {}) as Record<string, unknown>;
-      if (data[property] !== undefined) return data[property];
-      const meta = useMetadataStore.getState().getMetadata(node.type);
-      return meta?.properties.find((p) => p.name === property)?.default;
+      for (const entry of operationRuntimesRef.current.values()) {
+        const node = entry.workflow?.graph?.nodes?.find((n) => n.id === nodeId);
+        if (!node) continue;
+        const data = (node.data ?? {}) as Record<string, unknown>;
+        if (data[property] !== undefined) return data[property];
+        const meta = useMetadataStore.getState().getMetadata(node.type);
+        return meta?.properties.find((p) => p.name === property)?.default;
+      }
+      return undefined;
     },
-    [workflow]
+    []
   );
 
   const selectResource = useCallback(
@@ -548,7 +890,9 @@ export const useAppRuntime = (
       store,
       io,
       scope,
-      operation,
+      operation: defaultOperation,
+      operations,
+      theme: document?.theme?.id,
       resources: document?.resources ?? [],
       designMode,
       dispatch,
@@ -560,7 +904,8 @@ export const useAppRuntime = (
       store,
       io,
       scope,
-      operation,
+      defaultOperation,
+      operations,
       document,
       designMode,
       dispatch,

--- a/web/src/components/appbuilder/runtime/variablePersistence.ts
+++ b/web/src/components/appbuilder/runtime/variablePersistence.ts
@@ -1,0 +1,97 @@
+/**
+ * Persistence for user-scoped app variables.
+ *
+ * A `VariableDeclaration` carries `scope` and `persist`, and the document
+ * parser enforces that only user-scoped variables may persist. This is the
+ * layer that honours it: those variables survive a reload, everything else —
+ * instance variables, widget-local `view` state, outputs — starts empty.
+ *
+ * Values are keyed by app identity (the application record when the app has
+ * one, otherwise the host workflow), so two apps never read each other's
+ * values.
+ */
+import type { VariableDeclaration } from "@nodetool-ai/app-runtime";
+
+const STORAGE_PREFIX = "nodetool.app.variables.";
+
+/** The storage key for one app's persisted variables. */
+export const variableStorageKey = (appIdentity: string): string =>
+  `${STORAGE_PREFIX}${appIdentity}`;
+
+/**
+ * Identity a persisted value is stored under: the application record when the
+ * app has one, otherwise the workflow that hosts the document.
+ */
+export const appVariableIdentity = (
+  applicationId: string | undefined,
+  workflowId: string | undefined
+): string | null => {
+  if (applicationId) return `application:${applicationId}`;
+  if (workflowId) return `workflow:${workflowId}`;
+  return null;
+};
+
+const persistable = (
+  variables: ReadonlyArray<VariableDeclaration>
+): VariableDeclaration[] =>
+  variables.filter((variable) => variable.scope === "user" && variable.persist);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Restore the persisted values of an app's user-scoped variables. Feed the
+ * result to `seedVariables` **before** the declared defaults: seeding never
+ * clobbers, so a restored value wins over the document's default.
+ *
+ * A value stored for a variable the document no longer declares (or no longer
+ * persists) is ignored rather than resurrected.
+ */
+export const loadPersistedVariables = (
+  appIdentity: string | null,
+  variables: ReadonlyArray<VariableDeclaration>
+): Record<string, unknown> => {
+  const declared = persistable(variables);
+  if (!appIdentity || declared.length === 0) return {};
+  let stored: unknown;
+  try {
+    const raw = window.localStorage.getItem(variableStorageKey(appIdentity));
+    if (!raw) return {};
+    stored = JSON.parse(raw);
+  } catch {
+    // Unreadable storage (disabled, quota-evicted, corrupt) is not an error the
+    // app can act on — it just starts from its declared defaults.
+    return {};
+  }
+  if (!isRecord(stored)) return {};
+  const values: Record<string, unknown> = {};
+  for (const variable of declared) {
+    const value = stored[variable.id];
+    if (value !== undefined) values[variable.id] = value;
+  }
+  return values;
+};
+
+/** Write back the current value of every persisting user-scoped variable. */
+export const savePersistedVariables = (
+  appIdentity: string | null,
+  variables: ReadonlyArray<VariableDeclaration>,
+  values: Record<string, unknown>
+): void => {
+  const declared = persistable(variables);
+  if (!appIdentity || declared.length === 0) return;
+  const payload: Record<string, unknown> = {};
+  for (const variable of declared) {
+    const value = values[variable.id];
+    if (value !== undefined) payload[variable.id] = value;
+  }
+  try {
+    window.localStorage.setItem(
+      variableStorageKey(appIdentity),
+      JSON.stringify(payload)
+    );
+  } catch {
+    // Storage full or unavailable: the app keeps working, the value just does
+    // not survive the reload.
+  }
+};

--- a/web/src/components/workspace/ApplicationSurface.tsx
+++ b/web/src/components/workspace/ApplicationSurface.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useState, type MouseEvent } from "react";
 
 import ApplicationGovernancePanel from "../applications/ApplicationGovernancePanel";
 import ApplicationAppBuilder from "../appbuilder/ApplicationAppBuilder";
+import ApplicationRunView from "../appbuilder/ApplicationRunView";
 import { useApplication } from "../../hooks/useApplications";
 import {
   Box,
@@ -21,7 +22,7 @@ export interface ApplicationSurfaceProps {
   refId: string;
 }
 
-type ApplicationView = "design" | "settings";
+type ApplicationView = "design" | "run" | "settings";
 
 /**
  * Workspace surface for a mini app: the WYSIWYG canvas over the app's own
@@ -84,12 +85,15 @@ const ApplicationSurface = ({ refId }: ApplicationSurfaceProps) => {
           aria-label="App view"
         >
           <ToggleOption value="design">Design</ToggleOption>
+          <ToggleOption value="run">Run</ToggleOption>
           <ToggleOption value="settings">Settings</ToggleOption>
         </ToggleGroup>
       </FlexRow>
       <Box sx={{ flex: 1, minHeight: 0 }}>
         {view === "design" ? (
           <ApplicationAppBuilder applicationId={application.id} />
+        ) : view === "run" ? (
+          <ApplicationRunView applicationId={application.id} />
         ) : (
           <ScrollArea fullHeight>
             <FlexColumn gap={SPACING.lg} padding={SPACING.xl} fullWidth>

--- a/web/src/hooks/useApplications.ts
+++ b/web/src/hooks/useApplications.ts
@@ -80,6 +80,17 @@ export const useApplicationVersions = (id: string | null | undefined) =>
 export const useReleasedApplicationVersion = (id: string | null | undefined) =>
   trpc.applications.released.useQuery({ id: id ?? "" }, { enabled: !!id });
 
+/**
+ * What a published app should actually run: the released snapshot's document
+ * plus the workflow graphs it pinned. Null when nothing is released, which is
+ * the signal to fall back to the mutable draft.
+ */
+export const useReleasedApplicationDocument = (id: string | null | undefined) =>
+  trpc.applications.releasedDocument.useQuery(
+    { id: id ?? "" },
+    { enabled: !!id }
+  );
+
 export const usePublishApplication = () => {
   const utils = trpc.useUtils();
   return trpc.applications.publish.useMutation({

--- a/web/src/lib/tools/builtin/puck.ts
+++ b/web/src/lib/tools/builtin/puck.ts
@@ -521,7 +521,8 @@ FrontendToolRegistry.register({
     "List everything a widget can bind to, with the exact token to store in " +
     "its `binding` prop: each operation's input and output nodes " +
     "(op:<opId>/in:<nodeId>, op:<opId>/out:<nodeId>), its execution fields " +
-    "(op:<opId>/exec#running|progress|error), and every variable (var:<id>). " +
+    "(op:<opId>/exec#running|progress|error|activity), and every variable " +
+    "(var:<id>). " +
     "Call this before binding a widget instead of guessing a name. An " +
     "operation over a workflow this editor has not loaded reports " +
     "ioAvailable: false and no node lists.",


### PR DESCRIPTION
An audit of the mini-app platform found its main weakness is not missing design — it is that the application document declares a set of capabilities no runtime executes. Fields parse, round-trip through save, appear in `doc-ops`, and are unit-tested in isolation, but nothing reads them at runtime.

This PR wires them up. It is landing in phases; the core is in, the adapters are in progress.

## The gaps

Declared in the schema, executed by nobody:

- **`OutputMapping { to: "variable" }`** — `outputVariableTargets()` had unit tests and zero callers. This is the feature the app-builder README sells as the reason variables exist ("operation A writes a variable, a display widget shows it, operation B reads it"). Chained multi-step apps did not work.
- **`OperationPolicy`** (`replace` / `queue` / `parallel`) — parsed, defaulted everywhere, enforced nowhere. Every policy behaved as parallel.
- **`OperationBinding.timeoutMs`** — parsed, never read.
- **`OperationBinding.workflowVersion`** — commented "pinned in a release, floating in a draft", but `publishApplication()` copied the draft verbatim and never set it. A released app floated on the live graph: editing the workflow silently changed what shipped.
- **`VariableDeclaration.default`** — parsed; no runtime seeded it. Every variable started `undefined`.
- **`persist` / `scope: "user"`** — the parser carefully enforces "only user-scoped variables may persist", guarding a behavior that did not exist. There was no persistence layer at all.
- **`ThemeRef`** — parsed, preserved on save, applied by nobody.
- **`AppAction.cancel.invocationId`** — in the type; `eventToAction` never emitted it.

Beyond the dead fields:

- **Multi-operation apps did not exist.** Bindings are namespaced `operationId:nodeId` precisely to allow several, and the agent has `ui_app_add_operation` — but both runtimes did `document.operations[0]`, so a run action naming another operation silently ran the first one against the host workflow.
- **The fold dropped four message types.** `tool_call_update`, `planning_update`, `task_update`, and the top-level `error` were all discarded, so an app over an agent workflow showed a spinner and nothing else.
- **Publishing was bookkeeping.** `publish`/`release`/`released` worked server-side, but nothing rendered a released version — running an app always used the mutable draft. Publish and rollback changed what a panel said, not what anyone ran.
- **No widget could lay out an array**, though the core's `appendValue` produces them and `Json` was the only thing that could show one.

## Changes

**`packages/app-runtime` (landed)** — the pure core: `initialVariableValues` + a non-clobbering `seedVariables` event, `FoldContext.outputVariable` fanning a node's value into a variable, `decideRun` resolving policy against live invocations, cancel-by-invocation, the four dropped message types folded into a bindable `activity` label (`op:<id>/exec#activity`), condition ops `contains`/`gte`/`lte`, format filters `lower`/`join`, and a `Table` catalog entry.

**`packages/models` + applications router** — pin the release snapshot so an edited workflow cannot mutate what shipped, and expose the released document so it can be run.

**`web/`, `mobile/`, `packages/cli/app-debug`** — the three adapters wire the same semantics: multi-operation dispatch, policy, `timeoutMs`, variable defaults and user-scoped persistence, activity display, `Table`, and rendering the released snapshot rather than the draft. The CLI harness also gains verdict checks for the misconfigurations these features newly make possible.

## Deliberately out of scope

- **Public app distribution.** Every applications procedure is `protectedProcedure` and the table has no public/slug/share-token column, so a published app is unreachable by anyone but its owner — which is why the budget system, built explicitly for "apps published to people other than their author", is currently unreachable in practice. Closing it needs an auth and security design (anonymous run quotas, whose secrets execute the run), not a patch.
- **Repeater / tabs / chat widgets and multi-page apps.** A repeater needs per-item binding scope, a real extension to the binding language. `Table` covers the array-of-results case without touching it.

Where an item could not be honestly completed, it is reported as a documented boundary rather than a silent no-op — see the commit messages.

## Testing

`npm run typecheck`, `npm run lint`, and `npm run test` across the affected workspaces; each phase lands green before the next starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfnKiM9hszMrroYuEziiqR)_