### PR TITLE
Skip auto-focus on touch devices

### DIFF
--- a/web/src/components/applications/ApplicationListPanel.tsx
+++ b/web/src/components/applications/ApplicationListPanel.tsx
@@ -36,6 +36,7 @@ import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
   Dialog,
   EmptyState,
@@ -393,10 +394,15 @@ const ApplicationListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
 
+  // Focus the filter on open so users can immediately type to search — except
+  // on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
 
   const { data, isLoading, isError, error } = useApplications();
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -85,6 +85,7 @@ import useModelPreferencesStore from "../../../stores/ModelPreferencesStore";
 import { StopGenerationButton } from "./StopGenerationButton";
 import PermissionSelector from "./PermissionSelector";
 import { useElapsedTime } from "../../../hooks/useElapsedTime";
+import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 
 function formatElapsed(seconds: number): string {
   if (seconds < 5) return "Starting…";
@@ -167,6 +168,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const theme = useTheme();
   const styles = useMemo(() => createMediaComposerStyles(theme), [theme]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const [prompt, setPrompt] = useState("");
 
   // Mode + media params from persistent store
@@ -310,11 +312,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     adjustHeight();
   }, [prompt, adjustHeight]);
 
+  // Skipped on touch, where the virtual keyboard would cover the composer.
   useEffect(() => {
-    if (autoFocus) {
+    if (autoFocus && autoFocusEnabled) {
       textareaRef.current?.focus();
     }
-  }, [autoFocus]);
+  }, [autoFocus, autoFocusEnabled]);
 
   // Close any open model / option dialogs whenever the mode changes. The
   // image- and video-model dialogs are intentionally shared between the

--- a/web/src/components/chat/composer/MessageInput.tsx
+++ b/web/src/components/chat/composer/MessageInput.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useCallback, memo, useLayoutEffect } from "react";
+import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 
 interface MessageInputProps {
   value: string;
@@ -24,6 +25,7 @@ export const MessageInput = memo(forwardRef<HTMLTextAreaElement, MessageInputPro
   ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
     const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+    const autoFocusEnabled = useAutoFocusEnabled();
 
     const adjustHeight = useCallback(() => {
       const textarea = textareaRef.current;
@@ -41,12 +43,13 @@ export const MessageInput = memo(forwardRef<HTMLTextAreaElement, MessageInputPro
       adjustHeight();
     }, [value, adjustHeight]);
 
+    // Skipped on touch, where the virtual keyboard would cover the thread.
     useLayoutEffect(() => {
       const textarea = textareaRef.current;
-      if (textarea && !disabled) {
+      if (textarea && !disabled && autoFocusEnabled) {
         textarea.focus();
       }
-    }, [textareaRef, disabled]);
+    }, [textareaRef, disabled, autoFocusEnabled]);
 
     const handleChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange(event);

--- a/web/src/components/context_menus/ConnectableNodes.tsx
+++ b/web/src/components/context_menus/ConnectableNodes.tsx
@@ -30,6 +30,7 @@ import { useNodes } from "../../contexts/NodeContext";
 import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 const NODE_ROW_HEIGHT = 34;
 
@@ -159,6 +160,7 @@ const ConnectableNodes: React.FC = React.memo(function ConnectableNodes() {
   const [searchTerm, setSearchTerm] = useState("");
   const reactFlowInstance = useReactFlow();
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const recentNodes = useRecentNodesStore((state) => state.recentNodes);
   const recentNodeTypes = useMemo(
     () => recentNodes.map((node) => node.nodeType),
@@ -318,18 +320,17 @@ const ConnectableNodes: React.FC = React.memo(function ConnectableNodes() {
     []
   );
 
+  // Skipped on touch, where the virtual keyboard would cover the menu.
   useEffect(() => {
-    if (!isVisible) {
+    if (!isVisible || !autoFocusEnabled) {
       return;
     }
-
     const timeout = window.setTimeout(() => {
       searchInputRef.current?.focus();
       searchInputRef.current?.select();
     }, 0);
-
     return () => window.clearTimeout(timeout);
-  }, [isVisible]);
+  }, [isVisible, autoFocusEnabled]);
 
   if (!menuPosition || !isVisible) {return null;}
 
@@ -358,7 +359,7 @@ const ConnectableNodes: React.FC = React.memo(function ConnectableNodes() {
             onChange={handleSearchChange}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={handleSearchKeyDown}
-            autoFocus={isVisible}
+            autoFocus={isVisible && autoFocusEnabled}
             inputRef={searchInputRef}
             aria-label="Search nodes"
             sx={{

--- a/web/src/components/context_menus/InputContextMenu.tsx
+++ b/web/src/components/context_menus/InputContextMenu.tsx
@@ -38,6 +38,7 @@ import { filterTypesByOutputType } from "../node_menu/typeFilterUtils";
 import { rankSearchNodes } from "../../utils/nodeSearch";
 import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import NodeItem from "../node_menu/NodeItem";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 const NODE_ROW_HEIGHT = 28;
 
@@ -190,6 +191,7 @@ const InputContextMenu: React.FC = () => {
 
   const [searchTerm, setSearchTerm] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const scrollRef = useRef<HTMLDivElement>(null);
   const recentNodes = useRecentNodesStore((state) => state.recentNodes);
   const recentNodeTypes = useMemo(
@@ -800,8 +802,9 @@ const InputContextMenu: React.FC = () => {
     []
   );
 
+  // Skipped on touch, where the virtual keyboard would cover the menu.
   useEffect(() => {
-    if (!menuPosition) {
+    if (!menuPosition || !autoFocusEnabled) {
       return;
     }
     const timeout = window.setTimeout(() => {
@@ -809,7 +812,7 @@ const InputContextMenu: React.FC = () => {
       searchInputRef.current?.select();
     }, 0);
     return () => window.clearTimeout(timeout);
-  }, [menuPosition]);
+  }, [menuPosition, autoFocusEnabled]);
 
   const showStaticActions = searchTerm.trim().length === 0;
 

--- a/web/src/components/context_menus/OutputContextMenu.tsx
+++ b/web/src/components/context_menus/OutputContextMenu.tsx
@@ -35,6 +35,7 @@ import { filterTypesByInputType } from "../node_menu/typeFilterUtils";
 import { rankSearchNodes } from "../../utils/nodeSearch";
 import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import NodeItem from "../node_menu/NodeItem";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 const NODE_ROW_HEIGHT = 28;
 
@@ -110,6 +111,7 @@ const OutputContextMenu: React.FC = () => {
 
   const [searchTerm, setSearchTerm] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const scrollRef = useRef<HTMLDivElement>(null);
   const recentNodes = useRecentNodesStore((state) => state.recentNodes);
   const recentNodeTypes = useMemo(
@@ -431,8 +433,9 @@ const OutputContextMenu: React.FC = () => {
     ]
   );
 
+  // Skipped on touch, where the virtual keyboard would cover the menu.
   useEffect(() => {
-    if (!menuPosition) {
+    if (!menuPosition || !autoFocusEnabled) {
       return;
     }
     const timeout = window.setTimeout(() => {
@@ -440,7 +443,7 @@ const OutputContextMenu: React.FC = () => {
       searchInputRef.current?.select();
     }, 0);
     return () => window.clearTimeout(timeout);
-  }, [menuPosition]);
+  }, [menuPosition, autoFocusEnabled]);
 
   const saveLabel = `Save${
     sourceType?.type === "string"

--- a/web/src/components/inputs/Select.tsx
+++ b/web/src/components/inputs/Select.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { selectStyles, portalOptionsStyles } from "./selectStyles";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 interface Option {
   value: string;
@@ -68,6 +69,7 @@ const Select: React.FC<SelectProps> = ({
   const selectRef = useRef<HTMLDivElement>(null);
   const optionsRef = useRef<HTMLUListElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const { open, close, activeSelect, searchQuery, setSearchQuery } =
     useSelect();
   const id = useId();
@@ -162,11 +164,12 @@ const Select: React.FC<SelectProps> = ({
     };
   }, [close, activeSelect, id]);
 
+  // Skipped on touch, where the virtual keyboard would cover the options.
   useEffect(() => {
-    if (activeSelect === id && searchInputRef.current) {
-      searchInputRef.current.focus();
+    if (activeSelect === id && autoFocusEnabled) {
+      searchInputRef.current?.focus();
     }
-  }, [activeSelect, id]);
+  }, [activeSelect, id, autoFocusEnabled]);
 
   // Fuzzy-match the query against option labels, best matches first.
   const filteredOptions = useMemo(() => {

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -40,6 +40,7 @@ import { useRightPanelStore } from "../../stores/RightPanelStore";
 import { areNodesEqualIgnoringPosition } from "../../utils/nodeEquality";
 import { usePanelStore } from "../../stores/PanelStore";
 import { useCanvasChatDockStore } from "../../stores/CanvasChatDockStore";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 // Icons — Workflow
 import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
@@ -722,6 +723,7 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
 }) => {
   const [pastePosition, setPastePosition] = useState({ x: 0, y: 0 });
   const input = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const focusInputTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const executeAndClose = useCallback(
@@ -739,8 +741,9 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
     });
   }, [executeAndClose, reactFlowWrapper]);
 
+  // Skipped on touch, where the virtual keyboard would cover the command list.
   useEffect(() => {
-    if (open) {
+    if (open && autoFocusEnabled) {
       if (focusInputTimeoutRef.current) {
         clearTimeout(focusInputTimeoutRef.current);
       }
@@ -752,7 +755,7 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
         clearTimeout(focusInputTimeoutRef.current);
       }
     };
-  }, [open]);
+  }, [open, autoFocusEnabled]);
 
   useEffect(() => {
     return () => {

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -19,6 +19,7 @@ import NodeLibraryRow from "./NodeLibraryRow";
 import NodeInfo from "./NodeInfo";
 import useMetadataStore from "../../stores/MetadataStore";
 import useNodeMenuStore from "../../stores/NodeMenuStore";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import usePendingNodeCreateStore from "../../stores/PendingNodeCreateStore";
 import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import { serializeDragData } from "../../lib/dragdrop";
@@ -308,6 +309,7 @@ const NodeLibrary = memo<NodeLibraryProps>(
     const [query, setQuery] = useState("");
     const [hoveredType, setHoveredType] = useState<string | null>(null);
     const searchRef = useRef<HTMLInputElement>(null);
+    const autoFocusEnabled = useAutoFocusEnabled();
     const scrollRef = useRef<HTMLDivElement>(null);
 
     const category =
@@ -320,9 +322,12 @@ const NodeLibrary = memo<NodeLibraryProps>(
     const clearDrag = useDragDropStore((s) => s.clearDrag);
     const recentNodes = useRecentNodesStore((s) => s.recentNodes);
 
+    // Skipped on touch, where the virtual keyboard would cover the library.
     useEffect(() => {
-      searchRef.current?.focus();
-    }, []);
+      if (autoFocusEnabled) {
+        searchRef.current?.focus();
+      }
+    }, [autoFocusEnabled]);
 
     const allNodes = useMemo(
       () => Object.values(metadataRecord),

--- a/web/src/components/script/ScriptListPanel.tsx
+++ b/web/src/components/script/ScriptListPanel.tsx
@@ -28,6 +28,7 @@ import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
   EmptyState,
   FlexColumn,
@@ -259,12 +260,15 @@ const ScriptListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
 
-  // Focus the filter on open so users can immediately type to search,
-  // matching the workflows list panel.
+  // Focus the filter on open so users can immediately type to search — except
+  // on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
   const { data, isLoading, isError, error } = useScripts();
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -28,6 +28,7 @@ import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
   EmptyState,
   FlexColumn,
@@ -352,12 +353,15 @@ const SketchListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
 
-  // Focus the filter on open so users can immediately type to search,
-  // matching the workflows list panel.
+  // Focus the filter on open so users can immediately type to search — except
+  // on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
   const { data, isLoading, isError, error } = trpc.sketch.list.useQuery(
     {},
     { staleTime: 30_000 }

--- a/web/src/components/storyboard/StoryboardListPanel.tsx
+++ b/web/src/components/storyboard/StoryboardListPanel.tsx
@@ -31,6 +31,7 @@ import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
   EmptyState,
   FlexColumn,
@@ -262,12 +263,15 @@ const StoryboardListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
 
-  // Focus the filter on open so users can immediately type to search,
-  // matching the workflows list panel.
+  // Focus the filter on open so users can immediately type to search — except
+  // on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
   const { data, isLoading, isError, error } = useStoryboards();
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -29,6 +29,7 @@ import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
   EmptyState,
   FlexColumn,
@@ -348,13 +349,16 @@ const TimelineListPanel = () => {
   const theme = useTheme();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const { data, isLoading, isError, error } = useTimelines();
 
-  // Focus the filter on open so users can immediately type to search,
-  // matching the workflows list panel.
+  // Focus the filter on open so users can immediately type to search — except
+  // on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
   const setVisibility = usePanelStore((state) => state.setVisibility);

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -8,6 +8,7 @@ import { IconButton, Tooltip, InputAdornment, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 export interface SearchInputProps {
   /** Current search value */
@@ -22,7 +23,8 @@ export interface SearchInputProps {
   size?: "small" | "medium";
   /** Whether the input is disabled */
   disabled?: boolean;
-  /** Auto-focus on mount */
+  /** Auto-focus on mount. Ignored on touch devices, where it would raise the
+   * virtual keyboard over the panel that just opened. */
   autoFocus?: boolean;
   /** Debounce delay in ms (0 = no debounce) */
   debounceMs?: number;
@@ -136,6 +138,7 @@ export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>((
   sx
 }, ref) => {
   const theme = useTheme();
+  const autoFocusEnabled = useAutoFocusEnabled();
   const [localValue, setLocalValue] = useState(value);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   
@@ -192,7 +195,7 @@ export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>((
         placeholder={placeholder}
         size={size}
         disabled={disabled}
-        autoFocus={autoFocus}
+        autoFocus={autoFocus && autoFocusEnabled}
         fullWidth={fullWidth}
         sx={sx}
         inputRef={ref}

--- a/web/src/components/workflows/WorkflowList.tsx
+++ b/web/src/components/workflows/WorkflowList.tsx
@@ -21,6 +21,7 @@ import WorkflowListView from "./WorkflowListView";
 import SharedWithMeSection from "./SharedWithMeSection";
 import WorkflowFormModal from "./WorkflowFormModal";
 import { usePanelStore } from "../../stores/PanelStore";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import { useFavoriteWorkflowIds } from "../../stores/FavoriteWorkflowsStore";
 import { useSelectedTags } from "../../stores/WorkflowListViewStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
@@ -55,10 +56,14 @@ const WorkflowList = () => {
   const queryClient = useQueryClient();
   const [filterValue, setFilterValue] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
 
+  // Skipped on touch, where the virtual keyboard would cover the list.
   useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
+    if (autoFocusEnabled) {
+      searchRef.current?.focus();
+    }
+  }, [autoFocusEnabled]);
   const [workflowsToDelete, setWorkflowsToDelete] = useState<
     WorkflowAttributes[]
   >([]);

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -34,6 +34,7 @@ import {
   type WorkspaceTabType
 } from "../../stores/WorkspaceTabsStore";
 import { assetTabType } from "./assetTabType";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import type {
   WorkflowList,
   AssetWithPath,
@@ -142,6 +143,7 @@ const TEXT_FILE_TEMPLATES: readonly TextFileTemplate[] = [
  */
 const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const [view, setView] = useState<MenuView>("root");
+  const autoFocusEnabled = useAutoFocusEnabled();
   const [assetQuery, setAssetQuery] = useState("");
   const [wfFilter, setWfFilter] = useState("");
   const [chatFilter, setChatFilter] = useState("");
@@ -509,7 +511,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
             />
             <FlexRow sx={{ px: 1, py: 0.5 }}>
               <TextInput
-                autoFocus
+                autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Filter workflows"
                 value={wfFilter}
@@ -546,7 +548,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
             />
             <FlexRow sx={{ px: 1, py: 0.5 }}>
               <TextInput
-                autoFocus
+                autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Filter chats"
                 value={chatFilter}
@@ -583,7 +585,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
             />
             <FlexRow sx={{ px: 1, py: 0.5 }}>
               <TextInput
-                autoFocus
+                autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Search assets (2+ chars)"
                 value={assetQuery}

--- a/web/src/hooks/__tests__/useAutoFocusEnabled.test.tsx
+++ b/web/src/hooks/__tests__/useAutoFocusEnabled.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react";
+import { useAutoFocusEnabled } from "../useAutoFocusEnabled";
+
+const mockMatchMedia = (coarse: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes("pointer: coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+describe("useAutoFocusEnabled", () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  it("allows auto-focus on a fine pointer", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useAutoFocusEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it("suppresses auto-focus on a coarse pointer", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useAutoFocusEnabled());
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/src/hooks/useAutoFocusEnabled.ts
+++ b/web/src/hooks/useAutoFocusEnabled.ts
@@ -1,0 +1,19 @@
+import { useMediaQuery } from "@mui/material";
+
+/**
+ * Whether focusing a field on mount/open is appropriate for this device.
+ *
+ * On touch devices focus raises the virtual keyboard, which covers most of the
+ * panel that just opened — the sidebar list panels became unusable on mobile
+ * web because their filter field grabbed focus every time. Search and filter
+ * fields therefore stay unfocused on a coarse pointer; the user taps the field
+ * when they actually want to type.
+ *
+ * Fields the user explicitly opened for typing (rename inputs, the chat
+ * composer after tapping it) keep their focus — this is for focus the user
+ * didn't ask for.
+ */
+export const useAutoFocusEnabled = (): boolean =>
+  !useMediaQuery("(pointer: coarse)");
+
+export default useAutoFocusEnabled;


### PR DESCRIPTION
## Problem

The sidebar list panels focus their filter field on mount. On mobile web that raises the virtual keyboard every time a panel opens, covering the list it was supposed to show — the sidebar is effectively unusable. The same focus-on-open pattern appears in the node library, command menu, node context menus, select dropdowns, and the chat composer.

## Change

New hook `web/src/hooks/useAutoFocusEnabled.ts` — returns `false` on `(pointer: coarse)`, matching the signal `MobileClassProvider` already uses. Every focus-on-mount/open path is gated on it:

- Sidebar list panels: `WorkflowList`, `ApplicationListPanel`, `ScriptListPanel`, `SketchListPanel`, `TimelineListPanel`, `StoryboardListPanel`
- `NodeLibrary`, `CommandMenu`, `OpenMenu` (workflow/chat/asset filters)
- `ConnectableNodes`, `InputContextMenu`, `OutputContextMenu`
- `Select` dropdown search, `MessageInput`, `MediaChatComposer`

`ui_primitives/SearchInput` now ignores its `autoFocus` prop on a coarse pointer, which covers call sites that pass the prop instead of driving a ref (e.g. `AddClipMenu`).

Focus the user explicitly asked for is untouched: rename inputs when entering edit mode, refocus after clicking a clear button, and keyboard-shortcut focus (⌘K in the chat sidebar, `/` in the package manager and dashboard templates).

## Testing

- `web/src/hooks/__tests__/useAutoFocusEnabled.test.tsx` covers both pointer types.
- `npm run typecheck` and `npm run lint` pass.
- Jest suites for the touched areas pass (`ui_primitives`, `chat`, `context_menus`, `node_menu`, `menus`, `workflows`, `applications`, `script`, `sketch`, `timeline`, `storyboard`, `inputs`, `workspace` — 3618 tests). jsdom has no `matchMedia`, so `useMediaQuery` falls back to `false` and existing focus assertions are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjDfTGbcDSjMi26nypNFSc)_