### PR TITLE
fix(triggers): dispatch on acceptance, not run completion

### DIFF
--- a/packages/websocket/src/headless-job-runner.ts
+++ b/packages/websocket/src/headless-job-runner.ts
@@ -51,6 +51,14 @@ export interface StartHeadlessJobOptions {
   jobName?: string;
   /** Node registry to resolve executors from. Defaults to the bootstrapped server registry. */
   registry?: NodeRegistry;
+  /**
+   * Called once the run is *accepted* — the workflow resolved and the `Job` row
+   * exists — which is long before this function's promise settles on terminal
+   * status. Callers that must not block for the run's whole duration (the
+   * trigger dispatcher) use it as their handoff point. A throwing callback is
+   * swallowed: acceptance reporting must never fail the run.
+   */
+  onAccepted?: (jobId: string) => void;
 }
 
 export type HeadlessJobStatus =
@@ -108,7 +116,8 @@ function normalizeRunnableGraph(graph: {
   });
   const edges = (graph.edges as Array<Record<string, unknown>>)
     .filter(
-      (e) => keep.has(String(e.source ?? "")) && keep.has(String(e.target ?? ""))
+      (e) =>
+        keep.has(String(e.source ?? "")) && keep.has(String(e.target ?? ""))
     )
     .map((edge) => {
       const rawEdgeType = edge.edge_type ?? edge.type;
@@ -185,6 +194,17 @@ export async function startHeadlessJob(
     graph
   })) as Job;
 
+  // The run is accepted from here on: everything above could still reject and
+  // leave the caller free to redeliver, everything below is an executing run.
+  try {
+    options.onAccepted?.(job.id);
+  } catch (err) {
+    log.warn("headless job onAccepted callback threw", {
+      jobId: job.id,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+
   const workspaceDir = await resolveWorkflowWorkspace(workflowId, userId);
   const context = new ProcessingContext({
     jobId: job.id,
@@ -193,9 +213,7 @@ export async function startHeadlessJob(
     secretResolver: getSecret,
     storage: new FileStorageAdapter(getDefaultAssetsPath()),
     workspaceDir,
-    workspaceStorage: workspaceDir
-      ? new FileStorageAdapter(workspaceDir)
-      : null
+    workspaceStorage: workspaceDir ? new FileStorageAdapter(workspaceDir) : null
   });
 
   // Python nodes go through a lazily-connected worker bridge, exactly like the
@@ -231,9 +249,7 @@ export async function startHeadlessJob(
         job_id: job.id,
         workflow_id: workflowId,
         params,
-        ...(options.triggerEvent
-          ? { trigger_event: options.triggerEvent }
-          : {})
+        ...(options.triggerEvent ? { trigger_event: options.triggerEvent } : {})
       },
       hydrateGraphNodeFlags(graph as unknown as GraphData, registry)
     );

--- a/packages/websocket/src/triggers/dispatcher.ts
+++ b/packages/websocket/src/triggers/dispatcher.ts
@@ -26,10 +26,26 @@
  * would loop forever) and the run error is still written to
  * `registration.last_error` so the UI shows the last outcome.
  *
+ * ## Acceptance vs. completion
+ *
+ * `startJob` resolves on *terminal* status — it does not come back until the
+ * workflow has finished. A pass that awaited that would hold every other
+ * registration behind the slowest run in flight: a webhook arriving one second
+ * into a ten-minute triggered run waited ten minutes for its own dispatch.
+ *
+ * So a pass awaits **acceptance**, not completion. `startHeadlessJob` reports
+ * acceptance through `onAccepted` the moment the workflow resolves and the
+ * `Job` row exists; the run itself settles later, on its own. `drain()` is what
+ * awaits the runs, for shutdown and for tests.
+ *
+ * A `startJob` that never calls `onAccepted` (the test fakes, any other job
+ * starter) still works: acceptance then resolves when the job promise does,
+ * which is exactly the old behaviour.
+ *
  * ## Idempotency and the crash window
  *
- * An input is marked processed **after** the run is accepted, never before. In
- * process, `_inflight` (keyed by `inputId`) makes overlapping passes and
+ * An input is marked processed **when the run is accepted**, never before. In
+ * process, `inflight` (keyed by `inputId`) makes overlapping passes and
  * concurrent `dispatchInput` calls join the same dispatch instead of starting a
  * second run.
  *
@@ -38,6 +54,10 @@
  * redelivered and the run happens twice. This is deliberate — at-least-once
  * delivery. Dropping an event is worse than repeating one, and marking first
  * would turn any crash before acceptance into a silently lost event.
+ *
+ * A run that was never accepted (`startJob` rejected) leaves `last_fired_at`
+ * alone: nothing fired, and stamping it made the editor report a delivery that
+ * never happened.
  *
  * ## Who writes `last_fired_at`
  *
@@ -155,6 +175,46 @@ interface RegistrationState {
   chain: Promise<unknown>;
 }
 
+/**
+ * One input's dispatch, split at the acceptance point: `accepted` settles when
+ * the run was taken on (or refused), `done` when it has finished.
+ */
+interface Dispatch {
+  accepted: Promise<void>;
+  done: Promise<DispatchOutcome>;
+}
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+  settled: boolean;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const d: Deferred = {
+    promise,
+    settled: false,
+    resolve: () => {
+      if (d.settled) return;
+      d.settled = true;
+      resolve();
+    },
+    reject: (reason) => {
+      if (d.settled) return;
+      d.settled = true;
+      reject(reason);
+    }
+  };
+  return d;
+}
+
 function readPolicy(registration: TriggerRegistration): ConcurrencyPolicy {
   const raw = registration.config_json?.concurrency;
   if (raw === "queue" || raw === "skip" || raw === "parallel") return raw;
@@ -193,7 +253,9 @@ export class TriggerDispatcher {
   private readonly batchSize: number;
 
   private readonly states = new Map<string, RegistrationState>();
-  private readonly inflight = new Map<string, Promise<DispatchOutcome>>();
+  private readonly inflight = new Map<string, Dispatch>();
+  /** Runs a pass handed off but that have not finished. `drain()` awaits these. */
+  private readonly outstanding = new Set<Promise<unknown>>();
 
   private pass: Promise<void> | null = null;
   private pending = false;
@@ -208,12 +270,14 @@ export class TriggerDispatcher {
 
   /**
    * Drain every enabled registration's unprocessed inputs once. Resolves when
-   * all runs this pass started have settled; a single input's failure does not
-   * abort the pass.
+   * every input this pass picked up has been *accepted* — not when its run has
+   * finished, so one slow workflow cannot hold up the next pass (see the
+   * acceptance-vs-completion note above). Use `drain()` to await the runs. A
+   * single input's failure does not abort the pass.
    */
   async runOnce(): Promise<void> {
     const registrations = await listEnabledRegistrations();
-    const started: Array<Promise<unknown>> = [];
+    const accepted: Array<Promise<unknown>> = [];
 
     for (const registration of registrations) {
       const inputs = await this.store.findUnprocessed(
@@ -223,11 +287,13 @@ export class TriggerDispatcher {
       );
       for (const input of inputs) {
         // Swallow here only: each dispatch already records its own error.
-        started.push(this.enqueue(input, registration).catch(() => undefined));
+        accepted.push(
+          this.enqueue(input, registration).accepted.catch(() => undefined)
+        );
       }
     }
 
-    await Promise.all(started);
+    await Promise.all(accepted);
   }
 
   /** Adapter hint: run a pass now, coalescing concurrent notifies. */
@@ -240,10 +306,17 @@ export class TriggerDispatcher {
     });
   };
 
-  /** Await the currently running pass (and any pass it coalesced). */
+  /**
+   * Await the currently running pass (and any pass it coalesced) *and* every
+   * run those passes handed off. A settling run can enqueue nothing new, but a
+   * pass can, so both are re-checked until the two are quiet together.
+   */
   async drain(): Promise<void> {
-    while (this.pass) {
-      await this.pass;
+    while (this.pass || this.outstanding.size > 0) {
+      if (this.pass) await this.pass;
+      await Promise.all(
+        [...this.outstanding].map((p) => p.catch(() => undefined))
+      );
     }
   }
 
@@ -261,7 +334,7 @@ export class TriggerDispatcher {
   async dispatchInput(inputId: string): Promise<{ jobId: string }> {
     const existing = this.inflight.get(inputId);
     const settled = existing
-      ? await existing
+      ? await existing.done
       : await this.dispatchStoredInput(inputId);
     if (settled.status !== "dispatched") {
       throw new Error(`dispatch skipped: ${settled.reason}`);
@@ -283,7 +356,7 @@ export class TriggerDispatcher {
     if (registration.enabled !== 1) {
       throw new Error(`registration disabled: ${registration.id}`);
     }
-    return this.enqueue(input, registration);
+    return this.enqueue(input, registration).done;
   }
 
   /**
@@ -335,19 +408,31 @@ export class TriggerDispatcher {
   private enqueue(
     input: TriggerInput,
     registration: TriggerRegistration
-  ): Promise<DispatchOutcome> {
+  ): Dispatch {
     const existing = this.inflight.get(input.inputId);
     if (existing) return existing;
 
     const policy = readPolicy(registration);
     const state = this.stateFor(registration.id);
 
+    const acceptance = deferred();
+    /**
+     * The handoff point: the input is marked processed and the pass that
+     * picked it up is released. Idempotent, because a `startJob` that reports
+     * acceptance early also resolves when it finishes.
+     */
+    const accept = async (): Promise<void> => {
+      if (acceptance.settled) return;
+      await this.store.markProcessed(input.inputId);
+      acceptance.resolve();
+    };
+
     // The synchronous prefix of `run` (the `running` bump) executes as soon as
     // `run()` is called, so a second input enqueued in the same tick sees it.
     const run = async (): Promise<DispatchOutcome> => {
       if (policy === "skip" && state.running > 0) {
         await this.emitReceived(input, registration, policy, false);
-        await this.store.markProcessed(input.inputId);
+        await accept();
         log.debug("Trigger input skipped (run already in flight)", {
           inputId: input.inputId,
           registrationId: registration.id
@@ -359,34 +444,46 @@ export class TriggerDispatcher {
       }
       state.running += 1;
       try {
-        return await this.dispatchOne(input, registration, policy);
+        return await this.dispatchOne(input, registration, policy, accept);
       } finally {
         state.running -= 1;
       }
     };
 
-    let promise: Promise<DispatchOutcome>;
+    let done: Promise<DispatchOutcome>;
     if (policy === "queue") {
       // Both handlers run the dispatch: a failed predecessor must not cancel
       // its successors.
-      promise = state.chain.then(run, run);
-      state.chain = promise.catch(() => undefined);
+      done = state.chain.then(run, run);
+      state.chain = done.catch(() => undefined);
     } else {
-      promise = run();
+      done = run();
     }
 
-    this.inflight.set(input.inputId, promise);
-    const forget = (): void => {
+    const dispatch: Dispatch = { accepted: acceptance.promise, done };
+    this.inflight.set(input.inputId, dispatch);
+    this.outstanding.add(done);
+
+    const forget = (err?: unknown): void => {
       this.inflight.delete(input.inputId);
+      this.outstanding.delete(done);
+      // A dispatch that failed before it was ever accepted must not leave the
+      // pass awaiting an acceptance that will never come.
+      acceptance.reject(err);
     };
-    void promise.then(forget, forget);
-    return promise;
+    void done.then(() => forget(), forget);
+    // The pass attaches its own handler, but `dispatchInput` callers only take
+    // `done` — keep a rejected acceptance from surfacing as unhandled.
+    void acceptance.promise.catch(() => undefined);
+
+    return dispatch;
   }
 
   private async dispatchOne(
     input: TriggerInput,
     registration: TriggerRegistration,
-    policy: ConcurrencyPolicy
+    policy: ConcurrencyPolicy,
+    accept: () => Promise<void>
   ): Promise<DispatchOutcome> {
     const nowMs = Date.now();
     const gate = checkTriggerBounds(registration, nowMs);
@@ -394,7 +491,7 @@ export class TriggerDispatcher {
       // Exhausted: drop the event rather than leave it to redeliver forever,
       // and disarm so the next one never gets this far.
       await this.emitReceived(input, registration, policy, false);
-      await this.store.markProcessed(input.inputId);
+      await accept();
       disableTrigger(registration, gate.reason);
       await registration.save();
       log.info("Trigger registration disabled before dispatch", {
@@ -417,17 +514,24 @@ export class TriggerDispatcher {
           payload: input.payload,
           input_id: input.inputId
         },
+        // Release the pass as soon as the run is taken on, so a long workflow
+        // doesn't hold up every other registration's dispatch.
+        onAccepted: () => {
+          void accept();
+        },
         ...(this.registry ? { registry: this.registry } : {})
       });
     } catch (err) {
       // The run was never accepted: leave the input unprocessed so the next
       // tick redelivers it. It still counts as a failure — a registration
-      // whose workflow has gone missing redelivers forever otherwise.
+      // whose workflow has gone missing redelivers forever otherwise. Nothing
+      // fired, so `last_fired_at` is left alone.
       const error = err instanceof Error ? err : new Error(String(err));
       await this.settle(
         registration,
         `dispatch failed: ${error.message}`,
-        nowMs
+        nowMs,
+        { fired: false }
       );
       log.warn(
         `Trigger dispatch failed for input ${input.inputId} (registration ${registration.id})`,
@@ -437,7 +541,8 @@ export class TriggerDispatcher {
     }
 
     // Accepted — mark processed only now (see the crash-window note above).
-    await this.store.markProcessed(input.inputId);
+    // A no-op when `onAccepted` already fired mid-run.
+    await accept();
 
     await this.settle(
       registration,
@@ -489,13 +594,18 @@ export class TriggerDispatcher {
    * Record what the run did to the registration: its outcome, the failure
    * counters, and — for the kinds no ingestion adapter stamps — the fire time
    * the editor shows as "Last fired".
+   *
+   * `fired: false` marks an outcome where no run ever started, so there is no
+   * fire time to record however the kind is owned.
    */
   private async settle(
     registration: TriggerRegistration,
     error: string | null,
-    nowMs: number
+    nowMs: number,
+    opts: { fired: boolean } = { fired: true }
   ): Promise<void> {
-    const stampFiredAt = !ADAPTER_STAMPS_FIRED_AT.has(registration.kind);
+    const stampFiredAt =
+      opts.fired && !ADAPTER_STAMPS_FIRED_AT.has(registration.kind);
     const disabled = settleTriggerOutcome(registration, {
       error,
       stampFiredAt,

--- a/packages/websocket/src/trpc/routers/triggers.ts
+++ b/packages/websocket/src/trpc/routers/triggers.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
-import { TriggerRegistration, createTimeOrderedUuid } from "@nodetool-ai/models";
+import {
+  TriggerRegistration,
+  createTimeOrderedUuid
+} from "@nodetool-ai/models";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
-import { getTriggerWakeupService, dispatchInput } from "../../triggers/dispatcher.js";
+import {
+  getTriggerWakeupService,
+  dispatchInput
+} from "../../triggers/dispatcher.js";
 import {
   nextFireAtIso,
   scheduleIntervalSeconds
@@ -75,23 +81,31 @@ export const triggersRouter = router({
       };
     }),
 
-  fire: protectedProcedure
-    .input(fireInput)
-    .mutation(async ({ ctx, input }) => {
-      const reg = (await TriggerRegistration.get(
-        input.registrationId
-      )) as TriggerRegistration | null;
-      if (!reg || reg.user_id !== ctx.userId) {
-        throwApiError(ApiErrorCode.NOT_FOUND, "Trigger registration not found");
-      }
-      const inputId = input.idempotencyKey ?? createTimeOrderedUuid();
-      await getTriggerWakeupService().deliverTriggerInput({
-        runId: reg.workflow_id,
-        nodeId: reg.node_id,
-        inputId,
-        payload: input.payload ?? {}
-      });
-      const { jobId } = await dispatchInput(inputId);
-      return { job_id: jobId };
-    })
+  fire: protectedProcedure.input(fireInput).mutation(async ({ ctx, input }) => {
+    const reg = (await TriggerRegistration.get(
+      input.registrationId
+    )) as TriggerRegistration | null;
+    if (!reg || reg.user_id !== ctx.userId) {
+      throwApiError(ApiErrorCode.NOT_FOUND, "Trigger registration not found");
+    }
+    // Refuse before delivering, not after. The dispatcher rejects a disabled
+    // registration too, but by then the input is durably stored — and since
+    // a pass only scans *enabled* registrations, it would sit unprocessed
+    // until someone re-armed the trigger and then fire as a surprise.
+    if (reg.enabled !== 1) {
+      throwApiError(
+        ApiErrorCode.INVALID_INPUT,
+        "Trigger is not active — activate it before firing"
+      );
+    }
+    const inputId = input.idempotencyKey ?? createTimeOrderedUuid();
+    await getTriggerWakeupService().deliverTriggerInput({
+      runId: reg.workflow_id,
+      nodeId: reg.node_id,
+      inputId,
+      payload: input.payload ?? {}
+    });
+    const { jobId } = await dispatchInput(inputId);
+    return { job_id: jobId };
+  })
 });

--- a/packages/websocket/tests/trigger-dispatcher.test.ts
+++ b/packages/websocket/tests/trigger-dispatcher.test.ts
@@ -315,6 +315,108 @@ describe("trigger dispatcher", () => {
     expect(await isProcessed("in-1")).toBe(true);
   });
 
+  describe("acceptance vs. completion", () => {
+    /** A job starter whose runs hang until released, reporting acceptance the
+     * way `startHeadlessJob` does — as soon as the Job row exists. */
+    function hangingJobStarter() {
+      const started: string[] = [];
+      const gates = new Map<string, () => void>();
+      const startJob = vi.fn(
+        async (opts: {
+          workflowId: string;
+          onAccepted?: (jobId: string) => void;
+        }) => {
+          started.push(opts.workflowId);
+          opts.onAccepted?.(`job-${opts.workflowId}`);
+          await new Promise<void>((resolve) =>
+            gates.set(opts.workflowId, resolve)
+          );
+          return okJob(`job-${opts.workflowId}`);
+        }
+      );
+      return {
+        started,
+        startJob,
+        release: (workflowId: string) => gates.get(workflowId)?.()
+      };
+    }
+
+    it("does not hold one registration's dispatch behind another's in-flight run", async () => {
+      await makeRegistration({ workflowId: "wf-A" });
+      await makeRegistration({ workflowId: "wf-B" });
+      const { started, startJob, release } = hangingJobStarter();
+      const handle = startDispatcher({
+        store,
+        startJob,
+        intervalMs: 1_000_000
+      });
+
+      // A's event arrives first and its run hangs.
+      await storeInput(store, "a-1", { runId: "wf-A" });
+      handle.notify();
+      await vi.waitFor(() => expect(started).toEqual(["wf-A"]));
+
+      // B's event arrives while A is still running — it must not wait for A.
+      await storeInput(store, "b-1", { runId: "wf-B" });
+      handle.notify();
+      await vi.waitFor(() => expect(started).toEqual(["wf-A", "wf-B"]));
+
+      release("wf-A");
+      release("wf-B");
+      await handle.drain();
+      handle();
+    });
+
+    it("marks an input processed at acceptance, not at run completion", async () => {
+      await makeRegistration();
+      const { startJob, release } = hangingJobStarter();
+      const handle = startDispatcher({
+        store,
+        startJob,
+        intervalMs: 1_000_000
+      });
+
+      await storeInput(store, "in-1");
+      handle.notify();
+      await vi.waitFor(async () =>
+        expect(await isProcessed("in-1")).toBe(true)
+      );
+
+      release("wf-1");
+      await handle.drain();
+      handle();
+    });
+
+    it("drain() still waits for the runs a pass handed off", async () => {
+      const registration = await makeRegistration();
+      const { startJob, release } = hangingJobStarter();
+      const handle = startDispatcher({
+        store,
+        startJob,
+        intervalMs: 1_000_000
+      });
+
+      await storeInput(store, "in-1");
+      handle.notify();
+      await vi.waitFor(() => expect(startJob).toHaveBeenCalledTimes(1));
+
+      // The run has not settled, so the outcome is not recorded yet.
+      let updated = (await TriggerRegistration.get(
+        registration.id
+      )) as TriggerRegistration;
+      expect(updated.run_count).toBe(0);
+
+      release("wf-1");
+      await handle.drain();
+
+      updated = (await TriggerRegistration.get(
+        registration.id
+      )) as TriggerRegistration;
+      expect(updated.run_count).toBe(1);
+      handle();
+    });
+  });
+
   describe("dispatchInput", () => {
     it("dispatches one stored input immediately and resolves with the job id", async () => {
       await makeRegistration();
@@ -500,6 +602,33 @@ describe("trigger dispatcher", () => {
       expect(updated.last_error).toBe("run failed: boom");
     });
 
+    it("leaves the fire time alone when the run was never accepted", async () => {
+      // `startJob` rejecting means no run happened at all — a missing workflow,
+      // a DB hiccup. Stamping made the editor report "Last fired: just now" for
+      // a webhook that has never once delivered.
+      const registration = await makeRegistration({ kind: "webhook" });
+      await storeInput(store, "in-1");
+
+      const dispatcher = createTriggerDispatcher({
+        store,
+        startJob: async () => {
+          throw new Error("Workflow not found: wf-1");
+        }
+      });
+      await dispatcher.runOnce();
+
+      const updated = (await TriggerRegistration.get(
+        registration.id
+      )) as TriggerRegistration;
+      expect(updated.last_fired_at).toBeNull();
+      expect(updated.last_error).toBe(
+        "dispatch failed: Workflow not found: wf-1"
+      );
+      expect(updated.consecutive_failures).toBe(1);
+      // Still unprocessed, so the next tick redelivers it.
+      expect(await isProcessed("in-1")).toBe(false);
+    });
+
     it.each(["schedule", "file_watch"])(
       "leaves a %s registration's fire time alone — its adapter stamped it",
       async (kind) => {
@@ -538,7 +667,9 @@ describe("trigger dispatcher", () => {
         }
       });
       const pass = dispatcher.runOnce();
-      await vi.waitFor(async () => expect(await isProcessed("in-2")).toBe(true));
+      await vi.waitFor(async () =>
+        expect(await isProcessed("in-2")).toBe(true)
+      );
 
       // in-2 has been dropped while in-1's run is still in flight: a dropped
       // event is not a fire, so nothing has been stamped yet.

--- a/packages/websocket/tests/triggers-router.test.ts
+++ b/packages/websocket/tests/triggers-router.test.ts
@@ -111,9 +111,7 @@ describe("triggers router", () => {
         inputId: expect.any(String),
         payload: { test: "data" }
       });
-      expect(dispatchInput).toHaveBeenCalledWith(
-        expect.any(String)
-      );
+      expect(dispatchInput).toHaveBeenCalledWith(expect.any(String));
     });
 
     it("throws NOT_FOUND when registration is owned by another user", async () => {
@@ -152,6 +150,31 @@ describe("triggers router", () => {
       });
     });
 
+    it("refuses a disabled registration without storing an input", async () => {
+      // Delivering first and rejecting afterwards left the input durably
+      // stored but unprocessed — a pass only scans enabled registrations — so
+      // it fired as a surprise the moment someone re-armed the trigger.
+      const reg = makeTriggerRegistration({ id: "reg-1", enabled: 0 });
+      (TriggerRegistration.get as ReturnType<typeof vi.fn>).mockResolvedValue(
+        reg
+      );
+      const mockWakeupService = {
+        deliverTriggerInput: vi.fn().mockResolvedValue(true)
+      };
+      (getTriggerWakeupService as ReturnType<typeof vi.fn>).mockReturnValue(
+        mockWakeupService
+      );
+
+      const caller = createCaller(makeCtx());
+
+      await expect(
+        caller.triggers.fire({ registrationId: "reg-1", payload: {} })
+      ).rejects.toThrow(/not active/);
+
+      expect(mockWakeupService.deliverTriggerInput).not.toHaveBeenCalled();
+      expect(dispatchInput).not.toHaveBeenCalled();
+    });
+
     it("uses idempotencyKey when provided to avoid duplicate runs", async () => {
       const reg = makeTriggerRegistration({
         id: "reg-1",
@@ -183,9 +206,9 @@ describe("triggers router", () => {
       expect(result1.job_id).toBe("job-123");
 
       // Get the inputId from the first call
-      const firstCall =
-        (mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>)
-          .mock.calls[0];
+      const firstCall = (
+        mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
       const firstInputId = firstCall[0].inputId;
 
       // Second call with same idempotency key should reuse the same inputId
@@ -193,7 +216,9 @@ describe("triggers router", () => {
       (getTriggerWakeupService as ReturnType<typeof vi.fn>).mockReturnValue(
         mockWakeupService
       );
-      (mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>).mockClear();
+      (
+        mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>
+      ).mockClear();
 
       await caller.triggers.fire({
         registrationId: "reg-1",
@@ -202,9 +227,9 @@ describe("triggers router", () => {
       });
 
       // Should use the same inputId due to idempotency key
-      const secondCall =
-        (mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>)
-          .mock.calls[0];
+      const secondCall = (
+        mockWakeupService.deliverTriggerInput as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
       const secondInputId = secondCall[0].inputId;
 
       expect(firstInputId).toBe(secondInputId);


### PR DESCRIPTION
Three fixes found while reviewing the trigger subsystem. Each was verified against the real dispatcher and DB before being fixed, and each has a regression test.

## 1. One slow workflow held up every other registration

A dispatch pass awaited `startJob`, which resolves only on *terminal* run status — `startHeadlessJob` does not come back until the workflow has finished. `notify()` collapses into `pending` while a pass is in flight, so a webhook arriving one second into a ten-minute triggered run waited the full ten minutes for its own dispatch, even for an unrelated registration.

`startHeadlessJob` now reports acceptance through a new `onAccepted` callback, fired the moment the workflow resolves and the `Job` row exists. A pass awaits acceptance; the runs settle on their own afterwards. `drain()` waits for the runs, for graceful shutdown and for tests.

A job starter that never calls `onAccepted` — the test fakes, any other caller — still has acceptance resolve when the job promise does, which is the old behaviour exactly. That is why the existing 104-test trigger suite needed no changes.

Marking an input processed moves to the same acceptance point, which is where the module docs already claimed it happened.

## 2. Firing a disabled trigger left an orphan that fired on re-arm

`triggers.fire` stored the input via `deliverTriggerInput` and *then* called `dispatchInput`, which rejects a disabled registration. The input was already durable and unprocessed, and since a pass only scans enabled registrations it sat there — firing as a surprise the moment someone hit Activate.

The router now refuses before delivering.

## 3. `last_fired_at` stamped when nothing fired

The `startJob` catch path — the run was never accepted: missing workflow, DB hiccup — still stamped `last_fired_at` for `webhook` and `manual` kinds, so the editor reported "Last fired: just now" for a webhook that had never once delivered. It also contradicted the module doc, which says the column is stamped on a *delivered* dispatch.

`settle()` takes a `fired` flag; the never-accepted path passes `false`.

## Testing

- `packages/websocket`: 122 files, 1621 tests, all passing
- New tests: cross-registration dispatch isolation, processed-at-acceptance, `drain()` still awaiting handed-off runs, `last_fired_at` untouched on an unaccepted run, and `fire` refusing a disabled registration without storing anything
- `npm run lint` clean; web and electron typecheck clean (mobile's 372 errors are pre-existing in this container — its dependency tree isn't installed)

## Not addressed

Other findings from the review are left open: `triggers.fire` blocking for the whole run, user-supplied `idempotencyKey` sharing the global `input_id` namespace, the webhook route's full-table scan per delivery, and `expires_at`/`max_runs` having no write path.

---
_Generated by [Claude Code](https://claude.ai/code/session_014nJ7aKmDNdmvHZ2f44u57E)_