### PR TITLE
ci: upgrade Claude workflows to Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --append-system-prompt "When reviewing this PR, also flag any AI-slop introduced by the change using the unslop skill (.claude/skills/unslop/SKILL.md) — speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing in the PR body."
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,6 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
 

--- a/.github/workflows/dead-code-cleanup.yaml
+++ b/.github/workflows/dead-code-cleanup.yaml
@@ -53,7 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/dependency-cleanup.yaml
+++ b/.github/workflows/dependency-cleanup.yaml
@@ -53,7 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Read,Grep,Glob"
           prompt: |
             # Triage a New Issue

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -44,7 +44,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,WebFetch,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/performance-optimization.yaml
+++ b/.github/workflows/performance-optimization.yaml
@@ -53,7 +53,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -74,7 +74,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -63,7 +63,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -69,7 +69,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/type-safety.yaml
+++ b/.github/workflows/type-safety.yaml
@@ -71,7 +71,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/ui-primitives-compliance.yaml
+++ b/.github/workflows/ui-primitives-compliance.yaml
@@ -90,7 +90,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, useEffect+fetch instead of useQuery, and prose throat-clearing."
           prompt: |

--- a/.github/workflows/workflow-example-validation.yaml
+++ b/.github/workflows/workflow-example-validation.yaml
@@ -78,7 +78,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
             --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff."
           prompt: |


### PR DESCRIPTION
Bumps the `--model` pin passed to `claude-code-action` from `claude-opus-4-6` to `claude-opus-5` in every workflow that runs it.

Files changed (13):

- `claude.yml`
- `claude-code-review.yml`
- `issue-triage.yml`
- `opencode.yml`
- `dead-code-cleanup.yaml`
- `dependency-cleanup.yaml`
- `performance-optimization.yaml`
- `quality-assurance.yaml`
- `security-audit.yaml`
- `test-coverage.yaml`
- `type-safety.yaml`
- `ui-primitives-compliance.yaml`
- `workflow-example-validation.yaml`

No other changes — the action versions, permissions, triggers, and prompts are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkZUZ829DsRjjxuY8w3MSY)_