### PR TITLE
ci: EAS cloud builds for the mobile app

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,7 @@
 | **chromatic.yml** | PR + push to main (web/Storybook paths) | Component visual regression — builds Storybook, publishes to Chromatic with TurboSnap (`onlyChanged`), surfaces per-story diffs on the PR. Non-blocking (`exitZeroOnChanges`). Needs `CHROMATIC_PROJECT_TOKEN`. |
 | **visual-regression.yml** | PR + push to main (visual suite/web paths) | E2E/page visual regression — Playwright screenshot assertions; uploads HTML report + diffs. Non-blocking while baselines mature. |
 | **release.yaml** | Git tags `v*` + manual | Build and sign cross-platform release artifacts |
+| **eas-build.yml** | Manual + git tags `mobile-v*` (+ config check on mobile config PRs) | Cloud-build the Expo app in `mobile/` on EAS (profile/platform selectable; tags build and submit `production`). Needs `EAS_TOKEN`. |
 | **flatpak-ci.yml** | Push to main + manual | Build Flatpak desktop package |
 | **jekyll.yml** | Push to main + manual | Build and deploy docs site to GitHub Pages |
 | **marketing-ci.yml** | Push/PR touching `marketing/**` | Typecheck, lint, build & Playwright smoke tests for the marketing site; on push to main, deploys it to Cloudflare Workers (OpenNext) after the gates pass |

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,161 @@
+name: EAS Build (mobile)
+
+# Cloud builds for the Expo app in `mobile/` (EAS project
+# ce40c43d-6adf-4476-98b1-761aa4d29c40, owner `mgeorgi`).
+#
+# Builds cost EAS credits, so nothing here fires on an ordinary push: they are
+# started by hand (`workflow_dispatch`) or by pushing a `mobile-v*` tag, which
+# runs the `production` profile. PRs that touch `mobile/` only get the cheap
+# config check below — it never talks to the build queue.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build
+        type: choice
+        default: all
+        options: [all, android, ios]
+      profile:
+        description: eas.json build profile
+        type: choice
+        default: preview
+        options: [development, development-simulator, preview, production]
+      wait:
+        description: Wait for the build to finish (needed to submit)
+        type: boolean
+        default: false
+      submit:
+        description: Submit the finished build to the stores (production only)
+        type: boolean
+        default: false
+  push:
+    tags:
+      - "mobile-v*"
+  pull_request:
+    paths:
+      - "mobile/app.json"
+      - "mobile/eas.json"
+      - "mobile/package.json"
+      - "mobile/package-lock.json"
+      - ".github/workflows/eas-build.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Catches a malformed app.json/eas.json before someone spends credits on a
+  # build that would fail during setup. No EAS_TOKEN, no build queue.
+  config:
+    name: Validate Expo config
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      # Same cache key as quality-checks.yml, so this job usually restores the
+      # tree that workflow already installed instead of running `npm ci`.
+      - name: Cache mobile node_modules
+        id: mobile-node-modules
+        uses: actions/cache@v5
+        with:
+          path: mobile/node_modules
+          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
+
+      - name: Install mobile dependencies
+        if: steps.mobile-node-modules.outputs.cache-hit != 'true'
+        run: cd mobile && npm ci
+
+      - name: Resolve the app config
+        run: cd mobile && npx expo config --type prebuild > /dev/null
+
+  build:
+    name: EAS build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    # Generous, because `--wait` blocks on the EAS queue, which can be long when
+    # the tier is busy. Fire-and-forget runs finish in a couple of minutes.
+    timeout-minutes: 120
+    env:
+      # eas-cli authenticates with EXPO_TOKEN; the repository secret is EAS_TOKEN.
+      EXPO_TOKEN: ${{ secrets.EAS_TOKEN }}
+      PLATFORM: ${{ inputs.platform || 'all' }}
+      PROFILE: ${{ github.event_name == 'push' && 'production' || inputs.profile }}
+    steps:
+      - name: Check for the EAS token
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::EAS_TOKEN is not set on this repository." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+          packager: npm
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Build
+        id: build
+        working-directory: mobile
+        run: |
+          set -o pipefail
+          WAIT_FLAG=--no-wait
+          if [ "${{ github.event_name == 'push' || inputs.wait || inputs.submit }}" = "true" ]; then
+            WAIT_FLAG=--wait
+          fi
+          eas build \
+            --non-interactive \
+            --platform "$PLATFORM" \
+            --profile "$PROFILE" \
+            "$WAIT_FLAG" \
+            --json | tee build.json
+
+      - name: Summarize
+        if: always() && steps.build.outcome != 'skipped'
+        working-directory: mobile
+        run: |
+          {
+            echo "### EAS build — \`$PROFILE\` / \`$PLATFORM\`"
+            echo
+            if [ -s build.json ]; then
+              node -e '
+                const builds = JSON.parse(require("fs").readFileSync("build.json", "utf8"));
+                for (const b of [builds].flat()) {
+                  console.log(`- **${b.platform}** \`${b.status}\` — [build ${b.id}](https://expo.dev/accounts/${b.project?.ownerAccount?.name ?? "mgeorgi"}/projects/${b.project?.slug ?? "nodetool"}/builds/${b.id})`);
+                  if (b.artifacts?.buildUrl) console.log(`  - [artifact](${b.artifacts.buildUrl})`);
+                }
+              '
+            else
+              echo "No build was queued — see the job log."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # `--latest` picks the build this job just queued, since the wait above
+      # means it is the newest one for the profile.
+      - name: Submit
+        if: (github.event_name == 'push' || inputs.submit) && env.PROFILE == 'production'
+        working-directory: mobile
+        run: |
+          eas submit \
+            --non-interactive \
+            --platform "$PLATFORM" \
+            --profile production \
+            --latest

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -20,7 +20,12 @@ npm run lint             # oxlint src
 npm run lint:fix         # oxlint --fix
 npm start                # Expo dev server
 npm run ios | android | web
+npm run build:preview    # EAS cloud build (also: build:dev, build:production)
 ```
+
+Cloud builds go through EAS (`eas.json`), by hand with the scripts above or from
+the `EAS Build (mobile)` GitHub workflow, which authenticates with the
+`EAS_TOKEN` secret. See [README.md § Building for Production](README.md#building-for-production).
 
 ## Important: not in the npm workspaces
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -162,62 +162,54 @@ consistency:
 
 ## Building for Production
 
-NodeTool uses **EAS Build** (Expo's cloud build service) for creating production builds. This requires an Expo account and the EAS CLI.
+Builds run on **EAS Build** (Expo's cloud build service) against the EAS project
+declared in `app.json` (`extra.eas.projectId`, owner `mgeorgi`).
 
-### Prerequisites
+### From CI (preferred)
 
-1. Create an Expo account: https://expo.dev/signup
-2. Install EAS CLI:
-   ```bash
-   npm install -g eas-cli
-   ```
-3. Log in to your Expo account:
-   ```bash
-   eas login
-   ```
+The `.github/workflows/eas-build.yml` workflow authenticates with the
+`EAS_TOKEN` repository secret (an Expo access token, passed to eas-cli as
+`EXPO_TOKEN`). Builds cost credits, so no ordinary push starts one:
 
-### Building for Android (APK/AAB)
+- **Manual**: Actions → *EAS Build (mobile)* → *Run workflow*. Pick the platform
+  and profile; `wait` blocks on the EAS queue, `submit` uploads the finished
+  production build to the stores.
+- **Release**: pushing a `mobile-v*` tag builds the `production` profile for
+  both platforms, waits for it, and submits it.
+- **Pull requests** that touch `app.json`, `eas.json`, or the lockfile only run
+  the config check — it resolves the Expo config and never queues a build.
 
-```bash
-# Build for Android (APK for direct installation)
-eas build --platform android --profile preview
+Each run writes the build IDs, statuses, and artifact links to the job summary.
 
-# Or build for Google Play Store submission (AAB format)
-eas build --platform android --profile production
-```
-
-### Building for iOS (IPA)
+### From a workstation
 
 ```bash
-# Build for iOS (requires Apple Developer account)
-eas build --platform ios --profile preview
+cd mobile
+npx eas-cli login            # once; or export EXPO_TOKEN
+
+npm run build:dev            # development client, internal distribution
+npm run build:preview        # Android APK + iOS internal build
+npm run build:production     # Android AAB + iOS store build
+npm run submit:production    # submit the latest production build
 ```
 
-### Building for Both Platforms
+Anything the scripts don't cover goes through the CLI directly, e.g.
+`npm run eas -- build --platform ios --profile preview`.
 
-```bash
-# Build for all platforms at once
-eas build --platform all --profile preview
-```
+### Build profiles
 
-### EAS Build Profiles
+`eas.json` profiles all extend `base`, which pins Node to 22.22.1 so cloud
+builds use the same version as the repo (`.nvmrc`):
 
-The app uses EAS Build profiles defined in `eas.json`:
+| Profile                   | Use                                                       |
+| ------------------------- | --------------------------------------------------------- |
+| `development`             | Dev client on a physical device, internal distribution     |
+| `development-simulator`   | Same, but an iOS Simulator build                           |
+| `preview`                 | Testing builds — Android APK you can sideload              |
+| `production`              | Store builds — Android AAB, version auto-incremented       |
 
-- **preview**: For testing builds (simpler configuration)
-- **production**: For store submissions (includes app versioning, icons, etc.)
-
-### Submitting to App Stores
-
-After building, you can submit directly to stores:
-
-```bash
-# Submit to Google Play Store
-eas submit --platform android
-
-# Submit to Apple App Store
-eas submit --platform ios
-```
+`cli.appVersionSource` is `remote`, so EAS owns the build number; the
+`production` profile increments it on every build.
 
 ### Local Builds (Advanced)
 

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -4,18 +4,33 @@
     "appVersionSource": "remote"
   },
   "build": {
+    "base": {
+      "node": "22.22.1"
+    },
     "development": {
+      "extends": "base",
       "developmentClient": true,
       "distribution": "internal"
     },
+    "development-simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    },
     "preview": {
+      "extends": "base",
       "distribution": "internal",
       "android": {
         "buildType": "apk"
       }
     },
     "production": {
-      "autoIncrement": true
+      "extends": "base",
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      }
     }
   },
   "submit": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,7 +14,12 @@
     "lint:eslint:fix": "eslint src --ext .tsx,.ts,.js,.jsx --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "eas": "npx --yes --package eas-cli -- eas",
+    "build:dev": "npm run eas -- build --profile development --platform all",
+    "build:preview": "npm run eas -- build --profile preview --platform all",
+    "build:production": "npm run eas -- build --profile production --platform all",
+    "submit:production": "npm run eas -- submit --profile production --platform all --latest"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",


### PR DESCRIPTION
Wires the Expo app in `mobile/` up to EAS Build from CI, using the `EAS_TOKEN` repository secret.

## Workflow — `.github/workflows/eas-build.yml`

Builds cost EAS credits, so nothing fires on an ordinary push:

- **Manual** (`workflow_dispatch`): pick platform (`all`/`android`/`ios`) and profile; `wait` blocks on the EAS queue, `submit` uploads the finished production build to the stores.
- **Release**: pushing a `mobile-v*` tag builds the `production` profile for both platforms, waits, and submits.
- **Pull requests** touching `app.json`/`eas.json`/the lockfile only resolve the Expo config (`expo config --type prebuild`) — no build queued, no token needed. It reuses the same `mobile/node_modules` cache key as `quality-checks.yml`.

eas-cli authenticates with `EXPO_TOKEN`, so the job maps `EAS_TOKEN` onto it and fails fast with a clear message when the secret is missing. Build IDs, statuses, and artifact links go to the job summary.

## `mobile/eas.json`

- All profiles extend a new `base` profile that pins Node to **22.22.1**, so cloud builds match `.nvmrc`.
- `production` now builds an Android **app-bundle** explicitly (was implicit) and keeps `autoIncrement` with `appVersionSource: remote`.
- New `development-simulator` profile for iOS Simulator dev clients, leaving `development` as the device build.

Verified by resolving every profile/platform pair through `@expo/eas-json`'s `EasJsonUtils` — schema-valid and each profile inherits as intended.

## Scripts and docs

`mobile/package.json` gains `build:dev`, `build:preview`, `build:production`, `submit:production`, and an `eas` passthrough (`npm run eas -- <args>`, via `npx --package eas-cli`, so no global install). `mobile/README.md`'s "Building for Production" section is rewritten around the CI flow and profile table; `mobile/AGENTS.md` and `.github/workflows/README.md` get a pointer.

Only JSON/YAML/Markdown changed — no TypeScript, so the quality gate is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0175UWM9pofPwbYjYEJV8ujB)_