### PR TITLE
Give every provider node with displayable output a content-card body

### DIFF
--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -700,6 +701,9 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
     value: { output: spec.outputType },
     configurable: true
   });
+  // Every AtlasCloud model generates an image or a video — preview it in the
+  // node body.
+  applyContentCardBody(AtlasNodeClass);
 
   const { inlineFields, inputFields } = computeFieldClassification(spec.fields);
   Object.defineProperty(AtlasNodeClass, "inlineFields", {

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -560,13 +561,6 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
       value: true,
       configurable: true
     });
-    // Media generators render as a content card (image/video/audio/3D body).
-    // This is the metadata-driven equivalent of the frontend's old
-    // "fal.* namespace + media output" heuristic.
-    Object.defineProperty(FalNodeClass, "body", {
-      value: "content_card",
-      configurable: true
-    });
   }
 
   if (isImageOutput) {
@@ -620,6 +614,11 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
       configurable: true
     });
   }
+
+  // Preview-forward body for anything the editor can display. Read off the
+  // resolved outputs, not `spec.outputType` — endpoints that declare their
+  // media through `outputFields` carry a bare "dict"/"any" there.
+  applyContentCardBody(FalNodeClass);
 
   // Compute and set field classification
   const { inlineFields, inputFields } = computeFieldClassification(spec.inputFields);

--- a/packages/huggingface-nodes/src/index.ts
+++ b/packages/huggingface-nodes/src/index.ts
@@ -1,3 +1,4 @@
+import { tagContentCardBodies } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { HUGGINGFACE_TEXT_NODES } from "./nodes/text.js";
 import { HUGGINGFACE_IMAGE_NODES } from "./nodes/image.js";
@@ -10,13 +11,19 @@ export * from "./nodes/image.js";
 export * from "./nodes/audio.js";
 export * from "./nodes/video.js";
 
-/** Every Hugging Face Inference Providers node, across all task modalities. */
-export const HUGGINGFACE_NODES: readonly NodeClass[] = [
+/**
+ * Every Hugging Face Inference Providers node, across all task modalities.
+ *
+ * Nodes whose primary output is displayable (generated media, or the text a
+ * generator/captioner/transcriber returns) render a content card; the ones
+ * that return scores or bounding boxes keep the generic body.
+ */
+export const HUGGINGFACE_NODES: readonly NodeClass[] = tagContentCardBodies([
   ...HUGGINGFACE_TEXT_NODES,
   ...HUGGINGFACE_IMAGE_NODES,
   ...HUGGINGFACE_AUDIO_NODES,
   ...HUGGINGFACE_VIDEO_NODES
-];
+]);
 
 export function registerHuggingFaceNodes(registry: {
   register: (nodeClass: NodeClass) => void;

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -485,17 +486,14 @@ export function createKieNodeClass(spec: KieManifestEntry): NodeClass {
       value: true,
       configurable: true
     });
-    // Media generators render as a content card. Metadata-driven equivalent of
-    // the frontend's old "kie.* namespace + media output" heuristic.
-    Object.defineProperty(KieNodeClass, "body", {
-      value: "content_card",
-      configurable: true
-    });
   }
   Object.defineProperty(KieNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType },
     configurable: true
   });
+  // Preview-forward body for anything the editor can display — the media
+  // generators plus the text-output models.
+  applyContentCardBody(KieNodeClass);
 
   // Compute and set field classification
   const { inlineFields, inputFields } = computeFieldClassification(spec.fields);

--- a/packages/node-sdk/src/content-card.ts
+++ b/packages/node-sdk/src/content-card.ts
@@ -1,0 +1,86 @@
+/**
+ * Which output types render as a content card.
+ *
+ * A node whose primary output is one of these has something to *show* — an
+ * image, a video, an audio waveform, a 3D model, or text. The editor renders
+ * those with `ContentCardBody` (a preview-forward body) instead of the generic
+ * input/output layout, driven by `body: "content_card"` in the node metadata.
+ *
+ * Provider packs derive the flag from their manifest rather than declaring it
+ * per node, so a new model added to a manifest gets the right body for free.
+ * Keep this list in sync with `getContentCardVariant` in
+ * `web/src/components/node_types/contentCardRegistry.ts`, which maps the same
+ * types onto the concrete preview variant.
+ */
+const CONTENT_CARD_OUTPUT_TYPES: ReadonlySet<string> = new Set([
+  "image",
+  "image_mask",
+  "mask",
+  "video",
+  "audio",
+  "model_3d",
+  "asset_3d",
+  "str",
+  "text"
+]);
+
+import type { DeclaredOutputTypes } from "./base-node.js";
+
+/** The parts of a node class this module reads and writes. */
+interface ContentCardTarget {
+  metadataOutputTypes?: DeclaredOutputTypes | undefined;
+  outputTypes?: DeclaredOutputTypes;
+  body?: string | undefined;
+}
+
+/** True when a node with this primary output type should render a content card. */
+export function isContentCardOutputType(
+  outputType: string | undefined
+): boolean {
+  return outputType !== undefined && CONTENT_CARD_OUTPUT_TYPES.has(outputType);
+}
+
+/**
+ * Type of the output slot the editor previews — the one `getNodeMetadata`
+ * puts at `outputs[0]`, so the resolution order matches it: an explicit
+ * `metadataOutputTypes` map wins over `outputTypes`.
+ */
+export function primaryDeclaredOutputType(
+  nodeClass: ContentCardTarget
+): string | undefined {
+  const declared = nodeClass.metadataOutputTypes ?? nodeClass.outputTypes ?? {};
+  return Object.values(declared)[0];
+}
+
+/**
+ * Stamp `body = "content_card"` on a generated node class whose primary output
+ * is displayable. A class that already declares its own `body` keeps it —
+ * per-node overrides win (e.g. the "small" voice-picker bodies).
+ *
+ * Call after the class's output types are defined.
+ */
+export function applyContentCardBody(nodeClass: ContentCardTarget): void {
+  if (nodeClass.body !== undefined) {
+    return;
+  }
+  if (!isContentCardOutputType(primaryDeclaredOutputType(nodeClass))) {
+    return;
+  }
+  Object.defineProperty(nodeClass, "body", {
+    value: "content_card",
+    configurable: true
+  });
+}
+
+/**
+ * List form of {@link applyContentCardBody}, for hand-written node packs that
+ * export a node array. Returns `classes` so it can wrap the array literal.
+ */
+export function tagContentCardBodies<T extends readonly ContentCardTarget[]>(
+  classes: T
+): T {
+  for (const cls of classes) {
+    applyContentCardBody(cls);
+  }
+  return classes;
+}

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./base-node.js";
 export * from "./class-name-to-title.js";
+export * from "./content-card.js";
 export * from "./pricing-bundle.js";
 export * from "./cost-estimate.js";
 export * from "./field-classification.js";

--- a/packages/node-sdk/tests/content-card.test.ts
+++ b/packages/node-sdk/tests/content-card.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyContentCardBody,
+  isContentCardOutputType,
+  primaryDeclaredOutputType,
+  tagContentCardBodies
+} from "../src/content-card.js";
+
+describe("isContentCardOutputType", () => {
+  it("accepts the displayable types", () => {
+    for (const t of [
+      "image",
+      "image_mask",
+      "mask",
+      "video",
+      "audio",
+      "model_3d",
+      "asset_3d",
+      "str",
+      "text"
+    ]) {
+      expect(isContentCardOutputType(t)).toBe(true);
+    }
+  });
+
+  it("rejects everything else", () => {
+    for (const t of ["dict", "any", "list", "float", "int", "bool", undefined]) {
+      expect(isContentCardOutputType(t)).toBe(false);
+    }
+  });
+});
+
+describe("primaryDeclaredOutputType", () => {
+  it("prefers metadataOutputTypes over outputTypes", () => {
+    expect(
+      primaryDeclaredOutputType({
+        metadataOutputTypes: { video_url: "video" },
+        outputTypes: { video_url: "dict", thumbnail: "image" }
+      })
+    ).toBe("video");
+  });
+
+  it("falls back to outputTypes", () => {
+    expect(primaryDeclaredOutputType({ outputTypes: { output: "str" } })).toBe(
+      "str"
+    );
+  });
+
+  it("returns undefined when nothing is declared", () => {
+    expect(primaryDeclaredOutputType({})).toBeUndefined();
+  });
+});
+
+describe("applyContentCardBody", () => {
+  it("stamps a displayable primary output", () => {
+    const cls = { metadataOutputTypes: { output: "video" } };
+    applyContentCardBody(cls);
+    expect((cls as { body?: string }).body).toBe("content_card");
+  });
+
+  it("leaves a non-displayable primary output alone", () => {
+    const cls = { outputTypes: { output: "dict" } };
+    applyContentCardBody(cls);
+    expect((cls as { body?: string }).body).toBeUndefined();
+  });
+
+  it("keeps an explicitly declared body", () => {
+    const cls = { outputTypes: { voice_id: "str" }, body: "small" };
+    applyContentCardBody(cls);
+    expect(cls.body).toBe("small");
+  });
+
+  it("ignores secondary outputs", () => {
+    // Only the first slot drives the preview, matching getNodeMetadata.
+    const cls = { outputTypes: { scores: "list", label: "str" } };
+    applyContentCardBody(cls);
+    expect((cls as { body?: string }).body).toBeUndefined();
+  });
+});
+
+describe("tagContentCardBodies", () => {
+  it("stamps each qualifying class and returns the list", () => {
+    const classes = [
+      { metadataOutputTypes: { output: "audio" } },
+      { outputTypes: { output: "list" } }
+    ];
+    expect(tagContentCardBodies(classes)).toBe(classes);
+    expect((classes[0] as { body?: string }).body).toBe("content_card");
+    expect((classes[1] as { body?: string }).body).toBeUndefined();
+  });
+});

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -348,17 +349,14 @@ export function createReplicateNodeClass(
       value: true,
       configurable: true
     });
-    // Media generators render as a content card. Metadata-driven equivalent of
-    // the frontend's old "replicate.* namespace + media output" heuristic.
-    Object.defineProperty(ReplicateNodeClass, "body", {
-      value: "content_card",
-      configurable: true
-    });
   }
   Object.defineProperty(ReplicateNodeClass, "metadataOutputTypes", {
     value: { output: spec.outputType === "dict" ? "any" : spec.outputType },
     configurable: true
   });
+  // Preview-forward body for anything the editor can display — the media
+  // generators plus the text-output models (captioners, transcribers, LLMs).
+  applyContentCardBody(ReplicateNodeClass);
 
   // Compute and set field classification
   const { inlineFields, inputFields } = computeFieldClassification(spec.inputFields);

--- a/packages/together-nodes/src/together-factory.ts
+++ b/packages/together-nodes/src/together-factory.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -347,6 +348,9 @@ export function createTogetherNodeClass(spec: TogetherManifestEntry): NodeClass 
     "metadataOutputTypes",
     isMedia ? { output: spec.outputType } : { text: "str" }
   );
+  // Preview-forward body for anything the editor can display — the image,
+  // video and audio generators plus the text-output transcribers.
+  applyContentCardBody(TogetherNodeClass);
 
   const { inlineFields, inputFields } = classifyFields(
     spec.fields.map((f) => ({ name: f.name, propType: f.type }))

--- a/packages/topaz-nodes/src/topaz-factory.ts
+++ b/packages/topaz-nodes/src/topaz-factory.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  applyContentCardBody,
   BaseNode,
   classifyFields,
   classNameToTitle,
@@ -219,6 +220,8 @@ export function createTopazNodeClass(spec: TopazManifestEntry): NodeClass {
     value: { output: spec.outputType },
     configurable: true
   });
+  // Enhancers return an image or a video — preview it in the node body.
+  applyContentCardBody(TopazNodeClass);
 
   const { inlineFields, inputFields } = computeFieldClassification(spec.fields);
   Object.defineProperty(TopazNodeClass, "inlineFields", {

--- a/packages/transformers-js-nodes/src/index.ts
+++ b/packages/transformers-js-nodes/src/index.ts
@@ -1,3 +1,4 @@
+import { tagContentCardBodies } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 
 import { TEXT_CLASSIFICATION_NODES } from "./nodes/text-classification.js";
@@ -82,24 +83,33 @@ export {
   type TjsDownloadProgress
 } from "./tjs-downloader.js";
 
-export const TRANSFORMERS_JS_NODES: readonly NodeClass[] = [
-  ...TEXT_CLASSIFICATION_NODES,
-  ...TOKEN_CLASSIFICATION_NODES,
-  ...QUESTION_ANSWERING_NODES,
-  ...SUMMARIZATION_NODES,
-  ...TRANSLATION_NODES,
-  ...TEXT_GENERATION_NODES,
-  ...FILL_MASK_NODES,
-  ...FEATURE_EXTRACTION_NODES,
-  ...ZERO_SHOT_CLASSIFICATION_NODES,
-  ...IMAGE_CLASSIFICATION_NODES,
-  ...OBJECT_DETECTION_NODES,
-  ...IMAGE_TO_TEXT_NODES,
-  ...ZERO_SHOT_IMAGE_CLASSIFICATION_NODES,
-  ...AUTOMATIC_SPEECH_RECOGNITION_NODES,
-  ...AUDIO_CLASSIFICATION_NODES,
-  ...TEXT_TO_SPEECH_NODES
-];
+/**
+ * Every transformers.js node.
+ *
+ * Nodes whose primary output is displayable (generated speech, or the text a
+ * generator/captioner/transcriber returns) render a content card; the ones
+ * that return embeddings or bounding boxes keep the generic body.
+ */
+export const TRANSFORMERS_JS_NODES: readonly NodeClass[] = tagContentCardBodies(
+  [
+    ...TEXT_CLASSIFICATION_NODES,
+    ...TOKEN_CLASSIFICATION_NODES,
+    ...QUESTION_ANSWERING_NODES,
+    ...SUMMARIZATION_NODES,
+    ...TRANSLATION_NODES,
+    ...TEXT_GENERATION_NODES,
+    ...FILL_MASK_NODES,
+    ...FEATURE_EXTRACTION_NODES,
+    ...ZERO_SHOT_CLASSIFICATION_NODES,
+    ...IMAGE_CLASSIFICATION_NODES,
+    ...OBJECT_DETECTION_NODES,
+    ...IMAGE_TO_TEXT_NODES,
+    ...ZERO_SHOT_IMAGE_CLASSIFICATION_NODES,
+    ...AUTOMATIC_SPEECH_RECOGNITION_NODES,
+    ...AUDIO_CLASSIFICATION_NODES,
+    ...TEXT_TO_SPEECH_NODES
+  ]
+);
 
 export function registerTransformersJsNodes(registry: {
   register: (nodeClass: NodeClass) => void;


### PR DESCRIPTION
Content cards — the in-node image/video/audio/3D/text preview — were opt-in per provider pack, and the packs disagreed about when to opt in. An audit across the 12 registered packs found 390 provider nodes whose primary output the editor can display but which rendered the generic input/output layout instead.

## What was inconsistent

| Pack | Nodes affected | Why |
|---|---|---|
| atlascloud | 70 | factory never set `body` |
| together | 56 | factory never set `body` |
| topaz | 11 | factory never set `body` |
| fal | 131 | `isGenerativeOutput` read the raw manifest `outputType`, which stays `"dict"`/`"any"` for endpoints that declare media through `outputFields`; `"str"` was never in the list |
| replicate | 96 | `"str"` not in `isGenerativeOutput` — captioners, transcribers, LLMs |
| kie | 2 | `"text"` not in `isGenerativeOutput` |
| huggingface | 12 | hand-written text nodes had no opt-in |
| transformers-js | 12 | same |

Meanwhile the equivalent text nodes in `llm-nodes` (OpenAI, Gemini, xAI, Mistral) already declared `body = "content_card"`, so the same task rendered differently depending on which provider you picked.

## The change

`packages/node-sdk/src/content-card.ts` holds the rule in one place:

- `isContentCardOutputType` — the displayable set (`image`, `image_mask`, `mask`, `video`, `audio`, `model_3d`, `asset_3d`, `str`, `text`), kept in sync with `getContentCardVariant` in `web/src/components/node_types/contentCardRegistry.ts`.
- `primaryDeclaredOutputType` — resolves `outputs[0]` exactly the way `getNodeMetadata` does (`metadataOutputTypes` wins over `outputTypes`).
- `applyContentCardBody` / `tagContentCardBodies` — stamp `body = "content_card"` when the primary output qualifies.

Each provider factory calls `applyContentCardBody` after defining its output types; the two hand-written packs wrap their node array with `tagContentCardBodies`. Deriving from the resolved outputs rather than a manifest field means a new model added to a manifest gets the right body for free.

A class that declares its own `body` keeps it — `elevenlabs.StandardVoice` and `minimax.Voice` stay `"small"`, since a voice id isn't content to preview. Nodes returning scores, embeddings, or bounding boxes (`huggingface.ObjectDetection`, `transformers.FeatureExtraction`) keep the generic layout.

The `autoSaveAsset` flag is untouched — it kept its own media-only condition, which the previous code had bundled into the same `if`.

## Verification

Re-running the audit over all 12 packs: provider gaps go 633 → 243, and the 243 that remain are all in the `base` pack (text utilities, constants, inputs, code runners — not provider nodes) plus the two intentional `"small"` voice pickers. The 390-node delta matches the table above exactly, so nothing lost the body it already had.

- `npm run typecheck` — web and electron clean (mobile fails on missing `node_modules`; mobile isn't a workspace and isn't installed in this container).
- `npm run lint` — clean.
- `npm run test` — web 12,080 passed, electron 655 passed.
- `npm run test:packages` — 83/94 tasks pass; the one failing task is `image-nodes` (52 sharp/WebGPU pixel tests), which fails identically on a clean checkout of `main`.
- New unit tests in `packages/node-sdk/tests/content-card.test.ts` cover the type set, the `metadataOutputTypes`-over-`outputTypes` precedence, the explicit-`body` override, and that secondary outputs don't drive the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6shXbDov2WmhpiXUSoAvR


---
_Generated by [Claude Code](https://claude.ai/code/session_01L6shXbDov2WmhpiXUSoAvR)_