### PR TITLE
fix(web): make the chain view toggle switch the editor surface

### DIFF
--- a/web/src/components/workspace/WorkflowChainSurface.tsx
+++ b/web/src/components/workspace/WorkflowChainSurface.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { ChainEditor } from "../chain_editor/ChainEditor";
+import { useChainEditorStore } from "../chain_editor/useChainEditorStore";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import useMetadataStore from "../../stores/MetadataStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import type { NodeStore } from "../../stores/NodeStore";
+import { graphNodeToReactFlowNode } from "../../stores/graphNodeToReactFlowNode";
+import { graphEdgeToReactFlowEdge } from "../../stores/graphEdgeToReactFlowEdge";
+import type { Node as GraphNode } from "../../stores/ApiTypes";
+
+interface WorkflowChainSurfaceProps {
+  workflowId: string;
+  nodeStore: NodeStore;
+}
+
+/**
+ * The Chain surface for a workflow tab: the same workflow rendered as a linear
+ * list of node cards instead of the ReactFlow canvas. Toggled from the floating
+ * toolbar's view-mode button.
+ *
+ * The chain store is the editing surface; every change is mirrored back into
+ * the tab's NodeStore so running, saving and switching back to the graph all
+ * see the edits. Positions of nodes that already exist are preserved, so
+ * round-tripping through the chain view doesn't flatten a hand-made layout.
+ */
+const WorkflowChainSurface = ({
+  workflowId,
+  nodeStore
+}: WorkflowChainSurfaceProps) => {
+  const loadWorkflow = useChainEditorStore((state) => state.loadWorkflow);
+  const toWorkflowGraph = useChainEditorStore((state) => state.toWorkflowGraph);
+  const saveWorkflow = useWorkflowManager((state) => state.saveWorkflow);
+  const updateWorkflow = useWorkflowManager((state) => state.updateWorkflow);
+  const addNotification = useNotificationStore((state) => state.addNotification);
+  // Metadata arrives asynchronously, and the chain store drops nodes it has no
+  // metadata for — so wait for it before loading the graph in.
+  const metadataLoaded = useMetadataStore(
+    (state) => Object.keys(state.metadata).length > 0
+  );
+
+  const loadedRef = useRef<string | null>(null);
+  // Nodes the chain view can't represent (comments, groups, anything without
+  // metadata). They stay in the NodeStore untouched so a round-trip through the
+  // chain view never deletes them.
+  const passthroughRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!metadataLoaded || loadedRef.current === workflowId) {
+      return;
+    }
+    loadedRef.current = workflowId;
+    loadWorkflow(nodeStore.getState().getWorkflow());
+    const chainIds = new Set(
+      useChainEditorStore.getState().chain.map((node) => node.id)
+    );
+    passthroughRef.current = new Set(
+      nodeStore
+        .getState()
+        .nodes.filter((node) => !chainIds.has(node.id))
+        .map((node) => node.id)
+    );
+  }, [metadataLoaded, workflowId, loadWorkflow, nodeStore]);
+
+  const applyToNodeStore = useCallback(() => {
+    const graph = toWorkflowGraph();
+    const { nodes, edges, workflow, setNodes, setEdges } = nodeStore.getState();
+    const passthrough = passthroughRef.current;
+    const existingUi = new Map(
+      nodes.map((node) => [
+        node.id,
+        { position: node.position, width: node.width, height: node.height }
+      ])
+    );
+
+    const merged: GraphNode[] = graph.nodes.map((node) => {
+      const existing = existingUi.get(node.id);
+      if (!existing) {
+        return node;
+      }
+      return {
+        ...node,
+        ui_properties: {
+          ...(node.ui_properties as Record<string, unknown>),
+          position: existing.position,
+          ...(existing.width ? { width: existing.width } : {}),
+          ...(existing.height ? { height: existing.height } : {})
+        }
+      };
+    });
+
+    const keptNodes = nodes.filter((node) => passthrough.has(node.id));
+    setNodes([
+      ...merged.map((node) =>
+        graphNodeToReactFlowNode(
+          { ...workflow, graph: { nodes: [], edges: [] } },
+          node
+        )
+      ),
+      ...keptNodes
+    ]);
+
+    const liveIds = new Set([
+      ...graph.nodes.map((node) => node.id),
+      ...keptNodes.map((node) => node.id)
+    ]);
+    const keptEdges = edges.filter(
+      (edge) =>
+        (passthrough.has(edge.source) || passthrough.has(edge.target)) &&
+        liveIds.has(edge.source) &&
+        liveIds.has(edge.target)
+    );
+    setEdges([...graph.edges.map(graphEdgeToReactFlowEdge), ...keptEdges]);
+  }, [nodeStore, toWorkflowGraph]);
+
+  // Mirror chain edits into the NodeStore. Subscribing (rather than reacting to
+  // rendered state) keeps the write out of the render path; the chain store is
+  // never written back from here, so there is no feedback loop.
+  useEffect(() => {
+    if (!metadataLoaded) {
+      return;
+    }
+    return useChainEditorStore.subscribe((state, prev) => {
+      if (state.workflowId !== workflowId) {
+        return;
+      }
+      if (state.chain === prev.chain && state.connections === prev.connections) {
+        return;
+      }
+      applyToNodeStore();
+    });
+  }, [applyToNodeStore, metadataLoaded, workflowId]);
+
+  const handleSave = useCallback(async () => {
+    applyToNodeStore();
+    const name = useChainEditorStore.getState().workflowName;
+    const current = nodeStore.getState().workflow;
+    if (name && name !== current.name) {
+      updateWorkflow({ ...current, name });
+    }
+    try {
+      await saveWorkflow(nodeStore.getState().getWorkflow());
+      nodeStore.getState().setWorkflowDirty(false);
+    } catch (error) {
+      addNotification({
+        type: "error",
+        alert: true,
+        content:
+          error instanceof Error ? error.message : "Failed to save workflow"
+      });
+    }
+  }, [
+    applyToNodeStore,
+    addNotification,
+    nodeStore,
+    saveWorkflow,
+    updateWorkflow
+  ]);
+
+  return <ChainEditor onSave={handleSave} />;
+};
+
+export default WorkflowChainSurface;

--- a/web/src/components/workspace/WorkflowEditorSurface.tsx
+++ b/web/src/components/workspace/WorkflowEditorSurface.tsx
@@ -16,6 +16,8 @@ import FloatingToolBar from "../panels/FloatingToolBar";
 import QueueOverlay from "../panels/QueueOverlay";
 import StatusMessage from "../panels/StatusMessage";
 import NodeCreateBridge from "../editor/NodeCreateBridge";
+import WorkflowChainSurface from "./WorkflowChainSurface";
+import { useSettingsStore } from "../../stores/SettingsStore";
 import { FlexColumn, LoadingSpinner } from "../ui_primitives";
 
 // Floating editor status message: sits above the canvas and node overlays but
@@ -42,6 +44,9 @@ const WorkflowEditorSurface = ({
   const nodeStore = useWorkflowManager((state) => state.getNodeStore(workflowId));
   const fetchWorkflow = useWorkflowManager((state) => state.fetchWorkflow);
   const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
+  const editorViewMode = useSettingsStore(
+    (state) => state.settings.editorViewMode
+  );
   const [missing, setMissing] = useState(false);
 
   useEffect(() => {
@@ -79,6 +84,8 @@ const WorkflowEditorSurface = ({
     );
   }
 
+  const showChain = active && editorViewMode === "chain";
+
   return (
     <NodeContext.Provider value={nodeStore}>
       <ReactFlowProvider>
@@ -106,7 +113,33 @@ const WorkflowEditorSurface = ({
                   height: "100%"
                 }}
               >
-                <NodeEditor workflowId={workflowId} active={active} />
+                {/* The chain view replaces the canvas for the active tab. The
+                    node editor stays mounted underneath so toggling back keeps
+                    its viewport and transient editor state. */}
+                <div
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    display: showChain ? "none" : undefined
+                  }}
+                >
+                  <NodeEditor workflowId={workflowId} active={active} />
+                </div>
+                {showChain && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      display: "flex",
+                      flexDirection: "column"
+                    }}
+                  >
+                    <WorkflowChainSurface
+                      workflowId={workflowId}
+                      nodeStore={nodeStore}
+                    />
+                  </div>
+                )}
               </div>
               {active && <FloatingToolBar />}
               {active && <QueueOverlay />}

--- a/web/src/components/workspace/__tests__/WorkflowChainSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkflowChainSurface.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import WorkflowChainSurface from "../WorkflowChainSurface";
+import { useChainEditorStore } from "../../chain_editor/useChainEditorStore";
+import useMetadataStore from "../../../stores/MetadataStore";
+import { createNodeStore } from "../../../stores/NodeStore";
+import type {
+  NodeMetadata,
+  Property,
+  TypeMetadata,
+  Workflow
+} from "../../../stores/ApiTypes";
+
+const saveWorkflow = jest.fn().mockResolvedValue(undefined);
+const updateWorkflow = jest.fn();
+
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  __esModule: true,
+  useWorkflowManager: (selector: (state: unknown) => unknown) =>
+    selector({ saveWorkflow, updateWorkflow })
+}));
+
+jest.mock("../../chain_editor/ChainEditor", () => ({
+  __esModule: true,
+  ChainEditor: () => <div data-testid="chain-editor" />
+}));
+
+const strType: TypeMetadata = { type: "str", type_args: [], optional: false };
+
+const makeMetadata = (nodeType: string): NodeMetadata =>
+  ({
+    title: nodeType,
+    description: "",
+    namespace: "test",
+    node_type: nodeType,
+    properties: [
+      {
+        name: "value",
+        type: strType,
+        default: "",
+        description: "",
+        required: false
+      } as Property
+    ],
+    outputs: [{ name: "output", type: strType, stream: false }],
+    layout: "default",
+    supports_dynamic_inputs: false,
+    supports_dynamic_outputs: false,
+    is_streaming_output: false,
+    recommended_models: [],
+    required_settings: []
+  }) as NodeMetadata;
+
+const workflow: Workflow = {
+  id: "wf-1",
+  name: "Chain workflow",
+  access: "private",
+  created_at: "",
+  updated_at: "",
+  description: "",
+  tags: [],
+  graph: {
+    nodes: [
+      {
+        id: "a",
+        type: "test.A",
+        data: { value: "hello" },
+        ui_properties: { position: { x: 120, y: 40 } }
+      },
+      {
+        id: "b",
+        type: "test.B",
+        data: {},
+        ui_properties: { position: { x: 420, y: 40 } }
+      }
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "a",
+        sourceHandle: "output",
+        target: "b",
+        targetHandle: "value"
+      }
+    ]
+  }
+} as unknown as Workflow;
+
+describe("WorkflowChainSurface", () => {
+  beforeEach(() => {
+    saveWorkflow.mockClear();
+    updateWorkflow.mockClear();
+    useMetadataStore.getState().setMetadata({
+      "test.A": makeMetadata("test.A"),
+      "test.B": makeMetadata("test.B")
+    });
+    useChainEditorStore.getState().newWorkflow();
+  });
+
+  it("loads the tab's workflow into the chain store", async () => {
+    const nodeStore = createNodeStore(workflow);
+
+    render(
+      <WorkflowChainSurface workflowId="wf-1" nodeStore={nodeStore} />
+    );
+
+    expect(screen.getByTestId("chain-editor")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(useChainEditorStore.getState().workflowId).toBe("wf-1");
+    });
+    expect(useChainEditorStore.getState().chain.map((n) => n.id)).toEqual([
+      "a",
+      "b"
+    ]);
+  });
+
+  it("mirrors chain edits back into the node store, keeping positions", async () => {
+    const nodeStore = createNodeStore(workflow);
+
+    render(
+      <WorkflowChainSurface workflowId="wf-1" nodeStore={nodeStore} />
+    );
+
+    await waitFor(() => {
+      expect(useChainEditorStore.getState().chain).toHaveLength(2);
+    });
+
+    useChainEditorStore.getState().updateProperty("a", "value", "edited");
+
+    await waitFor(() => {
+      const node = nodeStore.getState().nodes.find((n) => n.id === "a");
+      expect(node?.data.properties.value).toBe("edited");
+    });
+    const nodeA = nodeStore.getState().nodes.find((n) => n.id === "a");
+    expect(nodeA?.position).toEqual({ x: 120, y: 40 });
+    expect(nodeStore.getState().edges).toHaveLength(1);
+  });
+
+  it("keeps nodes the chain view cannot represent", async () => {
+    const withComment = {
+      ...workflow,
+      graph: {
+        ...workflow.graph,
+        nodes: [
+          ...workflow.graph.nodes,
+          {
+            id: "c",
+            type: "nodetool.workflows.base_node.Comment",
+            data: {},
+            ui_properties: { position: { x: 0, y: 300 } }
+          }
+        ]
+      }
+    } as unknown as Workflow;
+    const nodeStore = createNodeStore(withComment);
+
+    render(<WorkflowChainSurface workflowId="wf-1" nodeStore={nodeStore} />);
+
+    await waitFor(() => {
+      expect(useChainEditorStore.getState().chain).toHaveLength(2);
+    });
+
+    useChainEditorStore.getState().updateProperty("a", "value", "edited");
+
+    await waitFor(() => {
+      const node = nodeStore.getState().nodes.find((n) => n.id === "a");
+      expect(node?.data.properties.value).toBe("edited");
+    });
+    expect(nodeStore.getState().nodes.map((n) => n.id).sort()).toEqual([
+      "a",
+      "b",
+      "c"
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

On web, switching to Chain View from the floating toolbar's editor menu did nothing — the workflow tab kept showing the ReactFlow canvas in both toggle states.

`handleToggleViewMode` in `FloatingToolBar.tsx` flips `settings.editorViewMode`, but the only other readers of that setting were the toolbar itself (hiding a couple of buttons). `WorkflowEditorSurface` always rendered `NodeEditor`, so the chain editor was reachable only through the standalone `/chain/:workflowId` route.

## Changes

- `WorkflowEditorSurface` reads `editorViewMode` and renders the new chain surface for the **active** tab when the mode is `chain`. The node editor stays mounted but hidden, so toggling back keeps its viewport and transient editor state.
- New `WorkflowChainSurface`: loads the tab's workflow from its `NodeStore` into the chain store (waiting for node metadata, which the chain store needs), and mirrors every chain edit back into the `NodeStore` via a store subscription — so running, saving, and switching back to the graph all see the edits.
  - Positions/sizes of nodes that already exist are preserved, so a round-trip doesn't flatten a hand-made layout.
  - Nodes the chain view can't represent (comments, groups, anything without metadata) and the edges touching them pass through untouched instead of being deleted on write-back.
  - Save applies the chain to the node store, propagates a renamed workflow through `updateWorkflow`, then saves; failures surface as an error notification.

Only the active tab mounts the chain surface, since the chain store is a singleton.

## Testing

- `web/src/components/workspace/__tests__/WorkflowChainSurface.test.tsx` (new): loading a tab's workflow into the chain store, mirroring an edit back while keeping node positions, and preserving a comment node across the round-trip.
- `npx jest src/components/workspace src/components/chain_editor` — 8 suites, 66 tests pass.
- `eslint` clean on the touched files; `tsc --noEmit` reports no errors in them (the sandbox's remaining errors are pre-existing, from unbuilt `packages/*` dist).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBwGRqR1joUAk1wFo9kVaj)_