### PR TITLE
docs: rewrite the Mini App pages in plain language

### DIFF
--- a/docs/app-builder.md
+++ b/docs/app-builder.md
@@ -1,98 +1,93 @@
 ---
 layout: page
 title: "App Builder"
-description: "Design the interface of a Mini App: place widgets, bind them to workflow inputs and outputs, publish."
+description: "Design the screen of a Mini App: place widgets, wire them to workflow inputs and outputs, publish."
 ---
 
-App Builder is the **Design** view of an app tab. You place widgets on a canvas,
-bind them to the inputs and outputs of the workflows the app runs, and save the
-result onto the application.
+App Builder is the **Design** view of an app tab. You drag widgets onto a canvas,
+wire them to the inputs and outputs of the workflows the app runs, and save.
 
-This page covers the editor. For what Mini Apps solve and how the runtime works,
-see [Mini Apps](mini-apps.md); for step-by-step recipes, see
-[Building Mini Apps](mini-apps-guide.md); for the widget, binding, and schema
-tables, see the [Reference](mini-apps-reference.md).
+This page covers the editor itself. For what Mini Apps are and how they run, see
+[Mini Apps](mini-apps.md); for step-by-step recipes, see
+[Building Mini Apps](mini-apps-guide.md); for every widget and setting, see the
+[Reference](mini-apps-reference.md).
 
 ## What it does
 
-- Edits the app's document: layout blocks, input widgets, actions, and display
-  widgets.
-- Binds widgets to the Input and Output nodes of each operation's workflow.
-- Runs an operation from a button or a change event.
-- Streams outputs into bound display widgets.
-- Publishes a version that pins the graph of every bound workflow.
+- Lays out the app screen: boxes, fields, buttons, and result displays.
+- Wires widgets to the Input and Output nodes of the workflows the app runs.
+- Runs a workflow from a button, or when a field changes.
+- Shows results as they stream in.
+- Publishes a version that locks in the current state of every workflow it runs.
 
-## Where this fits
+## Where it fits
 
-A Mini App is how work reaches people who should not have to read a node graph.
-App Builder wraps one or more workflows in a form: input widgets bind to Input
-nodes, buttons run operations, and display widgets stream Output nodes back. It
-is the share end of NodeTool's loop, exposing the same **assets** a workflow
-produces on the canvas as a usable app.
+A Mini App is how your work reaches people who shouldn't have to read a node
+graph. App Builder wraps one or more workflows in a screen: fields feed the
+workflow's inputs, buttons start runs, and result widgets show what comes back.
 
-See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together)
-for the full loop.
+See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together).
 
-## Open App Builder
+## Open it
 
 1. Open the **Apps** panel in the left sidebar.
 2. Click an app, or create one with **New app** or **New app from workflow**.
 3. On the app tab, switch to **Design**.
 
-**Run** shows the app as its users see it. **Settings** holds the name,
-description, versions, and budget.
+**Run** shows the app the way its users see it. **Settings** holds the name,
+description, versions, and spending limit.
 
 ## Build an app
 
-1. Make sure each bound workflow has the Input and Output nodes the app needs.
-   Open one from the **Linked workflows** menu to edit it; it opens as its own
-   workflow tab.
-2. Add input widgets such as Text Input, Number Input, Slider, Switch, or Select.
-3. Bind each input widget to the matching Input node.
-4. Add a Button with the **Run workflow** action, targeting the operation to run.
-5. Add display widgets such as Text, Markdown, Image, JSON, or Progress.
-6. Bind each display widget to the matching Output node.
+1. Check that each workflow has the Input and Output nodes the app needs. Open
+   one from the **Linked workflows** menu; it opens as its own workflow tab.
+2. Add fields — Text Input, Number Input, Slider, Switch, Select.
+3. Wire each field to the matching Input node.
+4. Add a Button with the **Run workflow** action, pointing at the workflow to
+   run.
+5. Add result widgets — Text, Markdown, Image, JSON, Progress.
+6. Wire each result widget to the matching Output node.
 7. Click **Save**.
 
-## Agent-assisted editing
+## Letting the agent do it
 
-Click **Ask Agent** to open the builder agent. It can read the app's workflows,
-add widgets, set bindings, declare operations and variables, and edit a graph
-when the app needs new Input, Output, or Variable nodes.
+Click **Ask Agent**. It can read the app's workflows, add widgets, wire them up,
+declare operations and variables, and even edit a graph when the app needs new
+Input, Output, or Variable nodes.
 
-Good prompts name the result you want:
+Good prompts describe the result you want:
 
 > Build a compact app with all inputs on the left, a run button below them, and
 > outputs on the right.
 
-## Bindings
+## Wiring
 
-The binding picker lists what each operation's live graph offers. Bindings key
-on node ids, so renaming a node does not break the app.
+The picker lists what each workflow actually offers. Wiring points at node ids,
+so renaming a node doesn't break the app.
 
-| Widget kind | Binds to |
+| Widget kind | Wires to |
 | --- | --- |
-| Input widgets | An operation input (`op:<opId>/in:<nodeId>`) or a node property |
-| Display widgets | An operation output (`op:<opId>/out:<nodeId>`) or a variable |
-| State controls | A declared variable (`var:<variableId>`) |
+| Fields the user edits | A workflow input (`op:<opId>/in:<nodeId>`) or a node setting |
+| Result displays | A workflow output (`op:<opId>/out:<nodeId>`) or a variable |
+| Toggles and selects | A variable (`var:<variableId>`) |
 
-A binding that resolves to nothing is reported as a validation error, in the
-editor and in `nodetool app debug`. The full grammar is in the
-[Reference](mini-apps-reference.md#binding-grammar).
+Wiring that points at nothing is reported as an error, both in the editor and in
+`nodetool app debug`. The full list is in the
+[Reference](mini-apps-reference.md#bindings).
 
-## Multiple workflows in one app
+## Several workflows in one app
 
-An app's operations are edited under **Operations**. Add one per workflow the
-app should run, each with its own input and output mappings, concurrency policy,
-and timeout. Buttons target an operation by id, so a two-step app is two
-operations and two buttons rather than two apps.
+Each workflow the app runs is an **operation**, edited under **Operations**. Give
+each one its own input and output wiring, its own rule for overlapping runs, and
+an optional time limit. Buttons point at an operation by name, so a two-step app
+is two operations and two buttons — not two apps.
 
 ## Publish and share
 
-**Publish** in Settings snapshots the document and pins the graph of every bound
-workflow, so the released app keeps running those graphs while you keep editing
-the draft. **Export bundle** writes the app and its workflows as one
-`ApplicationBundle` JSON file, which imports elsewhere as a working app.
+**Publish** in Settings takes a snapshot: it saves the screen and locks in the
+current state of every workflow the app runs, so the published app keeps working
+while you keep editing the drafts. **Export bundle** writes the app and its
+workflows to one JSON file, which imports elsewhere as a working app.
 
 ## Related topics
 
@@ -101,4 +96,3 @@ the draft. **Export bundle** writes the app and its workflows as one
 - [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
 - [Workflow Editor](workflow-editor.md)
 - [Chat & Agents](global-chat-agents.md)
-- [Key Concepts](key-concepts.md)

--- a/docs/mini-apps-guide.md
+++ b/docs/mini-apps-guide.md
@@ -1,270 +1,269 @@
 ---
 layout: page
 title: "Building Mini Apps"
-description: "Recipes for building Mini Apps: one-shot generators, streaming apps, batch galleries, live parameter tuning, two-step review flows, and resource editors."
+description: "Nine kinds of Mini App, each built step by step: one-shot generators, streaming text, galleries, sliders that re-run, two-step approvals, and more."
 ---
 
-Nine app shapes, each built step by step. They share a base recipe; the
-differences are which widgets you place and what they bind to.
+Nine kinds of app, each built step by step. They all start from the same short
+recipe; what differs is which widgets you place and what you wire them to.
 
-New to Mini Apps? Read [Mini Apps](mini-apps.md) first for how apps, bindings,
-operations, and instance state fit together. The widget list, binding grammar,
-and full schema are in the [Reference](mini-apps-reference.md).
+New here? Read [Mini Apps](mini-apps.md) first — it explains what a widget, a
+binding, and an operation are in a page. Every widget and setting is listed in
+the [Reference](mini-apps-reference.md).
 
-## Before you start
+## Fix the workflow first
 
-The workflows decide what the app can expose. Get this right first and the app
-is twenty minutes of layout:
+The workflow decides what the app can show and change. Sort this out first and
+the app itself is twenty minutes of layout.
 
-1. **Every value the user changes needs an Input node.** Its `name` is what the
-   widget binds to. A value with no Input node cannot be edited from the app,
-   except through the node-property binding used in [recipe 5](#5-live-parameter-tuning).
-2. **Every value the user sees needs an Output node.** A workflow that ends in a
-   terminal node with no Output attached produces nothing an app can display.
-3. **Give inputs sensible defaults.** An app whose first Run needs the user to
-   type into four empty fields gets abandoned. Defaults make the first run one
+1. **Anything the user should change needs an Input node.** That's what the
+   widget wires to. A value with no Input node can't be edited from the app —
+   except through the node-setting trick in [recipe 5](#5-a-slider-that-re-runs).
+2. **Anything the user should see needs an Output node.** A workflow that just
+   ends, with no Output node attached, produces nothing an app can display.
+3. **Give every input a sensible default.** An app whose first Run needs four
+   empty fields filled in gets abandoned. With defaults, the first run is one
    click.
-4. **Run each workflow once in its own tab.** Debug the graph as a graph. An app
+4. **Run the workflow once on its own first.** Debug a graph as a graph. An app
    over a broken workflow only tells you the app is broken.
 
-## The base recipe
+## The starting recipe
 
-Every app below starts here.
+Every app below begins here.
 
 1. Open the **Apps** panel in the left sidebar.
-2. Click **New app** for an empty document, or **New app from workflow** to
-   scaffold one operation and a widget per Input and Output node. Either way the
-   app opens as its own workspace tab.
-3. Switch the tab to **Design** to open App Builder.
+2. Click **New app** for an empty screen, or **New app from workflow** to get a
+   starting layout with one widget per Input and Output node. Either way the app
+   opens as its own workspace tab.
+3. Switch the tab to **Design**. That's App Builder.
 4. Drag widgets from the palette onto the canvas.
-5. Select a widget and set its **binding** in the right-hand panel. The picker
-   lists what the operation's live graph offers: Input nodes for write widgets,
-   Output nodes and variables for read widgets.
-6. Add a **Button**, and give it an **On click** event with the **Run workflow**
+5. Select a widget and pick what it's wired to in the right-hand panel. The menu
+   lists what the workflow actually offers: Input nodes for widgets the user
+   types into, Output nodes and variables for widgets that show results.
+6. Add a **Button** and give it an **On click** event with the **Run workflow**
    action.
 7. Click **Save**.
-8. Switch the tab to **Run** and use it. Then run
+8. Switch the tab to **Run** and try it. Then run
    `nodetool app debug <application_id>` to check the wiring the way the runtime
    sees it.
 
-To edit a graph while you build, open **Linked workflows** on the app tab and
-click the workflow. It opens as a normal workflow tab; the app tab stays where
-it is.
+To edit the graph while you build, open **Linked workflows** on the app tab and
+click the workflow. It opens as a normal workflow tab; the app tab stays put.
 
-**Ask Agent** in App Builder opens the builder agent, which reads the app's
-workflows and edits the document through the `ui_app_*` tools. It can place
-widgets, set bindings, declare variables and operations, and add the Input,
-Output, or Set Variable nodes a layout needs. It is the fastest way to do the
-parts the visual editor does not expose: multiple operations, typed variables
-with scopes, and resource bindings.
+**Ask Agent** in App Builder opens an assistant that can read the app's workflows
+and edit the app for you: place widgets, wire them up, declare variables and
+operations, and add the Input, Output, or Set Variable nodes a layout needs. It's
+the quickest route to the parts the visual editor doesn't expose — several
+operations, typed variables, and resources.
 
 ---
 
-## 1. One-shot generator
+## 1. Fill a form, get a result
 
-**Shape:** fill a few fields, click Run, see one result.
-**Fits:** image generation, copy rewriting, summarization, translation,
-classification.
+**Shape:** fill a few fields, click a button, see one result.
+**Good for:** image generation, rewriting copy, summarizing, translating,
+classifying.
 
-This is the default app and the one most workflows should get.
+This is the default app, and what most workflows should get.
 
-1. Place a **Text Input** for each Input node the user should fill. Bind each to
-   its Input node. Set a label and a placeholder that says what good input looks
-   like.
-2. Place a **Button** labelled for the result, not the mechanism: "Write the
+1. Place a **Text Input** for each Input node the user should fill, and wire each
+   one to its Input node. Give it a label and a placeholder that shows what good
+   input looks like.
+2. Place a **Button** named after the result, not the machinery: "Write the
    caption" beats "Run".
-3. Place one display widget per Output node, bound to it:
-   **Markdown** for prose, **Image**, **Audio**, **Video**, **Json** for
-   structured data, **Table** for rows, **Output** when the type varies.
-4. Give the display widget a **placeholder** ("Your caption appears here") so
-   the app reads as intentional before the first run.
+3. Place one display widget per Output node, wired to it: **Markdown** for prose,
+   **Image**, **Audio**, **Video**, **Json** for structured data, **Table** for
+   rows, **Output** when the type varies.
+4. Give each display widget a **placeholder** ("Your caption appears here") so
+   the app looks finished before the first run.
 
-Two layout habits that pay off: put inputs and the button in one **Panel** and
-outputs in another, and use **Columns** so inputs sit left and results right on
-a wide screen.
+Two layout habits worth having: put the fields and the button in one **Panel**
+and the results in another, and use **Columns** so fields sit left and results
+right on a wide screen.
 
-## 2. Long-running and agent apps
+## 2. Runs that take a while
 
-**Shape:** a run that takes 30 seconds to several minutes.
-**Fits:** agent workflows, batch processing, video generation, research tasks.
+**Shape:** a run lasting 30 seconds to several minutes.
+**Good for:** agents, batch jobs, video generation, research tasks.
 
-Build recipe 1, then add feedback. Without it the app looks frozen and the user
-clicks Run again.
+Build recipe 1, then add signs of life. Without them the app looks frozen and the
+user clicks Run again.
 
-1. Place a **Progress** widget bound to `op:main/exec#progress`.
-2. Place a **Text** widget bound to `op:main/exec#activity`. This is the label
-   the run reports about itself: the tool an agent is calling, the planning
-   phase, the step it is on.
+1. Place a **Progress** widget wired to `op:main/exec#progress`.
+2. Place a **Text** widget wired to `op:main/exec#activity` — the line the run
+   writes about itself: the tool an agent is calling, the planning stage, the
+   step it's on.
 3. Set the Run button's `disabledWhen` to `op:main/exec#running` `is not empty`,
-   so it cannot be double-fired.
-4. Place a second **Button** with the **Cancel run** action and
-   `visibleWhen` = `op:main/exec#running` `is not empty`.
-5. Place a **Text** widget bound to `op:main/exec#error`, with
-   `visibleWhen` on the same binding `is not empty`.
+   so it can't be clicked twice.
+4. Place a second **Button** with the **Cancel run** action, and set its
+   `visibleWhen` to `op:main/exec#running` `is not empty`.
+5. Place a **Text** widget wired to `op:main/exec#error`, shown only when that
+   `is not empty`.
 
-An agent app without an `activity` binding is the single most common complaint
-about Mini Apps. Bind it.
+An agent app with no `activity` on screen is the single most common complaint
+about Mini Apps. Add it.
 
-## 3. Streaming text
+## 3. Text that types itself out
 
-**Shape:** text that appears token by token.
-**Fits:** chat-style answers, long-form drafting, live transcripts.
+**Shape:** the answer appears a few words at a time.
+**Good for:** chat-style answers, long drafts, live transcripts.
 
-1. Build recipe 1 with a **Markdown** widget bound to the streaming Output node.
-2. Nothing else is required. Streamed strings concatenate into the output slot,
-   so one streamed response renders as one Markdown block rather than N
-   fragments.
-3. If the same text also feeds a later step, map the output `to: "variable"` on
-   the operation. It accumulates in the variable the same way, and a new run
-   starts a fresh value instead of appending to the last one's.
+1. Build recipe 1 with a **Markdown** widget wired to the Output node that
+   streams.
+2. That's it. The pieces are collected as they arrive, so one streamed answer
+   renders as one block of Markdown instead of a flicker of fragments.
+3. If that same text feeds a later step, wire the output to a variable as well
+   (`to: "variable"` on the operation). It builds up there the same way, and the
+   next run starts a fresh value rather than continuing the last one.
 
-## 4. Batch gallery
+## 4. A gallery of results
 
-**Shape:** one run produces many results; the user keeps generating.
-**Fits:** image variations, ad creative, thumbnail sets, name candidates.
+**Shape:** one run makes several results, and the user keeps generating.
+**Good for:** image variations, ad creative, thumbnail sets, name candidates.
 
-1. Point the display widget at an Output node the workflow emits repeatedly.
-   Streamed items collect into a list rather than replacing each other.
+1. Point the display widget at an Output node the workflow emits more than once.
+   The items collect into a list instead of replacing each other.
 2. Use **Table** for structured rows, or an **Image** widget for a stream of
    images.
-3. Add a second **Button** labelled "Make another" with the **Run workflow**
-   action, placed under the results. The user never scrolls back up to the form.
-4. If a fresh set should replace the previous one, give the operation the
-   `replace` policy so a second click cancels the run in flight first.
+3. Add a second **Button** labelled "Make another", with the **Run workflow**
+   action, placed *below* the results. Now nobody scrolls back up to the form.
+4. If a new set should replace the old one, give the operation the `replace`
+   rule, so a second click cancels the run in flight first.
 
-The shipped example apps use exactly this pattern. Install one from the
-[Templates Gallery](templates-gallery.md) and open it in Design to see it wired.
+The example apps NodeTool ships use this pattern. Install one from the
+[Templates Gallery](templates-gallery.md) and open it in Design to see how it's
+wired.
 
-## 5. Live parameter tuning
+## 5. A slider that re-runs
 
 **Shape:** drag a slider, the workflow re-runs, the result updates.
-**Fits:** image enhancement, color grading, thresholds, strength and guidance
-parameters.
+**Good for:** image enhancement, color grading, thresholds, strength and guidance
+settings.
 
-This is the one recipe that does not need an Input node. A widget can drive a
-node property directly.
+This is the one recipe that doesn't need an Input node — a widget can drive a
+node's setting directly.
 
-1. Place a **Slider**. Bind it to the node property rather than an input:
-   `op:main/prop:<nodeId>#<property>`. The binding picker lists any node with
-   properties, not only Input nodes.
-2. Set min, max, and step to the property's real range.
+1. Place a **Slider** and wire it to the node setting rather than to an input:
+   `op:main/prop:<nodeId>#<property>`. The picker lists any node with settings,
+   not just Input nodes.
+2. Set min, max, and step to the setting's real range.
 3. Add an **On change** event with the **Run workflow** action.
-4. Set the event's **Pacing** to **On release**. The slider commits once when
-   the user lets go, instead of firing a run per pixel. Use **Debounced** for a
-   text field, and **Live** only for something cheap.
-5. Give the operation the `replace` policy: a new value should cancel the run
-   for the old one, not queue behind it.
+4. Set the event's **Pacing** to **On release**, so the slider fires once when
+   the user lets go instead of once per pixel. Use **Debounced** for a text
+   field, and **Live** only for something cheap.
+5. Give the operation the `replace` rule: a new value should cancel the run for
+   the old one, not line up behind it.
 
-Pacing and policy work together. `live` pacing with a `queue` policy on a
-five-second workflow will build a backlog the user cannot escape.
+Pacing and the run rule work together. Live pacing plus a `queue` rule on a
+five-second workflow builds a backlog the user can't escape.
 
-## 6. Two-step review
+## 6. Approve, then continue
 
 **Shape:** run a step, look at the result, then run the next one.
-**Fits:** draft then publish, extract then post, analyze then act, generate then
-upscale.
+**Good for:** draft then publish, extract then post, analyze then act, generate
+then upscale.
 
 This needs two operations and a variable, so build it with **Ask Agent** or by
-editing the document.
+editing the document directly.
 
-1. Declare a variable — say `draft`.
-2. Declare operation `draft` bound to the drafting workflow, with its text
-   output mapped `to: "variable"` targeting `draft`.
-3. Declare operation `publish` bound to the publishing workflow, with its input
-   mapped `from: "variable"` reading `draft`.
-4. Place a **Markdown** widget bound to `var:draft` so the user reads what will
-   be published.
-5. Place a Run button targeting the `draft` operation, and a second one
-   targeting `publish` with `visibleWhen` = `var:draft` `is not empty`.
+1. Declare a variable — call it `draft`.
+2. Declare an operation `draft` running the drafting workflow, with its text
+   output wired into that variable (`to: "variable"`).
+3. Declare an operation `publish` running the publishing workflow, with its input
+   reading that variable (`from: "variable"`).
+4. Place a **Markdown** widget wired to `var:draft`, so the user reads what's
+   about to be published.
+5. Place a Run button for the `draft` operation, and a second one for `publish`
+   whose `visibleWhen` is `var:draft` `is not empty`.
 
-The second button cannot fire until the first produced something. That is the
-whole approval gate, and no app-level logic was written to get it.
+The second button can't appear until the first produced something. That's the
+whole approval gate, with no app-level logic written to get it.
 
 ## 7. Settings that stick
 
-**Shape:** a tool used daily that should remember how it is configured.
-**Fits:** tone and brand voice, target language, output format, default model.
+**Shape:** a tool used every day that should remember how it's set up.
+**Good for:** tone of voice, target language, output format, default model.
 
-1. Declare a variable with `scope: "user"` and `persist: true`. Only
-   user-scoped variables may persist; an `instance`-scoped one marked `persist`
-   is reported as a warning rather than silently persisted.
-2. Give it a `default`, which seeds the first session. A restored value is
-   seeded first and wins over the default.
-3. Bind a **Select** or **Switch** to `var:<id>` with an **On change** event
+1. Declare a variable with `scope: "user"` and `persist: true`. Only user-scoped
+   variables can be remembered; marking an instance-scoped one as persistent
+   raises a warning instead of quietly working.
+2. Give it a default, which seeds the first session. A remembered value is
+   loaded first and beats the default.
+3. Wire a **Select** or **Switch** to `var:<id>`, with an **On change** event
    using the **Set variable** action.
-4. Map the operation input that consumes it `from: "variable"`.
+4. Have the operation input that uses it read `from: "variable"`.
 
-The setting now survives reload and is not part of the form the user fills each
-run.
+The setting now survives a reload and drops out of the form the user fills in
+each run.
 
-## 8. Conditional and multi-mode apps
+## 8. One app, several modes
 
-**Shape:** one app, several modes, each showing only what its mode needs.
-**Fits:** a tool that handles both image and text input, a form with an advanced
+**Shape:** one app with modes, each showing only what its mode needs.
+**Good for:** a tool that takes either an image or text, a form with an advanced
 section, an app that switches between two workflows.
 
-1. Place a **Select** bound to a variable — say `mode` — with options `image`
-   and `text`, and an **On change** event with the **Set variable** action.
-2. Give each mode-specific widget a `visibleWhen` of `var:mode` `equals`
-   `image` (or `text`).
-3. For an advanced section, wrap the widgets in a **Panel** and put
-   `visibleWhen` on the panel — one condition instead of nine.
+1. Place a **Select** wired to a variable — call it `mode` — with options `image`
+   and `text`, and an **On change** event using the **Set variable** action.
+2. Give each mode-specific widget a `visibleWhen` of `var:mode` `equals` `image`
+   (or `text`).
+3. For an advanced section, wrap the widgets in a **Panel** and put the condition
+   on the panel — one condition instead of nine.
 4. To switch workflows rather than fields, declare two operations and give each
-   Run button its own `operationId` and `visibleWhen`.
+   Run button its own operation and its own condition.
 
-Conditions compare one bound value against a literal. Anything more involved —
+A condition compares one value against one fixed value. Anything more involved —
 "show this when the score is high *and* the language is German" — belongs in the
-graph: emit a single flag from a node and condition on that.
+graph: emit one flag from a node and condition on that.
 
-## 9. Resource-backed apps
+## 9. Apps that edit a document
 
-**Shape:** the app reads and writes a document rather than loose values.
-**Fits:** storyboard editing, sketch iteration, curated asset collections.
+**Shape:** the app reads and writes a real document rather than loose values.
+**Good for:** storyboard editing, sketch iteration, curated asset collections.
 
-1. Declare a **resource binding**: a kind (`asset`, `timeline`, `storyboard`, or
-   `sketch`), a scope (a project, or one pinned document), and the operations
-   the app may perform (`read`, `create`, `update`, `delete`).
-2. Place a **Resource Picker** to choose one, or a **Resource Gallery** to show
-   a grid of them.
-3. Map the operation input that consumes it `from: "resource"`, naming the
-   resource binding.
-4. **Storyboard Scenes** edits the bound document through the resource provider
-   directly, so it fires no event of its own.
+1. Declare a **resource**: its kind (`asset`, `timeline`, `storyboard`, or
+   `sketch`), what it may point at (a project, or one fixed document), and what
+   the app may do with it (`read`, `create`, `update`, `delete`).
+2. Place a **Resource Picker** to choose one, or a **Resource Gallery** to show a
+   grid of them.
+3. Have the operation input that uses it read `from: "resource"`, naming that
+   resource.
+4. **Storyboard Scenes** edits the document directly, so it fires no event of its
+   own.
 
-`nodetool app debug` cannot simulate `from: "resource"` inputs — there is no
-resource provider outside the browser. Test these in the app.
+`nodetool app debug` can't simulate resource inputs — resources only exist in the
+browser. Test these in the app.
 
 ---
 
-## Checklist before you ship
+## Before you share it
 
-- [ ] Every input widget's binding resolves. `nodetool app debug --no-run`
-      reports the ones that do not.
-- [ ] Every display widget receives a value from a completed run.
-- [ ] The app has at least one run trigger.
+- [ ] Every input widget is wired to something real.
+      `nodetool app debug --no-run` names the ones that aren't.
+- [ ] Every display widget actually receives a value from a finished run.
+- [ ] The app has at least one way to start a run.
 - [ ] Runs longer than a few seconds show progress, activity, or both.
 - [ ] The Run button is disabled while a run is in flight.
-- [ ] Errors are visible — a bound `exec#error` widget, not a silent no-op.
-- [ ] Inputs have defaults, so the first Run is one click.
-- [ ] Display widgets have placeholders, so the empty app reads as finished.
-- [ ] Labels name results, not mechanisms.
+- [ ] Errors are visible on screen, not swallowed.
+- [ ] Inputs have defaults, so the first run is one click.
+- [ ] Display widgets have placeholders, so the empty app looks finished.
+- [ ] Buttons are named after results, not mechanisms.
 
-## Common mistakes
+## When something's wrong
 
-| Symptom | Cause |
+| What you see | What's usually causing it |
 | --- | --- |
-| A widget shows nothing after a run | It is bound to a node the run never emits, or to an Output node the graph does not have. |
-| A widget silently does nothing | Its binding does not resolve. Run `app debug --no-run`. |
-| Values from another run appear | Not possible by design: messages are matched by `job_id` and foreign ones are dropped. If values look wrong, the binding points at the wrong node. |
-| The slider fires dozens of runs | Pacing is `live`. Use `release`. |
-| Runs pile up behind each other | The operation policy is `queue`. Use `replace`. |
-| A persisted setting resets | The variable is `instance`-scoped. Only `user` scope persists. |
-| The app broke after a graph edit | A legacy name-based binding pointed at a renamed node. Re-bind; the editor writes ID-based bindings, which survive renames. |
+| A widget stays empty after a run | It's wired to a node the run never emits, or to an Output node the graph doesn't have. |
+| A widget does nothing at all | Its wiring points at nothing. Run `app debug --no-run`. |
+| Values from another run show up | Can't happen by design — messages are matched by job id and foreign ones are dropped. If the values look wrong, the widget is wired to the wrong node. |
+| The slider fires dozens of runs | Pacing is set to live. Use on-release. |
+| Runs pile up behind each other | The operation's rule is `queue`. Use `replace`. |
+| A remembered setting resets | The variable is instance-scoped. Only user-scoped ones are remembered. |
+| The app broke after a graph edit | An old name-based wiring pointed at a renamed node. Re-select it; the editor writes id-based wiring, which survives renames. |
 
 ## Related
 
-- [Mini Apps](mini-apps.md) — how the runtime works
+- [Mini Apps](mini-apps.md) — the concepts and how the runtime works
 - [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
 - [App Builder](app-builder.md) — the editor
-- [Templates Gallery](templates-gallery.md) — shipped example apps and workflows
+- [Templates Gallery](templates-gallery.md) — example apps and workflows
 - [Workflow Debugging](workflow-debugging.md) — debugging the graph underneath

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -1,161 +1,171 @@
 ---
 layout: page
 title: "Mini App Reference"
-description: "Widget catalog, binding grammar, actions, conditions, format filters, and the app document schema."
+description: "Every widget, binding, action, condition, and format filter, plus the app document schema."
 ---
 
-The complete surface of the Mini App layer. For what these mean, see
-[Mini Apps](mini-apps.md); for how to combine them, see
+Every part of a Mini App, in tables. For what these things are, read
+[Mini Apps](mini-apps.md); for how to put them together, read
 [Building Mini Apps](mini-apps-guide.md).
 
-Everything here is defined in `packages/app-runtime`, which the web runtime, the
-`nodetool app debug` harness, and the eval suites all share.
+All of it is defined in `packages/app-runtime`, shared by the browser, the
+`nodetool app debug` harness, and the test suites — so all three behave the same.
 
 ## Widgets
 
-Every widget accepts `binding`, `visibleWhen`, `disabledWhen`, and `format` on
-top of its own fields.
+A widget is one thing on the app screen. Every widget can be wired to a value
+(`binding`), shown only under a condition (`visibleWhen`), greyed out under a
+condition (`disabledWhen`), and reformatted before display (`format`), on top of
+its own settings.
 
-### Display
+### Widgets that show something
 
 | Widget | Shows |
 | --- | --- |
-| Heading | Static text at H1–H3. |
-| Text | Static or formatted text. |
+| Heading | Fixed text at H1–H3. |
+| Text | Fixed or formatted text. |
 | Markdown | Rendered Markdown. The right choice for streamed prose. |
-| Image | An image value. Fit `contain` or `cover`, fixed height, placeholder. |
-| Audio | An audio value with a player. |
-| Video | A video value with a player, max height, placeholder. |
-| JSON | A structured value, formatted. |
-| Table | An array value as rows. Max height, placeholder. |
-| Output | A value whose type varies; renders by shape. |
-| Progress | The bound operation's progress. |
+| Image | An image. Fit `contain` or `cover`, fixed height, placeholder. |
+| Audio | An audio file, with a player. |
+| Video | A video, with a player, max height, placeholder. |
+| JSON | Structured data, formatted. |
+| Table | A list, as rows. Max height, placeholder. |
+| Output | A value whose type varies; picks a display based on what arrives. |
+| Progress | How far along the run is. |
 
-### Inputs
+### Widgets the user changes
 
-| Widget | Writes | Commits |
+"Commits" means the control reports a final value when you let go or click away.
+That's what makes on-release pacing possible — see
+[Triggers and pacing](#triggers-and-pacing).
+
+| Widget | Takes | Commits |
 | --- | --- | --- |
-| Workflow Input | The bound Input node, rendered from its declared type. | no |
+| Workflow Input | Whatever the bound Input node declares, rendered to match. | no |
 | Text Input | Text. Single-line or multiline. | yes |
 | Number Input | A number. Min, max, step. | yes |
 | Slider | A number. Min, max, step. | yes |
-| Switch | A boolean. | no |
-| Select | One of a fixed option list. | no |
+| Switch | On or off. | no |
+| Select | One option from a fixed list. | no |
 | Image Input | An image. | no |
 | Audio Input | An audio file. | no |
-| Video Input | A video file. | no |
+| Video Input | A video. | no |
 | Document Input | A document. | no |
 | Color Input | A color. | no |
-| Resource Picker | The selected resource of a resource binding. | no |
-| Resource Gallery | The selected resource, from a grid. Tile size. | no |
-| Storyboard Scenes | Edits the bound storyboard through the resource provider. Fires no event. | no |
+| Resource Picker | Picks which document a resource points at. | no |
+| Resource Gallery | The same, from a grid of tiles. Tile size. | no |
+| Storyboard Scenes | Edits the bound storyboard directly. Fires no event. | no |
 
-"Commits" means the control reports a settled value on release or blur, which is
-what makes `release` pacing meaningful.
-
-### Actions and layout
+### Buttons and layout
 
 | Widget | Does |
 | --- | --- |
-| Button | Fires its click events. Variant `contained`/`outlined`/`text`, color `primary`/`secondary`/`warning`. |
-| Panel | A titled container holding other widgets. |
-| Columns | Two slots, `left` and `right`. |
-| Divider | A horizontal rule. |
+| Button | Runs its click action. Style `contained`/`outlined`/`text`, color `primary`/`secondary`/`warning`. |
+| Panel | A titled box holding other widgets. |
+| Columns | Two side-by-side slots, `left` and `right`. |
+| Divider | A horizontal line. |
 
-## Binding grammar
+## Bindings
 
-A binding is one string. Bindings key on node **IDs**, so renaming a node in the
-graph editor never breaks an app.
+A binding is the string that says what a widget is wired to. You usually pick
+these from a menu rather than typing them. They point at node **ids**, so
+renaming a node in the graph editor never breaks an app.
 
-| Token | Addresses |
+| Binding | Points at |
 | --- | --- |
-| `op:<opId>/in:<nodeId>` | An operation input. |
-| `op:<opId>/out:<nodeId>` | An operation output. |
-| `op:<opId>/prop:<nodeId>#<prop>` | A node property driven by a widget. |
-| `op:<opId>/exec#<field>` | Execution state: `running`, `progress`, `error`, `activity`. |
-| `var:<variableId>` | A declared app variable. |
-| `view:<componentId>#<prop>` | Widget-local state. Never persisted. |
-| `node:<nodeId>#<prop>` | Legacy node property, resolved against the default operation. |
-| `<name>` | Legacy bare name, resolved against the live graph. |
+| `op:<opId>/in:<nodeId>` | An input of one of the app's workflows. |
+| `op:<opId>/out:<nodeId>` | An output of one of the app's workflows. |
+| `op:<opId>/prop:<nodeId>#<prop>` | A setting on a node, driven by a widget. |
+| `op:<opId>/exec#<field>` | Run status: `running`, `progress`, `error`, `activity`. |
+| `var:<variableId>` | A value the app remembers. |
+| `view:<componentId>#<prop>` | State belonging to one widget. Never saved. |
+| `node:<nodeId>#<prop>` | Old form of a node setting, resolved against the default operation. |
+| `<name>` | Old form: a bare node name, looked up in the live graph. |
 
-A bare name resolves by how the widget uses it: a write widget looks for an
-Input node, a read widget looks for an Output node and then a variable, and a
-condition or `format` token tries outputs, then inputs, then variables. A name
-that matches nothing is a validation error, not a silent no-op.
+A bare name is looked up according to how the widget uses it: a widget the user
+types into looks for an Input node, a widget that displays looks for an Output
+node and then a variable, and a condition or `format` token tries outputs, then
+inputs, then variables. A name that matches nothing is an error, not a silent
+no-op.
 
 ## Actions
 
-A widget event dispatches one action. Actions are data the runtime interprets.
+A widget event runs one action. Actions are settings the runtime carries out —
+there's nowhere to write code.
 
-| Action | Fields | Effect |
+| Action | Settings | Effect |
 | --- | --- | --- |
-| `run` | `operationId` | Runs the operation, subject to its policy. |
-| `cancel` | `operationId`, optional `invocationId` | Cancels the operation's live runs, or one specific run. |
-| `setVariable` | `variableId`, `value` or the firing widget's value | Writes a variable. |
-| `toggleVariable` | `variableId` | Inverts a boolean variable. |
-| `resourceCommand` | `resourceBindingId`, `command` | `read`, `create`, `update`, `delete`, or `upload` on a resource binding. |
-| `openResource` | `resourceBindingId` | Opens the bound resource in its editor. |
+| `run` | `operationId` | Runs that workflow, following its concurrency rule. |
+| `cancel` | `operationId`, optional `invocationId` | Cancels that operation's runs, or one specific run. |
+| `setVariable` | `variableId`, and a `value` or the widget's own value | Writes a variable. |
+| `toggleVariable` | `variableId` | Flips an on/off variable. |
+| `resourceCommand` | `resourceBindingId`, `command` | `read`, `create`, `update`, `delete`, or `upload` on a resource. |
+| `openResource` | `resourceBindingId` | Opens that document in its editor. |
 
-The visual editor exposes **Run workflow**, **Cancel run**, **Set variable**,
-and **Toggle variable**. The resource actions are set through the agent or by
-editing the document.
+The visual editor offers **Run workflow**, **Cancel run**, **Set variable**, and
+**Toggle variable**. The resource actions are set through the agent or by editing
+the document.
 
 ### Triggers and pacing
 
-Events fire on `click` (Button) or `change` (input widgets). A change event has a
-pace:
+Events fire on `click` (buttons) or `change` (everything the user edits). A
+change event also has a pace, which decides how often it fires while the user is
+still editing:
 
 | Pace | Fires |
 | --- | --- |
 | `live` | On every change. |
-| `release` | When the control commits — slider release, input blur. Only offered on committing controls. |
-| `debounce` | Trailing, after a quiet moment. |
+| `release` | Once, when the control settles — the slider is let go, the field loses focus. Only offered on controls that commit. |
+| `debounce` | Once, after a short pause in editing. |
 
 ## Conditions
 
-`visibleWhen` and `disabledWhen` each hold a binding, an operator, and a
-literal. An unresolvable condition is treated as no condition, so a broken
-binding never silently hides a widget.
+`visibleWhen` and `disabledWhen` each hold a binding, an operator, and a value to
+compare against. A condition whose binding points at nothing is treated as no
+condition, so broken wiring never silently hides a widget.
 
 | Operator | Editor label | True when |
 | --- | --- | --- |
 | `notEmpty` | is not empty | The value is set, non-empty, and not `false`. |
 | `empty` | is empty | The value is unset, empty, or `false`. |
-| `eq` | equals | Equal, after coercing the literal to the value's type. |
+| `eq` | equals | Equal, after converting your value to the same type. |
 | `neq` | does not equal | Not equal. |
-| `gt` / `gte` | is greater than / is at least | Numeric comparison. A non-numeric value never satisfies one. |
-| `lt` / `lte` | is less than / is at most | Numeric comparison. |
-| `contains` | contains | A string contains the substring, or an array contains the item. |
+| `gt` / `gte` | is greater than / is at least | Numbers. A non-number never satisfies these. |
+| `lt` / `lte` | is less than / is at most | Numbers. |
+| `contains` | contains | Text contains the substring, or a list contains the item. |
 
-Literals are stored as strings and coerced to the shape of the value they are
-compared against, so `count gt "3"` compares numbers and `dark eq "true"`
-compares booleans.
+You always type the comparison value as text, and it's converted to match what
+it's compared against — so `count gt "3"` compares numbers and `dark eq "true"`
+compares on/off.
 
 ## Format templates
 
-`format` renders `{binding}` tokens in place of the raw value, with one optional
-filter: `{op:main/out:n1|truncate:80}`. An unknown filter or unresolvable
-binding renders as the empty string.
+`format` replaces `{binding}` tokens with the value, optionally passed through
+one filter: `{op:main/out:n1|truncate:80}`. An unknown filter or a binding that
+points at nothing renders as nothing.
 
 | Filter | Argument | Result |
 | --- | --- | --- |
-| `number` | digits | The value as a number, optionally fixed to N digits. |
-| `date` | `short` | Locale date-time, or locale date with `short`. |
-| `upper` | — | Uppercased. |
-| `lower` | — | Lowercased. |
-| `join` | separator | An array joined; defaults to `", "`. |
-| `truncate` | length | Cut to N characters with an ellipsis. |
+| `number` | digits | The value as a number, optionally to N decimal places. |
+| `date` | `short` | Local date and time, or just the date with `short`. |
+| `upper` | — | UPPERCASE. |
+| `lower` | — | lowercase. |
+| `join` | separator | A list joined into text; defaults to `", "`. |
+| `truncate` | length | Cut to N characters, with an ellipsis. |
 
 ## Document schema
 
-An application row holds one `ApplicationDocument` in its `document` column.
-Schema version 3 is current; version 1 and 2 documents are lifted to 3 on load,
-with one implicit `main` operation bound to the workflow they came from.
+The rest of this page is the saved shape of an app — useful when editing a
+document by hand or reading one the agent wrote.
+
+An app is stored as one `ApplicationDocument`. Version 3 is current; version 1
+and 2 documents are upgraded on load, gaining one implicit `main` operation bound
+to the workflow they came from.
 
 ```ts
 interface ApplicationDocument {
   schemaVersion: number;      // 3
-  ui: PuckData;               // { root, content, zones }
+  ui: PuckData;               // the layout: { root, content, zones }
   operations: OperationBinding[];
   resources: ResourceBinding[];
   variables: VariableDeclaration[];
@@ -165,12 +175,14 @@ interface ApplicationDocument {
 
 ### Operations
 
+One operation is one workflow the app can run, plus its wiring.
+
 ```ts
 interface OperationBinding {
   id: string;
   name: string;
   workflowId: string;
-  workflowVersion?: number;   // pinned in a release, floating in a draft
+  workflowVersion?: number;   // fixed in a published app, latest in a draft
   inputs: Record<string, InputMapping>;    // keyed by node id
   outputs: Record<string, OutputMapping>;  // keyed by node id
   policy: "parallel" | "replace" | "queue";
@@ -178,27 +190,26 @@ interface OperationBinding {
 }
 ```
 
-| Input mapping | Value comes from |
+| Input mapping | Where the value comes from |
 | --- | --- |
-| `{ from: "widget" }` | The bound widget. The default when an input has no mapping. |
-| `{ from: "variable", variableId }` | An app variable. |
+| `{ from: "widget" }` | The widget wired to it. The default when nothing else is set. |
+| `{ from: "variable", variableId }` | A value the app remembers. |
 | `{ from: "constant", value }` | A fixed value. |
-| `{ from: "resource", resourceBindingId }` | The resource currently selected for that binding. |
+| `{ from: "resource", resourceBindingId }` | Whichever document that resource currently points at. |
 
-| Output mapping | Value goes to |
+| Output mapping | Where the value goes |
 | --- | --- |
-| `{ to: "display" }` | The output slot display widgets read. |
-| `{ to: "variable", variableId }` | An app variable, *and* the display slot. |
+| `{ to: "display" }` | The slot display widgets read. |
+| `{ to: "variable", variableId }` | A variable, *and* the display slot. |
 
-| Policy | On a second run while one is live |
+| `policy` | If you start a run while one is already going |
 | --- | --- |
 | `parallel` | Start anyway. |
-| `replace` | Cancel the live runs, then start. The default. |
-| `queue` | Wait for them to settle, then start. |
+| `replace` | Cancel the running one, then start. The default. |
+| `queue` | Wait for it to finish, then start. |
 
-An operation's `workflowId` points at a workflow the app binds. Several
-operations may point at the same one with different mappings, and an app that
-binds three workflows declares three operations.
+Several operations may point at the same workflow with different wiring, and an
+app that runs three workflows declares three operations.
 
 ### Variables
 
@@ -208,8 +219,8 @@ interface VariableDeclaration {
   name: string;
   type?: { type: string; optional?: boolean } | null;
   default?: unknown;
-  scope: "instance" | "user";  // this open app, or persisted per user
-  persist: boolean;            // only user-scoped variables may persist
+  scope: "instance" | "user";  // this open app, or saved per user
+  persist: boolean;            // only user-scoped variables may be saved
 }
 ```
 
@@ -218,6 +229,8 @@ publishes. Typed variables with a scope, default, and persistence are declared
 through the agent or by editing the document.
 
 ### Resources
+
+A resource is a handle to a real document the app may read or edit.
 
 ```ts
 interface ResourceBinding {
@@ -229,11 +242,11 @@ interface ResourceBinding {
 }
 ```
 
-## ApplicationBundle
+## Bundles
 
-The portable form of an app: the document plus the full graph of every workflow
-it binds, in one JSON file. Export, import, and the shipped example apps all use
-it.
+A bundle is an app packaged for sharing: the app plus the full graph of every
+workflow it runs, in one JSON file. Export, import, and the shipped example apps
+all use it.
 
 ```ts
 interface ApplicationBundle {
@@ -243,32 +256,31 @@ interface ApplicationBundle {
 }
 ```
 
-Inside a bundle each `OperationBinding.workflowId` holds a bundle-local `key`
-rather than a real id. Import creates the workflows and rewrites the keys to the
-new ids, the same indirection `.nodetool` workflow bundles use for `bundle://`
-asset refs. A bundle exported from a released app carries the pinned graphs, so
-it reproduces what that release ran.
+Inside a bundle, each operation's `workflowId` holds a local nickname (`key`)
+instead of a real id. Importing creates the workflows and swaps the nicknames for
+the new ids — the same trick `.nodetool` workflow bundles use for their asset
+references. A bundle exported from a published app carries the locked-in graphs,
+so it reproduces exactly what that release ran.
 
-## Instance state
+## What one open app holds
 
-| Namespace | Key | Holds |
+| Group | Keyed by | Holds |
 | --- | --- | --- |
-| `inputs` | `opId:nodeId`, or `opId:nodeId#prop` | `{ value, dirty, revision }`. `dirty` is true once a widget rather than a default wrote it. |
+| `inputs` | `opId:nodeId`, or `opId:nodeId#prop` | `{ value, dirty, revision }`. `dirty` turns true once a widget rather than a default wrote it. |
 | `outputs` | `opId:nodeId` | `{ value, invocationId, status, revision }`. Status is `empty`, `pending`, `streaming`, or `done`. |
 | `variables` | variable id | The current value. |
-| `view` | `componentId:prop` | Widget-local state. |
+| `view` | `componentId:prop` | State belonging to one widget. |
 | `invocations` | job id | `{ id, operationId, status, progress, error, startedAt }`. |
 
-Invocation status is `pending`, `running`, `completed`, `failed`, or
-`cancelled`. Streamed values append: strings concatenate, structured items
-collect into a list. A message whose `job_id` this instance did not start is
-dropped.
+A run's status is `pending`, `running`, `completed`, `failed`, or `cancelled`.
+Streamed values accumulate: text is joined, structured items collect into a list.
+A message from a job this app didn't start is thrown away.
 
 ## Agent tools
 
-The builder agent edits the open document through these frontend tools. Every
-one takes an `application_id` — the app's own id, listed in the `ui_context`
-block. A workflow id is never accepted; the workflows an app runs are named by
+The builder agent edits the open app through these tools. Every one takes an
+`application_id` — the app's own id, listed in the `ui_context` block. A workflow
+id is never accepted; the workflows an app runs are named by
 `target_workflow_id` on its operations.
 
 | Area | Tools |
@@ -284,23 +296,24 @@ block. A workflow id is never accepted; the workflows an app runs are named by
 ```bash
 npm run dev:nodetool -- app debug <application_id>
 npm run dev:nodetool -- app debug my-app.json --params '{"prompt":"hi"}'
-npm run dev:nodetool -- app debug <id> --no-run    # static wiring check
-npm run dev:nodetool -- app debug <id> --json      # full AppDebugReport
+npm run dev:nodetool -- app debug <id> --no-run    # check the wiring, don't run
+npm run dev:nodetool -- app debug <id> --json      # full report
 
-# Scripted interactions
+# Script the clicks and typing
 npm run dev:nodetool -- app debug <id> --interact \
   '[{"set":{"key":"prompt","value":"hi"}},{"click":"Button-1"}]'
 npm run dev:nodetool -- app debug <id> --interact \
   '[{"set":{"key":"tone","value":"terse","operationId":"draft"}},{"run":"draft"}]'
 ```
 
-The harness runs every declared operation, not only the first. Widgets are
-clicked by component id, unique type, or unique label. The bundle lands in
-`nodetool-debug/app-<id>-<ts>/` with `report.json`, `report.md`, `app.json`,
-`workflow.json`, and one `server/run-N.messages.jsonl` per triggered run.
+The harness runs every operation the app declares, not just the first. Widgets
+are clicked by component id, by type if only one exists, or by label if it's
+unique. Results land in `nodetool-debug/app-<id>-<ts>/` as `report.json`,
+`report.md`, `app.json`, `workflow.json`, and one
+`server/run-N.messages.jsonl` per run.
 
-Not simulated: `visibleWhen`, `disabledWhen`, `format`, and `from: "resource"`
-inputs.
+Not simulated: `visibleWhen`, `disabledWhen`, `format`, and inputs that come from
+a resource.
 
 ## Related
 

--- a/docs/mini-apps.md
+++ b/docs/mini-apps.md
@@ -1,271 +1,278 @@
 ---
 layout: page
 title: "Mini Apps"
-description: "What Mini Apps are, where they live, and how the app document, bindings, and runtime fit together."
+description: "What a Mini App is, the words you need to read the rest of the docs, and how the pieces fit together."
 ---
 
-A Mini App is a face over one or more workflows. The graphs stay where they are;
-the app puts a form in front of them, runs them on a click or a change, and
-streams the outputs back into widgets. Nobody using the app sees a node.
+A Mini App is a simple screen in front of a workflow. Instead of a canvas full of
+connected nodes, the person using it sees a text box, a button, and a result.
 
-An app is its own resource, not a mode of a workflow. It has an id, a name, a
-version history, releases, and a spend budget, none of which belong on a graph.
-You create one from the **Apps** panel in the left sidebar and open it as its own
-workspace tab. Workflows the app binds are listed under **Linked workflows** on
-that tab and open as ordinary workflow tabs when you ask for them.
+Say you built a workflow that turns a product photo into a caption. It has a
+dozen nodes: the model, the prompt, retries, formatting. You want a coworker to
+use it, but not to edit it, and not to have to understand it. So you build a Mini
+App: one field for the photo, one button that says "Write the caption", and one
+box where the caption appears. Same workflow underneath, nothing to break.
 
-- **[Building Mini Apps](mini-apps-guide.md)** — recipes for nine app shapes,
-  each built step by step.
-- **[Mini App Reference](mini-apps-reference.md)** — widgets, binding tokens,
-  actions, conditions, format filters, and the document schema.
-- **[App Builder](app-builder.md)** — the editor itself.
+- **[Building Mini Apps](mini-apps-guide.md)** — nine app shapes, each built step
+  by step. Start here if you want to make one.
+- **[Mini App Reference](mini-apps-reference.md)** — every widget, setting, and
+  field, in tables.
+- **[App Builder](app-builder.md)** — the editor you build the screen in.
 
-## What Mini Apps are for
+## The words
 
-A workflow graph is the right surface for the person building the pipeline and
-the wrong one for everyone else. The graph exposes model choices, retry paths,
-and intermediate nodes that a person who just wants a caption written does not
-need and should not be able to break. A Mini App narrows that surface to the
-three fields that actually vary.
+These five terms cover most of what the rest of these pages say.
 
-Concretely, apps solve these:
-
-| Problem | What the app does |
+| Term | What it means |
 | --- | --- |
-| A teammate needs to run your workflow but not edit it | Inputs bound to Input nodes, one Run button. The graph is not reachable from the app. |
-| The workflow has 40 nodes and 3 things worth changing | Only those 3 get widgets. Everything else stays fixed in the graph. |
-| A run takes 90 seconds and looks frozen | Bind a Progress widget and an activity label to the operation's execution state. |
-| The result is a stream, not a value | Display widgets accumulate streamed chunks; text concatenates, structured items collect into a list. |
-| One screen drives several workflows | Declare an operation per workflow. Each has its own inputs, outputs, state, and Run button. |
-| A step needs review before the next one | Operation A writes an app variable, a widget shows it, a second button runs operation B reading that variable. |
-| A parameter should re-run the workflow as you drag it | A slider bound to a node property with a `change` event and `release` pacing. |
-| The same tool is used daily with the same settings | A user-scoped variable with `persist: true` remembers the setting across sessions. |
+| **Workflow** | The node graph that does the actual work. It already exists before you build an app. |
+| **Widget** | One thing on the app screen: a text box, a button, an image, a slider. |
+| **Binding** | The wiring between a widget and the workflow. "This text box fills the Prompt input." "This image shows the Result output." |
+| **Operation** | One workflow the app can run, plus how its inputs and outputs are wired. An app that runs two workflows has two operations. |
+| **Variable** | A value the app remembers between runs — a draft to review, a setting like "always translate to German". |
 
-When **not** to build one: a workflow you run once, a pipeline driven by another
-program (use the [Workflow API](workflow-api.md)), or an open-ended task with no
-fixed shape (use [Chat](global-chat.md) instead).
+Two more you meet in the workflow editor, not the app:
+
+- An **Input node** is a node in the graph that marks a value coming in from
+  outside. Widgets that the user types into bind to Input nodes.
+- An **Output node** marks a value going out. Widgets that show a result bind to
+  Output nodes.
+
+If a value has no Input node, no widget can change it. If a result has no Output
+node, no widget can show it. Getting these into the graph is the first step of
+building any app.
+
+## What Mini Apps are good for
+
+A node graph is the right screen for the person who built the pipeline and the
+wrong one for everyone else. It shows model choices, retry paths, and half-built
+intermediate steps that someone who just wants a caption doesn't need and
+shouldn't be able to break. A Mini App narrows it to the two or three fields that
+actually change.
+
+| The situation | What the app does about it |
+| --- | --- |
+| A coworker needs to run your workflow but not edit it | They get fields and a Run button. The graph isn't reachable from the app. |
+| The workflow has 40 nodes and 3 things worth changing | Only those 3 get widgets. The rest stays fixed in the graph. |
+| A run takes 90 seconds and looks frozen | Add a progress bar and a status line that says what the run is doing right now. |
+| The result arrives a word at a time | Display widgets collect what streams in. Text builds up into one block instead of flickering. |
+| One screen should drive several workflows | Give the app one operation per workflow. Each gets its own fields, results, and button. |
+| Someone must approve a draft before the next step | Step one writes a variable, a widget shows it, a second button runs step two using that variable. |
+| Dragging a slider should re-run the workflow | Bind the slider to a setting in the graph and have it re-run when you let go. |
+| The same tool is used daily with the same settings | Mark a variable as remembered, and it survives across sessions. |
+
+Don't build one for a workflow you'll run once, for a pipeline another program
+calls (use the [Workflow API](workflow-api.md)), or for an open-ended task with
+no fixed shape (use [Chat](global-chat.md)).
 
 ## Where apps live
 
-Each app is a row in the `applications` table: name, description, project, and
-the `ApplicationDocument` it renders. Nothing about an app is stored on a
-workflow, and opening a workflow never produces an app.
+An app is its own thing, not a setting on a workflow. It has its own name,
+version history, releases, and spending limit — none of which belong on a graph.
+Opening a workflow never creates an app, and a workflow without an app is just a
+workflow.
 
-| Surface | How to get there |
+| Where | How to get there |
 | --- | --- |
 | Apps panel | Left sidebar → **Apps**. Every app you own, plus **New app** and **New app from workflow**. |
-| App tab | Click an app in the panel. One workspace tab per app, with **Design**, **Run**, and **Settings**. |
-| Linked workflows | The menu on the app tab. Lists the workflows the app's operations bind; clicking one opens a workflow tab. |
-| Headless | `nodetool app debug <application_id>`. See [Debugging an app](#debugging-an-app). |
+| App tab | Click an app. It opens as a workspace tab with three views: **Design**, **Run**, **Settings**. |
+| Linked workflows | A menu on the app tab, listing the workflows this app runs. Click one to open it as a normal workflow tab. |
+| Terminal | `nodetool app debug <application_id>`. See [Checking an app](#checking-an-app). |
 
-Apps run wherever their workflows run: the desktop app, a self-hosted server, or
-NodeTool Cloud. Mobile opens a published app as its own screen, one app per
-screen.
+Apps run wherever their workflows run: the desktop app, a server you host, or
+NodeTool Cloud. On mobile, a published app opens as its own screen.
 
-### Creating an app
+### Making one
 
-Two ways, both deliberate:
-
-- **New app** starts from an empty document. Add an operation, pick the workflow
-  it runs, place widgets.
-- **New app from workflow** scaffolds a document whose single operation is bound
-  to the workflow you picked, with a widget per Input and Output node. It is a
-  one-way copy: the app is a separate resource from that moment on, and editing
-  either side does not touch the other.
-
-There is no automatic app. A workflow without an app is just a workflow.
+- **New app** starts empty. You add an operation, pick the workflow it runs, and
+  place widgets yourself.
+- **New app from workflow** builds a starting point for you: one operation bound
+  to the workflow you picked, and a widget for every Input and Output node it
+  has. This is a copy, made once. From then on the app and the workflow are
+  separate, and editing one doesn't change the other.
 
 ### Publishing and sharing
 
-**Publish** snapshots the document as a version and pins the graph of every
-workflow the app binds, so a released app keeps running the graphs it was
-released with while you go on editing the drafts. Budgets cap what a published
-app may spend, and each run is metered against them.
+**Publish** takes a snapshot. It saves the current screen as a version and locks
+in the current state of every workflow the app runs, so a published app keeps
+working the way it did on release day while you keep editing the drafts. A
+spending limit caps what a published app may cost, and every run counts against
+it.
 
-An **ApplicationBundle** is the portable form: one JSON document carrying the app
-plus the full graph of every workflow it binds. Export a bundle, hand it over,
-import it, and the recipient gets a working app together with its workflows.
-Inside the bundle each operation names a bundle-local workflow key, and import
-rewrites those keys to the ids of the workflows it creates. Shipped example apps
-are bundles installed through the same path.
+To hand an app to someone else, export a **bundle**: one JSON file holding the
+app *and* the full graph of every workflow it runs. They import it and get a
+working app plus its workflows. Inside the file the app refers to its workflows
+by a local nickname; importing swaps those for the real ids of the workflows it
+creates. The example apps NodeTool ships are bundles, installed the same way.
 
-## How a Mini App works
+## How it works
 
-Four pieces, and only one of them computes.
+Four pieces. Only one of them computes anything.
 
 ```
-ApplicationDocument            (what you author)
-  ui           Puck layout, widgets, bindings
-  operations   named workflow bindings + input/output mappings
-  variables    declared app state slots
-  resources    typed handles to assets, timelines, storyboards, sketches
+App document               (what you build in the editor)
+  ui           the layout: which widgets, where, wired to what
+  operations   which workflows the app runs, and how they're wired
+  variables    values the app remembers
+  resources    handles to an asset, timeline, storyboard, or sketch
         │
-        │  bindings resolve against the live graphs
+        │  the wiring is checked against the real graphs
         ▼
-AppInstanceState               (what one open app holds)
-  inputs · outputs · variables · view · invocations
+Instance state             (what one open copy of the app is holding)
+  inputs · outputs · variables · widget state · runs in flight
         │
-        │  streaming fold: run messages → state events
+        │  messages from the run update the state as they arrive
         ▼
-Workflow runs                  (where all the logic lives)
+Workflow runs              (where all the actual work happens)
 ```
 
-The document is configuration. Nothing in it branches, loops, or calls a
-provider; that is the graph's job. This is deliberate: logic in the graph is
-testable, cacheable, and visible to the agent, and logic in the app layer is
-none of those.
+The document is configuration, not code. Nothing in it branches, loops, or calls
+a model — that's the graph's job. This is on purpose: logic in a graph can be
+tested, cached, and read by the agent. Logic hidden in an app screen can't.
 
 ### The app document
 
-The `document` column of an application row holds an `ApplicationDocument`, four
-collections plus a schema version (currently 3):
+Everything you build in the editor is saved as one document with four parts:
 
-- **`ui`** — the Puck layout: which widgets are placed where, and what each one
-  is bound to.
-- **`operations`** — named bindings to workflows. An operation has an id, a
-  workflow id, an optional pinned version, per-input and per-output mappings, a
-  concurrency policy, and an optional timeout. One app can bind several
-  workflows, and the same workflow twice with different mappings
-  (`translateTitle`, `translateBody`).
-- **`variables`** — declared app state slots, each with a type, a default, a
-  scope (`instance` or `user`), and whether it persists.
-- **`resources`** — typed handles to an asset, timeline, storyboard, or sketch,
-  scoped to a project or pinned to one document, with the operations the app may
-  perform on it.
+- **`ui`** — the layout. Which widgets are on the screen, where, and what each
+  one is wired to.
+- **`operations`** — the workflows this app can run. Each operation has a name,
+  the workflow it runs, wiring for each input and output, a rule for what happens
+  when you click Run while it's already running, and an optional time limit. One
+  app can run several workflows, or the same workflow twice wired differently
+  (`translateTitle` and `translateBody`).
+- **`variables`** — the values the app remembers, each with a type, a starting
+  value, and whether it survives a reload.
+- **`resources`** — handles to a real document (an asset, timeline, storyboard,
+  or sketch) that the app is allowed to read or edit.
 
-Operations are what make an app more than a form over one graph. A transcribe
-app can bind a transcription workflow, a summarizer, and a translator, and drive
-all three from one screen.
+Operations are what make an app more than a form over one graph. A transcription
+app can run a transcriber, a summarizer, and a translator from one screen.
 
 ### Bindings
 
-A binding is the string that connects one widget to one slot of app state. It
-travels through the document as a single token:
+A binding is a short string that says which slot a widget is wired to. You pick
+these from a menu in the editor; you rarely type them. They look like this:
 
 ```
-op:<opId>/in:<nodeId>            an operation input
-op:<opId>/out:<nodeId>           an operation output
-op:<opId>/prop:<nodeId>#<prop>   a node property driven by a widget
-op:<opId>/exec#<field>           running | progress | error | activity
-var:<variableId>                 a declared app variable
-view:<componentId>#<prop>        widget-local state, never persisted
+op:<opId>/in:<nodeId>            an input of a workflow
+op:<opId>/out:<nodeId>           an output of a workflow
+op:<opId>/prop:<nodeId>#<prop>   a setting on a node, driven by a widget
+op:<opId>/exec#<field>           run status: running | progress | error | activity
+var:<variableId>                 a value the app remembers
+view:<componentId>#<prop>        state that belongs to one widget, never saved
 ```
 
-Bindings carry the operation id, so two operations that share a workflow never
-read each other's values. They key on node **IDs**, not names, so renaming an
-Input node in the graph editor cannot break an app. Names are still accepted and
-resolved against the live graph, which is how older documents keep working; the
-editor rewrites them to the ID form when it can and reports the ones it cannot.
+Two details worth knowing:
 
-How a bare name resolves depends on how the widget uses it. A write widget looks
-for an Input node, a read widget looks for an Output node and then a variable,
-and a condition or `format` token tries outputs, then inputs, then variables.
+- Every binding names its operation, so two operations running the same workflow
+  never read each other's values.
+- Bindings point at node **ids**, not names. Renaming an Input node in the graph
+  editor can't break an app. Older apps that used names still work — the name is
+  looked up in the live graph, and the editor rewrites it to the id form when it
+  can.
 
-A binding that resolves to nothing is a validation error, not a silent no-op.
-Both App Builder and `nodetool app debug` report it.
+A binding that points at nothing is reported as an error, not quietly ignored.
+Both the editor and `nodetool app debug` will tell you.
 
-### Instance state
+### What one open app holds
 
-One open app holds one `AppInstanceState`, split into five namespaces so nothing
-collides:
+While an app is open it holds a bundle of current values, split into five groups
+so nothing collides:
 
-| Namespace | Key | Holds |
+| Group | Keyed by | Holds |
 | --- | --- | --- |
-| `inputs` | `opId:nodeId` | Current input values, plus whether a widget (rather than a default) wrote them. |
-| `outputs` | `opId:nodeId` | Streamed output values with their status: `empty`, `pending`, `streaming`, `done`. |
-| `variables` | variable id | Declared app state. |
-| `view` | `componentId:prop` | Widget-local state. Never persisted. |
-| `invocations` | job id | Status, progress, error, and activity label per run. |
+| `inputs` | operation + node | What's currently in each field, and whether the user typed it or it's still the default. |
+| `outputs` | operation + node | Each result and its status: `empty`, `pending`, `streaming`, `done`. |
+| `variables` | variable | The values the app remembers. |
+| `view` | widget + property | State belonging to one widget. Never saved. |
+| `invocations` | job id | One entry per run: status, progress, error, and what it's doing. |
 
 Keying inputs and outputs by operation *and* node is what lets one app run
-several workflows without their values overwriting each other.
+several workflows without their values landing on top of each other.
 
-The reducer is pure, and the web runtime, the CLI harness, and the eval suites
-all drive the same one. What you see in `nodetool app debug` is what the browser
+The same code updates this state in the browser, in the `nodetool app debug`
+harness, and in the test suites. What the harness reports is what the browser
 does.
 
-### The run lifecycle
+### What happens when you click Run
 
-1. A widget event dispatches an action — `run`, `cancel`, `setVariable`,
-   `toggleVariable`, `resourceCommand`, or `openResource`. Actions are data the
-   runtime interprets; there is no place to write a statement.
-2. For `run`, the operation's policy decides what happens if it is already
-   running: `parallel` starts anyway, `replace` cancels the live invocations
-   first, `queue` waits for them to settle.
-3. Params are built at the execution boundary. Each input takes its value from
-   its mapping: the bound widget (the default), a variable, a constant, or the
-   currently selected resource. Node IDs become the names the run protocol
-   wants, which is why a graph rename never reaches the document.
-4. The invocation is created, its output slots go `pending`, and the run starts
-   on the operation's workflow.
-5. Run messages fold into state events. Every message is matched to an
-   invocation by `job_id`; a message from a job this instance did not start is
-   dropped. That is what keeps a second tab, an overlapping run, or a run
-   launched from a workflow tab from contaminating what the app shows.
-6. Values land in their output slot, and, when the operation maps that output
-   `to: "variable"`, in an app variable too. Streamed strings concatenate;
-   structured items collect into a list. A new run starts a fresh value rather
-   than appending to the previous one's.
+1. The widget fires an action: `run`, `cancel`, `setVariable`, `toggleVariable`,
+   or one of the resource actions. Actions are settings the runtime carries out;
+   there's nowhere to write a statement.
+2. If the operation is already running, its rule decides: `parallel` starts
+   another anyway, `replace` cancels the one in flight first, `queue` waits.
+3. The values are collected. Each input takes its value from wherever it's wired:
+   the widget (the usual case), a variable, a fixed value, or the currently
+   selected resource.
+4. The run starts, and every result slot it will fill goes to `pending`.
+5. Messages come back from the run and update the screen. Each one is matched to
+   the run that produced it by job id, and anything from a job this app didn't
+   start is thrown away. That's what stops a second tab, an overlapping run, or a
+   run launched from a workflow tab from polluting what the app shows.
+6. Values land in their result slot — and also in a variable, if the operation is
+   wired that way. Streamed text builds up; streamed items collect into a list.
+   Clicking Run again starts fresh instead of appending to the last result.
 
-### Execution state
+### Showing that something is happening
 
-Every operation exposes four fields a widget can bind to, so an app over a slow
-or agentic workflow shows more than a spinner:
+Every operation exposes four things a widget can display, so an app over a slow
+workflow shows more than a spinner:
 
-- `running` — true while any invocation is live.
-- `progress` — the active invocation's progress.
-- `error` — the active invocation's error.
-- `activity` — the most recent human-readable label the run emitted: the tool an
-  agent is calling, the planning phase it is in, the step it is on.
+- `running` — true while a run is in flight.
+- `progress` — how far along it is.
+- `error` — what went wrong, if anything.
+- `activity` — a line of plain text the run writes about itself: the tool an
+  agent is calling, the planning stage, the step it's on.
 
-Bind `activity` to a Text widget on any app that wraps an agent. Without it the
-user watches a spinner for two minutes with no idea whether anything is
-happening.
+If your app wraps an agent, put `activity` on the screen. Without it the user
+stares at a spinner for two minutes with no idea whether anything is happening.
 
-### The logic that lives in the app
+### The little logic an app can do
 
-Three things, and the vocabulary is closed on purpose:
+Three things, and the list is short on purpose:
 
-- **`visibleWhen`** — hide a widget unless a condition holds.
-- **`disabledWhen`** — disable it while a condition holds.
-- **`format`** — a `{binding|filter}` template rendered in place of the raw
-  value.
+- **Show a widget only when something is true** (`visibleWhen`).
+- **Grey a widget out while something is true** (`disabledWhen`).
+- **Reformat a value before showing it** (`format`) — round a number, shorten a
+  string, join a list.
 
-Conditions compare one bound value against a literal with one of nine
-operators. Format templates pipe a value through one of six filters. Anything
-beyond that belongs in the graph. If your app wants a derived value, compute it
-in a node and bind a widget to the output.
+A condition compares one value against one fixed value, using one of nine
+operators. Formatting runs a value through one of six filters. Anything past
+that belongs in the graph: compute the value in a node and show that node's
+output.
 
-## Debugging an app
+## Checking an app
 
-`nodetool app debug` runs the whole app headlessly: it validates every binding
-against each operation's workflow, seeds input defaults, applies params, clicks
-the run trigger (or a scripted interaction sequence), executes on the kernel
-runner, folds the streamed messages, and reports each widget's final state. It
-runs every declared operation, not only the first.
+`nodetool app debug` runs the whole app without a browser. It checks every
+binding against the real workflow, fills in the default values, clicks the Run
+button (or follows a script you give it), runs the workflow, and reports what
+every widget ended up showing. It runs all of the app's operations, not just the
+first.
 
 ```bash
 npm run dev:nodetool -- app debug <application_id>
-npm run dev:nodetool -- app debug my-app.json      # an ApplicationBundle file
-npm run dev:nodetool -- app debug <id> --no-run    # wiring check only
+npm run dev:nodetool -- app debug my-app.json      # a bundle file
+npm run dev:nodetool -- app debug <id> --no-run    # check the wiring, don't run
 npm run dev:nodetool -- app debug <id> --json      # full report
 ```
 
-The verdict catches app-level failures a workflow-only run cannot: a binding to
-a missing input or output, an app with no run trigger, a display widget that
-never receives a value, an output mapped to an undeclared variable, an event
-naming an operation the document does not declare, and an elapsed timeout.
+It catches the mistakes a workflow-only test can't: a widget wired to an input or
+output that doesn't exist, an app with no way to start a run, a display widget
+that never receives anything, a result wired to a variable that was never
+declared, a button pointing at an operation the app doesn't have, and a run that
+hit its time limit.
 
-Two things it does not simulate: `visibleWhen`/`disabledWhen`/`format` (a widget
-hidden by a condition is reported as if visible), and `from: "resource"` inputs,
-which have no provider outside the browser.
+Two things it can't check: `visibleWhen`, `disabledWhen`, and `format` (a widget
+hidden by a condition is reported as if it were visible), and inputs that come
+from a resource, since resources only exist in the browser.
 
-For a workflow underneath, `nodetool validate` is the cheap pre-flight and
+To debug the workflow itself, `nodetool validate` is the quick check and
 `nodetool debug` is the full run. See [Workflow Debugging](workflow-debugging.md).
 
 ## Related
 
-- [Building Mini Apps](mini-apps-guide.md) — recipes per use case
+- [Building Mini Apps](mini-apps-guide.md) — recipes, step by step
 - [Mini App Reference](mini-apps-reference.md) — widgets, bindings, schema
 - [App Builder](app-builder.md) — the editor
 - [Workflow Editor](workflow-editor.md) — building the graphs underneath


### PR DESCRIPTION
The four Mini App pages read like they were written for someone who already
knew the system. They opened with terms — binding, operation, app document,
instance state, execution state, pacing, concurrency policy — that are only
defined further down, or not at all.

Rewritten for a first-time reader. No behavior, API, or schema described here
changed; this is a prose pass.

## What changed

**`docs/mini-apps.md`** — opens with a concrete example (a caption workflow a
coworker should be able to run but not edit) instead of "a face over one or more
workflows". Adds a **The words** table defining the five terms that carry the
rest of the docs — workflow, widget, binding, operation, variable — plus what an
Input node and an Output node are, since those are the first thing a newcomer
has to get right. The runtime sections keep every fact but state it in plain
terms: "What one open app holds" rather than "Instance state", "What happens when
you click Run" rather than "The run lifecycle".

**`docs/mini-apps-guide.md`** — recipes renamed after what they do: "Fill a form,
get a result", "Runs that take a while", "Text that types itself out", "A slider
that re-runs", "Approve, then continue". "Before you start" became "Fix the
workflow first", the checklist became "Before you share it", "Common mistakes"
became "When something's wrong". Shorthand like "concurrency policy" and
"`release` pacing" is now said in words on first use.

**`docs/mini-apps-reference.md`** — still a reference, still the same tables.
Each section gets a one-line gloss of what the thing is, the widget tables are
split by what a reader is looking for ("Widgets that show something", "Widgets
the user changes"), and the schema half is introduced as what it's for — reading
or hand-editing a saved document.

**`docs/app-builder.md`** — "wire" for "bind", "screen" for "interface", and
operations explained where they're first mentioned.

## Checks

- No forbidden expressions from [docs/WRITING_STYLE.md](docs/WRITING_STYLE.md).
- All relative doc links resolve to existing files.
- Renaming the guide's recipe headings changed their anchors; the one in-repo
  anchor link into them (`#5-live-parameter-tuning`) was updated, and a
  repo-wide grep found no others. `app-builder.md`'s link to
  `mini-apps-reference.md#binding-grammar` was updated to `#bindings`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhjmzY3zXP8FHkSKY5zXBG)_