### PR TITLE
feat: Google Workspace tools and nodes from the Google login

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -166,6 +166,39 @@ for await (const msg of agent.execute(ctx)) {
 const result = agent.getResults();
 ```
 
+## Google Workspace Tools (`src/tools/google-workspace-tools.ts`)
+
+Drive, Gmail, Docs, Sheets and Calendar tools that authenticate with the access
+token from the user's Google sign-in — there is no API key. The Supabase Google
+login hands the browser a `provider_token`, the web app posts it to
+`POST /api/oauth/google/session`, and the server stores it as an
+`OAuthCredential` under provider `google`. Tools read it back through the
+virtual secret key `GOOGLE_ACCESS_TOKEN`, which `getSecret` routes to
+`resolveGoogleAccessToken` (refreshing a stale token when `GOOGLE_CLIENT_ID` and
+`GOOGLE_CLIENT_SECRET` are set).
+
+They are not in `BUILTIN_TOOL_CLASSES`. A server without a login can never
+produce a token, so the chat toolbelt adds them only when
+`isGoogleWorkspaceEnabled()` (`@nodetool-ai/config`) is true — Supabase auth
+mode, or `NODETOOL_GOOGLE_WORKSPACE=1`. The matching `lib.google.*` nodes are
+filtered out of `/api/nodes/metadata` under the same condition.
+
+```ts
+import {
+  getGoogleWorkspaceTools,
+  registerGoogleWorkspaceTools
+} from "@nodetool-ai/agents";
+
+if (isGoogleWorkspaceEnabled()) {
+  registerGoogleWorkspaceTools();   // makes resolveTool(name) work
+  toolbelt.push(...getGoogleWorkspaceTools());
+}
+```
+
+A missing or revoked credential surfaces as `{ error }` telling the user to sign
+in with Google again, rather than throwing — the agent can then pick another
+route instead of failing the whole step.
+
 ## Plan Approval Gate
 
 `Agent` can pause after planning and present the plan for user approval before

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -187,6 +187,11 @@ export {
   registerBuiltinTools,
   resetBuiltinToolsRegistration
 } from "./tools/builtin-tools.js";
+export {
+  GOOGLE_WORKSPACE_TOOL_CLASSES,
+  getGoogleWorkspaceTools,
+  registerGoogleWorkspaceTools
+} from "./tools/google-workspace-tools.js";
 
 export {
   WorkspaceReadTool,

--- a/packages/agents/src/tools/google-workspace-tools.ts
+++ b/packages/agents/src/tools/google-workspace-tools.ts
@@ -1,0 +1,707 @@
+/**
+ * Google Workspace agent tools — Drive, Gmail, Docs, Sheets and Calendar.
+ *
+ * These authenticate with the access token from the user's Google sign-in
+ * (resolved through `getSecret("GOOGLE_ACCESS_TOKEN")`), so there is no API key
+ * to configure. They are only offered when the server runs in Supabase auth
+ * mode — see `isGoogleWorkspaceEnabled()` in `@nodetool-ai/config`.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  requireGoogleAccessToken,
+  driveSearchFiles,
+  driveGetFile,
+  driveReadFile,
+  driveCreateFile,
+  gmailSearchMessages,
+  gmailGetMessage,
+  gmailSendMessage,
+  gmailModifyLabels,
+  gmailListLabels,
+  docsGetDocument,
+  docsCreateDocument,
+  docsAppendText,
+  sheetsReadRange,
+  sheetsAppendRows,
+  sheetsUpdateRange,
+  sheetsCreateSpreadsheet,
+  calendarListCalendars,
+  calendarListEvents,
+  calendarCreateEvent,
+  calendarDeleteEvent
+} from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+import { registerTool } from "./tool-registry.js";
+
+/**
+ * Shared plumbing: resolve the token, run the call, and turn a failure into a
+ * `{ error }` result rather than a thrown exception, so the agent can recover
+ * (re-authenticate, pick another file) instead of aborting the step.
+ */
+abstract class GoogleWorkspaceTool extends Tool {
+  protected abstract run(
+    token: string,
+    params: Record<string, unknown>
+  ): Promise<unknown>;
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    try {
+      const token = await requireGoogleAccessToken(context);
+      return await this.run(token, params);
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+}
+
+const str = (params: Record<string, unknown>, key: string): string => {
+  const value = params[key];
+  return typeof value === "string" ? value.trim() : "";
+};
+
+const num = (
+  params: Record<string, unknown>,
+  key: string,
+  fallback: number
+): number => {
+  const value = params[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+};
+
+const rows = (params: Record<string, unknown>, key: string): unknown[][] => {
+  const value = params[key];
+  if (!Array.isArray(value)) return [];
+  return value.map((row) => (Array.isArray(row) ? row : [row]));
+};
+
+const strList = (params: Record<string, unknown>, key: string): string[] => {
+  const value = params[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+};
+
+// ── Drive ────────────────────────────────────────────────────────────
+
+export class GoogleDriveSearchTool extends GoogleWorkspaceTool {
+  readonly name = "google_drive_search";
+  readonly description =
+    "Search the user's Google Drive. Accepts a plain phrase (full-text " +
+    "search) or Drive query syntax such as \"mimeType = 'application/vnd.google-apps.spreadsheet'\".";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      query: { type: "string", description: "Search phrase or Drive query" },
+      max_results: {
+        type: "integer",
+        description: "Maximum files to return (1-100)",
+        default: 20
+      }
+    },
+    required: ["query"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Searching Drive for "${str(params, "query")}"`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    const files = await driveSearchFiles(token, {
+      q: str(params, "query"),
+      maxResults: num(params, "max_results", 20)
+    });
+    return { files };
+  }
+}
+
+export class GoogleDriveReadFileTool extends GoogleWorkspaceTool {
+  readonly name = "google_drive_read_file";
+  readonly description =
+    "Read a Google Drive file as text. Google Docs, Sheets and Slides are " +
+    "exported to plain text/CSV; other files are downloaded as-is.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      file_id: { type: "string", description: "Drive file id" }
+    },
+    required: ["file_id"]
+  };
+
+  userMessage(): string {
+    return "Reading a Drive file";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return driveReadFile(token, str(params, "file_id"));
+  }
+}
+
+export class GoogleDriveGetFileTool extends GoogleWorkspaceTool {
+  readonly name = "google_drive_get_file";
+  readonly description =
+    "Get metadata (name, mime type, size, owners, link) for a Drive file.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      file_id: { type: "string", description: "Drive file id" }
+    },
+    required: ["file_id"]
+  };
+
+  userMessage(): string {
+    return "Fetching Drive file details";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return driveGetFile(token, str(params, "file_id"));
+  }
+}
+
+export class GoogleDriveCreateFileTool extends GoogleWorkspaceTool {
+  readonly name = "google_drive_create_file";
+  readonly description = "Create a text file in the user's Google Drive.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      name: { type: "string", description: "File name" },
+      content: { type: "string", description: "File contents" },
+      mime_type: {
+        type: "string",
+        description: "MIME type (default text/plain)"
+      },
+      folder_id: {
+        type: "string",
+        description: "Parent folder id (default: My Drive root)"
+      }
+    },
+    required: ["name", "content"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Creating "${str(params, "name")}" in Drive`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return driveCreateFile(token, {
+      name: str(params, "name"),
+      content: str(params, "content"),
+      mimeType: str(params, "mime_type") || undefined,
+      folderId: str(params, "folder_id") || undefined
+    });
+  }
+}
+
+// ── Gmail ────────────────────────────────────────────────────────────
+
+export class GmailSearchTool extends GoogleWorkspaceTool {
+  readonly name = "gmail_search";
+  readonly description =
+    "Search the user's Gmail with Gmail query syntax (e.g. " +
+    "'from:alice@example.com is:unread newer_than:7d'). Returns parsed " +
+    "messages with subject, sender, date and body.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      query: { type: "string", description: "Gmail search query" },
+      max_results: {
+        type: "integer",
+        description: "Maximum messages to return (1-50)",
+        default: 10
+      }
+    },
+    required: ["query"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Searching Gmail for "${str(params, "query")}"`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    const messages = await gmailSearchMessages(token, {
+      q: str(params, "query"),
+      maxResults: num(params, "max_results", 10)
+    });
+    return { messages };
+  }
+}
+
+export class GmailGetMessageTool extends GoogleWorkspaceTool {
+  readonly name = "gmail_get_message";
+  readonly description = "Fetch one Gmail message by id, fully parsed.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      message_id: { type: "string", description: "Gmail message id" }
+    },
+    required: ["message_id"]
+  };
+
+  userMessage(): string {
+    return "Reading an email";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return gmailGetMessage(token, str(params, "message_id"));
+  }
+}
+
+export class GmailSendMessageTool extends GoogleWorkspaceTool {
+  readonly name = "gmail_send_message";
+  readonly description =
+    "Send a plain-text email from the user's Gmail account.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      to: { type: "string", description: "Recipient address(es), comma-separated" },
+      subject: { type: "string", description: "Subject line" },
+      body: { type: "string", description: "Plain-text body" },
+      cc: { type: "string", description: "Cc address(es), comma-separated" },
+      bcc: { type: "string", description: "Bcc address(es), comma-separated" }
+    },
+    required: ["to", "subject", "body"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Sending an email to ${str(params, "to")}`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return gmailSendMessage(token, {
+      to: str(params, "to"),
+      subject: str(params, "subject"),
+      body: str(params, "body"),
+      cc: str(params, "cc") || undefined,
+      bcc: str(params, "bcc") || undefined
+    });
+  }
+}
+
+export class GmailModifyLabelsTool extends GoogleWorkspaceTool {
+  readonly name = "gmail_modify_labels";
+  readonly description =
+    "Add or remove Gmail labels on a message. Archive by removing 'INBOX'; " +
+    "mark read by removing 'UNREAD'.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      message_id: { type: "string", description: "Gmail message id" },
+      add_label_ids: {
+        type: "array",
+        items: { type: "string" },
+        description: "Label ids to add"
+      },
+      remove_label_ids: {
+        type: "array",
+        items: { type: "string" },
+        description: "Label ids to remove"
+      }
+    },
+    required: ["message_id"]
+  };
+
+  userMessage(): string {
+    return "Updating email labels";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return gmailModifyLabels(token, {
+      messageId: str(params, "message_id"),
+      addLabelIds: strList(params, "add_label_ids"),
+      removeLabelIds: strList(params, "remove_label_ids")
+    });
+  }
+}
+
+export class GmailListLabelsTool extends GoogleWorkspaceTool {
+  readonly name = "gmail_list_labels";
+  readonly description =
+    "List the Gmail labels available in the user's mailbox (id and name).";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {}
+  };
+
+  userMessage(): string {
+    return "Listing Gmail labels";
+  }
+
+  protected async run(token: string) {
+    return { labels: await gmailListLabels(token) };
+  }
+}
+
+// ── Docs ─────────────────────────────────────────────────────────────
+
+export class GoogleDocsReadTool extends GoogleWorkspaceTool {
+  readonly name = "google_docs_read";
+  readonly description = "Read a Google Doc's title and full text.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      document_id: { type: "string", description: "Google Docs document id" }
+    },
+    required: ["document_id"]
+  };
+
+  userMessage(): string {
+    return "Reading a Google Doc";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return docsGetDocument(token, str(params, "document_id"));
+  }
+}
+
+export class GoogleDocsCreateTool extends GoogleWorkspaceTool {
+  readonly name = "google_docs_create";
+  readonly description =
+    "Create a Google Doc, optionally seeded with text. Returns its id and URL.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      title: { type: "string", description: "Document title" },
+      text: { type: "string", description: "Initial body text" }
+    },
+    required: ["title"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Creating the doc "${str(params, "title")}"`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return docsCreateDocument(token, {
+      title: str(params, "title"),
+      text: str(params, "text") || undefined
+    });
+  }
+}
+
+export class GoogleDocsAppendTool extends GoogleWorkspaceTool {
+  readonly name = "google_docs_append";
+  readonly description = "Append text to the end of a Google Doc.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      document_id: { type: "string", description: "Google Docs document id" },
+      text: { type: "string", description: "Text to append" }
+    },
+    required: ["document_id", "text"]
+  };
+
+  userMessage(): string {
+    return "Appending to a Google Doc";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    await docsAppendText(token, {
+      documentId: str(params, "document_id"),
+      text: str(params, "text")
+    });
+    return { success: true, document_id: str(params, "document_id") };
+  }
+}
+
+// ── Sheets ───────────────────────────────────────────────────────────
+
+export class GoogleSheetsReadTool extends GoogleWorkspaceTool {
+  readonly name = "google_sheets_read";
+  readonly description =
+    "Read a range from a Google Sheet in A1 notation (e.g. 'Sheet1!A1:D50'). " +
+    "Returns rows of cell values.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      spreadsheet_id: { type: "string", description: "Spreadsheet id" },
+      range: { type: "string", description: "A1 range, e.g. Sheet1!A1:D50" }
+    },
+    required: ["spreadsheet_id", "range"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Reading ${str(params, "range")} from a Google Sheet`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    const values = await sheetsReadRange(token, {
+      spreadsheetId: str(params, "spreadsheet_id"),
+      range: str(params, "range")
+    });
+    return { values, row_count: values.length };
+  }
+}
+
+export class GoogleSheetsAppendTool extends GoogleWorkspaceTool {
+  readonly name = "google_sheets_append";
+  readonly description =
+    "Append rows below the last populated row of a Google Sheet range.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      spreadsheet_id: { type: "string", description: "Spreadsheet id" },
+      range: {
+        type: "string",
+        description: "A1 range identifying the table, e.g. Sheet1!A:D"
+      },
+      values: {
+        type: "array",
+        items: { type: "array", items: {} },
+        description: "Rows to append, each an array of cell values"
+      }
+    },
+    required: ["spreadsheet_id", "range", "values"]
+  };
+
+  userMessage(): string {
+    return "Appending rows to a Google Sheet";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return sheetsAppendRows(token, {
+      spreadsheetId: str(params, "spreadsheet_id"),
+      range: str(params, "range"),
+      values: rows(params, "values")
+    });
+  }
+}
+
+export class GoogleSheetsUpdateTool extends GoogleWorkspaceTool {
+  readonly name = "google_sheets_update";
+  readonly description = "Overwrite a Google Sheet range with new values.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      spreadsheet_id: { type: "string", description: "Spreadsheet id" },
+      range: { type: "string", description: "A1 range to overwrite" },
+      values: {
+        type: "array",
+        items: { type: "array", items: {} },
+        description: "Rows of cell values"
+      }
+    },
+    required: ["spreadsheet_id", "range", "values"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Updating ${str(params, "range")} in a Google Sheet`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return sheetsUpdateRange(token, {
+      spreadsheetId: str(params, "spreadsheet_id"),
+      range: str(params, "range"),
+      values: rows(params, "values")
+    });
+  }
+}
+
+export class GoogleSheetsCreateTool extends GoogleWorkspaceTool {
+  readonly name = "google_sheets_create";
+  readonly description =
+    "Create a Google Sheet, optionally seeded with rows. Returns id and URL.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      title: { type: "string", description: "Spreadsheet title" },
+      values: {
+        type: "array",
+        items: { type: "array", items: {} },
+        description: "Initial rows, written starting at A1"
+      }
+    },
+    required: ["title"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Creating the sheet "${str(params, "title")}"`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return sheetsCreateSpreadsheet(token, {
+      title: str(params, "title"),
+      values: rows(params, "values")
+    });
+  }
+}
+
+// ── Calendar ─────────────────────────────────────────────────────────
+
+export class GoogleCalendarListCalendarsTool extends GoogleWorkspaceTool {
+  readonly name = "google_calendar_list_calendars";
+  readonly description = "List the user's Google calendars (id and name).";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {}
+  };
+
+  userMessage(): string {
+    return "Listing Google calendars";
+  }
+
+  protected async run(token: string) {
+    return { calendars: await calendarListCalendars(token) };
+  }
+}
+
+export class GoogleCalendarListEventsTool extends GoogleWorkspaceTool {
+  readonly name = "google_calendar_list_events";
+  readonly description =
+    "List Google Calendar events in a time window, soonest first. Times are " +
+    "RFC3339 timestamps; `time_min` defaults to now.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      calendar_id: {
+        type: "string",
+        description: "Calendar id (default: primary)"
+      },
+      time_min: { type: "string", description: "RFC3339 window start" },
+      time_max: { type: "string", description: "RFC3339 window end" },
+      query: { type: "string", description: "Free-text event filter" },
+      max_results: {
+        type: "integer",
+        description: "Maximum events to return (1-250)",
+        default: 20
+      }
+    }
+  };
+
+  userMessage(): string {
+    return "Checking the calendar";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    const events = await calendarListEvents(token, {
+      calendarId: str(params, "calendar_id") || undefined,
+      timeMin: str(params, "time_min") || undefined,
+      timeMax: str(params, "time_max") || undefined,
+      q: str(params, "query") || undefined,
+      maxResults: num(params, "max_results", 20)
+    });
+    return { events };
+  }
+}
+
+export class GoogleCalendarCreateEventTool extends GoogleWorkspaceTool {
+  readonly name = "google_calendar_create_event";
+  readonly description =
+    "Create a Google Calendar event. `start` and `end` are RFC3339 timestamps " +
+    "with an offset, e.g. '2026-07-27T15:00:00-07:00'.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      summary: { type: "string", description: "Event title" },
+      start: { type: "string", description: "RFC3339 start time" },
+      end: { type: "string", description: "RFC3339 end time" },
+      calendar_id: {
+        type: "string",
+        description: "Calendar id (default: primary)"
+      },
+      description: { type: "string", description: "Event description" },
+      location: { type: "string", description: "Event location" },
+      attendees: {
+        type: "array",
+        items: { type: "string" },
+        description: "Attendee email addresses"
+      }
+    },
+    required: ["summary", "start", "end"]
+  };
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Creating the event "${str(params, "summary")}"`;
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    return calendarCreateEvent(token, {
+      calendarId: str(params, "calendar_id") || undefined,
+      summary: str(params, "summary"),
+      start: str(params, "start"),
+      end: str(params, "end"),
+      description: str(params, "description") || undefined,
+      location: str(params, "location") || undefined,
+      attendees: strList(params, "attendees")
+    });
+  }
+}
+
+export class GoogleCalendarDeleteEventTool extends GoogleWorkspaceTool {
+  readonly name = "google_calendar_delete_event";
+  readonly description = "Delete a Google Calendar event by id.";
+  protected readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      event_id: { type: "string", description: "Event id" },
+      calendar_id: {
+        type: "string",
+        description: "Calendar id (default: primary)"
+      }
+    },
+    required: ["event_id"]
+  };
+
+  userMessage(): string {
+    return "Deleting a calendar event";
+  }
+
+  protected async run(token: string, params: Record<string, unknown>) {
+    await calendarDeleteEvent(token, {
+      calendarId: str(params, "calendar_id") || undefined,
+      eventId: str(params, "event_id")
+    });
+    return { success: true, event_id: str(params, "event_id") };
+  }
+}
+
+/**
+ * Every Google Workspace tool class. Kept separate from
+ * `BUILTIN_TOOL_CLASSES` because they are only offered when the deployment can
+ * produce a Google login token.
+ */
+export const GOOGLE_WORKSPACE_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
+  GoogleDriveSearchTool,
+  GoogleDriveGetFileTool,
+  GoogleDriveReadFileTool,
+  GoogleDriveCreateFileTool,
+  GmailSearchTool,
+  GmailGetMessageTool,
+  GmailSendMessageTool,
+  GmailModifyLabelsTool,
+  GmailListLabelsTool,
+  GoogleDocsReadTool,
+  GoogleDocsCreateTool,
+  GoogleDocsAppendTool,
+  GoogleSheetsReadTool,
+  GoogleSheetsAppendTool,
+  GoogleSheetsUpdateTool,
+  GoogleSheetsCreateTool,
+  GoogleCalendarListCalendarsTool,
+  GoogleCalendarListEventsTool,
+  GoogleCalendarCreateEventTool,
+  GoogleCalendarDeleteEventTool
+];
+
+/** One fresh instance per Google Workspace tool. */
+export function getGoogleWorkspaceTools(): Tool[] {
+  return GOOGLE_WORKSPACE_TOOL_CLASSES.map((Cls) => new Cls());
+}
+
+let registeredNames: string[] | null = null;
+
+/**
+ * Register the Google Workspace tools so `resolveTool(name)` finds them.
+ * Idempotent. Callers gate this on `isGoogleWorkspaceEnabled()`.
+ */
+export function registerGoogleWorkspaceTools(): string[] {
+  if (registeredNames) return registeredNames;
+  const names: string[] = [];
+  for (const tool of getGoogleWorkspaceTools()) {
+    registerTool(tool);
+    names.push(tool.name);
+  }
+  registeredNames = names;
+  return names;
+}

--- a/packages/agents/tests/google-workspace-tools.test.ts
+++ b/packages/agents/tests/google-workspace-tools.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  GOOGLE_WORKSPACE_TOOL_CLASSES,
+  getGoogleWorkspaceTools,
+  GoogleDriveSearchTool,
+  GmailSendMessageTool,
+  GoogleSheetsAppendTool,
+  GoogleCalendarListEventsTool
+} from "../src/tools/google-workspace-tools.js";
+import { registerGoogleWorkspaceTools } from "../src/tools/google-workspace-tools.js";
+import { resolveTool } from "../src/tools/tool-registry.js";
+
+const TOKEN = "ya29.test-token";
+
+let originalFetch: typeof globalThis.fetch;
+let requests: string[] = [];
+
+function contextWithToken(token: string | null): ProcessingContext {
+  return { getSecret: async () => token } as unknown as ProcessingContext;
+}
+
+function mockFetch(body: unknown, status = 200): void {
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    requests.push(String(input));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" }
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  requests = [];
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Google Workspace toolbelt", () => {
+  it("exposes uniquely-named tools across Drive, Gmail, Docs, Sheets and Calendar", () => {
+    const names = getGoogleWorkspaceTools().map((t) => t.name);
+    expect(names).toHaveLength(GOOGLE_WORKSPACE_TOOL_CLASSES.length);
+    expect(new Set(names).size).toBe(names.length);
+    for (const prefix of [
+      "google_drive_",
+      "gmail_",
+      "google_docs_",
+      "google_sheets_",
+      "google_calendar_"
+    ]) {
+      expect(names.some((n) => n.startsWith(prefix))).toBe(true);
+    }
+  });
+
+  it("resolves by name once registered", () => {
+    registerGoogleWorkspaceTools();
+    expect(resolveTool("google_drive_search")?.name).toBe(
+      "google_drive_search"
+    );
+  });
+});
+
+describe("token handling", () => {
+  it("returns a sign-in hint instead of throwing when no account is connected", async () => {
+    const result = (await new GoogleDriveSearchTool().process(
+      contextWithToken(null),
+      { query: "notes" }
+    )) as { error?: string };
+
+    expect(result.error).toMatch(/Sign in with Google/);
+  });
+
+  it("turns a Google API failure into an error result the agent can read", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("insufficient scope", { status: 403 })
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = (await new GoogleDriveSearchTool().process(
+      contextWithToken(TOKEN),
+      { query: "notes" }
+    )) as { error?: string };
+
+    expect(result.error).toContain("403");
+  });
+});
+
+describe("tool calls", () => {
+  it("searches Drive and returns the file list", async () => {
+    mockFetch({ files: [{ id: "1", name: "Report", mimeType: "text/plain" }] });
+
+    const result = (await new GoogleDriveSearchTool().process(
+      contextWithToken(TOKEN),
+      { query: "Report", max_results: 5 }
+    )) as { files: unknown[] };
+
+    expect(result.files).toHaveLength(1);
+    expect(requests[0]).toContain("drive/v3/files");
+  });
+
+  it("sends mail through the Gmail send endpoint", async () => {
+    mockFetch({ id: "sent-1", threadId: "t1" });
+
+    const result = (await new GmailSendMessageTool().process(
+      contextWithToken(TOKEN),
+      { to: "bob@example.com", subject: "Hi", body: "there" }
+    )) as { id: string };
+
+    expect(result.id).toBe("sent-1");
+    expect(requests[0]).toContain("/messages/send");
+  });
+
+  it("coerces a flat value list into a single sheet row", async () => {
+    mockFetch({ updates: { updatedRange: "A2:B2", updatedRows: 1 } });
+
+    const result = (await new GoogleSheetsAppendTool().process(
+      contextWithToken(TOKEN),
+      { spreadsheet_id: "s1", range: "A:B", values: ["Alice", 30] }
+    )) as { updatedRows: number };
+
+    expect(result.updatedRows).toBe(1);
+  });
+
+  it("lists calendar events", async () => {
+    mockFetch({
+      items: [
+        {
+          id: "e1",
+          summary: "Standup",
+          start: { dateTime: "2026-07-27T09:00:00Z" },
+          end: { dateTime: "2026-07-27T09:15:00Z" }
+        }
+      ]
+    });
+
+    const result = (await new GoogleCalendarListEventsTool().process(
+      contextWithToken(TOKEN),
+      {}
+    )) as { events: Array<{ summary: string }> };
+
+    expect(result.events[0].summary).toBe("Standup");
+  });
+});

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -610,6 +610,23 @@ export {
   LIB_NOTION_NODES
 } from "@nodetool-ai/integration-nodes/nodes/lib-notion";
 export {
+  GoogleDriveSearchLibNode,
+  GoogleDriveReadFileLibNode,
+  GoogleDriveCreateFileLibNode,
+  GoogleGmailSearchLibNode,
+  GoogleGmailSendLibNode,
+  GoogleGmailModifyLabelsLibNode,
+  GoogleDocsReadLibNode,
+  GoogleDocsCreateLibNode,
+  GoogleDocsAppendLibNode,
+  GoogleSheetsReadLibNode,
+  GoogleSheetsAppendLibNode,
+  GoogleSheetsUpdateLibNode,
+  GoogleCalendarListEventsLibNode,
+  GoogleCalendarCreateEventLibNode,
+  LIB_GOOGLE_NODES
+} from "@nodetool-ai/integration-nodes/nodes/lib-google";
+export {
   S3ListBucketsLibNode,
   S3ListObjectsLibNode,
   S3GetObjectLibNode,
@@ -806,6 +823,7 @@ import { LIB_PPTX_NODES } from "@nodetool-ai/document-nodes/nodes/lib-pptx";
 import { LIB_OCR_NODES } from "@nodetool-ai/automation-nodes/nodes/lib-ocr";
 import { LIB_TENSORFLOW_NODES } from "@nodetool-ai/automation-nodes/nodes/lib-tensorflow";
 import { LIB_NOTION_NODES } from "@nodetool-ai/integration-nodes/nodes/lib-notion";
+import { LIB_GOOGLE_NODES } from "@nodetool-ai/integration-nodes/nodes/lib-google";
 import { KIE_DYNAMIC_NODES } from "@nodetool-ai/integration-nodes/nodes/kie-dynamic";
 import { VECTOR_NODES } from "@nodetool-ai/core-nodes/nodes/vector";
 import { GEMINI_NODES } from "@nodetool-ai/llm-nodes/nodes/gemini";
@@ -898,6 +916,7 @@ export const ALL_BASE_NODES: readonly NodeClass[] = [
   ...LIB_OCR_NODES,
   ...LIB_TENSORFLOW_NODES,
   ...LIB_NOTION_NODES,
+  ...LIB_GOOGLE_NODES,
   ...KIE_DYNAMIC_NODES,
   ...VECTOR_NODES,
   ...GEMINI_NODES,

--- a/packages/config/src/__tests__/google-workspace.test.ts
+++ b/packages/config/src/__tests__/google-workspace.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isGoogleWorkspaceEnabled } from "../google-workspace.js";
+
+const KEYS = ["SUPABASE_URL", "SUPABASE_KEY", "NODETOOL_GOOGLE_WORKSPACE"];
+
+describe("isGoogleWorkspaceEnabled", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+    for (const key of KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("is off in local mode", () => {
+    expect(isGoogleWorkspaceEnabled()).toBe(false);
+  });
+
+  it("is on when Supabase auth is configured", () => {
+    process.env.SUPABASE_URL = "https://project.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+    expect(isGoogleWorkspaceEnabled()).toBe(true);
+  });
+
+  it("stays off when only one Supabase variable is set", () => {
+    process.env.SUPABASE_URL = "https://project.supabase.co";
+    expect(isGoogleWorkspaceEnabled()).toBe(false);
+  });
+
+  it("honours the explicit override in both directions", () => {
+    process.env.NODETOOL_GOOGLE_WORKSPACE = "1";
+    expect(isGoogleWorkspaceEnabled()).toBe(true);
+
+    process.env.SUPABASE_URL = "https://project.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+    process.env.NODETOOL_GOOGLE_WORKSPACE = "0";
+    expect(isGoogleWorkspaceEnabled()).toBe(false);
+  });
+});

--- a/packages/config/src/google-workspace.ts
+++ b/packages/config/src/google-workspace.ts
@@ -1,0 +1,30 @@
+/**
+ * Availability gate for the Google Workspace integration (Drive, Gmail, Docs,
+ * Sheets, Calendar).
+ *
+ * Those tools and nodes authenticate with the Google access token the user's
+ * Supabase Google login hands back — there is no API key to paste. A local
+ * install has no login, so the integration would only ever surface an error;
+ * it is hidden there instead.
+ *
+ * Set `NODETOOL_GOOGLE_WORKSPACE=1` to force it on (useful when a local server
+ * points at a hosted Supabase project), or `0` to force it off.
+ */
+
+/** True when the server enforces Supabase auth, i.e. logins produce a token. */
+function isSupabaseAuthMode(): boolean {
+  return Boolean(
+    process.env["SUPABASE_URL"]?.trim() && process.env["SUPABASE_KEY"]?.trim()
+  );
+}
+
+/** Node namespace holding the Google Workspace nodes. */
+export const GOOGLE_WORKSPACE_NAMESPACE = "lib.google";
+
+/** Whether Google Workspace tools and nodes should be offered. */
+export function isGoogleWorkspaceEnabled(): boolean {
+  const override = process.env["NODETOOL_GOOGLE_WORKSPACE"]?.trim();
+  if (override === "1" || override === "true") return true;
+  if (override === "0" || override === "false") return false;
+  return isSupabaseAuthMode();
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,11 @@ export {
 export { getByteLimitEnv } from "./byte-limits.js";
 
 export {
+  isGoogleWorkspaceEnabled,
+  GOOGLE_WORKSPACE_NAMESPACE
+} from "./google-workspace.js";
+
+export {
   registerSetting,
   getSettings,
   clearSettings,

--- a/packages/integration-nodes/README.md
+++ b/packages/integration-nodes/README.md
@@ -35,6 +35,13 @@ npm install @nodetool-ai/integration-nodes
 **Mail** (`lib.mail.*`) — `SendEmail`, `GmailSearch`, `AddLabel`,
 `MoveToArchive`.
 
+**Google Workspace** (`lib.google.*`) — `DriveSearch`, `DriveReadFile`,
+`DriveCreateFile`, `GmailSearch`, `GmailSend`, `GmailModifyLabels`, `DocsRead`,
+`DocsCreate`, `DocsAppend`, `SheetsRead`, `SheetsAppend`, `SheetsUpdate`,
+`CalendarListEvents`, `CalendarCreateEvent`. These take no API key — they use
+the access token from the user's Google sign-in, so they appear only on servers
+that have a login (see Configuration below).
+
 **Messaging** (`messaging.*`) — Discord and Telegram bot triggers and senders:
 `discord.DiscordBotTrigger`, `discord.DiscordSendMessage`,
 `telegram.TelegramBotTrigger`, `telegram.TelegramSendMessage`.
@@ -65,6 +72,13 @@ Keys) or as environment variables:
 - KIE: `KIE_API_KEY`
 - Discord: `DISCORD_BOT_TOKEN`
 - Telegram: `TELEGRAM_BOT_TOKEN`
+
+The `lib.google.*` nodes are the exception: they authenticate with the Google
+token from the Supabase Google login, which the web app posts to
+`POST /api/oauth/google/session`. They are hidden when the server runs without a
+login (Local mode); set `NODETOOL_GOOGLE_WORKSPACE=1` to force them on, and
+`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` so the server can refresh the
+one-hour Google access token.
 
 ## Links
 

--- a/packages/integration-nodes/src/index.ts
+++ b/packages/integration-nodes/src/index.ts
@@ -3,6 +3,7 @@ export * from "./nodes/lib-graphql.js";
 export * from "./nodes/lib-s3.js";
 export * from "./nodes/lib-supabase.js";
 export * from "./nodes/lib-notion.js";
+export * from "./nodes/lib-google.js";
 export * from "./nodes/lib-twilio.js";
 export * from "./nodes/apify.js";
 export * from "./nodes/lib-mail.js";

--- a/packages/integration-nodes/src/nodes/lib-google.ts
+++ b/packages/integration-nodes/src/nodes/lib-google.ts
@@ -1,0 +1,755 @@
+/**
+ * Google Workspace nodes — Drive, Gmail, Docs, Sheets and Calendar.
+ *
+ * These authenticate with the access token from the user's Google sign-in
+ * rather than an API key, so they carry no `requiredSettings`. On a server
+ * without a login there is no token, and the nodes are filtered out of the
+ * palette — see `isGoogleWorkspaceEnabled()` in `@nodetool-ai/config`.
+ */
+
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  requireGoogleAccessToken,
+  driveSearchFiles,
+  driveReadFile,
+  driveCreateFile,
+  gmailSearchMessages,
+  gmailSendMessage,
+  gmailModifyLabels,
+  docsGetDocument,
+  docsCreateDocument,
+  docsAppendText,
+  sheetsReadRange,
+  sheetsAppendRows,
+  sheetsUpdateRange,
+  calendarListEvents,
+  calendarCreateEvent
+} from "@nodetool-ai/runtime";
+import { tagAsServer } from "@nodetool-ai/nodes-utils";
+
+/** Correlation shared by every node that emits one item plus the whole list. */
+const ITEM_AND_LIST: Record<string, OutputCorrelation> = {
+  output: { kind: "iteration", source: "__execution__", group: "items" },
+  outputs: { kind: "single", source: "__execution__" }
+};
+
+const str = (value: unknown, fallback = ""): string => {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed || fallback;
+};
+
+/** Parse a JSON rows property (`[["a",1],["b",2]]`) into a value matrix. */
+function parseRows(value: unknown, label: string): unknown[][] {
+  if (Array.isArray(value)) {
+    return value.map((row) => (Array.isArray(row) ? row : [row]));
+  }
+  const raw = str(value);
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON for ${label}: ${raw}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON array of rows`);
+  }
+  return parsed.map((row) => (Array.isArray(row) ? row : [row]));
+}
+
+/** Split a comma/newline separated list into trimmed entries. */
+function splitList(value: unknown): string[] {
+  return str(value)
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+// ── Drive ────────────────────────────────────────────────────────────
+
+export class GoogleDriveSearchLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DriveSearch";
+  static readonly title = "Google Drive Search";
+  static readonly inlineFields = ["query"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Search files in the signed-in user's Google Drive.\n    google, drive, search, files, cloud";
+  static readonly metadataOutputTypes = {
+    output: "dict",
+    outputs: "list"
+  };
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation = ITEM_AND_LIST;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Query",
+    description:
+      "Search phrase, or Drive query syntax such as \"name contains 'report'\""
+  })
+  declare query: any;
+
+  @prop({
+    type: "int",
+    default: 20,
+    title: "Max Results",
+    description: "Maximum number of files to return"
+  })
+  declare max_results: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const token = await requireGoogleAccessToken(context);
+    const files = await driveSearchFiles(token, {
+      q: str(this.query),
+      maxResults: Number(this.max_results ?? 20)
+    });
+    return { output: files[0] ?? null, outputs: files };
+  }
+}
+
+export class GoogleDriveReadFileLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DriveReadFile";
+  static readonly title = "Google Drive Read File";
+  static readonly inlineFields = ["file_id"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Read a Drive file as text. Docs, Sheets and Slides are exported to plain text or CSV.\n    google, drive, read, download, file";
+  static readonly metadataOutputTypes = {
+    output: "str",
+    name: "str",
+    mime_type: "str"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "File ID",
+    description: "Drive file id"
+  })
+  declare file_id: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const fileId = str(this.file_id);
+    if (!fileId) throw new Error("file_id is required");
+    const token = await requireGoogleAccessToken(context);
+    const file = await driveReadFile(token, fileId);
+    return {
+      output: file.content,
+      name: file.name,
+      mime_type: file.mimeType
+    };
+  }
+}
+
+export class GoogleDriveCreateFileLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DriveCreateFile";
+  static readonly title = "Google Drive Create File";
+  static readonly inlineFields = ["name"];
+  static readonly inputFields = ["content"];
+  static readonly description =
+    "Create a text file in the signed-in user's Google Drive.\n    google, drive, create, upload, file";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Name",
+    description: "File name"
+  })
+  declare name: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Content",
+    description: "File contents"
+  })
+  declare content: any;
+
+  @prop({
+    type: "str",
+    default: "text/plain",
+    title: "MIME Type",
+    description: "MIME type of the uploaded content"
+  })
+  declare mime_type: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Folder ID",
+    description: "Parent folder id (blank for My Drive root)"
+  })
+  declare folder_id: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const name = str(this.name);
+    if (!name) throw new Error("name is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await driveCreateFile(token, {
+        name,
+        content: str(this.content),
+        mimeType: str(this.mime_type, "text/plain"),
+        folderId: str(this.folder_id) || undefined
+      })
+    };
+  }
+}
+
+// ── Gmail ────────────────────────────────────────────────────────────
+
+export class GoogleGmailSearchLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.GmailSearch";
+  static readonly title = "Gmail Search";
+  static readonly inlineFields = ["query"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Search Gmail with Gmail query syntax and return parsed messages.\n    google, gmail, email, search, inbox";
+  static readonly metadataOutputTypes = {
+    output: "dict",
+    outputs: "list"
+  };
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation = ITEM_AND_LIST;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Query",
+    description: "Gmail query, e.g. 'from:alice@example.com newer_than:7d'"
+  })
+  declare query: any;
+
+  @prop({
+    type: "int",
+    default: 10,
+    title: "Max Results",
+    description: "Maximum number of messages to return"
+  })
+  declare max_results: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const token = await requireGoogleAccessToken(context);
+    const messages = await gmailSearchMessages(token, {
+      q: str(this.query),
+      maxResults: Number(this.max_results ?? 10)
+    });
+    return { output: messages[0] ?? null, outputs: messages };
+  }
+}
+
+export class GoogleGmailSendLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.GmailSend";
+  static readonly title = "Gmail Send";
+  static readonly inlineFields = ["to", "subject"];
+  static readonly inputFields = ["body"];
+  static readonly description =
+    "Send a plain-text email from the signed-in user's Gmail account.\n    google, gmail, email, send, message";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "To",
+    description: "Recipient address(es), comma-separated"
+  })
+  declare to: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Subject",
+    description: "Subject line"
+  })
+  declare subject: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Body",
+    description: "Plain-text body"
+  })
+  declare body: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Cc",
+    description: "Cc address(es), comma-separated"
+  })
+  declare cc: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const to = str(this.to);
+    if (!to) throw new Error("to is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await gmailSendMessage(token, {
+        to,
+        subject: str(this.subject),
+        body: str(this.body),
+        cc: str(this.cc) || undefined
+      })
+    };
+  }
+}
+
+export class GoogleGmailModifyLabelsLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.GmailModifyLabels";
+  static readonly title = "Gmail Modify Labels";
+  static readonly inlineFields = ["message_id"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Add or remove Gmail labels on a message. Archive by removing INBOX.\n    google, gmail, label, archive, organize";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Message ID",
+    description: "Gmail message id"
+  })
+  declare message_id: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Add Labels",
+    description: "Label ids to add, comma-separated"
+  })
+  declare add_labels: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Remove Labels",
+    description: "Label ids to remove, comma-separated"
+  })
+  declare remove_labels: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const messageId = str(this.message_id);
+    if (!messageId) throw new Error("message_id is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await gmailModifyLabels(token, {
+        messageId,
+        addLabelIds: splitList(this.add_labels),
+        removeLabelIds: splitList(this.remove_labels)
+      })
+    };
+  }
+}
+
+// ── Docs ─────────────────────────────────────────────────────────────
+
+export class GoogleDocsReadLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DocsRead";
+  static readonly title = "Google Docs Read";
+  static readonly inlineFields = ["document_id"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Read a Google Doc's title and full text.\n    google, docs, document, read, text";
+  static readonly metadataOutputTypes = {
+    output: "str",
+    title: "str"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Document ID",
+    description: "Google Docs document id"
+  })
+  declare document_id: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const documentId = str(this.document_id);
+    if (!documentId) throw new Error("document_id is required");
+    const token = await requireGoogleAccessToken(context);
+    const doc = await docsGetDocument(token, documentId);
+    return { output: doc.text, title: doc.title };
+  }
+}
+
+export class GoogleDocsCreateLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DocsCreate";
+  static readonly title = "Google Docs Create";
+  static readonly inlineFields = ["title"];
+  static readonly inputFields = ["text"];
+  static readonly description =
+    "Create a Google Doc, optionally seeded with text.\n    google, docs, document, create, write";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Title",
+    description: "Document title"
+  })
+  declare title: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Text",
+    description: "Initial body text"
+  })
+  declare text: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const title = str(this.title);
+    if (!title) throw new Error("title is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await docsCreateDocument(token, {
+        title,
+        text: str(this.text) || undefined
+      })
+    };
+  }
+}
+
+export class GoogleDocsAppendLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.DocsAppend";
+  static readonly title = "Google Docs Append";
+  static readonly inlineFields = ["document_id"];
+  static readonly inputFields = ["text"];
+  static readonly description =
+    "Append text to the end of a Google Doc.\n    google, docs, document, append, write";
+  static readonly metadataOutputTypes = {
+    output: "str"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Document ID",
+    description: "Google Docs document id"
+  })
+  declare document_id: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Text",
+    description: "Text to append"
+  })
+  declare text: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const documentId = str(this.document_id);
+    if (!documentId) throw new Error("document_id is required");
+    const token = await requireGoogleAccessToken(context);
+    await docsAppendText(token, { documentId, text: str(this.text) });
+    return { output: documentId };
+  }
+}
+
+// ── Sheets ───────────────────────────────────────────────────────────
+
+export class GoogleSheetsReadLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.SheetsRead";
+  static readonly title = "Google Sheets Read";
+  static readonly inlineFields = ["spreadsheet_id", "range"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Read a range from a Google Sheet as rows of cell values.\n    google, sheets, spreadsheet, read, rows";
+  static readonly metadataOutputTypes = {
+    output: "list"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Spreadsheet ID",
+    description: "Google Sheets spreadsheet id"
+  })
+  declare spreadsheet_id: any;
+
+  @prop({
+    type: "str",
+    default: "A1:Z1000",
+    title: "Range",
+    description: "A1 notation range, e.g. Sheet1!A1:D50"
+  })
+  declare range: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const spreadsheetId = str(this.spreadsheet_id);
+    if (!spreadsheetId) throw new Error("spreadsheet_id is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await sheetsReadRange(token, {
+        spreadsheetId,
+        range: str(this.range, "A1:Z1000")
+      })
+    };
+  }
+}
+
+export class GoogleSheetsAppendLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.SheetsAppend";
+  static readonly title = "Google Sheets Append";
+  static readonly inlineFields = ["spreadsheet_id", "range"];
+  static readonly inputFields = ["values"];
+  static readonly description =
+    "Append rows below the last populated row of a Google Sheet range.\n    google, sheets, spreadsheet, append, rows";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Spreadsheet ID",
+    description: "Google Sheets spreadsheet id"
+  })
+  declare spreadsheet_id: any;
+
+  @prop({
+    type: "str",
+    default: "A:Z",
+    title: "Range",
+    description: "A1 notation range identifying the table"
+  })
+  declare range: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Values",
+    description: 'Rows as JSON, e.g. [["Alice", 30], ["Bob", 41]]'
+  })
+  declare values: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const spreadsheetId = str(this.spreadsheet_id);
+    if (!spreadsheetId) throw new Error("spreadsheet_id is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await sheetsAppendRows(token, {
+        spreadsheetId,
+        range: str(this.range, "A:Z"),
+        values: parseRows(this.values, "values")
+      })
+    };
+  }
+}
+
+export class GoogleSheetsUpdateLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.SheetsUpdate";
+  static readonly title = "Google Sheets Update";
+  static readonly inlineFields = ["spreadsheet_id", "range"];
+  static readonly inputFields = ["values"];
+  static readonly description =
+    "Overwrite a Google Sheet range with new values.\n    google, sheets, spreadsheet, update, write";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Spreadsheet ID",
+    description: "Google Sheets spreadsheet id"
+  })
+  declare spreadsheet_id: any;
+
+  @prop({
+    type: "str",
+    default: "A1",
+    title: "Range",
+    description: "A1 notation range to overwrite"
+  })
+  declare range: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Values",
+    description: 'Rows as JSON, e.g. [["Alice", 30], ["Bob", 41]]'
+  })
+  declare values: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const spreadsheetId = str(this.spreadsheet_id);
+    if (!spreadsheetId) throw new Error("spreadsheet_id is required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await sheetsUpdateRange(token, {
+        spreadsheetId,
+        range: str(this.range, "A1"),
+        values: parseRows(this.values, "values")
+      })
+    };
+  }
+}
+
+// ── Calendar ─────────────────────────────────────────────────────────
+
+export class GoogleCalendarListEventsLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.CalendarListEvents";
+  static readonly title = "Google Calendar List Events";
+  static readonly inlineFields = ["calendar_id"];
+  static readonly inputFields = [];
+  static readonly description =
+    "List Google Calendar events in a time window, soonest first.\n    google, calendar, events, schedule, agenda";
+  static readonly metadataOutputTypes = {
+    output: "dict",
+    outputs: "list"
+  };
+  static readonly inputMode: InputMode = "buffered";
+  static readonly outputCorrelation = ITEM_AND_LIST;
+
+  @prop({
+    type: "str",
+    default: "primary",
+    title: "Calendar ID",
+    description: "Calendar id, or 'primary' for the default calendar"
+  })
+  declare calendar_id: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Time Min",
+    description: "RFC3339 window start (blank for now)"
+  })
+  declare time_min: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Time Max",
+    description: "RFC3339 window end"
+  })
+  declare time_max: any;
+
+  @prop({
+    type: "int",
+    default: 20,
+    title: "Max Results",
+    description: "Maximum number of events to return"
+  })
+  declare max_results: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const token = await requireGoogleAccessToken(context);
+    const events = await calendarListEvents(token, {
+      calendarId: str(this.calendar_id, "primary"),
+      timeMin: str(this.time_min) || undefined,
+      timeMax: str(this.time_max) || undefined,
+      maxResults: Number(this.max_results ?? 20)
+    });
+    return { output: events[0] ?? null, outputs: events };
+  }
+}
+
+export class GoogleCalendarCreateEventLibNode extends BaseNode {
+  static readonly nodeType = "lib.google.CalendarCreateEvent";
+  static readonly title = "Google Calendar Create Event";
+  static readonly inlineFields = ["summary", "start", "end"];
+  static readonly inputFields = [];
+  static readonly description =
+    "Create a Google Calendar event from RFC3339 start and end times.\n    google, calendar, event, create, schedule";
+  static readonly metadataOutputTypes = {
+    output: "dict"
+  };
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Summary",
+    description: "Event title"
+  })
+  declare summary: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Start",
+    description: "RFC3339 start time, e.g. 2026-07-27T15:00:00-07:00"
+  })
+  declare start: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "End",
+    description: "RFC3339 end time"
+  })
+  declare end: any;
+
+  @prop({
+    type: "str",
+    default: "primary",
+    title: "Calendar ID",
+    description: "Calendar id, or 'primary' for the default calendar"
+  })
+  declare calendar_id: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Description",
+    description: "Event description"
+  })
+  declare description: any;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Attendees",
+    description: "Attendee email addresses, comma-separated"
+  })
+  declare attendees: any;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const summary = str(this.summary);
+    const start = str(this.start);
+    const end = str(this.end);
+    if (!summary) throw new Error("summary is required");
+    if (!start || !end) throw new Error("start and end are required");
+    const token = await requireGoogleAccessToken(context);
+    return {
+      output: await calendarCreateEvent(token, {
+        calendarId: str(this.calendar_id, "primary"),
+        summary,
+        start,
+        end,
+        description: str(this.description) || undefined,
+        attendees: splitList(this.attendees)
+      })
+    };
+  }
+}
+
+export const LIB_GOOGLE_NODES = tagAsServer([
+  GoogleDriveSearchLibNode,
+  GoogleDriveReadFileLibNode,
+  GoogleDriveCreateFileLibNode,
+  GoogleGmailSearchLibNode,
+  GoogleGmailSendLibNode,
+  GoogleGmailModifyLabelsLibNode,
+  GoogleDocsReadLibNode,
+  GoogleDocsCreateLibNode,
+  GoogleDocsAppendLibNode,
+  GoogleSheetsReadLibNode,
+  GoogleSheetsAppendLibNode,
+  GoogleSheetsUpdateLibNode,
+  GoogleCalendarListEventsLibNode,
+  GoogleCalendarCreateEventLibNode
+]);

--- a/packages/integration-nodes/tests/lib-google.test.ts
+++ b/packages/integration-nodes/tests/lib-google.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  LIB_GOOGLE_NODES,
+  GoogleDriveSearchLibNode,
+  GoogleDriveReadFileLibNode,
+  GoogleDriveCreateFileLibNode,
+  GoogleGmailSearchLibNode,
+  GoogleGmailSendLibNode,
+  GoogleGmailModifyLabelsLibNode,
+  GoogleDocsReadLibNode,
+  GoogleDocsCreateLibNode,
+  GoogleDocsAppendLibNode,
+  GoogleSheetsReadLibNode,
+  GoogleSheetsAppendLibNode,
+  GoogleSheetsUpdateLibNode,
+  GoogleCalendarListEventsLibNode,
+  GoogleCalendarCreateEventLibNode
+} from "../src/nodes/lib-google.js";
+
+const TOKEN = "ya29.test-token";
+
+let originalFetch: typeof globalThis.fetch;
+let requests: Array<{ url: string; init: RequestInit }> = [];
+
+function contextWithToken(token: string | null): ProcessingContext {
+  return { getSecret: async () => token } as unknown as ProcessingContext;
+}
+
+function mockFetch(reply: (url: string) => unknown): void {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    requests.push({ url, init: init ?? {} });
+    return new Response(JSON.stringify(reply(url)), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  requests = [];
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Google Workspace nodes", () => {
+  it("all live in the lib.google namespace and declare no API-key settings", () => {
+    expect(LIB_GOOGLE_NODES.length).toBeGreaterThan(0);
+    for (const node of LIB_GOOGLE_NODES) {
+      expect(node.nodeType.startsWith("lib.google.")).toBe(true);
+      expect(node.requiredSettings ?? []).toEqual([]);
+    }
+  });
+
+  it("tells the user to sign in when no Google account is connected", async () => {
+    const node = new GoogleDriveSearchLibNode({ query: "notes" });
+    await expect(node.process(contextWithToken(null))).rejects.toThrow(
+      /Sign in with Google/
+    );
+  });
+
+  it("emits the first file plus the full list from a Drive search", async () => {
+    mockFetch(() => ({
+      files: [
+        { id: "1", name: "A", mimeType: "text/plain" },
+        { id: "2", name: "B", mimeType: "text/plain" }
+      ]
+    }));
+
+    const node = new GoogleDriveSearchLibNode({ query: "notes", max_results: 5 });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect((result.output as { id: string }).id).toBe("1");
+    expect(result.outputs).toHaveLength(2);
+  });
+
+  it("exports a Google Doc to plain text when reading it from Drive", async () => {
+    globalThis.fetch = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      requests.push({ url, init: {} });
+      if (url.includes("/export")) {
+        return new Response("doc body", { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          id: "d1",
+          name: "Plan",
+          mimeType: "application/vnd.google-apps.document"
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const node = new GoogleDriveReadFileLibNode({ file_id: "d1" });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect(result.output).toBe("doc body");
+    expect(result.mime_type).toBe("text/plain");
+  });
+
+  it("uploads new Drive files as multipart with the parent folder", async () => {
+    mockFetch(() => ({ id: "f1", name: "notes.txt" }));
+
+    const node = new GoogleDriveCreateFileLibNode({
+      name: "notes.txt",
+      content: "hello",
+      folder_id: "folder-1"
+    });
+    await node.process(contextWithToken(TOKEN));
+
+    const headers = requests[0].init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toMatch(/^multipart\/related; boundary=/);
+    expect(String(requests[0].init.body)).toContain('"parents":["folder-1"]');
+  });
+
+  it("emits the first message plus the full list from a Gmail search", async () => {
+    mockFetch((url) =>
+      url.includes("/messages?")
+        ? { messages: [{ id: "m1" }] }
+        : {
+            id: "m1",
+            threadId: "t1",
+            payload: { headers: [{ name: "Subject", value: "Status" }] }
+          }
+    );
+
+    const node = new GoogleGmailSearchLibNode({ query: "is:unread" });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect((result.output as { subject: string }).subject).toBe("Status");
+    expect(result.outputs).toHaveLength(1);
+  });
+
+  it("archives a message by removing the INBOX label", async () => {
+    mockFetch(() => ({ id: "m1", labelIds: [] }));
+
+    const node = new GoogleGmailModifyLabelsLibNode({
+      message_id: "m1",
+      remove_labels: "INBOX, UNREAD"
+    });
+    await node.process(contextWithToken(TOKEN));
+
+    expect(JSON.parse(String(requests[0].init.body)).removeLabelIds).toEqual([
+      "INBOX",
+      "UNREAD"
+    ]);
+  });
+
+  it("flattens a Google Doc to text when reading it", async () => {
+    mockFetch(() => ({
+      documentId: "doc-1",
+      title: "Plan",
+      body: {
+        content: [
+          { paragraph: { elements: [{ textRun: { content: "Intro" } }] } }
+        ]
+      }
+    }));
+
+    const node = new GoogleDocsReadLibNode({ document_id: "doc-1" });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect(result.output).toBe("Intro");
+    expect(result.title).toBe("Plan");
+  });
+
+  it("creates a doc and seeds it with the given text", async () => {
+    mockFetch(() => ({ documentId: "doc-1", title: "Plan" }));
+
+    const node = new GoogleDocsCreateLibNode({ title: "Plan", text: "Intro" });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect((result.output as { documentId: string }).documentId).toBe("doc-1");
+    // Creation, then a batchUpdate that inserts the seed text.
+    expect(requests[1].url).toContain(":batchUpdate");
+  });
+
+  it("appends text to an existing doc", async () => {
+    mockFetch(() => ({}));
+
+    const node = new GoogleDocsAppendLibNode({
+      document_id: "doc-1",
+      text: "More"
+    });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect(result.output).toBe("doc-1");
+    expect(
+      JSON.parse(String(requests[0].init.body)).requests[0].insertText.text
+    ).toBe("More");
+  });
+
+  it("reads a sheet range and returns its rows", async () => {
+    mockFetch(() => ({ values: [["a", "b"], ["c", "d"]] }));
+
+    const node = new GoogleSheetsReadLibNode({
+      spreadsheet_id: "s1",
+      range: "Sheet1!A1:B2"
+    });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect(result.output).toEqual([
+      ["a", "b"],
+      ["c", "d"]
+    ]);
+  });
+
+  it("overwrites a sheet range with a PUT", async () => {
+    mockFetch(() => ({ updatedRange: "A1:B1", updatedCells: 2 }));
+
+    const node = new GoogleSheetsUpdateLibNode({
+      spreadsheet_id: "s1",
+      range: "A1",
+      values: '[["Alice", 30]]'
+    });
+    await node.process(contextWithToken(TOKEN));
+
+    expect(requests[0].init.method).toBe("PUT");
+  });
+
+  it("lists calendar events with the primary calendar by default", async () => {
+    mockFetch(() => ({
+      items: [
+        {
+          id: "e1",
+          summary: "Standup",
+          start: { dateTime: "2026-07-27T09:00:00Z" },
+          end: { dateTime: "2026-07-27T09:15:00Z" }
+        }
+      ]
+    }));
+
+    const node = new GoogleCalendarListEventsLibNode({});
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect((result.output as { summary: string }).summary).toBe("Standup");
+    expect(requests[0].url).toContain("/calendars/primary/events");
+  });
+
+  it("requires a recipient before sending mail", async () => {
+    const node = new GoogleGmailSendLibNode({ subject: "Hi", body: "there" });
+    await expect(node.process(contextWithToken(TOKEN))).rejects.toThrow(
+      "to is required"
+    );
+  });
+
+  it("parses JSON rows for a sheet append", async () => {
+    mockFetch(() => ({ updates: { updatedRange: "A2:B2", updatedRows: 1 } }));
+
+    const node = new GoogleSheetsAppendLibNode({
+      spreadsheet_id: "s1",
+      range: "A:B",
+      values: '[["Alice", 30]]'
+    });
+    const result = await node.process(contextWithToken(TOKEN));
+
+    expect((result.output as { updatedRows: number }).updatedRows).toBe(1);
+    expect(JSON.parse(String(requests[0].init.body)).values).toEqual([
+      ["Alice", 30]
+    ]);
+  });
+
+  it("rejects malformed JSON rows with the offending value", async () => {
+    const node = new GoogleSheetsAppendLibNode({
+      spreadsheet_id: "s1",
+      range: "A:B",
+      values: "not json"
+    });
+    await expect(node.process(contextWithToken(TOKEN))).rejects.toThrow(
+      /Invalid JSON for values/
+    );
+  });
+
+  it("splits a comma-separated attendee list into addresses", async () => {
+    mockFetch(() => ({ id: "e1", summary: "Sync" }));
+
+    const node = new GoogleCalendarCreateEventLibNode({
+      summary: "Sync",
+      start: "2026-07-27T15:00:00-07:00",
+      end: "2026-07-27T15:30:00-07:00",
+      attendees: "a@example.com, b@example.com"
+    });
+    await node.process(contextWithToken(TOKEN));
+
+    expect(JSON.parse(String(requests[0].init.body)).attendees).toEqual([
+      { email: "a@example.com" },
+      { email: "b@example.com" }
+    ]);
+  });
+});

--- a/packages/models/src/google-token.ts
+++ b/packages/models/src/google-token.ts
@@ -1,0 +1,197 @@
+/**
+ * Google Workspace OAuth token resolution.
+ *
+ * In production the web app signs in through Supabase's Google provider, which
+ * hands back a Google `provider_token` (and, with `access_type=offline`, a
+ * `provider_refresh_token`). The frontend posts those to
+ * `POST /api/oauth/google/session`, which stores them as an
+ * {@link OAuthCredential} under provider `"google"`.
+ *
+ * Tools and nodes consume the access token via
+ * `getSecret("GOOGLE_ACCESS_TOKEN")`; this module returns a currently-valid
+ * token, refreshing it against Google's token endpoint when it has (nearly)
+ * expired and persisting the rotated token back.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+import { OAuthCredential } from "./oauth-credential.js";
+
+const log = createLogger("nodetool.models.google-token");
+
+/** Treat a token expiring within this window as already expired. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** Provider namespace the Google login credential is stored under. */
+export const GOOGLE_CREDENTIAL_PROVIDER = "google";
+
+/** Virtual secret key that resolves to a valid Google access token. */
+export const GOOGLE_ACCESS_TOKEN_KEY = "GOOGLE_ACCESS_TOKEN";
+
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+function isExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  const expiryMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiryMs)) return false;
+  return Date.now() >= expiryMs - EXPIRY_SKEW_MS;
+}
+
+interface RefreshResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  token_type?: unknown;
+  scope?: unknown;
+  expires_in?: unknown;
+}
+
+/**
+ * Refresh the credential's access token in place. Returns the new token, or
+ * null when there is no refresh token or no configured Google OAuth client.
+ *
+ * The client id/secret are the same pair configured in the Supabase dashboard
+ * for the Google provider — Supabase does not refresh provider tokens for us,
+ * so the server needs them to keep a long-running agent alive past the one-hour
+ * Google access-token lifetime.
+ */
+async function refreshCredential(
+  credential: OAuthCredential
+): Promise<string | null> {
+  const refreshToken = await credential.getDecryptedRefreshToken();
+  if (!refreshToken) return null;
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    log.warn(
+      "Google token expired but GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET are unset"
+    );
+    return null;
+  }
+
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json"
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret
+    }).toString()
+  });
+
+  if (!res.ok) {
+    log.warn("Google token refresh failed", { status: res.status });
+    return null;
+  }
+
+  const body = (await res.json()) as RefreshResponse;
+  const accessToken =
+    typeof body.access_token === "string" ? body.access_token : null;
+  if (!accessToken) return null;
+
+  const expiresIn =
+    typeof body.expires_in === "number" ? body.expires_in : null;
+  await credential.updateTokens({
+    accessToken,
+    // Google only returns a new refresh token on re-consent; keep the old one.
+    refreshToken:
+      typeof body.refresh_token === "string" ? body.refresh_token : undefined,
+    tokenType:
+      typeof body.token_type === "string" ? body.token_type : undefined,
+    scope: typeof body.scope === "string" ? body.scope : undefined,
+    receivedAt: new Date().toISOString(),
+    expiresAt:
+      expiresIn != null
+        ? new Date(Date.now() + expiresIn * 1000).toISOString()
+        : undefined
+  });
+  return accessToken;
+}
+
+/**
+ * Resolve a valid Google access token for a user, or null when the user has
+ * not signed in with Google. Refreshes a (nearly) expired token when a refresh
+ * token and OAuth client credentials are available.
+ */
+export async function resolveGoogleAccessToken(
+  userId: string
+): Promise<string | null> {
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    userId,
+    GOOGLE_CREDENTIAL_PROVIDER
+  );
+  // listForUserAndProvider is ordered by updated_at desc — use the freshest.
+  const credential = credentials[0];
+  if (!credential) return null;
+
+  if (isExpired(credential.expires_at)) {
+    try {
+      const refreshed = await refreshCredential(credential);
+      if (refreshed) return refreshed;
+      // Refresh unavailable or failed — return the stored token anyway so the
+      // caller surfaces Google's own 401 instead of a vague "not connected".
+    } catch (err) {
+      log.warn("Google token refresh threw", { error: String(err) });
+    }
+  }
+
+  return credential.getDecryptedAccessToken();
+}
+
+/** The Google scopes the stored credential was granted, or an empty array. */
+export async function getGoogleGrantedScopes(
+  userId: string
+): Promise<string[]> {
+  const [credential] = await OAuthCredential.listForUserAndProvider(
+    userId,
+    GOOGLE_CREDENTIAL_PROVIDER
+  );
+  if (!credential?.scope) return [];
+  return credential.scope.split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Persist the Google tokens handed to the browser by a Supabase Google login.
+ *
+ * `accountId` is the Google account identity (the Supabase user id when the
+ * Google `sub` is not available), so re-logins update one row per account.
+ */
+export async function storeGoogleCredential(opts: {
+  userId: string;
+  accountId: string;
+  accessToken: string;
+  refreshToken?: string | null;
+  email?: string | null;
+  scope?: string | null;
+  expiresAt?: string | null;
+}): Promise<OAuthCredential> {
+  return OAuthCredential.upsert({
+    user_id: opts.userId,
+    provider: GOOGLE_CREDENTIAL_PROVIDER,
+    account_id: opts.accountId,
+    access_token: opts.accessToken,
+    refresh_token: opts.refreshToken ?? null,
+    username: opts.email ?? null,
+    token_type: "Bearer",
+    scope: opts.scope ?? null,
+    received_at: new Date().toISOString(),
+    expires_at: opts.expiresAt ?? null
+  });
+}
+
+/** Delete every stored Google credential for a user. Returns the count. */
+export async function deleteGoogleCredentials(
+  userId: string
+): Promise<number> {
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    userId,
+    GOOGLE_CREDENTIAL_PROVIDER
+  );
+  for (const credential of credentials) {
+    await credential.delete();
+  }
+  return credentials.length;
+}

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -207,6 +207,14 @@ export type {
 
 export { OAuthCredential } from "./oauth-credential.js";
 export { resolveCodexAccessToken } from "./codex-token.js";
+export {
+  GOOGLE_ACCESS_TOKEN_KEY,
+  GOOGLE_CREDENTIAL_PROVIDER,
+  resolveGoogleAccessToken,
+  getGoogleGrantedScopes,
+  storeGoogleCredential,
+  deleteGoogleCredentials
+} from "./google-token.js";
 
 export { Prediction } from "./prediction.js";
 export type {

--- a/packages/models/src/secret-helper.ts
+++ b/packages/models/src/secret-helper.ts
@@ -16,6 +16,10 @@
 import { createLogger } from "@nodetool-ai/config";
 import { Secret } from "./secret.js";
 import { resolveCodexAccessToken } from "./codex-token.js";
+import {
+  GOOGLE_ACCESS_TOKEN_KEY,
+  resolveGoogleAccessToken
+} from "./google-token.js";
 
 const log = createLogger("nodetool.models.secret-helper");
 
@@ -55,6 +59,21 @@ export async function getSecret(
       return await resolveCodexAccessToken(resolvedUserId);
     } catch (err) {
       log.error("Codex token resolution failed", {
+        userId: resolvedUserId,
+        error: String(err)
+      });
+      return null;
+    }
+  }
+
+  // The Google Workspace bearer comes from the user's Google login, not from a
+  // stored Secret, and may need a refresh. Resolve it directly — never cache,
+  // since the value rotates roughly hourly.
+  if (key === GOOGLE_ACCESS_TOKEN_KEY) {
+    try {
+      return await resolveGoogleAccessToken(resolvedUserId);
+    } catch (err) {
+      log.error("Google token resolution failed", {
         userId: resolvedUserId,
         error: String(err)
       });

--- a/packages/models/tests/google-token.test.ts
+++ b/packages/models/tests/google-token.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ModelObserver } from "../src/base-model.js";
+import { initTestDb } from "../src/db.js";
+import { setMasterKey } from "@nodetool-ai/security";
+import {
+  resolveGoogleAccessToken,
+  storeGoogleCredential,
+  deleteGoogleCredentials,
+  getGoogleGrantedScopes
+} from "../src/google-token.js";
+
+const TEST_MASTER_KEY = "dGVzdC1tYXN0ZXIta2V5LWZvci11bml0LXRlc3Rz"; // base64
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  initTestDb();
+  setMasterKey(TEST_MASTER_KEY);
+  originalFetch = globalThis.fetch;
+  delete process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_SECRET;
+});
+
+afterEach(() => {
+  ModelObserver.clear();
+  globalThis.fetch = originalFetch;
+});
+
+describe("storeGoogleCredential", () => {
+  it("encrypts the tokens and round-trips the access token", async () => {
+    const credential = await storeGoogleCredential({
+      userId: "u1",
+      accountId: "alice@example.com",
+      accessToken: "ya29.first",
+      refreshToken: "refresh-1",
+      email: "alice@example.com",
+      scope: "https://www.googleapis.com/auth/drive"
+    });
+
+    expect(credential.encrypted_access_token).not.toBe("ya29.first");
+    await expect(resolveGoogleAccessToken("u1")).resolves.toBe("ya29.first");
+    await expect(getGoogleGrantedScopes("u1")).resolves.toEqual([
+      "https://www.googleapis.com/auth/drive"
+    ]);
+  });
+
+  it("updates the existing row on re-login", async () => {
+    await storeGoogleCredential({
+      userId: "u1",
+      accountId: "alice@example.com",
+      accessToken: "ya29.first"
+    });
+    await storeGoogleCredential({
+      userId: "u1",
+      accountId: "alice@example.com",
+      accessToken: "ya29.second"
+    });
+
+    await expect(resolveGoogleAccessToken("u1")).resolves.toBe("ya29.second");
+    await expect(deleteGoogleCredentials("u1")).resolves.toBe(1);
+  });
+});
+
+describe("resolveGoogleAccessToken", () => {
+  it("returns null when the user has not signed in with Google", async () => {
+    await expect(resolveGoogleAccessToken("nobody")).resolves.toBeNull();
+  });
+
+  it("refreshes an expired token when the OAuth client is configured", async () => {
+    process.env.GOOGLE_CLIENT_ID = "client-id";
+    process.env.GOOGLE_CLIENT_SECRET = "client-secret";
+    await storeGoogleCredential({
+      userId: "u1",
+      accountId: "alice@example.com",
+      accessToken: "ya29.stale",
+      refreshToken: "refresh-1",
+      expiresAt: new Date(Date.now() - 60_000).toISOString()
+    });
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ access_token: "ya29.fresh", expires_in: 3600 }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    ) as unknown as typeof globalThis.fetch;
+
+    await expect(resolveGoogleAccessToken("u1")).resolves.toBe("ya29.fresh");
+    // The rotated token is persisted, so the next call needs no refresh.
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("should not refresh again");
+    }) as unknown as typeof globalThis.fetch;
+    await expect(resolveGoogleAccessToken("u1")).resolves.toBe("ya29.fresh");
+  });
+
+  it("returns the stale token when no OAuth client is configured", async () => {
+    await storeGoogleCredential({
+      userId: "u1",
+      accountId: "alice@example.com",
+      accessToken: "ya29.stale",
+      refreshToken: "refresh-1",
+      expiresAt: new Date(Date.now() - 60_000).toISOString()
+    });
+
+    await expect(resolveGoogleAccessToken("u1")).resolves.toBe("ya29.stale");
+  });
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -96,7 +96,13 @@
       "import": "./dist/zod-schema.js",
       "default": "./dist/zod-schema.js"
     },
-    "./providers/aki-manifest.json": "./dist/providers/aki-manifest.json"
+    "./providers/aki-manifest.json": "./dist/providers/aki-manifest.json",
+    "./google": {
+      "nodetool-dev": "./src/google/index.ts",
+      "types": "./dist/google/index.d.ts",
+      "import": "./dist/google/index.js",
+      "default": "./dist/google/index.js"
+    }
   },
   "license": "MIT",
   "repository": {

--- a/packages/runtime/src/google/client.ts
+++ b/packages/runtime/src/google/client.ts
@@ -1,0 +1,674 @@
+/**
+ * Google Workspace REST client — Drive, Gmail, Docs, Sheets and Calendar.
+ *
+ * Deliberately dependency-free (plain `fetch`, no googleapis SDK): the calls we
+ * need are a handful of REST endpoints, and the token comes from the user's
+ * Google login rather than a service account.
+ *
+ * Every function takes an OAuth access token. Callers resolve it from the
+ * processing context (`getSecret("GOOGLE_ACCESS_TOKEN")`), which is backed by
+ * the credential stored at login time.
+ */
+
+const DRIVE_API = "https://www.googleapis.com/drive/v3";
+const DRIVE_UPLOAD_API = "https://www.googleapis.com/upload/drive/v3";
+const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
+const DOCS_API = "https://docs.googleapis.com/v1/documents";
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
+
+/** Scopes the Google login requests so the whole toolbelt works. */
+export const GOOGLE_WORKSPACE_SCOPES = [
+  "https://www.googleapis.com/auth/drive",
+  "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/documents",
+  "https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/calendar"
+];
+
+/** An error carrying the HTTP status Google replied with. */
+export class GoogleApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "GoogleApiError";
+    this.status = status;
+  }
+}
+
+async function request<T>(
+  token: string,
+  url: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    ...((init.headers as Record<string, string>) ?? {})
+  };
+  if (init.body && !headers["Content-Type"]) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new GoogleApiError(
+      res.status,
+      res.status === 401 || res.status === 403
+        ? `Google API ${res.status}: ${text || "access denied"}. The Google ` +
+          "sign-in may have expired or lacks the required scope — sign out " +
+          "and sign back in with Google to re-grant access."
+        : `Google API ${res.status}: ${text}`
+    );
+  }
+  if (res.status === 204) return undefined as T;
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return (await res.json()) as T;
+  }
+  return (await res.text()) as unknown as T;
+}
+
+function query(params: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === "") continue;
+    search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
+}
+
+// ── Drive ────────────────────────────────────────────────────────────
+
+export interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime?: string;
+  size?: string;
+  webViewLink?: string;
+  owners?: Array<{ emailAddress?: string; displayName?: string }>;
+}
+
+/** Google-native mime types and the plain export format we read them as. */
+const DRIVE_EXPORT_FORMATS: Record<string, string> = {
+  "application/vnd.google-apps.document": "text/plain",
+  "application/vnd.google-apps.spreadsheet": "text/csv",
+  "application/vnd.google-apps.presentation": "text/plain"
+};
+
+/**
+ * List Drive files matching a query.
+ *
+ * `q` is Drive's own query syntax. A bare phrase is wrapped into a full-text
+ * search so callers can pass "quarterly report" directly.
+ */
+export async function driveSearchFiles(
+  token: string,
+  opts: { q?: string; maxResults?: number; orderBy?: string } = {}
+): Promise<DriveFile[]> {
+  const raw = (opts.q ?? "").trim();
+  const isDriveQuery = /(\bcontains\b|\b=\b|\bin parents\b|\bmimeType\b)/.test(
+    raw
+  );
+  const q = !raw
+    ? "trashed = false"
+    : isDriveQuery
+      ? raw
+      : `fullText contains '${raw.replace(/'/g, "\\'")}' and trashed = false`;
+
+  const url = `${DRIVE_API}/files${query({
+    q,
+    pageSize: Math.min(Math.max(opts.maxResults ?? 20, 1), 100),
+    orderBy: opts.orderBy,
+    fields:
+      "files(id,name,mimeType,modifiedTime,size,webViewLink,owners(emailAddress,displayName))"
+  })}`;
+  const data = await request<{ files?: DriveFile[] }>(token, url);
+  return data.files ?? [];
+}
+
+/** Fetch a file's metadata. */
+export async function driveGetFile(
+  token: string,
+  fileId: string
+): Promise<DriveFile> {
+  return request<DriveFile>(
+    token,
+    `${DRIVE_API}/files/${encodeURIComponent(fileId)}${query({
+      fields:
+        "id,name,mimeType,modifiedTime,size,webViewLink,owners(emailAddress,displayName)"
+    })}`
+  );
+}
+
+/**
+ * Read a file's content as text. Google-native files (Docs, Sheets, Slides)
+ * are exported to a plain format; everything else is downloaded as-is.
+ */
+export async function driveReadFile(
+  token: string,
+  fileId: string
+): Promise<{ name: string; mimeType: string; content: string }> {
+  const meta = await driveGetFile(token, fileId);
+  const exportFormat = DRIVE_EXPORT_FORMATS[meta.mimeType];
+  const url = exportFormat
+    ? `${DRIVE_API}/files/${encodeURIComponent(fileId)}/export${query({
+        mimeType: exportFormat
+      })}`
+    : `${DRIVE_API}/files/${encodeURIComponent(fileId)}${query({ alt: "media" })}`;
+
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new GoogleApiError(res.status, `Drive download failed: ${text}`);
+  }
+  return {
+    name: meta.name,
+    mimeType: exportFormat ?? meta.mimeType,
+    content: await res.text()
+  };
+}
+
+/** Create a plain-text file in Drive (optionally inside a folder). */
+export async function driveCreateFile(
+  token: string,
+  opts: {
+    name: string;
+    content: string;
+    mimeType?: string;
+    folderId?: string;
+  }
+): Promise<DriveFile> {
+  const metadata: Record<string, unknown> = { name: opts.name };
+  if (opts.folderId) metadata.parents = [opts.folderId];
+
+  const boundary = `nodetool-${Math.random().toString(36).slice(2)}`;
+  const mimeType = opts.mimeType ?? "text/plain";
+  const body =
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n` +
+    `${JSON.stringify(metadata)}\r\n` +
+    `--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n` +
+    `${opts.content}\r\n--${boundary}--`;
+
+  return request<DriveFile>(
+    token,
+    `${DRIVE_UPLOAD_API}/files${query({
+      uploadType: "multipart",
+      fields: "id,name,mimeType,webViewLink"
+    })}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": `multipart/related; boundary=${boundary}` },
+      body
+    }
+  );
+}
+
+// ── Gmail ────────────────────────────────────────────────────────────
+
+export interface GmailMessage {
+  id: string;
+  threadId: string;
+  subject: string;
+  from: string;
+  to: string;
+  date: string;
+  snippet: string;
+  body: string;
+  labelIds: string[];
+}
+
+interface GmailPayloadPart {
+  mimeType?: string;
+  filename?: string;
+  headers?: Array<{ name: string; value: string }>;
+  body?: { data?: string; size?: number };
+  parts?: GmailPayloadPart[];
+}
+
+interface GmailRawMessage {
+  id: string;
+  threadId: string;
+  snippet?: string;
+  labelIds?: string[];
+  payload?: GmailPayloadPart;
+}
+
+function decodeBase64Url(data: string): string {
+  return Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64")
+    .toString("utf8");
+}
+
+function header(part: GmailPayloadPart | undefined, name: string): string {
+  const match = part?.headers?.find(
+    (h) => h.name.toLowerCase() === name.toLowerCase()
+  );
+  return match?.value ?? "";
+}
+
+/** Walk the MIME tree and return the first text/plain body (else text/html). */
+function extractBody(part: GmailPayloadPart | undefined): string {
+  if (!part) return "";
+  if (part.body?.data && part.mimeType?.startsWith("text/")) {
+    return decodeBase64Url(part.body.data);
+  }
+  for (const child of part.parts ?? []) {
+    if (child.mimeType === "text/plain" && child.body?.data) {
+      return decodeBase64Url(child.body.data);
+    }
+  }
+  for (const child of part.parts ?? []) {
+    const nested = extractBody(child);
+    if (nested) return nested;
+  }
+  return "";
+}
+
+function toGmailMessage(raw: GmailRawMessage): GmailMessage {
+  return {
+    id: raw.id,
+    threadId: raw.threadId,
+    subject: header(raw.payload, "Subject"),
+    from: header(raw.payload, "From"),
+    to: header(raw.payload, "To"),
+    date: header(raw.payload, "Date"),
+    snippet: raw.snippet ?? "",
+    body: extractBody(raw.payload),
+    labelIds: raw.labelIds ?? []
+  };
+}
+
+/** Fetch one message, fully parsed. */
+export async function gmailGetMessage(
+  token: string,
+  messageId: string
+): Promise<GmailMessage> {
+  const raw = await request<GmailRawMessage>(
+    token,
+    `${GMAIL_API}/messages/${encodeURIComponent(messageId)}${query({
+      format: "full"
+    })}`
+  );
+  return toGmailMessage(raw);
+}
+
+/**
+ * Search the mailbox with Gmail's own query syntax
+ * (e.g. `from:alice@example.com is:unread newer_than:7d`).
+ */
+export async function gmailSearchMessages(
+  token: string,
+  opts: { q?: string; maxResults?: number } = {}
+): Promise<GmailMessage[]> {
+  const list = await request<{ messages?: Array<{ id: string }> }>(
+    token,
+    `${GMAIL_API}/messages${query({
+      q: opts.q,
+      maxResults: Math.min(Math.max(opts.maxResults ?? 10, 1), 50)
+    })}`
+  );
+  const ids = (list.messages ?? []).map((m) => m.id);
+  return Promise.all(ids.map((id) => gmailGetMessage(token, id)));
+}
+
+/** Send a plain-text email. Returns the created message id. */
+export async function gmailSendMessage(
+  token: string,
+  opts: { to: string; subject: string; body: string; cc?: string; bcc?: string }
+): Promise<{ id: string; threadId: string }> {
+  const lines = [
+    `To: ${opts.to}`,
+    opts.cc ? `Cc: ${opts.cc}` : null,
+    opts.bcc ? `Bcc: ${opts.bcc}` : null,
+    `Subject: ${opts.subject}`,
+    "Content-Type: text/plain; charset=UTF-8",
+    "",
+    opts.body
+  ].filter((line): line is string => line !== null);
+
+  const raw = Buffer.from(lines.join("\r\n"), "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+  return request<{ id: string; threadId: string }>(
+    token,
+    `${GMAIL_API}/messages/send`,
+    { method: "POST", body: JSON.stringify({ raw }) }
+  );
+}
+
+/** Add and/or remove labels on a message (archive = remove `INBOX`). */
+export async function gmailModifyLabels(
+  token: string,
+  opts: { messageId: string; addLabelIds?: string[]; removeLabelIds?: string[] }
+): Promise<{ id: string; labelIds: string[] }> {
+  return request<{ id: string; labelIds: string[] }>(
+    token,
+    `${GMAIL_API}/messages/${encodeURIComponent(opts.messageId)}/modify`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        addLabelIds: opts.addLabelIds ?? [],
+        removeLabelIds: opts.removeLabelIds ?? []
+      })
+    }
+  );
+}
+
+/** List the mailbox's labels (id + name). */
+export async function gmailListLabels(
+  token: string
+): Promise<Array<{ id: string; name: string }>> {
+  const data = await request<{
+    labels?: Array<{ id: string; name: string }>;
+  }>(token, `${GMAIL_API}/labels`);
+  return data.labels ?? [];
+}
+
+// ── Docs ─────────────────────────────────────────────────────────────
+
+interface DocsTextRun {
+  textRun?: { content?: string };
+}
+
+interface DocsStructuralElement {
+  paragraph?: { elements?: DocsTextRun[] };
+  table?: {
+    tableRows?: Array<{
+      tableCells?: Array<{ content?: DocsStructuralElement[] }>;
+    }>;
+  };
+}
+
+interface DocsDocument {
+  documentId: string;
+  title?: string;
+  body?: { content?: DocsStructuralElement[] };
+}
+
+function docsToText(content: DocsStructuralElement[] | undefined): string {
+  let out = "";
+  for (const element of content ?? []) {
+    for (const run of element.paragraph?.elements ?? []) {
+      out += run.textRun?.content ?? "";
+    }
+    for (const row of element.table?.tableRows ?? []) {
+      for (const cell of row.tableCells ?? []) {
+        out += docsToText(cell.content);
+      }
+    }
+  }
+  return out;
+}
+
+/** Read a Google Doc as plain text. */
+export async function docsGetDocument(
+  token: string,
+  documentId: string
+): Promise<{ documentId: string; title: string; text: string }> {
+  const doc = await request<DocsDocument>(
+    token,
+    `${DOCS_API}/${encodeURIComponent(documentId)}`
+  );
+  return {
+    documentId: doc.documentId,
+    title: doc.title ?? "",
+    text: docsToText(doc.body?.content)
+  };
+}
+
+/** Create a Google Doc, optionally seeded with text. */
+export async function docsCreateDocument(
+  token: string,
+  opts: { title: string; text?: string }
+): Promise<{ documentId: string; title: string; url: string }> {
+  const doc = await request<DocsDocument>(token, DOCS_API, {
+    method: "POST",
+    body: JSON.stringify({ title: opts.title })
+  });
+  if (opts.text) {
+    await docsAppendText(token, { documentId: doc.documentId, text: opts.text });
+  }
+  return {
+    documentId: doc.documentId,
+    title: doc.title ?? opts.title,
+    url: `https://docs.google.com/document/d/${doc.documentId}/edit`
+  };
+}
+
+/** Append text to the end of a Google Doc. */
+export async function docsAppendText(
+  token: string,
+  opts: { documentId: string; text: string }
+): Promise<void> {
+  await request(
+    token,
+    `${DOCS_API}/${encodeURIComponent(opts.documentId)}:batchUpdate`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        requests: [
+          { insertText: { endOfSegmentLocation: {}, text: opts.text } }
+        ]
+      })
+    }
+  );
+}
+
+// ── Sheets ───────────────────────────────────────────────────────────
+
+/** Read a range (A1 notation) as a row-major array of cell strings. */
+export async function sheetsReadRange(
+  token: string,
+  opts: { spreadsheetId: string; range: string }
+): Promise<string[][]> {
+  const data = await request<{ values?: string[][] }>(
+    token,
+    `${SHEETS_API}/${encodeURIComponent(opts.spreadsheetId)}/values/${encodeURIComponent(
+      opts.range
+    )}`
+  );
+  return data.values ?? [];
+}
+
+/** Append rows below the last populated row of a range. */
+export async function sheetsAppendRows(
+  token: string,
+  opts: { spreadsheetId: string; range: string; values: unknown[][] }
+): Promise<{ updatedRange: string; updatedRows: number }> {
+  const data = await request<{
+    updates?: { updatedRange?: string; updatedRows?: number };
+  }>(
+    token,
+    `${SHEETS_API}/${encodeURIComponent(opts.spreadsheetId)}/values/${encodeURIComponent(
+      opts.range
+    )}:append${query({
+      valueInputOption: "USER_ENTERED",
+      insertDataOption: "INSERT_ROWS"
+    })}`,
+    { method: "POST", body: JSON.stringify({ values: opts.values }) }
+  );
+  return {
+    updatedRange: data.updates?.updatedRange ?? opts.range,
+    updatedRows: data.updates?.updatedRows ?? 0
+  };
+}
+
+/** Overwrite a range with the given values. */
+export async function sheetsUpdateRange(
+  token: string,
+  opts: { spreadsheetId: string; range: string; values: unknown[][] }
+): Promise<{ updatedRange: string; updatedCells: number }> {
+  const data = await request<{
+    updatedRange?: string;
+    updatedCells?: number;
+  }>(
+    token,
+    `${SHEETS_API}/${encodeURIComponent(opts.spreadsheetId)}/values/${encodeURIComponent(
+      opts.range
+    )}${query({ valueInputOption: "USER_ENTERED" })}`,
+    { method: "PUT", body: JSON.stringify({ values: opts.values }) }
+  );
+  return {
+    updatedRange: data.updatedRange ?? opts.range,
+    updatedCells: data.updatedCells ?? 0
+  };
+}
+
+/** Create a spreadsheet, optionally seeded with rows on the first sheet. */
+export async function sheetsCreateSpreadsheet(
+  token: string,
+  opts: { title: string; values?: unknown[][] }
+): Promise<{ spreadsheetId: string; url: string }> {
+  const data = await request<{ spreadsheetId: string; spreadsheetUrl?: string }>(
+    token,
+    SHEETS_API,
+    {
+      method: "POST",
+      body: JSON.stringify({ properties: { title: opts.title } })
+    }
+  );
+  if (opts.values?.length) {
+    await sheetsUpdateRange(token, {
+      spreadsheetId: data.spreadsheetId,
+      range: "A1",
+      values: opts.values
+    });
+  }
+  return {
+    spreadsheetId: data.spreadsheetId,
+    url:
+      data.spreadsheetUrl ??
+      `https://docs.google.com/spreadsheets/d/${data.spreadsheetId}/edit`
+  };
+}
+
+// ── Calendar ─────────────────────────────────────────────────────────
+
+export interface CalendarEvent {
+  id: string;
+  summary: string;
+  description?: string;
+  location?: string;
+  start: string;
+  end: string;
+  attendees: string[];
+  htmlLink?: string;
+}
+
+interface RawCalendarEvent {
+  id: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  htmlLink?: string;
+  start?: { dateTime?: string; date?: string };
+  end?: { dateTime?: string; date?: string };
+  attendees?: Array<{ email?: string }>;
+}
+
+function toCalendarEvent(raw: RawCalendarEvent): CalendarEvent {
+  return {
+    id: raw.id,
+    summary: raw.summary ?? "",
+    description: raw.description,
+    location: raw.location,
+    start: raw.start?.dateTime ?? raw.start?.date ?? "",
+    end: raw.end?.dateTime ?? raw.end?.date ?? "",
+    attendees: (raw.attendees ?? [])
+      .map((a) => a.email)
+      .filter((e): e is string => Boolean(e)),
+    htmlLink: raw.htmlLink
+  };
+}
+
+/** List the user's calendars. */
+export async function calendarListCalendars(
+  token: string
+): Promise<Array<{ id: string; summary: string; primary?: boolean }>> {
+  const data = await request<{
+    items?: Array<{ id: string; summary: string; primary?: boolean }>;
+  }>(token, `${CALENDAR_API}/users/me/calendarList`);
+  return data.items ?? [];
+}
+
+/** List events in a time window, soonest first. */
+export async function calendarListEvents(
+  token: string,
+  opts: {
+    calendarId?: string;
+    timeMin?: string;
+    timeMax?: string;
+    q?: string;
+    maxResults?: number;
+  } = {}
+): Promise<CalendarEvent[]> {
+  const calendarId = opts.calendarId || "primary";
+  const data = await request<{ items?: RawCalendarEvent[] }>(
+    token,
+    `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events${query({
+      timeMin: opts.timeMin ?? new Date().toISOString(),
+      timeMax: opts.timeMax,
+      q: opts.q,
+      maxResults: Math.min(Math.max(opts.maxResults ?? 20, 1), 250),
+      singleEvents: "true",
+      orderBy: "startTime"
+    })}`
+  );
+  return (data.items ?? []).map(toCalendarEvent);
+}
+
+/** Create an event. Times are RFC3339 (`2026-07-27T15:00:00-07:00`). */
+export async function calendarCreateEvent(
+  token: string,
+  opts: {
+    calendarId?: string;
+    summary: string;
+    start: string;
+    end: string;
+    description?: string;
+    location?: string;
+    attendees?: string[];
+  }
+): Promise<CalendarEvent> {
+  const calendarId = opts.calendarId || "primary";
+  const raw = await request<RawCalendarEvent>(
+    token,
+    `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        summary: opts.summary,
+        description: opts.description,
+        location: opts.location,
+        start: { dateTime: opts.start },
+        end: { dateTime: opts.end },
+        attendees: (opts.attendees ?? []).map((email) => ({ email }))
+      })
+    }
+  );
+  return toCalendarEvent(raw);
+}
+
+/** Delete an event. */
+export async function calendarDeleteEvent(
+  token: string,
+  opts: { calendarId?: string; eventId: string }
+): Promise<void> {
+  const calendarId = opts.calendarId || "primary";
+  await request(
+    token,
+    `${CALENDAR_API}/calendars/${encodeURIComponent(
+      calendarId
+    )}/events/${encodeURIComponent(opts.eventId)}`,
+    { method: "DELETE" }
+  );
+}

--- a/packages/runtime/src/google/client.ts
+++ b/packages/runtime/src/google/client.ts
@@ -101,6 +101,17 @@ const DRIVE_EXPORT_FORMATS: Record<string, string> = {
 };
 
 /**
+ * Escape a phrase for a single-quoted Drive query literal.
+ *
+ * Backslashes go first: escaping only the quote would turn an input containing
+ * `\'` into `\\'`, where the backslash escapes itself and the quote closes the
+ * literal early — letting the rest of the phrase run as query syntax.
+ */
+function escapeDriveLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/**
  * List Drive files matching a query.
  *
  * `q` is Drive's own query syntax. A bare phrase is wrapped into a full-text
@@ -118,7 +129,7 @@ export async function driveSearchFiles(
     ? "trashed = false"
     : isDriveQuery
       ? raw
-      : `fullText contains '${raw.replace(/'/g, "\\'")}' and trashed = false`;
+      : `fullText contains '${escapeDriveLiteral(raw)}' and trashed = false`;
 
   const url = `${DRIVE_API}/files${query({
     q,
@@ -241,8 +252,7 @@ interface GmailRawMessage {
 }
 
 function decodeBase64Url(data: string): string {
-  return Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64")
-    .toString("utf8");
+  return Buffer.from(data, "base64url").toString("utf8");
 }
 
 function header(part: GmailPayloadPart | undefined, name: string): string {
@@ -332,11 +342,7 @@ export async function gmailSendMessage(
     opts.body
   ].filter((line): line is string => line !== null);
 
-  const raw = Buffer.from(lines.join("\r\n"), "utf8")
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
+  const raw = Buffer.from(lines.join("\r\n"), "utf8").toString("base64url");
 
   return request<{ id: string; threadId: string }>(
     token,

--- a/packages/runtime/src/google/index.ts
+++ b/packages/runtime/src/google/index.ts
@@ -1,0 +1,2 @@
+export * from "./client.js";
+export { requireGoogleAccessToken } from "./token.js";

--- a/packages/runtime/src/google/token.ts
+++ b/packages/runtime/src/google/token.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve the Google access token a tool or node needs from the processing
+ * context.
+ *
+ * The token is not a pasted API key: it comes from the user's Google sign-in
+ * and is stored server-side as an OAuth credential. `getSecret` routes the
+ * `GOOGLE_ACCESS_TOKEN` key to that credential (refreshing it when stale), so
+ * every caller resolves it the same way.
+ */
+
+import type { ProcessingContext } from "../context.js";
+
+/** Virtual secret key backed by the user's stored Google credential. */
+export const GOOGLE_ACCESS_TOKEN_KEY = "GOOGLE_ACCESS_TOKEN";
+
+const NOT_CONNECTED =
+  "No Google account connected. Sign in with Google to give NodeTool access " +
+  "to your Drive, Gmail, Docs, Sheets and Calendar.";
+
+/** Return the caller's Google access token, or throw a user-facing error. */
+export async function requireGoogleAccessToken(
+  context?: Pick<ProcessingContext, "getSecret">
+): Promise<string> {
+  const token = context
+    ? await context.getSecret(GOOGLE_ACCESS_TOKEN_KEY)
+    : (process.env[GOOGLE_ACCESS_TOKEN_KEY] ?? null);
+  if (!token) {
+    throw new Error(NOT_CONNECTED);
+  }
+  return token;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -173,3 +173,4 @@ export type {
   CostReconcileInput,
   ReconciledCost
 } from "./cost-reconciler.js";
+export * from "./google/index.js";

--- a/packages/runtime/tests/google-client.test.ts
+++ b/packages/runtime/tests/google-client.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  GoogleApiError,
+  driveSearchFiles,
+  driveCreateFile,
+  gmailSearchMessages,
+  gmailSendMessage,
+  docsGetDocument,
+  sheetsAppendRows,
+  calendarListEvents,
+  calendarCreateEvent
+} from "../src/google/client.js";
+import { requireGoogleAccessToken } from "../src/google/token.js";
+
+const TOKEN = "ya29.test-token";
+
+interface Call {
+  url: string;
+  init: RequestInit;
+}
+
+let calls: Call[] = [];
+let originalFetch: typeof globalThis.fetch;
+
+function jsonReply(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response): void {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init: init ?? {} });
+    return handler(url, init ?? {});
+  }) as unknown as typeof globalThis.fetch;
+}
+
+/** Gmail bodies arrive base64url-encoded. */
+function b64url(text: string): string {
+  return Buffer.from(text, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+beforeEach(() => {
+  calls = [];
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("requireGoogleAccessToken", () => {
+  it("returns the token from the context", async () => {
+    const context = { getSecret: async () => TOKEN };
+    await expect(requireGoogleAccessToken(context)).resolves.toBe(TOKEN);
+  });
+
+  it("throws a sign-in hint when no credential is stored", async () => {
+    const context = { getSecret: async () => null };
+    await expect(requireGoogleAccessToken(context)).rejects.toThrow(
+      /Sign in with Google/
+    );
+  });
+});
+
+describe("drive", () => {
+  it("wraps a bare phrase into a full-text query", async () => {
+    mockFetch(() => jsonReply({ files: [{ id: "1", name: "Report" }] }));
+    const files = await driveSearchFiles(TOKEN, { q: "quarterly report" });
+
+    expect(files).toHaveLength(1);
+    const q = new URL(calls[0].url).searchParams.get("q");
+    expect(q).toBe("fullText contains 'quarterly report' and trashed = false");
+  });
+
+  it("passes Drive query syntax through untouched", async () => {
+    mockFetch(() => jsonReply({ files: [] }));
+    await driveSearchFiles(TOKEN, { q: "name contains 'budget'" });
+
+    expect(new URL(calls[0].url).searchParams.get("q")).toBe(
+      "name contains 'budget'"
+    );
+  });
+
+  it("sends a multipart upload when creating a file", async () => {
+    mockFetch(() => jsonReply({ id: "new-file", name: "notes.txt" }));
+    await driveCreateFile(TOKEN, {
+      name: "notes.txt",
+      content: "hello",
+      folderId: "folder-1"
+    });
+
+    const { init } = calls[0];
+    const contentType = (init.headers as Record<string, string>)["Content-Type"];
+    expect(contentType).toMatch(/^multipart\/related; boundary=/);
+    expect(String(init.body)).toContain('"parents":["folder-1"]');
+    expect(String(init.body)).toContain("hello");
+  });
+
+  it("surfaces the re-authentication hint on a 403", async () => {
+    mockFetch(() => new Response("insufficient scope", { status: 403 }));
+    await expect(driveSearchFiles(TOKEN, { q: "x" })).rejects.toThrow(
+      GoogleApiError
+    );
+  });
+});
+
+describe("gmail", () => {
+  it("decodes the plain-text part of a multipart message", async () => {
+    mockFetch((url) => {
+      if (url.includes("/messages?")) {
+        return jsonReply({ messages: [{ id: "m1" }] });
+      }
+      return jsonReply({
+        id: "m1",
+        threadId: "t1",
+        snippet: "hi",
+        labelIds: ["INBOX"],
+        payload: {
+          mimeType: "multipart/alternative",
+          headers: [
+            { name: "Subject", value: "Status" },
+            { name: "From", value: "alice@example.com" }
+          ],
+          parts: [
+            { mimeType: "text/html", body: { data: b64url("<b>no</b>") } },
+            { mimeType: "text/plain", body: { data: b64url("the body") } }
+          ]
+        }
+      });
+    });
+
+    const [message] = await gmailSearchMessages(TOKEN, { q: "is:unread" });
+    expect(message.subject).toBe("Status");
+    expect(message.from).toBe("alice@example.com");
+    expect(message.body).toBe("the body");
+  });
+
+  it("base64url-encodes the RFC822 message when sending", async () => {
+    mockFetch(() => jsonReply({ id: "sent-1", threadId: "t1" }));
+    await gmailSendMessage(TOKEN, {
+      to: "bob@example.com",
+      subject: "Hi",
+      body: "there"
+    });
+
+    const raw = JSON.parse(String(calls[0].init.body)).raw as string;
+    expect(raw).not.toMatch(/[+/=]/);
+    const decoded = Buffer.from(
+      raw.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64"
+    ).toString("utf8");
+    expect(decoded).toContain("To: bob@example.com");
+    expect(decoded).toContain("Subject: Hi");
+    expect(decoded).toContain("there");
+  });
+});
+
+describe("docs", () => {
+  it("flattens paragraphs and table cells into plain text", async () => {
+    mockFetch(() =>
+      jsonReply({
+        documentId: "doc-1",
+        title: "Plan",
+        body: {
+          content: [
+            { paragraph: { elements: [{ textRun: { content: "Intro\n" } }] } },
+            {
+              table: {
+                tableRows: [
+                  {
+                    tableCells: [
+                      {
+                        content: [
+                          {
+                            paragraph: {
+                              elements: [{ textRun: { content: "Cell" } }]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    );
+
+    const doc = await docsGetDocument(TOKEN, "doc-1");
+    expect(doc.title).toBe("Plan");
+    expect(doc.text).toBe("Intro\nCell");
+  });
+});
+
+describe("sheets", () => {
+  it("appends rows with USER_ENTERED input", async () => {
+    mockFetch(() =>
+      jsonReply({ updates: { updatedRange: "Sheet1!A2:B2", updatedRows: 1 } })
+    );
+    const result = await sheetsAppendRows(TOKEN, {
+      spreadsheetId: "sheet-1",
+      range: "Sheet1!A:B",
+      values: [["Alice", 30]]
+    });
+
+    expect(result.updatedRows).toBe(1);
+    expect(new URL(calls[0].url).searchParams.get("valueInputOption")).toBe(
+      "USER_ENTERED"
+    );
+  });
+});
+
+describe("calendar", () => {
+  it("normalises all-day and timed events to a flat shape", async () => {
+    mockFetch(() =>
+      jsonReply({
+        items: [
+          {
+            id: "e1",
+            summary: "Standup",
+            start: { dateTime: "2026-07-27T09:00:00Z" },
+            end: { dateTime: "2026-07-27T09:15:00Z" },
+            attendees: [{ email: "a@example.com" }, {}]
+          },
+          {
+            id: "e2",
+            summary: "Holiday",
+            start: { date: "2026-07-28" },
+            end: { date: "2026-07-29" }
+          }
+        ]
+      })
+    );
+
+    const events = await calendarListEvents(TOKEN);
+    expect(events[0].start).toBe("2026-07-27T09:00:00Z");
+    expect(events[0].attendees).toEqual(["a@example.com"]);
+    expect(events[1].start).toBe("2026-07-28");
+    expect(events[1].attendees).toEqual([]);
+  });
+
+  it("defaults to the primary calendar when none is given", async () => {
+    mockFetch(() => jsonReply({ id: "e1", summary: "Sync" }));
+    await calendarCreateEvent(TOKEN, {
+      summary: "Sync",
+      start: "2026-07-27T15:00:00-07:00",
+      end: "2026-07-27T15:30:00-07:00"
+    });
+
+    expect(calls[0].url).toContain("/calendars/primary/events");
+  });
+});

--- a/packages/runtime/tests/google-client.test.ts
+++ b/packages/runtime/tests/google-client.test.ts
@@ -79,6 +79,18 @@ describe("drive", () => {
     expect(q).toBe("fullText contains 'quarterly report' and trashed = false");
   });
 
+  it("escapes backslashes before quotes so a phrase cannot break out of the literal", async () => {
+    mockFetch(() => jsonReply({ files: [] }));
+    // Escaping only the quote would yield `\\'`, closing the literal early and
+    // letting `and trashed = true` run as query syntax.
+    await driveSearchFiles(TOKEN, { q: "a\\' and trashed = true and 'b" });
+
+    const q = new URL(calls[0].url).searchParams.get("q");
+    expect(q).toBe(
+      "fullText contains 'a\\\\\\' and trashed = true and \\'b' and trashed = false"
+    );
+  });
+
   it("passes Drive query syntax through untouched", async () => {
     mockFetch(() => jsonReply({ files: [] }));
     await driveSearchFiles(TOKEN, { q: "name contains 'budget'" });

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -19,6 +19,8 @@ import {
 import {
   createLogger,
   loadAssetStorageConfig,
+  isGoogleWorkspaceEnabled,
+  GOOGLE_WORKSPACE_NAMESPACE,
   type StorageConfig
 } from "@nodetool-ai/config";
 import { createAssetUrlBuilder } from "@nodetool-ai/storage";
@@ -434,6 +436,15 @@ export async function handleNodeMetadata(
     nodes = [...loaded.nodesByType.values()];
   }
   nodes.sort((a, b) => a.node_type.localeCompare(b.node_type));
+
+  // Google Workspace nodes authenticate with the token from the user's Google
+  // sign-in. A server with no login can never produce one, so they stay out of
+  // the palette there rather than failing at run time.
+  if (!isGoogleWorkspaceEnabled()) {
+    nodes = nodes.filter(
+      (n) => !n.node_type.startsWith(`${GOOGLE_WORKSPACE_NAMESPACE}.`)
+    );
+  }
 
   // Exact node_type lookup returns the full metadata for that one node.
   if (nodeType) {

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -7,8 +7,13 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
-import { createLogger } from "@nodetool-ai/config";
-import { OAuthCredential } from "@nodetool-ai/models";
+import { createLogger, isGoogleWorkspaceEnabled } from "@nodetool-ai/config";
+import {
+  OAuthCredential,
+  storeGoogleCredential,
+  deleteGoogleCredentials,
+  GOOGLE_CREDENTIAL_PROVIDER
+} from "@nodetool-ai/models";
 import {
   OAuthClient,
   LocalCallbackServer,
@@ -1019,6 +1024,105 @@ async function handleOpenAIDisconnect(
   return jsonResponse({ success: true, removed: credentials.length });
 }
 
+// ── Google Workspace Endpoints ───────────────────────────────────────
+//
+// Unlike the flows above, there is no authorization round-trip here. The user
+// already signed in with Google through Supabase, which handed the browser a
+// Google `provider_token` (and, with `access_type=offline`, a
+// `provider_refresh_token`). Supabase does not expose those server-side, so the
+// web app posts them once per login and the server keeps them for agent tools
+// and workflow nodes.
+
+interface GoogleSessionBody {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_at?: unknown;
+  scope?: unknown;
+  email?: unknown;
+  account_id?: unknown;
+}
+
+/** Coerce Supabase's `expires_at` (unix seconds or ISO string) to ISO. */
+function toIsoExpiry(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString();
+  }
+  if (typeof value === "string" && value) {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return new Date(parsed).toISOString();
+  }
+  return null;
+}
+
+async function handleGoogleSession(
+  request: Request,
+  getUserId: () => string
+): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+  if (!isGoogleWorkspaceEnabled()) {
+    return errorResponse(404, "Google Workspace integration is not enabled");
+  }
+
+  let body: GoogleSessionBody;
+  try {
+    body = (await request.json()) as GoogleSessionBody;
+  } catch {
+    return errorResponse(400, "Invalid JSON body");
+  }
+
+  const accessToken =
+    typeof body.access_token === "string" ? body.access_token : "";
+  if (!accessToken) {
+    return errorResponse(400, "access_token is required");
+  }
+
+  const userId = getUserId();
+  const email = typeof body.email === "string" ? body.email : null;
+  const credential = await storeGoogleCredential({
+    userId,
+    // One credential row per Google account. The email is the stable identity
+    // the user recognises; fall back to the NodeTool user id.
+    accountId:
+      (typeof body.account_id === "string" && body.account_id) ||
+      email ||
+      userId,
+    accessToken,
+    refreshToken:
+      typeof body.refresh_token === "string" ? body.refresh_token : null,
+    email,
+    scope: typeof body.scope === "string" ? body.scope : null,
+    expiresAt: toIsoExpiry(body.expires_at)
+  });
+
+  logger.info("Google session token stored", { accountId: credential.account_id });
+  return jsonResponse({ success: true, token: toTokenMetadata(credential) });
+}
+
+async function handleGoogleTokens(getUserId: () => string): Promise<Response> {
+  if (!isGoogleWorkspaceEnabled()) {
+    return jsonResponse({ enabled: false, tokens: [] });
+  }
+  const credentials = await OAuthCredential.listForUserAndProvider(
+    getUserId(),
+    GOOGLE_CREDENTIAL_PROVIDER
+  );
+  return jsonResponse({
+    enabled: true,
+    tokens: credentials.map(toTokenMetadata)
+  });
+}
+
+async function handleGoogleDisconnect(
+  request: Request,
+  getUserId: () => string
+): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+  const removed = await deleteGoogleCredentials(getUserId());
+  return jsonResponse({ success: true, removed });
+}
+
 // ── Simple hash helper (replicates Python's hash() for fallback) ─────
 
 function hashCode(str: string): number {
@@ -1084,6 +1188,14 @@ export async function handleOAuthRequest(
       return handleOpenAITokens(getUserId);
     case "/api/oauth/openai/disconnect":
       return handleOpenAIDisconnect(request, getUserId);
+
+    // Google Workspace (token comes from the Supabase Google login)
+    case "/api/oauth/google/session":
+      return handleGoogleSession(request, getUserId);
+    case "/api/oauth/google/tokens":
+      return handleGoogleTokens(getUserId);
+    case "/api/oauth/google/disconnect":
+      return handleGoogleDisconnect(request, getUserId);
 
     default:
       return null;

--- a/packages/websocket/src/routes/config.ts
+++ b/packages/websocket/src/routes/config.ts
@@ -1,4 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
+import { isGoogleWorkspaceEnabled } from "@nodetool-ai/config";
+import { GOOGLE_WORKSPACE_SCOPES } from "@nodetool-ai/runtime";
 import { getVersion } from "./health.js";
 
 /**
@@ -26,11 +28,17 @@ const configRoute: FastifyPluginAsync = async (app) => {
     const authMode: "supabase" | "local" =
       supabaseUrl && supabaseServiceKey ? "supabase" : "local";
 
+    // When enabled, the web app asks Google for the Workspace scopes at login
+    // and posts the resulting provider token to /api/oauth/google/session.
+    const googleWorkspace = isGoogleWorkspaceEnabled();
+
     return reply.status(200).send({
       authMode,
       supabaseUrl,
       supabaseAnonKey,
       authRedirectUrl,
+      googleWorkspace,
+      googleScopes: googleWorkspace ? GOOGLE_WORKSPACE_SCOPES : [],
       version: getVersion()
     });
   });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -9,7 +9,8 @@ import {
   createLogger,
   getDefaultAssetsPath,
   buildAssetUrl,
-  getByteLimitEnv
+  getByteLimitEnv,
+  isGoogleWorkspaceEnabled
 } from "@nodetool-ai/config";
 import { getAssetAdapter, getTempAdapter } from "./lib/storage.js";
 import { FileStorageAdapter } from "@nodetool-ai/storage";
@@ -108,6 +109,8 @@ import {
   getBuiltinTools,
   getAllMcpTools,
   registerBuiltinTools,
+  getGoogleWorkspaceTools,
+  registerGoogleWorkspaceTools,
   ListCollectionsTool,
   QueryCollectionTool,
   gateTools,
@@ -3926,9 +3929,14 @@ export class UnifiedWebSocketRunner {
     // selection anymore — the agent reasons over the full toolbelt and the
     // permission gate (below) governs execution.
     registerBuiltinTools();
+    // Google Workspace runs on the token from the user's Google sign-in, so it
+    // only exists on deployments that have a login. Local mode never sees it.
+    const googleWorkspace = isGoogleWorkspaceEnabled();
+    if (googleWorkspace) registerGoogleWorkspaceTools();
     const chatProviders = await this.getConfiguredProviders(userId);
     const rawToolbelt: Tool[] = [
       ...getBuiltinTools(),
+      ...(googleWorkspace ? getGoogleWorkspaceTools() : []),
       ...getAllMcpTools({
         registry: this.nodeRegistry,
         providers: chatProviders

--- a/packages/websocket/tests/config-api.test.ts
+++ b/packages/websocket/tests/config-api.test.ts
@@ -9,7 +9,8 @@ const ENV_KEYS = [
   "SUPABASE_URL",
   "SUPABASE_KEY",
   "SUPABASE_ANON_KEY",
-  "AUTH_REDIRECT_URL"
+  "AUTH_REDIRECT_URL",
+  "NODETOOL_GOOGLE_WORKSPACE"
 ] as const;
 
 describe("/api/config endpoint", () => {
@@ -63,10 +64,31 @@ describe("/api/config endpoint", () => {
     expect(Object.keys(JSON.parse(res.body)).sort()).toEqual([
       "authMode",
       "authRedirectUrl",
+      "googleScopes",
+      "googleWorkspace",
       "supabaseAnonKey",
       "supabaseUrl",
       "version"
     ]);
+  });
+
+  it("advertises the Google Workspace scopes only in Supabase mode", async () => {
+    const local = JSON.parse(
+      (await app.inject({ method: "GET", url: "/api/config" })).body
+    );
+    expect(local.googleWorkspace).toBe(false);
+    expect(local.googleScopes).toEqual([]);
+
+    process.env.SUPABASE_URL = "https://x.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+
+    const hosted = JSON.parse(
+      (await app.inject({ method: "GET", url: "/api/config" })).body
+    );
+    expect(hosted.googleWorkspace).toBe(true);
+    expect(hosted.googleScopes).toContain(
+      "https://www.googleapis.com/auth/drive"
+    );
   });
 
   it("stays in local mode when only the anon key is set", async () => {

--- a/packages/websocket/tests/node-metadata-google.test.ts
+++ b/packages/websocket/tests/node-metadata-google.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { handleNodeMetadata } from "../src/http-api.js";
+
+const NODES = [
+  {
+    node_type: "nodetool.text.Concat",
+    title: "Concat",
+    description: "join strings",
+    namespace: "nodetool.text"
+  },
+  {
+    node_type: "lib.google.DriveSearch",
+    title: "Google Drive Search",
+    description: "search drive",
+    namespace: "lib.google"
+  },
+  {
+    node_type: "lib.google.GmailSearch",
+    title: "Gmail Search",
+    description: "search gmail",
+    namespace: "lib.google"
+  }
+];
+
+const registry = { listMetadata: () => NODES } as unknown as NodeRegistry;
+
+async function nodeTypes(): Promise<string[]> {
+  const res = await handleNodeMetadata(
+    new Request("http://localhost:7777/api/nodes/metadata"),
+    { registry }
+  );
+  const data = (await res.json()) as Array<{ node_type: string }>;
+  return data.map((n) => n.node_type);
+}
+
+const ENV_KEYS = ["SUPABASE_URL", "SUPABASE_KEY", "NODETOOL_GOOGLE_WORKSPACE"];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe("node metadata: Google Workspace visibility", () => {
+  it("hides the lib.google nodes in local mode", async () => {
+    const types = await nodeTypes();
+    expect(types).toEqual(["nodetool.text.Concat"]);
+  });
+
+  it("includes them when Supabase auth is configured", async () => {
+    process.env.SUPABASE_URL = "https://project.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+
+    const types = await nodeTypes();
+    expect(types).toContain("lib.google.DriveSearch");
+    expect(types).toContain("lib.google.GmailSearch");
+  });
+
+  it("hides an exact node_type lookup too, so a local run cannot resolve one", async () => {
+    const res = await handleNodeMetadata(
+      new Request(
+        "http://localhost:7777/api/nodes/metadata?node_type=lib.google.DriveSearch"
+      ),
+      { registry }
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/websocket/tests/oauth-google.test.ts
+++ b/packages/websocket/tests/oauth-google.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initTestDb, resolveGoogleAccessToken } from "@nodetool-ai/models";
+import { handleOAuthRequest } from "../src/oauth-api.js";
+
+const USER_ID = "test-user-google";
+
+function getUserId(): string {
+  return USER_ID;
+}
+
+async function jsonBody(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+function post(path: string, body: unknown): Request {
+  return new Request(`http://localhost:7777${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+const ENV_KEYS = ["SUPABASE_URL", "SUPABASE_KEY", "NODETOOL_GOOGLE_WORKSPACE"];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  initTestDb();
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  // Simulate a production deployment: Supabase auth configured.
+  process.env.SUPABASE_URL = "https://project.supabase.co";
+  process.env.SUPABASE_KEY = "service-role-key";
+  delete process.env.NODETOOL_GOOGLE_WORKSPACE;
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe("POST /api/oauth/google/session", () => {
+  it("stores the provider token so tools can resolve it", async () => {
+    const response = await handleOAuthRequest(
+      post("/api/oauth/google/session", {
+        access_token: "ya29.from-login",
+        refresh_token: "refresh-1",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        scope: "https://www.googleapis.com/auth/drive",
+        email: "alice@example.com"
+      }),
+      "/api/oauth/google/session",
+      getUserId
+    );
+
+    expect(response?.status).toBe(200);
+    const body = await jsonBody(response as Response);
+    expect(body.success).toBe(true);
+    // The response never echoes the token back.
+    expect(JSON.stringify(body)).not.toContain("ya29.from-login");
+
+    await expect(resolveGoogleAccessToken(USER_ID)).resolves.toBe(
+      "ya29.from-login"
+    );
+  });
+
+  it("rejects a body without an access token", async () => {
+    const response = await handleOAuthRequest(
+      post("/api/oauth/google/session", { refresh_token: "r" }),
+      "/api/oauth/google/session",
+      getUserId
+    );
+
+    expect(response?.status).toBe(400);
+  });
+
+  it("is not available in local mode", async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_KEY;
+
+    const response = await handleOAuthRequest(
+      post("/api/oauth/google/session", { access_token: "ya29.x" }),
+      "/api/oauth/google/session",
+      getUserId
+    );
+
+    expect(response?.status).toBe(404);
+    await expect(resolveGoogleAccessToken(USER_ID)).resolves.toBeNull();
+  });
+});
+
+describe("GET /api/oauth/google/tokens", () => {
+  it("reports the connection without exposing the token", async () => {
+    await handleOAuthRequest(
+      post("/api/oauth/google/session", {
+        access_token: "ya29.from-login",
+        email: "alice@example.com"
+      }),
+      "/api/oauth/google/session",
+      getUserId
+    );
+
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/google/tokens"),
+      "/api/oauth/google/tokens",
+      getUserId
+    );
+    const body = await jsonBody(response as Response);
+
+    expect(body.enabled).toBe(true);
+    expect((body.tokens as unknown[]).length).toBe(1);
+    expect(JSON.stringify(body)).not.toContain("ya29.from-login");
+  });
+
+  it("reports disabled in local mode", async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_KEY;
+
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/google/tokens"),
+      "/api/oauth/google/tokens",
+      getUserId
+    );
+    const body = await jsonBody(response as Response);
+
+    expect(body.enabled).toBe(false);
+    expect(body.tokens).toEqual([]);
+  });
+});
+
+describe("POST /api/oauth/google/disconnect", () => {
+  it("removes the stored credential", async () => {
+    await handleOAuthRequest(
+      post("/api/oauth/google/session", { access_token: "ya29.from-login" }),
+      "/api/oauth/google/session",
+      getUserId
+    );
+
+    const response = await handleOAuthRequest(
+      post("/api/oauth/google/disconnect", {}),
+      "/api/oauth/google/disconnect",
+      getUserId
+    );
+    const body = await jsonBody(response as Response);
+
+    expect(body.removed).toBe(1);
+    await expect(resolveGoogleAccessToken(USER_ID)).resolves.toBeNull();
+  });
+});

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -38,6 +38,7 @@ import {
 } from "../ui_primitives";
 import { ToolbarIconButton } from "../ui_primitives";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
+import GoogleWorkspaceCard from "./GoogleWorkspaceCard";
 
 // Provider icons vendored from @lobehub/icons-static-svg (see src/icons/providers/README.md)
 import openaiIcon from "../../icons/providers/openai.svg";
@@ -1231,6 +1232,10 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
           provider — once anything is configured, the Connected Providers
           section above makes the banner redundant. */}
       {connected.length === 0 && <GetStartedBanner theme={theme} />}
+
+      {/* Google Workspace has no API key — access rides on the Google login.
+          Renders nothing when the backend does not offer the integration. */}
+      <GoogleWorkspaceCard />
 
       {!hasContent && lowerSearch && (
         <EmptyState

--- a/web/src/components/menus/GoogleWorkspaceCard.tsx
+++ b/web/src/components/menus/GoogleWorkspaceCard.tsx
@@ -1,0 +1,132 @@
+import React, { memo, useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import LinkOffIcon from "@mui/icons-material/LinkOff";
+
+import { restFetch } from "../../lib/rest-fetch";
+import { isGoogleWorkspaceEnabled } from "../../lib/runtimeConfig";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import googleColorIcon from "../../icons/providers/google-color.svg";
+import {
+  Box,
+  Card,
+  Caption,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Text,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+
+interface GoogleTokensResponse {
+  enabled: boolean;
+  tokens: Array<{ username?: string | null }>;
+}
+
+const QUERY_KEY = ["oauth-token", "google"];
+
+/**
+ * Google Workspace connection status.
+ *
+ * There is no connect button: access comes from signing in with Google, which
+ * grants Drive, Gmail, Docs, Sheets and Calendar in the same consent step. The
+ * card renders nothing on servers without a login (Local mode), where the
+ * integration does not exist.
+ */
+const GoogleWorkspaceCard = () => {
+  const queryClient = useQueryClient();
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+  const enabled = isGoogleWorkspaceEnabled();
+
+  const { data } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const response = await restFetch("/api/oauth/google/tokens");
+      if (!response.ok) {
+        throw new Error("Failed to fetch Google connection");
+      }
+      return (await response.json()) as GoogleTokensResponse;
+    },
+    enabled
+  });
+
+  const account = data?.tokens?.[0]?.username ?? null;
+  const isConnected = (data?.tokens?.length ?? 0) > 0;
+
+  const disconnect = useCallback(async () => {
+    try {
+      const response = await restFetch("/api/oauth/google/disconnect", {
+        method: "POST"
+      });
+      if (!response.ok) {
+        throw new Error("Failed to disconnect");
+      }
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      addNotification({
+        content:
+          "Disconnected Google Workspace. Sign in with Google again to restore access.",
+        type: "success",
+        alert: true
+      });
+    } catch {
+      addNotification({
+        content: "Failed to disconnect Google Workspace",
+        type: "error",
+        alert: true
+      });
+    }
+  }, [queryClient, addNotification]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Card sx={{ padding: getSpacingPx(SPACING.md) }}>
+      <FlexRow align="center" justify="space-between" gap={SPACING.md}>
+        <FlexRow align="center" gap={SPACING.md}>
+          <Box
+            component="img"
+            src={googleColorIcon}
+            alt=""
+            sx={{ width: 24, height: 24 }}
+          />
+          <FlexColumn gap={SPACING.xs}>
+            <FlexRow align="center" gap={SPACING.sm}>
+              <Text>Google Workspace</Text>
+              <Chip
+                label={isConnected ? "Connected" : "Not connected"}
+                color={isConnected ? "success" : "default"}
+                size="small"
+              />
+            </FlexRow>
+            <Caption>
+              {isConnected
+                ? `Drive, Gmail, Docs, Sheets and Calendar${
+                    account ? ` as ${account}` : ""
+                  }`
+                : "Sign in with Google to give agents and nodes access to Drive, Gmail, Docs, Sheets and Calendar."}
+            </Caption>
+          </FlexColumn>
+        </FlexRow>
+
+        {isConnected && (
+          <EditorButton
+            density="compact"
+            variant="text"
+            size="small"
+            startIcon={<LinkOffIcon sx={{ fontSize: 14 }} />}
+            onClick={disconnect}
+          >
+            Disconnect
+          </EditorButton>
+        )}
+      </FlexRow>
+    </Card>
+  );
+};
+
+export default memo(GoogleWorkspaceCard);

--- a/web/src/lib/__tests__/googleSession.test.ts
+++ b/web/src/lib/__tests__/googleSession.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import type { Session } from "@supabase/supabase-js";
+
+const mockRestFetch = jest.fn();
+let mockGoogleEnabled = true;
+
+jest.mock("../rest-fetch", () => ({
+  restFetch: (...args: unknown[]) => mockRestFetch(...args)
+}));
+
+jest.mock("../runtimeConfig", () => ({
+  isGoogleWorkspaceEnabled: () => mockGoogleEnabled,
+  getRuntimeConfig: () => ({
+    googleScopes: ["https://www.googleapis.com/auth/drive"]
+  })
+}));
+
+import { syncGoogleProviderToken } from "../googleSession";
+
+const googleSession = (
+  overrides: Partial<Session> = {}
+): Session =>
+  ({
+    provider_token: "ya29.provider",
+    provider_refresh_token: "refresh-1",
+    user: {
+      email: "alice@example.com",
+      app_metadata: { provider: "google" }
+    },
+    ...overrides
+  }) as unknown as Session;
+
+describe("syncGoogleProviderToken", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGoogleEnabled = true;
+    mockRestFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+  });
+
+  it("posts the provider tokens to the backend", async () => {
+    await syncGoogleProviderToken(googleSession());
+
+    expect(mockRestFetch).toHaveBeenCalledTimes(1);
+    const [path, init] = mockRestFetch.mock.calls[0];
+    expect(path).toBe("/api/oauth/google/session");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.access_token).toBe("ya29.provider");
+    expect(body.refresh_token).toBe("refresh-1");
+    expect(body.email).toBe("alice@example.com");
+    expect(body.scope).toBe("https://www.googleapis.com/auth/drive");
+  });
+
+  it("does nothing without a session", async () => {
+    await syncGoogleProviderToken(null);
+    expect(mockRestFetch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the backend has the integration disabled", async () => {
+    mockGoogleEnabled = false;
+    await syncGoogleProviderToken(googleSession());
+    expect(mockRestFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores a session issued by another provider", async () => {
+    await syncGoogleProviderToken(
+      googleSession({
+        user: {
+          email: "alice@example.com",
+          app_metadata: { provider: "github" }
+        }
+      } as Partial<Session>)
+    );
+    expect(mockRestFetch).not.toHaveBeenCalled();
+  });
+
+  it("swallows a backend failure so login still completes", async () => {
+    mockRestFetch.mockRejectedValue(new Error("network down"));
+    await expect(
+      syncGoogleProviderToken(googleSession())
+    ).resolves.toBeUndefined();
+  });
+});

--- a/web/src/lib/googleSession.ts
+++ b/web/src/lib/googleSession.ts
@@ -1,0 +1,53 @@
+import type { Session } from "@supabase/supabase-js";
+
+import { restFetch } from "./rest-fetch";
+import { getRuntimeConfig, isGoogleWorkspaceEnabled } from "./runtimeConfig";
+
+/**
+ * Hand the Google tokens from a Supabase login to the backend.
+ *
+ * Supabase surfaces the Google `provider_token` (and `provider_refresh_token`
+ * when the login asked for offline access) to the browser only — it is not
+ * readable server-side. Posting it once per sign-in is what lets agent tools
+ * and workflow nodes reach the user's Drive, Gmail, Docs, Sheets and Calendar.
+ *
+ * Best-effort: a failure here costs the Google integration for the session, not
+ * the login itself.
+ */
+export const syncGoogleProviderToken = async (
+  session: Session | null
+): Promise<void> => {
+  if (!session?.provider_token || !isGoogleWorkspaceEnabled()) {
+    return;
+  }
+  // Supabase reports the provider that issued the session on the identity, so a
+  // GitHub or email login never posts its token to the Google endpoint.
+  const isGoogle = session.user?.app_metadata?.provider === "google";
+  if (!isGoogle) {
+    return;
+  }
+
+  try {
+    const response = await restFetch("/api/oauth/google/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        access_token: session.provider_token,
+        refresh_token: session.provider_refresh_token ?? null,
+        // Google access tokens last an hour; Supabase does not report their
+        // expiry, so record the conservative default the backend refreshes on.
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        scope: getRuntimeConfig().googleScopes.join(" "),
+        email: session.user?.email ?? null
+      })
+    });
+    if (!response.ok) {
+      console.warn(
+        "Google: storing the provider token failed",
+        response.status
+      );
+    }
+  } catch (error) {
+    console.warn("Google: storing the provider token failed", error);
+  }
+};

--- a/web/src/lib/runtimeConfig.ts
+++ b/web/src/lib/runtimeConfig.ts
@@ -23,6 +23,14 @@ export interface RuntimeConfig {
   supabaseAnonKey: string | null;
   /** Optional OAuth redirect override. */
   authRedirectUrl: string | null;
+  /**
+   * Whether the backend offers the Google Workspace integration (Drive, Gmail,
+   * Docs, Sheets, Calendar). It runs on the token from the Google login, so it
+   * is off in Local mode.
+   */
+  googleWorkspace: boolean;
+  /** Google OAuth scopes to request at sign-in when the integration is on. */
+  googleScopes: string[];
   /** Backend version, for diagnostics. */
   version: string | null;
 }
@@ -32,6 +40,8 @@ const DEFAULT_CONFIG: RuntimeConfig = {
   supabaseUrl: null,
   supabaseAnonKey: null,
   authRedirectUrl: null,
+  googleWorkspace: false,
+  googleScopes: [],
   version: null
 };
 
@@ -52,9 +62,14 @@ const coerce = (data: unknown): RuntimeConfig => {
     supabaseUrl: d.supabaseUrl ?? null,
     supabaseAnonKey: d.supabaseAnonKey ?? null,
     authRedirectUrl: d.authRedirectUrl ?? null,
+    googleWorkspace: d.googleWorkspace === true,
+    googleScopes: Array.isArray(d.googleScopes) ? d.googleScopes : [],
     version: d.version ?? null
   };
 };
+
+/** True when the backend offers the Google Workspace tools and nodes. */
+export const isGoogleWorkspaceEnabled = (): boolean => current.googleWorkspace;
 
 /**
  * Fetch public runtime config from the backend (`GET /api/config`). Cached

--- a/web/src/stores/useAuth.ts
+++ b/web/src/stores/useAuth.ts
@@ -2,7 +2,12 @@ import { create } from "zustand";
 import { createErrorMessage } from "../utils/errorHandling";
 import { supabase } from "../lib/supabaseClient"; // Import Supabase client
 import type { Session, User, Provider } from "@supabase/supabase-js"; // Import Supabase types
-import { getRuntimeConfig, isAuthRequired } from "../lib/runtimeConfig";
+import {
+  getRuntimeConfig,
+  isAuthRequired,
+  isGoogleWorkspaceEnabled
+} from "../lib/runtimeConfig";
+import { syncGoogleProviderToken } from "../lib/googleSession";
 
 type OAuthProviderSupabase = Extract<Provider, "google" | "facebook">;
 
@@ -158,6 +163,7 @@ export const useAuth = create<LoginStore>((set, get) => ({
         "Auth: Initial session checked.",
         session ? "Found" : "Not found"
       );
+      void syncGoogleProviderToken(session);
 
       // Subscribe to auth state changes and store the subscription for cleanup
       const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
@@ -173,6 +179,11 @@ export const useAuth = create<LoginStore>((set, get) => ({
           state: session ? "logged_in" : "logged_out",
           error: null
         });
+        // A fresh sign-in is the only moment Supabase exposes the Google
+        // provider token; forward it before it drops out of the session.
+        if (event === "SIGNED_IN") {
+          void syncGoogleProviderToken(session);
+        }
       });
 
       // Store subscription reference for cleanup
@@ -199,9 +210,23 @@ export const useAuth = create<LoginStore>((set, get) => ({
   signInWithProvider: async (provider: OAuthProviderSupabase) => {
     set({ state: "loading", error: null });
     try {
+      // Ask Google for the Workspace scopes up front so one consent screen
+      // covers login and the Drive/Gmail/Docs/Sheets/Calendar tools.
+      // `access_type=offline` is what yields a refresh token, and Google only
+      // re-issues one when consent is shown again.
+      const googleScopes =
+        provider === "google" && isGoogleWorkspaceEnabled()
+          ? getRuntimeConfig().googleScopes
+          : [];
       const { error } = await supabase.auth.signInWithOAuth({
         provider: provider,
         options: {
+          ...(googleScopes.length > 0
+            ? {
+                scopes: googleScopes.join(" "),
+                queryParams: { access_type: "offline", prompt: "consent" }
+              }
+            : {}),
           // URL to redirect to after successful authentication.
           // Must be added to your Supabase project's redirect allow list,
           // otherwise Supabase falls back to the project's Site URL


### PR DESCRIPTION
In production, signing in with Google already produces a Google access token. This uses it to reach Drive, Gmail, Docs, Sheets and Calendar from both the agent toolbelt and the workflow graph — no API key to paste anywhere.

Everything is hidden in Local mode, where there is no login and therefore no token.

## How the token gets to the server

Supabase hands the Google `provider_token` (and, with `access_type=offline`, a `provider_refresh_token`) to the **browser** only — it is not readable server-side. So:

1. `signInWithProvider("google")` now requests the Workspace scopes with `access_type=offline&prompt=consent`, so one consent screen covers login and API access.
2. On `SIGNED_IN`, the web app posts the tokens to `POST /api/oauth/google/session`.
3. The server stores them as an `OAuthCredential` under provider `google` (encrypted at rest, like the HuggingFace/GitHub/Codex credentials).
4. Tools and nodes read the token back through the virtual secret key `GOOGLE_ACCESS_TOKEN`, which `getSecret` routes to `resolveGoogleAccessToken` — the same pattern `CODEX_ACCESS_TOKEN` already uses. A stale token is refreshed against Google when `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are set (the pair already configured in the Supabase dashboard).

## Local-mode gating

`isGoogleWorkspaceEnabled()` (`@nodetool-ai/config`) is true in Supabase auth mode, overridable with `NODETOOL_GOOGLE_WORKSPACE=1|0`. It gates three surfaces:

- the chat toolbelt in `unified-websocket-runner`
- `lib.google.*` in `GET /api/nodes/metadata` (list *and* exact-`node_type` lookup)
- `POST /api/oauth/google/session`, and the `googleWorkspace` / `googleScopes` fields in `GET /api/config` that drive the frontend

## What's included

**Client** — `packages/runtime/src/google/`: dependency-free REST client (plain `fetch`, no googleapis SDK) for Drive, Gmail, Docs, Sheets and Calendar, exported as `@nodetool-ai/runtime/google`.

**Agent tools** (20, `packages/agents/src/tools/google-workspace-tools.ts`) — `google_drive_search|get_file|read_file|create_file`, `gmail_search|get_message|send_message|modify_labels|list_labels`, `google_docs_read|create|append`, `google_sheets_read|append|update|create`, `google_calendar_list_calendars|list_events|create_event|delete_event`. A missing or revoked credential returns `{ error: "…Sign in with Google…" }` rather than throwing, so the agent can route around it instead of failing the step.

**Nodes** (14, `lib.google.*`) — DriveSearch, DriveReadFile, DriveCreateFile, GmailSearch, GmailSend, GmailModifyLabels, DocsRead, DocsCreate, DocsAppend, SheetsRead, SheetsAppend, SheetsUpdate, CalendarListEvents, CalendarCreateEvent. They declare no `requiredSettings` — the UI would otherwise render them as "missing API key" forever.

**UI** — a Google Workspace status card in Settings → API Keys showing the connected account with a Disconnect action. It has no Connect button (access comes from the login) and renders nothing in Local mode.

## Notes on the API surface

- Drive search accepts a bare phrase (wrapped into `fullText contains …`) or Drive query syntax passed through untouched.
- Drive reads export Google-native files (Docs → text, Sheets → CSV, Slides → text) and download everything else as-is.
- Gmail bodies are walked through the MIME tree, preferring `text/plain`.
- A Google 401/403 is rewritten with a "sign out and sign back in with Google" hint, since that is nearly always the fix (expired token or a scope the user did not grant).

## Testing

`npm run typecheck`, `npm run lint`, and the affected package suites all pass, plus web and electron jest:

- `packages/config` — mode gating in all four combinations
- `packages/models` — credential round-trip, refresh-on-expiry, and the no-client-configured fallback
- `packages/runtime` — 12 client tests over a stubbed fetch (query wrapping, multipart upload, MIME walking, base64url encoding, Docs flattening, calendar normalisation)
- `packages/agents` — tool naming/registration, both token-failure paths, and four call paths
- `packages/integration-nodes` — 17 node tests
- `packages/websocket` — the three OAuth endpoints (including "not available in local mode" and never echoing the token back), metadata filtering, `/api/config` shape
- `web` — provider-token sync, including the cases where it must stay silent (no session, integration off, non-Google provider, backend failure)

`packages/image-nodes` fails in this container for an unrelated reason (no Vulkan/WebGPU device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146hJL6YYTV11wzQXsWUWMc

---
_Generated by [Claude Code](https://claude.ai/code/session_0146hJL6YYTV11wzQXsWUWMc)_