### PR TITLE
security: scope storage per owner, upload direct to Supabase/S3, sandbox local-file reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,6 +558,20 @@ npm run dev:nodetool -- costs by-provider                       # Grouped by pro
 npm run dev:nodetool -- costs by-model --provider openai        # Grouped by model
 ```
 
+### nodetool storage
+
+Asset objects live at `<userId>/<assetId>.<ext>` so the owner is the leading
+path segment — the boundary a Supabase RLS policy or S3 bucket policy can
+enforce on the object itself. `migrate-keys` moves objects written under the
+older flat layout. Required on Supabase/S3 when upgrading; the local file
+backend falls back to the flat key on a miss.
+
+```bash
+npm run dev:nodetool -- storage migrate-keys --dry-run     # Report, write nothing
+npm run dev:nodetool -- storage migrate-keys               # Move them
+npm run dev:nodetool -- storage migrate-keys --user-id <id> --json
+```
+
 ### nodetool secrets
 
 ```bash

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,7 +31,7 @@ For detailed schemas, see [Chat API](chat-api.md) and [Workflow API](workflow-ap
 | Agent WS  | `/ws/agent`                       | WebSocket         | Bearer header or `api_key` query when enforced | yes                         | Agent runtime |
 | Extension WS | `/ws/extension`                | WebSocket         | Follows global auth settings                   | yes                         | Browser extension channel |
 | Download WS | `/ws/download`                  | WebSocket         | Follows global auth settings                   | yes                         | Model/file downloads |
-| Storage   | `/api/storage/*`                  | `HEAD/GET`        | Depends on `AUTH_PROVIDER`                     | streaming for `GET`         | Asset bytes, scoped to the caller's assets. Read-only: writes go through the asset API, deletes through tRPC `storage.delete` |
+| Storage   | `/api/storage/*`                  | `HEAD/GET`        | Depends on `AUTH_PROVIDER`                     | streaming for `GET`         | Asset bytes at `<userId>/<assetId>.<ext>`, scoped to the caller. Read-only: writes go through the asset API, deletes through tRPC `storage.delete` |
 | Health    | `/health`                         | `GET`             | none                                           | no                          | JSON: `{status, timestamp, uptime, services}` (`200`/`503`) |
 | Health    | `/api/health`                     | `GET`             | none                                           | no                          | JSON: `{version, uptime}` |
 | Liveness  | `/ready`                          | `GET`             | none                                           | no                          | Always `200` with `{status:"ok"}` |
@@ -206,6 +206,25 @@ Response:
 curl "http://localhost:7777/api/workflows" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
+
+### Uploading an Asset
+
+On a cloud storage backend (Supabase or S3) the bytes go straight from the
+client to the bucket — the API only mints a target and confirms the result.
+
+1. `assets.createUpload` (tRPC) with the file's name, content type, parent
+   folder, and size. It creates the asset row, picks the storage key
+   (`<userId>/<assetId>.<ext>` — never the client's choice), and returns a
+   short-lived upload target.
+2. Send the bytes to `upload.url` with `upload.method` and `upload.headers`.
+3. `assets.finalizeUpload` with the returned `asset_id`. The server reads the
+   object's real size back off the bucket, records it, and generates a
+   thumbnail. A missing, empty, or over-cap upload is rejected and the pending
+   row removed.
+
+`upload` comes back `null` on the local file backend, which has no
+direct-upload concept; fall back to the multipart `POST /api/assets`. The web
+client does this automatically.
 
 ### Health Check
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,7 +31,7 @@ For detailed schemas, see [Chat API](chat-api.md) and [Workflow API](workflow-ap
 | Agent WS  | `/ws/agent`                       | WebSocket         | Bearer header or `api_key` query when enforced | yes                         | Agent runtime |
 | Extension WS | `/ws/extension`                | WebSocket         | Follows global auth settings                   | yes                         | Browser extension channel |
 | Download WS | `/ws/download`                  | WebSocket         | Follows global auth settings                   | yes                         | Model/file downloads |
-| Storage   | `/api/storage/*`                  | `HEAD/GET/PUT/DELETE` | Depends on `AUTH_PROVIDER`                  | streaming for `GET`         | Asset/temp storage |
+| Storage   | `/api/storage/*`                  | `HEAD/GET`        | Depends on `AUTH_PROVIDER`                     | streaming for `GET`         | Asset bytes, scoped to the caller's assets. Read-only: writes go through the asset API, deletes through tRPC `storage.delete` |
 | Health    | `/health`                         | `GET`             | none                                           | no                          | JSON: `{status, timestamp, uptime, services}` (`200`/`503`) |
 | Health    | `/api/health`                     | `GET`             | none                                           | no                          | JSON: `{version, uptime}` |
 | Liveness  | `/ready`                          | `GET`             | none                                           | no                          | Always `200` with `{status:"ok"}` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,7 @@ Security notes:
 | `NODETOOL_TRUST_LOCALHOST` | Allow loopback connections to bypass auth as user `1` | no | Defaults **off** when auth is enforced (Supabase), **on** otherwise. Leave off behind a reverse proxy/SSH tunnel where the proxy connects from loopback. |
 | `NODETOOL_TRUST_LOCAL_NETWORKS` | ⚠️ Source CIDRs trusted as user `1` **without a password** (Local mode only) | no | Comma-separated IPs/CIDRs; ignored in Supabase mode. Needed so Docker's NAT'd bridge traffic isn't rejected — scope to the bridge (`172.16.0.0/12`), **never `0.0.0.0/0`** on a public IP. See [Authentication → Local mode in Docker](authentication.md#local-mode-in-docker). |
 | `NODETOOL_TRUSTED_PROXIES` | Reverse proxies whose `X-Forwarded-For` is trusted | no | Comma-separated IPs/CIDRs. When unset, `X-Forwarded-For` is ignored and the socket peer address is used. |
+| `NODETOOL_LOCAL_FILE_ROOTS` | Directories the file browser and local-file previews may read | no | Platform-delimited (`:` on POSIX, `;` on Windows), `~` expands. Defaults to the user's home directory. Both surfaces are disabled entirely when `NODETOOL_ENV=production`. See [Security hardening](security-hardening.md#local-file-access). |
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` | Provider access | yes | Set only the providers you use |
 | `HF_TOKEN` / `FAL_API_KEY` / `REPLICATE_API_TOKEN` | HuggingFace-family providers | yes | Optional per workflow |
 | `OLLAMA_API_URL` | Local Ollama base URL | no | Default `http://127.0.0.1:11434` |

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -39,6 +39,26 @@ These apply to **every** deployment, regardless of environment:
 - **Never commit `.env` files** with secrets. Add `.env` to `.gitignore`.
 - Provide the encryption master key (`SECRETS_MASTER_KEY`) on every server so they share one key, and store all other deployment secrets in your platform's secrets manager.
 
+### Asset Storage
+
+Asset objects live at `<userId>/<assetId>.<ext>`. The owner is the leading
+path segment, so the tenant boundary is enforceable by the storage backend
+itself, not just by the API:
+
+- **Run `nodetool storage migrate-keys`** when upgrading a deployment that
+  predates this layout. The local file backend falls back to the old flat key
+  on a miss, but Supabase and S3 resolve through signed URLs and need the
+  objects actually moved. `--dry-run` reports what would move.
+- **Keep the bucket private.** Reads go through short-lived signed URLs minted
+  per request; a public bucket bypasses that entirely.
+- **Add a storage policy keyed on the prefix** on Supabase (an RLS policy on
+  `storage.objects` matching `(storage.foldername(name))[1] = auth.uid()::text`)
+  or S3 (a bucket policy on the key prefix). The API already enforces this, but
+  a policy makes it hold even if a signed URL leaks or a handler regresses.
+- **Never ship `SUPABASE_KEY` to a client.** The service-role key stays
+  server-side; browsers upload through the one-shot, key-scoped targets that
+  `assets.createUpload` mints, which authorise a write to exactly one object.
+
 ### Local File Access
 
 The file browser (tRPC `files.list`) and the preview stream

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -39,6 +39,23 @@ These apply to **every** deployment, regardless of environment:
 - **Never commit `.env` files** with secrets. Add `.env` to `.gitignore`.
 - Provide the encryption master key (`SECRETS_MASTER_KEY`) on every server so they share one key, and store all other deployment secrets in your platform's secrets manager.
 
+### Local File Access
+
+The file browser (tRPC `files.list`) and the preview stream
+(`GET /api/files/local`) read the server's own filesystem. Both are off when
+`NODETOOL_ENV=production`, and outside production both resolve paths against an
+allowlist of roots — the user's home directory unless
+`NODETOOL_LOCAL_FILE_ROOTS` overrides it (platform-delimited, like `PATH`).
+Sensitive entries under home (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`,
+`.config/gcloud`, `.netrc`, `.pgpass`, `.npmrc`) are refused inside a root, and
+symlinks that leave the roots are refused too.
+
+- **Keep the roots narrow.** Widen `NODETOOL_LOCAL_FILE_ROOTS` only to the
+  directories that actually hold media you preview — an external volume, a
+  scratch dir — never to `/`.
+- **Set `NODETOOL_ENV=production`** on any deployment more than one person can
+  reach, which disables both surfaces outright.
+
 ### Resource Limits
 
 - **Set container resource limits**: Use `mem_limit` and `cpus` to prevent runaway workloads.

--- a/packages/cli/src/commands/storage.ts
+++ b/packages/cli/src/commands/storage.ts
@@ -1,0 +1,143 @@
+/**
+ * `nodetool storage migrate-keys` — move asset objects from the flat
+ * `<assetId>.<ext>` layout under their owner's prefix, `<userId>/<assetId>.<ext>`.
+ *
+ * The owner prefix is what makes the tenant boundary enforceable outside the
+ * server process (a Supabase Storage RLS policy or an S3 bucket policy can
+ * match on it), so a deployment on a cloud backend needs this to have run.
+ * The local file backend keeps working without it — `/api/storage` falls back
+ * to the legacy path — but should be migrated too so the layouts agree.
+ *
+ * Safe to re-run: an object already at its prefixed key is left alone, and
+ * the legacy object is only removed once the new one reads back.
+ */
+import { Asset } from "@nodetool-ai/models";
+import { loadAssetStorageConfig } from "@nodetool-ai/config";
+import {
+  assetObjectKey,
+  createStorageAdapter,
+  type StorageAdapter
+} from "@nodetool-ai/storage";
+import { getAssetFileName } from "@nodetool-ai/websocket";
+
+export interface MigrateKeysOptions {
+  dryRun?: boolean;
+  /** Migrate only this user's objects. */
+  userId?: string;
+  json?: boolean;
+}
+
+export interface MigrateKeysReport {
+  scanned: number;
+  moved: number;
+  alreadyMigrated: number;
+  missing: number;
+  failed: number;
+  entries: Array<{
+    assetId: string;
+    from: string;
+    to: string;
+    status: "moved" | "already" | "missing" | "failed";
+    error?: string;
+  }>;
+}
+
+/** Every object belonging to an asset: the bytes plus its thumbnail. */
+function fileNamesFor(assetId: string, contentType: string): string[] {
+  return [getAssetFileName(assetId, contentType), `${assetId}_thumb.jpg`];
+}
+
+async function migrateOne(
+  adapter: StorageAdapter,
+  userId: string,
+  fileName: string,
+  dryRun: boolean
+): Promise<"moved" | "already" | "missing" | "failed"> {
+  const target = assetObjectKey(userId, fileName);
+  if (await adapter.exists(adapter.uriForKey(target))) return "already";
+  if (!(await adapter.exists(adapter.uriForKey(fileName)))) return "missing";
+  if (dryRun) return "moved";
+
+  const bytes = await adapter.retrieve(adapter.uriForKey(fileName));
+  if (!bytes) return "missing";
+  await adapter.store(target, bytes);
+  // Only drop the original once the copy reads back, so an interrupted run
+  // leaves the asset readable at one key or the other, never neither.
+  if (!(await adapter.exists(adapter.uriForKey(target)))) return "failed";
+  await adapter.delete(adapter.uriForKey(fileName));
+  return "moved";
+}
+
+export async function migrateStorageKeys(
+  opts: MigrateKeysOptions = {}
+): Promise<MigrateKeysReport> {
+  const adapter = createStorageAdapter(loadAssetStorageConfig());
+  const dryRun = opts.dryRun ?? false;
+  const report: MigrateKeysReport = {
+    scanned: 0,
+    moved: 0,
+    alreadyMigrated: 0,
+    missing: 0,
+    failed: 0,
+    entries: []
+  };
+
+  const assets = await Asset.allForMigration(opts.userId);
+  for (const asset of assets) {
+    if (asset.content_type === "folder") continue;
+    for (const fileName of fileNamesFor(asset.id, asset.content_type)) {
+      report.scanned += 1;
+      const to = assetObjectKey(asset.user_id, fileName);
+      let status: "moved" | "already" | "missing" | "failed";
+      let error: string | undefined;
+      try {
+        status = await migrateOne(adapter, asset.user_id, fileName, dryRun);
+      } catch (err) {
+        status = "failed";
+        error = err instanceof Error ? err.message : String(err);
+      }
+
+      if (status === "moved") report.moved += 1;
+      else if (status === "already") report.alreadyMigrated += 1;
+      else if (status === "missing") report.missing += 1;
+      else report.failed += 1;
+
+      // A thumbnail that was never generated is the common "missing" case and
+      // is not worth a line of output.
+      if (status !== "missing") {
+        report.entries.push({
+          assetId: asset.id,
+          from: fileName,
+          to,
+          status,
+          ...(error ? { error } : {})
+        });
+      }
+    }
+  }
+
+  return report;
+}
+
+export function formatMigrateKeysReport(
+  report: MigrateKeysReport,
+  dryRun: boolean
+): string {
+  const lines: string[] = [];
+  for (const entry of report.entries) {
+    if (entry.status === "failed") {
+      lines.push(`FAILED  ${entry.from} -> ${entry.to}: ${entry.error ?? ""}`);
+    } else if (entry.status === "moved") {
+      lines.push(`${dryRun ? "would move" : "moved"}  ${entry.from} -> ${entry.to}`);
+    }
+  }
+  lines.push("");
+  lines.push(
+    `scanned ${report.scanned}, ${dryRun ? "would move" : "moved"} ${report.moved}, ` +
+      `already migrated ${report.alreadyMigrated}, absent ${report.missing}, failed ${report.failed}`
+  );
+  if (dryRun) {
+    lines.push("Dry run — nothing was written. Re-run without --dry-run.");
+  }
+  return lines.join("\n");
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -1493,6 +1493,44 @@ models
   });
 
 // ---------------------------------------------------------------------------
+// storage
+// ---------------------------------------------------------------------------
+
+const storage = program
+  .command("storage")
+  .description("Maintain the asset storage backend");
+
+storage
+  .command("migrate-keys")
+  .description(
+    "Move asset objects under their owner's prefix (<userId>/<assetId>.<ext>)"
+  )
+  .option("--dry-run", "Report what would move without writing anything")
+  .option("--user-id <id>", "Migrate only this user's objects")
+  .option("--json", "Output the report as JSON")
+  .action(async (opts) => {
+    await setupDb();
+    const { migrateStorageKeys, formatMigrateKeysReport } = await import(
+      "./commands/storage.js"
+    );
+    try {
+      const report = await migrateStorageKeys({
+        dryRun: Boolean(opts.dryRun),
+        ...(opts.userId ? { userId: opts.userId } : {})
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        console.log(formatMigrateKeysReport(report, Boolean(opts.dryRun)));
+      }
+      if (report.failed > 0) process.exit(1);
+    } catch (e) {
+      console.error(String(e));
+      process.exit(1);
+    }
+  });
+
+// ---------------------------------------------------------------------------
 // secrets
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/tests/storage-migrate-keys.test.ts
+++ b/packages/cli/tests/storage-migrate-keys.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for `nodetool storage migrate-keys` — moving flat asset objects under
+ * their owner's prefix. Backed by an in-memory adapter stub so the behaviour
+ * that matters (ordering of copy vs delete, idempotency, per-user scoping) is
+ * observable without a real backend.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  allForMigration: vi.fn(),
+  objects: new Map<string, Uint8Array>(),
+  /** When set, `store` silently drops the write (simulates a backend fault). */
+  dropWrites: { value: false }
+}));
+
+vi.mock("@nodetool-ai/models", () => ({
+  Asset: { allForMigration: mocks.allForMigration }
+}));
+
+vi.mock("@nodetool-ai/config", () => ({
+  loadAssetStorageConfig: () => ({ kind: "file", rootDir: "/tmp/assets" })
+}));
+
+vi.mock("@nodetool-ai/websocket", () => ({
+  getAssetFileName: (id: string, contentType: string) =>
+    `${id}.${contentType === "image/png" ? "png" : "bin"}`
+}));
+
+vi.mock("@nodetool-ai/storage", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/storage")>();
+  return {
+    ...actual,
+    createStorageAdapter: () => ({
+      uriForKey: (key: string) => `mem://${key}`,
+      exists: async (uri: string) => mocks.objects.has(uri.slice(6)),
+      retrieve: async (uri: string) => mocks.objects.get(uri.slice(6)) ?? null,
+      store: async (key: string, bytes: Uint8Array) => {
+        if (!mocks.dropWrites.value) mocks.objects.set(key, bytes);
+        return `mem://${key}`;
+      },
+      delete: async (uri: string) => mocks.objects.delete(uri.slice(6))
+    })
+  };
+});
+
+import { migrateStorageKeys } from "../src/commands/storage.js";
+
+function asset(id: string, userId: string, contentType = "image/png") {
+  return { id, user_id: userId, content_type: contentType };
+}
+
+beforeEach(() => {
+  mocks.objects.clear();
+  mocks.dropWrites.value = false;
+  mocks.allForMigration.mockReset();
+});
+
+describe("migrateStorageKeys", () => {
+  it("moves a flat object under its owner's prefix", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1, 2, 3]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+
+    const report = await migrateStorageKeys();
+
+    expect(report.moved).toBe(1);
+    expect(mocks.objects.has("user-1/a1.png")).toBe(true);
+    expect(mocks.objects.has("a1.png")).toBe(false);
+    expect([...mocks.objects.get("user-1/a1.png")!]).toEqual([1, 2, 3]);
+  });
+
+  it("moves the thumbnail alongside the object", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.objects.set("a1_thumb.jpg", new Uint8Array([2]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+
+    const report = await migrateStorageKeys();
+
+    expect(report.moved).toBe(2);
+    expect(mocks.objects.has("user-1/a1_thumb.jpg")).toBe(true);
+  });
+
+  it("writes nothing on a dry run", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+
+    const report = await migrateStorageKeys({ dryRun: true });
+
+    expect(report.moved).toBe(1);
+    expect(mocks.objects.has("a1.png")).toBe(true);
+    expect(mocks.objects.has("user-1/a1.png")).toBe(false);
+  });
+
+  it("is idempotent — a second run moves nothing", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+
+    await migrateStorageKeys();
+    const second = await migrateStorageKeys();
+
+    expect(second.moved).toBe(0);
+    expect(second.alreadyMigrated).toBe(1);
+  });
+
+  it("leaves an already-prefixed object untouched even if a flat one lingers", async () => {
+    mocks.objects.set("user-1/a1.png", new Uint8Array([9]));
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+
+    const report = await migrateStorageKeys();
+
+    expect(report.alreadyMigrated).toBe(1);
+    expect([...mocks.objects.get("user-1/a1.png")!]).toEqual([9]);
+  });
+
+  it("counts an asset with no object as absent rather than failed", async () => {
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+    const report = await migrateStorageKeys();
+    expect(report.missing).toBe(2); // object + thumbnail
+    expect(report.failed).toBe(0);
+    expect(report.entries).toHaveLength(0);
+  });
+
+  it("keeps each owner's objects in their own prefix", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.objects.set("a2.png", new Uint8Array([2]));
+    mocks.allForMigration.mockResolvedValue([
+      asset("a1", "user-1"),
+      asset("a2", "user-2")
+    ]);
+
+    await migrateStorageKeys();
+
+    expect(mocks.objects.has("user-1/a1.png")).toBe(true);
+    expect(mocks.objects.has("user-2/a2.png")).toBe(true);
+    expect(mocks.objects.has("user-2/a1.png")).toBe(false);
+  });
+
+  it("skips folders, which have no bytes", async () => {
+    mocks.allForMigration.mockResolvedValue([asset("f1", "user-1", "folder")]);
+    const report = await migrateStorageKeys();
+    expect(report.scanned).toBe(0);
+  });
+
+  it("narrows to one user when asked", async () => {
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+    await migrateStorageKeys({ userId: "user-1" });
+    expect(mocks.allForMigration).toHaveBeenCalledWith("user-1");
+  });
+
+  it("keeps the original when the copy does not read back", async () => {
+    mocks.objects.set("a1.png", new Uint8Array([1]));
+    mocks.allForMigration.mockResolvedValue([asset("a1", "user-1")]);
+    mocks.dropWrites.value = true;
+
+    const report = await migrateStorageKeys();
+
+    // The delete only runs after the target verifies, so an interrupted or
+    // faulty write leaves the asset readable at its old key.
+    expect(report.failed).toBeGreaterThan(0);
+    expect(report.moved).toBe(0);
+    expect(mocks.objects.has("a1.png")).toBe(true);
+  });
+});

--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -79,6 +79,20 @@ export class Asset extends DBModel {
     return asset;
   }
 
+  /**
+   * Every asset across all users, oldest first — for offline maintenance
+   * (the storage key backfill). Deliberately not user-scoped, so it must
+   * never back a request handler; pass `userId` to narrow it.
+   */
+  static async allForMigration(userId?: string): Promise<Asset[]> {
+    const db = getDb();
+    const query = db.select().from(assets);
+    const rows = await (userId
+      ? query.where(eq(assets.user_id, userId))
+      : query);
+    return rows.map((row) => new Asset(row as Partial<Asset>));
+  }
+
   /** List assets in a folder. */
   static async paginate(
     userId: string,

--- a/packages/protocol/src/api-schemas/assets.ts
+++ b/packages/protocol/src/api-schemas/assets.ts
@@ -67,6 +67,53 @@ export const createInput = z.object({
 });
 export type CreateInput = z.infer<typeof createInput>;
 
+// ── createUpload / finalizeUpload (client-direct upload) ─────────
+//
+// Two-step upload that keeps object bytes out of the API process. The server
+// creates the row, picks the storage key, and hands back a short-lived target
+// scoped to that one key; the client PUTs the bytes straight to the storage
+// backend and then calls `finalizeUpload`, which verifies what actually
+// landed. `upload` is null on backends with no direct-upload concept (the
+// local file store) — the client falls back to the multipart POST.
+
+export const uploadTarget = z.object({
+  url: z.string(),
+  method: z.enum(["PUT", "POST"]),
+  headers: z.record(z.string(), z.string()),
+  expires_at: z.number()
+});
+export type UploadTarget = z.infer<typeof uploadTarget>;
+
+export const createUploadInput = z.object({
+  name: z.string().min(1),
+  content_type: z.string().min(1),
+  parent_id: z.string().min(1),
+  /** Declared byte size, checked against the upload cap before minting. */
+  size: z.number().int().nonnegative(),
+  workflow_id: z.string().nullable().optional(),
+  node_id: z.string().nullable().optional(),
+  job_id: z.string().nullable().optional(),
+  timeline_id: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional()
+});
+export type CreateUploadInput = z.infer<typeof createUploadInput>;
+
+export const createUploadOutput = z.object({
+  asset_id: z.string(),
+  /** Storage key the server assigned. Never chosen by the client. */
+  key: z.string(),
+  upload: uploadTarget.nullable()
+});
+export type CreateUploadOutput = z.infer<typeof createUploadOutput>;
+
+export const finalizeUploadInput = z.object({
+  asset_id: z.string().min(1)
+});
+export type FinalizeUploadInput = z.infer<typeof finalizeUploadInput>;
+
+export const finalizeUploadOutput = assetResponse;
+export type FinalizeUploadOutput = z.infer<typeof finalizeUploadOutput>;
+
 // ── update (PUT /api/assets/:id) ─────────────────────────────────
 // The `data` field (base64 or utf-8 content) is supported here for
 // small text/data writes; large binary uploads should go through the

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -16,8 +16,19 @@ export type {
   StorageAdapter,
   StorageEntry,
   StorageListResult,
-  StorageStat
+  StorageStat,
+  UploadTarget,
+  UploadUrlOptions
 } from "./storage-adapter.js";
+
+// Storage key helpers (owner-prefixed asset layout + legacy fallback)
+export {
+  normalizeStorageKey,
+  joinStorageKey,
+  assetObjectKey,
+  assetKeyCandidates,
+  assetKeyOwner
+} from "./storage-keys.js";
 export { InMemoryStorageAdapter } from "./memory-storage-adapter.js";
 export { FileStorageAdapter } from "./file-storage-adapter.js";
 export {
@@ -53,6 +64,7 @@ export {
   type S3ObjectSummary,
   type S3BucketSummary,
   type S3PresignGetObjectInput,
+  type S3PresignPutObjectInput,
   type S3RetryOptions,
   type SigV4Credentials,
   createDefaultCredentialProvider,

--- a/packages/storage/src/s3-storage-adapter.ts
+++ b/packages/storage/src/s3-storage-adapter.ts
@@ -3,7 +3,9 @@ import type {
   StorageAdapter,
   StorageEntry,
   StorageListResult,
-  StorageStat
+  StorageStat,
+  UploadTarget,
+  UploadUrlOptions
 } from "./storage-adapter.js";
 import { assertUploadWithinLimit } from "./storage-limits.js";
 import { joinStorageKey, normalizeStorageKey } from "./storage-keys.js";
@@ -229,5 +231,34 @@ export class S3StorageAdapter implements StorageAdapter {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Presigned PUT for `key`, so a client uploads straight to S3. Returns
+   * `null` when the injected client can't presign (test fakes). The URL
+   * authorises a write to this one key; it does not bound the body, so the
+   * caller must verify size and type after the upload lands.
+   */
+  async createUploadUrl(
+    key: string,
+    opts: UploadUrlOptions = {}
+  ): Promise<UploadTarget | null> {
+    const client = this.getClient();
+    if (!client.presignPutObject) return null;
+    const objectKey = joinStorageKey(this.prefix ?? undefined, key);
+    const expiresIn = Math.min(opts.expiresIn ?? 3600, 604800);
+    const url = await client.presignPutObject({
+      bucket: this.bucket,
+      key: objectKey,
+      expiresIn
+    });
+    const headers: Record<string, string> = {};
+    if (opts.contentType) headers["content-type"] = opts.contentType;
+    return {
+      url,
+      method: "PUT",
+      headers,
+      expiresAt: Date.now() + expiresIn * 1000
+    };
   }
 }

--- a/packages/storage/src/s3/client.ts
+++ b/packages/storage/src/s3/client.ts
@@ -115,6 +115,8 @@ export interface S3PresignGetObjectInput extends S3ObjectRef {
   expiresIn: number;
 }
 
+export type S3PresignPutObjectInput = S3PresignGetObjectInput;
+
 /**
  * The object-level surface `S3StorageAdapter` needs. `S3Client` implements
  * it; tests inject fakes.
@@ -125,6 +127,11 @@ export interface S3Api {
   headObject(input: S3ObjectRef): Promise<S3HeadObjectResult>;
   deleteObject(input: S3ObjectRef): Promise<void>;
   listObjectsV2(input: S3ListObjectsV2Input): Promise<S3ListObjectsV2Result>;
+  /**
+   * Optional so test fakes need not implement it. Callers that offer
+   * client-direct uploads must treat its absence as "not supported".
+   */
+  presignPutObject?(input: S3PresignPutObjectInput): Promise<string>;
 }
 
 export interface S3RetryOptions {
@@ -598,6 +605,32 @@ export class S3Client implements S3Api {
     }
     const target = this.target(input.bucket, input.key);
     return presignUrl({
+      protocol: target.protocol,
+      host: target.host,
+      path: target.path,
+      region: this.region,
+      credentials: await this.credentialProvider(),
+      expiresIn: input.expiresIn
+    });
+  }
+
+  /**
+   * Presigned PUT URL, valid for `expiresIn` seconds. Lets a client upload
+   * bytes straight to S3 without them passing through this process. Only
+   * `host` is signed (the presign flow's UNSIGNED-PAYLOAD form), so the URL
+   * authorises a write to exactly this key and nothing else — but it does not
+   * constrain the body or its Content-Type. Callers must therefore verify the
+   * object after upload rather than trusting what the client claimed.
+   */
+  async presignPutObject(input: S3PresignPutObjectInput): Promise<string> {
+    if (hasDotSegments(input.key)) {
+      throw new Error(
+        `Cannot presign S3 key "${input.key}": keys with "." or ".." path segments are normalized away by URL clients, so the signed URL would not address this object.`
+      );
+    }
+    const target = this.target(input.bucket, input.key);
+    return presignUrl({
+      method: "PUT",
       protocol: target.protocol,
       host: target.host,
       path: target.path,

--- a/packages/storage/src/s3/index.ts
+++ b/packages/storage/src/s3/index.ts
@@ -14,6 +14,7 @@ export {
   type S3ObjectSummary,
   type S3BucketSummary,
   type S3PresignGetObjectInput,
+  type S3PresignPutObjectInput,
   type S3RetryOptions
 } from "./client.js";
 export {

--- a/packages/storage/src/storage-adapter.ts
+++ b/packages/storage/src/storage-adapter.ts
@@ -41,6 +41,40 @@ export interface StorageAdapter {
 
   /** Stat an entry by URI. Returns null if it doesn't exist. */
   stat(uri: string): Promise<StorageStat | null>;
+
+  /**
+   * Mint a short-lived target the *client* can upload to directly, so object
+   * bytes never pass through the API process. The key is chosen by the
+   * caller (the server), never by the browser, so a client can only ever
+   * write where it was told to.
+   *
+   * Returns `null` on backends with no such concept — the local file store
+   * and the in-memory store — which is the signal to fall back to a
+   * server-side upload.
+   */
+  createUploadUrl?(
+    key: string,
+    opts?: UploadUrlOptions
+  ): Promise<UploadTarget | null>;
+}
+
+export interface UploadUrlOptions {
+  /** Sent as the object's Content-Type when the client uploads. */
+  contentType?: string;
+  /** Lifetime in seconds. Backends may clamp this to their own maximum. */
+  expiresIn?: number;
+}
+
+/** A one-shot, key-scoped upload target handed to a client. */
+export interface UploadTarget {
+  /** Absolute URL the client sends the bytes to. */
+  url: string;
+  /** HTTP method the client must use. */
+  method: "PUT" | "POST";
+  /** Headers the client must send verbatim (e.g. Content-Type). */
+  headers: Record<string, string>;
+  /** Epoch milliseconds after which the target stops working. */
+  expiresAt: number;
 }
 
 export interface StorageEntry {

--- a/packages/storage/src/storage-keys.ts
+++ b/packages/storage/src/storage-keys.ts
@@ -27,3 +27,56 @@ export function joinStorageKey(
   const normalizedPrefix = normalizeStorageKey(prefix);
   return `${normalizedPrefix}/${normalizedKey}`;
 }
+
+// ── Per-owner asset keys ────────────────────────────────────────────────────
+//
+// Asset objects live at `<userId>/<assetId>.<ext>` (thumbnail:
+// `<userId>/<assetId>_thumb.jpg`). The owner is the first path segment, which
+// is what makes the boundary enforceable outside this process: a Supabase
+// Storage RLS policy or an S3 bucket policy can match on the leading segment,
+// and a signed upload URL scoped to such a key can only ever write into its
+// owner's prefix.
+//
+// Objects written before this layout are flat (`<assetId>.<ext>`). Reads fall
+// back to that legacy shape — see `assetKeyCandidates` — so a deployment can
+// roll forward before its backfill finishes.
+
+/**
+ * Prefixes the runtime owns. A user id must never collide with one, or that
+ * user's objects would land in a namespace the read path treats as shared
+ * scratch.
+ */
+export const RESERVED_KEY_PREFIXES = ["temp", "assets"] as const;
+
+/** Owner-prefixed key for an asset object. */
+export function assetObjectKey(userId: string, fileName: string): string {
+  if (!userId) throw new Error("userId is required for an asset storage key");
+  if (userId.includes("/") || userId.includes("\\")) {
+    throw new Error(`Invalid userId for a storage key: ${userId}`);
+  }
+  if ((RESERVED_KEY_PREFIXES as readonly string[]).includes(userId)) {
+    throw new Error(
+      `Invalid userId for a storage key: "${userId}" is a reserved prefix`
+    );
+  }
+  return joinStorageKey(userId, fileName);
+}
+
+/**
+ * Keys to try when reading, newest layout first. A caller reads the first one
+ * that exists; a backfilled deployment always hits the first.
+ */
+export function assetKeyCandidates(
+  userId: string,
+  fileName: string
+): [string, string] {
+  return [assetObjectKey(userId, fileName), normalizeStorageKey(fileName)];
+}
+
+/** The owner encoded in a key, or null for a legacy flat key. */
+export function assetKeyOwner(key: string): string | null {
+  const normalized = normalizeStorageKey(key);
+  const slash = normalized.indexOf("/");
+  if (slash <= 0) return null;
+  return normalized.slice(0, slash);
+}

--- a/packages/storage/src/supabase-rest.ts
+++ b/packages/storage/src/supabase-rest.ts
@@ -55,6 +55,18 @@ export interface SupabaseBucketApi {
     key: string,
     expiresIn: number
   ): Promise<{ data: { signedUrl: string } | null; error: SupabaseError | null }>;
+  /**
+   * Mint a one-shot upload URL for `key`. The caller (typically a browser)
+   * PUTs the bytes straight to the returned URL, so object bytes never pass
+   * through this process. The token is scoped to this exact key — it cannot
+   * be redirected at another object.
+   */
+  createSignedUploadUrl(
+    key: string
+  ): Promise<{
+    data: { signedUrl: string; token: string } | null;
+    error: SupabaseError | null;
+  }>;
   getPublicUrl(key: string): { data: { publicUrl: string } };
 }
 
@@ -206,6 +218,34 @@ export function createSupabaseStorageClient(
               data: { signedUrl: `${base}/storage/v1${body.signedURL}` },
               error: null
             };
+          },
+
+          async createSignedUploadUrl(key) {
+            const response = await fetch(
+              `${base}/storage/v1/object/upload/sign/${bucket}/${encodeKey(key)}`,
+              { method: "POST", headers: authHeaders }
+            );
+            if (!response.ok) {
+              return { data: null, error: await readError(response) };
+            }
+            const body = (await response.json()) as { url?: string };
+            if (!body.url) {
+              return {
+                data: null,
+                error: { message: "Supabase sign response missing url" }
+              };
+            }
+            // `url` comes back relative (`/object/upload/sign/<bucket>/<key>?token=…`).
+            const signedUrl = `${base}/storage/v1${body.url}`;
+            const token =
+              new URL(signedUrl).searchParams.get("token") ?? "";
+            if (!token) {
+              return {
+                data: null,
+                error: { message: "Supabase sign response missing token" }
+              };
+            }
+            return { data: { signedUrl, token }, error: null };
           },
 
           getPublicUrl(key) {

--- a/packages/storage/src/supabase-storage-adapter.ts
+++ b/packages/storage/src/supabase-storage-adapter.ts
@@ -6,10 +6,15 @@ import type {
   StorageAdapter,
   StorageEntry,
   StorageListResult,
-  StorageStat
+  StorageStat,
+  UploadTarget,
+  UploadUrlOptions
 } from "./storage-adapter.js";
 import { normalizeStorageKey } from "./storage-keys.js";
 import { assertUploadWithinLimit } from "./storage-limits.js";
+
+/** Supabase upload tokens last two hours and the sign call takes no TTL. */
+const SUPABASE_UPLOAD_URL_TTL_MS = 2 * 60 * 60 * 1000;
 
 export interface SupabaseStorageAdapterOptions {
   url: string;
@@ -209,6 +214,39 @@ export class SupabaseStorageAdapter implements StorageAdapter {
       ...(item.metadata?.mimetype
         ? { contentType: item.metadata.mimetype as string }
         : {})
+    };
+  }
+
+  /**
+   * One-shot Supabase upload token for `key`. The browser PUTs the bytes to
+   * the returned URL, so they never transit this process. The token is bound
+   * to this exact key server-side, so a client holding it cannot write
+   * anywhere else — that is what lets the browser upload without ever seeing
+   * the service-role key.
+   */
+  async createUploadUrl(
+    key: string,
+    opts: UploadUrlOptions = {}
+  ): Promise<UploadTarget | null> {
+    const normalized = normalizeStorageKey(key);
+    const { data, error } = await this.getClient()
+      .storage.from(this.bucket)
+      .createSignedUploadUrl(normalized);
+    if (error || !data) {
+      throw new Error(
+        `Supabase upload URL failed for key "${key}": ${error?.message ?? "no data"}`
+      );
+    }
+    const headers: Record<string, string> = {};
+    if (opts.contentType) headers["content-type"] = opts.contentType;
+    return {
+      url: data.signedUrl,
+      method: "PUT",
+      headers,
+      // Supabase upload tokens are valid for two hours and the TTL is not
+      // configurable on the sign call, so report that rather than echoing a
+      // requested value we cannot enforce.
+      expiresAt: Date.now() + SUPABASE_UPLOAD_URL_TTL_MS
     };
   }
 

--- a/packages/storage/tests/s3-client.test.ts
+++ b/packages/storage/tests/s3-client.test.ts
@@ -258,6 +258,41 @@ describe("S3Client operations", () => {
     expect(parsed.searchParams.get("X-Amz-SignedHeaders")).toBe("host");
     expect(parsed.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
   });
+
+  it("presignPutObject signs for PUT, not GET", async () => {
+    const s3 = client(mockFetch());
+    const put = await s3.presignPutObject({
+      bucket: "b",
+      key: "user-1/f.png",
+      expiresIn: 900
+    });
+    const get = await s3.presignGetObject({
+      bucket: "b",
+      key: "user-1/f.png",
+      expiresIn: 900
+    });
+    const parsed = new URL(put);
+    expect(parsed.host).toBe("b.s3.us-east-1.amazonaws.com");
+    expect(parsed.pathname).toBe("/user-1/f.png");
+    expect(parsed.searchParams.get("X-Amz-Expires")).toBe("900");
+    expect(parsed.searchParams.get("X-Amz-Signature")).toMatch(
+      /^[0-9a-f]{64}$/
+    );
+    // Method is part of the canonical request, so the two must differ.
+    expect(parsed.searchParams.get("X-Amz-Signature")).not.toBe(
+      new URL(get).searchParams.get("X-Amz-Signature")
+    );
+  });
+
+  it("presignPutObject refuses keys with dot segments", async () => {
+    await expect(
+      client(mockFetch()).presignPutObject({
+        bucket: "b",
+        key: "user-1/../other/f.png",
+        expiresIn: 900
+      })
+    ).rejects.toThrow(/normalized away/);
+  });
 });
 
 describe("S3Client error mapping", () => {

--- a/packages/storage/tests/storage-keys.test.ts
+++ b/packages/storage/tests/storage-keys.test.ts
@@ -3,6 +3,10 @@ import {
   isWithinRoot,
   normalizeStorageKey,
   joinStorageKey,
+  assetObjectKey,
+  assetKeyCandidates,
+  assetKeyOwner,
+  RESERVED_KEY_PREFIXES
 } from "../src/storage-keys.js";
 
 describe("isWithinRoot", () => {
@@ -94,5 +98,56 @@ describe("joinStorageKey", () => {
     expect(() => joinStorageKey("../etc", "passwd")).toThrow(
       "Invalid storage key"
     );
+  });
+});
+
+describe("assetObjectKey", () => {
+  it("prefixes the file name with the owner", () => {
+    expect(assetObjectKey("user-1", "abc.png")).toBe("user-1/abc.png");
+  });
+
+  it("rejects a userId that would escape its own prefix", () => {
+    expect(() => assetObjectKey("a/b", "abc.png")).toThrow("Invalid userId");
+    expect(() => assetObjectKey("a\\b", "abc.png")).toThrow("Invalid userId");
+  });
+
+  it("rejects an empty userId", () => {
+    expect(() => assetObjectKey("", "abc.png")).toThrow("userId is required");
+  });
+
+  it("rejects a userId colliding with a runtime prefix", () => {
+    for (const reserved of RESERVED_KEY_PREFIXES) {
+      expect(() => assetObjectKey(reserved, "abc.png")).toThrow("reserved");
+    }
+  });
+
+  it("still rejects traversal in the file name", () => {
+    expect(() => assetObjectKey("user-1", "../secret")).toThrow(
+      "Invalid storage key"
+    );
+  });
+});
+
+describe("assetKeyCandidates", () => {
+  it("prefers the owner-prefixed key over the legacy flat key", () => {
+    expect(assetKeyCandidates("user-1", "abc.png")).toEqual([
+      "user-1/abc.png",
+      "abc.png"
+    ]);
+  });
+});
+
+describe("assetKeyOwner", () => {
+  it("reads the owner from a prefixed key", () => {
+    expect(assetKeyOwner("user-1/abc.png")).toBe("user-1");
+    expect(assetKeyOwner("user-1/nested/abc.png")).toBe("user-1");
+  });
+
+  it("returns null for a legacy flat key", () => {
+    expect(assetKeyOwner("abc.png")).toBeNull();
+  });
+
+  it("ignores a leading slash rather than reporting an empty owner", () => {
+    expect(assetKeyOwner("/abc.png")).toBeNull();
   });
 });

--- a/packages/storage/tests/supabase-rest.test.ts
+++ b/packages/storage/tests/supabase-rest.test.ts
@@ -186,3 +186,67 @@ describe("createAssetUrlBuilder (supabase)", () => {
     );
   });
 });
+
+describe("createSignedUploadUrl", () => {
+  it("POSTs to the upload-sign endpoint and returns an absolute URL + token", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        url: "/object/upload/sign/assets/user-1/abc.png?token=tok-123"
+      })
+    );
+    const { data, error } = await client()
+      .storage.from("assets")
+      .createSignedUploadUrl("user-1/abc.png");
+
+    expect(error).toBeNull();
+    expect(data).toEqual({
+      signedUrl:
+        "https://xyz.supabase.co/storage/v1/object/upload/sign/assets/user-1/abc.png?token=tok-123",
+      token: "tok-123"
+    });
+    const { url, init } = lastRequest();
+    expect(url).toBe(
+      "https://xyz.supabase.co/storage/v1/object/upload/sign/assets/user-1/abc.png"
+    );
+    expect(init.method).toBe("POST");
+  });
+
+  it("percent-encodes each key segment but keeps slashes", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ url: "/object/upload/sign/assets/u/a%20b.png?token=t" })
+    );
+    await client().storage.from("assets").createSignedUploadUrl("u/a b.png");
+    expect(lastRequest().url).toBe(
+      "https://xyz.supabase.co/storage/v1/object/upload/sign/assets/u/a%20b.png"
+    );
+  });
+
+  it("surfaces an API error instead of a URL", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ message: "denied" }, 403));
+    const { data, error } = await client()
+      .storage.from("assets")
+      .createSignedUploadUrl("user-1/abc.png");
+    expect(data).toBeNull();
+    expect(error?.message).toBe("denied");
+  });
+
+  it("errors when the response carries no url", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}));
+    const { data, error } = await client()
+      .storage.from("assets")
+      .createSignedUploadUrl("user-1/abc.png");
+    expect(data).toBeNull();
+    expect(error?.message).toMatch(/missing url/);
+  });
+
+  it("errors when the signed url carries no token", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ url: "/object/upload/sign/assets/user-1/abc.png" })
+    );
+    const { data, error } = await client()
+      .storage.from("assets")
+      .createSignedUploadUrl("user-1/abc.png");
+    expect(data).toBeNull();
+    expect(error?.message).toMatch(/missing token/);
+  });
+});

--- a/packages/websocket/src/file-api.ts
+++ b/packages/websocket/src/file-api.ts
@@ -11,12 +11,15 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import {
   corsHeaders,
   nodeStreamToWebStream,
   parseRangeHeader
 } from "./storage-api.js";
+import {
+  localPathDenialMessage,
+  resolveLocalPath
+} from "./lib/local-file-access.js";
 
 function errorResponse(status: number, detail: string): Response {
   return new Response(JSON.stringify({ detail }), {
@@ -51,32 +54,6 @@ const LOCAL_MIME_TYPES: Record<string, string> = {
   ".json": "application/json"
 };
 
-// Files that are never a legitimate part of a preview flow — refuse them even
-// though this endpoint is dev/desktop-only. Mirrors the Electron main-process
-// denylist so the two file-read surfaces stay consistent.
-const SENSITIVE_HOME_ENTRIES = [
-  ".ssh",
-  ".aws",
-  ".gnupg",
-  ".kube",
-  ".docker",
-  ".config/gcloud",
-  ".netrc",
-  ".pgpass",
-  ".npmrc"
-];
-
-function isDeniedPath(resolved: string): boolean {
-  const home = os.homedir();
-  for (const entry of SENSITIVE_HOME_ENTRIES) {
-    const forbidden = path.resolve(home, entry);
-    if (resolved === forbidden || resolved.startsWith(forbidden + path.sep)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function localMimeType(filePath: string): string {
   return (
     LOCAL_MIME_TYPES[path.extname(filePath).toLowerCase()] ??
@@ -90,28 +67,16 @@ async function handleLocalFileStream(
 ): Promise<Response> {
   const userPath = url.searchParams.get("path");
   if (!userPath) return errorResponse(400, "path parameter is required");
-  if (userPath.includes("\0")) return errorResponse(400, "Invalid path");
 
-  const resolved = path.resolve(userPath);
-  if (!path.isAbsolute(resolved)) {
-    return errorResponse(400, "Path must be absolute");
+  // Allowlist, not denylist: the path must resolve inside a configured root
+  // (home by default), both lexically and after symlinks. Same policy the
+  // tRPC file browser applies — see lib/local-file-access.ts.
+  const allowed = await resolveLocalPath(userPath);
+  if (!allowed.ok) {
+    const status = allowed.reason === "invalid" ? 400 : 403;
+    return errorResponse(status, localPathDenialMessage(allowed.reason));
   }
-  if (isDeniedPath(resolved)) {
-    return errorResponse(403, "Access to this path is not permitted");
-  }
-
-  // Re-run the denylist against the symlink-resolved path: a symlink at a
-  // non-denied location (e.g. /tmp/x -> ~/.ssh/id_rsa) passes the lexical check
-  // above but the stat/stream below follow it. A missing file still 404s.
-  let realResolved: string;
-  try {
-    realResolved = await fs.realpath(resolved);
-  } catch {
-    return errorResponse(404, "File not found");
-  }
-  if (isDeniedPath(realResolved)) {
-    return errorResponse(403, "Access to this path is not permitted");
-  }
+  const resolved = allowed.path;
 
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -78,8 +78,10 @@ const log = createLogger("nodetool.websocket.http");
 // graph. Re-exported here for any remaining REST callers.
 import {
   getAssetFileName,
-  getAssetStoragePath
+  getAssetStoragePath,
+  retrieveAssetBytes
 } from "./lib/asset-paths.js";
+import { assetObjectKey } from "@nodetool-ai/storage";
 export { getAssetFileName, getAssetStoragePath };
 
 type JsonObject = Record<string, unknown>;
@@ -1221,14 +1223,20 @@ async function resolveAssetBytesForExport(
   try {
     if (ref.startsWith("asset://")) {
       const rest = ref.slice("asset://".length).split("?")[0].split("#")[0];
-      let key = rest;
+      const adapter = getAssetAdapter();
       if (!nodePath.extname(rest)) {
         const asset = (await Asset.get(rest)) as Asset | null;
         if (!asset) return null;
-        key = getAssetFileName(asset.id, asset.content_type);
+        return await retrieveAssetBytes(
+          adapter,
+          asset.user_id,
+          asset.id,
+          asset.content_type
+        );
       }
-      const adapter = getAssetAdapter();
-      return await adapter.retrieve(adapter.uriForKey(key));
+      // Already a key — owner-prefixed for anything written since the
+      // per-owner layout, flat for older `asset://` refs stored in graphs.
+      return await adapter.retrieve(adapter.uriForKey(rest));
     }
     if (ref.includes("/api/storage/")) {
       const key = decodeURIComponent(
@@ -1386,7 +1394,13 @@ export async function handleWorkflowImportBundle(
           size: bytes.byteLength
         })) as Asset;
         const storedName = getAssetFileName(asset.id, asset.content_type);
-        await storeAssetWithThumbnail(asset.id, storedName, bytes, asset.content_type);
+        await storeAssetWithThumbnail(
+          asset.user_id,
+          asset.id,
+          storedName,
+          bytes,
+          asset.content_type
+        );
         return { uri: `asset://${storedName}`, assetId: asset.id };
       }
     });
@@ -1751,7 +1765,9 @@ export async function toAssetResponse(asset: Asset): Promise<JsonObject> {
     ? null
     : getAssetFileName(asset.id, asset.content_type);
   const getUrl = fileName
-    ? await getHttpUrlBuilder()(fileName).catch(() => null)
+    ? await getHttpUrlBuilder()(
+        assetObjectKey(asset.user_id, fileName)
+      ).catch(() => null)
     : null;
 
   const hasThumbnail =
@@ -1760,7 +1776,9 @@ export async function toAssetResponse(asset: Asset): Promise<JsonObject> {
     asset.content_type.startsWith("audio/") ||
     asset.content_type === "application/pdf";
   const thumbUrl = hasThumbnail
-    ? await getHttpUrlBuilder()(thumbnailKey(asset.id)).catch(() => null)
+    ? await getHttpUrlBuilder()(
+        assetObjectKey(asset.user_id, thumbnailKey(asset.id))
+      ).catch(() => null)
     : null;
 
   return {
@@ -1869,6 +1887,7 @@ export async function handleAssetsRoot(
         bytes: fileBuffer.byteLength
       });
       await storeAssetWithThumbnail(
+        asset.user_id,
         asset.id,
         fileName,
         new Uint8Array(fileBuffer),
@@ -1909,9 +1928,12 @@ export async function handleExtractAudio(
     return errorResponse(400, "Asset is not a video");
   }
 
-  const adapter = getAssetAdapter();
-  const sourceKey = getAssetFileName(source.id, source.content_type);
-  const videoBytes = await adapter.retrieve(adapter.uriForKey(sourceKey));
+  const videoBytes = await retrieveAssetBytes(
+    getAssetAdapter(),
+    source.user_id,
+    source.id,
+    source.content_type
+  );
   if (!videoBytes) {
     return errorResponse(404, "Asset bytes not found");
   }
@@ -1955,6 +1977,7 @@ export async function handleExtractAudio(
 
   const audioKey = getAssetFileName(audioAsset.id, audioAsset.content_type);
   await storeAssetWithThumbnail(
+    audioAsset.user_id,
     audioAsset.id,
     audioKey,
     wavBytes,

--- a/packages/websocket/src/lib/asset-paths.ts
+++ b/packages/websocket/src/lib/asset-paths.ts
@@ -6,6 +6,11 @@
  */
 
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
+import {
+  assetKeyCandidates,
+  assetObjectKey,
+  type StorageAdapter
+} from "@nodetool-ai/storage";
 import type { StorageHandlerOptions } from "../storage-api.js";
 
 const CONTENT_TYPE_TO_EXTENSION: Record<string, string> = {
@@ -41,11 +46,77 @@ function getFileExtension(contentType: string): string {
   return CONTENT_TYPE_TO_EXTENSION[contentType] ?? "bin";
 }
 
+/**
+ * The object's file name, with no owner prefix. This is the *legacy* key
+ * shape and stays exported because stored `asset://` refs and already-written
+ * objects use it; new writes go through `getAssetStorageKey`.
+ */
 export function getAssetFileName(
   assetId: string,
   contentType: string
 ): string {
   return `${assetId}.${getFileExtension(contentType)}`;
+}
+
+/**
+ * Where an asset's bytes live: `<userId>/<assetId>.<ext>`. The owner is the
+ * leading path segment so the tenant boundary is expressible outside this
+ * process — a Supabase RLS policy or bucket policy can match on it, and a
+ * signed upload URL scoped to such a key can only write into its own owner's
+ * prefix.
+ */
+export function getAssetStorageKey(
+  userId: string,
+  assetId: string,
+  contentType: string
+): string {
+  return assetObjectKey(userId, getAssetFileName(assetId, contentType));
+}
+
+/** Owner-prefixed thumbnail key for an asset. */
+export function getAssetThumbnailKey(
+  userId: string,
+  assetId: string
+): string {
+  return assetObjectKey(userId, `${assetId}_thumb.jpg`);
+}
+
+/**
+ * Resolve the key an asset's bytes actually live under, preferring the
+ * owner-prefixed layout and falling back to the flat legacy key. Lets a
+ * deployment roll forward before `nodetool storage migrate-keys` has moved
+ * its existing objects. Returns null when neither exists.
+ */
+export async function resolveExistingAssetKey(
+  adapter: StorageAdapter,
+  userId: string,
+  fileName: string
+): Promise<string | null> {
+  for (const candidate of assetKeyCandidates(userId, fileName)) {
+    if (await adapter.exists(adapter.uriForKey(candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Read an asset's bytes, trying the owner-prefixed key first and the legacy
+ * flat key second. Callers have already established that `userId` owns
+ * `assetId` (they loaded the row to get `contentType`).
+ */
+export async function retrieveAssetBytes(
+  adapter: StorageAdapter,
+  userId: string,
+  assetId: string,
+  contentType: string
+): Promise<Uint8Array | null> {
+  const fileName = getAssetFileName(assetId, contentType);
+  for (const candidate of assetKeyCandidates(userId, fileName)) {
+    const bytes = await adapter.retrieve(adapter.uriForKey(candidate));
+    if (bytes) return bytes;
+  }
+  return null;
 }
 
 export function getAssetStoragePath(opts?: StorageHandlerOptions): string {

--- a/packages/websocket/src/lib/local-file-access.ts
+++ b/packages/websocket/src/lib/local-file-access.ts
@@ -1,0 +1,172 @@
+/**
+ * Path policy shared by the two surfaces that read arbitrary local files: the
+ * REST preview stream (`GET /api/files/local`) and the tRPC file browser
+ * (`files.list`).
+ *
+ * The two used to disagree. The browser was sandboxed to `$HOME`, while the
+ * preview stream took any absolute path and only refused a handful of
+ * sensitive dotfiles — so an authenticated caller could stream `/etc/passwd`,
+ * the SQLite database, or a `.env` holding `SECRETS_MASTER_KEY`. Both now
+ * resolve through `resolveLocalPath`, which is an allowlist: a path must sit
+ * inside a configured root, and the denylist applies on top of that.
+ *
+ * Roots default to the user's home directory. `NODETOOL_LOCAL_FILE_ROOTS`
+ * (platform path-delimited) replaces that default, which is how a desktop user
+ * previews media off an external volume.
+ *
+ * These surfaces are already disabled when `NODETOOL_ENV=production`; this is
+ * the second layer, for the dev/desktop/self-hosted deployments where the file
+ * browser is live and more than one person can reach the port.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+export const LOCAL_FILE_ROOTS_ENV = "NODETOOL_LOCAL_FILE_ROOTS";
+
+/**
+ * Never part of a legitimate preview or browse flow, even inside a root.
+ * Mirrors the Electron main-process denylist so the file-read surfaces agree.
+ */
+const SENSITIVE_HOME_ENTRIES = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".kube",
+  ".docker",
+  ".config/gcloud",
+  ".netrc",
+  ".pgpass",
+  ".npmrc"
+];
+
+/** Roots a local path may resolve into. Never empty. */
+export function getLocalFileRoots(): string[] {
+  const configured = process.env[LOCAL_FILE_ROOTS_ENV];
+  if (configured) {
+    const roots = configured
+      .split(path.delimiter)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map((entry) => path.resolve(expandTilde(entry)));
+    if (roots.length > 0) return roots;
+  }
+  return [path.resolve(os.homedir())];
+}
+
+function expandTilde(candidate: string): string {
+  if (candidate === "~") return os.homedir();
+  if (candidate.startsWith("~/") || candidate.startsWith("~\\")) {
+    return path.join(os.homedir(), candidate.slice(2));
+  }
+  return candidate;
+}
+
+function isWithin(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+function isWithinAnyRoot(candidate: string, roots: string[]): boolean {
+  return roots.some((root) => isWithin(candidate, root));
+}
+
+function isSensitivePath(resolved: string): boolean {
+  const home = path.resolve(os.homedir());
+  return SENSITIVE_HOME_ENTRIES.some((entry) => {
+    const forbidden = path.resolve(home, entry);
+    return isWithin(resolved, forbidden);
+  });
+}
+
+/** The roots plus their symlink-resolved forms, deduped. */
+async function realRoots(roots: string[]): Promise<string[]> {
+  const all = new Set(roots);
+  for (const root of roots) {
+    try {
+      all.add(await fs.realpath(root));
+    } catch {
+      // A configured root that doesn't exist just contributes nothing.
+    }
+  }
+  return [...all];
+}
+
+export type LocalPathDenial = "invalid" | "outside_roots" | "sensitive";
+
+export type LocalPathResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: LocalPathDenial };
+
+/** Human-readable reason, safe to return to the caller. */
+export function localPathDenialMessage(reason: LocalPathDenial): string {
+  switch (reason) {
+    case "invalid":
+      return "Invalid path";
+    case "sensitive":
+      return "Access to this path is not permitted";
+    case "outside_roots":
+      return (
+        "Path is outside the allowed roots " +
+        `(set ${LOCAL_FILE_ROOTS_ENV} to allow more)`
+      );
+  }
+}
+
+/**
+ * Resolve a caller-supplied path against the allowed roots.
+ *
+ * A relative path resolves against the first root, so the file browser's "."
+ * still means "home". A leading `~` expands. Containment is checked twice:
+ * lexically on the resolved path, then again on the symlink-resolved path —
+ * a link at an allowed location (`~/shortcut -> /etc`) passes the first check
+ * but the stat/stream that follows would traverse it. realpath runs against
+ * the deepest existing ancestor so a not-yet-created leaf still gets its
+ * parent chain verified.
+ */
+export async function resolveLocalPath(
+  userPath: string,
+  roots: string[] = getLocalFileRoots()
+): Promise<LocalPathResult> {
+  if (!userPath || userPath.includes("\0")) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  const expanded = expandTilde(userPath);
+  const resolved = path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(roots[0], expanded);
+
+  if (!isWithinAnyRoot(resolved, roots)) {
+    return { ok: false, reason: "outside_roots" };
+  }
+  if (isSensitivePath(resolved)) {
+    return { ok: false, reason: "sensitive" };
+  }
+
+  // A root can itself sit behind a symlink (macOS `/var` → `/private/var`), so
+  // the post-realpath containment check compares against the real roots too.
+  const resolvedRoots = await realRoots(roots);
+
+  let probe = resolved;
+  for (;;) {
+    try {
+      const real = await fs.realpath(probe);
+      // Re-anchor the not-yet-resolved tail onto the real ancestor so a link
+      // in the middle of the path can't smuggle the leaf out of the roots.
+      const realResolved = path.join(real, path.relative(probe, resolved));
+      if (!isWithinAnyRoot(realResolved, resolvedRoots)) {
+        return { ok: false, reason: "outside_roots" };
+      }
+      if (isSensitivePath(realResolved)) {
+        return { ok: false, reason: "sensitive" };
+      }
+      break;
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) break; // reached the filesystem root unresolved
+      probe = parent;
+    }
+  }
+
+  return { ok: true, path: resolved };
+}

--- a/packages/websocket/src/lib/storage-access.ts
+++ b/packages/websocket/src/lib/storage-access.ts
@@ -1,0 +1,73 @@
+/**
+ * Ownership rules for `/api/storage/<key>`.
+ *
+ * The local storage backend is a single shared directory with no per-user
+ * prefix: an asset's bytes live at `<assetId>.<ext>` (thumbnail:
+ * `<assetId>_thumb.jpg`), whoever created it. The only thing that ties a key
+ * to a user is the `assets` row, so every read has to go through it — without
+ * that check any authenticated caller could read (and, when PUT was open,
+ * overwrite) another tenant's asset bytes by id alone.
+ *
+ * The tRPC `storage.signUrl` procedure already gated on this; these helpers
+ * are the shared implementation so REST and tRPC can't drift apart again.
+ */
+import path from "node:path";
+import { Asset } from "@nodetool-ai/models";
+
+/**
+ * Key prefixes the runtime writes to directly, with no `assets` row behind
+ * them: `temp/<uuid>.<ext>` (temp_url asset outputs) and `assets/<uuid>.<ext>`
+ * (storage_url outputs, binary tool results). They are capability keys — a
+ * random v4 UUID minted per run and handed only to the caller who triggered
+ * it — so they stay readable without an ownership record. Nothing can
+ * overwrite them: `/api/storage` no longer accepts writes at all.
+ */
+const RUNTIME_SCRATCH_PREFIXES = ["temp/", "assets/"];
+
+function normalizeKey(key: string): string {
+  return key.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+export function isRuntimeScratchKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  return RUNTIME_SCRATCH_PREFIXES.some((prefix) =>
+    normalized.startsWith(prefix)
+  );
+}
+
+/**
+ * Derive the owning asset id from a storage key. Asset files are stored flat
+ * as `<assetId>.<ext>` and `<assetId>_thumb.jpg`.
+ */
+export function assetIdFromKey(key: string): string | null {
+  const base = path.basename(normalizeKey(key));
+  const withoutExt = base.replace(/\.[^.]+$/, "");
+  const id = withoutExt.replace(/_thumb$/, "");
+  return id || null;
+}
+
+/**
+ * Whether `userId` owns the asset a key refers to. Fails closed: a key that
+ * maps to no asset row, or a lookup that throws, is not owned.
+ */
+export async function callerOwnsStorageKey(
+  userId: string,
+  key: string
+): Promise<boolean> {
+  const assetId = assetIdFromKey(key);
+  if (!assetId) return false;
+  try {
+    return (await Asset.find(userId, assetId)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Whether `userId` may read the bytes at `key`. */
+export async function canReadStorageKey(
+  userId: string,
+  key: string
+): Promise<boolean> {
+  if (isRuntimeScratchKey(key)) return true;
+  return callerOwnsStorageKey(userId, key);
+}

--- a/packages/websocket/src/lib/storage-access.ts
+++ b/packages/websocket/src/lib/storage-access.ts
@@ -13,6 +13,7 @@
  */
 import path from "node:path";
 import { Asset } from "@nodetool-ai/models";
+import { assetKeyOwner } from "@nodetool-ai/storage";
 
 /**
  * Key prefixes the runtime writes to directly, with no `assets` row behind
@@ -63,11 +64,20 @@ export async function callerOwnsStorageKey(
   }
 }
 
-/** Whether `userId` may read the bytes at `key`. */
+/**
+ * Whether `userId` may read the bytes at `key`.
+ *
+ * Owner-prefixed keys (`<userId>/<assetId>.<ext>`) are settled by the prefix
+ * alone — no database round trip, and the same rule a Supabase RLS policy or
+ * bucket policy applies to the object itself. Legacy flat keys, written
+ * before that layout, still need the `assets` lookup.
+ */
 export async function canReadStorageKey(
   userId: string,
   key: string
 ): Promise<boolean> {
   if (isRuntimeScratchKey(key)) return true;
+  const owner = assetKeyOwner(key);
+  if (owner !== null) return owner === userId;
   return callerOwnsStorageKey(userId, key);
 }

--- a/packages/websocket/src/lib/thumbnail.ts
+++ b/packages/websocket/src/lib/thumbnail.ts
@@ -23,6 +23,7 @@ import { promisify } from "node:util";
 
 import sharp from "sharp";
 import { createLogger } from "@nodetool-ai/config";
+import { assetObjectKey } from "@nodetool-ai/storage";
 import { getAssetAdapter } from "./storage.js";
 
 const log = createLogger("nodetool.thumbnail");
@@ -165,13 +166,14 @@ async function generateAudioThumb(bytes: Uint8Array): Promise<Buffer> {
  * upload still succeeds.
  */
 export async function storeAssetWithThumbnail(
+  userId: string,
   assetId: string,
   fileName: string,
   bytes: Uint8Array,
   contentType: string
 ): Promise<void> {
   const adapter = getAssetAdapter();
-  await adapter.store(fileName, bytes, contentType);
+  await adapter.store(assetObjectKey(userId, fileName), bytes, contentType);
 
   const generator = contentType.startsWith("image/")
     ? generateImageThumb
@@ -187,7 +189,7 @@ export async function storeAssetWithThumbnail(
   try {
     const thumb = await generator(bytes);
     await adapter.store(
-      thumbnailKey(assetId),
+      assetObjectKey(userId, thumbnailKey(assetId)),
       new Uint8Array(thumb),
       THUMB_CONTENT_TYPE
     );

--- a/packages/websocket/src/lib/thumbnail.ts
+++ b/packages/websocket/src/lib/thumbnail.ts
@@ -25,6 +25,7 @@ import sharp from "sharp";
 import { createLogger } from "@nodetool-ai/config";
 import { assetObjectKey } from "@nodetool-ai/storage";
 import { getAssetAdapter } from "./storage.js";
+import { retrieveAssetBytes } from "./asset-paths.js";
 
 const log = createLogger("nodetool.thumbnail");
 const execFileAsync = promisify(execFile);
@@ -160,6 +161,57 @@ async function generateAudioThumb(bytes: Uint8Array): Promise<Buffer> {
   ]);
 }
 
+/** Largest object we'll pull back out of storage just to thumbnail it. */
+export const THUMBNAIL_SOURCE_MAX_BYTES = 100 * 1024 * 1024;
+
+function thumbGeneratorFor(
+  contentType: string
+): ((bytes: Uint8Array) => Promise<Buffer>) | null {
+  if (contentType.startsWith("image/")) return generateImageThumb;
+  if (contentType.startsWith("video/")) return generateVideoThumb;
+  if (contentType.startsWith("audio/")) return generateAudioThumb;
+  if (contentType === "application/pdf") return generatePdfThumb;
+  return null;
+}
+
+/**
+ * Generate a thumbnail for an object already in storage — the client-direct
+ * upload path, where the bytes never passed through this process. Reads them
+ * back once. Failures are logged and swallowed; the asset stays usable
+ * without a thumbnail.
+ */
+export async function generateThumbnailForStoredAsset(
+  userId: string,
+  assetId: string,
+  contentType: string
+): Promise<void> {
+  const generator = thumbGeneratorFor(contentType);
+  if (!generator) return;
+
+  const adapter = getAssetAdapter();
+  try {
+    const bytes = await retrieveAssetBytes(
+      adapter,
+      userId,
+      assetId,
+      contentType
+    );
+    if (!bytes) return;
+    const thumb = await generator(bytes);
+    await adapter.store(
+      assetObjectKey(userId, thumbnailKey(assetId)),
+      new Uint8Array(thumb),
+      THUMB_CONTENT_TYPE
+    );
+  } catch (err) {
+    log.warn("thumbnail generation failed", {
+      assetId,
+      contentType,
+      error: String(err)
+    });
+  }
+}
+
 /**
  * Store an asset's bytes and, when applicable, generate and store a
  * thumbnail. Thumbnail failures are logged and swallowed — the original
@@ -175,15 +227,7 @@ export async function storeAssetWithThumbnail(
   const adapter = getAssetAdapter();
   await adapter.store(assetObjectKey(userId, fileName), bytes, contentType);
 
-  const generator = contentType.startsWith("image/")
-    ? generateImageThumb
-    : contentType.startsWith("video/")
-      ? generateVideoThumb
-      : contentType.startsWith("audio/")
-        ? generateAudioThumb
-        : contentType === "application/pdf"
-          ? generatePdfThumb
-          : null;
+  const generator = thumbGeneratorFor(contentType);
   if (!generator) return;
 
   try {

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -94,7 +94,13 @@ function buildAgentToolContext(userId: string): ProcessingContext {
       if (args.content) {
         const ext = MIME_TO_EXT[args.contentType] ?? "bin";
         const key = `${asset.id}.${ext}`;
-        await storeAssetWithThumbnail(asset.id, key, args.content, args.contentType);
+        await storeAssetWithThumbnail(
+          asset.user_id,
+          asset.id,
+          key,
+          args.content,
+          args.contentType
+        );
         asset.size = args.content.length;
       }
       await asset.save();

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -15,6 +15,7 @@ import {
 } from "@modelcontextprotocol/ext-apps/server";
 import { z } from "zod";
 import { getListAssetsAppHtml } from "./mcp-apps/list-assets-app.js";
+import { assetKeyCandidates } from "@nodetool-ai/storage";
 import { getAssetAdapter } from "./lib/storage.js";
 import { thumbnailKey } from "./lib/thumbnail.js";
 import { getListWorkflowsAppHtml } from "./mcp-apps/list-workflows-app.js";
@@ -940,7 +941,12 @@ function assetHasThumb(asset: Asset): boolean {
 
 async function loadAssetThumb(asset: Asset): Promise<LoadedThumb | null> {
   if (!assetHasThumb(asset)) return null;
-  return loadStorageThumb(thumbnailKey(asset.id));
+  const fileName = thumbnailKey(asset.id);
+  for (const key of assetKeyCandidates(asset.user_id, fileName)) {
+    const thumb = await loadStorageThumb(key);
+    if (thumb) return thumb;
+  }
+  return null;
 }
 
 async function loadAssetThumbs(

--- a/packages/websocket/src/storage-api.ts
+++ b/packages/websocket/src/storage-api.ts
@@ -6,8 +6,12 @@ import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import path, { extname } from "node:path";
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
+import { assetKeyOwner } from "@nodetool-ai/storage";
 import { resolveAllowedOrigin } from "./cors.js";
-import { canReadStorageKey } from "./lib/storage-access.js";
+import {
+  callerOwnsStorageKey,
+  canReadStorageKey
+} from "./lib/storage-access.js";
 
 // ── MIME types ────────────────────────────────────────────────────
 
@@ -86,6 +90,27 @@ function validateStorageKey(key: string): string | null {
   if (parts.some((p) => p === ".."))
     return "Key must not contain path traversal";
   return null; // valid
+}
+
+/**
+ * The pre-prefix key an owner-prefixed asset key used to live at, or null for
+ * a key that already has no prefix.
+ */
+function legacyKeyFor(key: string): string | null {
+  const normalized = key.replace(/\\/g, "/");
+  const slash = normalized.lastIndexOf("/");
+  if (slash <= 0) return null;
+  const base = normalized.slice(slash + 1);
+  return base && base !== normalized ? base : null;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function resolveStoragePath(rootDir: string, key: string): string {
@@ -213,7 +238,19 @@ async function handleStorageRequest(
     });
   }
 
-  const filePath = resolveStoragePath(rootDir, key);
+  let filePath = resolveStoragePath(rootDir, key);
+
+  // Objects written before the owner-prefixed layout are flat. Fall back to
+  // the legacy path when the prefixed one is missing, re-checking ownership
+  // against the `assets` row since the prefix no longer vouches for it. Only
+  // the local backend needs this — cloud backends resolve through the URL
+  // builder, so they require `nodetool storage migrate-keys`.
+  const legacy = assetKeyOwner(key) === userId ? legacyKeyFor(key) : null;
+  if (legacy && !(await pathExists(filePath))) {
+    if (await callerOwnsStorageKey(userId, legacy)) {
+      filePath = resolveStoragePath(rootDir, legacy);
+    }
+  }
 
   // HEAD
   if (request.method === "HEAD") {

--- a/packages/websocket/src/storage-api.ts
+++ b/packages/websocket/src/storage-api.ts
@@ -1,13 +1,13 @@
 /**
- * Storage REST API — binary PUT/GET/HEAD only.
+ * Storage REST API — binary GET/HEAD only.
  * JSON ops (list, metadata, delete) have moved to the tRPC `storage` router.
  */
 import { createReadStream } from "node:fs";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import path, { extname } from "node:path";
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
-import { getMaxUploadBytes } from "@nodetool-ai/storage";
 import { resolveAllowedOrigin } from "./cors.js";
+import { canReadStorageKey } from "./lib/storage-access.js";
 
 // ── MIME types ────────────────────────────────────────────────────
 
@@ -190,6 +190,29 @@ async function handleStorageRequest(
     });
   }
 
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    // Read-only surface. PUT used to write any key, which — with a shared
+    // storage directory keyed only by asset id — let one tenant overwrite
+    // another's asset bytes. Nothing ever called it: bytes are written
+    // in-process through the storage adapter (asset upload, workflow
+    // outputs), never over HTTP. DELETE moved to tRPC `storage.delete`.
+    return new Response(JSON.stringify({ detail: "Method not allowed" }), {
+      status: 405,
+      headers: { ...cors, "content-type": "application/json" }
+    });
+  }
+
+  // The storage directory is one flat bucket, so the key alone says nothing
+  // about who owns the bytes. 404 rather than 403 on a foreign key: the
+  // caller shouldn't learn which asset ids exist.
+  const userId = request.headers.get("x-user-id") ?? "1";
+  if (!(await canReadStorageKey(userId, key))) {
+    return new Response(JSON.stringify({ detail: "Not found" }), {
+      status: 404,
+      headers: { ...cors, "content-type": "application/json" }
+    });
+  }
+
   const filePath = resolveStoragePath(rootDir, key);
 
   // HEAD
@@ -213,119 +236,77 @@ async function handleStorageRequest(
   }
 
   // GET
-  if (request.method === "GET") {
-    let fileStat: Awaited<ReturnType<typeof stat>>;
-    try {
-      fileStat = await stat(filePath);
-    } catch {
-      return new Response(JSON.stringify({ detail: "Not found" }), {
-        status: 404,
-        headers: { ...cors, "content-type": "application/json" }
-      });
+  let fileStat: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    return new Response(JSON.stringify({ detail: "Not found" }), {
+      status: 404,
+      headers: { ...cors, "content-type": "application/json" }
+    });
+  }
+
+  const mtime = fileStat.mtime;
+  const lastModified = mtime.toUTCString();
+  const fileSize = fileStat.size;
+  const contentType = getMimeType(filePath);
+
+  // If-Modified-Since check
+  const ifModifiedSince = request.headers.get("If-Modified-Since");
+  if (ifModifiedSince) {
+    const ifModifiedSinceDate = new Date(ifModifiedSince);
+    if (
+      !Number.isNaN(ifModifiedSinceDate.getTime()) &&
+      mtime <= ifModifiedSinceDate
+    ) {
+      return new Response(null, { status: 304, headers: cors });
     }
+  }
 
-    const mtime = fileStat.mtime;
-    const lastModified = mtime.toUTCString();
-    const fileSize = fileStat.size;
-    const contentType = getMimeType(filePath);
-
-    // If-Modified-Since check
-    const ifModifiedSince = request.headers.get("If-Modified-Since");
-    if (ifModifiedSince) {
-      const ifModifiedSinceDate = new Date(ifModifiedSince);
-      if (
-        !Number.isNaN(ifModifiedSinceDate.getTime()) &&
-        mtime <= ifModifiedSinceDate
-      ) {
-        return new Response(null, { status: 304, headers: cors });
+  // Range request
+  const rangeHeader = request.headers.get("Range");
+  const range = rangeHeader ? parseRangeHeader(rangeHeader, fileSize) : null;
+  // A parsed-but-unsatisfiable range → 416. An unparseable/unsupported header
+  // (range === null while a header was present) is ignored and the full file
+  // is served with 200, per RFC 7233.
+  if (range === "unsatisfiable") {
+    return new Response(JSON.stringify({ detail: "Range Not Satisfiable" }), {
+      status: 416,
+      headers: {
+        ...cors,
+        "content-type": "application/json",
+        "Content-Range": `bytes */${fileSize}`
       }
-    }
-
-    // Range request
-    const rangeHeader = request.headers.get("Range");
-    const range = rangeHeader
-      ? parseRangeHeader(rangeHeader, fileSize)
-      : null;
-    // A parsed-but-unsatisfiable range → 416. An unparseable/unsupported header
-    // (range === null while a header was present) is ignored and the full file
-    // is served with 200, per RFC 7233.
-    if (range === "unsatisfiable") {
-      return new Response(JSON.stringify({ detail: "Range Not Satisfiable" }), {
-        status: 416,
-        headers: {
-          ...cors,
-          "content-type": "application/json",
-          "Content-Range": `bytes */${fileSize}`
-        }
-      });
-    }
-    if (range) {
-      const { start, end } = range;
-      const chunkSize = end - start + 1;
-      const body = nodeStreamToWebStream(filePath, { start, end });
-      return new Response(body, {
-        status: 206,
-        headers: {
-          ...cors,
-          "Content-Type": contentType,
-          "Content-Length": String(chunkSize),
-          "Content-Range": `bytes ${start}-${end}/${fileSize}`,
-          "Last-Modified": lastModified,
-          "Accept-Ranges": "bytes"
-        }
-      });
-    }
-
-    // Full file
-    const body = nodeStreamToWebStream(filePath);
+    });
+  }
+  if (range) {
+    const { start, end } = range;
+    const chunkSize = end - start + 1;
+    const body = nodeStreamToWebStream(filePath, { start, end });
     return new Response(body, {
-      status: 200,
+      status: 206,
       headers: {
         ...cors,
         "Content-Type": contentType,
-        "Content-Length": String(fileSize),
+        "Content-Length": String(chunkSize),
+        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
         "Last-Modified": lastModified,
         "Accept-Ranges": "bytes"
       }
     });
   }
 
-  // PUT
-  if (request.method === "PUT") {
-    const max = getMaxUploadBytes();
-    const tooLarge = (size: number): Response =>
-      new Response(
-        JSON.stringify({
-          detail:
-            `Upload exceeds maximum size: ${size} > ${max} bytes ` +
-            `(set NODETOOL_MAX_UPLOAD_BYTES to raise the limit)`
-        }),
-        {
-          status: 413,
-          headers: { ...cors, "content-type": "application/json" }
-        }
-      );
-
-    // Reject before buffering when the client declares an over-limit size, so a
-    // huge PUT can't force the server to allocate the whole body first.
-    const declaredLength = Number(request.headers.get("content-length"));
-    if (Number.isFinite(declaredLength) && declaredLength > max) {
-      return tooLarge(declaredLength);
+  // Full file
+  const body = nodeStreamToWebStream(filePath);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      ...cors,
+      "Content-Type": contentType,
+      "Content-Length": String(fileSize),
+      "Last-Modified": lastModified,
+      "Accept-Ranges": "bytes"
     }
-
-    // Fall back to a post-read check for chunked bodies with no Content-Length.
-    const bodyBuffer = await request.arrayBuffer();
-    if (bodyBuffer.byteLength > max) {
-      return tooLarge(bodyBuffer.byteLength);
-    }
-    await mkdir(path.dirname(filePath), { recursive: true });
-    await writeFile(filePath, Buffer.from(bodyBuffer));
-    return new Response(null, { status: 200, headers: cors });
-  }
-
-  return new Response(JSON.stringify({ detail: "Method not allowed" }), {
-    status: 405,
-    headers: { ...cors, "content-type": "application/json" }
   });
 }
 

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -19,7 +19,7 @@ import {
 } from "@nodetool-ai/config";
 
 const log = createLogger("nodetool.assets");
-import { createAssetUrlBuilder } from "@nodetool-ai/storage";
+import { assetObjectKey, createAssetUrlBuilder } from "@nodetool-ai/storage";
 import { getAssetFileName } from "../../lib/asset-paths.js";
 import {
   storeAssetWithThumbnail,
@@ -63,8 +63,13 @@ async function toAssetResponse(asset: AssetModel): Promise<AssetResponse> {
   const fileName = isFolder
     ? null
     : getAssetFileName(asset.id, asset.content_type);
+  // Owner-prefixed keys. Objects written before this layout are flat; the
+  // `/api/storage` route falls back to the legacy path on a miss, and cloud
+  // backends need `nodetool storage migrate-keys` (see docs/configuration.md).
   const getUrl = fileName
-    ? await getUrlBuilder()(fileName).catch(() => null)
+    ? await getUrlBuilder()(assetObjectKey(asset.user_id, fileName)).catch(
+        () => null
+      )
     : null;
 
   const hasThumbnail =
@@ -73,7 +78,9 @@ async function toAssetResponse(asset: AssetModel): Promise<AssetResponse> {
     asset.content_type.startsWith("audio/") ||
     asset.content_type === "application/pdf";
   const thumbUrl = hasThumbnail
-    ? await getUrlBuilder()(thumbnailKey(asset.id)).catch(() => null)
+    ? await getUrlBuilder()(
+        assetObjectKey(asset.user_id, thumbnailKey(asset.id))
+      ).catch(() => null)
     : null;
 
   return {
@@ -252,6 +259,7 @@ export const assetsRouter = router({
           bytes: buf.byteLength
         });
         await storeAssetWithThumbnail(
+          asset.user_id,
           asset.id,
           fileName,
           new Uint8Array(buf),

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -19,11 +19,21 @@ import {
 } from "@nodetool-ai/config";
 
 const log = createLogger("nodetool.assets");
-import { assetObjectKey, createAssetUrlBuilder } from "@nodetool-ai/storage";
-import { getAssetFileName } from "../../lib/asset-paths.js";
 import {
+  assetObjectKey,
+  createAssetUrlBuilder,
+  getMaxUploadBytes
+} from "@nodetool-ai/storage";
+import {
+  getAssetFileName,
+  getAssetStorageKey
+} from "../../lib/asset-paths.js";
+import { getAssetAdapter } from "../../lib/storage.js";
+import {
+  generateThumbnailForStoredAsset,
   storeAssetWithThumbnail,
-  thumbnailKey
+  thumbnailKey,
+  THUMBNAIL_SOURCE_MAX_BYTES
 } from "../../lib/thumbnail.js";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
@@ -35,6 +45,10 @@ import {
   getInput,
   assetResponse,
   updateInput,
+  createUploadInput,
+  createUploadOutput,
+  finalizeUploadInput,
+  finalizeUploadOutput,
   deleteInput,
   deleteOutput,
   recursiveInput,
@@ -205,6 +219,121 @@ export const assetsRouter = router({
       if (!asset) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Asset not found");
       }
+      return toAssetResponse(asset);
+    }),
+
+  /**
+   * Step 1 of a client-direct upload: create the row, pick the key, and mint
+   * a short-lived target scoped to that key. The client never chooses where
+   * it writes, so a stolen or replayed target can only overwrite the one
+   * pending object it was issued for — inside its own owner's prefix.
+   *
+   * `upload` comes back null on backends with no direct-upload concept (the
+   * local file store); the client then falls back to `POST /api/assets`.
+   */
+  createUpload: protectedProcedure
+    .input(createUploadInput)
+    .output(createUploadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const max = getMaxUploadBytes();
+      if (input.size > max) {
+        throwApiError(
+          ApiErrorCode.INVALID_INPUT,
+          `Upload exceeds maximum size: ${input.size} > ${max} bytes`
+        );
+      }
+
+      const asset = (await Asset.create({
+        user_id: ctx.userId,
+        name: input.name,
+        content_type: input.content_type,
+        parent_id: input.parent_id,
+        workflow_id: input.workflow_id ?? null,
+        node_id: input.node_id ?? null,
+        job_id: input.job_id ?? null,
+        timeline_id: input.timeline_id ?? null,
+        metadata: input.metadata ?? null,
+        // Recorded on finalize from what actually landed, not from the claim.
+        size: null
+      })) as AssetModel;
+
+      const key = getAssetStorageKey(
+        ctx.userId,
+        asset.id,
+        asset.content_type
+      );
+      const adapter = getAssetAdapter();
+      const target = adapter.createUploadUrl
+        ? await adapter.createUploadUrl(key, {
+            contentType: input.content_type
+          })
+        : null;
+
+      return {
+        asset_id: asset.id,
+        key,
+        upload: target
+          ? {
+              url: target.url,
+              method: target.method,
+              headers: target.headers,
+              expires_at: target.expiresAt
+            }
+          : null
+      };
+    }),
+
+  /**
+   * Step 2: confirm what actually landed. The signed target bounds *where* a
+   * client can write but not *what* — so the size is read back off the object
+   * rather than trusted from the client, and an over-cap or absent upload is
+   * rejected and the pending row removed.
+   */
+  finalizeUpload: protectedProcedure
+    .input(finalizeUploadInput)
+    .output(finalizeUploadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const asset = await Asset.find(ctx.userId, input.asset_id);
+      if (!asset) {
+        throwApiError(ApiErrorCode.NOT_FOUND, "Asset not found");
+      }
+
+      const adapter = getAssetAdapter();
+      const key = getAssetStorageKey(
+        asset.user_id,
+        asset.id,
+        asset.content_type
+      );
+      const stat = await adapter.stat(adapter.uriForKey(key));
+      if (!stat || stat.size === 0) {
+        await asset.delete();
+        throwApiError(ApiErrorCode.INVALID_INPUT, "No uploaded object found");
+      }
+
+      const max = getMaxUploadBytes();
+      if (stat.size > max) {
+        await adapter.delete(adapter.uriForKey(key));
+        await asset.delete();
+        throwApiError(
+          ApiErrorCode.INVALID_INPUT,
+          `Upload exceeds maximum size: ${stat.size} > ${max} bytes`
+        );
+      }
+
+      asset.size = stat.size;
+      await asset.save();
+
+      // The bytes are already in the bucket, so a thumbnail costs one download
+      // back into this process. Worth it for ordinary media, not for a
+      // multi-gigabyte video — those simply go without.
+      if (stat.size <= THUMBNAIL_SOURCE_MAX_BYTES) {
+        await generateThumbnailForStoredAsset(
+          asset.user_id,
+          asset.id,
+          asset.content_type
+        );
+      }
+
       return toAssetResponse(asset);
     }),
 

--- a/packages/websocket/src/trpc/routers/files.ts
+++ b/packages/websocket/src/trpc/routers/files.ts
@@ -4,11 +4,14 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
+import {
+  localPathDenialMessage,
+  resolveLocalPath
+} from "../../lib/local-file-access.js";
 import {
   listFilesInput,
   listFilesOutput
@@ -17,64 +20,20 @@ import { ApiErrorCode } from "@nodetool-ai/protocol/api-schemas/api-error-code.j
 
 // ── Sandbox helpers ─────────────────────────────────────────────────────────
 
-function getRootDir(): string {
-  return os.homedir();
-}
-
-function isWithinRoot(candidate: string, normalizedRoot: string): boolean {
-  return (
-    candidate === normalizedRoot ||
-    candidate.startsWith(normalizedRoot + path.sep)
-  );
-}
-
 /**
- * Resolve a user-provided path within the sandbox root.
- * Returns the resolved absolute path, or throws FORBIDDEN if the path escapes.
- *
- * The lexical check alone is not enough: a symlink that lives under the root but
- * points outside it passes `startsWith` yet resolves elsewhere at the syscall
- * level. So the real (symlink-resolved) path is also verified to stay within the
- * root. realpath is resolved on the deepest existing ancestor so a not-yet-
- * existing leaf still gets its parent chain checked.
+ * Resolve a caller-supplied path inside the allowed roots, or throw FORBIDDEN.
+ * The policy itself lives in lib/local-file-access.ts, shared with the REST
+ * preview stream (`GET /api/files/local`) so the two can't diverge.
  */
-async function resolveSandboxed(
-  rootDir: string,
-  userPath: string
-): Promise<string> {
-  const resolved = path.resolve(
-    rootDir,
-    userPath.startsWith("/") ? "." + userPath : userPath
-  );
-  const normalizedRoot = path.resolve(rootDir);
-  if (!isWithinRoot(resolved, normalizedRoot)) {
-    throwApiError(ApiErrorCode.FORBIDDEN, "Path traversal not allowed");
+async function resolveSandboxed(userPath: string): Promise<string> {
+  const result = await resolveLocalPath(userPath);
+  if (!result.ok) {
+    throwApiError(
+      ApiErrorCode.FORBIDDEN,
+      localPathDenialMessage(result.reason)
+    );
   }
-
-  // Resolve symlinks on the deepest existing ancestor and re-check containment.
-  let probe = resolved;
-  for (;;) {
-    try {
-      const real = await fs.realpath(probe);
-      if (!isWithinRoot(real, normalizedRoot)) {
-        throwApiError(ApiErrorCode.FORBIDDEN, "Path traversal not allowed");
-      }
-      break;
-    } catch (err) {
-      if (
-        err &&
-        typeof err === "object" &&
-        "name" in err &&
-        (err as { name: string }).name === "TRPCError"
-      ) {
-        throw err; // FORBIDDEN from the containment check above
-      }
-      const parent = path.dirname(probe);
-      if (parent === probe) break; // reached filesystem root without resolving
-      probe = parent;
-    }
-  }
-  return resolved;
+  return result.path;
 }
 
 // ── Router ──────────────────────────────────────────────────────────────────
@@ -91,8 +50,7 @@ export const filesRouter = router({
         );
       }
 
-      const rootDir = getRootDir();
-      const resolved = await resolveSandboxed(rootDir, input.path);
+      const resolved = await resolveSandboxed(input.path);
 
       try {
         const entries = await fs.readdir(resolved, { withFileTypes: true });

--- a/packages/websocket/src/trpc/routers/storage.ts
+++ b/packages/websocket/src/trpc/routers/storage.ts
@@ -8,7 +8,10 @@ import { createAssetUrlBuilder } from "@nodetool-ai/storage";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
-import { callerOwnsStorageKey } from "../../lib/storage-access.js";
+import { assetKeyOwner } from "@nodetool-ai/storage";
+import { canReadStorageKey } from "../../lib/storage-access.js";
+import { resolveExistingAssetKey } from "../../lib/asset-paths.js";
+import { getAssetAdapter } from "../../lib/storage.js";
 import {
   signUrlInput,
   signUrlOutput
@@ -54,10 +57,23 @@ export const storageRouter = router({
       if (validationError) {
         throwApiError(ApiErrorCode.INVALID_INPUT, validationError);
       }
-      if (!(await callerOwnsStorageKey(ctx.userId, input.key))) {
+      if (!(await canReadStorageKey(ctx.userId, input.key))) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Object not found");
       }
-      const url = await getUrlBuilder()(input.key);
+      // Prefer the owner-prefixed object; fall back to the flat legacy key
+      // when a deployment hasn't run `nodetool storage migrate-keys` yet.
+      const adapter = getAssetAdapter();
+      const owner = assetKeyOwner(input.key);
+      let key = input.key;
+      if (owner === ctx.userId) {
+        const resolved = await resolveExistingAssetKey(
+          adapter,
+          ctx.userId,
+          input.key.slice(owner.length + 1)
+        );
+        if (resolved) key = resolved;
+      }
+      const url = await getUrlBuilder()(key);
       return { url };
     })
 });

--- a/packages/websocket/src/trpc/routers/storage.ts
+++ b/packages/websocket/src/trpc/routers/storage.ts
@@ -2,14 +2,13 @@
  * tRPC router for the storage domain — JSON ops only.
  * Binary PUT/GET stay as REST (/api/storage/*).
  */
-import path from "node:path";
 import { loadAssetStorageConfig } from "@nodetool-ai/config";
 import { createAssetUrlBuilder } from "@nodetool-ai/storage";
-import { Asset } from "@nodetool-ai/models";
 
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
+import { callerOwnsStorageKey } from "../../lib/storage-access.js";
 import {
   signUrlInput,
   signUrlOutput
@@ -28,32 +27,6 @@ function validateStorageKey(key: string): string | null {
   if (parts.some((p) => p === ".."))
     return "Key must not contain path traversal";
   return null; // valid
-}
-
-// Asset files are stored flat as `{assetId}.{ext}` and `{assetId}_thumb.jpg`.
-// Derive the owning asset id from a storage key so operations can be scoped to
-// the caller — the storage dir is a single shared bucket with no per-user
-// prefix, so without this any authenticated user could enumerate/read/delete
-// every other user's asset files (IDOR).
-function assetIdFromKey(key: string): string | null {
-  const base = path.basename(key.replace(/\\/g, "/"));
-  const withoutExt = base.replace(/\.[^.]+$/, "");
-  const id = withoutExt.replace(/_thumb$/, "");
-  return id || null;
-}
-
-// Verifies the key references an asset owned by `userId`. Returns false (fail
-// closed) for keys that don't map to an owned asset, so a traversal-clean but
-// foreign key can't be read or deleted.
-async function callerOwnsKey(userId: string, key: string): Promise<boolean> {
-  const assetId = assetIdFromKey(key);
-  if (!assetId) return false;
-  try {
-    return (await Asset.find(userId, assetId)) !== null;
-  } catch {
-    // Fail closed: deny when ownership can't be verified.
-    return false;
-  }
 }
 
 // ── URL builder (lazy, cached per backend kind) ───────────────────────────────
@@ -81,7 +54,7 @@ export const storageRouter = router({
       if (validationError) {
         throwApiError(ApiErrorCode.INVALID_INPUT, validationError);
       }
-      if (!(await callerOwnsKey(ctx.userId, input.key))) {
+      if (!(await callerOwnsStorageKey(ctx.userId, input.key))) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Object not found");
       }
       const url = await getUrlBuilder()(input.key);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -132,7 +132,7 @@ import type { PythonBridge } from "@nodetool-ai/runtime";
 import { appRouter } from "./trpc/router.js";
 import { createCallerFactory } from "./trpc/index.js";
 import type { HttpApiOptions } from "./http-api.js";
-import { getAssetFileName } from "./lib/asset-paths.js";
+import { getAssetFileName, retrieveAssetBytes } from "./lib/asset-paths.js";
 
 const log = createLogger("nodetool.websocket.runner");
 const DATA_URI_PATTERN = /data:([^;,]+)?;base64,[A-Za-z0-9+/=\r\n]+/gi;
@@ -724,7 +724,13 @@ async function autoSaveAssets(
 
     const fileName = getAssetFileName(asset.id, contentType);
     try {
-      await storeAssetWithThumbnail(asset.id, fileName, bytes, contentType);
+      await storeAssetWithThumbnail(
+        asset.user_id,
+        asset.id,
+        fileName,
+        bytes,
+        contentType
+      );
       asset.size = bytes.length;
       await asset.save();
 
@@ -775,7 +781,13 @@ async function autoSaveAssets(
           : { text: previewText };
       const fileName = `${asset.id}.txt`;
       try {
-        await storeAssetWithThumbnail(asset.id, fileName, bytes, "text/plain");
+        await storeAssetWithThumbnail(
+          asset.user_id,
+          asset.id,
+          fileName,
+          bytes,
+          "text/plain"
+        );
         asset.size = bytes.length;
         await asset.save();
       } catch (err) {
@@ -831,6 +843,7 @@ async function autoSaveAssets(
         const fileName = `${asset.id}.json`;
         try {
           await storeAssetWithThumbnail(
+            asset.user_id,
             asset.id,
             fileName,
             bytes,
@@ -939,6 +952,7 @@ function createRuntimeContext(opts: {
         const ext = MIME_TO_EXT[args.contentType] ?? "bin";
         const key = `${asset.id}.${ext}`;
         await storeAssetWithThumbnail(
+          asset.user_id,
           asset.id,
           key,
           args.content,
@@ -3221,7 +3235,13 @@ export class UnifiedWebSocketRunner {
           parent_id: null
         });
         const fileName = `${asset.id}.${ext}`;
-        await storeAssetWithThumbnail(asset.id, fileName, bytes, mimeType);
+        await storeAssetWithThumbnail(
+          asset.user_id,
+          asset.id,
+          fileName,
+          bytes,
+          mimeType
+        );
         asset.size = bytes.length;
         await asset.save();
         // The DB / wire shape mirrors handleMediaGenerationMessage: an asset_id
@@ -4953,7 +4973,13 @@ export class UnifiedWebSocketRunner {
         parent_id: null
       });
       const fileName = `${asset.id}.${ext}`;
-      await storeAssetWithThumbnail(asset.id, fileName, bytes, contentType);
+      await storeAssetWithThumbnail(
+        asset.user_id,
+        asset.id,
+        fileName,
+        bytes,
+        contentType
+      );
       asset.size = bytes.length;
       await asset.save();
       return asset.id;
@@ -5542,9 +5568,11 @@ export class UnifiedWebSocketRunner {
       try {
         const asset = await Asset.find(userId, assetId);
         if (!asset) return null;
-        const adapter = getAssetAdapter();
-        return await adapter.retrieve(
-          adapter.uriForKey(getAssetFileName(assetId, asset.content_type))
+        return await retrieveAssetBytes(
+          getAssetAdapter(),
+          userId,
+          assetId,
+          asset.content_type
         );
       } catch (err) {
         log.warn("resolveSourceImageBytes: asset load failed", {
@@ -6229,7 +6257,13 @@ export class UnifiedWebSocketRunner {
         parent_id: null
       });
       const fileName = `${asset.id}.${ext}`;
-      await storeAssetWithThumbnail(asset.id, fileName, bytes, contentType);
+      await storeAssetWithThumbnail(
+        asset.user_id,
+        asset.id,
+        fileName,
+        bytes,
+        contentType
+      );
       asset.size = bytes.length;
       await asset.save();
       return asset.id;
@@ -6390,15 +6424,17 @@ export class UnifiedWebSocketRunner {
       if (!maskAsset)
         throw new Error(`Mask asset not found: ${req.maskAssetId}`);
       const [sourceBytes, maskBytes] = await Promise.all([
-        adapter.retrieve(
-          adapter.uriForKey(
-            getAssetFileName(req.sourceAssetId, sourceAsset.content_type)
-          )
+        retrieveAssetBytes(
+          adapter,
+          userId,
+          req.sourceAssetId,
+          sourceAsset.content_type
         ),
-        adapter.retrieve(
-          adapter.uriForKey(
-            getAssetFileName(req.maskAssetId, maskAsset.content_type)
-          )
+        retrieveAssetBytes(
+          adapter,
+          userId,
+          req.maskAssetId,
+          maskAsset.content_type
         )
       ]);
       if (!sourceBytes)
@@ -6425,11 +6461,11 @@ export class UnifiedWebSocketRunner {
       if (!sourceAsset) {
         throw new Error(`Source asset not found: ${req.sourceAssetId}`);
       }
-      const adapter = getAssetAdapter();
-      const sourceBytes = await adapter.retrieve(
-        adapter.uriForKey(
-          getAssetFileName(req.sourceAssetId, sourceAsset.content_type)
-        )
+      const sourceBytes = await retrieveAssetBytes(
+        getAssetAdapter(),
+        userId,
+        req.sourceAssetId,
+        sourceAsset.content_type
       );
       if (!sourceBytes) {
         throw new Error(`Source asset bytes not found: ${req.sourceAssetId}`);
@@ -6485,9 +6521,11 @@ export class UnifiedWebSocketRunner {
     if (!asset) {
       throw new Error(`Audio asset not found: ${req.assetId}`);
     }
-    const adapter = getAssetAdapter();
-    const bytes = await adapter.retrieve(
-      adapter.uriForKey(getAssetFileName(req.assetId, asset.content_type))
+    const bytes = await retrieveAssetBytes(
+      getAssetAdapter(),
+      userId,
+      req.assetId,
+      asset.content_type
     );
     if (!bytes) {
       throw new Error(`Audio asset bytes not found: ${req.assetId}`);

--- a/packages/websocket/tests/file-api.test.ts
+++ b/packages/websocket/tests/file-api.test.ts
@@ -17,10 +17,14 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "file-api-test-"));
   // Remove production flag
   delete process.env["NODETOOL_ENV"];
+  // The endpoint only serves paths inside the configured roots (home by
+  // default); point them at the fixture dir for these tests.
+  process.env["NODETOOL_LOCAL_FILE_ROOTS"] = tmpDir;
 });
 
 afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env["NODETOOL_LOCAL_FILE_ROOTS"];
   vi.restoreAllMocks();
 });
 
@@ -108,9 +112,57 @@ describe("/api/files/local", () => {
   });
 
   it("denies sensitive home paths (e.g. ~/.ssh)", async () => {
+    // Sensitive entries are refused even when home is an allowed root.
+    process.env["NODETOOL_LOCAL_FILE_ROOTS"] = os.homedir();
     const sshKey = path.join(os.homedir(), ".ssh", "id_rsa");
     const res = await handleFileRequest(localRequest(sshKey));
     expect(res.status).toBe(403);
+  });
+
+  it("denies a path outside the allowed roots", async () => {
+    const res = await handleFileRequest(localRequest("/etc/passwd"));
+    expect(res.status).toBe(403);
+    expect((await res.json()).detail).toContain("outside the allowed roots");
+  });
+
+  it("defaults the root to the home directory", async () => {
+    delete process.env["NODETOOL_LOCAL_FILE_ROOTS"];
+    const file = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(file, "video-bytes");
+    // tmpDir is outside home, so the default policy refuses it.
+    const res = await handleFileRequest(localRequest(file));
+    expect(res.status).toBe(403);
+  });
+
+  it("denies a symlink that escapes the roots", async () => {
+    const link = path.join(tmpDir, "escape.txt");
+    await fs.symlink("/etc/passwd", link);
+    const res = await handleFileRequest(localRequest(link));
+    expect(res.status).toBe(403);
+  });
+
+  it("denies a path that escapes through a symlinked parent", async () => {
+    const linkDir = path.join(tmpDir, "outside");
+    await fs.symlink("/etc", linkDir);
+    const res = await handleFileRequest(
+      localRequest(path.join(linkDir, "passwd"))
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows multiple configured roots", async () => {
+    const otherDir = await fs.mkdtemp(path.join(os.tmpdir(), "file-api-alt-"));
+    try {
+      process.env["NODETOOL_LOCAL_FILE_ROOTS"] = [tmpDir, otherDir].join(
+        path.delimiter
+      );
+      const file = path.join(otherDir, "clip.mp4");
+      await fs.writeFile(file, "video-bytes");
+      const res = await handleFileRequest(localRequest(file));
+      expect(res.status).toBe(200);
+    } finally {
+      await fs.rm(otherDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects non-GET/HEAD methods", async () => {

--- a/packages/websocket/tests/local-file-access.test.ts
+++ b/packages/websocket/tests/local-file-access.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the local-file path policy shared by `GET /api/files/local`
+ * and the tRPC `files.list` browser. The handler tests cover how the verdicts
+ * are turned into responses; these cover the policy itself.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  LOCAL_FILE_ROOTS_ENV,
+  getLocalFileRoots,
+  localPathDenialMessage,
+  resolveLocalPath
+} from "../src/lib/local-file-access.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-file-access-"));
+  delete process.env[LOCAL_FILE_ROOTS_ENV];
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env[LOCAL_FILE_ROOTS_ENV];
+});
+
+describe("getLocalFileRoots", () => {
+  it("defaults to the home directory", () => {
+    expect(getLocalFileRoots()).toEqual([path.resolve(os.homedir())]);
+  });
+
+  it("reads a delimited list from the environment", () => {
+    process.env[LOCAL_FILE_ROOTS_ENV] = [tmpDir, "/srv/media"].join(
+      path.delimiter
+    );
+    expect(getLocalFileRoots()).toEqual([
+      path.resolve(tmpDir),
+      path.resolve("/srv/media")
+    ]);
+  });
+
+  it("expands a leading tilde in a configured root", () => {
+    process.env[LOCAL_FILE_ROOTS_ENV] = "~/media";
+    expect(getLocalFileRoots()).toEqual([path.join(os.homedir(), "media")]);
+  });
+
+  it("falls back to home when the variable holds only separators", () => {
+    process.env[LOCAL_FILE_ROOTS_ENV] = path.delimiter + " ";
+    expect(getLocalFileRoots()).toEqual([path.resolve(os.homedir())]);
+  });
+});
+
+describe("resolveLocalPath", () => {
+  it("accepts an absolute path inside a root", async () => {
+    const file = path.join(tmpDir, "clip.mp4");
+    await fs.writeFile(file, "x");
+    const result = await resolveLocalPath(file, [tmpDir]);
+    expect(result).toEqual({ ok: true, path: file });
+  });
+
+  it("resolves a relative path against the first root", async () => {
+    const result = await resolveLocalPath("sub/clip.mp4", [tmpDir]);
+    expect(result).toEqual({
+      ok: true,
+      path: path.join(tmpDir, "sub", "clip.mp4")
+    });
+  });
+
+  it("accepts a path that does not exist yet, inside a root", async () => {
+    const result = await resolveLocalPath(
+      path.join(tmpDir, "not", "created", "yet.png"),
+      [tmpDir]
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a path outside every root", async () => {
+    const result = await resolveLocalPath("/etc/passwd", [tmpDir]);
+    expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+
+  it("rejects traversal out of a root", async () => {
+    const result = await resolveLocalPath("../../etc/passwd", [tmpDir]);
+    expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+
+  it("rejects a NUL byte", async () => {
+    const result = await resolveLocalPath("/tmp/a\0b", [tmpDir]);
+    expect(result).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("rejects an empty path", async () => {
+    const result = await resolveLocalPath("", [tmpDir]);
+    expect(result).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("rejects a symlink pointing outside the roots", async () => {
+    const link = path.join(tmpDir, "escape");
+    await fs.symlink("/etc/passwd", link);
+    const result = await resolveLocalPath(link, [tmpDir]);
+    expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+
+  it("rejects a leaf reached through a symlinked parent", async () => {
+    await fs.symlink("/etc", path.join(tmpDir, "outside"));
+    const result = await resolveLocalPath(
+      path.join(tmpDir, "outside", "passwd"),
+      [tmpDir]
+    );
+    expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+
+  it("allows a symlink that stays inside the roots", async () => {
+    const target = path.join(tmpDir, "real.txt");
+    await fs.writeFile(target, "x");
+    const link = path.join(tmpDir, "alias.txt");
+    await fs.symlink(target, link);
+    const result = await resolveLocalPath(link, [tmpDir]);
+    expect(result).toEqual({ ok: true, path: link });
+  });
+
+  it("rejects sensitive home entries even inside a root", async () => {
+    const home = os.homedir();
+    for (const entry of [".ssh/id_rsa", ".aws/credentials", ".npmrc"]) {
+      const result = await resolveLocalPath(path.join(home, entry), [home]);
+      expect(result).toEqual({ ok: false, reason: "sensitive" });
+    }
+  });
+
+  it("expands a leading tilde", async () => {
+    const home = os.homedir();
+    const result = await resolveLocalPath("~/Documents", [home]);
+    expect(result).toEqual({ ok: true, path: path.join(home, "Documents") });
+  });
+
+  it("treats a root's own path as inside it", async () => {
+    const result = await resolveLocalPath(tmpDir, [tmpDir]);
+    expect(result).toEqual({ ok: true, path: tmpDir });
+  });
+
+  it("does not treat a sibling with a shared prefix as inside a root", async () => {
+    const result = await resolveLocalPath(`${tmpDir}-sibling/file.txt`, [
+      tmpDir
+    ]);
+    expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+});
+
+describe("localPathDenialMessage", () => {
+  it("names the override variable when a path is out of bounds", () => {
+    expect(localPathDenialMessage("outside_roots")).toContain(
+      LOCAL_FILE_ROOTS_ENV
+    );
+  });
+
+  it("returns a message for every reason", () => {
+    for (const reason of ["invalid", "outside_roots", "sensitive"] as const) {
+      expect(localPathDenialMessage(reason)).toBeTruthy();
+    }
+  });
+});

--- a/packages/websocket/tests/storage-access.test.ts
+++ b/packages/websocket/tests/storage-access.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the `/api/storage/<key>` ownership rules. The REST handler and
+ * tRPC router tests cover how these are applied; these cover the helpers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findAsset = vi.fn();
+vi.mock("@nodetool-ai/models", () => ({
+  Asset: { find: (...args: unknown[]) => findAsset(...args) }
+}));
+
+import {
+  assetIdFromKey,
+  callerOwnsStorageKey,
+  canReadStorageKey,
+  isRuntimeScratchKey
+} from "../src/lib/storage-access.js";
+
+beforeEach(() => {
+  findAsset.mockReset();
+});
+
+describe("assetIdFromKey", () => {
+  it.each([
+    ["abc123.png", "abc123"],
+    ["abc123_thumb.jpg", "abc123"],
+    ["abc123", "abc123"],
+    ["nested/dir/abc123.png", "abc123"],
+    ["nested\\dir\\abc123.png", "abc123"]
+  ])("maps %s to %s", (key, expected) => {
+    expect(assetIdFromKey(key)).toBe(expected);
+  });
+
+  it("returns null when no id remains", () => {
+    expect(assetIdFromKey("")).toBeNull();
+    expect(assetIdFromKey(".png")).toBeNull();
+  });
+});
+
+describe("isRuntimeScratchKey", () => {
+  it.each(["temp/x.png", "assets/x.bin", "/temp/x.png", "temp/nested/x.png"])(
+    "recognises %s",
+    (key) => {
+      expect(isRuntimeScratchKey(key)).toBe(true);
+    }
+  );
+
+  it.each(["x.png", "tempx/x.png", "assetsy/x.png", "a/temp/x.png"])(
+    "does not recognise %s",
+    (key) => {
+      expect(isRuntimeScratchKey(key)).toBe(false);
+    }
+  );
+});
+
+describe("callerOwnsStorageKey", () => {
+  it("grants the owner", async () => {
+    findAsset.mockResolvedValue({ id: "abc", user_id: "user-a" });
+    await expect(callerOwnsStorageKey("user-a", "abc.png")).resolves.toBe(true);
+    expect(findAsset).toHaveBeenCalledWith("user-a", "abc");
+  });
+
+  it("denies when the asset is not the caller's", async () => {
+    findAsset.mockResolvedValue(null);
+    await expect(callerOwnsStorageKey("user-b", "abc.png")).resolves.toBe(
+      false
+    );
+  });
+
+  it("scopes a thumbnail to the underlying asset", async () => {
+    findAsset.mockResolvedValue({ id: "abc", user_id: "user-a" });
+    await expect(
+      callerOwnsStorageKey("user-a", "abc_thumb.jpg")
+    ).resolves.toBe(true);
+    expect(findAsset).toHaveBeenCalledWith("user-a", "abc");
+  });
+
+  it("fails closed when the lookup throws", async () => {
+    findAsset.mockRejectedValue(new Error("db down"));
+    await expect(callerOwnsStorageKey("user-a", "abc.png")).resolves.toBe(
+      false
+    );
+  });
+
+  it("fails closed for a key with no derivable id", async () => {
+    await expect(callerOwnsStorageKey("user-a", "")).resolves.toBe(false);
+    expect(findAsset).not.toHaveBeenCalled();
+  });
+});
+
+describe("canReadStorageKey", () => {
+  it("allows runtime scratch keys without a lookup", async () => {
+    await expect(canReadStorageKey("anyone", "temp/x.png")).resolves.toBe(true);
+    expect(findAsset).not.toHaveBeenCalled();
+  });
+
+  it("requires ownership for asset keys", async () => {
+    findAsset.mockResolvedValue(null);
+    await expect(canReadStorageKey("user-b", "abc.png")).resolves.toBe(false);
+  });
+});

--- a/packages/websocket/tests/storage-access.test.ts
+++ b/packages/websocket/tests/storage-access.test.ts
@@ -94,7 +94,35 @@ describe("canReadStorageKey", () => {
     expect(findAsset).not.toHaveBeenCalled();
   });
 
-  it("requires ownership for asset keys", async () => {
+  it("settles an owner-prefixed key from the prefix alone", async () => {
+    await expect(
+      canReadStorageKey("user-a", "user-a/abc.png")
+    ).resolves.toBe(true);
+    expect(findAsset).not.toHaveBeenCalled();
+  });
+
+  it("denies another owner's prefix even when the asset row would match", async () => {
+    // A stale/permissive row must not override the prefix — the prefix is the
+    // same boundary the bucket policy enforces on the object itself.
+    findAsset.mockResolvedValue({ id: "abc", user_id: "user-b" });
+    await expect(
+      canReadStorageKey("user-b", "user-a/abc.png")
+    ).resolves.toBe(false);
+  });
+
+  it("does not treat a prefix match as a substring match", async () => {
+    await expect(
+      canReadStorageKey("user-a", "user-abc/abc.png")
+    ).resolves.toBe(false);
+  });
+
+  it("falls back to the asset row for legacy flat keys", async () => {
+    findAsset.mockResolvedValue({ id: "abc", user_id: "user-a" });
+    await expect(canReadStorageKey("user-a", "abc.png")).resolves.toBe(true);
+    expect(findAsset).toHaveBeenCalledWith("user-a", "abc");
+  });
+
+  it("requires ownership for legacy flat keys", async () => {
     findAsset.mockResolvedValue(null);
     await expect(canReadStorageKey("user-b", "abc.png")).resolves.toBe(false);
   });

--- a/packages/websocket/tests/storage-api.test.ts
+++ b/packages/websocket/tests/storage-api.test.ts
@@ -3,10 +3,22 @@
  * and full request handling via createStorageHandler.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
+
+// Reads are scoped to assets the caller owns. These tests exercise the binary
+// surface, so ownership is stubbed; `ownsAsset` is re-pointed per test to cover
+// the scoping rules themselves.
+let ownsAsset: (userId: string, assetId: string) => boolean;
+vi.mock("@nodetool-ai/models", () => ({
+  Asset: {
+    find: async (userId: string, assetId: string) =>
+      ownsAsset(userId, assetId) ? { id: assetId, user_id: userId } : null
+  }
+}));
+
 import { createStorageHandler } from "../src/storage-api.js";
 import { resetCorsConfig } from "../src/cors.js";
 
@@ -18,6 +30,8 @@ let tmpDir: string;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "storage-api-test-"));
+  // Default: the anonymous/local caller ("1") owns everything it asks for.
+  ownsAsset = (userId) => userId === "1";
 });
 
 afterEach(async () => {
@@ -25,10 +39,7 @@ afterEach(async () => {
 });
 
 function makeHandler() {
-  return createStorageHandler({
-    storagePath: tmpDir,
-    tempStoragePath: path.join(tmpDir, "temp")
-  });
+  return createStorageHandler({ storagePath: tmpDir });
 }
 
 function makeRequest(
@@ -240,36 +251,124 @@ describe("range requests", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PUT / GET lifecycle (DELETE migrated to tRPC)
+// Read-only surface (writes and deletes are not exposed over REST)
 // ---------------------------------------------------------------------------
 
-describe("PUT / GET lifecycle", () => {
-  it("uploads and retrieves a file", async () => {
+describe("read-only surface", () => {
+  it("retrieves a stored file", async () => {
     const handler = makeHandler();
     const data = "test file content";
+    await fs.mkdir(path.join(tmpDir, "lifecycle"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "lifecycle", "test.txt"), data);
 
-    // PUT
-    const putRes = await handler(
-      makeRequest("/api/storage/lifecycle/test.txt", "PUT", {}, data)
-    );
-    expect(putRes.status).toBe(200);
-
-    // GET
     const getRes = await handler(
       makeRequest("/api/storage/lifecycle/test.txt")
     );
     expect(getRes.status).toBe(200);
     expect(getRes.headers.get("Content-Type")).toBe("text/plain");
-    const body = await getRes.text();
-    expect(body).toBe(data);
+    expect(await getRes.text()).toBe(data);
   });
 
-  it("DELETE returns 405 (moved to tRPC storage.delete)", async () => {
+  it.each(["PUT", "POST", "PATCH", "DELETE"])(
+    "%s returns 405",
+    async (method) => {
+      const handler = makeHandler();
+      const res = await handler(
+        makeRequest("/api/storage/test.txt", method, {}, "payload")
+      );
+      expect(res.status).toBe(405);
+    }
+  );
+
+  it("PUT never writes the file it was pointed at", async () => {
     const handler = makeHandler();
+    const target = path.join(tmpDir, "victim.png");
+    await fs.writeFile(target, "original");
+
     const res = await handler(
-      makeRequest("/api/storage/nonexistent.txt", "DELETE")
+      makeRequest("/api/storage/victim.png", "PUT", {}, "overwritten")
     );
     expect(res.status).toBe(405);
+    expect(await fs.readFile(target, "utf8")).toBe("original");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-user scoping
+// ---------------------------------------------------------------------------
+
+describe("ownership scoping", () => {
+  beforeEach(async () => {
+    await fs.writeFile(path.join(tmpDir, "asset-a.png"), "a-bytes");
+    await fs.writeFile(path.join(tmpDir, "asset-a_thumb.jpg"), "a-thumb");
+    await fs.mkdir(path.join(tmpDir, "temp"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "temp", "scratch.png"), "t-bytes");
+    // Only user-a owns asset-a.
+    ownsAsset = (userId, assetId) => userId === "user-a" && assetId === "asset-a";
+  });
+
+  it("serves the owner's asset", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/asset-a.png", "GET", { "x-user-id": "user-a" })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("a-bytes");
+  });
+
+  it("serves the owner's thumbnail", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/asset-a_thumb.jpg", "GET", {
+        "x-user-id": "user-a"
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("hides another user's asset behind a 404", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/asset-a.png", "GET", { "x-user-id": "user-b" })
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain("a-bytes");
+  });
+
+  it("hides another user's thumbnail too", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/asset-a_thumb.jpg", "HEAD", {
+        "x-user-id": "user-b"
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a key that maps to no asset at all", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/orphan.png", "GET", { "x-user-id": "user-a" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("serves runtime scratch keys, which have no asset row", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/temp/scratch.png", "GET", {
+        "x-user-id": "user-b"
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("t-bytes");
+  });
+
+  it("does not treat a missing x-user-id as a bypass", async () => {
+    // No header → the local single-user id "1", which still has to own the key.
+    const handler = makeHandler();
+    const res = await handler(makeRequest("/api/storage/asset-a.png"));
+    expect(res.status).toBe(404);
   });
 });
 
@@ -329,22 +428,15 @@ describe("If-Modified-Since", () => {
 // ---------------------------------------------------------------------------
 
 describe("temp storage routing", () => {
-  it("routes /api/storage/temp/ to temp storage path", async () => {
+  it("serves /api/storage/temp/ from the temp subdirectory of the root", async () => {
     const handler = makeHandler();
     const data = "temp data";
+    await fs.mkdir(path.join(tmpDir, "temp"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "temp", "tmp-file.txt"), data);
 
-    const putRes = await handler(
-      makeRequest("/api/storage/temp/tmp-file.txt", "PUT", {}, data)
-    );
-    expect(putRes.status).toBe(200);
-
-    // Verify file exists in temp dir
-    const filePath = path.join(tmpDir, "temp", "tmp-file.txt");
-    const exists = await fs
-      .stat(filePath)
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).toBe(true);
+    const res = await handler(makeRequest("/api/storage/temp/tmp-file.txt"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(data);
   });
 });
 

--- a/packages/websocket/tests/storage-api.test.ts
+++ b/packages/websocket/tests/storage-api.test.ts
@@ -258,12 +258,11 @@ describe("read-only surface", () => {
   it("retrieves a stored file", async () => {
     const handler = makeHandler();
     const data = "test file content";
-    await fs.mkdir(path.join(tmpDir, "lifecycle"), { recursive: true });
-    await fs.writeFile(path.join(tmpDir, "lifecycle", "test.txt"), data);
+    // Keys are owner-prefixed: `<userId>/<assetId>.<ext>`.
+    await fs.mkdir(path.join(tmpDir, "1"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "1", "test.txt"), data);
 
-    const getRes = await handler(
-      makeRequest("/api/storage/lifecycle/test.txt")
-    );
+    const getRes = await handler(makeRequest("/api/storage/1/test.txt"));
     expect(getRes.status).toBe(200);
     expect(getRes.headers.get("Content-Type")).toBe("text/plain");
     expect(await getRes.text()).toBe(data);
@@ -362,6 +361,57 @@ describe("ownership scoping", () => {
     );
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("t-bytes");
+  });
+
+  it("serves an owner-prefixed key without consulting the asset row", async () => {
+    const handler = makeHandler();
+    await fs.mkdir(path.join(tmpDir, "user-a"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "user-a", "new.png"), "new-bytes");
+    ownsAsset = () => false; // prefix alone must be enough
+
+    const res = await handler(
+      makeRequest("/api/storage/user-a/new.png", "GET", {
+        "x-user-id": "user-a"
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("new-bytes");
+  });
+
+  it("denies a key under another owner's prefix", async () => {
+    const handler = makeHandler();
+    await fs.mkdir(path.join(tmpDir, "user-a"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "user-a", "new.png"), "new-bytes");
+
+    const res = await handler(
+      makeRequest("/api/storage/user-a/new.png", "GET", {
+        "x-user-id": "user-b"
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("falls back to the legacy flat object when the prefixed one is missing", async () => {
+    // Pre-migration deployments still have flat objects on disk; the owner is
+    // re-established from the asset row before serving one.
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/user-a/asset-a.png", "GET", {
+        "x-user-id": "user-a"
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("a-bytes");
+  });
+
+  it("does not serve a legacy object the caller does not own", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest("/api/storage/user-b/asset-a.png", "GET", {
+        "x-user-id": "user-b"
+      })
+    );
+    expect(res.status).toBe(404);
   });
 
   it("does not treat a missing x-user-id as a bypass", async () => {

--- a/packages/websocket/tests/thumbnail-extra-coverage.test.ts
+++ b/packages/websocket/tests/thumbnail-extra-coverage.test.ts
@@ -46,6 +46,7 @@ describe("storeAssetWithThumbnail", () => {
 
   it("stores only the original for a non-media content type", async () => {
     await storeAssetWithThumbnail(
+      "u1",
       "a1",
       "notes.txt",
       new Uint8Array([1, 2, 3]),
@@ -54,7 +55,7 @@ describe("storeAssetWithThumbnail", () => {
     // No generator -> exactly one store (the original), no thumbnail store.
     expect(store).toHaveBeenCalledTimes(1);
     expect(store).toHaveBeenCalledWith(
-      "notes.txt",
+      "u1/notes.txt",
       expect.any(Uint8Array),
       "text/plain"
     );
@@ -62,12 +63,12 @@ describe("storeAssetWithThumbnail", () => {
 
   it("stores original and a JPEG thumbnail for an image", async () => {
     const bytes = await tinyPng();
-    await storeAssetWithThumbnail("img1", "pic.png", bytes, "image/png");
+    await storeAssetWithThumbnail("u1", "img1", "pic.png", bytes, "image/png");
     expect(store).toHaveBeenCalledTimes(2);
-    expect(store).toHaveBeenNthCalledWith(1, "pic.png", bytes, "image/png");
+    expect(store).toHaveBeenNthCalledWith(1, "u1/pic.png", bytes, "image/png");
     expect(store).toHaveBeenNthCalledWith(
       2,
-      "img1_thumb.jpg",
+      "u1/img1_thumb.jpg",
       expect.any(Uint8Array),
       "image/jpeg"
     );
@@ -77,6 +78,7 @@ describe("storeAssetWithThumbnail", () => {
     // Invalid image bytes: both the trim pass and the untrimmed fallback in
     // generateImageThumb throw, and storeAssetWithThumbnail swallows it.
     await storeAssetWithThumbnail(
+      "u1",
       "bad",
       "broken.png",
       new Uint8Array([0, 1, 2, 3, 4]),
@@ -85,7 +87,7 @@ describe("storeAssetWithThumbnail", () => {
     // Original stored; thumbnail store never reached.
     expect(store).toHaveBeenCalledTimes(1);
     expect(store).toHaveBeenCalledWith(
-      "broken.png",
+      "u1/broken.png",
       expect.any(Uint8Array),
       "image/png"
     );
@@ -93,6 +95,7 @@ describe("storeAssetWithThumbnail", () => {
 
   it("selects the video generator and swallows ffmpeg failures", async () => {
     await storeAssetWithThumbnail(
+      "u1",
       "vid",
       "clip.mp4",
       new Uint8Array([0, 1, 2, 3]),
@@ -100,7 +103,7 @@ describe("storeAssetWithThumbnail", () => {
     );
     expect(store).toHaveBeenCalledTimes(1);
     expect(store).toHaveBeenCalledWith(
-      "clip.mp4",
+      "u1/clip.mp4",
       expect.any(Uint8Array),
       "video/mp4"
     );
@@ -108,6 +111,7 @@ describe("storeAssetWithThumbnail", () => {
 
   it("selects the audio generator and swallows ffmpeg failures", async () => {
     await storeAssetWithThumbnail(
+      "u1",
       "aud",
       "sound.mp3",
       new Uint8Array([0, 1, 2, 3]),
@@ -115,7 +119,7 @@ describe("storeAssetWithThumbnail", () => {
     );
     expect(store).toHaveBeenCalledTimes(1);
     expect(store).toHaveBeenCalledWith(
-      "sound.mp3",
+      "u1/sound.mp3",
       expect.any(Uint8Array),
       "audio/mpeg"
     );
@@ -123,6 +127,7 @@ describe("storeAssetWithThumbnail", () => {
 
   it("selects the pdf generator and swallows parse failures", async () => {
     await storeAssetWithThumbnail(
+      "u1",
       "doc",
       "file.pdf",
       new Uint8Array([0, 1, 2, 3]),
@@ -130,7 +135,7 @@ describe("storeAssetWithThumbnail", () => {
     );
     expect(store).toHaveBeenCalledTimes(1);
     expect(store).toHaveBeenCalledWith(
-      "file.pdf",
+      "u1/file.pdf",
       expect.any(Uint8Array),
       "application/pdf"
     );

--- a/packages/websocket/tests/thumbnail-store-coverage.test.ts
+++ b/packages/websocket/tests/thumbnail-store-coverage.test.ts
@@ -39,6 +39,7 @@ describe("storeAssetWithThumbnail", () => {
 
   it("stores the original but no thumbnail for an unsupported content type", async () => {
     await storeAssetWithThumbnail(
+      "u1",
       "id1",
       "file.txt",
       new Uint8Array([1, 2, 3]),
@@ -46,7 +47,7 @@ describe("storeAssetWithThumbnail", () => {
     );
     expect(storeMock).toHaveBeenCalledTimes(1);
     expect(storeMock).toHaveBeenCalledWith(
-      "file.txt",
+      "u1/file.txt",
       expect.any(Uint8Array),
       "text/plain"
     );
@@ -54,32 +55,33 @@ describe("storeAssetWithThumbnail", () => {
 
   it("stores original and a jpeg thumbnail for an image", async () => {
     const png = await tinyPng();
-    await storeAssetWithThumbnail("id2", "pic.png", new Uint8Array(png), "image/png");
+    await storeAssetWithThumbnail("u1", "id2", "pic.png", new Uint8Array(png), "image/png");
     expect(storeMock).toHaveBeenCalledTimes(2);
     // second call stores the thumbnail
     const thumbCall = storeMock.mock.calls[1];
-    expect(thumbCall[0]).toBe("id2_thumb.jpg");
+    expect(thumbCall[0]).toBe("u1/id2_thumb.jpg");
     expect(thumbCall[2]).toBe("image/jpeg");
   });
 
   it("swallows thumbnail generation failure but still stores the original", async () => {
     const notAnImage = new Uint8Array([0, 1, 2, 3, 4]);
-    await storeAssetWithThumbnail("id3", "broken.png", notAnImage, "image/png");
+    await storeAssetWithThumbnail("u1", "id3", "broken.png", notAnImage, "image/png");
     // original stored; thumbnail generation failed and was swallowed
     expect(storeMock).toHaveBeenCalledTimes(1);
-    expect(storeMock.mock.calls[0][0]).toBe("broken.png");
+    expect(storeMock.mock.calls[0][0]).toBe("u1/broken.png");
   });
 
   it("selects the generator by content-type prefix (audio path attempts thumb)", async () => {
     // audio uses ffmpeg which will fail on these bytes; failure is swallowed,
     // so only the original store call remains.
     await storeAssetWithThumbnail(
+      "u1",
       "id4",
       "clip.wav",
       new Uint8Array([1, 2, 3]),
       "audio/wav"
     );
-    expect(storeMock.mock.calls[0][0]).toBe("clip.wav");
+    expect(storeMock.mock.calls[0][0]).toBe("u1/clip.wav");
   });
 });
 

--- a/packages/websocket/tests/trpc-assets-upload.test.ts
+++ b/packages/websocket/tests/trpc-assets-upload.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the client-direct upload procedures: `assets.createUpload` mints
+ * a target for a key the *server* picks, and `assets.finalizeUpload` records
+ * what actually landed rather than what the client claimed.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assetCreate: vi.fn(),
+  assetFind: vi.fn(),
+  generateThumb: vi.fn(),
+  adapter: {
+    createUploadUrl: vi.fn() as ReturnType<typeof vi.fn> | undefined,
+    stat: vi.fn(),
+    delete: vi.fn(),
+    uriForKey: (key: string) => `file:///assets/${key}`,
+    store: vi.fn(),
+    retrieve: vi.fn()
+  }
+}));
+const { assetCreate, assetFind, generateThumb, adapter } = mocks;
+
+vi.mock("@nodetool-ai/models", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/models")>();
+  return {
+    ...actual,
+    Asset: {
+      ...actual.Asset,
+      create: mocks.assetCreate,
+      find: mocks.assetFind
+    }
+  };
+});
+
+vi.mock("../src/lib/storage.js", () => ({
+  getAssetAdapter: () => mocks.adapter
+}));
+
+vi.mock("../src/lib/thumbnail.js", async (orig) => {
+  const actual = await orig<typeof import("../src/lib/thumbnail.js")>();
+  return { ...actual, generateThumbnailForStoredAsset: mocks.generateThumb };
+});
+
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(userId = "user-1"): Context {
+  return {
+    userId,
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false
+  } as Context;
+}
+
+function pendingAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "a1",
+    user_id: "user-1",
+    parent_id: "user-1",
+    name: "pic.png",
+    content_type: "image/png",
+    size: null,
+    metadata: null,
+    workflow_id: null,
+    node_id: null,
+    job_id: null,
+    timeline_id: null,
+    duration: null,
+    sketch_document_id: null,
+    created_at: "2026-07-27T00:00:00Z",
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env["NODETOOL_MAX_UPLOAD_BYTES"];
+  adapter.createUploadUrl.mockResolvedValue({
+    url: "https://xyz.supabase.co/storage/v1/object/upload/sign/assets/user-1/a1.png?token=t",
+    method: "PUT",
+    headers: { "content-type": "image/png" },
+    expiresAt: 1_800_000_000_000
+  });
+});
+
+describe("assets.createUpload", () => {
+  it("assigns an owner-prefixed key the client never chose", async () => {
+    assetCreate.mockResolvedValue(pendingAsset());
+    const result = await createCaller(makeCtx()).assets.createUpload({
+      name: "pic.png",
+      content_type: "image/png",
+      parent_id: "user-1",
+      size: 1024
+    });
+
+    expect(result.key).toBe("user-1/a1.png");
+    expect(result.asset_id).toBe("a1");
+    expect(adapter.createUploadUrl).toHaveBeenCalledWith("user-1/a1.png", {
+      contentType: "image/png"
+    });
+    expect(result.upload?.method).toBe("PUT");
+  });
+
+  it("creates the row owned by the caller, with size left unset", async () => {
+    assetCreate.mockResolvedValue(pendingAsset());
+    await createCaller(makeCtx()).assets.createUpload({
+      name: "pic.png",
+      content_type: "image/png",
+      parent_id: "user-1",
+      size: 1024
+    });
+    expect(assetCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "user-1", size: null })
+    );
+  });
+
+  it("rejects a declared size over the cap before minting anything", async () => {
+    process.env["NODETOOL_MAX_UPLOAD_BYTES"] = "1000";
+    await expect(
+      createCaller(makeCtx()).assets.createUpload({
+        name: "big.png",
+        content_type: "image/png",
+        parent_id: "user-1",
+        size: 5000
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(assetCreate).not.toHaveBeenCalled();
+    expect(adapter.createUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns a null target on a backend with no direct upload", async () => {
+    assetCreate.mockResolvedValue(pendingAsset());
+    const restore = adapter.createUploadUrl;
+    adapter.createUploadUrl = undefined;
+    try {
+      const result = await createCaller(makeCtx()).assets.createUpload({
+        name: "pic.png",
+        content_type: "image/png",
+        parent_id: "user-1",
+        size: 1024
+      });
+      expect(result.upload).toBeNull();
+      expect(result.key).toBe("user-1/a1.png");
+    } finally {
+      adapter.createUploadUrl = restore;
+    }
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    await expect(
+      createCaller({ ...makeCtx(), userId: null } as Context).assets.createUpload(
+        {
+          name: "pic.png",
+          content_type: "image/png",
+          parent_id: "user-1",
+          size: 1
+        }
+      )
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});
+
+describe("assets.finalizeUpload", () => {
+  it("records the size read off the object, not the client's claim", async () => {
+    const asset = pendingAsset();
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue({ key: "user-1/a1.png", size: 4096, modifiedAt: 0 });
+
+    const result = await createCaller(makeCtx()).assets.finalizeUpload({
+      asset_id: "a1"
+    });
+
+    expect(adapter.stat).toHaveBeenCalledWith("file:///assets/user-1/a1.png");
+    expect(asset.size).toBe(4096);
+    expect(asset.save).toHaveBeenCalled();
+    expect(result.size).toBe(4096);
+  });
+
+  it("deletes the pending row when nothing was uploaded", async () => {
+    const asset = pendingAsset();
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue(null);
+
+    await expect(
+      createCaller(makeCtx()).assets.finalizeUpload({ asset_id: "a1" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(asset.delete).toHaveBeenCalled();
+  });
+
+  it("treats a zero-byte object as no upload", async () => {
+    const asset = pendingAsset();
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue({ key: "user-1/a1.png", size: 0, modifiedAt: 0 });
+
+    await expect(
+      createCaller(makeCtx()).assets.finalizeUpload({ asset_id: "a1" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(asset.delete).toHaveBeenCalled();
+  });
+
+  it("removes an over-cap object instead of keeping it", async () => {
+    process.env["NODETOOL_MAX_UPLOAD_BYTES"] = "1000";
+    const asset = pendingAsset();
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue({ key: "user-1/a1.png", size: 9999, modifiedAt: 0 });
+
+    await expect(
+      createCaller(makeCtx()).assets.finalizeUpload({ asset_id: "a1" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(adapter.delete).toHaveBeenCalledWith(
+      "file:///assets/user-1/a1.png"
+    );
+    expect(asset.delete).toHaveBeenCalled();
+  });
+
+  it("does not finalize another user's asset", async () => {
+    assetFind.mockResolvedValue(null);
+    await expect(
+      createCaller(makeCtx("user-b")).assets.finalizeUpload({ asset_id: "a1" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(assetFind).toHaveBeenCalledWith("user-b", "a1");
+  });
+
+  it("skips the thumbnail download for an oversized object", async () => {
+    const asset = pendingAsset({ content_type: "video/mp4", name: "clip.mp4" });
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue({
+      key: "user-1/a1.mp4",
+      size: 200 * 1024 * 1024,
+      modifiedAt: 0
+    });
+
+    await createCaller(makeCtx()).assets.finalizeUpload({ asset_id: "a1" });
+    expect(generateThumb).not.toHaveBeenCalled();
+  });
+
+  it("generates a thumbnail for an ordinary-sized object", async () => {
+    const asset = pendingAsset();
+    assetFind.mockResolvedValue(asset);
+    adapter.stat.mockResolvedValue({ key: "user-1/a1.png", size: 4096, modifiedAt: 0 });
+
+    await createCaller(makeCtx()).assets.finalizeUpload({ asset_id: "a1" });
+    expect(generateThumb).toHaveBeenCalledWith("user-1", "a1", "image/png");
+  });
+});

--- a/packages/websocket/tests/ws-phase2.test.ts
+++ b/packages/websocket/tests/ws-phase2.test.ts
@@ -160,82 +160,45 @@ describe("T-WS-11: Storage KV API", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ws-storage-test-"));
-    handler = createStorageHandler({
-      storagePath: tmpDir,
-      tempStoragePath: path.join(tmpDir, "temp")
-    });
+    handler = createStorageHandler({ storagePath: tmpDir });
+    await fs.mkdir(path.join(tmpDir, "temp"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "temp", "mykey.txt"), "hello world");
   });
 
   afterEach(async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("PUT /api/storage/{key} stores a value", async () => {
-    const res = await handler(
-      new Request("http://localhost/api/storage/mykey.txt", {
-        method: "PUT",
-        body: "hello world"
-      })
-    );
-    expect(res.status).toBe(200);
-  });
-
   it("GET /api/storage/{key} retrieves a stored value", async () => {
-    // Store first
-    await handler(
-      new Request("http://localhost/api/storage/mykey.txt", {
-        method: "PUT",
-        body: "hello world"
-      })
-    );
-
     const res = await handler(
-      new Request("http://localhost/api/storage/mykey.txt")
+      new Request("http://localhost/api/storage/temp/mykey.txt")
     );
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toBe("hello world");
+    expect(await res.text()).toBe("hello world");
   });
 
   it("GET /api/storage/{key} returns 404 for missing key", async () => {
     const res = await handler(
-      new Request("http://localhost/api/storage/nope.txt")
+      new Request("http://localhost/api/storage/temp/nope.txt")
     );
     expect(res.status).toBe(404);
   });
 
-  it("DELETE /api/storage/{key} returns 405 (moved to tRPC storage.delete)", async () => {
-    // DELETE has been migrated to the tRPC `storage.delete` procedure.
-    // The REST handler now returns 405 Method Not Allowed.
-    await handler(
-      new Request("http://localhost/api/storage/mykey.txt", {
-        method: "PUT",
-        body: "hello"
-      })
-    );
+  it.each(["PUT", "POST", "DELETE"])(
+    "%s /api/storage/{key} returns 405 — the REST surface is read-only",
+    async (method) => {
+      const res = await handler(
+        new Request("http://localhost/api/storage/temp/mykey.txt", {
+          method,
+          body: method === "DELETE" ? undefined : "data"
+        })
+      );
+      expect(res.status).toBe(405);
+    }
+  );
 
-    const delRes = await handler(
-      new Request("http://localhost/api/storage/mykey.txt", {
-        method: "DELETE"
-      })
-    );
-    expect(delRes.status).toBe(405);
-  });
-
-  it("DELETE /api/storage/{key} returns 405 for missing key too (moved to tRPC)", async () => {
-    const res = await handler(
-      new Request("http://localhost/api/storage/nope.txt", { method: "DELETE" })
-    );
-    expect(res.status).toBe(405);
-  });
-
-  it("PUT /api/storage with empty key returns 400", async () => {
-    const res = await handler(
-      new Request("http://localhost/api/storage/", {
-        method: "PUT",
-        body: "data"
-      })
-    );
+  it("GET /api/storage with empty key returns 400", async () => {
+    const res = await handler(new Request("http://localhost/api/storage/"));
     expect(res.status).toBe(400);
   });
 });

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -58,23 +58,76 @@ const emitUploadProgress = (
   });
 };
 
+/**
+ * Upload the bytes straight to the storage backend (Supabase/S3) using a
+ * server-minted, key-scoped target, then have the server confirm what landed.
+ * The file never passes through the API.
+ *
+ * Returns null when the backend has no direct-upload path (the local file
+ * store), which is the signal to fall back to the multipart POST below.
+ */
+const uploadAssetDirect = async (
+  payload: AssetCreatePayload,
+  file: File,
+  onUploadProgress?: (progressEvent: UploadProgressEvent) => void
+): Promise<Asset | null> => {
+  const created = await trpcClient.assets.createUpload.mutate({
+    name: payload.name ?? file.name,
+    content_type: payload.content_type || file.type || "application/octet-stream",
+    parent_id: payload.parent_id ?? "",
+    size: file.size,
+    ...(payload.workflow_id ? { workflow_id: payload.workflow_id } : {})
+  });
+
+  if (!created.upload) {
+    return null;
+  }
+
+  const response = await fetch(created.upload.url, {
+    method: created.upload.method,
+    headers: created.upload.headers,
+    body: file
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Upload to storage failed with status ${response.status}`
+    );
+  }
+
+  emitUploadProgress(onUploadProgress, file.size, file.size);
+  return normalizeAssetUrls(
+    (await trpcClient.assets.finalizeUpload.mutate({
+      asset_id: created.asset_id
+    })) as Asset
+  );
+};
+
 const uploadAsset = async (
   payload: AssetCreatePayload,
   file?: File,
   onUploadProgress?: (progressEvent: UploadProgressEvent) => void,
   errorMessage = "Failed to create asset"
 ): Promise<Asset> => {
+  // Provide basic progress feedback even though fetch-based uploads
+  // don't stream progress events.
+  const total = file?.size ?? 1;
+  emitUploadProgress(onUploadProgress, 0, total);
+
+  if (file) {
+    try {
+      const direct = await uploadAssetDirect(payload, file, onUploadProgress);
+      if (direct) return direct;
+    } catch (error) {
+      normalizeAssetError(error, errorMessage);
+    }
+  }
+
   const formData = new FormData();
   formData.append("json", JSON.stringify(payload));
 
   if (file) {
     formData.append("file", file);
   }
-
-  // Provide basic progress feedback even though fetch-based uploads
-  // don't stream progress events.
-  const total = file?.size ?? 1;
-  emitUploadProgress(onUploadProgress, 0, total);
 
   try {
     const response = await restFetch("/api/assets/", {

--- a/web/src/stores/__tests__/AssetStore.test.ts
+++ b/web/src/stores/__tests__/AssetStore.test.ts
@@ -19,6 +19,8 @@ jest.mock("../../trpc/client", () => ({
       list: { query: jest.fn() },
       get: { query: jest.fn() },
       create: { mutate: jest.fn() },
+      createUpload: { mutate: jest.fn() },
+      finalizeUpload: { mutate: jest.fn() },
       update: { mutate: jest.fn() },
       delete: { mutate: jest.fn() },
       children: { query: jest.fn() },
@@ -57,6 +59,7 @@ import { trpcClient } from "../../trpc/client";
 const mockRestFetch = restFetch as jest.Mock;
 const mockAuthHeader = authHeader as jest.Mock;
 
+const createUploadMutate = trpcClient.assets.createUpload.mutate as jest.Mock;
 const listQuery = trpcClient.assets.list.query as jest.Mock;
 const getQuery = trpcClient.assets.get.query as jest.Mock;
 const updateMutate = trpcClient.assets.update.mutate as jest.Mock;
@@ -83,6 +86,15 @@ describe("AssetStore", () => {
     });
 
     jest.clearAllMocks();
+
+    // Default to a backend with no client-direct upload, so these tests keep
+    // exercising the multipart REST fallback. The direct path has its own
+    // describe block below.
+    createUploadMutate.mockResolvedValue({
+      asset_id: "mock-id",
+      key: "user-1/mock-id.png",
+      upload: null
+    });
 
     // Mock URL APIs used by download()
     (window as any).URL = {
@@ -202,6 +214,87 @@ describe("AssetStore", () => {
 
       expect(mockRestFetch).toHaveBeenCalledWith("/api/assets/", expect.objectContaining({ method: "POST", body: expect.any(FormData) }));
       expect(result).toEqual(mockAsset);
+    });
+
+    describe("client-direct upload (cloud storage backends)", () => {
+      const finalizeMutate = trpcClient.assets.finalizeUpload
+        .mutate as jest.Mock;
+      const uploadTarget = {
+        asset_id: "direct-id",
+        key: "test-user/direct-id.jpg",
+        upload: {
+          url: "https://xyz.supabase.co/storage/v1/object/upload/sign/assets/test-user/direct-id.jpg?token=t",
+          method: "PUT" as const,
+          headers: { "content-type": "image/jpeg" },
+          expires_at: 1_800_000_000_000
+        }
+      };
+      const finalized: Asset = {
+        id: "direct-id",
+        name: "test.jpg",
+        content_type: "image/jpeg",
+        size: 12,
+        created_at: "2026-07-27T00:00:00Z",
+        parent_id: "",
+        user_id: "test-user",
+        get_url: "/assets/direct-id",
+        workflow_id: null,
+        thumb_url: null,
+        metadata: {}
+      };
+      let fetchMock: jest.Mock;
+      let originalFetch: typeof global.fetch;
+
+      beforeEach(() => {
+        createUploadMutate.mockResolvedValue(uploadTarget);
+        finalizeMutate.mockResolvedValue(finalized);
+        fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+        originalFetch = global.fetch;
+        (global as any).fetch = fetchMock;
+      });
+
+      afterEach(() => {
+        global.fetch = originalFetch;
+      });
+
+      it("sends the bytes to storage and never through the API", async () => {
+        const file = new File(["test content"], "test.jpg", {
+          type: "image/jpeg"
+        });
+        const result = await useAssetStore.getState().createAsset(file);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          uploadTarget.upload.url,
+          expect.objectContaining({
+            method: "PUT",
+            headers: uploadTarget.upload.headers,
+            body: file
+          })
+        );
+        expect(mockRestFetch).not.toHaveBeenCalled();
+        expect(finalizeMutate).toHaveBeenCalledWith({ asset_id: "direct-id" });
+        expect(result.id).toBe("direct-id");
+      });
+
+      it("declares the real byte size so the server can pre-check the cap", async () => {
+        const file = new File(["test content"], "test.jpg", {
+          type: "image/jpeg"
+        });
+        await useAssetStore.getState().createAsset(file);
+        expect(createUploadMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ size: file.size })
+        );
+      });
+
+      it("surfaces a failed storage upload instead of finalizing", async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 403 });
+        const file = new File(["x"], "test.jpg", { type: "image/jpeg" });
+
+        await expect(
+          useAssetStore.getState().createAsset(file)
+        ).rejects.toThrow();
+        expect(finalizeMutate).not.toHaveBeenCalled();
+      });
     });
 
     it("uploads valid clipboard PNG payload as image", async () => {


### PR DESCRIPTION
Follow-up to #4520. Two authenticated-but-unscoped gaps, plus the Supabase storage rework that falls out of fixing the first one properly.

## 1. `/api/storage/*` — keys weren't user-scoped

The local backend was one flat directory keyed by asset id, so the key alone said nothing about who owned the bytes. Any authenticated caller could `GET` another tenant's asset by id, and `PUT` let them overwrite it.

**Keys now carry their owner:** `{userId}/{assetId}.{ext}` (thumbnail `{userId}/{assetId}_thumb.jpg`). That's the change that makes the tenant boundary enforceable *outside* the server process — a Supabase Storage RLS policy or an S3 bucket policy can match on the leading segment, and a signed upload URL scoped to such a key can only ever write into its own owner's prefix. `canReadStorageKey` settles a prefixed key from the prefix alone: no DB round trip, and a stale `assets` row can't override it.

**`PUT` and every other verb return 405.** Nothing called it — bytes are written in-process through the storage adapter (asset upload, workflow outputs, thumbnails), never over HTTP. The adapters keep enforcing `NODETOOL_MAX_UPLOAD_BYTES`, so the cap from #4520 is unaffected. `DELETE` already 405'd.

**Rollout is not a hard cutover.** Reads fall back to the flat `{assetId}.{ext}` key: `assetKeyCandidates` for adapter reads, and a stat-and-retry in the `/api/storage` route that re-establishes ownership from the `assets` row before serving a legacy object. `nodetool storage migrate-keys` moves existing objects (`--dry-run`, `--user-id`, safe to re-run; the original is deleted only once the copy reads back, so an interrupted run leaves every asset readable at one key or the other). Cloud backends resolve through signed URLs rather than that fallback, so **Supabase/S3 deployments must run the backfill.**

A user id colliding with a runtime prefix (`temp`, `assets`) is rejected rather than silently landing that user's objects in shared scratch space.

## 2. Supabase/S3 uploads go straight from the browser

Uploads used to proxy through `POST /api/assets` — the whole file buffered in the Node process, double bandwidth, and a request-size ceiling between browser and bucket.

- `StorageAdapter.createUploadUrl(key, opts)` returns a one-shot, key-scoped target. Supabase implements it via `POST /object/upload/sign/…`; S3 via a presigned PUT.
- `assets.createUpload` creates the row, **picks the key** (never the client), and returns the target. `assets.finalizeUpload` reads the object's real size back off the bucket and records that — the signed target bounds *where* a client writes but not *what*, so a missing, empty, or over-cap upload is rejected and the pending row and object removed.
- The web client tries this path first and falls back to multipart when `upload` is null (the local file store), so desktop and local dev are unchanged.
- Thumbnails on this path cost one download back into the process, since the bytes never passed through it. Worth it for ordinary media; objects over 100 MB skip it rather than stream a multi-gigabyte video through the API to make a 512px JPEG.

The service-role key stays server-side throughout — the browser only ever holds a target scoped to one object.

## 3. `GET /api/files/local` accepted any absolute path

It took any absolute path behind a nine-entry denylist while its tRPC counterpart (`files.list`) was sandboxed to `$HOME` — so it would stream `/etc/passwd`, the SQLite database, or a `.env` holding `SECRETS_MASTER_KEY` to any authenticated caller.

Both surfaces now share `lib/local-file-access.ts`: an **allowlist** of roots (home by default, `NODETOOL_LOCAL_FILE_ROOTS` to widen), the sensitive entries still denied *inside* a root, and containment re-checked after symlink resolution — with the unresolved tail re-anchored onto the real ancestor, so neither a symlinked leaf nor a symlinked parent escapes. Roots are compared against their own realpaths too (macOS `/var` → `/private/var`). Both stay disabled outright under `NODETOOL_ENV=production`.

Two file-browser fixes fall out of sharing the resolver: an absolute path is no longer reinterpreted as root-relative (the old `"." + path` trick double-prefixed home, breaking navigation from a listing's own `path` values), and a leading `~` expands.

## Tests

New: `storage-access`, `local-file-access`, `trpc-assets-upload`, `storage-migrate-keys`, plus owner-prefix cases in `storage-keys`, signed-upload cases in `supabase-rest` and `s3-client`, direct-upload cases in the web `AssetStore` suite. Existing suites updated for the new key layout and `storeAssetWithThumbnail` signature.

Green locally: packages/websocket 1735, storage 364, models 757, cli 439, protocol 617, web 12153. `npm run lint` and typecheck (web + electron) clean. The `mobile/` typecheck failures in that environment are its uninstalled Expo tree — not a root workspace, and no mobile file is touched here.

## Docs

`docs/api-reference.md` (storage is `HEAD/GET` and owner-scoped; the two-step upload flow), `docs/configuration.md` (`NODETOOL_LOCAL_FILE_ROOTS`), `docs/security-hardening.md` (asset storage: private bucket, prefix-keyed storage policy, service-role key stays server-side; local file access), `CLAUDE.md` (`nodetool storage migrate-keys`).

## Deploy note

Run `nodetool storage migrate-keys` against any Supabase or S3 deployment as part of this release.

## Not included

The Supabase RLS policies themselves. This PR adds the key layout that makes them expressible and documents the recommended policy shape, but the repo has no SQL migration path for storage policies (only `packages/vectorstore/sql/`), and the exact policy depends on the bucket name. Happy to add it if you want it here.