### PR TITLE
fix: typed dynamic slots keep values the runner rejects

### DIFF
--- a/packages/models/src/api-graph.ts
+++ b/packages/models/src/api-graph.ts
@@ -16,6 +16,8 @@ export interface ApiNode {
   data: Record<string, unknown>;
   ui_properties?: Record<string, unknown>;
   dynamic_properties?: Record<string, unknown>;
+  /** Typed dynamic input slot declarations; empty means every slot is `any`. */
+  dynamic_inputs?: Record<string, unknown>;
   dynamic_outputs?: Record<string, unknown>;
 }
 
@@ -50,6 +52,7 @@ export function toApiNode(node: NodeDescriptor): ApiNode {
     data: (node.properties as Record<string, unknown>) ?? {},
     ui_properties: node.ui_properties ?? {},
     dynamic_properties: node.dynamic_properties ?? {},
+    dynamic_inputs: (node.dynamic_inputs as Record<string, unknown>) ?? {},
     dynamic_outputs: (node.dynamic_outputs as Record<string, unknown>) ?? {}
   };
 }

--- a/packages/models/tests/api-graph-parity-regression.test.ts
+++ b/packages/models/tests/api-graph-parity-regression.test.ts
@@ -28,6 +28,7 @@ describe("Python parity — API graph node serialization", () => {
       data: { prompt: "hello" },
       ui_properties: { x: 10, y: 20 },
       dynamic_properties: { model: "gpt" },
+      dynamic_inputs: {},
       dynamic_outputs: { branch_a: { type: "string" } }
     });
   });
@@ -45,6 +46,7 @@ describe("Python parity — API graph node serialization", () => {
       data: {},
       ui_properties: {},
       dynamic_properties: {},
+      dynamic_inputs: {},
       dynamic_outputs: {}
     });
   });

--- a/packages/models/tests/api-graph.test.ts
+++ b/packages/models/tests/api-graph.test.ts
@@ -40,6 +40,7 @@ describe("toApiNode", () => {
       data: { a: 1, b: 2 },
       ui_properties: { x: 10, y: 20 },
       dynamic_properties: { extra: "value" },
+      dynamic_inputs: {},
       dynamic_outputs: { alt: { type: "string" } }
     });
     // Runtime fields should NOT be present
@@ -69,7 +70,20 @@ describe("toApiNode", () => {
       data: {},
       ui_properties: {},
       dynamic_properties: {},
+      dynamic_inputs: {},
       dynamic_outputs: {}
+    });
+  });
+
+  it("carries typed dynamic slot declarations", () => {
+    const node: NodeDescriptor = {
+      id: "n5",
+      type: "test.Dynamic",
+      dynamic_properties: { picture: null },
+      dynamic_inputs: { picture: { type: { type: "image", type_args: [] } } }
+    };
+    expect(toApiNode(node).dynamic_inputs).toEqual({
+      picture: { type: { type: "image", type_args: [] } }
     });
   });
 });

--- a/web/src/components/context_menus/PropertyContextMenu.tsx
+++ b/web/src/components/context_menus/PropertyContextMenu.tsx
@@ -22,7 +22,8 @@ import useMetadataStore from "../../stores/MetadataStore";
 import { Property, TypeMetadata } from "../../stores/ApiTypes";
 import {
   defaultValueForType,
-  normalizeDynamicSlots
+  normalizeDynamicSlots,
+  valueFitsType
 } from "../../utils/dynamicSlots";
 import {
   allowedSlotTypes,
@@ -159,10 +160,14 @@ const PropertyContextMenuComponent: React.FC = () => {
       if (!node) {
         continue;
       }
+      // Keep a value the new type can still hold — same rule the slot-type
+      // chip applies, so the two entry points agree on one retype.
+      const previous = node.data.dynamic_properties?.[handleId];
+      const keepValue = previous !== undefined && valueFitsType(previous, type);
       updateNodeData(nid, {
         dynamic_properties: {
           ...node.data.dynamic_properties,
-          [handleId]: defaultValueForType(type)
+          [handleId]: keepValue ? previous : defaultValueForType(type)
         },
         dynamic_inputs: {
           ...normalizeDynamicSlots(node.data.dynamic_inputs),

--- a/web/src/core/workflow/__tests__/graphMapping.test.ts
+++ b/web/src/core/workflow/__tests__/graphMapping.test.ts
@@ -133,8 +133,51 @@ describe("graphMapping helpers", () => {
       );
 
       const target = sanitizedNodes.find((n) => n.id === "b");
-      expect(target?.data.dynamic_properties).toEqual({ new_field: "" });
+      // Seeded from the declared type, not a bare "" — the value doubles as
+      // the runner's fallback when the edge delivers nothing on a run.
+      expect(target?.data.dynamic_properties).toEqual({ new_field: null });
       expect(sanitizedEdges).toHaveLength(1);
+    });
+
+    it("seeds the repaired slot from its declared type", () => {
+      const typedMeta = (type: string): NodeMetadata =>
+        ({
+          ...baseMetadata,
+          node_type: `test.out.${type}`,
+          outputs: [
+            {
+              name: "output",
+              type: {
+                type,
+                optional: false,
+                values: null,
+                type_args: [],
+                type_name: null
+              },
+              stream: false
+            }
+          ]
+        }) as NodeMetadata;
+
+      const seedFor = (type: string): unknown => {
+        const nodes = [
+          makeNode("a", `test.out.${type}`),
+          makeNode("b", "test.dynamic")
+        ];
+        const edges = [makeEdge("e1", "a", "b", "output", "new_field")];
+        const { nodes: sanitized } = sanitizeGraph(nodes, edges, {
+          [`test.out.${type}`]: typedMeta(type),
+          "test.dynamic": dynamicMeta
+        });
+        return sanitized.find((n) => n.id === "b")?.data.dynamic_properties
+          ?.new_field;
+      };
+
+      expect(seedFor("str")).toBe("");
+      expect(seedFor("int")).toBe(0);
+      // An `image` slot seeded with "" would make the run throw on the type
+      // check; null is the empty value every declared type accepts.
+      expect(seedFor("image")).toBeNull();
     });
 
     it("declares the repaired slot with the source output's type", () => {

--- a/web/src/core/workflow/graphMapping.ts
+++ b/web/src/core/workflow/graphMapping.ts
@@ -7,7 +7,10 @@ import {
   hasInputHandle,
   hasOutputHandle
 } from "../../utils/handleUtils";
-import { normalizeDynamicSlots } from "../../utils/dynamicSlots";
+import {
+  defaultValueForType,
+  normalizeDynamicSlots
+} from "../../utils/dynamicSlots";
 import { CONTROL_HANDLE_ID } from "../../stores/graphEdgeToReactFlowEdge";
 import { addExposedInput } from "../../utils/exposedInputs";
 
@@ -103,16 +106,19 @@ const ensureHandlesForEdges = (
             edge.sourceHandle,
             metadata
           );
-          // The value is driven by the edge, so it stays `""` as before —
-          // only the declaration is new.
+          const typed = inferred && inferred.type !== "any" ? inferred : null;
+          // The edge drives the value, but `dynamic_properties` is also the
+          // default the runner falls back to when the edge delivers nothing on
+          // a given run — so it has to be a value the declared type accepts.
+          // A bare `""` under an `image` declaration makes that run throw.
           patch.dynamic_properties = {
             ...currentDynProps,
-            [edge.targetHandle]: ""
+            [edge.targetHandle]: typed ? defaultValueForType(typed) : ""
           };
-          if (inferred && inferred.type !== "any") {
+          if (typed) {
             patch.dynamic_inputs = {
               ...currentDynInputs,
-              [edge.targetHandle]: { type: inferred }
+              [edge.targetHandle]: { type: typed }
             };
           }
         }

--- a/web/src/hooks/nodes/__tests__/useDynamicProperty.test.ts
+++ b/web/src/hooks/nodes/__tests__/useDynamicProperty.test.ts
@@ -257,6 +257,39 @@ describe("useDynamicProperty", () => {
         dynamic_inputs: { n: { type: type("float"), description: "a count" } }
       });
     });
+
+    it("reseeds when the old ref is a different ref type", () => {
+      nodeSlots = { pic: { type: type("image") } };
+      const { result } = renderHook(() =>
+        useDynamicProperty("node-1", { pic: { type: "image", uri: "a.png" } })
+      );
+
+      act(() => {
+        result.current.handleUpdatePropertyType("pic", type("audio"));
+      });
+
+      expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+        dynamic_properties: { pic: null },
+        dynamic_inputs: { pic: { type: type("audio") } }
+      });
+    });
+
+    it("keeps a ref the new type still accepts", () => {
+      nodeSlots = { pic: { type: type("any") } };
+      const ref = { type: "image", uri: "a.png" };
+      const { result } = renderHook(() =>
+        useDynamicProperty("node-1", { pic: ref })
+      );
+
+      act(() => {
+        result.current.handleUpdatePropertyType("pic", type("image"));
+      });
+
+      expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {
+        dynamic_properties: { pic: ref },
+        dynamic_inputs: { pic: { type: type("image") } }
+      });
+    });
   });
 
   it("memoizes callbacks based on dependencies", () => {

--- a/web/src/hooks/nodes/useDynamicProperty.ts
+++ b/web/src/hooks/nodes/useDynamicProperty.ts
@@ -4,7 +4,8 @@ import type { TypeMetadata } from "../../stores/ApiTypes";
 import type { DynamicSlotDeclaration } from "../../stores/NodeData";
 import {
   defaultValueForType,
-  normalizeDynamicSlots
+  normalizeDynamicSlots,
+  valueFitsType
 } from "../../utils/dynamicSlots";
 
 export interface UseDynamicPropertyResult {
@@ -109,15 +110,16 @@ export const useDynamicProperty = (
       };
 
       // Reseed the inline value when the old one can't be a value of the new
-      // type (a `str` left in an `image` slot renders as a broken editor).
+      // type (a `str` left in an `image` slot renders as a broken editor, an
+      // image ref left in an `audio` slot makes the runner throw). The check
+      // is the runner's own, so what the editor keeps is what the run accepts.
       const previous = dynamicProperties[propertyName];
-      const seeded = defaultValueForType(type);
-      const keepValue = typeof previous === typeof seeded && previous !== null;
+      const keepValue = previous !== undefined && valueFitsType(previous, type);
 
       updateNodeData(nodeId, {
         dynamic_properties: {
           ...dynamicProperties,
-          [propertyName]: keepValue ? previous : seeded
+          [propertyName]: keepValue ? previous : defaultValueForType(type)
         },
         dynamic_inputs: updatedSlots
       });

--- a/web/src/utils/__tests__/dynamicSlots.test.ts
+++ b/web/src/utils/__tests__/dynamicSlots.test.ts
@@ -5,7 +5,8 @@ import {
   normalizeDynamicSlot,
   normalizeDynamicSlots,
   normalizeTypeMetadata,
-  slotType
+  slotType,
+  valueFitsType
 } from "../dynamicSlots";
 
 describe("normalizeTypeMetadata", () => {
@@ -145,5 +146,43 @@ describe("defaultValueForType", () => {
 
   it("seeds asset refs with null", () => {
     expect(defaultValueForType({ ...ANY_TYPE, type: "image" })).toBeNull();
+  });
+});
+
+describe("valueFitsType", () => {
+  const t = (type: string) => ({ ...ANY_TYPE, type });
+
+  it("accepts an empty value for any type", () => {
+    expect(valueFitsType(null, t("image"))).toBe(true);
+    expect(valueFitsType(undefined, t("image"))).toBe(true);
+  });
+
+  it("reads a tagged ref by its own type, not as a plain object", () => {
+    expect(valueFitsType({ type: "image", uri: "x" }, t("image"))).toBe(true);
+    expect(valueFitsType({ type: "image", uri: "x" }, t("audio"))).toBe(false);
+    expect(valueFitsType({ type: "dataframe" }, t("image"))).toBe(false);
+  });
+
+  it("matches the runner on scalars", () => {
+    expect(valueFitsType("hi", t("str"))).toBe(true);
+    expect(valueFitsType("hi", t("image"))).toBe(false);
+    expect(valueFitsType(7, t("float"))).toBe(true);
+    expect(valueFitsType(7, t("str"))).toBe(false);
+    expect(valueFitsType(false, t("bool"))).toBe(true);
+  });
+
+  it("accepts anything for an `any` slot", () => {
+    expect(valueFitsType({ type: "image" }, ANY_TYPE)).toBe(true);
+  });
+
+  it("compares list element types", () => {
+    const listOf = (inner: string) => ({
+      ...ANY_TYPE,
+      type: "list",
+      type_args: [t(inner)]
+    });
+    expect(valueFitsType(["a"], listOf("str"))).toBe(true);
+    expect(valueFitsType(["a"], listOf("image"))).toBe(false);
+    expect(valueFitsType([], listOf("image"))).toBe(true);
   });
 });

--- a/web/src/utils/dynamicSlots.ts
+++ b/web/src/utils/dynamicSlots.ts
@@ -134,3 +134,78 @@ export const defaultValueForType = (type: TypeMetadata): unknown => {
       return null;
   }
 };
+
+const NUMERIC_TYPES: ReadonlySet<string> = new Set(["int", "float", "number"]);
+
+/**
+ * Type of a runtime value, as the runner sees it. Mirrors `inferValueType` in
+ * `packages/kernel/src/dynamic-slots.ts` — notably, a tagged ref carries its
+ * NodeTool type inline (`{ type: "image", … }`), so an image ref is an
+ * `image`, not an anonymous object.
+ *
+ * `undefined` means nothing can be said (null/undefined), which callers read
+ * as "no check possible".
+ */
+const inferValueType = (value: unknown): TypeMetadata | undefined => {
+  if (value === null || value === undefined) return undefined;
+  switch (typeof value) {
+    case "string":
+      return { ...ANY_TYPE, type: "str" };
+    case "boolean":
+      return { ...ANY_TYPE, type: "bool" };
+    case "number":
+      return { ...ANY_TYPE, type: Number.isInteger(value) ? "int" : "float" };
+    case "object":
+      break;
+    default:
+      return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const element = value.length > 0 ? inferValueType(value[0]) : undefined;
+    return {
+      ...ANY_TYPE,
+      type: "list",
+      type_args: element ? [element] : []
+    };
+  }
+
+  const tag = (value as Record<string, unknown>).type;
+  if (typeof tag === "string" && tag.length > 0) {
+    return { ...ANY_TYPE, type: tag };
+  }
+  return { ...ANY_TYPE, type: "dict" };
+};
+
+/** Mirrors `TypeMetadata.isCompatibleWith` in `@nodetool-ai/protocol`. */
+const typesCompatible = (a: TypeMetadata, b: TypeMetadata): boolean => {
+  if (a.type === "any" || b.type === "any") return true;
+
+  const aArgs = a.type_args ?? [];
+  const bArgs = b.type_args ?? [];
+  if (a.type === b.type) {
+    if (aArgs.length === 0 && bArgs.length === 0) return true;
+    // Different arities stay a loose match, as the runner does.
+    if (aArgs.length !== bArgs.length) return true;
+    return aArgs.every((arg, i) => typesCompatible(arg, bArgs[i]));
+  }
+
+  if (NUMERIC_TYPES.has(a.type) && NUMERIC_TYPES.has(b.type)) return true;
+  if (a.type === "union") return aArgs.some((arg) => typesCompatible(arg, b));
+  if (b.type === "union") return bArgs.some((arg) => typesCompatible(arg, a));
+  return false;
+};
+
+/**
+ * Whether an inline slot value can still be a value of `type`, judged the way
+ * the runner judges it. `false` means keeping the value would make the node
+ * throw on its next run, so the caller must reseed.
+ *
+ * A value the runner cannot type at all (null/undefined) fits everything —
+ * it is the empty state of every slot.
+ */
+export const valueFitsType = (value: unknown, type: TypeMetadata): boolean => {
+  const actual = inferValueType(value);
+  if (!actual) return true;
+  return typesCompatible(actual, type);
+};


### PR DESCRIPTION
Three defects found reviewing #4511, all where the editor's idea of a slot value drifted from the runner's.

## A retype keeps a ref the new type can't hold

`handleUpdatePropertyType` decided whether to keep the inline value with `typeof previous === typeof seeded`. `defaultValueForType` returns `null` for every ref type and `typeof null === "object"`, so retyping a slot from `image` to `audio` kept the image ref under an `audio` declaration. The next run hit `applyDynamicSlotTypes` and threw `Dynamic input "x" … expects type audio but received image` — a node error from a pure UI change. Same for dataframe→image, image→document, and so on.

The check is now `valueFitsType`, which mirrors the runner's own rule (`inferValueType` + `TypeMetadata.isCompatibleWith` in `packages/kernel/src/dynamic-slots.ts`): a tagged ref is read as its own type, not as an anonymous object. What the editor keeps is what the run accepts.

`handleSetSlotType` in the property context menu had the opposite problem — it always discarded the value, so the same operation behaved differently depending on which control you used. Both entry points now apply the one rule.

## A repaired slot is declared typed but seeded `""`

`ensureHandlesForEdges` declares a repaired dynamic slot with the source output's type but still seeded `dynamic_properties[handle] = ""`. That map is also the default the actor falls back to for a handle that receives no envelope (`actor.ts:689-694`, `:1079-1086`), so on a run where the upstream branch never fires the node executes with `""` in an `image` slot and throws. It now seeds from the declared type, like every other slot-creation path.

## `toApiNode` drops `dynamic_inputs`

Never updated for the new field: it carries `dynamic_properties` and `dynamic_outputs` and silently drops the typed slot declarations, so a graph round-tripped through it loses every typed slot. Latent — the function is exported from `packages/models` but has no production call site — which is why nothing broke. The parity tests now cover the field.

## Tests

- `valueFitsType`: tagged refs by their own type, scalars, `any`, list element types, empty values.
- `useDynamicProperty`: reseeds on image→audio, keeps a ref the new type accepts.
- `graphMapping`: repaired slot seeds `""`/`0`/`null` per declared type.
- `api-graph`: declarations survive `toApiNode`.

## Verification

```
npm run build --workspace=packages/models     ✓
npm run test  --workspace=packages/models     ✓ (44 files, 757 passed)
cd web && npx jest                            ✓ (1019 suites, 12150 passed)
npm run typecheck:web                         ✓
npm run lint                                  ✓ (exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ud6PoxE8reV5uNZGUWmMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ud6PoxE8reV5uNZGUWmMZ)_