### PR TITLE
security: close unauthenticated reads and scope collections to their owner

### DIFF
--- a/packages/websocket/src/collection-api.ts
+++ b/packages/websocket/src/collection-api.ts
@@ -6,13 +6,18 @@
  * moved to the tRPC `collections` router.
  */
 
+import { createLogger } from "@nodetool-ai/config";
+import { getMaxUploadBytes } from "@nodetool-ai/storage";
 import {
   getDefaultVectorProvider,
   CollectionNotFoundError,
   splitDocument
 } from "@nodetool-ai/vectorstore";
-import type { HttpApiOptions } from "./http-api.js";
+import { getUserId, type HttpApiOptions } from "./http-api.js";
 import { notifyResourceChange } from "./resource-events.js";
+import { canAccessCollection } from "./lib/collection-access.js";
+
+const log = createLogger("nodetool.websocket.collection-api");
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -39,7 +44,7 @@ function normalizePath(pathname: string): string {
 export async function handleCollectionRequest(
   request: Request,
   pathname: string,
-  _options: HttpApiOptions
+  options: HttpApiOptions
 ): Promise<Response | null> {
   pathname = normalizePath(pathname);
 
@@ -55,15 +60,41 @@ export async function handleCollectionRequest(
     return errorResponse(400, "Expected multipart/form-data");
   }
 
+  const collectionName = decodeURIComponent(indexMatch[1]);
+  const userId = getUserId(request, options.userIdHeader ?? "x-user-id");
+
   try {
     const provider = getDefaultVectorProvider();
-    const collectionName = decodeURIComponent(indexMatch[1]);
     const collection = await provider.getCollection({ name: collectionName });
+
+    // Same ownership rule the tRPC router enforces, and the same 404-not-403
+    // response for someone else's collection so this endpoint can't be used to
+    // probe for names. See lib/collection-access.ts.
+    if (
+      !canAccessCollection(
+        collection.metadata as Record<string, string | number | boolean>,
+        userId
+      )
+    ) {
+      return errorResponse(404, "Collection not found");
+    }
 
     const formData = await request.formData();
     const file = formData.get("file");
     if (!file || !(file instanceof File)) {
       return errorResponse(400, "No file provided");
+    }
+
+    // The whole file is read into a string and chunked in memory, so cap it at
+    // the same limit storage uploads use rather than relying on Fastify's
+    // 100 MB body limit.
+    const max = getMaxUploadBytes();
+    if (file.size > max) {
+      return errorResponse(
+        413,
+        `Upload exceeds maximum size: ${file.size} > ${max} bytes ` +
+          `(set NODETOOL_MAX_UPLOAD_BYTES to raise the limit)`
+      );
     }
 
     const text = await file.text();
@@ -96,7 +127,12 @@ export async function handleCollectionRequest(
     if (err instanceof CollectionNotFoundError) {
       return errorResponse(404, "Collection not found");
     }
-    const msg = err instanceof Error ? err.message : String(err);
-    return errorResponse(500, `Vector store error: ${msg}`);
+    // Log the detail, return a generic message: provider errors carry SQL
+    // text, file paths, and upstream URLs that shouldn't reach the client.
+    log.error("Collection index failed", {
+      collection: collectionName,
+      error: err instanceof Error ? err.message : String(err)
+    });
+    return errorResponse(500, "Vector store error");
   }
 }

--- a/packages/websocket/src/lib/collection-access.ts
+++ b/packages/websocket/src/lib/collection-access.ts
@@ -1,0 +1,108 @@
+/**
+ * Ownership and input rules for vector collections exposed over HTTP.
+ *
+ * The `VectorProvider` interface has no concept of a user — collections are a
+ * flat, global namespace shared by every caller. That is fine for the local
+ * single-user case, but in multi-user (Supabase) mode it means any
+ * authenticated user can list, read, rename, delete, and index into any other
+ * user's collection. Teaching every provider (sqlite-vec, Pinecone, Supabase,
+ * Chroma) about users is a much larger change, so ownership is recorded in
+ * collection metadata and enforced here, at the API boundary.
+ *
+ * In-process consumers — RAG nodes, agent tools, the CLI — talk to the
+ * provider directly and are deliberately unaffected: they already run with the
+ * privileges of whatever invoked them.
+ *
+ * Collections that predate this (no owner recorded) stay readable and writable
+ * by everyone. Retroactively assigning them to a user would lock existing
+ * deployments out of their own data, so they are treated as shared. Only
+ * collections created through the API from here on are isolated.
+ */
+
+/** Metadata key holding the id of the user who created the collection. */
+export const OWNER_METADATA_KEY = "owner_user_id";
+
+/**
+ * Metadata keys the server owns. A client that could set these through
+ * `collections.update` would be able to hand itself another user's collection,
+ * so they are stripped from client input and re-applied from server state.
+ */
+export const RESERVED_COLLECTION_METADATA_KEYS: readonly string[] = [
+  OWNER_METADATA_KEY
+];
+
+/** Longest accepted collection name. */
+export const MAX_COLLECTION_NAME_LENGTH = 128;
+
+type Metadata = Record<string, string | number | boolean>;
+
+/**
+ * The recorded owner of a collection, or `null` when it predates ownership
+ * tracking.
+ */
+export function collectionOwner(
+  metadata: Metadata | undefined
+): string | null {
+  const owner = metadata?.[OWNER_METADATA_KEY];
+  return typeof owner === "string" && owner ? owner : null;
+}
+
+/**
+ * Whether `userId` may read or mutate a collection carrying `metadata`.
+ * Unowned (pre-existing) collections are shared — see the module comment.
+ */
+export function canAccessCollection(
+  metadata: Metadata | undefined,
+  userId: string
+): boolean {
+  const owner = collectionOwner(metadata);
+  return owner === null || owner === userId;
+}
+
+/**
+ * Drop server-owned keys from client-supplied metadata.
+ *
+ * Built with `Object.fromEntries`, which defines each key as a data property
+ * rather than assigning it — so a `__proto__` key in a JSON body lands as an
+ * ordinary entry instead of reaching the result's prototype.
+ */
+export function stripReservedMetadata(
+  metadata: Record<string, string | number | boolean> | undefined
+): Metadata {
+  if (!metadata) return {};
+  return Object.fromEntries(
+    Object.entries(metadata).filter(
+      ([key]) => !RESERVED_COLLECTION_METADATA_KEYS.includes(key)
+    )
+  );
+}
+
+/**
+ * Validate a collection name. Returns an error message, or `null` when the
+ * name is acceptable.
+ *
+ * Deliberately permissive: names created before this check exist in live
+ * stores, and rejecting them would break those deployments on the next
+ * rename. This only rules out values that are already broken somewhere —
+ * path/route separators (the REST index route matches `[^/]+`, so a name with
+ * a slash is unreachable), control characters and NULs (which corrupt log
+ * lines and headers), surrounding whitespace (two names that look identical),
+ * and unbounded length.
+ */
+export function validateCollectionName(name: string): string | null {
+  if (!name) return "Collection name is required";
+  if (name.length > MAX_COLLECTION_NAME_LENGTH) {
+    return `Collection name exceeds ${MAX_COLLECTION_NAME_LENGTH} characters`;
+  }
+  if (name !== name.trim()) {
+    return "Collection name must not start or end with whitespace";
+  }
+  if (name.includes("/") || name.includes("\\")) {
+    return "Collection name must not contain path separators";
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(name)) {
+    return "Collection name must not contain control characters";
+  }
+  return null;
+}

--- a/packages/websocket/src/lib/public-routes.ts
+++ b/packages/websocket/src/lib/public-routes.ts
@@ -1,0 +1,58 @@
+/**
+ * The auth-exemption allowlist predicates used by the server's `onRequest`
+ * hook.
+ *
+ * These live in their own module so they are testable without booting the
+ * server (`server.ts` is an entry point: importing it opens the database and
+ * binds a port). Getting an entry wrong here is an unauthenticated read of
+ * someone's data, so each predicate is deliberately an allowlist of exact
+ * paths or prefixes that carry no per-caller state.
+ */
+
+/**
+ * Read-only workflow GETs that carry no per-user data: the shipped example
+ * templates and workflows the owner explicitly marked `access: "public"`.
+ *
+ * Nothing that reads the *caller's* library belongs here. The REST handlers
+ * resolve identity from the (server-set) `x-user-id` header and fall back to
+ * user "1" when it is absent, so an auth-exempt route serves the local user's
+ * private workflows — full graph included — to anyone who can reach the port.
+ * That is exactly the disclosure the "Remote access requires authentication"
+ * 401 exists to prevent, so `/api/workflows`, `/api/workflows/:id`,
+ * `/api/workflows/names`, `/api/workflows/tools`, and `:id/dsl-export` all
+ * stay behind auth. A genuinely public workflow is still reachable
+ * unauthenticated at `/api/workflows/public/:id`.
+ */
+export function isPublicWorkflowMetadataRequest(
+  pathname: string,
+  method: string
+): boolean {
+  if (method !== "GET") return false;
+  return (
+    pathname === "/api/workflows/public" ||
+    pathname.startsWith("/api/workflows/public/") ||
+    pathname === "/api/workflows/examples" ||
+    pathname.startsWith("/api/workflows/examples/")
+  );
+}
+
+/**
+ * OAuth paths reachable without a session. Only the two browser redirect
+ * targets qualify: the identity provider sends the user back with no
+ * `Authorization` header, and the handlers authenticate the callback through
+ * the single-use PKCE `state` they minted at `/start`.
+ *
+ * Every other `/api/oauth/*` path reads or mutates stored credentials for the
+ * caller's user id, so exempting the whole prefix let an unauthenticated
+ * caller enumerate linked accounts (`/tokens`), pull the linked third-party
+ * profile and email (`/hf/whoami`, `/github/user`), force token refreshes, and
+ * delete credentials (`/openai/disconnect`) as user "1". The OpenAI (Codex)
+ * flow needs no entry: it redirects to a loopback listener this process binds,
+ * not to a server route.
+ */
+export function isPublicOAuthRequest(pathname: string): boolean {
+  return (
+    pathname === "/api/oauth/hf/callback" ||
+    pathname === "/api/oauth/github/callback"
+  );
+}

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -26,6 +26,10 @@ import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import { corsOriginDelegate } from "./cors.js";
 import { zipExtensionDist } from "./lib/extension-dist.js";
 import {
+  isPublicOAuthRequest,
+  isPublicWorkflowMetadataRequest
+} from "./lib/public-routes.js";
+import {
   resolveTrustLocalhost,
   isLoopbackAddress,
   parseTrustedProxies,
@@ -138,33 +142,6 @@ const log = createLogger("nodetool.websocket.server");
 // initialises eagerly, but an explicit call here picks up any env mutations
 // made by the process launcher before this point).
 configureLogging();
-
-/**
- * Read-only workflow metadata GETs for SDK/editor boot (same role as
- * `/api/nodes/metadata`). Mutations still require auth below.
- */
-function isPublicWorkflowMetadataRequest(
-  pathname: string,
-  method: string
-): boolean {
-  if (method !== "GET") return false;
-  if (pathname === "/api/workflows" || pathname === "/api/workflows/") {
-    return true;
-  }
-  if (
-    pathname.startsWith("/api/workflows/public") ||
-    pathname.startsWith("/api/workflows/examples")
-  ) {
-    return true;
-  }
-  if (pathname === "/api/workflows/names" || pathname === "/api/workflows/tools") {
-    return true;
-  }
-  if (/^\/api\/workflows\/[^/]+\/dsl-export$/.test(pathname)) {
-    return true;
-  }
-  return /^\/api\/workflows\/[^/]+$/.test(pathname);
-}
 
 await initTelemetry();
 const startupT0 = performance.now();
@@ -688,6 +665,23 @@ app.addHook("onRequest", async (request) => {
 
 app.addHook("onSend", async (request, reply) => {
   reply.header("X-Request-Id", request.id);
+
+  // Baseline security response headers. The web app's CSP lives in a `<meta>`
+  // tag, which browsers ignore for `frame-ancestors` — that directive is only
+  // honoured in a header, so clickjacking protection has to be set here.
+  //
+  // `/api/storage/*` is exempt: those bytes are designed to be embedded from
+  // other origins (MCP App iframes, the Electron renderer, external preview
+  // clients — see storage-api.ts), and the endpoint deliberately serves
+  // unknown extensions as `application/octet-stream` for `<img>`/`<video>` to
+  // sniff. Both `nosniff` and the frame headers would break that contract.
+  const path = request.url.split("?")[0] ?? "/";
+  if (!path.startsWith("/api/storage/")) {
+    reply.header("X-Content-Type-Options", "nosniff");
+    reply.header("X-Frame-Options", "SAMEORIGIN");
+    reply.header("Content-Security-Policy", "frame-ancestors 'self'");
+  }
+  reply.header("Referrer-Policy", "strict-origin-when-cross-origin");
 });
 
 // CORS must be registered before hooks that can short-circuit. Auth failures
@@ -789,7 +783,7 @@ app.addHook("onRequest", async (req, reply) => {
     pathname === "/ready" ||
     pathname === "/api/health" ||
     pathname === "/api/config" ||
-    pathname.startsWith("/api/oauth/") ||
+    isPublicOAuthRequest(pathname) ||
     pathname === "/api/assets/packages" ||
     pathname.startsWith("/api/assets/packages/") ||
     pathname === "/api/nodes/metadata" ||

--- a/packages/websocket/src/trpc/routers/collections.ts
+++ b/packages/websocket/src/trpc/routers/collections.ts
@@ -18,6 +18,12 @@ import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
 import { notifyResourceChange } from "../../resource-events.js";
 import {
+  OWNER_METADATA_KEY,
+  canAccessCollection,
+  stripReservedMetadata,
+  validateCollectionName
+} from "../../lib/collection-access.js";
+import {
   listOutput,
   collectionResponse,
   createInput,
@@ -67,8 +73,50 @@ function rethrowAsTrpc(err: unknown): never {
   throw err;
 }
 
+/**
+ * Load a collection the caller is allowed to touch.
+ *
+ * A collection owned by someone else answers NOT_FOUND rather than FORBIDDEN:
+ * FORBIDDEN would confirm the name exists, turning this into an oracle for
+ * enumerating other users' collection names.
+ */
+async function loadAccessibleCollection(name: string, userId: string) {
+  const provider = getDefaultVectorProvider();
+  let collection;
+  try {
+    collection = await provider.getCollection({ name });
+  } catch (err) {
+    rethrowAsTrpc(err);
+  }
+  if (!canAccessCollection(normalizeMetadata(collection.metadata), userId)) {
+    throwApiError(ApiErrorCode.NOT_FOUND, "Collection not found");
+  }
+  return collection;
+}
+
+/** Whether a collection with this name is present, regardless of owner. */
+async function collectionExists(
+  provider: ReturnType<typeof getDefaultVectorProvider>,
+  name: string
+): Promise<boolean> {
+  try {
+    await provider.getCollection({ name });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reject a name that is malformed, before it reaches the provider. */
+function assertValidName(name: string): void {
+  const error = validateCollectionName(name);
+  if (error) {
+    throwApiError(ApiErrorCode.INVALID_INPUT, error);
+  }
+}
+
 export const collectionsRouter = router({
-  list: protectedProcedure.output(listOutput).query(async () => {
+  list: protectedProcedure.output(listOutput).query(async ({ ctx }) => {
     const provider = getDefaultVectorProvider();
     const collections = await provider.listCollections();
 
@@ -79,9 +127,12 @@ export const collectionsRouter = router({
     const settled = await Promise.all(
       collections.map(async (info) => {
         try {
+          const metadata = normalizeMetadata(info.metadata);
+          // Filter before counting: another user's collection must not even
+          // leak its size through this listing.
+          if (!canAccessCollection(metadata, ctx.userId)) return null;
           const collection = await provider.getCollection({ name: info.name });
           const count = await collection.count();
-          const metadata = normalizeMetadata(info.metadata);
           const workflowName = await resolveWorkflowName(
             typeof metadata.workflow === "string"
               ? metadata.workflow
@@ -101,9 +152,12 @@ export const collectionsRouter = router({
   create: protectedProcedure
     .input(createInput)
     .output(collectionResponse)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      assertValidName(input.name);
       const provider = getDefaultVectorProvider();
-      const metadata: ProviderCollectionMetadata = {};
+      const metadata: ProviderCollectionMetadata = {
+        [OWNER_METADATA_KEY]: ctx.userId
+      };
       if (input.embedding_model) {
         metadata.embedding_model = input.embedding_model;
       }
@@ -111,10 +165,25 @@ export const collectionsRouter = router({
         metadata.embedding_provider = input.embedding_provider;
       }
 
-      const collection = await provider.createCollection({
-        name: input.name,
-        metadata
-      });
+      // Names are globally unique in the store (`vec_collections.name` carries
+      // a UNIQUE constraint), so a duplicate surfaces as a driver-level
+      // constraint error. Answer ALREADY_EXISTS rather than letting the raw
+      // SQL message reach the client.
+      let collection;
+      try {
+        collection = await provider.createCollection({
+          name: input.name,
+          metadata
+        });
+      } catch (err) {
+        if (await collectionExists(provider, input.name)) {
+          throwApiError(
+            ApiErrorCode.ALREADY_EXISTS,
+            `Collection ${input.name} already exists`
+          );
+        }
+        throw err;
+      }
 
       notifyResourceChange({
         event: "created",
@@ -132,22 +201,45 @@ export const collectionsRouter = router({
   update: protectedProcedure
     .input(updateInput)
     .output(collectionResponse)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const provider = getDefaultVectorProvider();
-      let collection;
-      try {
-        collection = await provider.getCollection({ name: input.name });
-      } catch (err) {
-        rethrowAsTrpc(err);
-      }
+      const collection = await loadAccessibleCollection(
+        input.name,
+        ctx.userId
+      );
 
       const existing = normalizeMetadata(collection.metadata);
-      const merged: ProviderCollectionMetadata = { ...existing };
-      if (input.metadata) {
-        Object.assign(merged, input.metadata);
+      // Client metadata is merged with the server-owned keys stripped, then
+      // ownership is restored from server state — otherwise a caller could
+      // rewrite `owner_user_id` and take over (or give away) a collection.
+      // An unowned legacy collection stays unowned: stamping the first user to
+      // edit it as the owner would silently lock every other user out of a
+      // collection they had been sharing.
+      const merged: ProviderCollectionMetadata = {
+        ...existing,
+        ...stripReservedMetadata(input.metadata)
+      };
+      const owner = existing[OWNER_METADATA_KEY];
+      if (typeof owner === "string" && owner) {
+        merged[OWNER_METADATA_KEY] = owner;
+      } else {
+        delete merged[OWNER_METADATA_KEY];
       }
 
       const newName = input.rename ?? collection.name;
+      if (newName !== collection.name) {
+        assertValidName(newName);
+        // Renaming onto a name already in use would hit the store's UNIQUE
+        // constraint; check first so the caller gets ALREADY_EXISTS instead of
+        // a driver error, and so a rename cannot be used to probe for another
+        // user's collection names by error type.
+        if (await collectionExists(provider, newName)) {
+          throwApiError(
+            ApiErrorCode.ALREADY_EXISTS,
+            `Collection ${newName} already exists`
+          );
+        }
+      }
       await collection.modify({ name: newName, metadata: merged });
 
       notifyResourceChange({
@@ -167,8 +259,11 @@ export const collectionsRouter = router({
   delete: protectedProcedure
     .input(deleteInput)
     .output(deleteOutput)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const provider = getDefaultVectorProvider();
+      // Ownership is checked before the delete, not after — deleteCollection
+      // is irreversible.
+      await loadAccessibleCollection(input.name, ctx.userId);
       try {
         await provider.deleteCollection(input.name);
       } catch (err) {

--- a/packages/websocket/tests/collection-access.test.ts
+++ b/packages/websocket/tests/collection-access.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the collection ownership/input rules. The router and REST
+ * handler tests cover how these are applied; these cover the edges of the
+ * helpers themselves.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  OWNER_METADATA_KEY,
+  canAccessCollection,
+  collectionOwner,
+  stripReservedMetadata,
+  validateCollectionName,
+  MAX_COLLECTION_NAME_LENGTH
+} from "../src/lib/collection-access.js";
+
+describe("collectionOwner", () => {
+  it("reads the owner from metadata", () => {
+    expect(collectionOwner({ [OWNER_METADATA_KEY]: "user-1" })).toBe("user-1");
+  });
+
+  it("treats missing, empty, and non-string owners as unowned", () => {
+    expect(collectionOwner(undefined)).toBeNull();
+    expect(collectionOwner({})).toBeNull();
+    expect(collectionOwner({ [OWNER_METADATA_KEY]: "" })).toBeNull();
+    expect(collectionOwner({ [OWNER_METADATA_KEY]: 42 })).toBeNull();
+  });
+});
+
+describe("canAccessCollection", () => {
+  it("grants the owner", () => {
+    expect(
+      canAccessCollection({ [OWNER_METADATA_KEY]: "user-1" }, "user-1")
+    ).toBe(true);
+  });
+
+  it("denies a different user", () => {
+    expect(
+      canAccessCollection({ [OWNER_METADATA_KEY]: "user-2" }, "user-1")
+    ).toBe(false);
+  });
+
+  it("shares unowned legacy collections", () => {
+    expect(canAccessCollection({}, "user-1")).toBe(true);
+    expect(canAccessCollection(undefined, "anyone")).toBe(true);
+  });
+
+  it("does not treat a numeric owner as a match for its string form", () => {
+    expect(canAccessCollection({ [OWNER_METADATA_KEY]: 1 }, "1")).toBe(true);
+  });
+});
+
+describe("stripReservedMetadata", () => {
+  it("removes the owner key", () => {
+    expect(
+      stripReservedMetadata({ [OWNER_METADATA_KEY]: "user-2", a: "1" })
+    ).toEqual({ a: "1" });
+  });
+
+  it("returns an empty object for undefined input", () => {
+    expect(stripReservedMetadata(undefined)).toEqual({});
+  });
+
+  it("does not mutate the input", () => {
+    const input = { [OWNER_METADATA_KEY]: "user-2", a: "1" };
+    stripReservedMetadata(input);
+    expect(input[OWNER_METADATA_KEY]).toBe("user-2");
+  });
+
+  it("keeps a __proto__ key as data instead of touching the prototype", () => {
+    const input = JSON.parse('{"__proto__": "polluted", "a": "1"}') as Record<
+      string,
+      string
+    >;
+    const result = stripReservedMetadata(input);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(result.a).toBe("1");
+  });
+});
+
+describe("validateCollectionName", () => {
+  it("accepts ordinary names", () => {
+    for (const name of ["docs", "my_docs", "my-docs", "My Docs", "docs.v2"]) {
+      expect(validateCollectionName(name)).toBeNull();
+    }
+  });
+
+  it("rejects an empty name", () => {
+    expect(validateCollectionName("")).toContain("required");
+  });
+
+  it("rejects path separators", () => {
+    // The REST index route matches `[^/]+`, so a name with a slash is
+    // unreachable through that endpoint anyway.
+    expect(validateCollectionName("a/b")).toContain("path separators");
+    expect(validateCollectionName("a\\b")).toContain("path separators");
+  });
+
+  it("rejects control characters", () => {
+    expect(validateCollectionName("a\nb")).toContain("control characters");
+    expect(validateCollectionName("a\u0000b")).toContain("control characters");
+    expect(validateCollectionName("a\u007fb")).toContain("control characters");
+  });
+
+  it("rejects surrounding whitespace", () => {
+    expect(validateCollectionName(" docs")).toContain("whitespace");
+    expect(validateCollectionName("docs ")).toContain("whitespace");
+  });
+
+  it("rejects a name past the length cap but accepts one at it", () => {
+    expect(
+      validateCollectionName("x".repeat(MAX_COLLECTION_NAME_LENGTH))
+    ).toBeNull();
+    expect(
+      validateCollectionName("x".repeat(MAX_COLLECTION_NAME_LENGTH + 1))
+    ).toContain("exceeds");
+  });
+});

--- a/packages/websocket/tests/collection-api-coverage.test.ts
+++ b/packages/websocket/tests/collection-api-coverage.test.ts
@@ -227,9 +227,15 @@ describe("error handling", () => {
     expect(body.detail).toContain("Collection not found");
   });
 
-  it("maps a generic Error to 500 with the message", async () => {
+  it("maps a generic Error to a 500 that does not echo the message", async () => {
+    // Provider errors carry SQL text, file paths and upstream URLs; the client
+    // gets a generic message and the detail goes to the log instead.
     providerMock.mockReturnValue({
-      getCollection: vi.fn().mockRejectedValue(new Error("boom"))
+      getCollection: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("UNIQUE constraint failed: /var/lib/nodetool/vec.db")
+        )
     });
     const res = await handleCollectionRequest(
       uploadRequest("/api/collections/docs/index", {
@@ -240,11 +246,11 @@ describe("error handling", () => {
     );
     expect(res!.status).toBe(500);
     const body = await res!.json();
-    expect(body.detail).toContain("Vector store error");
-    expect(body.detail).toContain("boom");
+    expect(body.detail).toBe("Vector store error");
+    expect(body.detail).not.toContain("/var/lib");
   });
 
-  it("stringifies a non-Error throw in the 500 message", async () => {
+  it("does not surface a non-Error throw in the 500 body", async () => {
     providerMock.mockImplementation(() => {
       throw "raw failure";
     });
@@ -257,6 +263,102 @@ describe("error handling", () => {
     );
     expect(res!.status).toBe(500);
     const body = await res!.json();
-    expect(body.detail).toContain("raw failure");
+    expect(body.detail).toBe("Vector store error");
+    expect(body.detail).not.toContain("raw failure");
+  });
+});
+
+describe("ownership", () => {
+  // The index endpoint writes into a collection, so it enforces the same
+  // ownership rule as the tRPC router. See lib/collection-access.ts.
+  function requestAs(userId: string, urlPath: string) {
+    const form = new FormData();
+    form.set("file", new File(["hello world"], "note.txt"));
+    return new Request(`http://localhost${urlPath}`, {
+      method: "POST",
+      headers: { "x-user-id": userId },
+      body: form
+    });
+  }
+
+  it("refuses to index into another user's collection", async () => {
+    const collection = {
+      ...makeCollection(),
+      metadata: { owner_user_id: "user-2" }
+    };
+    providerMock.mockReturnValue({
+      getCollection: vi.fn().mockResolvedValue(collection)
+    });
+
+    const res = await handleCollectionRequest(
+      requestAs("user-1", "/api/collections/theirs/index"),
+      "/api/collections/theirs/index",
+      options
+    );
+
+    // 404 rather than 403 so the endpoint can't confirm the name exists.
+    expect(res!.status).toBe(404);
+    expect(collection.upsert).not.toHaveBeenCalled();
+  });
+
+  it("indexes into the caller's own collection", async () => {
+    const collection = {
+      ...makeCollection(),
+      metadata: { owner_user_id: "user-1" }
+    };
+    providerMock.mockReturnValue({
+      getCollection: vi.fn().mockResolvedValue(collection)
+    });
+
+    const res = await handleCollectionRequest(
+      requestAs("user-1", "/api/collections/mine/index"),
+      "/api/collections/mine/index",
+      options
+    );
+
+    expect(res!.status).toBe(200);
+    expect(collection.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("indexes into an unowned legacy collection", async () => {
+    const collection = { ...makeCollection(), metadata: {} };
+    providerMock.mockReturnValue({
+      getCollection: vi.fn().mockResolvedValue(collection)
+    });
+
+    const res = await handleCollectionRequest(
+      requestAs("user-1", "/api/collections/legacy/index"),
+      "/api/collections/legacy/index",
+      options
+    );
+
+    expect(res!.status).toBe(200);
+  });
+});
+
+describe("upload size cap", () => {
+  it("rejects a file over the configured limit with 413", async () => {
+    // The whole file is read into a string and chunked in memory, so the cap
+    // is enforced before that rather than relying on Fastify's body limit.
+    process.env.NODETOOL_MAX_UPLOAD_BYTES = "16";
+    try {
+      const collection = makeCollection();
+      providerMock.mockReturnValue({
+        getCollection: vi.fn().mockResolvedValue(collection)
+      });
+
+      const res = await handleCollectionRequest(
+        uploadRequest("/api/collections/docs/index", {
+          file: { name: "big.txt", content: "x".repeat(64) }
+        }),
+        "/api/collections/docs/index",
+        options
+      );
+
+      expect(res!.status).toBe(413);
+      expect(collection.upsert).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.NODETOOL_MAX_UPLOAD_BYTES;
+    }
   });
 });

--- a/packages/websocket/tests/public-routes.test.ts
+++ b/packages/websocket/tests/public-routes.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The auth-exemption allowlist is the boundary between "anyone who can reach
+ * the port" and the local user's data, so these tests pin down exactly which
+ * paths skip authentication.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isPublicOAuthRequest,
+  isPublicWorkflowMetadataRequest
+} from "../src/lib/public-routes.js";
+
+describe("isPublicWorkflowMetadataRequest", () => {
+  it("exempts shipped examples and explicitly-public workflows", () => {
+    for (const path of [
+      "/api/workflows/public",
+      "/api/workflows/public/wf-123",
+      "/api/workflows/examples",
+      "/api/workflows/examples/search",
+      "/api/workflows/examples/thumbnails/foo.png"
+    ]) {
+      expect(isPublicWorkflowMetadataRequest(path, "GET")).toBe(true);
+    }
+  });
+
+  it("keeps the caller's own library behind auth", () => {
+    // These resolve identity from the server-set x-user-id header and fall
+    // back to user "1", so exempting them discloses private workflows —
+    // graph included — to any unauthenticated caller.
+    for (const path of [
+      "/api/workflows",
+      "/api/workflows/",
+      "/api/workflows/wf-123",
+      "/api/workflows/names",
+      "/api/workflows/tools",
+      "/api/workflows/wf-123/dsl-export"
+    ]) {
+      expect(isPublicWorkflowMetadataRequest(path, "GET")).toBe(false);
+    }
+  });
+
+  it("does not exempt a private id that merely starts with a public prefix", () => {
+    // `publications` / `examples-of-mine` share a prefix with the allowlist
+    // but are ordinary workflow ids, so a startsWith check without the
+    // trailing separator would leak them.
+    expect(
+      isPublicWorkflowMetadataRequest("/api/workflows/publications", "GET")
+    ).toBe(false);
+    expect(
+      isPublicWorkflowMetadataRequest("/api/workflows/examples-of-mine", "GET")
+    ).toBe(false);
+  });
+
+  it("never exempts a mutation", () => {
+    for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
+      expect(
+        isPublicWorkflowMetadataRequest("/api/workflows/public", method)
+      ).toBe(false);
+    }
+  });
+});
+
+describe("isPublicOAuthRequest", () => {
+  it("exempts only the two browser redirect targets", () => {
+    expect(isPublicOAuthRequest("/api/oauth/hf/callback")).toBe(true);
+    expect(isPublicOAuthRequest("/api/oauth/github/callback")).toBe(true);
+  });
+
+  it("keeps credential read/write paths behind auth", () => {
+    for (const path of [
+      "/api/oauth/hf/start",
+      "/api/oauth/hf/tokens",
+      "/api/oauth/hf/refresh",
+      "/api/oauth/hf/whoami",
+      "/api/oauth/github/start",
+      "/api/oauth/github/tokens",
+      "/api/oauth/github/user",
+      "/api/oauth/openai/start",
+      "/api/oauth/openai/tokens",
+      "/api/oauth/openai/disconnect"
+    ]) {
+      expect(isPublicOAuthRequest(path)).toBe(false);
+    }
+  });
+});

--- a/packages/websocket/tests/trpc-collections.test.ts
+++ b/packages/websocket/tests/trpc-collections.test.ts
@@ -136,6 +136,7 @@ describe("collections router", () => {
       expect(createCollection).toHaveBeenCalledWith({
         name: "new-col",
         metadata: {
+          owner_user_id: "user-1",
           embedding_model: "text-embedding-3-small",
           embedding_provider: "openai"
         }
@@ -159,7 +160,7 @@ describe("collections router", () => {
       await caller.collections.create({ name: "bare" });
       expect(createCollection).toHaveBeenCalledWith({
         name: "bare",
-        metadata: {}
+        metadata: { owner_user_id: "user-1" }
       });
     });
   });
@@ -172,7 +173,10 @@ describe("collections router", () => {
         count: 3
       });
       mockedProvider.mockReturnValue({
-        getCollection: vi.fn().mockResolvedValue(col)
+        getCollection: vi.fn(async ({ name }: { name: string }) => {
+          if (name === "old-name") return col;
+          throw new CollectionNotFoundError(name);
+        })
       });
 
       const caller = createCaller(makeCtx());
@@ -229,7 +233,12 @@ describe("collections router", () => {
   describe("delete", () => {
     it("deletes a collection and returns confirmation", async () => {
       const deleteCollection = vi.fn().mockResolvedValue(undefined);
-      mockedProvider.mockReturnValue({ deleteCollection });
+      mockedProvider.mockReturnValue({
+        deleteCollection,
+        getCollection: vi
+          .fn()
+          .mockResolvedValue(makeCollection({ name: "doomed" }))
+      });
 
       const caller = createCaller(makeCtx());
       const result = await caller.collections.delete({ name: "doomed" });
@@ -240,13 +249,171 @@ describe("collections router", () => {
 
     it("throws NOT_FOUND when the collection is missing", async () => {
       mockedProvider.mockReturnValue({
-        deleteCollection: vi.fn().mockRejectedValue(new CollectionNotFoundError("missing"))
+        deleteCollection: vi.fn().mockResolvedValue(undefined),
+        getCollection: vi
+          .fn()
+          .mockRejectedValue(new CollectionNotFoundError("missing"))
       });
 
       const caller = createCaller(makeCtx());
       await expect(
         caller.collections.delete({ name: "missing" })
       ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+  });
+  // ── Ownership isolation ───────────────────────────────────────────
+  // Collections live in one global namespace in every provider, so these
+  // rules are the only thing separating tenants. See lib/collection-access.ts.
+  describe("ownership", () => {
+    /** A provider whose single collection belongs to someone else. */
+    function providerOwnedBy(owner: string, name = "theirs") {
+      const col = makeCollection({
+        name,
+        metadata: { owner_user_id: owner, secret: "value" },
+        count: 42
+      });
+      const deleteCollection = vi.fn().mockResolvedValue(undefined);
+      mockedProvider.mockReturnValue({
+        listCollections: vi
+          .fn()
+          .mockResolvedValue([{ name, metadata: { owner_user_id: owner } }]),
+        getCollection: vi.fn().mockResolvedValue(col),
+        deleteCollection
+      });
+      return { col, deleteCollection };
+    }
+
+    it("omits another user's collection from the listing", async () => {
+      providerOwnedBy("user-2");
+      const result = await createCaller(makeCtx()).collections.list();
+      expect(result.collections).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it("still lists the caller's own collections", async () => {
+      providerOwnedBy("user-1", "mine");
+      const result = await createCaller(makeCtx()).collections.list();
+      expect(result.collections.map((c) => c.name)).toEqual(["mine"]);
+    });
+
+    it("still lists unowned legacy collections", async () => {
+      const col = makeCollection({ name: "legacy", metadata: {} });
+      mockedProvider.mockReturnValue({
+        listCollections: vi
+          .fn()
+          .mockResolvedValue([{ name: "legacy", metadata: {} }]),
+        getCollection: vi.fn().mockResolvedValue(col)
+      });
+      const result = await createCaller(makeCtx()).collections.list();
+      expect(result.collections.map((c) => c.name)).toEqual(["legacy"]);
+    });
+
+    it("answers NOT_FOUND — not FORBIDDEN — when updating another user's collection", async () => {
+      // FORBIDDEN would confirm the name exists and let a caller enumerate
+      // other users' collections by probing.
+      const { col } = providerOwnedBy("user-2");
+      await expect(
+        createCaller(makeCtx()).collections.update({
+          name: "theirs",
+          metadata: { a: "1" }
+        })
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(col.modify).not.toHaveBeenCalled();
+    });
+
+    it("refuses to delete another user's collection", async () => {
+      const { deleteCollection } = providerOwnedBy("user-2");
+      await expect(
+        createCaller(makeCtx()).collections.delete({ name: "theirs" })
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(deleteCollection).not.toHaveBeenCalled();
+    });
+
+    it("ignores a client attempt to rewrite owner_user_id", async () => {
+      const col = makeCollection({
+        name: "mine",
+        metadata: { owner_user_id: "user-1" }
+      });
+      mockedProvider.mockReturnValue({
+        getCollection: vi.fn().mockResolvedValue(col)
+      });
+
+      await createCaller(makeCtx()).collections.update({
+        name: "mine",
+        metadata: { owner_user_id: "user-2", note: "hi" }
+      });
+
+      expect(col.modify).toHaveBeenCalledWith({
+        name: "mine",
+        metadata: { owner_user_id: "user-1", note: "hi" }
+      });
+    });
+
+    it("leaves an unowned collection unowned after an update", async () => {
+      // Claiming it for the first editor would lock out everyone else who had
+      // been sharing it.
+      const col = makeCollection({ name: "legacy", metadata: { a: "1" } });
+      mockedProvider.mockReturnValue({
+        getCollection: vi.fn().mockResolvedValue(col)
+      });
+
+      await createCaller(makeCtx()).collections.update({
+        name: "legacy",
+        metadata: { b: "2" }
+      });
+
+      expect(col.modify).toHaveBeenCalledWith({
+        name: "legacy",
+        metadata: { a: "1", b: "2" }
+      });
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects a name containing a path separator", async () => {
+      mockedProvider.mockReturnValue({ createCollection: vi.fn() });
+      await expect(
+        createCaller(makeCtx()).collections.create({ name: "a/b" })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("rejects an over-long name", async () => {
+      mockedProvider.mockReturnValue({ createCollection: vi.fn() });
+      await expect(
+        createCaller(makeCtx()).collections.create({ name: "x".repeat(129) })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("reports a duplicate name as ALREADY_EXISTS, not a driver error", async () => {
+      mockedProvider.mockReturnValue({
+        createCollection: vi
+          .fn()
+          .mockRejectedValue(
+            new Error("UNIQUE constraint failed: vec_collections.name")
+          ),
+        getCollection: vi
+          .fn()
+          .mockResolvedValue(makeCollection({ name: "dupe" }))
+      });
+
+      await expect(
+        createCaller(makeCtx()).collections.create({ name: "dupe" })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+    });
+
+    it("refuses to rename onto an existing collection", async () => {
+      const col = makeCollection({ name: "mine", metadata: {} });
+      mockedProvider.mockReturnValue({
+        getCollection: vi.fn().mockResolvedValue(col)
+      });
+
+      await expect(
+        createCaller(makeCtx()).collections.update({
+          name: "mine",
+          rename: "taken"
+        })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+      expect(col.modify).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -432,6 +432,12 @@ const PropertyDropzone = ({
           return (
             <iframe
               src={uri}
+              // Asset bytes are user content served from the app's own origin.
+              // An empty sandbox drops it into an opaque origin so a stored
+              // .html document can't run script against the session, matching
+              // every other HTML iframe in the app. The storage endpoint also
+              // serves .html as text/plain; this is the second lock.
+              sandbox=""
               style={{ width: "100%", height: "400px", border: "none" }}
               allow="fullscreen"
               title="Text viewer"


### PR DESCRIPTION
Security audit of the API (`packages/websocket`, `packages/auth`) and `web/`. Three confirmed access-control vulnerabilities, plus hardening. Findings I did **not** fix are listed at the bottom.

## 1. Private workflows readable without authentication (high)

The auth-exemption allowlist in the server's `onRequest` hook exempted `/api/workflows` (list), `/api/workflows/:id`, `/api/workflows/names`, `/api/workflows/tools`, and `:id/dsl-export`. The REST handlers resolve identity from the server-set `x-user-id` header and fall back to user `"1"` when it is absent (`getUserId`, `http-api.ts:366`), so those paths served the local user's library to anyone who could reach the port — defeating the `Remote access requires authentication` 401 that local mode otherwise applies to a server bound beyond loopback.

Verified against a running server with `NODETOOL_TRUST_LOCALHOST=false` and a seeded private workflow:

```
$ curl -s http://127.0.0.1:7788/api/workflows/wf-secret
{"id":"wf-secret","access":"private","name":"Prod deploy pipeline",
 "graph":{"nodes":[{"id":"1","type":"nodetool.constant.String",
 "data":{"value":"sk-live-SUPERSECRET"}}],"edges":[]}, ...}
```

The full graph is disclosed, so anything a user parks in a node property — prompts, internal endpoints, keys pasted into a constant — goes with it.

## 2. OAuth credential endpoints readable and mutable without authentication (high)

`pathname.startsWith("/api/oauth/")` exempted the entire prefix, but only the two browser redirect targets need it — the identity provider sends the user back with no `Authorization` header, and those handlers authenticate through the single-use PKCE `state` minted at `/start`. Every other path operates on stored credentials for the caller's user id:

```
$ curl -s http://127.0.0.1:7788/api/oauth/hf/tokens
{"tokens":[{"id":"oc1","provider":"huggingface","account_id":"acct-123",
 "username":"victim-hf-user","token_type":"Bearer","scope":"read-repos", ...}]}
```

Unauthenticated, that also reached `/hf/whoami` and `/github/user` (linked third-party profile and email), `/hf/refresh` (forced token refresh), and `/openai/disconnect` (credential deletion). Token *values* were never returned — they stay encrypted at rest and the handlers only expose metadata.

## 3. Vector collections were not scoped to a user (high, multi-user only)

Collections are a flat global namespace in every `VectorProvider` (sqlite-vec, Pinecone, Supabase, Chroma) — the interface has no concept of a user, and neither the tRPC router nor the REST index endpoint looked at `ctx.userId`. In multi-user (Supabase) mode any authenticated user could list, rename, delete, and index into any other user's collection, and see its document count.

Ownership is now recorded in collection metadata (`owner_user_id`, stamped on create) and enforced at the API boundary. Teaching four providers about users is a much larger change; this covers the surface an untrusted caller can actually reach. In-process consumers — RAG nodes, agent tools, the CLI — talk to the provider directly and are unaffected, since they already run with their invoker's privileges.

Two judgment calls worth review:

- **Pre-existing collections stay shared.** They carry no owner, so everyone can still use them, and an update does not claim an unowned collection for the first editor. Retroactively assigning them would lock existing deployments out of their own data, and claiming-on-edit would silently lock out everyone who had been sharing one.
- **Someone else's collection answers NOT_FOUND, not FORBIDDEN**, so the error can't be used to enumerate other users' collection names.

Client metadata is stripped of server-owned keys before merging, so a caller can't rewrite `owner_user_id` to seize or hand off a collection.

## 4. Missing security response headers (medium)

The web app's CSP lives in a `<meta>` tag, and browsers ignore `frame-ancestors` there — it is only honoured in a header — so the app had no clickjacking protection, and no `nosniff` or `Referrer-Policy` anywhere.

## 5. Unsandboxed document-preview iframe (medium)

`PropertyDropzone` rendered `.html`/`.txt` asset bytes in an iframe with no `sandbox` attribute, from the app's own origin. It was the only HTML iframe in the app missing one. Currently mitigated by `storage-api.ts` serving `.html` as `text/plain`; this adds the second lock.

## Other hardening in the collections surface

- Collection names are validated (no path separators, control characters, surrounding whitespace, or >128 chars). Deliberately permissive so existing names keep working.
- A duplicate name returns `ALREADY_EXISTS` instead of leaking the store's `UNIQUE constraint failed: vec_collections.name` text, and a rename onto a taken name is refused up front.
- The index endpoint caps uploads at `NODETOOL_MAX_UPLOAD_BYTES` — it reads the whole file into a string and chunks it in memory, so Fastify's 100 MB body limit was the only bound.
- Provider errors are logged and answered with a generic message rather than echoed; they carry SQL text, file paths, and upstream URLs.

## Changes

- `packages/websocket/src/lib/public-routes.ts` (new) — both auth-exemption predicates, extracted so they are testable without booting the server (`server.ts` opens the database and binds a port at import). The prefix matches also gained a trailing separator, so a workflow id like `publications` no longer matches `/api/workflows/public`.
- `packages/websocket/src/lib/collection-access.ts` (new) — ownership and name rules for collections.
- `packages/websocket/src/trpc/routers/collections.ts`, `src/collection-api.ts` — enforce ownership, validate names, cap uploads, stop echoing provider errors.
- `packages/websocket/src/server.ts` — use the narrowed predicates; add `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Content-Security-Policy: frame-ancestors 'self'`, and `Referrer-Policy: strict-origin-when-cross-origin`. `/api/storage/*` is exempt from `nosniff` and the frame headers to preserve its documented cross-origin embedding contract (MCP App iframes, Electron renderer) and the `application/octet-stream` fallback that `<img>`/`<video>` sniff.
- `web/src/components/properties/PropertyDropzone.tsx` — `sandbox=""` on the text/HTML preview iframe. The PDF iframe is left alone; Chrome's PDF viewer does not render inside an empty sandbox.
- Tests: `public-routes.test.ts` and `collection-access.test.ts` (new), plus ownership/validation cases added to the collections router and REST suites.

## Verification

Auth-exemption probes re-run against the rebuilt server:

| path | before | after |
|---|---|---|
| `/api/workflows`, `/api/workflows/:id`, `/names`, `/tools`, `:id/dsl-export` | 200 | 401 |
| `/api/oauth/{hf,github,openai}/tokens`, `/hf/whoami` | 200 | 401 |
| `/health`, `/api/config`, `/api/nodes/metadata` | 200 | 200 |
| `/api/workflows/public`, `/api/workflows/examples` | 200 | 200 |
| `/api/oauth/{hf,github}/callback` | 200 | 200 |

Collection isolation was checked end-to-end against the **real sqlite-vec provider, not mocks** — the scheme depends on metadata surviving the round trip:

```
PASS  owner persisted in store: alice
PASS  owner present in listCollections: alice
PASS  bob's listing is empty: 0
PASS  bob update / rename / delete blocked: NOT_FOUND
PASS  owner unchanged after metadata rewrite attempt: alice
PASS  duplicate name reports CONFLICT
PASS  duplicate error hides SQL text: false
```

`npm run lint` passes (remaining warnings pre-existing). `npx vitest run --root packages/websocket` — 124 files, 1653 tests passing. `web` PropertyDropzone suite passing. `npm run typecheck` passes for `packages` and `web`; `mobile` fails on missing modules because its dependency tree is not installed in this environment — pre-existing and unrelated.

## Reported, not fixed

- **`POST /api/kie/webhook` has no signature or shared-secret check.** Anyone who learns or guesses a `taskId` can resolve or reject an in-flight KIE generation with an attacker-controlled payload. The trigger webhook route (`triggers/webhook-route.ts`) does this correctly with a sha256 hash and `timingSafeEqual`. A fix means threading a secret through the `callBackUrl` built in `kie-base.ts` / `kie-provider.ts`, which I cannot test against the real KIE callback, so I left it rather than ship an untested change to a third-party integration.
- **`/api/storage/*` keys are not user-scoped.** Any authenticated user can `GET` or `PUT` any key, so in multi-user mode one tenant can overwrite another's asset bytes. Fixing this changes the asset URL scheme, so it needs its own migration.
- **`GET /api/files/local` accepts any absolute path**, guarded only by a small denylist of sensitive home directories — while the tRPC `files.list` equivalent is sandboxed to `$HOME`. It requires auth and is disabled when `NODETOOL_ENV=production`, but the two file-read surfaces disagree on how much of the disk is reachable.
- **Collection scoping covers the HTTP surface only.** A workflow node or agent tool that queries collections by name still reaches any collection in the store, because it bypasses this layer. Closing that means per-user scoping inside the providers.

## CI note

The CodeQL check reports one `js/missing-rate-limiting` alert on the auth hook in `server.ts`. It is a pre-existing false positive re-fingerprinted by this PR's line shifts — `@fastify/rate-limit` is registered globally *before* that hook and CodeQL has no model for it. Details in [this comment](https://github.com/nodetool-ai/nodetool/pull/4520#issuecomment-5088638578).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HznMLQE3frSF6xnRjk9gQB