### PR TITLE
Fix eight issues found reviewing the mini-app platform

### DIFF
--- a/packages/app-runtime/src/actions.ts
+++ b/packages/app-runtime/src/actions.ts
@@ -10,13 +10,7 @@ import type { ResourceOperation, ResourceRef } from "./document.js";
 export type AppAction =
   | { kind: "run"; operationId: string; from?: string }
   | { kind: "cancel"; operationId?: string; invocationId?: string }
-  | {
-      kind: "setVariable";
-      variableId: string;
-      value?: unknown;
-      /** Take the value from the widget that fired the event. */
-      fromWidget?: boolean;
-    }
+  | { kind: "setVariable"; variableId: string; value?: unknown }
   | { kind: "toggleVariable"; variableId: string }
   | {
       kind: "resourceCommand";
@@ -81,13 +75,19 @@ export interface EventContext {
 
 /**
  * Convert a stored widget event into an action, or null when the event is
- * incomplete (an unresolvable variable, a resource command with no binding).
+ * incomplete (an unresolvable variable, a resource command with no binding) or
+ * names a kind this runtime does not know. An unknown kind must not fall
+ * through to `run`: executing a workflow is the costly answer to give a typo.
+ *
+ * An absent or empty `kind` is the one exception — that is how a document
+ * written before the field existed spells "run", and how the app-debug parser
+ * has always read it.
  */
 export const eventToAction = (
   event: AppEvent,
   ctx: EventContext
 ): AppAction | null => {
-  switch (event.kind) {
+  switch (event.kind || "run") {
     case "setVariable":
     case "setState": {
       const variableId = ctx.resolveVariableId(event.key);
@@ -120,11 +120,12 @@ export const eventToAction = (
         ? { kind: "openResource", resourceBindingId: event.resourceBindingId }
         : null;
     case "run":
-    default:
       return {
         kind: "run",
         operationId: event.operationId ?? ctx.defaultOperationId,
         from: ctx.from
       };
+    default:
+      return null;
   }
 };

--- a/packages/app-runtime/src/document.ts
+++ b/packages/app-runtime/src/document.ts
@@ -133,6 +133,84 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isPuckData = (value: unknown): value is PuckData =>
   isRecord(value) && isRecord(value.root) && Array.isArray(value.content);
 
+/**
+ * Parse one input mapping, or null when the entry is not a mapping the union
+ * describes: a non-record, an unknown `from`, or a `variable`/`resource`
+ * mapping with no id to read. A `constant` keeps whatever `value` it carries,
+ * `undefined` included — that is a legitimate constant, and
+ * `resolveOperationParams` already omits undefined values from the run params.
+ */
+const parseInputMapping = (value: unknown): InputMapping | null => {
+  if (!isRecord(value)) return null;
+  switch (value.from) {
+    case "widget":
+      return { from: "widget" };
+    case "variable":
+      return typeof value.variableId === "string" && value.variableId.length > 0
+        ? { from: "variable", variableId: value.variableId }
+        : null;
+    case "constant":
+      return { from: "constant", value: value.value };
+    case "resource":
+      return typeof value.resourceBindingId === "string" &&
+        value.resourceBindingId.length > 0
+        ? { from: "resource", resourceBindingId: value.resourceBindingId }
+        : null;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Parse one output mapping, or null when the entry is not a mapping the union
+ * describes: a non-record, an unknown `to`, or a `variable` mapping with no id
+ * to write.
+ */
+const parseOutputMapping = (value: unknown): OutputMapping | null => {
+  if (!isRecord(value)) return null;
+  switch (value.to) {
+    case "display":
+      return { to: "display" };
+    case "variable":
+      return typeof value.variableId === "string" && value.variableId.length > 0
+        ? { to: "variable", variableId: value.variableId }
+        : null;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Parse a node-id-keyed mapping record, dropping every entry the mapping
+ * parser rejects. A dropped entry leaves the node unmapped, which is the
+ * documented default: an input takes its bound widget's value, an output
+ * displays. Losing one mapping is contained; rejecting the operation — and
+ * with it every other mapping and the widgets bound to it — is not.
+ */
+const parseMappings = <T>(
+  value: unknown,
+  parse: (entry: unknown) => T | null
+): Record<string, T> => {
+  if (!isRecord(value)) return {};
+  const mappings: Record<string, T> = {};
+  for (const [nodeId, entry] of Object.entries(value)) {
+    const mapping = parse(entry);
+    if (mapping !== null) mappings[nodeId] = mapping;
+  }
+  return mappings;
+};
+
+/**
+ * Parse one operation binding, or null when it carries no id or no workflow id.
+ *
+ * Every input and output mapping is parsed against its union, never cast:
+ * a malformed entry is dropped, so the returned binding's `inputs`/`outputs`
+ * only ever hold mappings with the ids their variant requires. That is what
+ * lets `resolveOperationParams` and `outputVariableTargets` read
+ * `mapping.variableId` without checking it — documents reach this parser from
+ * untrusted input (bundle import), and an id-less mapping used to become a
+ * read or a write keyed `undefined`.
+ */
 const parseOperation = (
   value: unknown,
   hostWorkflowId?: string
@@ -148,12 +226,8 @@ const parseOperation = (
     workflowId: workflowId || hostWorkflowId || "",
     workflowVersion:
       typeof value.workflowVersion === "number" ? value.workflowVersion : undefined,
-    inputs: isRecord(value.inputs)
-      ? (value.inputs as Record<string, InputMapping>)
-      : {},
-    outputs: isRecord(value.outputs)
-      ? (value.outputs as Record<string, OutputMapping>)
-      : {},
+    inputs: parseMappings(value.inputs, parseInputMapping),
+    outputs: parseMappings(value.outputs, parseOutputMapping),
     policy:
       policy === "parallel" || policy === "queue" ? policy : "replace",
     timeoutMs: typeof value.timeoutMs === "number" ? value.timeoutMs : undefined
@@ -228,6 +302,13 @@ export const DEFAULT_OPERATION_ID = "main";
  * they are resolved to node IDs against the live graph by `resolveBinding`,
  * which is where a missing name becomes a validation error rather than a
  * silent no-op.
+ *
+ * Everything outside `ui` is parsed, never cast. Malformed operations,
+ * variables, and resources are dropped; so is any single input/output mapping
+ * that does not match its union, which leaves that node on the documented
+ * default (an input reads its widget, an output displays). So a parsed
+ * document's mappings always carry the ids their variant requires — the
+ * runtimes can read `variableId` and `resourceBindingId` directly.
  */
 export const parseApplicationDocument = (
   value: unknown,

--- a/packages/app-runtime/src/state.ts
+++ b/packages/app-runtime/src/state.ts
@@ -7,7 +7,9 @@
  * collide with the same node in another. Invocations are tracked separately
  * and every streamed value carries the invocation that produced it — that is
  * what keeps a second tab, an overlapping run, or a graph-editor run from
- * contaminating what the app shows.
+ * contaminating what the app shows. Outputs and variables follow the same
+ * ownership rule: the newest run that writes a slot owns it, and a chunk from
+ * a run that a newer one superseded is dropped instead of folded in.
  *
  * Every function here is pure. The React store, the CLI harness, and the eval
  * suites all drive the same reducer.
@@ -68,9 +70,9 @@ export interface AppInstanceState {
   /** Keyed by invocation id: the latest activity label the run reported. */
   activity: Record<string, string>;
   /**
-   * Keyed by variable id: the invocation whose stream last appended to it.
-   * Bookkeeping for streamed output→variable writes, so a second run starts a
-   * fresh value instead of appending to the previous run's.
+   * Keyed by variable id: the invocation whose stream last appended to it —
+   * the variable's current owner. A later run starts a fresh value instead of
+   * appending to the previous run's; an earlier one is superseded and dropped.
    */
   variableWriters: Record<string, string>;
 }
@@ -108,7 +110,10 @@ export type AppStateEvent =
        * time. Defaults to "replace" — a widget writing a variable overwrites.
        */
       disposition?: Disposition;
-      /** The run doing the appending; a new run restarts the accumulation. */
+      /**
+       * The run doing the appending: a newer run restarts the accumulation, a
+       * superseded one is dropped. Absent for widget writes.
+       */
       invocationId?: string;
     }
   | { type: "toggleVariable"; variableId: string }
@@ -153,6 +158,23 @@ export const appendValue = (previous: unknown, next: unknown): unknown => {
   if (previous === undefined) return next;
   if (Array.isArray(previous)) return [...previous, next];
   return [previous, next];
+};
+
+/**
+ * Whether `candidate` has been superseded by `incumbent`, the run that
+ * currently owns a slot. Decidable only when this instance knows both runs;
+ * an unknown run has no start time to order by and is not treated as stale.
+ */
+const isSupersededBy = (
+  state: AppInstanceState,
+  candidateId: string,
+  incumbentId: string | undefined
+): boolean => {
+  if (incumbentId === undefined || incumbentId === candidateId) return false;
+  const candidate = state.invocations[candidateId];
+  const incumbent = state.invocations[incumbentId];
+  if (!candidate || !incumbent) return false;
+  return candidate.startedAt < incumbent.startedAt;
 };
 
 export const applyEvent = (
@@ -208,6 +230,28 @@ export const applyEvent = (
         };
       }
       const writer = state.variableWriters[event.variableId];
+      // Run identity, the rule the `outputValue` case applies to output slots:
+      // the newest run that writes a variable owns it. A chunk from a run that
+      // a newer one superseded — either the writer that took the variable over
+      // or a newer invocation of the chunk's own operation, which is what a
+      // "replace" policy produces — is dropped, so a cancelled run's tail
+      // cannot overwrite the live run's value. Ordering is by `startedAt`, the
+      // only ordering the reducer has; when either run is unknown to this
+      // instance there is nothing to compare and the write counts as a new run
+      // starting a fresh value.
+      if (event.invocationId !== undefined) {
+        const operationId = state.invocations[event.invocationId]?.operationId;
+        const active =
+          operationId === undefined
+            ? undefined
+            : state.activeInvocation[operationId];
+        if (
+          isSupersededBy(state, event.invocationId, writer) ||
+          isSupersededBy(state, event.invocationId, active)
+        ) {
+          return state;
+        }
+      }
       const sameRun = event.invocationId !== undefined && writer === event.invocationId;
       const previous = sameRun ? state.variables[event.variableId] : undefined;
       return {

--- a/packages/app-runtime/tests/actions.test.ts
+++ b/packages/app-runtime/tests/actions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { eventToAction, type AppEvent, type EventContext } from "../src/actions.js";
+
+const ctx: EventContext = {
+  defaultOperationId: "main",
+  resolveVariableId: (key) => (key === "dark" ? "var-dark" : null),
+  from: "widget-1"
+};
+
+const click = (event: Partial<AppEvent>): AppEvent => ({
+  trigger: "click",
+  kind: "run",
+  ...event
+});
+
+describe("eventToAction supported kinds", () => {
+  it("runs the named operation, or the default one", () => {
+    expect(eventToAction(click({ kind: "run" }), ctx)).toEqual({
+      kind: "run",
+      operationId: "main",
+      from: "widget-1"
+    });
+    expect(eventToAction(click({ kind: "run", operationId: "publish" }), ctx)).toEqual({
+      kind: "run",
+      operationId: "publish",
+      from: "widget-1"
+    });
+  });
+
+  it("reads an absent or empty kind as run, the pre-`kind` document shape", () => {
+    const legacy = { trigger: "click", operationId: "publish" } as unknown as AppEvent;
+    expect(eventToAction(legacy, ctx)).toEqual({
+      kind: "run",
+      operationId: "publish",
+      from: "widget-1"
+    });
+    expect(eventToAction(click({ kind: "" }), ctx)).toEqual({
+      kind: "run",
+      operationId: "main",
+      from: "widget-1"
+    });
+  });
+
+  it("sets and toggles variables under both the current and legacy names", () => {
+    expect(eventToAction(click({ kind: "setVariable", key: "dark", value: "1" }), ctx)).toEqual(
+      { kind: "setVariable", variableId: "var-dark", value: "1" }
+    );
+    expect(eventToAction(click({ kind: "setState", key: "dark", value: "1" }), ctx)).toEqual({
+      kind: "setVariable",
+      variableId: "var-dark",
+      value: "1"
+    });
+    expect(eventToAction(click({ kind: "toggleVariable", key: "dark" }), ctx)).toEqual({
+      kind: "toggleVariable",
+      variableId: "var-dark"
+    });
+    expect(eventToAction(click({ kind: "toggleState", key: "dark" }), ctx)).toEqual({
+      kind: "toggleVariable",
+      variableId: "var-dark"
+    });
+  });
+
+  it("defaults a setVariable with no literal to the empty string", () => {
+    expect(eventToAction(click({ kind: "setVariable", key: "dark" }), ctx)).toEqual({
+      kind: "setVariable",
+      variableId: "var-dark",
+      value: ""
+    });
+  });
+
+  it("cancels the default operation, or one named invocation", () => {
+    expect(eventToAction(click({ kind: "cancel" }), ctx)).toEqual({
+      kind: "cancel",
+      operationId: "main"
+    });
+    expect(
+      eventToAction(click({ kind: "cancel", operationId: "publish", invocationId: "j7" }), ctx)
+    ).toEqual({ kind: "cancel", operationId: "publish", invocationId: "j7" });
+  });
+
+  it("passes each resource command through", () => {
+    for (const command of ["read", "create", "update", "delete", "upload"]) {
+      expect(
+        eventToAction(click({ kind: "resourceCommand", resourceBindingId: "r1", command }), ctx)
+      ).toEqual({ kind: "resourceCommand", resourceBindingId: "r1", command });
+    }
+  });
+
+  it("opens a bound resource", () => {
+    expect(eventToAction(click({ kind: "openResource", resourceBindingId: "r1" }), ctx)).toEqual({
+      kind: "openResource",
+      resourceBindingId: "r1"
+    });
+  });
+});
+
+describe("eventToAction rejections", () => {
+  it("returns null for an unknown kind rather than running the workflow", () => {
+    for (const kind of ["runn", "RUN", "setVariabel", "navigate", " run"]) {
+      expect(eventToAction(click({ kind }), ctx)).toBeNull();
+    }
+  });
+
+  it("returns null when a variable action names no live variable", () => {
+    expect(eventToAction(click({ kind: "setVariable", key: "ghost" }), ctx)).toBeNull();
+    expect(eventToAction(click({ kind: "toggleVariable" }), ctx)).toBeNull();
+  });
+
+  it("returns null for a resource command missing a binding or naming no command", () => {
+    expect(eventToAction(click({ kind: "resourceCommand", command: "upload" }), ctx)).toBeNull();
+    expect(
+      eventToAction(click({ kind: "resourceCommand", resourceBindingId: "r1" }), ctx)
+    ).toBeNull();
+    expect(
+      eventToAction(
+        click({ kind: "resourceCommand", resourceBindingId: "r1", command: "rename" }),
+        ctx
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for openResource with no binding", () => {
+    expect(eventToAction(click({ kind: "openResource" }), ctx)).toBeNull();
+  });
+});

--- a/packages/app-runtime/tests/document.test.ts
+++ b/packages/app-runtime/tests/document.test.ts
@@ -95,6 +95,97 @@ describe("parseApplicationDocument", () => {
     expect(doc?.variables[0].persist).toBe(false);
   });
 
+  it("keeps every valid input and output mapping untouched", () => {
+    const inputs = {
+      n1: { from: "widget" },
+      n2: { from: "variable", variableId: "v1" },
+      n3: { from: "constant", value: { nested: [1, 2] } },
+      n4: { from: "constant", value: undefined },
+      n5: { from: "resource", resourceBindingId: "r1" }
+    };
+    const outputs = {
+      o1: { to: "display" },
+      o2: { to: "variable", variableId: "v1" }
+    };
+    const doc = parseApplicationDocument({
+      schemaVersion: 3,
+      ui: puck,
+      operations: [{ id: "main", workflowId: "wf1", inputs, outputs }]
+    });
+    expect(doc?.operations[0].inputs).toEqual(inputs);
+    expect(doc?.operations[0].outputs).toEqual(outputs);
+  });
+
+  it("drops malformed mappings and keeps the rest of the operation", () => {
+    const doc = parseApplicationDocument({
+      schemaVersion: 3,
+      ui: puck,
+      operations: [
+        {
+          id: "main",
+          workflowId: "wf1",
+          inputs: {
+            // Every shape the union does not describe.
+            noVariableId: { from: "variable" },
+            emptyVariableId: { from: "variable", variableId: "" },
+            wrongVariableIdType: { from: "variable", variableId: 7 },
+            noResourceId: { from: "resource" },
+            emptyResourceId: { from: "resource", resourceBindingId: "" },
+            unknownFrom: { from: "elsewhere" },
+            noFrom: {},
+            notARecord: "widget",
+            nullEntry: null,
+            arrayEntry: [{ from: "widget" }],
+            // …and one that is fine, to prove the operation survives.
+            ok: { from: "variable", variableId: "v1" }
+          },
+          outputs: {
+            noVariableId: { to: "variable" },
+            emptyVariableId: { to: "variable", variableId: "" },
+            wrongVariableIdType: { to: "variable", variableId: null },
+            unknownTo: { to: "somewhere" },
+            noTo: {},
+            notARecord: 42,
+            ok: { to: "variable", variableId: "v1" }
+          }
+        }
+      ]
+    });
+    const operation = doc?.operations[0];
+    expect(operation?.id).toBe("main");
+    expect(operation?.inputs).toEqual({ ok: { from: "variable", variableId: "v1" } });
+    expect(operation?.outputs).toEqual({ ok: { to: "variable", variableId: "v1" } });
+  });
+
+  it("drops mapping properties the union does not declare", () => {
+    const doc = parseApplicationDocument({
+      schemaVersion: 3,
+      ui: puck,
+      operations: [
+        {
+          id: "main",
+          workflowId: "wf1",
+          inputs: { n1: { from: "widget", variableId: "v1", stray: true } },
+          outputs: { o1: { to: "display", variableId: "v1" } }
+        }
+      ]
+    });
+    expect(doc?.operations[0].inputs).toEqual({ n1: { from: "widget" } });
+    expect(doc?.operations[0].outputs).toEqual({ o1: { to: "display" } });
+  });
+
+  it("treats non-record inputs and outputs as no mappings", () => {
+    const doc = parseApplicationDocument({
+      schemaVersion: 3,
+      ui: puck,
+      operations: [
+        { id: "main", workflowId: "wf1", inputs: "nope", outputs: [1, 2] }
+      ]
+    });
+    expect(doc?.operations[0].inputs).toEqual({});
+    expect(doc?.operations[0].outputs).toEqual({});
+  });
+
   it("rejects non-documents", () => {
     expect(parseApplicationDocument(null)).toBeNull();
     expect(parseApplicationDocument({ data: { root: {} } })).toBeNull();

--- a/packages/app-runtime/tests/state.test.ts
+++ b/packages/app-runtime/tests/state.test.ts
@@ -199,6 +199,117 @@ describe("appended variables", () => {
   });
 });
 
+describe("superseded runs", () => {
+  /** Run `j1` replaced by the newer `j2`, both on the same operation. */
+  const replaced = applyEvents(createInstanceState(), [
+    {
+      type: "runStarted",
+      invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+      outputKeys: []
+    },
+    {
+      type: "runStarted",
+      invocation: { id: "j2", operationId: "main", status: "running", startedAt: 2 },
+      outputKeys: []
+    },
+    { type: "invocationStatus", invocationId: "j1", status: "cancelled" }
+  ]);
+
+  it("drops a late chunk from a run the newer writer took over", () => {
+    const state = applyEvents(replaced, [
+      { type: "setVariable", variableId: "draft", value: "new ", disposition: "append", invocationId: "j2" },
+      { type: "setVariable", variableId: "draft", value: "run", disposition: "append", invocationId: "j2" },
+      { type: "setVariable", variableId: "draft", value: "stale", disposition: "append", invocationId: "j1" }
+    ]);
+    expect(state.variables.draft).toBe("new run");
+    expect(state.variableWriters.draft).toBe("j2");
+  });
+
+  it("drops a late chunk before the newer run has written the variable", () => {
+    const withStale = applyEvent(replaced, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "stale",
+      disposition: "append",
+      invocationId: "j1"
+    });
+    expect(withStale).toBe(replaced);
+    expect(withStale.variables.draft).toBeUndefined();
+  });
+
+  it("lets a genuinely newer run restart the accumulation", () => {
+    let state = applyEvents(createInstanceState(), [
+      {
+        type: "runStarted",
+        invocation: { id: "j1", operationId: "main", status: "running", startedAt: 1 },
+        outputKeys: []
+      },
+      { type: "setVariable", variableId: "draft", value: "He", disposition: "append", invocationId: "j1" },
+      { type: "setVariable", variableId: "draft", value: "llo", disposition: "append", invocationId: "j1" }
+    ]);
+    expect(state.variables.draft).toBe("Hello");
+
+    state = applyEvents(state, [
+      {
+        type: "runStarted",
+        invocation: { id: "j2", operationId: "main", status: "running", startedAt: 2 },
+        outputKeys: []
+      },
+      { type: "setVariable", variableId: "draft", value: "By", disposition: "append", invocationId: "j2" },
+      { type: "setVariable", variableId: "draft", value: "e", disposition: "append", invocationId: "j2" }
+    ]);
+    expect(state.variables.draft).toBe("Bye");
+    expect(state.variableWriters.draft).toBe("j2");
+  });
+
+  it("lets a widget write overwrite whatever a run left, superseded or not", () => {
+    let state = applyEvent(replaced, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "streamed",
+      disposition: "append",
+      invocationId: "j2"
+    });
+    state = applyEvent(state, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "typed"
+    });
+    expect(state.variables.draft).toBe("typed");
+    expect(state.variableWriters.draft).toBeUndefined();
+
+    // A widget write from an older run's operation is still a widget write.
+    state = applyEvent(state, {
+      type: "setVariable",
+      variableId: "draft",
+      value: "typed again",
+      disposition: "replace"
+    });
+    expect(state.variables.draft).toBe("typed again");
+  });
+
+  it("keeps runs of different operations from superseding each other", () => {
+    const twoOps = applyEvents(createInstanceState(), [
+      {
+        type: "runStarted",
+        invocation: { id: "a", operationId: "draft", status: "running", startedAt: 1 },
+        outputKeys: []
+      },
+      {
+        type: "runStarted",
+        invocation: { id: "b", operationId: "review", status: "running", startedAt: 2 },
+        outputKeys: []
+      }
+    ]);
+    const state = applyEvents(twoOps, [
+      { type: "setVariable", variableId: "notes", value: "from a", disposition: "append", invocationId: "a" },
+      { type: "setVariable", variableId: "other", value: "from b", disposition: "append", invocationId: "b" }
+    ]);
+    expect(state.variables.notes).toBe("from a");
+    expect(state.variables.other).toBe("from b");
+  });
+});
+
 describe("activity", () => {
   const running = applyEvent(createInstanceState(), {
     type: "runStarted",

--- a/packages/models/src/application-budget.ts
+++ b/packages/models/src/application-budget.ts
@@ -254,8 +254,15 @@ export async function recordInvocation(input: {
  * and hand the spend back — a completed run would free budget it may well have
  * used. A null leaves `actual_usd` unset, and `applicationUsage` keeps counting
  * the estimate.
+ *
+ * The update is scoped to `applicationId` as well as the invocation. An
+ * invocation id is a job id a caller can name freely, so an unscoped update let
+ * anyone settle a stranger's in-flight reservation at zero and hand its budget
+ * back. Settling a row that belongs to another app matches nothing and returns
+ * null, the same as settling an invocation that does not exist.
  */
 export async function settleInvocation(
+  applicationId: string,
   invocationId: string,
   actualUsd: number | null,
   status: "completed" | "failed" | "cancelled" = "completed"
@@ -268,7 +275,12 @@ export async function settleInvocation(
       status,
       settled_at: new Date().toISOString()
     })
-    .where(eq(applicationInvocations.invocation_id, invocationId))
+    .where(
+      and(
+        eq(applicationInvocations.application_id, applicationId),
+        eq(applicationInvocations.invocation_id, invocationId)
+      )
+    )
     .returning();
   const row = rows[0] as Record<string, unknown> | undefined;
   return row ? toRecord(row) : null;

--- a/packages/models/tests/application-budget.test.ts
+++ b/packages/models/tests/application-budget.test.ts
@@ -65,12 +65,31 @@ describe("application budgets", () => {
     await run("job-1", 2);
     expect((await applicationUsage(APP, "total")).spentUsd).toBe(2);
 
-    await settleInvocation("job-1", 0.25);
+    await settleInvocation(APP, "job-1", 0.25);
     expect((await applicationUsage(APP, "total")).spentUsd).toBe(0.25);
   });
 
   it("settling an unknown invocation reports nothing rather than throwing", async () => {
-    expect(await settleInvocation("ghost", 1)).toBeNull();
+    expect(await settleInvocation(APP, "ghost", 1)).toBeNull();
+  });
+
+  it("leaves an invocation belonging to another application untouched", async () => {
+    await run("job-1", 2);
+
+    expect(await settleInvocation("app-2", "job-1", 0)).toBeNull();
+
+    const [row] = await listInvocations(APP);
+    expect(row).toMatchObject({ actualUsd: null, status: "running" });
+    expect(row.settledAt).toBeNull();
+    // The reservation still stands, so the spend was not handed back.
+    expect((await applicationUsage(APP, "total")).spentUsd).toBe(2);
+  });
+
+  it("keeps the estimate standing when nothing measured the cost", async () => {
+    await run("job-1", 2);
+    const settled = await settleInvocation(APP, "job-1", null);
+    expect(settled).toMatchObject({ status: "completed", actualUsd: null });
+    expect((await applicationUsage(APP, "total")).spentUsd).toBe(2);
   });
 
   it("scopes usage to another application's ledger", async () => {

--- a/packages/websocket/src/trpc/routers/applications.ts
+++ b/packages/websocket/src/trpc/routers/applications.ts
@@ -203,13 +203,18 @@ export const applicationsRouter = router({
       return invocationRecord.parse(decision.record);
     }),
 
-  /** Close a run out with what it actually cost. */
+  /**
+   * Close a run out with what it actually cost. `loadOwned` authorizes the
+   * application, and the settle itself is scoped to that application, so an
+   * invocation id belonging to someone else's app settles nothing.
+   */
   settleInvocation: protectedProcedure
     .input(settleInvocationInput)
     .output(invocationRecord.nullable())
     .mutation(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
       const settled = await settleInvocation(
+        input.id,
         input.invocationId,
         input.actualUsd,
         input.status

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2253,30 +2253,39 @@ export class UnifiedWebSocketRunner {
     if (!applicationId) return true;
     const jobId = req.job_id ?? randomUUID();
     req.job_id = jobId;
+    // The connection's authenticated user, not `req.user_id`: the request body
+    // is the thing being authorized, so it cannot supply the identity that
+    // authorizes it.
+    const userId = this.userId ?? "1";
+    // Authorization sits outside the try below, which swallows a ledger outage
+    // on purpose. Metering fails open; ownership fails closed — a lookup this
+    // never completed is not permission to bill the app it names.
+    let owned = false;
     try {
-      // The connection's authenticated user, not `req.user_id`: the request
-      // body is the thing being authorized, so it cannot supply the identity
-      // that authorizes it.
-      const userId = this.userId ?? "1";
       const application = await Application.findById(applicationId);
-      if (!application || application.user_id !== userId) {
-        log.warn("Run refused: application not owned by this user", {
-          applicationId,
-          jobId,
-          userId
-        });
-        // Applications are owned by one user and there is no path today that
-        // serves someone else's app to run — `releasedApplicationDocument`
-        // itself requires ownership — so refusing cannot break a legitimate
-        // run, and it is the only answer that keeps the budget a hard stop.
-        return this.refuseRun(
-          req,
-          jobId,
-          ApiErrorCode.NOT_FOUND,
-          "Application not found"
-        );
-      }
+      owned = application?.user_id === userId;
+    } catch (err) {
+      this.logError("application ownership check failed", err);
+    }
+    if (!owned) {
+      log.warn("Run refused: application not owned by this user", {
+        applicationId,
+        jobId,
+        userId
+      });
+      // Applications are owned by one user and there is no path today that
+      // serves someone else's app to run — `releasedApplicationDocument`
+      // itself requires ownership — so refusing cannot break a legitimate
+      // run, and it is the only answer that keeps the budget a hard stop.
+      return this.refuseRun(
+        req,
+        jobId,
+        ApiErrorCode.NOT_FOUND,
+        "Application not found"
+      );
+    }
 
+    try {
       const estimatedUsd = this.estimateRunCost(req);
       // The client says whether this is a release run or a draft run; the
       // server says which release. Taking the number from the client would let

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { getSecret } from "@nodetool-ai/models";
 import { getSetting } from "./settings-registry.js";
+import { ApiErrorCode } from "./error-codes.js";
 import { JobConcurrencyQueue } from "./job-queue.js";
 import { pack, unpack } from "msgpackr";
 import {
@@ -32,6 +33,7 @@ import {
   type NodeValidator
 } from "@nodetool-ai/kernel";
 import {
+  Application,
   Asset,
   ImageDocument,
   Job,
@@ -2217,11 +2219,34 @@ export class UnifiedWebSocketRunner {
     }
   }
 
+  /** Tell the client a run was refused, in the shape a failed job takes. */
+  private refuseRun(
+    req: RunJobRequest,
+    jobId: string,
+    code: ApiErrorCode,
+    error: string
+  ): false {
+    this.sendDetached({
+      type: "job_update",
+      status: "failed",
+      job_id: jobId,
+      workflow_id: req.workflow_id ?? null,
+      error,
+      error_code: code
+    });
+    return false;
+  }
+
   /**
    * Gate an app's run on its spend budget. Runs of a published app execute with
    * the creator's secrets, so this refuses before the job exists rather than
    * reporting an overspend afterwards. Returns false when the run was refused
    * (the client has already been told why).
+   *
+   * `application_id` arrives on the wire, so before any of that the app has to
+   * be one this connection's user owns. Honouring the id as sent let a client
+   * name a stranger's app and spend their budget — and pollute their release
+   * telemetry, which is the same ledger.
    */
   private async admitApplicationRun(req: RunJobRequest): Promise<boolean> {
     const applicationId = req.application_id;
@@ -2229,21 +2254,63 @@ export class UnifiedWebSocketRunner {
     const jobId = req.job_id ?? randomUUID();
     req.job_id = jobId;
     try {
+      // The connection's authenticated user, not `req.user_id`: the request
+      // body is the thing being authorized, so it cannot supply the identity
+      // that authorizes it.
+      const userId = this.userId ?? "1";
+      const application = await Application.findById(applicationId);
+      if (!application || application.user_id !== userId) {
+        log.warn("Run refused: application not owned by this user", {
+          applicationId,
+          jobId,
+          userId
+        });
+        // Applications are owned by one user and there is no path today that
+        // serves someone else's app to run — `releasedApplicationDocument`
+        // itself requires ownership — so refusing cannot break a legitimate
+        // run, and it is the only answer that keeps the budget a hard stop.
+        return this.refuseRun(
+          req,
+          jobId,
+          ApiErrorCode.NOT_FOUND,
+          "Application not found"
+        );
+      }
+
       const estimatedUsd = this.estimateRunCost(req);
       // The client says whether this is a release run or a draft run; the
       // server says which release. Taking the number from the client would let
       // a run bill itself to a version it never executed, and the ledger is
       // also the release telemetry.
-      const version =
+      const released =
         req.application_version == null
           ? null
-          : ((await releasedApplicationVersion(applicationId))?.version ?? null);
+          : await releasedApplicationVersion(applicationId);
+      if (req.application_version != null && !released) {
+        // A release run of an app that has released nothing. The claim is
+        // unsupportable rather than merely stale, and letting it through would
+        // file the run in the telemetry ledger as a release that never shipped.
+        return this.refuseRun(
+          req,
+          jobId,
+          ApiErrorCode.INVALID_INPUT,
+          "This app has no released version to run"
+        );
+      }
+      if (released && released.version !== req.application_version) {
+        log.warn("Run claimed a version other than the released one", {
+          applicationId,
+          jobId,
+          claimed: req.application_version,
+          released: released.version
+        });
+      }
       // Reserving claims the run against the budget in the same transaction
       // that checks it, so concurrent runs of one app cannot each read a total
       // that excludes the others and all be admitted.
       const decision = await reserveInvocation({
         applicationId,
-        version,
+        version: released?.version ?? null,
         invocationId: jobId,
         estimatedUsd
       });
@@ -2253,19 +2320,17 @@ export class UnifiedWebSocketRunner {
           jobId,
           reason: decision.reason
         });
-        this.sendDetached({
-          type: "job_update",
-          status: "failed",
-          job_id: jobId,
-          workflow_id: req.workflow_id ?? null,
-          error: decision.reason,
-          error_code: "BUDGET_EXCEEDED"
-        });
-        return false;
+        return this.refuseRun(
+          req,
+          jobId,
+          ApiErrorCode.BUDGET_EXCEEDED,
+          decision.reason
+        );
       }
     } catch (err) {
       // A ledger that is unavailable must not take runs down with it; the
-      // refusal path above is the only one that blocks.
+      // refusals above are the only paths that block, and they return rather
+      // than throw so an outage can never swallow one.
       this.logError("application budget check failed", err);
     }
     return true;
@@ -2926,6 +2991,7 @@ export class UnifiedWebSocketRunner {
     if (active.applicationId) {
       try {
         await settleInvocation(
+          active.applicationId,
           active.jobId,
           active.providerCostTotal ?? null,
           active.status === "failed"

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -6,6 +6,10 @@
  * already been paid. These tests drive `runJob` with an `application_id` and
  * assert on both directions: refused runs never start, admitted runs land in
  * the ledger, and a settled run reports what it actually cost.
+ *
+ * `application_id` comes off the wire, so the gate also has to check that the
+ * connection's user owns the app it names — otherwise a client spends a
+ * stranger's budget by typing their id.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { unpack } from "msgpackr";
@@ -60,6 +64,41 @@ const messages = (ws: MockWebSocket): Array<Record<string, unknown>> =>
   ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
 
 const APP = "app-budget-gate";
+const OWNER = "u1";
+
+const appDocument = (workflowId = "wf1") => {
+  const document = createEmptyDocument("Demo");
+  document.operations = [
+    {
+      id: "main",
+      name: "Run",
+      workflowId,
+      inputs: {},
+      outputs: {},
+      policy: "replace"
+    }
+  ];
+  return document;
+};
+
+/** The app row the gate authorizes against, plus the workflow it binds. */
+const seedApp = async (
+  options: { id?: string; userId?: string } = {}
+): Promise<Application> => {
+  const workflowId = `wf-${options.id ?? APP}`;
+  await Workflow.create<Workflow>({
+    id: workflowId,
+    user_id: options.userId ?? OWNER,
+    name: "Demo workflow",
+    graph: { nodes: [], edges: [] }
+  });
+  return Application.create<Application>({
+    id: options.id ?? APP,
+    user_id: options.userId ?? OWNER,
+    name: "Demo app",
+    document: JSON.stringify(appDocument(workflowId))
+  });
+};
 
 describe("application budget gate", () => {
   let ws: MockWebSocket;
@@ -73,7 +112,7 @@ describe("application budget gate", () => {
     runner = new UnifiedWebSocketRunner({
       resolveExecutor: () => undefined as never
     });
-    await runner.connect(ws);
+    await runner.connect(ws, OWNER);
     // The gate's job is to decide whether a run starts; the run itself is
     // covered elsewhere, so stub it and assert on whether it was reached.
     startJob = vi.fn(async () => undefined);
@@ -103,46 +142,55 @@ describe("application budget gate", () => {
   });
 
   it("starts an app run and records it in the ledger", async () => {
+    await seedApp();
     await setApplicationBudget(APP, { period: "total", maxUsd: 10 });
-    await run({ application_id: APP, application_version: 2 });
+    await run({ application_id: APP });
 
     expect(startJob).toHaveBeenCalledOnce();
     const ledger = await listInvocations(APP);
     expect(ledger).toHaveLength(1);
     expect(ledger[0]).toMatchObject({
       invocationId: "job-1",
-      // The app has no release, so there is no version to bill the run to —
-      // the client's claim of one does not create it.
       version: null,
       status: "running"
     });
   });
 
+  it("starts an app run with no budget row, unmetered but still ledgered", async () => {
+    await seedApp();
+    await run({ application_id: APP });
+
+    expect(startJob).toHaveBeenCalledOnce();
+    expect((await listInvocations(APP)).map((r) => r.invocationId)).toEqual([
+      "job-1"
+    ]);
+  });
+
+  it("refuses a run naming an application this user does not own", async () => {
+    await seedApp({ userId: "someone-else" });
+    await setApplicationBudget(APP, { period: "total", maxUsd: 10 });
+
+    await run({ application_id: APP });
+
+    expect(startJob).not.toHaveBeenCalled();
+    const failure = messages(ws).find(
+      (m) => m.type === "job_update" && m.status === "failed"
+    );
+    expect(failure).toMatchObject({ error_code: "NOT_FOUND" });
+    // Nothing was billed to the victim, and their telemetry stayed clean.
+    expect(await listInvocations(APP)).toEqual([]);
+    expect((await applicationUsage(APP, "total")).invocations).toBe(0);
+  });
+
+  it("refuses a run naming an application that does not exist", async () => {
+    await run({ application_id: "no-such-app" });
+
+    expect(startJob).not.toHaveBeenCalled();
+    expect(await listInvocations("no-such-app")).toEqual([]);
+  });
+
   it("bills a release run to the released version, not the claimed one", async () => {
-    await Workflow.create<Workflow>({
-      id: "wf1",
-      user_id: "u1",
-      name: "Demo workflow",
-      graph: { nodes: [], edges: [] }
-    });
-    const document = createEmptyDocument("Demo");
-    document.operations = [
-      {
-        id: "main",
-        name: "Run",
-        workflowId: "wf1",
-        inputs: {},
-        outputs: {},
-        policy: "replace"
-      }
-    ];
-    const app = await Application.create<Application>({
-      id: APP,
-      user_id: "u1",
-      name: "Demo app",
-      document: JSON.stringify(document)
-    });
-    await publishApplication(app);
+    await publishApplication(await seedApp());
 
     await run({ application_id: APP, application_version: 99 });
 
@@ -150,31 +198,21 @@ describe("application budget gate", () => {
     expect(record).toMatchObject({ invocationId: "job-1", version: 1 });
   });
 
+  it("refuses a release run of an app that has released nothing", async () => {
+    await seedApp();
+
+    await run({ application_id: APP, application_version: 2 });
+
+    expect(startJob).not.toHaveBeenCalled();
+    const failure = messages(ws).find(
+      (m) => m.type === "job_update" && m.status === "failed"
+    );
+    expect(failure).toMatchObject({ error_code: "INVALID_INPUT" });
+    expect(await listInvocations(APP)).toEqual([]);
+  });
+
   it("records a draft run against no version even when a release exists", async () => {
-    await Workflow.create<Workflow>({
-      id: "wf1",
-      user_id: "u1",
-      name: "Demo workflow",
-      graph: { nodes: [], edges: [] }
-    });
-    const document = createEmptyDocument("Demo");
-    document.operations = [
-      {
-        id: "main",
-        name: "Run",
-        workflowId: "wf1",
-        inputs: {},
-        outputs: {},
-        policy: "replace"
-      }
-    ];
-    const app = await Application.create<Application>({
-      id: APP,
-      user_id: "u1",
-      name: "Demo app",
-      document: JSON.stringify(document)
-    });
-    await publishApplication(app);
+    await publishApplication(await seedApp());
 
     await run({ application_id: APP });
 
@@ -183,6 +221,7 @@ describe("application budget gate", () => {
   });
 
   it("refuses a run that would cross the budget, before the job exists", async () => {
+    await seedApp();
     await setApplicationBudget(APP, { period: "total", maxUsd: 1 });
     // Spend the budget with an earlier run.
     await run({ application_id: APP, job_id: "job-early" });
@@ -208,6 +247,7 @@ describe("application budget gate", () => {
   it("keeps runs flowing when the ledger itself errors", async () => {
     // A budget backend that is down must not take runs down with it; only an
     // explicit refusal blocks.
+    await seedApp();
     await setApplicationBudget(APP, { period: "total", maxUsd: 10 });
     const broken = vi
       .spyOn(runner as unknown as { estimateRunCost: () => number }, "estimateRunCost")
@@ -220,6 +260,7 @@ describe("application budget gate", () => {
   });
 
   it("counts an unsettled run at its estimate", async () => {
+    await seedApp();
     await run({ application_id: APP });
     const usage = await applicationUsage(APP, "total");
     expect(usage.invocations).toBe(1);
@@ -288,6 +329,20 @@ describe("application invocation settlement", () => {
     expect(record).toMatchObject({ status: "completed", actualUsd: 0.42 });
     // The estimate no longer counts once the real figure lands.
     expect((await applicationUsage(APP, "total")).spentUsd).toBeCloseTo(0.42);
+  });
+
+  it("leaves another application's reservation alone", async () => {
+    await recordInvocation({
+      applicationId: "other-app",
+      invocationId: "job-settle",
+      estimatedUsd: 5
+    });
+
+    await stream(activeJob("completed", 0), { status: "completed" });
+
+    const [record] = await listInvocations("other-app");
+    expect(record).toMatchObject({ status: "running", actualUsd: null });
+    expect((await applicationUsage("other-app", "total")).spentUsd).toBe(5);
   });
 
   it("settles a failed run too, so its spend is not stranded at the estimate", async () => {

--- a/web/src/components/appbuilder/__tests__/appRuntimeStore.test.ts
+++ b/web/src/components/appbuilder/__tests__/appRuntimeStore.test.ts
@@ -1,4 +1,5 @@
 import {
+  appInstanceId,
   createAppRuntimeStore,
   getAppRuntimeStore,
   disposeAppRuntimeStore,
@@ -61,6 +62,18 @@ describe("appRuntimeStore registry", () => {
     );
     expect(getAppRuntimeStore(workflowInstanceId("wf-2"))).not.toBe(first);
     disposeAppRuntimeStore(workflowInstanceId("wf-2"));
+  });
+
+  it("keys an application apart from the workflow that hosts it", () => {
+    const application = appInstanceId("application:app-1");
+    expect(application).not.toBe(workflowInstanceId("wf-1"));
+    getAppRuntimeStore(application)
+      .getState()
+      .dispatchEvent({ type: "setVariable", variableId: "result", value: "own" });
+    expect(
+      getAppRuntimeStore(instance).getState().variables.result
+    ).toBeUndefined();
+    disposeAppRuntimeStore(application);
   });
 
   it("dispose drops the stored state", () => {

--- a/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
+++ b/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
@@ -45,7 +45,11 @@ jest.mock("../../../../trpc/client", () => ({
 
 import { getWorkflowRunnerStore } from "../../../../stores/WorkflowRunner";
 import { useAppRuntime } from "../useAppRuntime";
-import { disposeAppRuntimeStore, workflowInstanceId } from "../appRuntimeStore";
+import {
+  appInstanceId,
+  disposeAppRuntimeStore,
+  workflowInstanceId
+} from "../appRuntimeStore";
 import { variableStorageKey } from "../variablePersistence";
 
 interface FakeRunnerState {
@@ -128,9 +132,12 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 const renderRuntime = (
   workflow: Workflow | undefined,
-  document?: ApplicationDocument
+  document?: ApplicationDocument,
+  application?: { id: string }
 ) =>
-  renderHook(() => useAppRuntime(workflow, false, { document }), { wrapper });
+  renderHook(() => useAppRuntime(workflow, false, { document, application }), {
+    wrapper
+  });
 
 /** Deliver a streaming message the way the websocket manager would. */
 const deliver = (message: Record<string, unknown>) =>
@@ -145,6 +152,8 @@ beforeEach(() => {
   cancelJob.mockClear();
   window.localStorage.clear();
   disposeAppRuntimeStore(workflowInstanceId("wf-a"));
+  disposeAppRuntimeStore(appInstanceId("application:app-1"));
+  disposeAppRuntimeStore(appInstanceId("application:app-2"));
   (getWorkflowRunnerStore as jest.Mock).mockImplementation(
     (id: string) => runners.get(id) ?? makeRunner(id)
   );
@@ -451,6 +460,205 @@ describe("useAppRuntime — multiple operations", () => {
     expect(failed).toHaveLength(1);
     expect(failed[0].status).toBe("failed");
     expect(failed[0].error).toMatch(/no operation "ghost"/);
+  });
+});
+
+describe("useAppRuntime — instance identity", () => {
+  const document = doc({
+    variables: [{ id: "tone", name: "Tone", scope: "instance", persist: false }]
+  });
+
+  it("gives two applications over the same workflow their own state", () => {
+    const one = renderRuntime(workflowA, document, { id: "app-1" });
+    const two = renderRuntime(workflowA, document, { id: "app-2" });
+
+    act(() => {
+      one.result.current.dispatch({
+        kind: "setVariable",
+        variableId: "tone",
+        value: "warm"
+      });
+    });
+
+    expect(one.result.current.store).not.toBe(two.result.current.store);
+    expect(two.result.current.store.getState().variables.tone).toBeUndefined();
+  });
+
+  it("keeps one application's state across a remount", () => {
+    const first = renderRuntime(workflowA, document, { id: "app-1" });
+    act(() => {
+      first.result.current.dispatch({
+        kind: "setVariable",
+        variableId: "tone",
+        value: "warm"
+      });
+    });
+    first.unmount();
+
+    const again = renderRuntime(workflowA, document, { id: "app-1" });
+    expect(again.result.current.store.getState().variables.tone).toBe("warm");
+  });
+});
+
+describe("useAppRuntime — messages that arrive before a job id", () => {
+  const parallelPair = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Draft",
+        workflowId: "wf-a",
+        inputs: {},
+        outputs: {},
+        policy: "parallel"
+      },
+      {
+        id: "second",
+        name: "Draft again",
+        workflowId: "wf-a",
+        inputs: {},
+        outputs: {},
+        policy: "parallel"
+      }
+    ]
+  });
+
+  it("replays each pending start only its own buffered messages", async () => {
+    const { result } = renderRuntime(workflowA, parallelPair);
+    const resolvers: Array<(jobId: string) => void> = [];
+    runnerState("wf-a").run.mockImplementation(
+      () => new Promise<string>((resolve) => resolvers.push(resolve))
+    );
+
+    act(() => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+      result.current.dispatch({ kind: "run", operationId: "second" });
+    });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    // Both runs stream before either has reported its job id.
+    deliver({
+      type: "output_update",
+      job_id: "job-main",
+      node_id: "out1",
+      value: "first",
+      disposition: "replace"
+    });
+    deliver({
+      type: "output_update",
+      job_id: "job-second",
+      node_id: "out1",
+      value: "second",
+      disposition: "replace"
+    });
+
+    await act(async () => {
+      resolvers[0]("job-main");
+      resolvers[1]("job-second");
+    });
+
+    const outputs = result.current.store.getState().outputs;
+    expect(outputs["main:out1"]?.value).toBe("first");
+    expect(outputs["second:out1"]?.value).toBe("second");
+  });
+
+  it("keeps a sibling's buffer when one start fails", async () => {
+    const { result } = renderRuntime(workflowA, parallelPair);
+    const resolvers: Array<{
+      resolve: (jobId: string) => void;
+      reject: (error: Error) => void;
+    }> = [];
+    runnerState("wf-a").run.mockImplementation(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          resolvers.push({ resolve, reject });
+        })
+    );
+
+    act(() => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+      result.current.dispatch({ kind: "run", operationId: "second" });
+    });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    deliver({
+      type: "output_update",
+      job_id: "job-second",
+      node_id: "out1",
+      value: "second",
+      disposition: "replace"
+    });
+
+    await act(async () => {
+      resolvers[0].reject(new Error("no capacity"));
+    });
+    await act(async () => {
+      resolvers[1].resolve("job-second");
+    });
+
+    expect(result.current.store.getState().outputs["second:out1"]?.value).toBe(
+      "second"
+    );
+  });
+});
+
+describe("useAppRuntime — design canvas", () => {
+  it("keeps its store when the document identity changes", () => {
+    const { result, rerender } = renderHook(
+      ({ document }: { document: ApplicationDocument }) =>
+        useAppRuntime(workflowA, true, { document }),
+      { wrapper, initialProps: { document: doc() } }
+    );
+    const store = result.current.store;
+    act(() => {
+      store
+        .getState()
+        .dispatchEvent({ type: "setView", key: "Slider-1:value", value: 7 });
+    });
+
+    rerender({ document: doc() });
+
+    expect(result.current.store).toBe(store);
+    expect(result.current.store.getState().view["Slider-1:value"]).toBe(7);
+  });
+});
+
+describe("useAppRuntime — queued runs", () => {
+  const queued = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf-a",
+        inputs: {},
+        outputs: {},
+        policy: "queue"
+      }
+    ]
+  });
+
+  it("drops the wait when the app unmounts before the predecessor settles", async () => {
+    const { result, unmount } = renderRuntime(workflowA, queued);
+    await act(async () => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    const first = await runnerState("wf-a").run.mock.results[0].value;
+
+    act(() => {
+      result.current.dispatch({ kind: "run", operationId: "main" });
+    });
+    expect(runnerState("wf-a").run).toHaveBeenCalledTimes(1);
+
+    const store = result.current.store;
+    unmount();
+    await act(async () => {
+      store.getState().dispatchEvent({
+        type: "invocationStatus",
+        invocationId: first,
+        status: "completed"
+      });
+    });
+
+    expect(runnerState("wf-a").run).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/src/components/appbuilder/runtime/appRuntimeStore.ts
+++ b/web/src/components/appbuilder/runtime/appRuntimeStore.ts
@@ -34,12 +34,24 @@ export const createAppRuntimeStore = (initial?: Partial<AppInstanceState>) =>
  * Live app stores keyed by app-instance id. Two apps built on the same workflow
  * get two stores; a design canvas gets an unregistered ephemeral one, so widget
  * writes there never leak into the published app's state.
+ *
+ * A workflow-hosted instance is disposed when its workflow closes
+ * (`WorkflowManagerStore.removeWorkflow`). An application-keyed instance has no
+ * such close event — it lives for the session so its values survive View↔Edit
+ * switches and refetches.
  */
 const appRuntimeStores = new Map<string, AppRuntimeStore>();
 
-/** The instance id an app opened over a workflow uses by default. */
+/**
+ * The instance id one open app uses. The key is the app's identity — the
+ * application record when it has one, otherwise the host workflow — so two
+ * applications over the same workflow keep separate state.
+ */
+export const appInstanceId = (identity: string): string => `app:${identity}`;
+
+/** The instance id of an app hosted straight by a workflow, with no record. */
 export const workflowInstanceId = (workflowId: string): string =>
-  `app:${workflowId}`;
+  appInstanceId(`workflow:${workflowId}`);
 
 export const getAppRuntimeStore = (instanceId: string): AppRuntimeStore => {
   let store = appRuntimeStores.get(instanceId);

--- a/web/src/components/appbuilder/runtime/useAppRuntime.ts
+++ b/web/src/components/appbuilder/runtime/useAppRuntime.ts
@@ -59,9 +59,9 @@ import { seedInputValue } from "../inputProperty";
 import { collectNodePropertyOverlays, withNodeProperties } from "../nodeBinding";
 import { buildTriggerSubgraph } from "./buildTriggerSubgraph";
 import {
+  appInstanceId,
   createAppRuntimeStore,
   getAppRuntimeStore,
-  workflowInstanceId,
   AppRuntimeStore
 } from "./appRuntimeStore";
 import {
@@ -233,20 +233,28 @@ export const useAppRuntime = (
     []
   );
 
-  // A design canvas gets an ephemeral store: widget writes there must not leak
-  // into the published app's state. A live app keeps its store in the instance
-  // registry so values survive View↔Edit tab switches and refetches.
+  // The app's identity — its application record when it has one, otherwise the
+  // host workflow — keys both its state and its persisted variables, so two
+  // applications over one workflow never share either.
   const identity = appVariableIdentity(application?.id, workflowId);
-  const store: AppRuntimeStore = useMemo(() => {
-    const target =
-      designMode || !workflowId
-        ? createAppRuntimeStore()
-        : getAppRuntimeStore(workflowInstanceId(workflowId));
-    const dispatchEvent = target.getState().dispatchEvent;
 
-    // Seeding fills only slots that have no value: workflow input defaults plus
-    // the select/boolean fallbacks the controls display, so an untouched form
-    // runs with what it shows.
+  // A design canvas gets an ephemeral store: widget writes there must not leak
+  // into the published app's state. It is created once per mount rather than
+  // per identity, so the canvas keeps its widget values when `document` or the
+  // operation runtimes are rebuilt. A live app keeps its store in the instance
+  // registry so values survive View↔Edit tab switches and refetches.
+  const designStoreRef = useRef<AppRuntimeStore | null>(null);
+  const store: AppRuntimeStore =
+    designMode || !identity
+      ? (designStoreRef.current ??= createAppRuntimeStore())
+      : getAppRuntimeStore(appInstanceId(identity));
+
+  // Seeding fills only slots that have no value: workflow input defaults plus
+  // the select/boolean fallbacks the controls display, so an untouched form
+  // runs with what it shows. Idempotent, so re-running it on any identity churn
+  // costs nothing and clobbers nothing.
+  useEffect(() => {
+    const dispatchEvent = store.getState().dispatchEvent;
     const values: Record<string, unknown> = {};
     for (const entry of operationRuntimes.values()) {
       for (const input of entry.io.inputs) {
@@ -276,8 +284,7 @@ export const useAppRuntime = (
       type: "seedVariables",
       values: initialVariableValues(variables)
     });
-    return target;
-  }, [designMode, document, identity, operationRuntimes, workflowId]);
+  }, [designMode, document, identity, operationRuntimes, store]);
 
   // Write persisting user-scoped variables back whenever they change. Instance
   // variables and widget-local view state are deliberately not persisted.
@@ -300,11 +307,15 @@ export const useAppRuntime = (
   // The resource each binding currently points at. A picker widget sets one;
   // an operation input mapped `from: "resource"` passes it to the run.
   const resourceRefsRef = useRef(new Map<string, ResourceRef>());
-  // Messages that arrived between dispatching a run and learning its job id.
-  const pendingRef = useRef<MsgpackData[]>([]);
+  // Messages that arrived between dispatching a run and learning its job id,
+  // buffered per job id. Two starts in flight — a `parallel` operation, or two
+  // operations dispatched at once — each replay only their own stream.
+  const pendingRef = useRef(new Map<string, MsgpackData[]>());
   const awaitingJobRef = useRef(0);
   // Timeout timers by invocation id, for operations that declare `timeoutMs`.
   const timersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  // Teardowns for the waits `awaitSettled` has open, so an unmount drops them.
+  const settleWaitsRef = useRef(new Set<() => void>());
 
   const clearTimeoutTimer = useCallback((invocationId: string) => {
     const timer = timersRef.current.get(invocationId);
@@ -315,9 +326,12 @@ export const useAppRuntime = (
 
   useEffect(() => {
     const timers = timersRef.current;
+    const waits = settleWaitsRef.current;
     return () => {
       for (const timer of timers.values()) clearTimeout(timer);
       timers.clear();
+      for (const stopWaiting of [...waits]) stopWaiting();
+      waits.clear();
     };
   }, []);
 
@@ -393,9 +407,14 @@ export const useAppRuntime = (
     [clearTimeoutTimer, stopJob, store]
   );
 
-  /** Resolve once every listed invocation has settled. */
+  /**
+   * Resolve once every listed invocation has settled. A predecessor that never
+   * reports would otherwise wedge the queue forever, so the waiting operation's
+   * own declared timeout is also the ceiling on the wait; an unmount drops the
+   * subscription and leaves the queued run unstarted.
+   */
   const awaitSettled = useCallback(
-    (invocationIds: ReadonlyArray<string>) =>
+    (invocationIds: ReadonlyArray<string>, timeoutMs?: number) =>
       new Promise<void>((resolve) => {
         const settled = () =>
           invocationIds.every((id) => {
@@ -406,11 +425,27 @@ export const useAppRuntime = (
           resolve();
           return;
         }
-        const unsubscribe = store.subscribe(() => {
+        const wait: {
+          timer?: ReturnType<typeof setTimeout>;
+          unsubscribe?: () => void;
+        } = {};
+        const stopWaiting = () => {
+          if (wait.timer) clearTimeout(wait.timer);
+          wait.unsubscribe?.();
+          settleWaitsRef.current.delete(stopWaiting);
+        };
+        settleWaitsRef.current.add(stopWaiting);
+        wait.unsubscribe = store.subscribe(() => {
           if (!settled()) return;
-          unsubscribe();
+          stopWaiting();
           resolve();
         });
+        if (timeoutMs && timeoutMs > 0) {
+          wait.timer = setTimeout(() => {
+            stopWaiting();
+            resolve();
+          }, timeoutMs);
+        }
       }),
     [store]
   );
@@ -458,8 +493,9 @@ export const useAppRuntime = (
         );
       }
 
-      const buffered = pendingRef.current;
-      pendingRef.current = [];
+      const buffered = pendingRef.current.get(jobId);
+      if (!buffered) return;
+      pendingRef.current.delete(jobId);
       for (const message of buffered) foldRef.current(message);
     },
     [outputKey, stopJob, store]
@@ -504,13 +540,19 @@ export const useAppRuntime = (
     // workflow was opened — calling into it here would double-append.
     const handler = (message: MsgpackData) => {
       const jobId = (message as Record<string, unknown>).job_id;
-      if (typeof jobId === "string" && ownedRef.current.has(jobId)) {
+      // A message carrying no job id cannot be attributed to an invocation, so
+      // folding it produces nothing either now or after a replay.
+      if (typeof jobId !== "string") return;
+      if (ownedRef.current.has(jobId)) {
         foldRef.current(message);
         return;
       }
-      // A run we started but whose job id has not come back yet. Buffer rather
-      // than drop, then replay once the id is known.
-      if (awaitingJobRef.current > 0) pendingRef.current.push(message);
+      // A run we started but whose job id has not come back yet. Buffer under
+      // that id rather than drop, then replay once the run claims it.
+      if (awaitingJobRef.current === 0) return;
+      const buffered = pendingRef.current.get(jobId);
+      if (buffered) buffered.push(message);
+      else pendingRef.current.set(jobId, [message]);
     };
 
     const unsubscribes = workflowIds.map((id) =>
@@ -581,7 +623,7 @@ export const useAppRuntime = (
       if (decision.kind === "replace") {
         await cancelInvocations(decision.cancel);
       } else if (decision.kind === "queue") {
-        await awaitSettled(decision.after);
+        await awaitSettled(decision.after, entry.operation.timeoutMs);
       }
 
       const state = store.getState();
@@ -630,13 +672,15 @@ export const useAppRuntime = (
           );
         claimInvocation(operationId, jobId, true);
       } catch (error) {
-        pendingRef.current = [];
         failInvocation(
           operationId,
           error instanceof Error ? error.message : "Run failed"
         );
       } finally {
         awaitingJobRef.current -= 1;
+        // Nothing is waiting for a job id any more, so whatever is still
+        // buffered belongs to a run this app never claimed.
+        if (awaitingJobRef.current === 0) pendingRef.current.clear();
       }
     },
     [


### PR DESCRIPTION
A review of the mini-app platform — the shared runtime, the web adapter, and the server-side spend governance — turned up eight issues. All are fixed here.

## Run identity and state ownership

**A superseded run could clobber an app variable.** `applyEvent`'s `outputValue` case drops a chunk from an invocation a newer run has taken over; the `setVariable` append branch had no such guard. So with `policy: "replace"` and an output mapped `to: "variable"`, a cancelled run's tail overwrote the live run's accumulated value — the two halves that `fold.ts` fans one node value out to disagreed about who owns a slot. Variables now follow the same newest-run-wins rule, ordered by `startedAt`, the only ordering the reducer has.

**A mini app's state was keyed by its host workflow.** Two applications whose first operation binds the same workflow shared one store: inputs, variables, outputs and invocations bled across them, and closing one disposed the other's. It now keys on the app's identity — application record first, workflow fallback — which is the precedence variable persistence already used and the one mobile already keys on.

## Robustness in the web runtime

- Pre-claim message buffering was a single global queue. With two starts in flight (a `parallel` operation, or two operations dispatched together) the first to learn its job id drained the buffer, and a failed start wiped a sibling's. Buffers are per job id now.
- `awaitSettled` never unsubscribed on unmount and hung forever if a predecessor never settled. Waits are torn down on unmount and bounded by the queuing operation's declared `timeoutMs`.
- Store creation dispatched seed events during render and minted a fresh design-canvas store whenever `document` identity churned, resetting the canvas's widget values. Seeding moved into an effect; the canvas store is created once per mount.

## Document validation

Operation input/output mappings were cast rather than parsed, while every other part of the document was validated. A `{from:"variable"}` with no `variableId` became a read of `state.variables[undefined]`, and `{to:"variable"}` without one became a `setVariable` keyed `undefined` — and documents reach the parser from untrusted input via bundle import. Both mapping unions are parsed now; a malformed entry is dropped, leaving that node on the documented default (an input reads its widget, an output displays) rather than taking the whole operation with it.

`eventToAction` also treated any unrecognised event `kind` as `run` — executing a workflow is the costly answer to give a typo. Unknown kinds return `null` like the other incomplete cases; an absent kind still means run, which is how pre-field documents spell it and how the app-debug parser has always read it. `AppAction.setVariable.fromWidget`, which nothing produced or consumed, is gone.

## Spend governance

A released app runs on the creator's secrets, so its budget is meant to be a hard stop. Two holes made it advisory:

- `settleInvocation` updated on `invocation_id` alone. The tRPC route authorized the application it was handed and then settled whatever invocation id came with it, so anyone could settle a stranger's in-flight reservation at zero and hand its budget back. The update is scoped to the application now.
- `application_id` arrived on the wire and was honoured as sent, letting a client name someone else's app, spend their budget, and file rows in their release telemetry. The runner now requires the app to belong to the connection's authenticated user — deliberately `this.userId`, not the client-overridable `req.user_id`. A release run claiming a version an app never released is refused rather than recorded.

Metering still fails open (a ledger outage must not take runs down); ownership fails closed — a lookup that never completed is not permission to bill the app it names.

**Known gap, not closed here.** A client that simply omits `application_id` still runs the same graph unmetered and unattributed. Ownership checking cannot reach it: the caller is not lying about an app, it is declining to name one. Closing it means the server deriving the app from the run — a run addressed as "operation *X* of application *Y*", with the pinned graph resolved server-side — instead of accepting a client-supplied graph with an optional app label. That is a run-protocol change and wants its own PR. Relatedly, `startJobInner`'s `req.user_id ?? this.userId` still lets a client relabel a run's execution identity; it no longer affects budget authorization, but it is worth closing separately.

## Verification

`npm run lint` clean. `npm run typecheck` clean for web and electron; mobile fails only on missing modules because `mobile/node_modules` is not installed in this environment (it is deliberately not a root workspace) and no mobile file is touched here.

Tests: app-runtime 156, models 759, websocket 1663, web appbuilder 225 — all passing. New coverage for each fix, including two applications over one workflow keeping separate state, concurrent starts replaying only their own buffered messages, a late chunk from a replaced run not overwriting the live one, every malformed mapping shape, and cross-app settlement being a no-op. The web agent verified its new hook tests fail against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eCsDBtGs6YADMVacc3E7D

---
_Generated by [Claude Code](https://claude.ai/code/session_016eCsDBtGs6YADMVacc3E7D)_