### PR TITLE
Run CLI DSL targets through argv instead of a shell string

### DIFF
--- a/packages/cli/src/debug/target.ts
+++ b/packages/cli/src/debug/target.ts
@@ -43,8 +43,10 @@ export async function readFileTarget(
 ): Promise<{ raw: unknown; source: "json" | "dsl" }> {
   if (looksLikeDsl(ref)) {
     // DSL file: execute via tsx and capture the emitted JSON workflow.
-    const { execSync } = await import("node:child_process");
-    const output = execSync(`npx tsx "${resolve(ref)}"`, {
+    // execFileSync, not execSync: the path goes through argv, so quotes or
+    // `$(...)` in a file name stay a file name instead of becoming shell.
+    const { execFileSync } = await import("node:child_process");
+    const output = execFileSync("npx", ["tsx", resolve(ref)], {
       encoding: "utf8",
       cwd: dirname(resolve(ref)),
       timeout: 30000

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -558,8 +558,8 @@ workflows
           let raw: any;
           if (idOrFile.endsWith(".ts") || idOrFile.endsWith(".tsx")) {
             // Execute DSL file via tsx and capture JSON output
-            const { execSync } = await import("node:child_process");
-            const output = execSync(`npx tsx "${resolve(idOrFile)}"`, {
+            const { execFileSync } = await import("node:child_process");
+            const output = execFileSync("npx", ["tsx", resolve(idOrFile)], {
               encoding: "utf8",
               cwd: dirname(resolve(idOrFile)),
               timeout: 30000


### PR DESCRIPTION
Follow-up to #4507, which merged before this fix could land on it.

CodeQL flagged a high-severity command injection on that PR's final commit. Both DSL execution paths in the CLI built a shell command by interpolating a resolved file path:

```js
execSync(`npx tsx "${resolve(ref)}"`, …)
```

The double quotes stop spaces from splitting the argument but do nothing about a path containing `"` or `$(…)` — a workflow file named so would execute as shell. `execFileSync("npx", ["tsx", resolve(ref)], …)` passes the path as an argument, which is what it always meant to be, and removes the shell entirely.

Two call sites: `packages/cli/src/debug/target.ts` (the `app debug` / `debug` file loader) and `packages/cli/src/nodetool.ts` (`workflows run` on a `.ts` DSL file).

## Not fixed here

`scripts/run-workflow.mjs:191` has the same pattern. It is a repo-local dev script untouched by #4507, so it is out of this change's scope — worth a separate pass if you want it consistent.

## Verification

`packages/cli` typecheck clean; full package suite passes (32 files, 426 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgA2WTqUaSqPNZbHKymnGD)_