### PR TITLE
ci(mobile): test iOS without signing — Expo Go previews, plus a Metro fix

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -19,7 +19,14 @@ on:
         description: eas.json build profile
         type: choice
         default: preview
-        options: [development, development-simulator, preview, production]
+        options:
+          [
+            development,
+            development-simulator,
+            preview,
+            preview-simulator,
+            production
+          ]
       wait:
         description: Wait for the build to finish (needed to submit)
         type: boolean
@@ -121,12 +128,31 @@ jobs:
           if [ "${{ github.event_name == 'push' || inputs.wait || inputs.submit }}" = "true" ]; then
             WAIT_FLAG=--wait
           fi
-          eas build \
-            --non-interactive \
-            --platform "$PLATFORM" \
-            --profile "$PROFILE" \
-            "$WAIT_FLAG" \
-            --json | tee build.json
+          # eas puts the JSON result on stdout and everything else — queue
+          # progress, credential errors — on stderr. Route stdout to build.json
+          # and pipe stderr through `tee` so it still streams into the job log
+          # during a long `--wait`, while leaving a copy to grep below. `tee` is
+          # the last pipeline member, so bash waits for it: no read-before-flush
+          # race. `set -e` is off so the hint below runs; the exit code is
+          # re-raised at the end.
+          set +e
+          { eas build \
+              --non-interactive \
+              --platform "$PLATFORM" \
+              --profile "$PROFILE" \
+              "$WAIT_FLAG" \
+              --json >build.json; echo $? >build.status; } 2>&1 | tee build.err
+          set -e
+          status=$(cat build.status)
+
+          # An iOS device build needs a distribution certificate and an ad-hoc
+          # provisioning profile on the Expo servers. Only an interactive Apple
+          # login can mint those the first time, so CI can never recover on its
+          # own — say what to do instead of leaving the raw EAS message.
+          if [ "$status" -ne 0 ] && grep -qi "couldn't find any credentials" build.err; then
+            echo "::error::No iOS credentials on the Expo servers for profile '$PROFILE'. Run 'cd mobile && npx eas-cli credentials --platform ios' once from a machine signed in to the Apple Developer account (an ad-hoc profile also needs each test device's UDID registered). To smoke-test without an Apple account, use the 'preview-simulator' profile or build '--platform android'."
+          fi
+          exit "$status"
 
       - name: Summarize
         if: always() && steps.build.outcome != 'skipped'

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -1,0 +1,80 @@
+name: Expo preview (mobile)
+
+# Publishes the PR's JS bundle as an EAS Update and comments a QR code on the
+# pull request. Scanning it with Expo Go runs that PR's code on a phone.
+#
+# This is the signing-free way to test on iOS: Expo Go is an ordinary App Store
+# app, so it installs on managed devices that refuse the ad-hoc provisioning
+# profiles an EAS internal-distribution build needs (see eas-build.yml). It
+# publishes a bundle rather than building a binary, so it costs no build credits
+# and finishes in a couple of minutes.
+#
+# The limit is the flip side: Expo Go ships a fixed set of native modules, so a
+# PR that adds or changes native code needs a real build, not an update.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "mobile/**"
+      - ".github/workflows/expo-preview.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Publish preview update
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Forks do not get the EXPO_TOKEN secret, and the update would fail at
+    # publish rather than at checkout. Skip them instead of failing the PR.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      EXPO_TOKEN: ${{ secrets.EAS_TOKEN }}
+    steps:
+      - name: Check for the EAS token
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::EAS_TOKEN is not set on this repository." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      # Same cache key as quality-checks.yml and eas-build.yml, so this usually
+      # restores a tree one of those already installed.
+      - name: Cache mobile node_modules
+        id: mobile-node-modules
+        uses: actions/cache@v5
+        with:
+          path: mobile/node_modules
+          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
+
+      - name: Install mobile dependencies
+        if: steps.mobile-node-modules.outputs.cache-hit != 'true'
+        run: cd mobile && npm ci
+
+      - uses: expo/expo-github-action@v9
+        with:
+          eas-version: latest
+          token: ${{ env.EXPO_TOKEN }}
+          packager: npm
+
+      # `--branch` keys the update to the PR's head ref, so each PR gets its own
+      # channel and scanning an older QR keeps showing that PR's code.
+      - uses: expo/expo-github-action/preview@v9
+        with:
+          working-directory: mobile
+          command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}
+          qr-target: expo-go
+          comment: true
+          github-token: ${{ github.token }}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -170,6 +170,23 @@ consistency:
 Builds run on **EAS Build** (Expo's cloud build service) against the EAS project
 declared in `app.json` (`extra.eas.projectId`, owner `mgeorgi`).
 
+### Testing a PR on a phone without signing it
+
+`.github/workflows/expo-preview.yml` publishes every PR that touches `mobile/`
+as an **EAS Update** and comments a QR code on the pull request. Scan it with
+**Expo Go** to run that PR's code on a device.
+
+This is the way onto an iOS device that a company-managed phone allows: Expo Go
+is an ordinary App Store app, so it installs where an EAS
+internal-distribution build cannot — those need an ad-hoc provisioning profile,
+which embeds an allow-list of device UDIDs and which MDM policies routinely
+block. Publishing a bundle also costs no build credits and takes a couple of
+minutes instead of a queue wait.
+
+The tradeoff: Expo Go ships a fixed set of native modules, so a PR that adds or
+changes native code needs a real build. Updates are keyed to the PR's head ref
+(`eas update --branch`), so each PR gets its own channel.
+
 ### From CI (preferred)
 
 The `.github/workflows/eas-build.yml` workflow authenticates with the

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -23,7 +23,8 @@ React Native mobile application for running NodeTool Mini Apps and AI Chat.
 React Native 0.85 + Expo SDK 56, React 19, TypeScript 6. Server state via a
 tRPC v11 client + TanStack Query v5 (REST via the global `fetch` — no Axios),
 local state via Zustand v5, realtime via WebSocket + MsgPack, auth via Supabase
-+ Google Sign-In. See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+
+- Google Sign-In. See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
 
 ## Prerequisites
 
@@ -61,6 +62,7 @@ npm start
 ```
 
 Then:
+
 - Press `i` to open in iOS Simulator (macOS only)
 - Press `a` to open in Android Emulator
 - Press `w` to open in web browser
@@ -133,7 +135,7 @@ mobile/
    - Tap stop button to halt generation
    - Tap + to start a new conversation
 3. **Browse Mini Apps**: View the list of available workflows
-4. **Run a Mini App**: 
+4. **Run a Mini App**:
    - Select a mini app from the list
    - Fill in the required inputs
    - Tap "Run" to execute the workflow
@@ -142,11 +144,13 @@ mobile/
 ## Server Configuration
 
 The app stores the server URL in AsyncStorage. You can:
+
 - Set it in the Settings screen
 - Test the connection before saving
 - The default value is `http://localhost:7777`
 
 For local development with a device/emulator:
+
 - iOS Simulator: Use `http://localhost:7777`
 - Android Emulator: Use `http://10.0.2.2:7777` (Android's localhost proxy)
 - Physical Device: Use your computer's IP address (e.g., `http://192.168.1.100:7777`)
@@ -155,6 +159,7 @@ For local development with a device/emulator:
 
 This app shares types and patterns with the web application and the backend protocol for
 consistency:
+
 - API/domain types come from the backend protocol via `src/types/ApiTypes.ts`.
 - Server state goes through a tRPC v11 client + TanStack Query v5; REST-only endpoints use
   the `fetch`-based `services/api.ts` (no Axios).
@@ -171,7 +176,7 @@ The `.github/workflows/eas-build.yml` workflow authenticates with the
 `EAS_TOKEN` repository secret (an Expo access token, passed to eas-cli as
 `EXPO_TOKEN`). Builds cost credits, so no ordinary push starts one:
 
-- **Manual**: Actions → *EAS Build (mobile)* → *Run workflow*. Pick the platform
+- **Manual**: Actions → _EAS Build (mobile)_ → _Run workflow_. Pick the platform
   and profile; `wait` blocks on the EAS queue, `submit` uploads the finished
   production build to the stores.
 - **Release**: pushing a `mobile-v*` tag builds the `production` profile for
@@ -201,12 +206,13 @@ Anything the scripts don't cover goes through the CLI directly, e.g.
 `eas.json` profiles all extend `base`, which pins Node to 22.22.1 so cloud
 builds use the same version as the repo (`.nvmrc`):
 
-| Profile                   | Use                                                       |
-| ------------------------- | --------------------------------------------------------- |
-| `development`             | Dev client on a physical device, internal distribution     |
-| `development-simulator`   | Same, but an iOS Simulator build                           |
-| `preview`                 | Testing builds — Android APK you can sideload              |
-| `production`              | Store builds — Android AAB, version auto-incremented       |
+| Profile                 | Use                                                       |
+| ----------------------- | --------------------------------------------------------- |
+| `development`           | Dev client on a physical device, internal distribution    |
+| `development-simulator` | Same, but an iOS Simulator build                          |
+| `preview`               | Testing builds — Android APK you can sideload             |
+| `preview-simulator`     | Same, but an iOS Simulator build — needs no Apple account |
+| `production`            | Store builds — Android AAB, version auto-incremented      |
 
 `cli.appVersionSource` is `remote`, so EAS owns the build number; the
 `production` profile increments it on every build.
@@ -227,11 +233,28 @@ eas build --platform ios --local
 
 ### Troubleshooting Builds
 
-- **Missing credentials**: Run `eas credentials` to configure store credentials
+- **`EAS CLI couldn't find any credentials suitable for internal distribution`**
+  (iOS): a valid `EAS_TOKEN` is not enough. An iOS build that runs on a device
+  needs a distribution certificate and an ad-hoc provisioning profile stored on
+  the Expo servers, and only an interactive Apple login can create them the
+  first time:
+
+  ```bash
+  cd mobile
+  npx eas-cli credentials --platform ios     # sign in to the Apple Developer account
+  ```
+
+  An ad-hoc profile only installs on devices whose UDID is registered
+  (`npx eas-cli device:create`), and adding a device means rebuilding. Once the
+  credentials exist, `--non-interactive` CI builds reuse them. To smoke-test
+  iOS without an Apple Developer account, build the `preview-simulator` profile
+  — a Simulator build needs no signing at all.
+
 - **Build failures**: Check the build logs in Expo dashboard
 - **Timeouts**: Larger apps may need increased build timeout settings
 
 For more details, see:
+
 - [EAS Build Documentation](https://docs.expo.dev/build/introduction/)
 - [EAS Submit Documentation](https://docs.expo.dev/submit/introduction/)
 - [Mobile Architecture](ARCHITECTURE.md)
@@ -239,12 +262,14 @@ For more details, see:
 ## Troubleshooting
 
 ### Cannot connect to server
+
 - Ensure the NodeTool server is running
 - Check the server URL in Settings
 - For physical devices, ensure your device and server are on the same network
 - For Android emulator, use `http://10.0.2.2:7777` instead of `localhost:7777`
 
 ### App crashes on startup
+
 - Clear the app data and restart
 - Check that all dependencies are installed: `npm install`
 - Try resetting the Metro bundler: `npm start --reset-cache`

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,6 +16,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "ai.nodetool.mobile",
       "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false,
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -52,6 +52,12 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
+    "updates": {
+      "url": "https://u.expo.dev/ce40c43d-6adf-4476-98b1-761aa4d29c40"
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "extra": {
       "supabaseUrl": "https://zmytgmyiwfmdajmxjbag.supabase.co",
       "supabaseAnonKey": "sb_publishable_sGCndMc7Ku5J6Bct80D9WQ_Ik96Qu9a",

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -25,6 +25,12 @@
         "buildType": "apk"
       }
     },
+    "preview-simulator": {
+      "extends": "preview",
+      "ios": {
+        "simulator": true
+      }
+    },
     "production": {
       "extends": "base",
       "autoIncrement": true,

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -20,6 +20,10 @@ module.exports = {
     // Shared timeline engine (split/trim/factories), also from source.
     '^@nodetool-ai/timeline$': '<rootDir>/../packages/timeline/src/index.ts',
     '^@nodetool-ai/gpu$': '<rootDir>/../packages/gpu/src/index.ts',
+    // Dependency-free protocol module, wired on its own so `zod` (reached via
+    // the package entry point's `toolSchemas`) stays out of mobile.
+    '^@nodetool-ai/protocol/triggers$':
+      '<rootDir>/../packages/protocol/src/triggers.ts',
     // Those packages' sources use ESM `.js` specifiers for their own modules.
     '^(\\.{1,2}/.+)\\.js$': '$1',
   },

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -36,6 +36,8 @@ const timelineRoot = path.resolve(repoRoot, "packages/timeline");
 const timelineSrc = path.join(timelineRoot, "src");
 const gpuRoot = path.resolve(repoRoot, "packages/gpu");
 const gpuSrc = path.join(gpuRoot, "src");
+const protocolRoot = path.resolve(repoRoot, "packages/protocol");
+const protocolSrc = path.join(protocolRoot, "src");
 
 /** Package entry points compiled from source, and the src roots they live in. */
 const SOURCE_PACKAGES = [
@@ -44,12 +46,35 @@ const SOURCE_PACKAGES = [
   { name: "@nodetool-ai/gpu", src: gpuSrc },
 ];
 
+/**
+ * Single modules compiled from source, mapped straight to their file.
+ *
+ * `protocol`'s entry point re-exports `toolSchemas`, which pulls in `zod` — a
+ * dependency mobile does not have and does not want in the bundle for one
+ * string helper. The modules named here are dependency-free, so they are wired
+ * individually rather than through the package root. Import them in `mobile/`
+ * by the same deep specifier.
+ */
+const SOURCE_MODULES = {
+  "@nodetool-ai/protocol/triggers": path.join(protocolSrc, "triggers.ts"),
+};
+
 const config = getDefaultConfig(projectRoot);
 
 config.projectRoot = projectRoot;
-config.watchFolders = [projectRoot, appRuntimeRoot, timelineRoot, gpuRoot];
+config.watchFolders = [
+  projectRoot,
+  appRuntimeRoot,
+  timelineRoot,
+  gpuRoot,
+  protocolRoot,
+];
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const modulePath = SOURCE_MODULES[moduleName];
+  if (modulePath) {
+    return { type: "sourceFile", filePath: modulePath };
+  }
   const entry = SOURCE_PACKAGES.find((pkg) => pkg.name === moduleName);
   if (entry) {
     return { type: "sourceFile", filePath: path.join(entry.src, "index.ts") };

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -35,6 +35,7 @@
         "expo-secure-store": "~56.0.4",
         "expo-speech-recognition": "^56.0.1",
         "expo-status-bar": "~56.0.4",
+        "expo-updates": "~56.0.23",
         "expo-video": "~56.1.4",
         "msgpackr": "^1.12.1",
         "react": "19.2.3",
@@ -6340,6 +6341,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-56.0.1.tgz",
+      "integrity": "sha512-r8h0ZIExacCrSRgY+ARfhMvFqosLHLJt1L7jyhvabfr1DN/ZDKDsYbovss2tzkpEUZGxZ3BPcB5epCwUsBBdOA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "56.0.8",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz",
@@ -6394,6 +6401,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "56.0.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-56.0.0.tgz",
+      "integrity": "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg==",
+      "license": "MIT"
+    },
     "node_modules/expo-linking": {
       "version": "56.0.16",
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-56.0.16.tgz",
@@ -6406,6 +6419,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "56.0.4",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-56.0.4.tgz",
+      "integrity": "sha512-Fokawl2UkiExIF0bqGoblRFA8lYpROVD+EpvDwSW4LgqQyPwNua1gLSgHZjdl5GsVugfRMMWE3LHaibDyX93hw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-media-library": {
@@ -6520,6 +6545,64 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "56.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-56.0.0.tgz",
+      "integrity": "sha512-Yv4x+SQxNnMQm4nu8NFfzx197YaDhdYH2N0u7tGErwWTmH9Tm1SAhqo7bLbBWLC9kf7W+kdzTshLU9rTiCXWGw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "56.0.23",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-56.0.23.tgz",
+      "integrity": "sha512-QRGJsJTAmFRzSLAThatt8ka/7QPOBgXub4xFlsu61/Tq43reQgy6UQAINbM1J+dggebErAhcKH9F3tHpGKuHeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.7.0",
+        "@expo/spawn-async": "^1.8.0",
+        "arg": "^4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~56.0.0",
+        "expo-manifests": "~56.0.4",
+        "expo-structured-headers": "~56.0.0",
+        "expo-updates-interface": "~56.0.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "nullthrows": "^1.1.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "expo-dev-client": "*",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-dev-client": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "56.0.2",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-56.0.2.tgz",
+      "integrity": "sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
     },
     "node_modules/expo-video": {
       "version": "56.1.4",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -49,6 +49,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-speech-recognition": "^56.0.1",
     "expo-status-bar": "~56.0.4",
+    "expo-updates": "~56.0.23",
     "expo-video": "~56.1.4",
     "msgpackr": "^1.12.1",
     "react": "19.2.3",

--- a/mobile/src/screens/TriggersScreen.tsx
+++ b/mobile/src/screens/TriggersScreen.tsx
@@ -29,7 +29,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { describeTriggerDisabledReason } from '@nodetool-ai/protocol';
+import { describeTriggerDisabledReason } from '@nodetool-ai/protocol/triggers';
 
 import { RootStackParamList } from '../navigation/types';
 import { trpc } from '../trpc/client';

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -30,6 +30,9 @@
       ],
       "@nodetool-ai/gpu": [
         "../packages/gpu/src/index.ts"
+      ],
+      "@nodetool-ai/protocol/triggers": [
+        "../packages/protocol/src/triggers.ts"
       ]
     }
   },


### PR DESCRIPTION
Started as "why does the EAS build fail when `EAS_TOKEN` is set", ended up somewhere more useful. Three commits, each standalone.

## 1. The EAS failure was never about the token

[Run 30261748738](https://github.com/nodetool-ai/nodetool/actions/runs/30261748738/job/89963016694) failed the `preview` / `ios` build with:

```
✔ Using remote iOS credentials (Expo server)
Failed to set up credentials.
You're in non-interactive mode. EAS CLI couldn't find any credentials
suitable for internal distribution.
```

A few lines above, the same job logs `mgeorgi (authenticated using EXPO_TOKEN)`. Auth was fine. `preview` is `distribution: internal`, which signs with an **ad-hoc provisioning profile** — and per Expo's docs that profile embeds "an allow-list of device UDIDs" fixed at build time. Creating one requires an interactive Apple login, so `--non-interactive` CI can never recover on its own. No token value fixes it.

So: catch that message in the build step and emit a `::error::` naming the one-time fix and the credential-free alternatives, instead of leaving the raw text. Add a `preview-simulator` profile (iOS Simulator needs no signing at all). Set `ios.infoPlist.ITSAppUsesNonExemptEncryption`, which the same run warned about and which otherwise forces a manual answer in App Store Connect.

The build step now routes stdout to `build.json` and pipes stderr through `tee`, so progress still streams during a long `--wait` while leaving a copy to grep. `tee` is the last pipeline member, so bash waits for it and the grep can't read before the flush.

## 2. Testing on a device that refuses ad-hoc profiles

Ad-hoc is exactly what a company-managed iPhone blocks, and no credential setup changes that. Expo Go is an ordinary App Store app, so it installs where ad-hoc cannot — and it loads JS bundles rather than signed binaries.

`expo-preview.yml` publishes each PR touching `mobile/` as an **EAS Update** and comments a QR code on the PR. Scan it with Expo Go and the phone runs that PR's code: no certificate, no provisioning profile, no build credits, a couple of minutes instead of a queue wait. Updates are keyed to the PR head ref, so each PR gets its own channel and an older QR keeps resolving to that PR. Forks are skipped rather than failed, since they don't receive the token.

`eas update` requires `expo-updates`, so that's installed and `updates.url` points at the EAS project with an `appVersion` runtime-version policy.

**Limit:** Expo Go ships a fixed set of native modules, so a PR that adds or changes native code still needs a real build. The workflow header and README say so.

## 3. Mobile doesn't currently bundle on `main`

The preview workflow failed on its first run — and it turned out to be a pre-existing bug, not a workflow bug. This is the first CI job that ever bundles mobile, so it surfaced something that shipped in #4501:

```
Unable to resolve module @nodetool-ai/protocol from
mobile/src/screens/TriggersScreen.tsx
```

`mobile/` isn't a root workspace and declares no `@nodetool-ai` dependencies — every shared module is hand-wired in `metro.config.js`, `tsconfig.json`, and `jest.config.js`. #4501 added the first *runtime* import of `protocol` from mobile, which none of the three knew about. Every other mobile import of protocol is `import type`, erased by Babel before Metro sees it, which is why only this one breaks. It breaks `expo export` **and** `expo start`.

Fixed by wiring the module, not mirroring the helper — its doc comment says it's shared so "the editor, the phone, and the server log all describe the same stop the same way," and a drifting hand-mirrored copy is what `protocol` exists to prevent.

The deep specifier `@nodetool-ai/protocol/triggers` is mapped in all three configs rather than the package root: `triggers.ts` has no imports at all, while the package entry point re-exports `toolSchemas`, which pulls in `zod` — not a mobile dependency, and not worth bundling for one string helper.

## Testing

- **`expo export --platform ios` builds.** It did not before commit 3 — reproduced the failure on a clean tree first. The bundle carries the helper's strings and gains no `zod` (the `zod` present is Expo CLI's own copy, pre-existing).
- **Mobile suite: 66 files, 916 tests, all passing.**
- Build-step shell logic exercised against a stub `eas` in both the credentials-failure and success cases: stderr streams, the exit code propagates, `build.json` holds the JSON, and the hint fires only on the credentials failure.
- `expo config --type prebuild --json` resolves, with `updates.url`, `runtimeVersion`, and `ITSAppUsesNonExemptEncryption` correct.
- Workflow YAML parses; `npm run lint` in `mobile/` shows only a pre-existing warning in an untouched file.

Formatting note: `metro.config.js`, `jest.config.js`, `tsconfig.json`, and `TriggersScreen.tsx` were already Prettier-unclean on `main` and no workflow runs Prettier on `mobile/`, so they're left alone rather than buried under a reformat.

Not exercised: a real EAS build, which costs credits and is `workflow_dispatch`-only.

## Note for the reviewer

Commit 3 fixes a defect from someone else's PR, because the preview workflow can't go green without it. It's isolated in `5ad4c06` and cherry-picks cleanly if you'd rather land it separately — but note that until it lands somewhere, mobile doesn't bundle.

Unblocking real iOS *device* builds is still a human step, once, from a machine signed in to the Apple Developer account: `npx eas-cli credentials --platform ios`. If the managed phone is the blocker rather than the laptop, TestFlight is the way — App Store distribution has no UDID allow-list — and that's not wired up here.