### PR TITLE
web: replace the document tab strip with a selector on mobile

### DIFF
--- a/web/src/components/workspace/MobileDocumentSelector.tsx
+++ b/web/src/components/workspace/MobileDocumentSelector.tsx
@@ -1,0 +1,284 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
+
+import type {
+  WorkspaceTab,
+  WorkspaceTabType
+} from "../../stores/WorkspaceTabsStore";
+import { useIsWorkflowRunning } from "../../hooks/useWorkflowRunnerState";
+import { useWorkflowDirty } from "../../hooks/useWorkflowDirty";
+import { useSettingsStore } from "../../stores/SettingsStore";
+import {
+  BORDER_RADIUS,
+  Caption,
+  CloseButton,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  LoadingSpinner,
+  MobileBottomSheet,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+
+export interface MobileDocumentSelectorProps {
+  tabs: WorkspaceTab[];
+  activeTabId: string | null;
+  typeColor: Record<WorkspaceTabType, string>;
+  typeGlyph: Record<WorkspaceTabType, string>;
+  onActivate: (tabId: string) => void;
+  onClose: (tab: WorkspaceTab) => void;
+  onCloseAll: () => void;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    WebkitAppRegion: "no-drag",
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    gap: getSpacingPx(SPACING.sm),
+    height: "100%",
+    padding: `0 ${getSpacingPx(SPACING.md)}`,
+    border: "none",
+    background: "transparent",
+    color: theme.vars.palette.text.primary,
+    fontSize: "var(--fontSizeSmall)",
+    cursor: "pointer",
+    textAlign: "left",
+    transition: `background-color ${MOTION.fast}`,
+    "&:active": {
+      backgroundColor: theme.vars.palette.action.hover
+    },
+    "& .glyph": { flexShrink: 0 },
+    "& .doc-title": {
+      flex: 1,
+      minWidth: 0,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    "& .doc-count": {
+      flexShrink: 0,
+      padding: `0 ${getSpacingPx(SPACING.sm)}`,
+      borderRadius: BORDER_RADIUS.pill,
+      backgroundColor: theme.vars.palette.action.selected,
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmaller)",
+      lineHeight: "18px"
+    },
+    "& .caret": {
+      flexShrink: 0,
+      width: "18px",
+      height: "18px",
+      color: theme.vars.palette.text.secondary
+    }
+  });
+
+const sheetStyles = (theme: Theme) =>
+  css({
+    paddingBottom: getSpacingPx(SPACING.xl),
+    "& .doc-row": {
+      minHeight: "44px",
+      gap: getSpacingPx(SPACING.md),
+      paddingLeft: getSpacingPx(SPACING.xl),
+      paddingRight: getSpacingPx(SPACING.xl),
+      "&.selected": {
+        backgroundColor: theme.vars.palette.action.selected
+      }
+    },
+    "& .row-glyph": {
+      flexShrink: 0,
+      width: "20px",
+      textAlign: "center"
+    },
+    "& .dirty-dot": {
+      width: "8px",
+      height: "8px",
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: theme.vars.palette.warning.main,
+      flexShrink: 0
+    },
+    "& .row-close": {
+      flexShrink: 0,
+      width: "44px",
+      height: "44px"
+    },
+    "& .close-all": {
+      minHeight: "44px",
+      paddingLeft: getSpacingPx(SPACING.xl),
+      color: theme.vars.palette.text.secondary
+    }
+  });
+
+/** Live per-document status: run spinner and unsaved-changes dot. */
+const DocumentStatus = memo(function DocumentStatus({
+  tab
+}: {
+  tab: WorkspaceTab;
+}) {
+  const workflowId = tab.type === "workflow" ? tab.ref : undefined;
+  const isDirty = useWorkflowDirty(workflowId);
+  const isRunning = useIsWorkflowRunning(workflowId);
+  // Instant-update re-runs on every keystroke, which would strobe the spinner.
+  const instantUpdate = useSettingsStore(
+    (state) => state.settings.instantUpdate
+  );
+
+  return (
+    <>
+      {isRunning && !instantUpdate && (
+        <LoadingSpinner
+          inline
+          variant="circular"
+          size={12}
+          thickness={4}
+          color="primary"
+        />
+      )}
+      {isDirty && (
+        <span className="dirty-dot" role="img" aria-label="unsaved changes" />
+      )}
+    </>
+  );
+});
+
+/**
+ * The mobile stand-in for the tab strip: a single button naming the open
+ * document, opening a bottom sheet that lists every open document. Tabs are
+ * unusable at phone widths — they truncate to a few characters and their close
+ * targets fall well under 44px.
+ */
+const MobileDocumentSelector = ({
+  tabs,
+  activeTabId,
+  typeColor,
+  typeGlyph,
+  onActivate,
+  onClose,
+  onCloseAll
+}: MobileDocumentSelectorProps) => {
+  const theme = useTheme();
+  const buttonStyles = useMemo(() => styles(theme), [theme]);
+  const listStyles = useMemo(() => sheetStyles(theme), [theme]);
+  const [open, setOpen] = useState(false);
+
+  const activeTab = useMemo(
+    () => tabs.find((tab) => tab.id === activeTabId) ?? null,
+    [tabs, activeTabId]
+  );
+
+  const closeSheet = useCallback(() => setOpen(false), []);
+
+  const handleSelect = useCallback(
+    (tabId: string) => {
+      onActivate(tabId);
+      setOpen(false);
+    },
+    [onActivate]
+  );
+
+  const handleCloseAll = useCallback(() => {
+    onCloseAll();
+    setOpen(false);
+  }, [onCloseAll]);
+
+  return (
+    <>
+      <button
+        type="button"
+        css={buttonStyles}
+        className="document-selector"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={
+          activeTab ? `Open document: ${activeTab.title}` : "Open documents"
+        }
+        onClick={() => setOpen(true)}
+      >
+        {activeTab && (
+          <span className="glyph" style={{ color: typeColor[activeTab.type] }}>
+            {typeGlyph[activeTab.type]}
+          </span>
+        )}
+        <span className="doc-title">
+          {activeTab ? activeTab.title : "No document open"}
+        </span>
+        {activeTab && <DocumentStatus tab={activeTab} />}
+        {tabs.length > 1 && <span className="doc-count">{tabs.length}</span>}
+        <ExpandMoreRoundedIcon className="caret" aria-hidden />
+      </button>
+
+      <MobileBottomSheet
+        open={open}
+        onClose={closeSheet}
+        title="Open documents"
+        ariaLabel="Switch between open documents"
+      >
+        <div css={listStyles}>
+          {tabs.length === 0 && (
+            <Caption color="secondary" sx={{ px: 2.5, py: 2 }}>
+              No documents open — use + to open or create one.
+            </Caption>
+          )}
+          <List dense disablePadding>
+            {tabs.map((tab) => (
+              <ListItem
+                key={tab.id}
+                disablePadding
+                secondaryAction={
+                  <CloseButton
+                    className="row-close"
+                    tooltip={`Close ${tab.title}`}
+                    onClick={() => onClose(tab)}
+                  />
+                }
+              >
+                <ListItemButton
+                  className={`doc-row${tab.id === activeTabId ? " selected" : ""}`}
+                  selected={tab.id === activeTabId}
+                  onClick={() => handleSelect(tab.id)}
+                >
+                  <span
+                    className="row-glyph"
+                    style={{ color: typeColor[tab.type] }}
+                    aria-hidden
+                  >
+                    {typeGlyph[tab.type]}
+                  </span>
+                  <ListItemText primary={tab.title} secondary={tab.type} />
+                  <DocumentStatus tab={tab} />
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+          {tabs.length > 1 && (
+            <>
+              <Divider />
+              <List dense disablePadding>
+                <ListItem disablePadding>
+                  <ListItemButton
+                    className="close-all"
+                    onClick={handleCloseAll}
+                  >
+                    <ListItemText primary="Close all documents" />
+                  </ListItemButton>
+                </ListItem>
+              </List>
+            </>
+          )}
+        </div>
+      </MobileBottomSheet>
+    </>
+  );
+};
+
+export default memo(MobileDocumentSelector);

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
   type DragEvent
 } from "react";
+import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
@@ -25,6 +26,7 @@ import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import NotificationButton from "../panels/NotificationButton";
 import OpenMenu from "./OpenMenu";
 import WorkspaceTabItem from "./WorkspaceTabItem";
+import MobileDocumentSelector from "./MobileDocumentSelector";
 
 /** Whether a document type supports both View and Edit (vs view-only). */
 const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
@@ -266,15 +268,12 @@ const styles = (theme: Theme) =>
     },
 
     // Mobile: no left rail to clear, and the bar grows to 48px so the global
-    // 44px touch-target minimum fits inside it. Text labels drop to icons.
+    // 44px touch-target minimum fits inside it. The tab strip is replaced by a
+    // single document selector (see MobileDocumentSelector); text labels drop
+    // to icons.
     [theme.breakpoints.down("sm")]: {
       height: "48px",
       paddingLeft: 0,
-      "& .tab": {
-        minWidth: "96px",
-        maxWidth: "160px",
-        padding: `0 ${getSpacingPx(SPACING.sm)} 0 ${getSpacingPx(SPACING.md)}`
-      },
       "& .new-tab": {
         padding: `0 ${getSpacingPx(SPACING.md)}`
       },
@@ -288,6 +287,7 @@ const styles = (theme: Theme) =>
 const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
   const theme = useTheme();
   const tabBarStyles = useMemo(() => styles(theme), [theme]);
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const tabs = useWorkspaceTabsStore((state) => state.tabs);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
   const setActiveTab = useWorkspaceTabsStore((state) => state.setActiveTab);
@@ -524,31 +524,45 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
           ▾
         </span>
       </button>
-      <div className="tabs">
-        {tabs.map((tab) => (
-          <WorkspaceTabItem
-            key={tab.id}
-            tab={tab}
-            isActive={tab.id === activeTabId}
-            isEditing={editingTabId === tab.id}
-            canRename={RENAMEABLE_TYPES.has(tab.type)}
-            dropPosition={dropTarget?.id === tab.id ? dropTarget.position : null}
-            typeColor={TYPE_COLOR[tab.type]}
-            typeGlyph={TYPE_GLYPH[tab.type]}
-            onActivate={setActiveTab}
-            onBeginRename={handleBeginRename}
-            onClose={handleClose}
-            onCloseOthers={handleCloseOthers}
-            onCloseAll={handleCloseAll}
-            onDragStart={handleDragStart}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            onCommitRename={commitRename}
-            onCancelRename={handleCancelRename}
-          />
-        ))}
-      </div>
+      {isMobile ? (
+        <MobileDocumentSelector
+          tabs={tabs}
+          activeTabId={activeTabId}
+          typeColor={TYPE_COLOR}
+          typeGlyph={TYPE_GLYPH}
+          onActivate={setActiveTab}
+          onClose={handleClose}
+          onCloseAll={handleCloseAll}
+        />
+      ) : (
+        <div className="tabs">
+          {tabs.map((tab) => (
+            <WorkspaceTabItem
+              key={tab.id}
+              tab={tab}
+              isActive={tab.id === activeTabId}
+              isEditing={editingTabId === tab.id}
+              canRename={RENAMEABLE_TYPES.has(tab.type)}
+              dropPosition={
+                dropTarget?.id === tab.id ? dropTarget.position : null
+              }
+              typeColor={TYPE_COLOR[tab.type]}
+              typeGlyph={TYPE_GLYPH[tab.type]}
+              onActivate={setActiveTab}
+              onBeginRename={handleBeginRename}
+              onClose={handleClose}
+              onCloseOthers={handleCloseOthers}
+              onCloseAll={handleCloseAll}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onCommitRename={commitRename}
+              onCancelRename={handleCancelRename}
+            />
+          ))}
+        </div>
+      )}
 
       <OpenMenu
         anchorEl={newTabButtonRef.current}

--- a/web/src/components/workspace/__tests__/MobileDocumentSelector.test.tsx
+++ b/web/src/components/workspace/__tests__/MobileDocumentSelector.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import type {
+  WorkspaceTab,
+  WorkspaceTabType
+} from "../../../stores/WorkspaceTabsStore";
+
+jest.mock("../../../hooks/useWorkflowDirty", () => ({
+  useWorkflowDirty: () => false
+}));
+jest.mock("../../../hooks/useWorkflowRunnerState", () => ({
+  useIsWorkflowRunning: () => false
+}));
+jest.mock("../../../stores/SettingsStore", () => ({
+  useSettingsStore: (selector: (s: unknown) => unknown) =>
+    selector({ settings: { instantUpdate: false } })
+}));
+
+import MobileDocumentSelector from "../MobileDocumentSelector";
+
+const tab = (ref: string, title: string): WorkspaceTab => ({
+  id: `workflow:${ref}`,
+  type: "workflow",
+  ref,
+  mode: "edit",
+  title
+});
+
+const TABS = [tab("a", "Alpha"), tab("b", "Beta")];
+
+const COLOR = { workflow: "#fff" } as Record<WorkspaceTabType, string>;
+const GLYPH = { workflow: "⬡" } as Record<WorkspaceTabType, string>;
+
+const renderSelector = (
+  overrides: Partial<React.ComponentProps<typeof MobileDocumentSelector>> = {}
+) => {
+  const props = {
+    tabs: TABS,
+    activeTabId: "workflow:a",
+    typeColor: COLOR,
+    typeGlyph: GLYPH,
+    onActivate: jest.fn(),
+    onClose: jest.fn(),
+    onCloseAll: jest.fn(),
+    ...overrides
+  };
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MobileDocumentSelector {...props} />
+    </ThemeProvider>
+  );
+  return props;
+};
+
+const openSheet = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /Open document: Alpha/ }));
+  await waitFor(() => expect(screen.getByText("Open documents")).toBeInTheDocument());
+  return user;
+};
+
+describe("MobileDocumentSelector", () => {
+  it("names the active document and its sibling count", () => {
+    renderSelector();
+    expect(screen.getByRole("button", { name: /Alpha/ })).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("switches documents from the sheet", async () => {
+    const props = renderSelector();
+    const user = await openSheet();
+    await user.click(screen.getByRole("button", { name: "Beta workflow" }));
+    expect(props.onActivate).toHaveBeenCalledWith("workflow:b");
+  });
+
+  it("closes a single document without switching to it", async () => {
+    const props = renderSelector();
+    const user = await openSheet();
+    await user.click(screen.getByRole("button", { name: "Close Beta" }));
+    expect(props.onClose).toHaveBeenCalledWith(TABS[1]);
+    expect(props.onActivate).not.toHaveBeenCalled();
+  });
+
+  it("closes every document at once", async () => {
+    const props = renderSelector();
+    const user = await openSheet();
+    await user.click(screen.getByRole("button", { name: "Close all documents" }));
+    expect(props.onCloseAll).toHaveBeenCalled();
+  });
+
+  it("says so when nothing is open", () => {
+    renderSelector({ tabs: [], activeTabId: null });
+    expect(screen.getByText("No document open")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Tabs don't work at phone widths — titles truncate to a few characters and the per-tab close target sits well under 44px, so switching documents on mobile web means fighting a horizontally-scrolling strip.

On viewports below `sm`, `WorkspaceTabBar` now renders a single document selector instead of the tab strip:

- The bar shows one button: the active document's type glyph, its title, its run spinner / unsaved-changes dot, and a count of how many documents are open.
- Tapping it opens a `MobileBottomSheet` listing every open document as a full-width row (glyph, title, type, live status), with a 44px close target per row and a "Close all documents" action.
- Selecting a row activates that document and dismisses the sheet.

Desktop is untouched — the tab strip, drag-to-reorder, double-click rename, and per-tab context menu all still render above `sm`. The mobile CSS overrides that were shrinking `.tab` are gone, since no tabs render there anymore.

New file: `web/src/components/workspace/MobileDocumentSelector.tsx`, with tests in `web/src/components/workspace/__tests__/MobileDocumentSelector.test.tsx` covering switching, closing one, closing all, and the empty state.

## Testing

- `npx jest src/components/workspace` — 27 tests pass (6 suites), including the 5 new ones.
- `npx eslint` clean on the touched files.
- `npm run typecheck` in `web/` reports only pre-existing `TS2307` errors from unbuilt `@nodetool-ai/*-nodes` packages; none in `src/components/workspace`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018b4q8Bp6ywT2GernVkdZEE)_