### PR TITLE
AtlasCloud: add chat models, and generate node fields from the published schemas

### DIFF
--- a/marketing/src/data/providerEntries.ts
+++ b/marketing/src/data/providerEntries.ts
@@ -294,21 +294,21 @@ const aggregators: ProviderEntry[] = [
     byokEnv: "ATLASCLOUD_API_KEY",
     accent: "amber",
     tagline:
-      "Run AtlasCloud's image and video models in a visual AI workflow — Seedance, GPT-Image and more, called with your own key at AtlasCloud's price.",
+      "Run AtlasCloud's chat, image and video models in a visual AI workflow — DeepSeek, Seedance, GPT-Image and more, called with your own key at AtlasCloud's price.",
     blurb: [
-      "AtlasCloud serves image and video generation models through a single API. NodeTool exposes each AtlasCloud model as a node you can compose with the rest of your graph.",
+      "AtlasCloud serves chat, image and video models through a single API. NodeTool exposes each image and video model as a node, and AtlasCloud's LLMs appear in the regular model picker alongside every other chat provider.",
       "Wire an AtlasCloud image model into a video model, add an upscaler, and you have a repeatable pipeline you can re-run and share. Swapping AtlasCloud for another provider is a single node change.",
       "AtlasCloud is BYOK: NodeTool calls it with your `ATLASCLOUD_API_KEY` at their list price. The catalog below comes from AtlasCloud's node manifest.",
     ],
-    strengths: ["Image", "Video"],
+    strengths: ["Chat", "Image", "Video"],
     faq: [
       {
         q: "How do I use AtlasCloud in NodeTool?",
-        a: "Store your key as `ATLASCLOUD_API_KEY` in NodeTool settings. AtlasCloud nodes then call the API directly.",
+        a: "Store your key as `ATLASCLOUD_API_KEY` in NodeTool settings. AtlasCloud nodes then call the API directly, and its chat models show up in the model picker.",
       },
       {
         q: "Which AtlasCloud models are supported?",
-        a: "The image and video models in AtlasCloud's node manifest, each a separate node. See the catalog below.",
+        a: "Every chat model AtlasCloud lists on its OpenAI-compatible endpoint, plus the image and video models in AtlasCloud's node manifest. See the catalog below.",
       },
       {
         q: "Does NodeTool add a markup?",

--- a/packages/atlascloud-nodes/AGENTS.md
+++ b/packages/atlascloud-nodes/AGENTS.md
@@ -29,3 +29,14 @@ Package specifics from shipped fixes:
   `array: true`.
 - **Don't expose an API option that yields an extra output** the single-output
   node can't surface (the `return_last_frame` Seedance option was dropped).
+- **The manifest is generated, not hand-edited.** `node
+  scripts/sync-atlascloud-manifest.mjs` reconciles every entry's fields against
+  the `Input` schema AtlasCloud publishes for that model (reachable from the
+  unauthenticated catalog at `GET /api/v1/models`); `--check` reports drift
+  without writing. Hand-tuned enums, wrong separators (`1024x1024` vs
+  `1024*1024`) and stale option lists are what the script exists to prevent. Add
+  a *model* by hand — the script only maintains the fields of models we ship.
+- **Chat is not a node concern.** AtlasCloud's LLMs are OpenAI-compatible at
+  `https://api.atlascloud.ai/v1` and are served by `AtlasCloudProvider` in
+  `packages/runtime`, which extends `OpenAICompatProvider`. Only the async
+  prediction API (image/video) lives in this package.

--- a/packages/atlascloud-nodes/README.md
+++ b/packages/atlascloud-nodes/README.md
@@ -2,7 +2,15 @@
 
 AtlasCloud.ai nodes for [NodeTool](https://nodetool.ai).
 
-Run [AtlasCloud](https://atlascloud.ai) models inside NodeTool workflows: ByteDance Seedance 2.0 video generation (text-to-video, image-to-video, reference-to-video) with native audio, plus GPT Image 2, Nano Banana 2, and Nano Banana Pro image generation and editing.
+Run [AtlasCloud](https://www.atlascloud.ai) image and video models inside NodeTool
+workflows — GPT Image, Nano Banana, Seedream, Qwen Image and Wan for images;
+Seedance, Veo, Kling, Wan, HappyHorse and Grok Imagine for video.
+
+Node fields are generated from AtlasCloud's published model schemas. Re-sync them
+with `node scripts/sync-atlascloud-manifest.mjs` (or `--check` to detect drift).
+
+AtlasCloud's chat models are not nodes — they come through the `atlascloud`
+model provider, so they show up in the regular LLM model picker.
 
 ## Install
 
@@ -12,22 +20,78 @@ npm install @nodetool-ai/atlascloud-nodes
 
 ## Nodes
 
-| Node | Type | Description |
-| --- | --- | --- |
-| Seedance 2.0 — Text to Video | `atlascloud.video.Seedance2TextToVideo` | Generate video from text with native audio. |
-| Seedance 2.0 — Image to Video | `atlascloud.video.Seedance2ImageToVideo` | Animate a still image into video. |
-| Seedance 2.0 — Reference to Video | `atlascloud.video.Seedance2ReferenceToVideo` | Generate video from reference frames. |
-| Seedance 2.0 Fast — Text to Video | `atlascloud.video.Seedance2FastTextToVideo` | Faster text-to-video. |
-| Seedance 2.0 Fast — Image to Video | `atlascloud.video.Seedance2FastImageToVideo` | Faster image-to-video. |
-| Seedance 2.0 Fast — Reference to Video | `atlascloud.video.Seedance2FastReferenceToVideo` | Faster reference-to-video. |
-| GPT Image 2 — Text to Image | `atlascloud.image.GPTImage2TextToImage` | Generate images from text. |
-| GPT Image 2 — Edit | `atlascloud.image.GPTImage2Edit` | Edit an image from a prompt. |
-| Nano Banana 2 — Text to Image | `atlascloud.image.NanoBanana2TextToImage` | Generate images from text. |
-| Nano Banana 2 — Edit | `atlascloud.image.NanoBanana2Edit` | Edit an image from a prompt. |
-| Nano Banana Pro — Text to Image | `atlascloud.image.NanoBananaProTextToImage` | Generate images from text. |
-| Nano Banana Pro — Edit | `atlascloud.image.NanoBananaProEdit` | Edit an image from a prompt. |
-| Nano Banana Pro — Text to Image (Ultra) | `atlascloud.image.NanoBananaProTextToImageUltra` | Higher-quality text-to-image. |
-| Nano Banana Pro — Edit (Ultra) | `atlascloud.image.NanoBananaProEditUltra` | Higher-quality image edit. |
+| Node | Type |
+| --- | --- |
+| GPT Image 1.5 — Edit | `atlascloud.image.GPTImage15Edit` |
+| GPT Image 1.5 — Text to Image | `atlascloud.image.GPTImage15TextToImage` |
+| GPT Image 2 — Edit | `atlascloud.image.GPTImage2Edit` |
+| GPT Image 2 — Text to Image | `atlascloud.image.GPTImage2TextToImage` |
+| Grok Imagine Image Quality — Edit | `atlascloud.image.GrokImagineImageQualityEdit` |
+| Grok Imagine Image Quality — Text to Image | `atlascloud.image.GrokImagineImageQualityTextToImage` |
+| MAI Image 2.5 — Edit | `atlascloud.image.MaiImage25Edit` |
+| MAI Image 2.5 — Text to Image | `atlascloud.image.MaiImage25TextToImage` |
+| MAI Image 2.5 Flash — Text to Image | `atlascloud.image.MaiImage25FlashTextToImage` |
+| Nano Banana 2 — Edit | `atlascloud.image.NanoBanana2Edit` |
+| Nano Banana 2 — Text to Image | `atlascloud.image.NanoBanana2TextToImage` |
+| Nano Banana 2 Lite — Edit | `atlascloud.image.NanoBanana2LiteEdit` |
+| Nano Banana 2 Lite — Text to Image | `atlascloud.image.NanoBanana2LiteTextToImage` |
+| Nano Banana Pro — Edit | `atlascloud.image.NanoBananaProEdit` |
+| Nano Banana Pro — Edit (Ultra) | `atlascloud.image.NanoBananaProEditUltra` |
+| Nano Banana Pro — Text to Image | `atlascloud.image.NanoBananaProTextToImage` |
+| Nano Banana Pro — Text to Image (Ultra) | `atlascloud.image.NanoBananaProTextToImageUltra` |
+| Qwen Image 2.0 — Edit | `atlascloud.image.QwenImage2Edit` |
+| Qwen Image 2.0 — Text to Image | `atlascloud.image.QwenImage2TextToImage` |
+| Qwen Image 2.0 Pro — Edit | `atlascloud.image.QwenImage2ProEdit` |
+| Qwen Image 2.0 Pro — Text to Image | `atlascloud.image.QwenImage2ProTextToImage` |
+| Seedream v5.0 Lite — Edit | `atlascloud.image.SeedreamV5LiteEdit` |
+| Seedream v5.0 Lite — Text to Image | `atlascloud.image.SeedreamV5LiteTextToImage` |
+| Seedream v5.0 Pro — Edit | `atlascloud.image.SeedreamV5ProEdit` |
+| Seedream v5.0 Pro — Text to Image | `atlascloud.image.SeedreamV5ProTextToImage` |
+| Wan 2.7 — Image Edit | `atlascloud.image.Wan27ImageEdit` |
+| Wan 2.7 — Text to Image | `atlascloud.image.Wan27TextToImage` |
+| Wan 2.7 Pro — Image Edit | `atlascloud.image.Wan27ProImageEdit` |
+| Wan 2.7 Pro — Text to Image | `atlascloud.image.Wan27ProTextToImage` |
+| Youchuan v8.1 — Blend | `atlascloud.image.YouchuanV81Blend` |
+| Youchuan v8.1 — Image to Image | `atlascloud.image.YouchuanV81ImageToImage` |
+| Youchuan v8.1 — Remove Background | `atlascloud.image.YouchuanV81RemoveBackground` |
+| Youchuan v8.1 — Style Transfer | `atlascloud.image.YouchuanV81StyleTransfer` |
+| Youchuan v8.1 — Text to Image | `atlascloud.image.YouchuanV81TextToImage` |
+| Z-Image Turbo — Text to Image | `atlascloud.image.ZImageTurboTextToImage` |
+| Avatar Omni Human 1.5 — Audio to Video | `atlascloud.video.AvatarOmniHuman15` |
+| Gemini Omni Flash — Image to Video | `atlascloud.video.GeminiOmniFlashImageToVideo` |
+| Gemini Omni Flash — Reference to Video | `atlascloud.video.GeminiOmniFlashReferenceToVideo` |
+| Gemini Omni Flash — Text to Video | `atlascloud.video.GeminiOmniFlashTextToVideo` |
+| Gemini Omni Flash — Video Edit | `atlascloud.video.GeminiOmniFlashVideoEdit` |
+| Grok Imagine Video v1.5 — Image to Video | `atlascloud.video.GrokImagineVideo15ImageToVideo` |
+| HappyHorse 1.1 — Image to Video | `atlascloud.video.HappyHorse11ImageToVideo` |
+| HappyHorse 1.1 — Reference to Video | `atlascloud.video.HappyHorse11ReferenceToVideo` |
+| HappyHorse 1.1 — Text to Video | `atlascloud.video.HappyHorse11TextToVideo` |
+| Kling v3.0 Pro — Image to Video | `atlascloud.video.KlingV3ProImageToVideo` |
+| Kling v3.0 Pro — Text to Video | `atlascloud.video.KlingV3ProTextToVideo` |
+| Kling v3.0 Std — Image to Video | `atlascloud.video.KlingV3StdImageToVideo` |
+| Kling v3.0 Std — Text to Video | `atlascloud.video.KlingV3StdTextToVideo` |
+| Kling v3.0 Turbo — Image to Video | `atlascloud.video.KlingV3TurboImageToVideo` |
+| Kling v3.0 Turbo — Text to Video | `atlascloud.video.KlingV3TurboTextToVideo` |
+| Kling Video O3 4K — Image to Video | `atlascloud.video.KlingVideoO34kImageToVideo` |
+| Kling Video O3 4K — Text to Video | `atlascloud.video.KlingVideoO34kTextToVideo` |
+| Seedance 2.0 — Image to Video | `atlascloud.video.Seedance2ImageToVideo` |
+| Seedance 2.0 — Reference to Video | `atlascloud.video.Seedance2ReferenceToVideo` |
+| Seedance 2.0 — Text to Video | `atlascloud.video.Seedance2TextToVideo` |
+| Seedance 2.0 Fast — Image to Video | `atlascloud.video.Seedance2FastImageToVideo` |
+| Seedance 2.0 Fast — Reference to Video | `atlascloud.video.Seedance2FastReferenceToVideo` |
+| Seedance 2.0 Fast — Text to Video | `atlascloud.video.Seedance2FastTextToVideo` |
+| Seedance 2.0 Mini — Image to Video | `atlascloud.video.Seedance2MiniImageToVideo` |
+| Seedance 2.0 Mini — Reference to Video | `atlascloud.video.Seedance2MiniReferenceToVideo` |
+| Seedance 2.0 Mini — Text to Video | `atlascloud.video.Seedance2MiniTextToVideo` |
+| Veo 3.1 — Image to Video | `atlascloud.video.Veo31ImageToVideo` |
+| Veo 3.1 — Text to Video | `atlascloud.video.Veo31TextToVideo` |
+| Veo 3.1 Fast — Image to Video | `atlascloud.video.Veo31FastImageToVideo` |
+| Veo 3.1 Fast — Text to Video | `atlascloud.video.Veo31FastTextToVideo` |
+| Veo 3.1 Lite — Image to Video | `atlascloud.video.Veo31LiteImageToVideo` |
+| Veo 3.1 Lite — Text to Video | `atlascloud.video.Veo31LiteTextToVideo` |
+| Wan 2.7 — Image to Video | `atlascloud.video.Wan27ImageToVideo` |
+| Wan 2.7 — Text to Video | `atlascloud.video.Wan27TextToVideo` |
+| Youchuan v8.1 — Image to Video | `atlascloud.video.YouchuanV81ImageToVideo` |
 
 ## Configuration
 
@@ -36,4 +100,5 @@ Set `ATLASCLOUD_API_KEY` in NodeTool's secret store (Settings → API Keys) or a
 ## Links
 
 - [NodeTool](https://nodetool.ai)
+- [AtlasCloud docs](https://www.atlascloud.ai/docs/get-started)
 - [GitHub](https://github.com/nodetool-ai/nodetool)

--- a/packages/atlascloud-nodes/src/atlascloud-manifest.json
+++ b/packages/atlascloud-nodes/src/atlascloud-manifest.json
@@ -5,8 +5,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0/text-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 \u2014 Text to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 \u2014 generates video from text with native audio. Supports adaptive aspect ratio.",
+    "title": "Seedance 2.0 — Text to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 — generates video from text with native audio. Supports adaptive aspect ratio.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -51,13 +51,14 @@
           "720p-SR",
           "1080p",
           "1080p-SR",
-          "1440p-SR"
+          "1440p-SR",
+          "4k"
         ]
       },
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -78,17 +79,30 @@
         "description": "Native synchronized audio (voice, sound effects, music)."
       },
       {
-        "name": "web_search",
-        "type": "bool",
-        "default": false,
-        "title": "Web Search",
-        "description": "Use web search to ground generation in real-time info."
-      },
-      {
         "name": "watermark",
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -98,8 +112,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0/image-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 \u2014 Image to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 \u2014 generates video from a first-frame image (and optional last frame) with native audio.",
+    "title": "Seedance 2.0 — Image to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 — generates video from a first-frame image (and optional last frame) with native audio.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -159,13 +173,14 @@
           "720p-SR",
           "1080p",
           "1080p-SR",
-          "1440p-SR"
+          "1440p-SR",
+          "4k"
         ]
       },
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -186,17 +201,30 @@
         "description": "Native synchronized audio (voice, sound effects, music)."
       },
       {
-        "name": "web_search",
-        "type": "bool",
-        "default": false,
-        "title": "Web Search",
-        "description": "Use web search to ground generation in real-time info."
-      },
-      {
         "name": "watermark",
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -206,8 +234,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-fast/text-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Fast \u2014 Text to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast \u2014 accelerated T2V with native audio.",
+    "title": "Seedance 2.0 Fast — Text to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast — accelerated T2V with native audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -257,7 +285,7 @@
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -278,17 +306,30 @@
         "description": "Native synchronized audio (voice, sound effects, music)."
       },
       {
-        "name": "web_search",
-        "type": "bool",
-        "default": false,
-        "title": "Web Search",
-        "description": "Use web search to ground generation in real-time info."
-      },
-      {
         "name": "watermark",
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -298,8 +339,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-fast/image-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Fast \u2014 Image to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast \u2014 accelerated I2V from a first-frame image with native audio.",
+    "title": "Seedance 2.0 Fast — Image to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast — accelerated I2V from a first-frame image with native audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -364,7 +405,7 @@
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -385,17 +426,30 @@
         "description": "Native synchronized audio (voice, sound effects, music)."
       },
       {
-        "name": "web_search",
-        "type": "bool",
-        "default": false,
-        "title": "Web Search",
-        "description": "Use web search to ground generation in real-time info."
-      },
-      {
         "name": "watermark",
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -405,8 +459,8 @@
     "modality": "image",
     "modelId": "openai/gpt-image-2/text-to-image",
     "outputType": "image",
-    "title": "GPT Image 2 \u2014 Text to Image",
-    "description": "AtlasCloud / OpenAI GPT Image 2 \u2014 fast, cost-efficient text-to-image powered by GPT-5 guidance.",
+    "title": "GPT Image 2 — Text to Image",
+    "description": "AtlasCloud / OpenAI GPT Image 2 — fast, cost-efficient text-to-image powered by GPT-5 guidance.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -423,13 +477,18 @@
         "default": "1024x1024",
         "title": "Size",
         "values": [
+          "1024x1024",
           "1024x768",
           "768x1024",
-          "1024x1024",
           "1024x1536",
           "1536x1024",
-          "2560x1440",
-          "1440x2560",
+          "2048x2048",
+          "2048x1152",
+          "1152x2048",
+          "2560x1088",
+          "1088x2560",
+          "2880x2160",
+          "2160x2880",
           "3840x2160",
           "2160x3840"
         ]
@@ -474,8 +533,8 @@
     "modality": "image",
     "modelId": "openai/gpt-image-2/edit",
     "outputType": "image",
-    "title": "GPT Image 2 \u2014 Edit",
-    "description": "AtlasCloud / OpenAI GPT Image 2 \u2014 precise natural-language image editing (add/remove objects, retouch, swap backgrounds, etc.).",
+    "title": "GPT Image 2 — Edit",
+    "description": "AtlasCloud / OpenAI GPT Image 2 — precise natural-language image editing (add/remove objects, retouch, swap backgrounds, etc.).",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -501,10 +560,17 @@
         "title": "Size",
         "values": [
           "1024x1024",
+          "1024x768",
+          "768x1024",
           "1024x1536",
           "1536x1024",
           "2048x2048",
           "2048x1152",
+          "1152x2048",
+          "2560x1088",
+          "1088x2560",
+          "2880x2160",
+          "2160x2880",
           "3840x2160",
           "2160x3840"
         ]
@@ -548,8 +614,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-2/text-to-image",
     "outputType": "image",
-    "title": "Nano Banana 2 \u2014 Text to Image",
-    "description": "AtlasCloud / Google Nano Banana 2 \u2014 fast 4K-capable text-to-image with native text rendering.",
+    "title": "Nano Banana 2 — Text to Image",
+    "description": "AtlasCloud / Google Nano Banana 2 — fast 4K-capable text-to-image with native text rendering.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -647,8 +713,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-2/edit",
     "outputType": "image",
-    "title": "Nano Banana 2 \u2014 Edit",
-    "description": "AtlasCloud / Google Nano Banana 2 \u2014 guided-diffusion image editing (up to 14 input images).",
+    "title": "Nano Banana 2 — Edit",
+    "description": "AtlasCloud / Google Nano Banana 2 — guided-diffusion image editing (up to 14 input images).",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -754,8 +820,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0/reference-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 \u2014 Reference to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 multimodal \u2014 generates video from reference images, videos, and/or audio. Refer to inputs in your prompt as 'image 1', 'video 1', etc.",
+    "title": "Seedance 2.0 — Reference to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 multimodal — generates video from reference images, videos, and/or audio. Refer to inputs in your prompt as 'image 1', 'video 1', etc.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -820,13 +886,14 @@
           "720p-SR",
           "1080p",
           "1080p-SR",
-          "1440p-SR"
+          "1440p-SR",
+          "4k"
         ]
       },
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -850,6 +917,26 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -859,8 +946,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-fast/reference-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Fast \u2014 Reference to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast multimodal \u2014 accelerated multimodal video gen from reference images/videos/audio.",
+    "title": "Seedance 2.0 Fast — Reference to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Fast multimodal — accelerated multimodal video gen from reference images/videos/audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -930,7 +1017,7 @@
       {
         "name": "ratio",
         "type": "enum",
-        "default": "16:9",
+        "default": "adaptive",
         "title": "Aspect Ratio",
         "description": "Aspect ratio of the output video. 'adaptive' lets the API choose.",
         "values": [
@@ -954,6 +1041,26 @@
         "type": "bool",
         "default": false,
         "title": "Watermark"
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -963,8 +1070,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-pro/text-to-image",
     "outputType": "image",
-    "title": "Nano Banana Pro \u2014 Text to Image",
-    "description": "AtlasCloud / Google Nano Banana Pro \u2014 higher-quality T2I with optional web grounding.",
+    "title": "Nano Banana Pro — Text to Image",
+    "description": "AtlasCloud / Google Nano Banana Pro — higher-quality T2I with optional web grounding.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1041,8 +1148,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-pro/edit",
     "outputType": "image",
-    "title": "Nano Banana Pro \u2014 Edit",
-    "description": "AtlasCloud / Google Nano Banana Pro \u2014 higher-quality image editing with optional web grounding.",
+    "title": "Nano Banana Pro — Edit",
+    "description": "AtlasCloud / Google Nano Banana Pro — higher-quality image editing with optional web grounding.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1127,8 +1234,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-pro/text-to-image-ultra",
     "outputType": "image",
-    "title": "Nano Banana Pro \u2014 Text to Image (Ultra)",
-    "description": "AtlasCloud / Google Nano Banana Pro Ultra \u2014 4K/8K text-to-image.",
+    "title": "Nano Banana Pro — Text to Image (Ultra)",
+    "description": "AtlasCloud / Google Nano Banana Pro Ultra — 4K/8K text-to-image.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1185,8 +1292,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-pro/edit-ultra",
     "outputType": "image",
-    "title": "Nano Banana Pro \u2014 Edit (Ultra)",
-    "description": "AtlasCloud / Google Nano Banana Pro Ultra \u2014 4K/8K image editing.",
+    "title": "Nano Banana Pro — Edit (Ultra)",
+    "description": "AtlasCloud / Google Nano Banana Pro Ultra — 4K/8K image editing.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1251,8 +1358,8 @@
     "modality": "image",
     "modelId": "bytedance/seedream-v5.0-pro/text-to-image",
     "outputType": "image",
-    "title": "Seedream v5.0 Pro \u2014 Text to Image",
-    "description": "AtlasCloud / ByteDance Seedream v5.0 Pro \u2014 flagship next-generation text-to-image with stronger prompt adherence.",
+    "title": "Seedream v5.0 Pro — Text to Image",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Pro — flagship next-generation text-to-image with stronger prompt adherence.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1296,6 +1403,17 @@
           "jpeg",
           "png"
         ]
+      },
+      {
+        "name": "thinking",
+        "type": "enum",
+        "default": "enabled",
+        "title": "Thinking",
+        "description": "Controls the deep-thinking phase of automatic prompt optimization.",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
       }
     ]
   },
@@ -1305,8 +1423,8 @@
     "modality": "image",
     "modelId": "bytedance/seedream-v5.0-pro/edit",
     "outputType": "image",
-    "title": "Seedream v5.0 Pro \u2014 Edit",
-    "description": "AtlasCloud / ByteDance Seedream v5.0 Pro \u2014 professional image editing with up to 10 reference images, preserving identity, lighting, and color tones.",
+    "title": "Seedream v5.0 Pro — Edit",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Pro — professional image editing with up to 10 reference images, preserving identity, lighting, and color tones.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1358,6 +1476,17 @@
           "jpeg",
           "png"
         ]
+      },
+      {
+        "name": "thinking",
+        "type": "enum",
+        "default": "enabled",
+        "title": "Thinking",
+        "description": "Controls the deep-thinking phase of automatic prompt optimization.",
+        "values": [
+          "enabled",
+          "disabled"
+        ]
       }
     ]
   },
@@ -1367,8 +1496,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-2-lite/text-to-image",
     "outputType": "image",
-    "title": "Nano Banana 2 Lite \u2014 Text to Image",
-    "description": "AtlasCloud / Google Nano Banana 2 Lite \u2014 fast, cost-efficient 1K text-to-image with sub-2-second latency.",
+    "title": "Nano Banana 2 Lite — Text to Image",
+    "description": "AtlasCloud / Google Nano Banana 2 Lite — fast, cost-efficient 1K text-to-image with sub-2-second latency.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1434,8 +1563,8 @@
     "modality": "image",
     "modelId": "google/nano-banana-2-lite/edit",
     "outputType": "image",
-    "title": "Nano Banana 2 Lite \u2014 Edit",
-    "description": "AtlasCloud / Google Nano Banana 2 Lite \u2014 fast multi-turn local edits (up to 14 input images).",
+    "title": "Nano Banana 2 Lite — Edit",
+    "description": "AtlasCloud / Google Nano Banana 2 Lite — fast multi-turn local edits (up to 14 input images).",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1509,8 +1638,8 @@
     "modality": "image",
     "modelId": "microsoft/mai-image-2.5/text-to-image",
     "outputType": "image",
-    "title": "MAI Image 2.5 \u2014 Text to Image",
-    "description": "AtlasCloud / Microsoft MAI Image 2.5 \u2014 flagship high-quality text-to-image.",
+    "title": "MAI Image 2.5 — Text to Image",
+    "description": "AtlasCloud / Microsoft MAI Image 2.5 — flagship high-quality text-to-image.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1527,7 +1656,7 @@
         "type": "str",
         "default": "1024*1024",
         "title": "Size",
-        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720). Minimum 768. The product of width \u00d7 height must not exceed 1,049,088."
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720). Minimum 768. The product of width × height must not exceed 1,049,088."
       }
     ]
   },
@@ -1537,8 +1666,8 @@
     "modality": "image",
     "modelId": "microsoft/mai-image-2.5/edit",
     "outputType": "image",
-    "title": "MAI Image 2.5 \u2014 Edit",
-    "description": "AtlasCloud / Microsoft MAI Image 2.5 \u2014 natural-language-guided image editing.",
+    "title": "MAI Image 2.5 — Edit",
+    "description": "AtlasCloud / Microsoft MAI Image 2.5 — natural-language-guided image editing.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1566,8 +1695,8 @@
     "modality": "image",
     "modelId": "microsoft/mai-image-2.5-flash/text-to-image",
     "outputType": "image",
-    "title": "MAI Image 2.5 Flash \u2014 Text to Image",
-    "description": "AtlasCloud / Microsoft MAI Image 2.5 Flash \u2014 fast, cost-optimized text-to-image.",
+    "title": "MAI Image 2.5 Flash — Text to Image",
+    "description": "AtlasCloud / Microsoft MAI Image 2.5 Flash — fast, cost-optimized text-to-image.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1584,7 +1713,7 @@
         "type": "str",
         "default": "1024*1024",
         "title": "Size",
-        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720). Minimum 768. The product of width \u00d7 height must not exceed 1,049,088."
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720). Minimum 768. The product of width × height must not exceed 1,049,088."
       }
     ]
   },
@@ -1594,8 +1723,8 @@
     "modality": "image",
     "modelId": "youchuan/v8.1/text-to-image",
     "outputType": "image",
-    "title": "Youchuan v8.1 \u2014 Text to Image",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 generates four images per task with optional native 2K HD.",
+    "title": "Youchuan v8.1 — Text to Image",
+    "description": "AtlasCloud / Youchuan v8.1 — generates four images per task with optional native 2K HD.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1676,6 +1805,13 @@
           1,
           4
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and prompt to get reproducible results. -1 = random."
       }
     ]
   },
@@ -1685,8 +1821,8 @@
     "modality": "image",
     "modelId": "youchuan/v8.1/image-to-image",
     "outputType": "image",
-    "title": "Youchuan v8.1 \u2014 Image to Image",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 re-imagines an input image with text guidance; returns four images.",
+    "title": "Youchuan v8.1 — Image to Image",
+    "description": "AtlasCloud / Youchuan v8.1 — re-imagines an input image with text guidance; returns four images.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1775,6 +1911,13 @@
           1,
           4
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and inputs to get reproducible results. -1 = random."
       }
     ]
   },
@@ -1784,8 +1927,8 @@
     "modality": "image",
     "modelId": "youchuan/v8.1/remove-background",
     "outputType": "image",
-    "title": "Youchuan v8.1 \u2014 Remove Background",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 automatic background removal.",
+    "title": "Youchuan v8.1 — Remove Background",
+    "description": "AtlasCloud / Youchuan v8.1 — automatic background removal.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1805,8 +1948,8 @@
     "modality": "image",
     "modelId": "youchuan/v8.1/style-transfer",
     "outputType": "image",
-    "title": "Youchuan v8.1 \u2014 Style Transfer",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 applies an artistic style described in the prompt to an input image.",
+    "title": "Youchuan v8.1 — Style Transfer",
+    "description": "AtlasCloud / Youchuan v8.1 — applies an artistic style described in the prompt to an input image.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1834,8 +1977,8 @@
     "modality": "image",
     "modelId": "youchuan/v8.1/blend",
     "outputType": "image",
-    "title": "Youchuan v8.1 \u2014 Blend",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 fuses 2-5 input images into blended results.",
+    "title": "Youchuan v8.1 — Blend",
+    "description": "AtlasCloud / Youchuan v8.1 — fuses 2-5 input images into blended results.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -1916,6 +2059,13 @@
           1,
           4
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and inputs to get reproducible results. -1 = random."
       }
     ]
   },
@@ -1925,8 +2075,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-mini/text-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Mini \u2014 Text to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini \u2014 lightweight text-to-video with native audio.",
+    "title": "Seedance 2.0 Mini — Text to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini — lightweight text-to-video with native audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2003,6 +2153,26 @@
         "default": false,
         "title": "Watermark",
         "description": "Whether to add a watermark."
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -2012,8 +2182,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-mini/image-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Mini \u2014 Image to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini \u2014 lightweight first/last-frame animation with native audio.",
+    "title": "Seedance 2.0 Mini — Image to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini — lightweight first/last-frame animation with native audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2104,6 +2274,26 @@
         "default": false,
         "title": "Watermark",
         "description": "Whether to add a watermark."
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -2113,8 +2303,8 @@
     "modality": "video",
     "modelId": "bytedance/seedance-2.0-mini/reference-to-video",
     "outputType": "video",
-    "title": "Seedance 2.0 Mini \u2014 Reference to Video",
-    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini multimodal \u2014 generates video from reference images, videos, and/or audio. Refer to inputs in your prompt as 'image 1', 'video 1', etc.",
+    "title": "Seedance 2.0 Mini — Reference to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.0 Mini multimodal — generates video from reference images, videos, and/or audio. Refer to inputs in your prompt as 'image 1', 'video 1', etc.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2211,6 +2401,26 @@
         "default": false,
         "title": "Watermark",
         "description": "Whether to add a watermark."
+      },
+      {
+        "name": "bitrate_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Bitrate Mode",
+        "description": "Output video bitrate mode. 'high' encodes at a higher bitrate for a crisper, larger file; 'standard' uses the normal bitrate. Does not affect token cost.",
+        "values": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Seed integer used to control the randomness of generated content. Value range: [-1, 2^32-1]. The default -1 means a random seed is used.",
+        "min": -1,
+        "max": 4294967295
       }
     ]
   },
@@ -2220,8 +2430,8 @@
     "modality": "video",
     "modelId": "alibaba/happyhorse-1.1/text-to-video",
     "outputType": "video",
-    "title": "HappyHorse 1.1 \u2014 Text to Video",
-    "description": "AtlasCloud / Alibaba HappyHorse 1.1 \u2014 720P/1080P text-to-video, 3-15 second durations.",
+    "title": "HappyHorse 1.1 — Text to Video",
+    "description": "AtlasCloud / Alibaba HappyHorse 1.1 — 720P/1080P text-to-video, 3-15 second durations.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2270,6 +2480,15 @@
         "description": "Video duration in seconds.",
         "min": 3,
         "max": 15
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
       }
     ]
   },
@@ -2279,8 +2498,8 @@
     "modality": "video",
     "modelId": "alibaba/happyhorse-1.1/image-to-video",
     "outputType": "video",
-    "title": "HappyHorse 1.1 \u2014 Image to Video",
-    "description": "AtlasCloud / Alibaba HappyHorse 1.1 \u2014 animates a first-frame image into a 3-15 second video.",
+    "title": "HappyHorse 1.1 — Image to Video",
+    "description": "AtlasCloud / Alibaba HappyHorse 1.1 — animates a first-frame image into a 3-15 second video.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2318,6 +2537,15 @@
         "description": "Video duration in seconds.",
         "min": 3,
         "max": 15
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
       }
     ]
   },
@@ -2327,8 +2555,8 @@
     "modality": "video",
     "modelId": "alibaba/happyhorse-1.1/reference-to-video",
     "outputType": "video",
-    "title": "HappyHorse 1.1 \u2014 Reference to Video",
-    "description": "AtlasCloud / Alibaba HappyHorse 1.1 \u2014 generates video from 1-9 reference images with a text prompt.",
+    "title": "HappyHorse 1.1 — Reference to Video",
+    "description": "AtlasCloud / Alibaba HappyHorse 1.1 — generates video from 1-9 reference images with a text prompt.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2385,6 +2613,15 @@
         "description": "Video duration in seconds.",
         "min": 3,
         "max": 15
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
       }
     ]
   },
@@ -2394,8 +2631,8 @@
     "modality": "video",
     "modelId": "google/gemini-omni-flash/text-to-video",
     "outputType": "video",
-    "title": "Gemini Omni Flash \u2014 Text to Video",
-    "description": "AtlasCloud / Google Gemini Omni Flash \u2014 cinematic text-to-video with synchronized native audio.",
+    "title": "Gemini Omni Flash — Text to Video",
+    "description": "AtlasCloud / Google Gemini Omni Flash — cinematic text-to-video with synchronized native audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2448,6 +2685,13 @@
           "high",
           "low"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
       }
     ]
   },
@@ -2457,8 +2701,8 @@
     "modality": "video",
     "modelId": "google/gemini-omni-flash/image-to-video",
     "outputType": "video",
-    "title": "Gemini Omni Flash \u2014 Image to Video",
-    "description": "AtlasCloud / Google Gemini Omni Flash \u2014 cinematic animation from an input image, preserving subjects.",
+    "title": "Gemini Omni Flash — Image to Video",
+    "description": "AtlasCloud / Google Gemini Omni Flash — cinematic animation from an input image, preserving subjects.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2519,6 +2763,13 @@
           "high",
           "low"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
       }
     ]
   },
@@ -2528,8 +2779,8 @@
     "modality": "video",
     "modelId": "google/gemini-omni-flash/reference-to-video",
     "outputType": "video",
-    "title": "Gemini Omni Flash \u2014 Reference to Video",
-    "description": "AtlasCloud / Google Gemini Omni Flash \u2014 video generation from 1-5 reference images, maintaining subject consistency.",
+    "title": "Gemini Omni Flash — Reference to Video",
+    "description": "AtlasCloud / Google Gemini Omni Flash — video generation from 1-5 reference images, maintaining subject consistency.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2590,6 +2841,13 @@
           "high",
           "low"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
       }
     ]
   },
@@ -2599,8 +2857,8 @@
     "modality": "video",
     "modelId": "google/gemini-omni-flash/video-edit",
     "outputType": "video",
-    "title": "Gemini Omni Flash \u2014 Video Edit",
-    "description": "AtlasCloud / Google Gemini Omni Flash \u2014 edits an existing video from a text prompt with optional reference images.",
+    "title": "Gemini Omni Flash — Video Edit",
+    "description": "AtlasCloud / Google Gemini Omni Flash — edits an existing video from a text prompt with optional reference images.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2648,6 +2906,13 @@
           "high",
           "low"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
       }
     ]
   },
@@ -2657,8 +2922,8 @@
     "modality": "video",
     "modelId": "bytedance/avatar-omni-human-v1.5",
     "outputType": "video",
-    "title": "Avatar Omni Human 1.5 \u2014 Audio to Video",
-    "description": "AtlasCloud / ByteDance Omni Human 1.5 \u2014 digital-human video from a portrait image and driving audio, with lip-sync and natural gestures.",
+    "title": "Avatar Omni Human 1.5 — Audio to Video",
+    "description": "AtlasCloud / ByteDance Omni Human 1.5 — digital-human video from a portrait image and driving audio, with lip-sync and natural gestures.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2674,7 +2939,7 @@
         "type": "image",
         "default": null,
         "title": "Portrait Image",
-        "description": "URL of the reference portrait image \u2014 a clear, front-facing face works best",
+        "description": "URL of the reference portrait image — a clear, front-facing face works best",
         "required": true
       },
       {
@@ -2695,6 +2960,13 @@
           720,
           1080
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed; -1 for random"
       }
     ]
   },
@@ -2704,8 +2976,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-turbo/text-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Turbo \u2014 Text to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Turbo \u2014 dynamic cinematic text-to-video.",
+    "title": "Kling v3.0 Turbo — Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Turbo — dynamic cinematic text-to-video.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2770,8 +3042,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-turbo/image-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Turbo \u2014 Image to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Turbo \u2014 image-to-video animation built on MVL technology.",
+    "title": "Kling v3.0 Turbo — Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Turbo — image-to-video animation built on MVL technology.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -2787,7 +3059,7 @@
         "type": "image",
         "default": null,
         "title": "Image",
-        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of\u2026",
+        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of…",
         "required": true
       },
       {
@@ -2831,8 +3103,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-video-o3-4k/text-to-video",
     "outputType": "video",
-    "title": "Kling Video O3 4K \u2014 Text to Video",
-    "description": "AtlasCloud / KwaiVGI Kling Video O3 4K \u2014 high-quality 4K text-to-video with optional audio.",
+    "title": "Kling Video O3 4K — Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling Video O3 4K — high-quality 4K text-to-video with optional audio.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2890,6 +3162,17 @@
         "default": false,
         "title": "Multi-Shot",
         "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
       }
     ]
   },
@@ -2899,8 +3182,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-video-o3-4k/image-to-video",
     "outputType": "video",
-    "title": "Kling Video O3 4K \u2014 Image to Video",
-    "description": "AtlasCloud / KwaiVGI Kling Video O3 4K \u2014 4K cinematic image-to-video with optional end frame and audio.",
+    "title": "Kling Video O3 4K — Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling Video O3 4K — 4K cinematic image-to-video with optional end frame and audio.",
     "pollInterval": 5000,
     "maxAttempts": 600,
     "fields": [
@@ -2961,6 +3244,17 @@
         "default": false,
         "title": "Multi-Shot",
         "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
       }
     ]
   },
@@ -2970,8 +3264,8 @@
     "modality": "video",
     "modelId": "youchuan/v8.1/image-to-video",
     "outputType": "video",
-    "title": "Youchuan v8.1 \u2014 Image to Video",
-    "description": "AtlasCloud / Youchuan v8.1 \u2014 four 5-second videos per task at 480p/720p from an input image.",
+    "title": "Youchuan v8.1 — Image to Video",
+    "description": "AtlasCloud / Youchuan v8.1 — four 5-second videos per task at 480p/720p from an input image.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3020,8 +3314,8 @@
     "modality": "video",
     "modelId": "alibaba/wan-2.7/text-to-video",
     "outputType": "video",
-    "title": "Wan 2.7 \u2014 Text to Video",
-    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 generates video from text with multi-shot narrative, audio generation, and sound-image synchronization.",
+    "title": "Wan 2.7 — Text to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — generates video from text with multi-shot narrative, audio generation, and sound-image synchronization.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3045,14 +3339,14 @@
         "type": "audio",
         "default": null,
         "title": "Audio (optional)",
-        "description": "URL of an audio file to use as the video soundtrack. Supported formats: wav, mp3. Duration: 2\u201330 seconds. Maximum file size: 15 MB. The alias `audio_url` is also accepted."
+        "description": "URL of an audio file to use as the video soundtrack. Supported formats: wav, mp3. Duration: 2–30 seconds. Maximum file size: 15 MB. The alias `audio_url` is also accepted."
       },
       {
         "name": "resolution",
         "type": "enum",
         "default": "1080P",
         "title": "Resolution",
-        "description": "Output video resolution. 720P and 1080P are native Wan 2.7 outputs. Choose 1080P-SR for sharper HD detail, cleaner edges, and better texture retention. For the same duration, 1080P\u2026",
+        "description": "Output video resolution. 720P and 1080P are native Wan 2.7 outputs. Choose 1080P-SR for sharper HD detail, cleaner edges, and better texture retention. For the same duration, 1080P…",
         "values": [
           "720P",
           "1080P",
@@ -3107,8 +3401,8 @@
     "modality": "video",
     "modelId": "alibaba/wan-2.7/image-to-video",
     "outputType": "video",
-    "title": "Wan 2.7 \u2014 Image to Video",
-    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 animates images into video with first-frame, first-and-last-frame, video continuation, and audio-driven modes.",
+    "title": "Wan 2.7 — Image to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — animates images into video with first-frame, first-and-last-frame, video continuation, and audio-driven modes.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3131,28 +3425,28 @@
         "type": "image",
         "default": null,
         "title": "Image",
-        "description": "First-frame image URL for image-based generation modes. The video starts from this image. Supported formats: JPEG, JPG, PNG (transparent channel not supported), BMP, WEBP. Width an\u2026"
+        "description": "First-frame image URL for image-based generation modes. The video starts from this image. Supported formats: JPEG, JPG, PNG (transparent channel not supported), BMP, WEBP. Width an…"
       },
       {
         "name": "last_image",
         "type": "image",
         "default": null,
         "title": "Last Frame (optional)",
-        "description": "Last-frame image URL for end-frame control. Use it with `image` to generate a start-to-end transition, or with `video` to continue a clip toward a target ending frame. Supported fo\u2026"
+        "description": "Last-frame image URL for end-frame control. Use it with `image` to generate a start-to-end transition, or with `video` to continue a clip toward a target ending frame. Supported fo…"
       },
       {
         "name": "video",
         "type": "video",
         "default": null,
         "title": "Video (optional)",
-        "description": "Video clip URL for video continuation modes. The model extends the content of this clip. `last_image` can be added for end-frame control. Supported formats: mp4, mov. Duration: 2\u20131\u2026"
+        "description": "Video clip URL for video continuation modes. The model extends the content of this clip. `last_image` can be added for end-frame control. Supported formats: mp4, mov. Duration: 2–1…"
       },
       {
         "name": "audio",
         "type": "audio",
         "default": null,
         "title": "Audio (optional)",
-        "description": "Driving audio URL for image-based generation modes. The model uses this audio to drive lip-sync or action-matched video generation. Supported only with `image`, or with `image` and\u2026"
+        "description": "Driving audio URL for image-based generation modes. The model uses this audio to drive lip-sync or action-matched video generation. Supported only with `image`, or with `image` and…"
       },
       {
         "name": "resolution",
@@ -3198,8 +3492,8 @@
     "modality": "image",
     "modelId": "alibaba/wan-2.7/text-to-image",
     "outputType": "image",
-    "title": "Wan 2.7 \u2014 Text to Image",
-    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 fast text-to-image with strong prompt fidelity for illustration and photorealistic outputs.",
+    "title": "Wan 2.7 — Text to Image",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — fast text-to-image with strong prompt fidelity for illustration and photorealistic outputs.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3255,8 +3549,8 @@
     "modality": "image",
     "modelId": "alibaba/wan-2.7/image-edit",
     "outputType": "image",
-    "title": "Wan 2.7 \u2014 Image Edit",
-    "description": "AtlasCloud / Alibaba Wan 2.7 \u2014 edits and recomposes images from text instructions with multi-image references.",
+    "title": "Wan 2.7 — Image Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — edits and recomposes images from text instructions with multi-image references.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3320,8 +3614,8 @@
     "modality": "image",
     "modelId": "alibaba/wan-2.7-pro/text-to-image",
     "outputType": "image",
-    "title": "Wan 2.7 Pro \u2014 Text to Image",
-    "description": "AtlasCloud / Alibaba Wan 2.7 Pro \u2014 higher-fidelity text-to-image with 4K-ready output.",
+    "title": "Wan 2.7 Pro — Text to Image",
+    "description": "AtlasCloud / Alibaba Wan 2.7 Pro — higher-fidelity text-to-image with 4K-ready output.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3378,8 +3672,8 @@
     "modality": "image",
     "modelId": "alibaba/wan-2.7-pro/image-edit",
     "outputType": "image",
-    "title": "Wan 2.7 Pro \u2014 Image Edit",
-    "description": "AtlasCloud / Alibaba Wan 2.7 Pro \u2014 higher-quality image editing from text instructions with multi-image references.",
+    "title": "Wan 2.7 Pro — Image Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.7 Pro — higher-quality image editing from text instructions with multi-image references.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3443,8 +3737,8 @@
     "modality": "video",
     "modelId": "google/veo3.1/text-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 \u2014 Text to Video",
-    "description": "AtlasCloud / Google Veo 3.1 \u2014 cinematic text-to-video with dynamic camera motion, lifelike detail, and optional audio.",
+    "title": "Veo 3.1 — Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 — cinematic text-to-video with dynamic camera motion, lifelike detail, and optional audio.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3474,9 +3768,9 @@
         "title": "Duration (seconds)",
         "description": "The duration of the generated media in seconds.",
         "values": [
+          8,
           4,
-          6,
-          8
+          6
         ]
       },
       {
@@ -3520,8 +3814,8 @@
     "modality": "video",
     "modelId": "google/veo3.1/image-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 \u2014 Image to Video",
-    "description": "AtlasCloud / Google Veo 3.1 \u2014 animates a first (and optional last) frame into cinematic video with realistic continuity and sound.",
+    "title": "Veo 3.1 — Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 — animates a first (and optional last) frame into cinematic video with realistic continuity and sound.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3566,9 +3860,9 @@
         "title": "Duration (seconds)",
         "description": "The duration of the generated media in seconds.",
         "values": [
+          8,
           4,
-          6,
-          8
+          6
         ]
       },
       {
@@ -3612,8 +3906,8 @@
     "modality": "video",
     "modelId": "google/veo3.1-fast/text-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 Fast \u2014 Text to Video",
-    "description": "AtlasCloud / Google Veo 3.1 Fast \u2014 speed-optimized text-to-video for rapid creative iteration.",
+    "title": "Veo 3.1 Fast — Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Fast — speed-optimized text-to-video for rapid creative iteration.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3643,9 +3937,9 @@
         "title": "Duration (seconds)",
         "description": "The duration of the generated media in seconds.",
         "values": [
+          8,
           4,
-          6,
-          8
+          6
         ]
       },
       {
@@ -3689,8 +3983,8 @@
     "modality": "video",
     "modelId": "google/veo3.1-fast/image-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 Fast \u2014 Image to Video",
-    "description": "AtlasCloud / Google Veo 3.1 Fast \u2014 speed-optimized image-to-video for fast previews and iteration.",
+    "title": "Veo 3.1 Fast — Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Fast — speed-optimized image-to-video for fast previews and iteration.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3735,9 +4029,9 @@
         "title": "Duration (seconds)",
         "description": "The duration of the generated media in seconds.",
         "values": [
+          8,
           4,
-          6,
-          8
+          6
         ]
       },
       {
@@ -3781,8 +4075,8 @@
     "modality": "video",
     "modelId": "google/veo3.1-lite/text-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 Lite \u2014 Text to Video",
-    "description": "AtlasCloud / Google Veo 3.1 Lite \u2014 cost-efficient text-to-video with synchronized audio at 720p/1080p.",
+    "title": "Veo 3.1 Lite — Text to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Lite — cost-efficient text-to-video with synchronized audio at 720p/1080p.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3843,8 +4137,8 @@
     "modality": "video",
     "modelId": "google/veo3.1-lite/image-to-video",
     "outputType": "video",
-    "title": "Veo 3.1 Lite \u2014 Image to Video",
-    "description": "AtlasCloud / Google Veo 3.1 Lite \u2014 cost-efficient image-to-video with synchronized audio at 720p/1080p.",
+    "title": "Veo 3.1 Lite — Image to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Lite — cost-efficient image-to-video with synchronized audio at 720p/1080p.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -3861,7 +4155,7 @@
         "type": "image",
         "default": null,
         "title": "Image",
-        "description": "Initial image to animate (instance image). Accepts a public image URL, a data URL, or raw base64-encoded image bytes (e.g. PNG/JPEG inline data). Input image up to 8MB per Veo 3.1\u2026",
+        "description": "Initial image to animate (instance image). Accepts a public image URL, a data URL, or raw base64-encoded image bytes (e.g. PNG/JPEG inline data). Input image up to 8MB per Veo 3.1…",
         "required": true
       },
       {
@@ -3913,8 +4207,8 @@
     "modality": "image",
     "modelId": "qwen/qwen-image-2.0/text-to-image",
     "outputType": "image",
-    "title": "Qwen Image 2.0 \u2014 Text to Image",
-    "description": "AtlasCloud / Qwen Image 2.0 \u2014 text-to-image with enhanced quality and prompt understanding, up to 2K.",
+    "title": "Qwen Image 2.0 — Text to Image",
+    "description": "AtlasCloud / Qwen Image 2.0 — text-to-image with enhanced quality and prompt understanding, up to 2K.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3948,8 +4242,8 @@
     "modality": "image",
     "modelId": "qwen/qwen-image-2.0/edit",
     "outputType": "image",
-    "title": "Qwen Image 2.0 \u2014 Edit",
-    "description": "AtlasCloud / Qwen Image 2.0 \u2014 instruction-driven image editing, up to 2K.",
+    "title": "Qwen Image 2.0 — Edit",
+    "description": "AtlasCloud / Qwen Image 2.0 — instruction-driven image editing, up to 2K.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -3991,8 +4285,8 @@
     "modality": "image",
     "modelId": "qwen/qwen-image-2.0-pro/text-to-image",
     "outputType": "image",
-    "title": "Qwen Image 2.0 Pro \u2014 Text to Image",
-    "description": "AtlasCloud / Qwen Image 2.0 Pro \u2014 professional-grade text-to-image with superior quality, up to 2K.",
+    "title": "Qwen Image 2.0 Pro — Text to Image",
+    "description": "AtlasCloud / Qwen Image 2.0 Pro — professional-grade text-to-image with superior quality, up to 2K.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4026,8 +4320,8 @@
     "modality": "image",
     "modelId": "qwen/qwen-image-2.0-pro/edit",
     "outputType": "image",
-    "title": "Qwen Image 2.0 Pro \u2014 Edit",
-    "description": "AtlasCloud / Qwen Image 2.0 Pro \u2014 professional-grade image editing with advanced instruction understanding, up to 2K.",
+    "title": "Qwen Image 2.0 Pro — Edit",
+    "description": "AtlasCloud / Qwen Image 2.0 Pro — professional-grade image editing with advanced instruction understanding, up to 2K.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4069,8 +4363,8 @@
     "modality": "image",
     "modelId": "bytedance/seedream-v5.0-lite",
     "outputType": "image",
-    "title": "Seedream v5.0 Lite \u2014 Text to Image",
-    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite \u2014 next-generation text-to-image with enhanced typography and poster design.",
+    "title": "Seedream v5.0 Lite — Text to Image",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite — next-generation text-to-image with enhanced typography and poster design.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4126,8 +4420,8 @@
     "modality": "image",
     "modelId": "bytedance/seedream-v5.0-lite/edit",
     "outputType": "image",
-    "title": "Seedream v5.0 Lite \u2014 Edit",
-    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite \u2014 image editing that preserves facial features, lighting, and color tones.",
+    "title": "Seedream v5.0 Lite — Edit",
+    "description": "AtlasCloud / ByteDance Seedream v5.0 Lite — image editing that preserves facial features, lighting, and color tones.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4191,8 +4485,8 @@
     "modality": "image",
     "modelId": "xai/grok-imagine-image-quality/text-to-image",
     "outputType": "image",
-    "title": "Grok Imagine Image Quality \u2014 Text to Image",
-    "description": "AtlasCloud / xAI Grok Imagine (Quality) \u2014 polished text-to-image at 1K or 2K with 13 aspect ratios.",
+    "title": "Grok Imagine Image Quality — Text to Image",
+    "description": "AtlasCloud / xAI Grok Imagine (Quality) — polished text-to-image at 1K or 2K with 13 aspect ratios.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4258,8 +4552,8 @@
     "modality": "image",
     "modelId": "xai/grok-imagine-image-quality/edit",
     "outputType": "image",
-    "title": "Grok Imagine Image Quality \u2014 Edit",
-    "description": "AtlasCloud / xAI Grok Imagine (Quality) \u2014 edits one or more reference images from natural-language instructions at 1K or 2K.",
+    "title": "Grok Imagine Image Quality — Edit",
+    "description": "AtlasCloud / xAI Grok Imagine (Quality) — edits one or more reference images from natural-language instructions at 1K or 2K.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4334,8 +4628,8 @@
     "modality": "video",
     "modelId": "xai/grok-imagine-video-v1.5/image-to-video",
     "outputType": "video",
-    "title": "Grok Imagine Video v1.5 \u2014 Image to Video",
-    "description": "AtlasCloud / xAI Grok Imagine Video v1.5 \u2014 animates a starting frame with natural-language motion prompts at 480p/720p/1080p.",
+    "title": "Grok Imagine Video v1.5 — Image to Video",
+    "description": "AtlasCloud / xAI Grok Imagine Video v1.5 — animates a starting frame with natural-language motion prompts at 480p/720p/1080p.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -4360,7 +4654,7 @@
         "type": "int",
         "default": 8,
         "title": "Duration (seconds)",
-        "description": "Length of generated video in seconds. Range: 1\u201315.",
+        "description": "Length of generated video in seconds. Range: 1–15.",
         "min": 1,
         "max": 15
       },
@@ -4400,8 +4694,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-pro/text-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Pro \u2014 Text to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro \u2014 premium text-to-video with multi-shot support and sound.",
+    "title": "Kling v3.0 Pro — Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro — premium text-to-video with multi-shot support and sound.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -4495,8 +4789,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-pro/image-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Pro \u2014 Image to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro \u2014 premium image-to-video with first/end-frame control and sound.",
+    "title": "Kling v3.0 Pro — Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Pro — premium image-to-video with first/end-frame control and sound.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -4519,7 +4813,7 @@
         "type": "image",
         "default": null,
         "title": "Image",
-        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of\u2026",
+        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of…",
         "required": true
       },
       {
@@ -4604,8 +4898,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-std/text-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Std \u2014 Text to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard \u2014 high-quality text-to-video generation.",
+    "title": "Kling v3.0 Std — Text to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard — high-quality text-to-video generation.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -4699,8 +4993,8 @@
     "modality": "video",
     "modelId": "kwaivgi/kling-v3.0-std/image-to-video",
     "outputType": "video",
-    "title": "Kling v3.0 Std \u2014 Image to Video",
-    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard \u2014 high-quality image-to-video generation.",
+    "title": "Kling v3.0 Std — Image to Video",
+    "description": "AtlasCloud / KwaiVGI Kling v3.0 Standard — high-quality image-to-video generation.",
     "pollInterval": 3000,
     "maxAttempts": 600,
     "fields": [
@@ -4723,7 +5017,7 @@
         "type": "image",
         "default": null,
         "title": "Image",
-        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of\u2026",
+        "description": "Supported image formats: .jpg/.jpeg/.png. The size of the image file should not exceed 10MB, the width and height of the image should be no less than 300px, and the aspect ratio of…",
         "required": true
       },
       {
@@ -4809,8 +5103,8 @@
     "modality": "image",
     "modelId": "openai/gpt-image-1.5/text-to-image",
     "outputType": "image",
-    "title": "GPT Image 1.5 \u2014 Text to Image",
-    "description": "AtlasCloud / OpenAI GPT Image 1.5 \u2014 fast, cost-efficient text-to-image powered by GPT-5 guidance.",
+    "title": "GPT Image 1.5 — Text to Image",
+    "description": "AtlasCloud / OpenAI GPT Image 1.5 — fast, cost-efficient text-to-image powered by GPT-5 guidance.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4865,8 +5159,8 @@
     "modality": "image",
     "modelId": "openai/gpt-image-1.5/edit",
     "outputType": "image",
-    "title": "GPT Image 1.5 \u2014 Edit",
-    "description": "AtlasCloud / OpenAI GPT Image 1.5 \u2014 precise natural-language image editing (add/remove objects, retouch, swap backgrounds, etc.).",
+    "title": "GPT Image 1.5 — Edit",
+    "description": "AtlasCloud / OpenAI GPT Image 1.5 — precise natural-language image editing (add/remove objects, retouch, swap backgrounds, etc.).",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [
@@ -4915,7 +5209,7 @@
         "type": "enum",
         "default": "high",
         "title": "Input Fidelity",
-        "description": "input fidelity, which allows you to better preserve details from the input images in the output. This is especially useful when using images that contain elements like faces or log\u2026",
+        "description": "input fidelity, which allows you to better preserve details from the input images in the output. This is especially useful when using images that contain elements like faces or log…",
         "values": [
           "low",
           "high"
@@ -4940,8 +5234,8 @@
     "modality": "image",
     "modelId": "z-image/turbo",
     "outputType": "image",
-    "title": "Z-Image Turbo \u2014 Text to Image",
-    "description": "AtlasCloud / Tongyi-MAI Z-Image Turbo \u2014 6B-parameter text-to-image generating photorealistic images in sub-second time.",
+    "title": "Z-Image Turbo — Text to Image",
+    "description": "AtlasCloud / Tongyi-MAI Z-Image Turbo — 6B-parameter text-to-image generating photorealistic images in sub-second time.",
     "pollInterval": 3000,
     "maxAttempts": 300,
     "fields": [

--- a/packages/protocol/src/builtin-packs.ts
+++ b/packages/protocol/src/builtin-packs.ts
@@ -116,7 +116,7 @@ export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
     id: "atlascloud",
     name: "AtlasCloud",
     description:
-      "Seedance video and GPT Image / Nano Banana image generation on AtlasCloud.",
+      "Image and video generation on AtlasCloud — GPT Image, Nano Banana, Seedream, Seedance, Veo, Kling, Wan.",
     namespaces: ["atlascloud"]
   },
   {

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -1,40 +1,51 @@
 /**
- * AtlasCloud Provider — exposes AtlasCloud.ai's hosted image and video models
- * through the standard {@link BaseProvider} interface, and surfaces the
- * `ATLASCLOUD_API_KEY` secret in Settings → API Keys.
+ * AtlasCloud Provider — AtlasCloud.ai aggregates chat, image and video models
+ * behind one API key (`ATLASCLOUD_API_KEY`, surfaced in Settings → API Keys).
  *
- * In addition to model listing, the provider implements:
- *   - textToImage / imageToImage
- *   - textToVideo / imageToVideo
+ * Two different wire protocols live behind that key, so this provider speaks
+ * both:
  *
- * so AtlasCloud models work from NodeTool's generic image/video generation
- * nodes (model picker), not just the AtlasCloud-specific node classes shipped
- * by `@nodetool-ai/atlascloud-nodes`.
+ *  1. Chat — OpenAI-compatible, `https://api.atlascloud.ai/v1`. Inherited from
+ *     {@link OpenAICompatProvider}; model discovery reads `GET /v1/models`.
+ *     https://www.atlascloud.ai/docs/get-started
  *
- * Wire spec (per AtlasCloud docs + Gap #3 in the POC INTEGRATION.md):
- *  - Auth:   `Authorization: Bearer <api_key>`
- *  - Submit: POST /api/v1/model/generate{Image,Video}, FLAT body
- *              { model, ...fields }   (NOT nested under `input`)
- *  - Poll:   GET  /api/v1/model/prediction/{id}
- *  - Submit POST is NEVER retried — a 429/5xx may have actually created the
- *    job upstream, and a retry would double-bill.
+ *  2. Image / video — AtlasCloud's own async prediction API:
+ *       - Submit: POST /api/v1/model/generate{Image,Video}, FLAT body
+ *                   { model, ...fields }  (NOT nested under `input`)
+ *                 → { data: { id } }
+ *       - Poll:   GET  /api/v1/model/prediction/{id}
+ *                 → { data: { status, outputs: [url], error? } }
+ *       - Submit POST is NEVER retried — a 429/5xx may have actually created
+ *         the job upstream, and a retry would double-bill.
+ *     https://www.atlascloud.ai/docs/models/image · /docs/predictions
+ *
+ * Request fields are validated against the per-model schema shipped in
+ * `@nodetool-ai/atlascloud-nodes`'s manifest (itself generated from
+ * AtlasCloud's published model schemas) before being sent, so a generic
+ * text-to-image call can't put `1024x1024` into a model whose `size` enum only
+ * accepts `1K`/`2K`, or an 10s duration into a model that only allows 4/6/8.
  */
 
-import { BaseProvider } from "./base-provider.js";
+import { OpenAICompatProvider } from "./openai-compat-provider.js";
+import type { OpenAICompatProviderOptions } from "./openai-compat-provider.js";
 import { createLogger } from "@nodetool-ai/config";
 import {
+  getManifestNodeMeta,
+  getModelInputFields,
   loadImageModels,
   loadManifest,
   loadVideoModels
 } from "./manifest-models.js";
 import type {
+  ASRModel,
+  EmbeddingModel,
   ImageModel,
   ImageToImageParams,
   ImageToVideoParams,
-  Message,
-  ProviderStreamItem,
+  LanguageModel,
   TextToImageParams,
   TextToVideoParams,
+  TTSModel,
   VideoModel
 } from "./types.js";
 
@@ -44,10 +55,11 @@ const ATLASCLOUD_MANIFEST_PKG = "@nodetool-ai/atlascloud-nodes";
 const ATLASCLOUD_MANIFEST_PATH = "atlascloud-manifest.json";
 
 const ATLAS_BASE = "https://api.atlascloud.ai";
+const ATLAS_CHAT_BASE_URL = `${ATLAS_BASE}/v1`;
 const SUBMIT_IMAGE = "/api/v1/model/generateImage";
 const SUBMIT_VIDEO = "/api/v1/model/generateVideo";
-const POLL_INTERVAL_MS = 3000;
-const MAX_POLL_ATTEMPTS = 600;
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+const DEFAULT_MAX_POLL_ATTEMPTS = 600;
 
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 const RETRY_MAX_WAIT_MS = 30000;
@@ -72,23 +84,28 @@ function parseRetryAfterMs(value: string | null): number | null {
 }
 
 // ---------------------------------------------------------------------------
-// Manifest peek — model id → declared field names + modality
+// Manifest peek — model id → declared fields + modality
 // ---------------------------------------------------------------------------
 
-interface AtlasManifestField {
-  name: string;
-  array?: boolean;
-}
-interface AtlasManifestEntry {
-  modelId: string;
-  modality?: "image" | "video";
-  outputType?: "image" | "video";
-  fields?: AtlasManifestField[];
+interface FieldInfo {
+  /** "str" | "enum" | "int" | "float" | "bool" | "image" | "list[image]" | … */
+  type: string;
+  /** Allowed values when the field is an enum. Numbers stay numbers. */
+  values?: Array<string | number>;
+  default?: unknown;
 }
 
 interface ModelInfo {
   modality: "image" | "video";
-  fields: Set<string>;
+  fields: Map<string, FieldInfo>;
+  pollInterval: number;
+  maxAttempts: number;
+}
+
+interface AtlasManifestEntry {
+  modelId?: string;
+  modality?: "image" | "video";
+  outputType?: "image" | "video";
 }
 
 function buildModelMap(): Map<string, ModelInfo> {
@@ -98,11 +115,33 @@ function buildModelMap(): Map<string, ModelInfo> {
     ATLASCLOUD_MANIFEST_PATH
   ) as AtlasManifestEntry[];
   for (const entry of manifest) {
-    if (!entry.modelId) continue;
+    const id = entry.modelId;
+    if (!id) continue;
     const modality = entry.modality ?? entry.outputType;
     if (modality !== "image" && modality !== "video") continue;
-    const fields = new Set<string>((entry.fields ?? []).map((f) => f.name));
-    map.set(entry.modelId, { modality, fields });
+    const fields = new Map<string, FieldInfo>();
+    for (const f of getModelInputFields(
+      ATLASCLOUD_MANIFEST_PKG,
+      ATLASCLOUD_MANIFEST_PATH,
+      id
+    )) {
+      fields.set(f.name, {
+        type: f.type,
+        ...(f.enumValues ? { values: f.enumValues } : {}),
+        ...(f.default !== undefined ? { default: f.default } : {})
+      });
+    }
+    const meta = getManifestNodeMeta(
+      ATLASCLOUD_MANIFEST_PKG,
+      ATLASCLOUD_MANIFEST_PATH,
+      id
+    );
+    map.set(id, {
+      modality,
+      fields,
+      pollInterval: meta?.pollInterval ?? DEFAULT_POLL_INTERVAL_MS,
+      maxAttempts: meta?.maxAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS
+    });
   }
   return map;
 }
@@ -142,14 +181,16 @@ async function atlasSubmit(
   apiKey: string,
   modality: "image" | "video",
   modelId: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<string> {
   const path = modality === "image" ? SUBMIT_IMAGE : SUBMIT_VIDEO;
   // Submit POST is not idempotent — never retry.
   const res = await fetch(`${ATLAS_BASE}${path}`, {
     method: "POST",
     headers: authHeaders(apiKey),
-    body: JSON.stringify({ model: modelId, ...input })
+    body: JSON.stringify({ model: modelId, ...input }),
+    ...(signal ? { signal } : {})
   });
   const text = await res.text();
   let data: { data?: { id?: string }; message?: string } | null;
@@ -178,15 +219,31 @@ interface AtlasPollResult {
   error?: string;
 }
 
+// AtlasCloud documents processing/completed/failed, but its workers have been
+// observed emitting synonyms for the terminal states. Accept them rather than
+// poll a finished job until the attempt budget runs out.
+const SUCCESS_STATUS = new Set([
+  "completed",
+  "complete",
+  "succeeded",
+  "success",
+  "done"
+]);
+const FAILURE_STATUS = new Set(["failed", "error", "canceled", "cancelled"]);
+
 async function atlasPoll(
   apiKey: string,
   predictionId: string,
-  pollInterval = POLL_INTERVAL_MS,
-  maxAttempts = MAX_POLL_ATTEMPTS
+  pollInterval: number,
+  maxAttempts: number,
+  signal?: AbortSignal
 ): Promise<AtlasPollResult> {
   const url = `${ATLAS_BASE}/api/v1/model/prediction/${predictionId}`;
   for (let i = 0; i < maxAttempts; i++) {
-    const res = await fetchWithRetry(url, { headers: authHeaders(apiKey) });
+    const res = await fetchWithRetry(url, {
+      headers: authHeaders(apiKey),
+      ...(signal ? { signal } : {})
+    });
     const text = await res.text();
     let data: { data?: AtlasPollResult; message?: string } | null;
     try {
@@ -194,12 +251,14 @@ async function atlasPoll(
     } catch {
       data = null;
     }
+    // A non-2xx can still carry a structured failure body (status: "failed",
+    // error: "…"). Report those as job failures so the user sees the reason.
     const d = data?.data ?? {};
     const status = String(d.status ?? "").toLowerCase();
-    if (status === "completed" || status === "succeeded" || status === "success") {
+    if (SUCCESS_STATUS.has(status)) {
       return d;
     }
-    if (status === "failed" || status === "error") {
+    if (FAILURE_STATUS.has(status)) {
       const msg = d.error || data?.message || text.slice(0, 500);
       throw new Error(
         `AtlasCloud job failed: ${msg} (predictionId: ${predictionId})`
@@ -265,11 +324,61 @@ function imageDataUri(bytes: Uint8Array): string {
 // Params → AtlasCloud input mapping
 // ---------------------------------------------------------------------------
 
+/** Coerce a value to the manifest-declared scalar type, or null when it can't. */
+function coerceToType(value: unknown, type: string): unknown {
+  switch (type) {
+    case "int": {
+      const n = typeof value === "number" ? value : Number(value);
+      return Number.isFinite(n) ? Math.trunc(n) : null;
+    }
+    case "float": {
+      const n = typeof value === "number" ? value : Number(value);
+      return Number.isFinite(n) ? n : null;
+    }
+    case "bool":
+      return typeof value === "boolean" ? value : String(value) === "true";
+    default:
+      return value;
+  }
+}
+
 /**
- * Set a field on `input` under the first manifest-declared name that matches.
- * Accepts a list of candidates because AtlasCloud is inconsistent: image
- * schemas use `aspect_ratio`, Seedance video schemas use `ratio`; GPT Image 2
- * uses `size` (`"WxH"`) instead of `width`/`height`.
+ * Resolve `value` against a declared field: coerce it to the field's type and,
+ * for enums, require membership. Numeric enums snap to the nearest allowed
+ * value (a 10-second request against a 4/6/8 model becomes 8 rather than a
+ * 422); string enums must match exactly. Returns null when the field can't
+ * take the value at all.
+ */
+function resolveForField(field: FieldInfo, value: unknown): unknown {
+  const coerced = coerceToType(value, field.type);
+  if (coerced === null || coerced === undefined || coerced === "") return null;
+  const allowed = field.values;
+  if (!allowed || allowed.length === 0) return coerced;
+  if (allowed.some((v) => String(v) === String(coerced))) {
+    // Return the declared member so numeric enums keep their JSON type.
+    return allowed.find((v) => String(v) === String(coerced));
+  }
+  if (typeof coerced === "number") {
+    // Negative members are sentinels ("-1" = let the model decide), never a
+    // sensible approximation of a number the caller actually asked for.
+    const numeric = allowed
+      .map((v) => Number(v))
+      .filter((v) => Number.isFinite(v) && v >= 0);
+    if (numeric.length > 0) {
+      return numeric.reduce((best, v) =>
+        Math.abs(v - coerced) < Math.abs(best - coerced) ? v : best
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Set a value on `input` under the first candidate field that both declares it
+ * and accepts the value. AtlasCloud is inconsistent across model families —
+ * image schemas use `aspect_ratio`, Seedance video schemas use `ratio`, Wan
+ * expresses resolution through a `size` enum of `1K`/`2K` — so callers pass
+ * every plausible name and let the declared schema pick.
  */
 function setIfDeclared(
   input: Record<string, unknown>,
@@ -279,11 +388,66 @@ function setIfDeclared(
 ): void {
   if (value === undefined || value === null || value === "") return;
   for (const name of candidates) {
-    if (info.fields.has(name)) {
-      input[name] = value;
+    const field = info.fields.get(name);
+    if (!field) continue;
+    const resolved = resolveForField(field, value);
+    if (resolved !== null) {
+      input[name] = resolved;
       return;
     }
   }
+  log.debug("AtlasCloud: dropping unsupported parameter", {
+    candidates,
+    value
+  });
+}
+
+/** Parse a `1024x768` / `1024*768` size string into pixel dimensions. */
+function parseSize(value: string): { w: number; h: number } | null {
+  const m = /^(\d+)\s*[x*]\s*(\d+)$/i.exec(value);
+  return m ? { w: Number(m[1]), h: Number(m[2]) } : null;
+}
+
+/**
+ * Render width×height for a model's `size` field.
+ *
+ * The field is a free string on some models and a fixed enum on others, and
+ * the separator differs by family (`1024x1024` on GPT Image, `1024*1024` on
+ * Seedream / Qwen / Wan). Free-string fields take the requested dimensions
+ * verbatim under the separator the model's own default uses; enum fields get
+ * the declared option closest in aspect ratio, then in area. Enums with no
+ * parseable dimensions at all (Wan's `1K`/`2K`) yield null — the caller leaves
+ * the model default in place instead of sending an option that would 422.
+ */
+function renderSize(field: FieldInfo, w: number, h: number): string | null {
+  const allowed = field.values;
+  if (!allowed || allowed.length === 0) {
+    const sep = String(field.default ?? "").includes("*") ? "*" : "x";
+    return `${w}${sep}${h}`;
+  }
+  const exact = allowed.find(
+    (v) => String(v) === `${w}x${h}` || String(v) === `${w}*${h}`
+  );
+  if (exact !== undefined) return String(exact);
+  const wanted = w / h;
+  const wantedArea = w * h;
+  let best: { value: string; ratioDelta: number; areaDelta: number } | null =
+    null;
+  for (const option of allowed) {
+    const parsed = parseSize(String(option));
+    if (!parsed) continue;
+    const ratioDelta = Math.abs(parsed.w / parsed.h - wanted);
+    const areaDelta = Math.abs(parsed.w * parsed.h - wantedArea);
+    if (
+      !best ||
+      ratioDelta < best.ratioDelta - 1e-6 ||
+      (Math.abs(ratioDelta - best.ratioDelta) <= 1e-6 &&
+        areaDelta < best.areaDelta)
+    ) {
+      best = { value: String(option), ratioDelta, areaDelta };
+    }
+  }
+  return best?.value ?? null;
 }
 
 /** Build the request input for a text-to-image / image-to-image call. */
@@ -293,19 +457,25 @@ function mapImageParams(
 ): Record<string, unknown> {
   const input: Record<string, unknown> = { prompt: params.prompt };
   setIfDeclared(input, info, params.aspectRatio, "aspect_ratio", "ratio");
-  setIfDeclared(input, info, params.resolution, "resolution");
+  // Wan expresses resolution as a `size` enum (`1K`/`2K`/`4K`); the membership
+  // check in setIfDeclared keeps the fallback from firing on pixel-size models.
+  setIfDeclared(input, info, params.resolution, "resolution", "size");
   setIfDeclared(input, info, params.quality, "quality");
   setIfDeclared(input, info, params.negativePrompt, "negative_prompt");
   setIfDeclared(input, info, params.seed, "seed");
-  // GPT Image 2 uses `size: "WxH"` instead of width/height.
-  if (info.fields.has("size")) {
+  setIfDeclared(input, info, params.guidanceScale, "cfg_scale");
+  const sizeField = info.fields.get("size");
+  if (sizeField && input.size === undefined) {
     const w =
       (params as TextToImageParams).width ??
       (params as ImageToImageParams).targetWidth;
     const h =
       (params as TextToImageParams).height ??
       (params as ImageToImageParams).targetHeight;
-    if (w && h) input.size = `${w}x${h}`;
+    if (w && h) {
+      const size = renderSize(sizeField, w, h);
+      if (size !== null) input.size = size;
+    }
   }
   return input;
 }
@@ -321,7 +491,9 @@ function mapVideoParams(
   setIfDeclared(input, info, params.resolution, "resolution");
   setIfDeclared(input, info, params.negativePrompt, "negative_prompt");
   setIfDeclared(input, info, params.seed, "seed");
-  // Seedance schemas: integer `duration` in seconds; -1 means "model decides".
+  setIfDeclared(input, info, params.guidanceScale, "cfg_scale");
+  // Duration is an integer count of seconds; the enums differ per model
+  // (Seedance takes 4–15, Veo only 4/6/8), so resolveForField snaps it.
   if (params.durationSeconds != null) {
     setIfDeclared(input, info, Math.trunc(params.durationSeconds), "duration");
   }
@@ -329,41 +501,115 @@ function mapVideoParams(
 }
 
 // ---------------------------------------------------------------------------
+// Chat models
+// ---------------------------------------------------------------------------
+
+interface AtlasChatModelRow {
+  id?: string;
+  name?: string;
+  supported_features?: string[];
+}
+
+// ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
 
-export class AtlasCloudProvider extends BaseProvider {
-  private readonly apiKey: string;
+export class AtlasCloudProvider extends OpenAICompatProvider {
   private modelMap: Map<string, ModelInfo> | null = null;
+  private chatModels: Promise<AtlasChatModelRow[]> | null = null;
+  private readonly atlasFetch: typeof fetch;
 
   static override requiredSecrets(): string[] {
     return ["ATLASCLOUD_API_KEY"];
   }
 
-  constructor(secrets: Record<string, unknown> = {}) {
-    super("atlascloud");
-    this.apiKey = (secrets["ATLASCLOUD_API_KEY"] as string) ?? "";
+  constructor(
+    secrets: { ATLASCLOUD_API_KEY?: string } = {},
+    options: OpenAICompatProviderOptions = {}
+  ) {
+    const apiKey = secrets.ATLASCLOUD_API_KEY;
+    if (!apiKey) {
+      throw new Error("ATLASCLOUD_API_KEY is required");
+    }
+    const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+    super(
+      { providerId: "atlascloud", apiKey, baseURL: ATLAS_CHAT_BASE_URL },
+      { ...options, fetchFn }
+    );
+    this.atlasFetch = fetchFn;
   }
 
   override getContainerEnv(): Record<string, string> {
     return { ATLASCLOUD_API_KEY: this.apiKey };
   }
 
-  async generateMessage(
-    _args: Parameters<BaseProvider["generateMessage"]>[0]
-  ): Promise<Message> {
-    throw new Error("atlascloud does not support chat generation");
+  // ─── Chat ────────────────────────────────────────────────────────────────
+
+  /**
+   * `GET /v1/models` — the OpenAI-compatible listing, which covers only the
+   * chat models. Image/video/audio models live in the separate
+   * `/api/v1/models` catalog and are served by the prediction API below.
+   */
+  private listChatModels(): Promise<AtlasChatModelRow[]> {
+    // Cache the successful listing; drop the cache on failure so a transient
+    // outage doesn't leave this provider instance permanently model-less.
+    this.chatModels ??= (async () => {
+      const res = await this.atlasFetch(`${ATLAS_CHAT_BASE_URL}/models`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` }
+      });
+      if (!res.ok) {
+        throw new Error(`AtlasCloud model listing failed: HTTP ${res.status}`);
+      }
+      const payload = (await res.json()) as { data?: AtlasChatModelRow[] };
+      return payload.data ?? [];
+    })().catch((err) => {
+      log.warn(`Failed to list AtlasCloud chat models: ${err}`);
+      this.chatModels = null;
+      return [];
+    });
+    return this.chatModels;
   }
 
-  // eslint-disable-next-line require-yield
-  async *generateMessages(
-    _args: Parameters<BaseProvider["generateMessages"]>[0]
-  ): AsyncGenerator<ProviderStreamItem> {
-    throw new Error("atlascloud does not support chat generation");
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    const rows = await this.listChatModels();
+    return rows
+      .filter((row): row is AtlasChatModelRow & { id: string } =>
+        Boolean(row.id)
+      )
+      .map((row) => ({
+        id: row.id,
+        name: row.name ?? row.id,
+        provider: "atlascloud" as const
+      }));
   }
+
+  /** AtlasCloud declares tool support per model in `supported_features`. */
+  override async hasToolSupport(model: string): Promise<boolean> {
+    const rows = await this.listChatModels();
+    const row = rows.find((r) => r.id === model);
+    // Unknown model: assume tools work rather than silently dropping them.
+    if (!row?.supported_features) return true;
+    return row.supported_features.includes("tools");
+  }
+
+  // AtlasCloud's OpenAI-compatible surface is chat-only — its audio and
+  // embedding models are not served from /v1. Suppress the OpenAI defaults so
+  // they don't surface as AtlasCloud models the provider can't actually run.
+  override async getAvailableTTSModels(): Promise<TTSModel[]> {
+    return [];
+  }
+
+  override async getAvailableASRModels(): Promise<ASRModel[]> {
+    return [];
+  }
+
+  override async getAvailableEmbeddingModels(): Promise<EmbeddingModel[]> {
+    return [];
+  }
+
+  // ─── Image / video models ────────────────────────────────────────────────
 
   override async getAvailableImageModels(): Promise<ImageModel[]> {
-    if (!this.apiKey) return [];
     try {
       return loadImageModels(
         ATLASCLOUD_MANIFEST_PKG,
@@ -377,7 +623,6 @@ export class AtlasCloudProvider extends BaseProvider {
   }
 
   override async getAvailableVideoModels(): Promise<VideoModel[]> {
-    if (!this.apiKey) return [];
     try {
       return loadVideoModels(
         ATLASCLOUD_MANIFEST_PKG,
@@ -390,15 +635,8 @@ export class AtlasCloudProvider extends BaseProvider {
     }
   }
 
-  private requireApiKey(): string {
-    if (!this.apiKey || !this.apiKey.trim()) {
-      throw new Error("ATLASCLOUD_API_KEY is not configured");
-    }
-    return this.apiKey;
-  }
-
   private getModelMap(): Map<string, ModelInfo> {
-    if (!this.modelMap) this.modelMap = buildModelMap();
+    this.modelMap ??= buildModelMap();
     return this.modelMap;
   }
 
@@ -419,12 +657,31 @@ export class AtlasCloudProvider extends BaseProvider {
   private async runJob(
     modality: "image" | "video",
     modelId: string,
-    input: Record<string, unknown>
+    info: ModelInfo,
+    input: Record<string, unknown>,
+    opts: { timeoutSeconds?: number | null; signal?: AbortSignal } = {}
   ): Promise<Uint8Array> {
-    const apiKey = this.requireApiKey();
+    const apiKey = this.apiKey;
     log.debug("AtlasCloud submit", { modality, model: modelId });
-    const predictionId = await atlasSubmit(apiKey, modality, modelId, input);
-    const result = await atlasPoll(apiKey, predictionId);
+    const predictionId = await atlasSubmit(
+      apiKey,
+      modality,
+      modelId,
+      input,
+      opts.signal
+    );
+    // A caller-supplied timeout bounds the polling window; without one the
+    // model's own manifest budget applies.
+    const maxAttempts = opts.timeoutSeconds
+      ? Math.max(1, Math.ceil((opts.timeoutSeconds * 1000) / info.pollInterval))
+      : info.maxAttempts;
+    const result = await atlasPoll(
+      apiKey,
+      predictionId,
+      info.pollInterval,
+      maxAttempts,
+      opts.signal
+    );
     const url = pickOutputUrl(result);
     const dl = await fetchWithRetry(url);
     if (!dl.ok) {
@@ -439,7 +696,9 @@ export class AtlasCloudProvider extends BaseProvider {
     if (!params.prompt) throw new Error("Prompt is required");
     const info = this.resolveModel(params.model.id, "image");
     const input = mapImageParams(info, params);
-    return this.runJob("image", params.model.id, input);
+    return this.runJob("image", params.model.id, info, input, {
+      ...(params.signal ? { signal: params.signal } : {})
+    });
   }
 
   override async imageToImage(
@@ -468,14 +727,19 @@ export class AtlasCloudProvider extends BaseProvider {
         `AtlasCloud model ${params.model.id} does not declare an input image field`
       );
     }
-    return this.runJob("image", params.model.id, input);
+    return this.runJob("image", params.model.id, info, input, {
+      ...(params.signal ? { signal: params.signal } : {})
+    });
   }
 
   override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
     if (!params.prompt) throw new Error("Prompt is required");
     const info = this.resolveModel(params.model.id, "video");
     const input = mapVideoParams(info, params);
-    return this.runJob("video", params.model.id, input);
+    return this.runJob("video", params.model.id, info, input, {
+      ...(params.timeoutSeconds ? { timeoutSeconds: params.timeoutSeconds } : {}),
+      ...(params.signal ? { signal: params.signal } : {})
+    });
   }
 
   override async imageToVideo(
@@ -505,6 +769,9 @@ export class AtlasCloudProvider extends BaseProvider {
         `AtlasCloud model ${params.model.id} does not accept an input image (try the Seedance image-to-video variant)`
       );
     }
-    return this.runJob("video", params.model.id, input);
+    return this.runJob("video", params.model.id, info, input, {
+      ...(params.timeoutSeconds ? { timeoutSeconds: params.timeoutSeconds } : {}),
+      ...(params.signal ? { signal: params.signal } : {})
+    });
   }
 }

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -84,23 +84,74 @@ describe("AtlasCloudProvider — metadata", () => {
     expect(p.getContainerEnv()).toEqual({ ATLASCLOUD_API_KEY: "k" });
   });
 
-  it("chat generation throws (not supported)", async () => {
+  it("requires an API key", () => {
+    expect(() => new AtlasCloudProvider({})).toThrow(
+      "ATLASCLOUD_API_KEY is required"
+    );
+  });
+});
+
+describe("AtlasCloudProvider — language models", () => {
+  function mockModelsFetch(rows: unknown[]): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: 200, msg: "succeed", data: rows })
+    })) as unknown as ReturnType<typeof vi.fn>;
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  }
+
+  it("lists chat models from the OpenAI-compatible /v1/models endpoint", async () => {
+    const fetchMock = mockModelsFetch([
+      { id: "deepseek-ai/DeepSeek-V3.1", name: "DeepSeek-V3.1" },
+      { id: "openai/gpt-5.2" }
+    ]);
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
-    await expect(
-      p.generateMessage({ messages: [], model: "x" } as never)
-    ).rejects.toThrow("does not support chat generation");
-    await expect(
-      p.generateMessages({ messages: [], model: "x" } as never).next()
-    ).rejects.toThrow("does not support chat generation");
+    expect(await p.getAvailableLanguageModels()).toEqual([
+      {
+        id: "deepseek-ai/DeepSeek-V3.1",
+        name: "DeepSeek-V3.1",
+        provider: "atlascloud"
+      },
+      { id: "openai/gpt-5.2", name: "openai/gpt-5.2", provider: "atlascloud" }
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.atlascloud.ai/v1/models",
+      { headers: { Authorization: "Bearer k" } }
+    );
+  });
+
+  it("reads tool support from the model's supported_features", async () => {
+    mockModelsFetch([
+      { id: "with-tools", supported_features: ["json_mode", "tools"] },
+      { id: "no-tools", supported_features: ["json_mode"] }
+    ]);
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    expect(await p.hasToolSupport("with-tools")).toBe(true);
+    expect(await p.hasToolSupport("no-tools")).toBe(false);
+    // An id the listing doesn't cover gets the benefit of the doubt.
+    expect(await p.hasToolSupport("unlisted")).toBe(true);
+  });
+
+  it("returns no models when the listing fails", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500
+    })) as unknown as typeof fetch;
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    expect(await p.getAvailableLanguageModels()).toEqual([]);
+  });
+
+  it("does not advertise audio or embedding models", async () => {
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    expect(await p.getAvailableTTSModels()).toEqual([]);
+    expect(await p.getAvailableASRModels()).toEqual([]);
+    expect(await p.getAvailableEmbeddingModels()).toEqual([]);
   });
 });
 
 describe("AtlasCloudProvider — getAvailableImageModels", () => {
-  it("returns an empty list when no API key is set", async () => {
-    const p = new AtlasCloudProvider({});
-    expect(await p.getAvailableImageModels()).toEqual([]);
-  });
-
   it("exposes the expected image entries from the manifest", async () => {
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
     const models = await p.getAvailableImageModels();
@@ -116,11 +167,6 @@ describe("AtlasCloudProvider — getAvailableImageModels", () => {
 });
 
 describe("AtlasCloudProvider — getAvailableVideoModels", () => {
-  it("returns an empty list when no API key is set", async () => {
-    const p = new AtlasCloudProvider({});
-    expect(await p.getAvailableVideoModels()).toEqual([]);
-  });
-
   it("exposes Seedance video entries with the right inferred tasks", async () => {
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
     const models = await p.getAvailableVideoModels();
@@ -212,14 +258,72 @@ describe("AtlasCloudProvider — textToImage", () => {
     });
   });
 
-  it("requires an API key", async () => {
-    const p = new AtlasCloudProvider({});
-    await expect(
-      p.textToImage({
-        model: imageModel("google/nano-banana-2/text-to-image"),
-        prompt: "x"
-      })
-    ).rejects.toThrow("ATLASCLOUD_API_KEY is not configured");
+  it("renders `size` with the separator the model's own default uses", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // Qwen declares a free-form `size` defaulting to "1024*1024" — asterisk,
+    // not the "x" GPT Image uses.
+    await p.textToImage({
+      model: imageModel("qwen/qwen-image-2.0/text-to-image"),
+      prompt: "a cat",
+      width: 1280,
+      height: 720
+    });
+    expect(capture.submitBody!.size).toBe("1280*720");
+  });
+
+  it("snaps `size` to the nearest declared option on enum models", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // Seedream only accepts a fixed list; 1600x1200 (4:3) is not on it.
+    await p.textToImage({
+      model: imageModel("bytedance/seedream-v5.0-pro/text-to-image"),
+      prompt: "a cat",
+      width: 1600,
+      height: 1200
+    });
+    expect(capture.submitBody!.size).toBe("2304*1728");
+  });
+
+  it("drops a `size` request the model can't express", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // Wan's `size` is a 1K/2K tier enum — pixel dimensions have no mapping, so
+    // the model default stands rather than a body the API would reject.
+    await p.textToImage({
+      model: imageModel("alibaba/wan-2.7/text-to-image"),
+      prompt: "a cat",
+      width: 1024,
+      height: 1024
+    });
+    expect(capture.submitBody!.size).toBeUndefined();
+  });
+
+  it("routes a resolution tier onto Wan's `size` enum", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    await p.textToImage({
+      model: imageModel("alibaba/wan-2.7/text-to-image"),
+      prompt: "a cat",
+      resolution: "1K"
+    });
+    expect(capture.submitBody!.size).toBe("1K");
+  });
+
+  it("drops an aspect ratio the model does not declare", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    await p.textToImage({
+      model: imageModel("google/nano-banana-2/text-to-image"),
+      prompt: "a cat",
+      aspectRatio: "7:3"
+    });
+    expect(capture.submitBody!.aspect_ratio).toBeUndefined();
   });
 });
 
@@ -278,6 +382,21 @@ describe("AtlasCloudProvider — textToVideo", () => {
       resolution: "1080p",
       duration: 6
     });
+  });
+
+  it("snaps a duration the model does not offer to the nearest one it does", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // Veo 3.1 only accepts 4, 6 or 8 seconds.
+    await p.textToVideo({
+      model: videoModel("google/veo3.1/text-to-video"),
+      prompt: "a flying cat",
+      durationSeconds: 10,
+      seed: 42
+    });
+    expect(capture.submitBody!.duration).toBe(8);
+    expect(capture.submitBody!.seed).toBe(42);
   });
 
   it("rejects an image model used for textToVideo", async () => {

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -401,7 +401,7 @@ sec(
 sec(
   "ATLASCLOUD_API_KEY",
   "AtlasCloud",
-  "AtlasCloud.ai API key for hosted image (GPT Image 2, Nano Banana) and video (Seedance 2.0) models. Get yours at https://www.atlascloud.ai/"
+  "AtlasCloud.ai API key for chat models (DeepSeek, Qwen, GPT, Claude, Gemini) plus hosted image (GPT Image, Nano Banana, Seedream) and video (Seedance, Veo, Kling, Wan) generation. Get yours at https://www.atlascloud.ai/"
 );
 sec("MESHY_API_KEY", "Meshy", "Meshy AI API key for 3D model generation. Get yours at https://app.meshy.ai/settings/api-keys");
 sec("RODIN_API_KEY", "Rodin", "Rodin AI API key for 3D model generation. Get yours at https://hyperhuman.deemos.com/");

--- a/scripts/sync-atlascloud-manifest.mjs
+++ b/scripts/sync-atlascloud-manifest.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Reconcile `packages/atlascloud-nodes/src/atlascloud-manifest.json` with the
+ * input schemas AtlasCloud publishes for each model.
+ *
+ * AtlasCloud serves a catalog at `GET https://api.atlascloud.ai/api/v1/models`
+ * (no auth) where every entry carries a `schema` URL pointing at an OpenAPI
+ * fragment with the model's `Input` properties. This script reads that catalog,
+ * fetches the schema for each model already in our manifest, and brings the
+ * manifest's fields back in line: enum options, defaults, numeric bounds,
+ * scalar types, required flags, plus fields that were added or removed upstream.
+ *
+ * It never invents entries — adding a *model* is a deliberate act (it needs a
+ * class name, module, title and description), so this only maintains the fields
+ * of models we already ship.
+ *
+ *   node scripts/sync-atlascloud-manifest.mjs           # rewrite the manifest
+ *   node scripts/sync-atlascloud-manifest.mjs --check   # exit 1 if out of date
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST = join(
+  ROOT,
+  "packages/atlascloud-nodes/src/atlascloud-manifest.json"
+);
+const CATALOG_URL = "https://api.atlascloud.ai/api/v1/models";
+
+const TYPE_MAP = {
+  string: "str",
+  integer: "int",
+  number: "float",
+  boolean: "bool"
+};
+const ASSET_TYPES = new Set(["image", "video", "audio"]);
+
+// Options AtlasCloud declares that we deliberately do not surface:
+//  - enable_base64_output / enable_sync_mode are flagged `disabled` upstream
+//    (API-only transport switches) and would break the poll+download flow.
+//  - return_last_frame makes the job emit a second output the single-output
+//    node can't surface, so the toggle would silently do nothing.
+const SUPPRESSED_FIELDS = new Set(["return_last_frame"]);
+
+const isAssetField = (field) =>
+  ASSET_TYPES.has(field.type) || field.type.startsWith("list[");
+
+/** Vendor descriptions run long; keep a sentence or two for the UI tooltip. */
+function trimDescription(text) {
+  if (!text) return undefined;
+  const collapsed = text.split(/\s+/).join(" ");
+  if (collapsed.length <= 180) return collapsed;
+  const cut = collapsed.slice(0, 180);
+  const lastSentence = cut.lastIndexOf(". ");
+  return lastSentence > 40 ? cut.slice(0, lastSentence + 1) : `${cut.trim()}…`;
+}
+
+const titleCase = (name) =>
+  name
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`GET ${url} → HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+function fieldFromSchema(name, prop, required) {
+  const field = {
+    name,
+    type: prop.enum ? "enum" : TYPE_MAP[prop.type],
+    default: prop.default ?? null,
+    title: titleCase(name)
+  };
+  const description = trimDescription(prop.description);
+  if (description) field.description = description;
+  if (prop.enum) field.values = prop.enum;
+  if (prop.type === "integer" || prop.type === "number") {
+    if (prop.minimum !== undefined) field.min = prop.minimum;
+    if (prop.maximum !== undefined) field.max = prop.maximum;
+  }
+  if (required) field.required = true;
+  return field;
+}
+
+/** Reconcile one manifest entry against its schema. Returns a change log. */
+function reconcile(entry, schema) {
+  const input = schema.components.schemas.Input;
+  const props = input.properties ?? {};
+  const required = new Set(input.required ?? []);
+  const changes = [];
+  const at = (msg) => changes.push(`${entry.modelId}: ${msg}`);
+
+  // Drop scalar fields the model no longer declares. Asset fields are left
+  // alone — the manifest models them as image/video/audio props whose names
+  // still match the schema, and they carry NodeTool-side metadata.
+  entry.fields = entry.fields.filter((field) => {
+    if (isAssetField(field)) return true;
+    if (props[field.name] && !SUPPRESSED_FIELDS.has(field.name)) return true;
+    at(`drop \`${field.name}\``);
+    return false;
+  });
+
+  const byName = new Map(entry.fields.map((f) => [f.name, f]));
+
+  for (const [name, prop] of Object.entries(props)) {
+    if (name === "model" || prop.disabled || SUPPRESSED_FIELDS.has(name)) {
+      continue;
+    }
+    const field = byName.get(name);
+
+    if (!field) {
+      if (!TYPE_MAP[prop.type]) {
+        at(`skip \`${name}\` — ${prop.type} is not a NodeTool prop type`);
+        continue;
+      }
+      const added = fieldFromSchema(name, prop, required.has(name));
+      entry.fields.push(added);
+      byName.set(name, added);
+      at(`add \`${name}\``);
+      continue;
+    }
+
+    if (isAssetField(field)) continue;
+
+    if (prop.enum) {
+      const same =
+        field.values?.length === prop.enum.length &&
+        field.values.every((v, i) => String(v) === String(prop.enum[i]));
+      if (!same) {
+        field.values = prop.enum;
+        if (field.type === "str") field.type = "enum";
+        at(`\`${name}\` values → ${JSON.stringify(prop.enum)}`);
+      }
+    } else if (field.type === "enum") {
+      // The schema dropped the enum (or never had one — AtlasCloud types some
+      // constrained strings as plain `string`). Keep our option list: it came
+      // from the upstream API's own docs and a free-text box is strictly worse.
+    } else if (TYPE_MAP[prop.type] && field.type !== TYPE_MAP[prop.type]) {
+      at(`\`${name}\` type ${field.type} → ${TYPE_MAP[prop.type]}`);
+      field.type = TYPE_MAP[prop.type];
+    }
+
+    // `prompt` keeps its empty default — upstream defaults are example prompts.
+    if (
+      name !== "prompt" &&
+      prop.default !== undefined &&
+      field.default !== prop.default
+    ) {
+      at(
+        `\`${name}\` default ${JSON.stringify(field.default)} → ${JSON.stringify(prop.default)}`
+      );
+      field.default = prop.default;
+    }
+
+    // Bounds apply to numeric props only. A string `size` carries min/max as
+    // per-axis pixel limits, which a scalar range control would misrepresent.
+    if (prop.type === "integer" || prop.type === "number") {
+      for (const [schemaKey, fieldKey] of [
+        ["minimum", "min"],
+        ["maximum", "max"]
+      ]) {
+        if (prop[schemaKey] !== undefined && field[fieldKey] !== prop[schemaKey]) {
+          at(`\`${name}\` ${fieldKey} → ${prop[schemaKey]}`);
+          field[fieldKey] = prop[schemaKey];
+        }
+      }
+    }
+
+    if (required.has(name) && !field.required) {
+      field.required = true;
+      at(`\`${name}\` required → true`);
+    } else if (!required.has(name) && field.required) {
+      delete field.required;
+      at(`\`${name}\` required → false`);
+    }
+  }
+
+  return changes;
+}
+
+async function main() {
+  const check = process.argv.includes("--check");
+  const original = readFileSync(MANIFEST, "utf8");
+  const manifest = JSON.parse(original);
+
+  const catalog = await fetchJson(CATALOG_URL);
+  const schemaUrls = new Map(
+    (catalog.data ?? []).map((model) => [model.model, model.schema])
+  );
+
+  const changes = [];
+  for (const entry of manifest) {
+    const url = schemaUrls.get(entry.modelId);
+    if (!url) {
+      changes.push(
+        `${entry.modelId}: NOT IN CATALOG — model may have been retired upstream`
+      );
+      continue;
+    }
+    reconcile(entry, await fetchJson(url)).forEach((c) => changes.push(c));
+  }
+
+  const updated = `${JSON.stringify(manifest, null, 2)}\n`;
+  if (updated === original) {
+    console.log("atlascloud-manifest.json is up to date.");
+    return;
+  }
+
+  console.log(changes.join("\n"));
+  if (check) {
+    console.error(
+      `\n${changes.length} drift(s) from AtlasCloud's published schemas. ` +
+        "Run `node scripts/sync-atlascloud-manifest.mjs` to apply."
+    );
+    process.exitCode = 1;
+    return;
+  }
+  writeFileSync(MANIFEST, updated);
+  console.log(`\nWrote ${changes.length} change(s) to ${MANIFEST}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -273,8 +273,8 @@ const PROVIDER_META: ProviderMeta[] = [
   {
     key: "ATLASCLOUD_API_KEY",
     name: "AtlasCloud",
-    description: "GPT Image 2, Nano Banana, and Seedance 2.0 video generation.",
-    section: "media",
+    description: "Chat, image, and video models behind one key.",
+    section: "gateways",
     docsUrl: "https://www.atlascloud.ai/",
     icon: atlascloudIcon
   },


### PR DESCRIPTION
AtlasCloud aggregates chat, image and video models behind one key, but our integration only ever spoke its async prediction API. Three gaps, each checked against [AtlasCloud's docs](https://www.atlascloud.ai/docs/get-started) and the input schemas it publishes per model.

## 1. Chat was missing entirely

`AtlasCloudProvider.generateMessage` threw `"atlascloud does not support chat generation"`, so the ~120 LLMs AtlasCloud serves — DeepSeek, Qwen, GLM, GPT, Claude, Gemini, Grok — were unreachable with a key that pays for them.

That surface is OpenAI-compatible at `https://api.atlascloud.ai/v1`, so the provider now extends `OpenAICompatProvider`:

- models come from `GET /v1/models`
- per-model tool support is read from the listing's `supported_features`, not assumed
- the OpenAI audio/embedding defaults are suppressed — AtlasCloud does not serve those from `/v1`, and advertising models the provider can't run is worse than showing none
- a missing key throws in the constructor, matching every other gateway provider (Together, GMI). Callers already treat a construction failure as "no models", so nothing regresses.

## 2. Generic image/video calls built bodies the API rejects

The provider wrote `size` as `` `${w}x${h}` `` for any model declaring a `size` field. Only OpenAI's image models spell it that way — Seedream, Qwen and Z-Image use `1024*1024`, and Wan's `size` is a `1K`/`2K` tier enum where pixel dimensions have no meaning at all. Aspect ratios, resolutions and durations were passed through unchecked too, so a 10-second request against Veo (4/6/8 only) became a 422.

Requests are now resolved against the model's declared schema:

- free-form `size` fields take the separator the model's own default uses
- enum `size` fields get the closest declared option by aspect ratio, then area
- numeric enums snap to the nearest allowed value (`10s` → `8s` on Veo)
- a value no candidate field can express is dropped rather than sent
- `guidanceScale` maps to `cfg_scale`; `timeoutSeconds` bounds the polling window; `signal` cancels in flight; each model's own poll interval and attempt budget are honored instead of one hardcoded pair

## 3. The manifest had drifted from upstream

`scripts/sync-atlascloud-manifest.mjs` reconciles the node manifest against the `Input` schema AtlasCloud publishes for each model (reachable from its unauthenticated catalog). `--check` reports drift without writing, so this can be a CI gate later.

Running it fixes 64 field-level discrepancies:

- GPT Image 2 offered two sizes the API rejects (`2560x1440`, `1440x2560`) and hid nine it accepts
- Seedance was missing `4k` resolution and defaulted `ratio` to `16:9` where upstream says `adaptive`
- `seed` was absent from 15 video models — no reproducible generations
- Seedream v5 Pro lost its `thinking` control; Kling o3 lost `shot_type`; Seedance lost `bitrate_mode`
- several `size` fields had no min/max, so the UI accepted values the API rejects
- Seedance carried a `web_search` field the schema does not declare

`return_last_frame` stays suppressed, as it was before — the single-output node can't surface a second output, so the toggle would silently do nothing. The script encodes that exclusion rather than leaving it to be re-added by the next hand edit.

## Also

Settings copy, the builtin-pack description, the provider catalog entry and the API-keys row now say chat as well as image/video (AtlasCloud moves from the "media" section to "gateways"). The package README lists all 70 nodes instead of the 14 it had.

## Testing

- `packages/runtime` provider suite: 27 tests, including the new chat-listing, tool-support, size-rendering, enum-snapping and parameter-dropping cases
- `packages/atlascloud-nodes` (78), `packages/websocket` (1571), `packages/protocol` (607), web menus + `nodeProvider` (59) — all pass
- `npm run lint` clean; `npm run typecheck` clean for web/electron/packages (mobile fails on missing Expo deps, which pre-exists in this container)

Not covered: AtlasCloud's 19 audio models. Its docs describe no audio generation endpoint, and I have no key to probe one, so I did not guess at a wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4RRVuzFMXMyvkz91P84Pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4RRVuzFMXMyvkz91P84Pi)_