### PR TITLE
Collapsible sketch tool settings + a way back from hidden panels

### DIFF
--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -41,6 +41,7 @@ import React, { memo, forwardRef, useEffect } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import {
   Chip,
   CollapsibleSection,
@@ -111,7 +112,9 @@ export interface SketchEditorHandle {
 const PRESET_SWATCH_SIZE = 18;
 
 /** Bright, uppercase, letter-spaced label for the right-panel section headers. */
-const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+const SectionTitle: React.FC<{ children: React.ReactNode }> = ({
+  children
+}) => (
   <Text
     size="small"
     sx={{
@@ -213,6 +216,7 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     // every child so the column's reserved width also collapses, letting
     // the canvas grow into the freed space.
     const panelsHidden = useSketchStore((s) => s.panelsHidden);
+    const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
     const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
 
     // On narrow/touch viewports the fixed side columns can't sit beside the
@@ -221,7 +225,9 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     const isMobile = useSketchIsMobile();
     const mobilePanelsOpen = useSketchStore((s) => s.mobilePanelsOpen);
     const setMobilePanelsOpen = useSketchStore((s) => s.setMobilePanelsOpen);
-    const setAssistantPanelOpen = useSketchStore((s) => s.setAssistantPanelOpen);
+    const setAssistantPanelOpen = useSketchStore(
+      (s) => s.setAssistantPanelOpen
+    );
 
     // The mobile panels sheet is a mobile-only surface. Clear its flag when the
     // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
@@ -373,7 +379,9 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
               session.layerActions.handleToggleExposedOutput
             }
             onLayerOpacityChange={session.layerActions.handleSetLayerOpacity}
-            onLayerBlendModeChange={session.layerActions.handleSetLayerBlendMode}
+            onLayerBlendModeChange={
+              session.layerActions.handleSetLayerBlendMode
+            }
             onRenameLayer={session.layerActions.handleRenameLayer}
             onAddGroup={session.layerActions.handleAddGroup}
             onToggleGroupCollapsed={
@@ -543,6 +551,28 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
                 }
               />
             </Container>
+
+            {/* Restoring the chrome is otherwise Tab-only, and a touch device
+              has no Tab key — keep one always-visible affordance on the bare
+              canvas. */}
+            {panelsHidden && (
+              <Tooltip title="Show panels">
+                <Fab
+                  className="sketch-editor__show-panels-fab"
+                  size="small"
+                  aria-label="Show panels"
+                  onClick={togglePanelsHidden}
+                  sx={{
+                    position: "absolute",
+                    top: (t) => t.spacing(1),
+                    right: (t) => t.spacing(1),
+                    zIndex: Z_INDEX.raised + 2
+                  }}
+                >
+                  <ViewSidebarOutlinedIcon fontSize="small" />
+                </Fab>
+              </Tooltip>
+            )}
           </FlexColumn>
 
           {/* Right column: color, layers, canvas size sections. The wrapper

--- a/web/src/components/sketch/SketchToolTopBar.tsx
+++ b/web/src/components/sketch/SketchToolTopBar.tsx
@@ -13,7 +13,15 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import FitScreenIcon from "@mui/icons-material/FitScreen";
-import { EditorButton, FlexRow, Text, Tooltip } from "../ui_primitives";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import {
+  EditorButton,
+  FlexRow,
+  IconButton,
+  Text,
+  Tooltip
+} from "../ui_primitives";
 import { getToolSettingsLabel } from "./tool-settings-panels/getToolSettingsLabel";
 import {
   SketchTool,
@@ -128,6 +136,10 @@ export interface SketchToolTopBarProps {
   onCheckSegmentModel?: () => void;
   /** Collapse the left tool rail + right panels for a chrome-less canvas. */
   onTogglePanelsHidden?: () => void;
+  /** When true, only the tool header and global actions render. */
+  settingsCollapsed?: boolean;
+  /** Toggles `settingsCollapsed`; the caret is omitted when not supplied. */
+  onToggleSettingsCollapsed?: () => void;
   /** Fit the document to the canvas viewport (zoom-to-fit, centered). */
   onFit?: () => void;
 }
@@ -192,7 +204,9 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
   onClearSegmentPrompts,
   onCheckSegmentModel,
   onTogglePanelsHidden,
-  onFit
+  onFit,
+  settingsCollapsed = false,
+  onToggleSettingsCollapsed
 }) => {
   const theme = useTheme();
 
@@ -217,68 +231,93 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
         <Text sx={{ fontSize: SKETCH_FONT.section, fontWeight: 600 }}>
           {getToolSettingsLabel(activeTool)}
         </Text>
+        {onToggleSettingsCollapsed && (
+          <Tooltip
+            title={
+              settingsCollapsed ? "Show tool settings" : "Hide tool settings"
+            }
+          >
+            <IconButton
+              size="small"
+              onClick={onToggleSettingsCollapsed}
+              aria-expanded={!settingsCollapsed}
+              aria-label={
+                settingsCollapsed ? "Show tool settings" : "Hide tool settings"
+              }
+              data-testid="sketch-toggle-tool-settings"
+            >
+              {settingsCollapsed ? (
+                <ExpandMoreIcon fontSize="small" />
+              ) : (
+                <ExpandLessIcon fontSize="small" />
+              )}
+            </IconButton>
+          </Tooltip>
+        )}
       </FlexRow>
 
-      <ToolSettingsPanel
-        activeTool={activeTool}
-        brushSettings={brushSettings}
-        pencilSettings={pencilSettings}
-        eraserSettings={eraserSettings}
-        shapeSettings={shapeSettings}
-        fillSettings={fillSettings}
-        blurSettings={blurSettings}
-        gradientSettings={gradientSettings}
-        cloneStampSettings={cloneStampSettings}
-        selectSettings={selectSettings}
-        hasActiveSelection={hasActiveSelection}
-        adjustBrightness={adjustBrightness}
-        adjustContrast={adjustContrast}
-        adjustSaturation={adjustSaturation}
-        onBrushSettingsChange={onBrushSettingsChange}
-        onPencilSettingsChange={onPencilSettingsChange}
-        onEraserSettingsChange={onEraserSettingsChange}
-        onShapeSettingsChange={onShapeSettingsChange}
-        onFillSettingsChange={onFillSettingsChange}
-        onBlurSettingsChange={onBlurSettingsChange}
-        onGradientSettingsChange={onGradientSettingsChange}
-        onCloneStampSettingsChange={onCloneStampSettingsChange}
-        onSelectSettingsChange={onSelectSettingsChange}
-        onInvertSelection={onInvertSelection}
-        onCropCanvasToSelection={onCropCanvasToSelection}
-        onFeatherSelection={onFeatherSelection}
-        onSmoothSelectionBorders={onSmoothSelectionBorders}
-        onConvertSelectionToBorder={onConvertSelectionToBorder}
-        onAdjustBrightnessChange={onAdjustBrightnessChange}
-        onAdjustContrastChange={onAdjustContrastChange}
-        onAdjustSaturationChange={onAdjustSaturationChange}
-        onAdjustApply={onAdjustApply}
-        onAdjustCancel={onAdjustCancel}
-        transformScaleX={transformScaleX}
-        transformScaleY={transformScaleY}
-        transformRotation={transformRotation}
-        onTransformCommit={onTransformCommit}
-        onTransformCancel={onTransformCancel}
-        onTransformReset={onTransformReset}
-        transformAutoSelect={transformAutoSelect}
-        transformMode={transformMode}
-        onTransformAutoSelectChange={onTransformAutoSelectChange}
-        onTransformModeChange={onTransformModeChange}
-        moveAutoSelect={moveAutoSelect}
-        onMoveAutoSelectChange={onMoveAutoSelectChange}
-        cropHasPendingRect={cropHasPendingRect}
-        onCropApply={onCropApply}
-        onCropCancelPreview={onCropCancelPreview}
-        segmentSettings={segmentSettings}
-        onSegmentSettingsChange={onSegmentSettingsChange}
-        segmentationStatus={segmentationStatus}
-        segmentModelInfo={segmentModelInfo}
-        onRunSegmentation={onRunSegmentation}
-        onApplySegmentResult={onApplySegmentResult}
-        onDiscardSegmentResult={onDiscardSegmentResult}
-        onCancelSegmentation={onCancelSegmentation}
-        onClearSegmentPrompts={onClearSegmentPrompts}
-        onCheckSegmentModel={onCheckSegmentModel}
-      />
+      {!settingsCollapsed && (
+        <ToolSettingsPanel
+          activeTool={activeTool}
+          brushSettings={brushSettings}
+          pencilSettings={pencilSettings}
+          eraserSettings={eraserSettings}
+          shapeSettings={shapeSettings}
+          fillSettings={fillSettings}
+          blurSettings={blurSettings}
+          gradientSettings={gradientSettings}
+          cloneStampSettings={cloneStampSettings}
+          selectSettings={selectSettings}
+          hasActiveSelection={hasActiveSelection}
+          adjustBrightness={adjustBrightness}
+          adjustContrast={adjustContrast}
+          adjustSaturation={adjustSaturation}
+          onBrushSettingsChange={onBrushSettingsChange}
+          onPencilSettingsChange={onPencilSettingsChange}
+          onEraserSettingsChange={onEraserSettingsChange}
+          onShapeSettingsChange={onShapeSettingsChange}
+          onFillSettingsChange={onFillSettingsChange}
+          onBlurSettingsChange={onBlurSettingsChange}
+          onGradientSettingsChange={onGradientSettingsChange}
+          onCloneStampSettingsChange={onCloneStampSettingsChange}
+          onSelectSettingsChange={onSelectSettingsChange}
+          onInvertSelection={onInvertSelection}
+          onCropCanvasToSelection={onCropCanvasToSelection}
+          onFeatherSelection={onFeatherSelection}
+          onSmoothSelectionBorders={onSmoothSelectionBorders}
+          onConvertSelectionToBorder={onConvertSelectionToBorder}
+          onAdjustBrightnessChange={onAdjustBrightnessChange}
+          onAdjustContrastChange={onAdjustContrastChange}
+          onAdjustSaturationChange={onAdjustSaturationChange}
+          onAdjustApply={onAdjustApply}
+          onAdjustCancel={onAdjustCancel}
+          transformScaleX={transformScaleX}
+          transformScaleY={transformScaleY}
+          transformRotation={transformRotation}
+          onTransformCommit={onTransformCommit}
+          onTransformCancel={onTransformCancel}
+          onTransformReset={onTransformReset}
+          transformAutoSelect={transformAutoSelect}
+          transformMode={transformMode}
+          onTransformAutoSelectChange={onTransformAutoSelectChange}
+          onTransformModeChange={onTransformModeChange}
+          moveAutoSelect={moveAutoSelect}
+          onMoveAutoSelectChange={onMoveAutoSelectChange}
+          cropHasPendingRect={cropHasPendingRect}
+          onCropApply={onCropApply}
+          onCropCancelPreview={onCropCancelPreview}
+          segmentSettings={segmentSettings}
+          onSegmentSettingsChange={onSegmentSettingsChange}
+          segmentationStatus={segmentationStatus}
+          segmentModelInfo={segmentModelInfo}
+          onRunSegmentation={onRunSegmentation}
+          onApplySegmentResult={onApplySegmentResult}
+          onDiscardSegmentResult={onDiscardSegmentResult}
+          onCancelSegmentation={onCancelSegmentation}
+          onClearSegmentPrompts={onClearSegmentPrompts}
+          onCheckSegmentModel={onCheckSegmentModel}
+        />
+      )}
 
       {(onFit || onTogglePanelsHidden) && (
         <FlexRow
@@ -303,7 +342,7 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
             </Tooltip>
           )}
           {onTogglePanelsHidden && (
-            <Tooltip title="Hide panels — press Tab to restore">
+            <Tooltip title="Hide panels — press Tab, or tap the corner button, to restore">
               <span>
                 <EditorButton
                   variant="text"

--- a/web/src/components/sketch/__tests__/toolTopBarCollapse.test.tsx
+++ b/web/src/components/sketch/__tests__/toolTopBarCollapse.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Tool-settings collapse in the top bar: the caret hides/shows the settings
+ * row, and narrow viewports start collapsed so the settings don't eat the
+ * canvas on a phone.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import { ConnectedToolTopBar } from "../editor-shell/ConnectedToolTopBar";
+import type { ConnectedToolTopBarProps } from "../editor-shell/ConnectedToolTopBar";
+import { useSketchStore } from "../state";
+import type { useSegmentation } from "../hooks/useSegmentation";
+
+const mockIsMobile = jest.fn(() => false);
+jest.mock("../hooks/useSketchIsMobile", () => ({
+  useSketchIsMobile: () => mockIsMobile()
+}));
+
+const segmentation = {
+  status: "idle",
+  modelInfo: null,
+  applyResult: jest.fn(),
+  discardResult: jest.fn(),
+  cancelSegmentation: jest.fn(),
+  checkModel: jest.fn()
+} as unknown as ReturnType<typeof useSegmentation>;
+
+const props: ConnectedToolTopBarProps = {
+  adjBrightness: 0,
+  adjContrast: 0,
+  adjSaturation: 0,
+  onAdjustBrightnessChange: jest.fn(),
+  onAdjustContrastChange: jest.fn(),
+  onAdjustSaturationChange: jest.fn(),
+  onAdjustApply: jest.fn(),
+  onAdjustCancel: jest.fn(),
+  onTransformCommit: jest.fn(),
+  onTransformCancel: jest.fn(),
+  onTransformReset: jest.fn(),
+  segmentation,
+  onRunSegmentation: jest.fn(),
+  onClearSegmentPrompts: jest.fn(),
+  onCropCanvasToSelection: jest.fn(),
+  onCropCommit: jest.fn(),
+  onCropCancelPreview: jest.fn()
+};
+
+function renderBar() {
+  return render(
+    <ThemeProvider theme={createTheme({ cssVariables: true })}>
+      <ConnectedToolTopBar {...props} />
+    </ThemeProvider>
+  );
+}
+
+beforeEach(() => {
+  mockIsMobile.mockReturnValue(false);
+  useSketchStore.setState((s) => ({
+    ...s,
+    panelsHidden: false,
+    toolSettingsCollapsed: false
+  }));
+  useSketchStore.getState().setActiveTool("brush");
+});
+
+describe("tool-settings collapse", () => {
+  it("shows the settings expanded on desktop", () => {
+    renderBar();
+    expect(screen.getByText("Brush")).toBeTruthy();
+    expect(screen.getByLabelText("Hide tool settings")).toBeTruthy();
+    expect(screen.getByText("Size")).toBeTruthy();
+  });
+
+  it("hides the settings when the caret is tapped, keeping the header", async () => {
+    const user = userEvent.setup();
+    renderBar();
+
+    await user.click(screen.getByTestId("sketch-toggle-tool-settings"));
+
+    expect(useSketchStore.getState().toolSettingsCollapsed).toBe(true);
+    expect(screen.queryByText("Size")).toBeNull();
+    expect(screen.getByText("Brush")).toBeTruthy();
+    expect(screen.getByLabelText("Show tool settings")).toBeTruthy();
+  });
+
+  it("starts collapsed on a narrow viewport", () => {
+    mockIsMobile.mockReturnValue(true);
+    renderBar();
+
+    expect(useSketchStore.getState().toolSettingsCollapsed).toBe(true);
+    expect(screen.queryByText("Size")).toBeNull();
+    expect(screen.getByTestId("sketch-toggle-tool-settings")).toBeTruthy();
+  });
+});

--- a/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
@@ -6,10 +6,14 @@
  * Action callbacks that depend on document are passed in as props; their
  * individual references are stable via `useCallback`.
  */
-import React, { memo, useCallback } from "react";
+import React, { memo, useCallback, useEffect } from "react";
 import SketchToolTopBar from "../SketchToolTopBar";
 import { useSketchStore, SKETCH_ZOOM_MIN, SKETCH_ZOOM_MAX } from "../state";
-import { useResolvedToolSettings, useToolChromeActions } from "../hooks";
+import {
+  useResolvedToolSettings,
+  useSketchIsMobile,
+  useToolChromeActions
+} from "../hooks";
 import {
   useTransformAdapter,
   type UseTransformAdapterParams
@@ -44,7 +48,23 @@ export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
   const panelsHidden = useSketchStore((s) => s.panelsHidden);
   const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
   const hasActiveSelection = useSketchStore((s) => s.hasActiveSelection);
+  const toolSettingsCollapsed = useSketchStore((s) => s.toolSettingsCollapsed);
+  const toggleToolSettingsCollapsed = useSketchStore(
+    (s) => s.toggleToolSettingsCollapsed
+  );
+  const setToolSettingsCollapsed = useSketchStore(
+    (s) => s.setToolSettingsCollapsed
+  );
   const toolSettings = useResolvedToolSettings();
+
+  // The settings rows wrap to two or three lines for most tools, which on a
+  // phone leaves little canvas. Start collapsed on mobile and expanded on
+  // desktop, re-applied on each breakpoint crossing (rotate/resize).
+  const isMobile = useSketchIsMobile();
+  useEffect(() => {
+    setToolSettingsCollapsed(isMobile);
+  }, [isMobile, setToolSettingsCollapsed]);
+
   const transform = useTransformAdapter({
     onTransformCommit: props.onTransformCommit,
     onTransformCancel: props.onTransformCancel,
@@ -162,6 +182,8 @@ export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
       onCheckSegmentModel={props.segmentation.checkModel}
       onTogglePanelsHidden={togglePanelsHidden}
       onFit={handleFit}
+      settingsCollapsed={toolSettingsCollapsed}
+      onToggleSettingsCollapsed={toggleToolSettingsCollapsed}
     />
   );
 });

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -17,6 +17,17 @@ export interface UiSlice {
   panelsHidden: boolean;
   togglePanelsHidden: () => void;
 
+  /**
+   * Whether the tool-settings row of the top bar is collapsed to just its
+   * "Tool <name>" header. The settings wrap onto several rows for most tools,
+   * which eats a large share of a phone-sized viewport — the header keeps a
+   * one-tap way back. Set on every mobile/desktop transition (collapsed on
+   * mobile, expanded on desktop) and toggled by the caret in the bar.
+   */
+  toolSettingsCollapsed: boolean;
+  toggleToolSettingsCollapsed: () => void;
+  setToolSettingsCollapsed: (collapsed: boolean) => void;
+
   /** Whether the AI assistant chat panel is open (right side of the editor). */
   assistantPanelOpen: boolean;
   toggleAssistantPanel: () => void;
@@ -79,6 +90,12 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
   panelsHidden: false,
   togglePanelsHidden: () =>
     set((state) => ({ panelsHidden: !state.panelsHidden })),
+
+  toolSettingsCollapsed: false,
+  toggleToolSettingsCollapsed: () =>
+    set((state) => ({ toolSettingsCollapsed: !state.toolSettingsCollapsed })),
+  setToolSettingsCollapsed: (collapsed: boolean) =>
+    set({ toolSettingsCollapsed: collapsed }),
 
   assistantPanelOpen: false,
   toggleAssistantPanel: () =>
@@ -171,7 +188,10 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
       // Written on every pointer move — skip the notify when the integer
       // position is unchanged so subscribers don't re-render per event.
       const prev = state.cursorDocPos;
-      if (prev === pos || (prev && pos && prev.x === pos.x && prev.y === pos.y)) {
+      if (
+        prev === pos ||
+        (prev && pos && prev.x === pos.x && prev.y === pos.y)
+      ) {
         return state;
       }
       return { ...state, cursorDocPos: pos };


### PR DESCRIPTION
Two mobile fixes in the sketch editor.

**Tool settings take too much room on a phone.** The settings row in `SketchToolTopBar` wraps onto several lines for most tools, leaving little canvas at phone widths. It now collapses to just its `Tool <name>` header, with a caret to expand:

- New `toolSettingsCollapsed` flag (+ toggle/set actions) in the sketch UI slice.
- `SketchToolTopBar` gains `settingsCollapsed` / `onToggleSettingsCollapsed`; the header, the caret, and the Fit / Hide-panels actions stay visible while collapsed.
- `ConnectedToolTopBar` sets the flag from `useSketchIsMobile` — collapsed on mobile, expanded on desktop, re-applied on each breakpoint crossing (rotate/resize).

**Hiding all panels had no way back on touch.** `panelsHidden` hides the tool rail, top bar, mode bar and status bar — including the button that toggles it — so only Tab could restore it, which a phone has no way to press. A small FAB now sits at the top-right of the bare canvas whenever panels are hidden, and the Hide-panels tooltip mentions it.

## Testing

- New `web/src/components/sketch/__tests__/toolTopBarCollapse.test.tsx`: expanded on desktop, caret collapses and keeps the header, collapsed by default on a narrow viewport.
- `npx jest src/components/sketch` — 114 suites / 1955 tests pass.
- Lint clean on the touched files; typecheck reports no sketch errors (the repo's pre-existing unbuilt-package errors in `browserRunnerCore.ts` are unrelated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBKhUVG6Rigd6LS2RhNp2D)_