### PR TITLE
docs: add Mini Apps section

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -59,6 +59,19 @@
         </ul>
       </details>
 
+      <details class="nav-section" data-section="mini-apps">
+        <summary class="nav-section-summary">
+          <h4 class="nav-section-title">Mini Apps</h4>
+          <span class="nav-section-chevron" aria-hidden="true"></span>
+        </summary>
+        <ul class="nav-section-list">
+          <li><a href="{{ '/mini-apps' | relative_url }}" class="sidebar-link" data-nav-path="/mini-apps">Overview</a></li>
+          <li><a href="{{ '/mini-apps-guide' | relative_url }}" class="sidebar-link" data-nav-path="/mini-apps-guide">Building Mini Apps</a></li>
+          <li><a href="{{ '/mini-apps-reference' | relative_url }}" class="sidebar-link" data-nav-path="/mini-apps-reference">Reference</a></li>
+          <li><a href="{{ '/app-builder' | relative_url }}" class="sidebar-link" data-nav-path="/app-builder">App Builder</a></li>
+        </ul>
+      </details>
+
       <details class="nav-section" data-section="chat">
         <summary class="nav-section-summary">
           <h4 class="nav-section-title">Chat &amp; Agents</h4>

--- a/docs/app-builder.md
+++ b/docs/app-builder.md
@@ -5,8 +5,13 @@ description: "Design Mini App interfaces for workflows"
 ---
 
 App Builder turns a workflow into a custom Mini App. You place widgets on a
-canvas, bind them to workflow inputs and outputs, and publish the app document
-onto the workflow.
+canvas, bind them to workflow inputs and outputs, and save the app document onto
+the workflow.
+
+This page covers the editor. For what Mini Apps solve and how the runtime works,
+see [Mini Apps](mini-apps.md); for step-by-step recipes, see
+[Building Mini Apps](mini-apps-guide.md); for the widget, binding, and schema
+tables, see the [Reference](mini-apps-reference.md).
 
 ## What it does
 
@@ -38,7 +43,7 @@ The builder opens at `/app-builder/:workflowId`.
 4. Add a Button with the **Run workflow** action.
 5. Add display widgets such as Text, Markdown, Image, JSON, or Progress.
 6. Set each display widget's binding to the matching Output node name.
-7. Click **Publish**.
+7. Click **Save**.
 
 ## Agent-assisted editing
 
@@ -70,7 +75,9 @@ no app document, NodeTool renders the generated input/output form.
 
 ## Related topics
 
+- [Mini Apps](mini-apps.md) — concepts and runtime
+- [Building Mini Apps](mini-apps-guide.md) — recipes per use case
+- [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
 - [Workflow Editor](workflow-editor.md)
-- [Mini Apps](getting-started.md#step-4--build-an-app)
 - [Chat & Agents](global-chat-agents.md)
 - [Key Concepts](key-concepts.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,9 @@ A Mini-App hides the graph and exposes inputs and outputs only — a form anyone
 2. Click **Mini-App** in the toolbar.
 3. Fill the inputs and run. Same workflow, no graph.
 
-Custom UI? See [App Builder](app-builder.md).
+Custom UI? See [Mini Apps](mini-apps.md) for what apps solve and how they work,
+[Building Mini Apps](mini-apps-guide.md) for recipes, and
+[App Builder](app-builder.md) for the editor.
 
 ---
 

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -91,7 +91,7 @@ An agent node takes a natural-language goal, breaks it into steps, and uses tool
 
 ### Mini-Apps
 
-A workflow with the graph hidden — just inputs and outputs. Share with people who shouldn't have to read a node graph.
+A workflow with the graph hidden — just inputs and outputs. Share with people who shouldn't have to read a node graph. See [Mini Apps](mini-apps.md).
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -38,6 +38,12 @@ NodeTool is an open-source, local-first visual environment for building AI workf
 - [Templates Gallery]({{ site.url }}/templates-gallery): Browse and open starter workflows.
 - [App Builder]({{ site.url }}/app-builder): Design Mini App interfaces for workflows.
 
+## Mini Apps
+
+- [Mini Apps]({{ site.url }}/mini-apps): What Mini Apps solve and how the document, bindings, and runtime work.
+- [Building Mini Apps]({{ site.url }}/mini-apps-guide): Recipes for generators, streaming apps, galleries, live tuning, and review flows.
+- [Mini App Reference]({{ site.url }}/mini-apps-reference): Widgets, binding grammar, actions, conditions, and the document schema.
+
 ## Chat & Agents
 
 - [Chat]({{ site.url }}/global-chat): Provider-agnostic chat interface.

--- a/docs/mini-apps-guide.md
+++ b/docs/mini-apps-guide.md
@@ -1,0 +1,265 @@
+---
+layout: page
+title: "Building Mini Apps"
+description: "Recipes for building Mini Apps: one-shot generators, streaming apps, batch galleries, live parameter tuning, two-step review flows, and resource editors."
+---
+
+Eight app shapes, each built step by step. They share a base recipe; the
+differences are which widgets you place and what they bind to.
+
+New to Mini Apps? Read [Mini Apps](mini-apps.md) first for how bindings,
+operations, and instance state fit together. The widget list, binding grammar,
+and full schema are in the [Reference](mini-apps-reference.md).
+
+## Before you start
+
+The graph decides what the app can expose. Get this right first and the app is
+twenty minutes of layout:
+
+1. **Every value the user changes needs an Input node.** Its `name` is what the
+   widget binds to. A value with no Input node cannot be edited from the app,
+   except through the node-property binding used in [recipe 5](#5-live-parameter-tuning).
+2. **Every value the user sees needs an Output node.** A workflow that ends in a
+   terminal node with no Output attached produces nothing an app can display.
+3. **Give inputs sensible defaults.** An app whose first Run needs the user to
+   type into four empty fields gets abandoned. Defaults make the first run one
+   click.
+4. **Run the workflow once in the editor.** Debug the graph as a graph. An app
+   over a broken workflow only tells you the app is broken.
+
+## The base recipe
+
+Every app below starts here.
+
+1. Open the workflow and switch the tab mode to **App**.
+2. Click **App Builder**.
+3. If the workflow has no app document yet, generate one from the graph's
+   Input/Output nodes and edit that, or start from an empty canvas.
+4. Drag widgets from the palette onto the canvas.
+5. Select a widget and set its **binding** in the right-hand panel. The picker
+   lists what the live graph offers: Input nodes for write widgets, Output nodes
+   and variables for read widgets.
+6. Add a **Button**, and give it an **On click** event with the **Run workflow**
+   action.
+7. Click **Save**.
+8. Switch back to App mode and use it. Then run
+   `nodetool app debug <workflow_id>` to check the wiring the way the runtime
+   sees it.
+
+**Ask Agent** in App Builder opens the builder agent, which reads the workflow
+and edits the document through the `ui_app_*` tools. It can place widgets, set
+bindings, declare variables and operations, and add the Input, Output, or Set
+Variable nodes a layout needs. It is the fastest way to do the parts the visual
+editor does not expose: multiple operations, typed variables with scopes, and
+resource bindings.
+
+---
+
+## 1. One-shot generator
+
+**Shape:** fill a few fields, click Run, see one result.
+**Fits:** image generation, copy rewriting, summarization, translation,
+classification.
+
+This is the default app and the one most workflows should get.
+
+1. Place a **Text Input** for each Input node the user should fill. Bind each to
+   its Input node. Set a label and a placeholder that says what good input looks
+   like.
+2. Place a **Button** labelled for the result, not the mechanism: "Write the
+   caption" beats "Run".
+3. Place one display widget per Output node, bound to it:
+   **Markdown** for prose, **Image**, **Audio**, **Video**, **Json** for
+   structured data, **Table** for rows, **Output** when the type varies.
+4. Give the display widget a **placeholder** ("Your caption appears here") so
+   the app reads as intentional before the first run.
+
+Two layout habits that pay off: put inputs and the button in one **Panel** and
+outputs in another, and use **Columns** so inputs sit left and results right on
+a wide screen.
+
+## 2. Long-running and agent apps
+
+**Shape:** a run that takes 30 seconds to several minutes.
+**Fits:** agent workflows, batch processing, video generation, research tasks.
+
+Build recipe 1, then add feedback. Without it the app looks frozen and the user
+clicks Run again.
+
+1. Place a **Progress** widget bound to `op:main/exec#progress`.
+2. Place a **Text** widget bound to `op:main/exec#activity`. This is the label
+   the run reports about itself: the tool an agent is calling, the planning
+   phase, the step it is on.
+3. Set the Run button's `disabledWhen` to `op:main/exec#running` `is not empty`,
+   so it cannot be double-fired.
+4. Place a second **Button** with the **Cancel run** action and
+   `visibleWhen` = `op:main/exec#running` `is not empty`.
+5. Place a **Text** widget bound to `op:main/exec#error`, with
+   `visibleWhen` on the same binding `is not empty`.
+
+An agent app without an `activity` binding is the single most common complaint
+about Mini Apps. Bind it.
+
+## 3. Streaming text
+
+**Shape:** text that appears token by token.
+**Fits:** chat-style answers, long-form drafting, live transcripts.
+
+1. Build recipe 1 with a **Markdown** widget bound to the streaming Output node.
+2. Nothing else is required. Streamed strings concatenate into the output slot,
+   so one streamed response renders as one Markdown block rather than N
+   fragments.
+3. If the same text also feeds a later step, map the output `to: "variable"` on
+   the operation. It accumulates in the variable the same way, and a new run
+   starts a fresh value instead of appending to the last one's.
+
+## 4. Batch gallery
+
+**Shape:** one run produces many results; the user keeps generating.
+**Fits:** image variations, ad creative, thumbnail sets, name candidates.
+
+1. Point the display widget at an Output node the workflow emits repeatedly.
+   Streamed items collect into a list rather than replacing each other.
+2. Use **Table** for structured rows, or an **Image** widget for a stream of
+   images.
+3. Add a second **Button** labelled "Make another" with the **Run workflow**
+   action, placed under the results. The user never scrolls back up to the form.
+4. If a fresh set should replace the previous one, give the operation the
+   `replace` policy so a second click cancels the run in flight first.
+
+The shipped workflow templates use exactly this pattern; open one from the
+[Templates Gallery](templates-gallery.md) in App Builder to see it wired.
+
+## 5. Live parameter tuning
+
+**Shape:** drag a slider, the workflow re-runs, the result updates.
+**Fits:** image enhancement, color grading, thresholds, strength and guidance
+parameters.
+
+This is the one recipe that does not need an Input node. A widget can drive a
+node property directly.
+
+1. Place a **Slider**. Bind it to the node property rather than an input:
+   `op:main/prop:<nodeId>#<property>`. The binding picker lists any node with
+   properties, not only Input nodes.
+2. Set min, max, and step to the property's real range.
+3. Add an **On change** event with the **Run workflow** action.
+4. Set the event's **Pacing** to **On release**. The slider commits once when
+   the user lets go, instead of firing a run per pixel. Use **Debounced** for a
+   text field, and **Live** only for something cheap.
+5. Give the operation the `replace` policy: a new value should cancel the run
+   for the old one, not queue behind it.
+
+Pacing and policy work together. `live` pacing with a `queue` policy on a
+five-second workflow will build a backlog the user cannot escape.
+
+## 6. Two-step review
+
+**Shape:** run a step, look at the result, then run the next one.
+**Fits:** draft then publish, extract then post, analyze then act, generate then
+upscale.
+
+This needs two operations and a variable, so build it with **Ask Agent** or by
+editing the document.
+
+1. Declare a variable — say `draft`.
+2. Declare operation `draft` bound to the drafting workflow, with its text
+   output mapped `to: "variable"` targeting `draft`.
+3. Declare operation `publish` bound to the publishing workflow, with its input
+   mapped `from: "variable"` reading `draft`.
+4. Place a **Markdown** widget bound to `var:draft` so the user reads what will
+   be published.
+5. Place a Run button targeting the `draft` operation, and a second one
+   targeting `publish` with `visibleWhen` = `var:draft` `is not empty`.
+
+The second button cannot fire until the first produced something. That is the
+whole approval gate, and no app-level logic was written to get it.
+
+## 7. Settings that stick
+
+**Shape:** a tool used daily that should remember how it is configured.
+**Fits:** tone and brand voice, target language, output format, default model.
+
+1. Declare a variable with `scope: "user"` and `persist: true`. Only
+   user-scoped variables may persist; an `instance`-scoped one marked `persist`
+   is reported as a warning rather than silently persisted.
+2. Give it a `default`, which seeds the first session. A restored value is
+   seeded first and wins over the default.
+3. Bind a **Select** or **Switch** to `var:<id>` with an **On change** event
+   using the **Set variable** action.
+4. Map the operation input that consumes it `from: "variable"`.
+
+The setting now survives reload and is not part of the form the user fills each
+run.
+
+## 8. Conditional and multi-mode apps
+
+**Shape:** one app, several modes, each showing only what its mode needs.
+**Fits:** a tool that handles both image and text input, a form with an advanced
+section, an app that switches between two workflows.
+
+1. Place a **Select** bound to a variable — say `mode` — with options `image`
+   and `text`, and an **On change** event with the **Set variable** action.
+2. Give each mode-specific widget a `visibleWhen` of `var:mode` `equals`
+   `image` (or `text`).
+3. For an advanced section, wrap the widgets in a **Panel** and put
+   `visibleWhen` on the panel — one condition instead of nine.
+4. To switch workflows rather than fields, declare two operations and give each
+   Run button its own `operationId` and `visibleWhen`.
+
+Conditions compare one bound value against a literal. Anything more involved —
+"show this when the score is high *and* the language is German" — belongs in the
+graph: emit a single flag from a node and condition on that.
+
+## 9. Resource-backed apps
+
+**Shape:** the app reads and writes a document rather than loose values.
+**Fits:** storyboard editing, sketch iteration, curated asset collections.
+
+1. Declare a **resource binding**: a kind (`asset`, `timeline`, `storyboard`, or
+   `sketch`), a scope (a project, or one pinned document), and the operations
+   the app may perform (`read`, `create`, `update`, `delete`).
+2. Place a **Resource Picker** to choose one, or a **Resource Gallery** to show
+   a grid of them.
+3. Map the operation input that consumes it `from: "resource"`, naming the
+   resource binding.
+4. **Storyboard Scenes** edits the bound document through the resource provider
+   directly, so it fires no event of its own.
+
+`nodetool app debug` cannot simulate `from: "resource"` inputs — there is no
+resource provider outside the browser. Test these in the app.
+
+---
+
+## Checklist before you ship
+
+- [ ] Every input widget's binding resolves. `nodetool app debug --no-run`
+      reports the ones that do not.
+- [ ] Every display widget receives a value from a completed run.
+- [ ] The app has at least one run trigger.
+- [ ] Runs longer than a few seconds show progress, activity, or both.
+- [ ] The Run button is disabled while a run is in flight.
+- [ ] Errors are visible — a bound `exec#error` widget, not a silent no-op.
+- [ ] Inputs have defaults, so the first Run is one click.
+- [ ] Display widgets have placeholders, so the empty app reads as finished.
+- [ ] Labels name results, not mechanisms.
+
+## Common mistakes
+
+| Symptom | Cause |
+| --- | --- |
+| A widget shows nothing after a run | It is bound to a node the run never emits, or to an Output node the graph does not have. |
+| A widget silently does nothing | Its binding does not resolve. Run `app debug --no-run`. |
+| Values from another run appear | Not possible by design: messages are matched by `job_id` and foreign ones are dropped. If values look wrong, the binding points at the wrong node. |
+| The slider fires dozens of runs | Pacing is `live`. Use `release`. |
+| Runs pile up behind each other | The operation policy is `queue`. Use `replace`. |
+| A persisted setting resets | The variable is `instance`-scoped. Only `user` scope persists. |
+| The app broke after a graph edit | A legacy name-based binding pointed at a renamed node. Re-bind; the editor writes ID-based bindings, which survive renames. |
+
+## Related
+
+- [Mini Apps](mini-apps.md) — how the runtime works
+- [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
+- [App Builder](app-builder.md) — the editor
+- [Templates Gallery](templates-gallery.md) — shipped workflows that already carry apps
+- [Workflow Debugging](workflow-debugging.md) — debugging the graph underneath

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -1,0 +1,283 @@
+---
+layout: page
+title: "Mini App Reference"
+description: "Widget catalog, binding grammar, actions, conditions, format filters, and the app document schema."
+---
+
+The complete surface of the Mini App layer. For what these mean, see
+[Mini Apps](mini-apps.md); for how to combine them, see
+[Building Mini Apps](mini-apps-guide.md).
+
+Everything here is defined in `packages/app-runtime`, which the web runtime, the
+`nodetool app debug` harness, and the eval suites all share.
+
+## Widgets
+
+Every widget accepts `binding`, `visibleWhen`, `disabledWhen`, and `format` on
+top of its own fields.
+
+### Display
+
+| Widget | Shows |
+| --- | --- |
+| Heading | Static text at H1–H3. |
+| Text | Static or formatted text. |
+| Markdown | Rendered Markdown. The right choice for streamed prose. |
+| Image | An image value. Fit `contain` or `cover`, fixed height, placeholder. |
+| Audio | An audio value with a player. |
+| Video | A video value with a player, max height, placeholder. |
+| JSON | A structured value, formatted. |
+| Table | An array value as rows. Max height, placeholder. |
+| Output | A value whose type varies; renders by shape. |
+| Progress | The bound operation's progress. |
+
+### Inputs
+
+| Widget | Writes | Commits |
+| --- | --- | --- |
+| Workflow Input | The bound Input node, rendered from its declared type. | no |
+| Text Input | Text. Single-line or multiline. | yes |
+| Number Input | A number. Min, max, step. | yes |
+| Slider | A number. Min, max, step. | yes |
+| Switch | A boolean. | no |
+| Select | One of a fixed option list. | no |
+| Image Input | An image. | no |
+| Audio Input | An audio file. | no |
+| Video Input | A video file. | no |
+| Document Input | A document. | no |
+| Color Input | A color. | no |
+| Resource Picker | The selected resource of a resource binding. | no |
+| Resource Gallery | The selected resource, from a grid. Tile size. | no |
+| Storyboard Scenes | Edits the bound storyboard through the resource provider. Fires no event. | no |
+
+"Commits" means the control reports a settled value on release or blur, which is
+what makes `release` pacing meaningful.
+
+### Actions and layout
+
+| Widget | Does |
+| --- | --- |
+| Button | Fires its click events. Variant `contained`/`outlined`/`text`, color `primary`/`secondary`/`warning`. |
+| Panel | A titled container holding other widgets. |
+| Columns | Two slots, `left` and `right`. |
+| Divider | A horizontal rule. |
+
+## Binding grammar
+
+A binding is one string. Bindings key on node **IDs**, so renaming a node in the
+graph editor never breaks an app.
+
+| Token | Addresses |
+| --- | --- |
+| `op:<opId>/in:<nodeId>` | An operation input. |
+| `op:<opId>/out:<nodeId>` | An operation output. |
+| `op:<opId>/prop:<nodeId>#<prop>` | A node property driven by a widget. |
+| `op:<opId>/exec#<field>` | Execution state: `running`, `progress`, `error`, `activity`. |
+| `var:<variableId>` | A declared app variable. |
+| `view:<componentId>#<prop>` | Widget-local state. Never persisted. |
+| `node:<nodeId>#<prop>` | Legacy node property, resolved against the default operation. |
+| `<name>` | Legacy bare name, resolved against the live graph. |
+
+A bare name resolves by how the widget uses it: a write widget looks for an
+Input node, a read widget looks for an Output node and then a variable, and a
+condition or `format` token tries outputs, then inputs, then variables. A name
+that matches nothing is a validation error, not a silent no-op.
+
+## Actions
+
+A widget event dispatches one action. Actions are data the runtime interprets.
+
+| Action | Fields | Effect |
+| --- | --- | --- |
+| `run` | `operationId` | Runs the operation, subject to its policy. |
+| `cancel` | `operationId`, optional `invocationId` | Cancels the operation's live runs, or one specific run. |
+| `setVariable` | `variableId`, `value` or the firing widget's value | Writes a variable. |
+| `toggleVariable` | `variableId` | Inverts a boolean variable. |
+| `resourceCommand` | `resourceBindingId`, `command` | `read`, `create`, `update`, `delete`, or `upload` on a resource binding. |
+| `openResource` | `resourceBindingId` | Opens the bound resource in its editor. |
+
+The visual editor exposes **Run workflow**, **Cancel run**, **Set variable**,
+and **Toggle variable**. The resource actions are set through the agent or by
+editing the document.
+
+### Triggers and pacing
+
+Events fire on `click` (Button) or `change` (input widgets). A change event has a
+pace:
+
+| Pace | Fires |
+| --- | --- |
+| `live` | On every change. |
+| `release` | When the control commits — slider release, input blur. Only offered on committing controls. |
+| `debounce` | Trailing, after a quiet moment. |
+
+## Conditions
+
+`visibleWhen` and `disabledWhen` each hold a binding, an operator, and a
+literal. An unresolvable condition is treated as no condition, so a broken
+binding never silently hides a widget.
+
+| Operator | Editor label | True when |
+| --- | --- | --- |
+| `notEmpty` | is not empty | The value is set, non-empty, and not `false`. |
+| `empty` | is empty | The value is unset, empty, or `false`. |
+| `eq` | equals | Equal, after coercing the literal to the value's type. |
+| `neq` | does not equal | Not equal. |
+| `gt` / `gte` | is greater than / is at least | Numeric comparison. A non-numeric value never satisfies one. |
+| `lt` / `lte` | is less than / is at most | Numeric comparison. |
+| `contains` | contains | A string contains the substring, or an array contains the item. |
+
+Literals are stored as strings and coerced to the shape of the value they are
+compared against, so `count gt "3"` compares numbers and `dark eq "true"`
+compares booleans.
+
+## Format templates
+
+`format` renders `{binding}` tokens in place of the raw value, with one optional
+filter: `{op:main/out:n1|truncate:80}`. An unknown filter or unresolvable
+binding renders as the empty string.
+
+| Filter | Argument | Result |
+| --- | --- | --- |
+| `number` | digits | The value as a number, optionally fixed to N digits. |
+| `date` | `short` | Locale date-time, or locale date with `short`. |
+| `upper` | — | Uppercased. |
+| `lower` | — | Lowercased. |
+| `join` | separator | An array joined; defaults to `", "`. |
+| `truncate` | length | Cut to N characters with an ellipsis. |
+
+## Document schema
+
+`workflow.app_doc` holds an `ApplicationDocument`. Schema version 3 is current;
+version 1 and 2 documents are lifted to 3 on load, with one implicit `main`
+operation bound to the host workflow.
+
+```ts
+interface ApplicationDocument {
+  schemaVersion: number;      // 3
+  ui: PuckData;               // { root, content, zones }
+  operations: OperationBinding[];
+  resources: ResourceBinding[];
+  variables: VariableDeclaration[];
+  theme?: { id: string };
+}
+```
+
+### Operations
+
+```ts
+interface OperationBinding {
+  id: string;
+  name: string;
+  workflowId: string;
+  workflowVersion?: number;   // pinned in a release, floating in a draft
+  inputs: Record<string, InputMapping>;    // keyed by node id
+  outputs: Record<string, OutputMapping>;  // keyed by node id
+  policy: "parallel" | "replace" | "queue";
+  timeoutMs?: number;
+}
+```
+
+| Input mapping | Value comes from |
+| --- | --- |
+| `{ from: "widget" }` | The bound widget. The default when an input has no mapping. |
+| `{ from: "variable", variableId }` | An app variable. |
+| `{ from: "constant", value }` | A fixed value. |
+| `{ from: "resource", resourceBindingId }` | The resource currently selected for that binding. |
+
+| Output mapping | Value goes to |
+| --- | --- |
+| `{ to: "display" }` | The output slot display widgets read. |
+| `{ to: "variable", variableId }` | An app variable, *and* the display slot. |
+
+| Policy | On a second run while one is live |
+| --- | --- |
+| `parallel` | Start anyway. |
+| `replace` | Cancel the live runs, then start. The default. |
+| `queue` | Wait for them to settle, then start. |
+
+### Variables
+
+```ts
+interface VariableDeclaration {
+  id: string;
+  name: string;
+  type?: { type: string; optional?: boolean } | null;
+  default?: unknown;
+  scope: "instance" | "user";  // this open app, or persisted per user
+  persist: boolean;            // only user-scoped variables may persist
+}
+```
+
+The visual editor's variable picker lists the Set Variable channels the graph
+publishes. Typed variables with a scope, default, and persistence are declared
+through the agent or by editing the document.
+
+### Resources
+
+```ts
+interface ResourceBinding {
+  id: string;
+  name: string;
+  kind: "asset" | "timeline" | "storyboard" | "sketch";
+  scope: { projectId?: string; fixedId?: string };
+  operations: ("read" | "create" | "update" | "delete")[];
+}
+```
+
+## Instance state
+
+| Namespace | Key | Holds |
+| --- | --- | --- |
+| `inputs` | `opId:nodeId`, or `opId:nodeId#prop` | `{ value, dirty, revision }`. `dirty` is true once a widget rather than a default wrote it. |
+| `outputs` | `opId:nodeId` | `{ value, invocationId, status, revision }`. Status is `empty`, `pending`, `streaming`, or `done`. |
+| `variables` | variable id | The current value. |
+| `view` | `componentId:prop` | Widget-local state. |
+| `invocations` | job id | `{ id, operationId, status, progress, error, startedAt }`. |
+
+Invocation status is `pending`, `running`, `completed`, `failed`, or
+`cancelled`. Streamed values append: strings concatenate, structured items
+collect into a list. A message whose `job_id` this instance did not start is
+dropped.
+
+## Agent tools
+
+The builder agent edits the open document through these frontend tools:
+
+| Area | Tools |
+| --- | --- |
+| Layout | `ui_app_get_snapshot`, `ui_app_list_component_types`, `ui_app_add_component`, `ui_app_update_component`, `ui_app_remove_component`, `ui_app_select_component`, `ui_app_set_title` |
+| Operations | `ui_app_list_operations`, `ui_app_add_operation`, `ui_app_update_operation`, `ui_app_remove_operation` |
+| Variables | `ui_app_list_variables`, `ui_app_declare_variable`, `ui_app_update_variable`, `ui_app_remove_variable` |
+| Resources | `ui_app_list_resources`, `ui_app_add_resource`, `ui_app_remove_resource` |
+| Bindings | `ui_app_get_binding_targets` |
+
+## CLI
+
+```bash
+npm run dev:nodetool -- app debug <workflow_id>
+npm run dev:nodetool -- app debug workflow.json --params '{"prompt":"hi"}'
+npm run dev:nodetool -- app debug <id> --no-run    # static wiring check
+npm run dev:nodetool -- app debug <id> --json      # full AppDebugReport
+
+# Scripted interactions
+npm run dev:nodetool -- app debug <id> --interact \
+  '[{"set":{"key":"prompt","value":"hi"}},{"click":"Button-1"}]'
+npm run dev:nodetool -- app debug <id> --interact \
+  '[{"set":{"key":"tone","value":"terse","operationId":"draft"}},{"run":"draft"}]'
+```
+
+The harness runs every declared operation, not only the first. Widgets are
+clicked by component id, unique type, or unique label. The bundle lands in
+`nodetool-debug/app-<id>-<ts>/` with `report.json`, `report.md`, `app.json`,
+`workflow.json`, and one `server/run-N.messages.jsonl` per triggered run.
+
+Not simulated: `visibleWhen`, `disabledWhen`, `format`, and `from: "resource"`
+inputs.
+
+## Related
+
+- [Mini Apps](mini-apps.md) — concepts and runtime
+- [Building Mini Apps](mini-apps-guide.md) — recipes per use case
+- [App Builder](app-builder.md) — the editor
+- [CLI](cli.md) — the full command reference

--- a/docs/mini-apps.md
+++ b/docs/mini-apps.md
@@ -1,0 +1,239 @@
+---
+layout: page
+title: "Mini Apps"
+description: "What Mini Apps are, which problems they solve, and how the app document, bindings, and runtime fit together."
+---
+
+A Mini App is a workflow with a face on it. The graph stays where it is; the app
+puts a form in front of it, runs it on a click or a change, and streams the
+outputs back into widgets. Nobody using the app sees a node.
+
+Every workflow can be a Mini App. Open a workflow, switch the tab to **App**,
+and NodeTool renders a form built from the graph's Input and Output nodes. Click
+**App Builder** and you replace that generated form with a layout you design.
+
+- **[Building Mini Apps](mini-apps-guide.md)** — recipes for eight app shapes,
+  each built step by step.
+- **[Mini App Reference](mini-apps-reference.md)** — widgets, binding tokens,
+  actions, conditions, format filters, and the document schema.
+- **[App Builder](app-builder.md)** — the editor itself.
+
+## What Mini Apps are for
+
+A workflow graph is the right surface for the person building the pipeline and
+the wrong one for everyone else. The graph exposes model choices, retry paths,
+and intermediate nodes that a person who just wants a caption written does not
+need and should not be able to break. A Mini App narrows that surface to the
+three fields that actually vary.
+
+Concretely, apps solve these:
+
+| Problem | What the app does |
+| --- | --- |
+| A teammate needs to run your workflow but not edit it | Inputs bound to Input nodes, one Run button. The graph is not reachable from the app. |
+| The workflow has 40 nodes and 3 things worth changing | Only those 3 get widgets. Everything else stays fixed in the graph. |
+| A run takes 90 seconds and looks frozen | Bind a Progress widget and an activity label to the operation's execution state. |
+| The result is a stream, not a value | Display widgets accumulate streamed chunks; text concatenates, structured items collect into a list. |
+| One screen needs two different workflows | Declare two operations. Each has its own inputs, outputs, state, and Run button. |
+| A step needs review before the next one | Operation A writes an app variable, a widget shows it, a second button runs operation B reading that variable. |
+| A parameter should re-run the workflow as you drag it | A slider bound to a node property with a `change` event and `release` pacing. |
+| The same tool is used daily with the same settings | A user-scoped variable with `persist: true` remembers the setting across sessions. |
+
+When **not** to build one: a workflow you run once, a pipeline driven by another
+program (use the [Workflow API](workflow-api.md)), or an open-ended task with no
+fixed shape (use [Chat](global-chat.md) instead).
+
+## Where apps run
+
+| Surface | How to get there |
+| --- | --- |
+| Workspace tab | Open a workflow, toggle the tab mode to **App**. |
+| Standalone page | `/miniapp/:workflowId` — the app with no editor chrome around it. |
+| App Builder | `/app-builder/:workflowId`, or the **App Builder** button in the tab bar. |
+| Headless | `nodetool app debug <workflow_id>` runs the app without a browser. See [Debugging](#debugging-an-app). |
+
+Mobile renders the same documents. Apps run wherever the workflow runs — the
+desktop app, a self-hosted server, or NodeTool Cloud.
+
+Sharing a Mini App means sharing the workflow that carries it. A workflow share
+link (`/share/:token`) hands the recipient the graph *and* its app document, so
+they open it in App mode and it works. There is no public, unauthenticated app
+host.
+
+## How a Mini App works
+
+Four pieces, and only one of them computes.
+
+```
+ApplicationDocument            (what you author)
+  ui           Puck layout, widgets, bindings
+  operations   named workflow bindings + input/output mappings
+  variables    declared app state slots
+  resources    typed handles to assets, timelines, storyboards, sketches
+        │
+        │  bindings resolve against the live graph
+        ▼
+AppInstanceState               (what one open app holds)
+  inputs · outputs · variables · view · invocations
+        │
+        │  streaming fold: run messages → state events
+        ▼
+Workflow run                   (where all the logic lives)
+```
+
+The document is configuration. Nothing in it branches, loops, or calls a
+provider — that is the graph's job. This is deliberate: logic in the graph is
+testable, cacheable, and visible to the agent, and logic in the app layer is
+none of those.
+
+### The app document
+
+`ApplicationDocument` lives on `workflow.app_doc` and carries four collections
+plus a schema version (currently 3):
+
+- **`ui`** — the Puck layout: which widgets are placed where, and what each one
+  is bound to.
+- **`operations`** — named bindings to workflows. An operation has an id, a
+  workflow id, an optional pinned version, per-input and per-output mappings, a
+  concurrency policy, and an optional timeout. The same workflow can be bound
+  twice with different mappings (`translateTitle`, `translateBody`).
+- **`variables`** — declared app state slots, each with a type, a default, a
+  scope (`instance` or `user`), and whether it persists.
+- **`resources`** — typed handles to an asset, timeline, storyboard, or sketch,
+  scoped to a project or pinned to one document, with the operations the app may
+  perform on it.
+
+An app with no explicit operations still runs: a legacy or generated document
+gets one implicit `main` operation bound to its host workflow, where every input
+takes its bound widget's value and every output displays.
+
+### Bindings
+
+A binding is the string that connects one widget to one slot of app state. It
+travels through the document as a single token:
+
+```
+op:<opId>/in:<nodeId>            an operation input
+op:<opId>/out:<nodeId>           an operation output
+op:<opId>/prop:<nodeId>#<prop>   a node property driven by a widget
+op:<opId>/exec#<field>           running | progress | error | activity
+var:<variableId>                 a declared app variable
+view:<componentId>#<prop>        widget-local state, never persisted
+```
+
+Bindings key on node **IDs**, not names. Renaming an Input node in the graph
+editor cannot break an app. Names are still accepted and resolved against the
+live graph, which is how documents written before ID bindings keep working; the
+editor rewrites them to the ID form when it can, and reports the ones it cannot.
+
+How a bare name resolves depends on how the widget uses it. A write widget looks
+for an Input node, a read widget looks for an Output node and then a variable,
+and a condition or `format` token tries outputs, then inputs, then variables.
+
+A binding that resolves to nothing is a validation error, not a silent no-op.
+Both App Builder and `nodetool app debug` report it.
+
+### Instance state
+
+One open app holds one `AppInstanceState`, split into five namespaces so nothing
+collides:
+
+| Namespace | Key | Holds |
+| --- | --- | --- |
+| `inputs` | `opId:nodeId` | Current input values, plus whether a widget (rather than a default) wrote them. |
+| `outputs` | `opId:nodeId` | Streamed output values with their status: `empty`, `pending`, `streaming`, `done`. |
+| `variables` | variable id | Declared app state. |
+| `view` | `componentId:prop` | Widget-local state. Never persisted. |
+| `invocations` | job id | Status, progress, error, and activity label per run. |
+
+Keying inputs and outputs by operation *and* node means two operations that
+share a workflow never overwrite each other.
+
+The reducer is pure, and the web runtime, the CLI harness, and the eval suites
+all drive the same one. What you see in `nodetool app debug` is what the browser
+does.
+
+### The run lifecycle
+
+1. A widget event dispatches an action — `run`, `cancel`, `setVariable`,
+   `toggleVariable`, `resourceCommand`, or `openResource`. Actions are data the
+   runtime interprets; there is no place to write a statement.
+2. For `run`, the operation's policy decides what happens if it is already
+   running: `parallel` starts anyway, `replace` cancels the live invocations
+   first, `queue` waits for them to settle.
+3. Params are built at the execution boundary. Each input takes its value from
+   its mapping: the bound widget (the default), a variable, a constant, or the
+   currently selected resource. Node IDs become the names the run protocol
+   wants, which is why a graph rename never reaches the document.
+4. The invocation is created, its output slots go `pending`, and the run starts.
+5. Run messages fold into state events. Every message is matched to an
+   invocation by `job_id`; a message from a job this instance did not start is
+   dropped. That is what keeps a second tab, an overlapping run, or a run
+   launched from the graph editor from contaminating what the app shows.
+6. Values land in their output slot, and — when the operation maps that output
+   `to: "variable"` — in an app variable too. Streamed strings concatenate;
+   structured items collect into a list. A new run starts a fresh value rather
+   than appending to the previous one's.
+
+### Execution state
+
+Every operation exposes four fields a widget can bind to, so an app over a slow
+or agentic workflow shows more than a spinner:
+
+- `running` — true while any invocation is live.
+- `progress` — the active invocation's progress.
+- `error` — the active invocation's error.
+- `activity` — the most recent human-readable label the run emitted: the tool an
+  agent is calling, the planning phase it is in, the step it is on.
+
+Bind `activity` to a Text widget on any app that wraps an agent. Without it the
+user watches a spinner for two minutes with no idea whether anything is
+happening.
+
+### The logic that lives in the app
+
+Three things, and the vocabulary is closed on purpose:
+
+- **`visibleWhen`** — hide a widget unless a condition holds.
+- **`disabledWhen`** — disable it while a condition holds.
+- **`format`** — a `{binding|filter}` template rendered in place of the raw
+  value.
+
+Conditions compare one bound value against a literal with one of nine
+operators. Format templates pipe a value through one of six filters. Anything
+beyond that belongs in the graph. If your app wants a derived value, compute it
+in a node and bind a widget to the output.
+
+## Debugging an app
+
+`nodetool app debug` runs the whole app headlessly: it validates every binding
+against the workflow's inputs, outputs, and variables, seeds input defaults,
+applies params, clicks the run trigger (or a scripted interaction sequence),
+executes on the kernel runner, folds the streamed messages, and reports each
+widget's final state.
+
+```bash
+npm run dev:nodetool -- app debug <workflow_id>
+npm run dev:nodetool -- app debug <workflow_id> --no-run   # wiring check only
+npm run dev:nodetool -- app debug <workflow_id> --json     # full report
+```
+
+The verdict catches app-level failures a workflow-only run cannot: a binding to
+a missing input or output, an app with no run trigger, a display widget that
+never receives a value, an output mapped to an undeclared variable, an event
+naming an operation the document does not declare, and an elapsed timeout.
+
+Two things it does not simulate: `visibleWhen`/`disabledWhen`/`format` (a widget
+hidden by a condition is reported as if visible), and `from: "resource"` inputs,
+which have no provider outside the browser.
+
+For the workflow underneath, `nodetool validate` is the cheap pre-flight and
+`nodetool debug` is the full run. See [Workflow Debugging](workflow-debugging.md).
+
+## Related
+
+- [Building Mini Apps](mini-apps-guide.md) — recipes per use case
+- [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
+- [App Builder](app-builder.md) — the editor
+- [Workflow Editor](workflow-editor.md) — building the graph underneath
+- [Key Concepts](key-concepts.md) — how workflows, assets, and apps fit together


### PR DESCRIPTION
Adds a Mini Apps section to the docs site: what they solve, how they work, and how to build one for a given use case. The only existing coverage was `app-builder.md` (76 lines describing the editor's buttons), which left the runtime, the document schema, and the actual app shapes undocumented.

## New pages

**`docs/mini-apps.md`** — the overview.
- A use-case table mapping problems to what the app does about them, plus when *not* to build one (one-off runs → editor, programmatic → Workflow API, open-ended → Chat).
- Where apps run: workspace App tab, `/miniapp/:workflowId`, App Builder, and headless via `nodetool app debug`. States plainly that sharing a Mini App means sharing the workflow that carries it — there's no public app host.
- How it works: the app document (`ui` / `operations` / `variables` / `resources`), the ID-based binding grammar and why renames don't break apps, the five instance-state namespaces, the six-step run lifecycle, execution state (`running`/`progress`/`error`/`activity`), and the deliberately closed logic vocabulary.

**`docs/mini-apps-guide.md`** — nine build recipes, each step by step: one-shot generator, long-running/agent apps, streaming text, batch gallery, live parameter tuning (node-property binding + `release` pacing), two-step review (two operations bridged by a variable), persisted settings, conditional multi-mode, and resource-backed apps. Opens with graph prerequisites and a base recipe, closes with a pre-ship checklist and a symptom/cause table.

**`docs/mini-apps-reference.md`** — the tables: widget catalog (display / inputs / actions / layout, with which controls commit), binding token grammar, the six actions and their triggers/pacing, the nine condition operators with their editor labels, the six format filters, the v3 document schema (`OperationBinding`, `InputMapping`, `OutputMapping`, policies, `VariableDeclaration`, `ResourceBinding`), instance state, the `ui_app_*` agent tools, and the `app debug` CLI with its two unsimulated surfaces.

Content is derived from `packages/app-runtime/src/` (`document.ts`, `bindings.ts`, `actions.ts`, `conditions.ts`, `state.ts`, `operations.ts`, `policy.ts`, `widgets.ts`, `fold.ts`), the Puck editor config in `web/src/components/appbuilder/`, and `web/src/lib/tools/builtin/puck.ts`.

## Existing pages touched

- `docs/_includes/sidebar.html` — new "Mini Apps" nav section (Overview, Building, Reference, App Builder).
- `docs/llms.txt` — matching section.
- `docs/app-builder.md` — cross-links into the new section; scoped to "this page covers the editor". Fixes a stale instruction: the builder's save control is labelled **Save**, not **Publish** (`PuckAppEditor.tsx` replaces Puck's built-in Publish button with a Save button).
- `docs/getting-started.md`, `docs/key-concepts.md` — links from their existing Mini-App mentions.

## Testing

Docs-only; no TypeScript touched. Verified every internal `.md` link in the new pages resolves to an existing file, and checked the prose against the forbidden-expressions list in `docs/WRITING_STYLE.md` (no hits).

Two claims worth a reviewer's eye, both drawn from the current code rather than assumed:
- The visual editor's variable picker only lists Set Variable channels the graph publishes, so typed/scoped/persisted variables and multi-operation documents are described as agent- or document-edited. (`web/src/components/appbuilder/puck/fields.tsx`)
- `visibleWhen` / `disabledWhen` / `format` and `from: "resource"` inputs are documented as not simulated by `app debug`, matching the caveat in `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VW85mEThToXm4bxMgaru6o)_