### PR TITLE
fix(web): extend the mobile-web pass to the surfaces it missed

### DIFF
--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -10,6 +10,7 @@ import {
   ToolbarIconButton
 } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 import AudioPlayer from "../audio/AudioPlayer";
 import AssetActionsMenu from "./AssetActionsMenu";
@@ -192,9 +193,9 @@ const AssetGrid: React.FC<AssetGridProps> = ({
 
   const theme = useTheme();
 
-  // Folders are always shown in fullscreen; in the sidebar they follow the
-  // user's toggle. Either way, hide the tree entirely when there are no
-  // folders to show.
+  // Folders are shown by default on the wide fullscreen page; elsewhere they
+  // follow the user's toggle. Either way, hide the tree entirely when there
+  // are no folders to show.
   const hasFolders = useMemo(
     () => !!folderTree && Object.keys(folderTree).length > 0,
     [folderTree]
@@ -206,10 +207,14 @@ const AssetGrid: React.FC<AssetGridProps> = ({
     !forceGlobalAssets &&
     !!currentWorkflowId &&
     workflowFilter === currentWorkflowId;
+  // The fullscreen page docks the folder tree beside the grid and pins it
+  // open. On a phone that 300px pane leaves no room for the grid and there is
+  // no control to close it, so narrow viewports fall back to the sidebar
+  // behaviour: folders stack above the grid and follow the toolbar toggle.
+  const isNarrow = useMediaQuery(theme.breakpoints.down("sm"));
+  const foldersDocked = Boolean(isFullscreenAssets) && !isNarrow;
   const effectiveFoldersVisible =
-    !isWorkflowOutputScope &&
-    hasFolders &&
-    (Boolean(isFullscreenAssets) || foldersVisible);
+    !isWorkflowOutputScope && hasFolders && (foldersDocked || foldersVisible);
 
   const user = useAuth((state) => state.user);
 
@@ -294,24 +299,24 @@ const AssetGrid: React.FC<AssetGridProps> = ({
         position: api.getPanel("asset-files")
           ? {
               referencePanel: "asset-files",
-              direction: isFullscreenAssets ? "left" : "above"
+              direction: foldersDocked ? "left" : "above"
             }
           : undefined,
-        ...(isFullscreenAssets
+        ...(foldersDocked
           ? { initialWidth: initialFoldersPanelWidth }
           : { initialHeight: FOLDERS_PANEL_HEIGHT })
       });
 
       const groupApi = foldersPanel?.group?.api ?? foldersPanel?.group;
       if (groupApi && typeof groupApi.setSize === "function") {
-        if (isFullscreenAssets) {
+        if (foldersDocked) {
           groupApi.setSize({ width: initialFoldersPanelWidth });
         } else {
           groupApi.setSize({ height: FOLDERS_PANEL_HEIGHT });
         }
       }
     },
-    [isFullscreenAssets, initialFoldersPanelWidth]
+    [isFullscreenAssets, foldersDocked, initialFoldersPanelWidth]
   );
 
   useEffect(() => {
@@ -375,7 +380,7 @@ const AssetGrid: React.FC<AssetGridProps> = ({
         <AssetActionsMenu
           maxItemSize={maxItemSize}
           onUploadFiles={uploadFiles}
-          isFullscreenAssets={isFullscreenAssets}
+          isFullscreenAssets={foldersDocked}
           hideFolderControls={isWorkflowOutputScope}
         />
       )}

--- a/web/src/components/assets/__tests__/AssetGridFolders.test.tsx
+++ b/web/src/components/assets/__tests__/AssetGridFolders.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * The fullscreen Assets page docks the folder tree beside the grid and pins it
+ * open — there is no control to close it. On a phone that pane leaves the grid
+ * no room, so narrow viewports must fall back to the toggleable sidebar
+ * behaviour.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const addPanel = jest.fn();
+const removePanel = jest.fn();
+const getPanel = jest.fn((id: string) =>
+  id === "asset-files" ? { id } : undefined
+);
+
+let matchesNarrow = false;
+
+jest.mock("@mui/material/useMediaQuery", () => ({
+  __esModule: true,
+  default: () => matchesNarrow
+}));
+
+jest.mock("dockview", () => ({
+  __esModule: true,
+  DockviewReact: ({ onReady }: { onReady: (e: unknown) => void }) => {
+    React.useEffect(() => {
+      onReady({ api: { addPanel, removePanel, getPanel } });
+    }, [onReady]);
+    return <div data-testid="dockview" />;
+  }
+}));
+
+jest.mock("../AssetActionsMenu", () => ({
+  __esModule: true,
+  default: ({ isFullscreenAssets }: { isFullscreenAssets?: boolean }) => (
+    <div data-testid="actions-menu" data-fullscreen={String(!!isFullscreenAssets)} />
+  )
+}));
+
+jest.mock("../AssetViewer", () => ({ __esModule: true, default: () => null }));
+jest.mock("../AssetCreateFolderConfirmation", () => ({ __esModule: true, default: () => null }));
+jest.mock("../AssetDeleteConfirmation", () => ({ __esModule: true, default: () => null }));
+jest.mock("../AssetMoveToFolderConfirmation", () => ({ __esModule: true, default: () => null }));
+jest.mock("../AssetRenameConfirmation", () => ({ __esModule: true, default: () => null }));
+jest.mock("../AssetUploadOverlay", () => ({ __esModule: true, default: () => null }));
+jest.mock("../ImageCompareDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../panels/AssetFoldersPanel", () => ({ __esModule: true, default: () => null }));
+jest.mock("../panels/AssetFilesPanel", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../context_menus/AssetItemContextMenu", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../context_menus/AssetGridContextMenu", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../audio/AudioPlayer", () => ({ __esModule: true, default: () => null }));
+jest.mock("../Dropzone", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}));
+
+jest.mock("../../../serverState/useAssets", () => ({
+  __esModule: true,
+  default: () => ({
+    error: null,
+    folderFiles: [],
+    folderFilesFiltered: [],
+    folderTree: { root: { id: "root", name: "Assets", children: [] } },
+    navigateToFolderId: jest.fn()
+  }),
+  useAssets: () => ({
+    error: null,
+    folderFiles: [],
+    folderFilesFiltered: [],
+    folderTree: { root: { id: "root", name: "Assets", children: [] } },
+    navigateToFolderId: jest.fn()
+  })
+}));
+
+jest.mock("../../../serverState/useAssetUpload", () => ({
+  __esModule: true,
+  useAssetUpload: () => ({ uploadAsset: jest.fn(), isUploading: false })
+}));
+
+jest.mock("../../../stores/useAuth", () => ({
+  __esModule: true,
+  default: (selector: (s: unknown) => unknown) =>
+    selector({ user: { id: "user-1" } })
+}));
+
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  __esModule: true,
+  useWorkflowManager: (selector: (s: unknown) => unknown) =>
+    selector({ currentWorkflowId: null })
+}));
+
+jest.mock("../../../stores/ContextMenuStore", () => ({
+  __esModule: true,
+  default: (selector: (s: unknown) => unknown) =>
+    selector({ openMenuType: null })
+}));
+
+jest.mock("../../../stores/KeyPressedStore", () => ({
+  __esModule: true,
+  useKeyPressedStore: (selector: (s: unknown) => unknown) =>
+    selector({ isKeyPressed: () => false })
+}));
+
+jest.mock("../../../hooks/assets/useAssetGridShortcuts", () => ({
+  __esModule: true,
+  useAssetGridShortcuts: jest.fn()
+}));
+
+jest.mock("../hooks/useClickOutsideDeselect", () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+import AssetGrid from "../AssetGrid";
+
+const renderGrid = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <AssetGrid isFullscreenAssets initialFoldersPanelWidth={300} />
+    </ThemeProvider>
+  );
+
+describe("AssetGrid folder pane", () => {
+  beforeEach(() => {
+    addPanel.mockClear();
+    removePanel.mockClear();
+    getPanel.mockClear();
+  });
+
+  it("docks the folder tree beside the grid on a wide viewport", async () => {
+    matchesNarrow = false;
+    renderGrid();
+
+    await screen.findByTestId("dockview");
+    const folderPanel = addPanel.mock.calls
+      .map(([args]) => args)
+      .find((args) => args.id === "asset-folders");
+    expect(folderPanel).toBeDefined();
+    expect(folderPanel.position.direction).toBe("left");
+    expect(screen.getByTestId("actions-menu")).toHaveAttribute(
+      "data-fullscreen",
+      "true"
+    );
+  });
+
+  it("leaves the folder tree closed and toggleable on a narrow viewport", async () => {
+    matchesNarrow = true;
+    renderGrid();
+
+    await screen.findByTestId("dockview");
+    const folderPanel = addPanel.mock.calls
+      .map(([args]) => args)
+      .find((args) => args.id === "asset-folders");
+    expect(folderPanel).toBeUndefined();
+    // The toolbar drops its fullscreen layout, which is what shows the
+    // "Show folders" toggle.
+    expect(screen.getByTestId("actions-menu")).toHaveAttribute(
+      "data-fullscreen",
+      "false"
+    );
+  });
+});

--- a/web/src/components/chain_editor/NodePickerDialog.tsx
+++ b/web/src/components/chain_editor/NodePickerDialog.tsx
@@ -25,6 +25,7 @@ import {
 import SearchIcon from "@mui/icons-material/Search";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import useMetadataStore from "../../stores/MetadataStore";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import { computeSearchResults } from "../../utils/nodeSearch";
 import {
   QUICK_ACTION_BUTTONS,
@@ -86,6 +87,7 @@ export const NodePickerDialog: React.FC<NodePickerDialogProps> = ({
 }) => {
   const theme = useTheme();
   const [searchQuery, setSearchQuery] = useState("");
+  const autoFocusEnabled = useAutoFocusEnabled();
   const allMetadata = useMetadataStore((s) => s.metadata);
   const getMetadata = useMetadataStore((s) => s.getMetadata);
 
@@ -143,15 +145,22 @@ export const NodePickerDialog: React.FC<NodePickerDialogProps> = ({
   });
 
   return (
-    <Dialog open={open} onClose={onClose} title="Add Node" minWidth={520}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Add Node"
+      minWidth="min(520px, 100vw - 32px)"
+    >
       <FlexColumn gap={2} sx={{ minHeight: 400, maxHeight: "70vh" }}>
+        {/* autoFocus is skipped on touch, where the virtual keyboard would
+            cover the node list the dialog just opened to show. */}
         <TextInput
           fullWidth
           size="small"
           placeholder="Search nodes..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          autoFocus
+          autoFocus={autoFocusEnabled}
           slotProps={{
             input: {
               startAdornment: (

--- a/web/src/components/chain_editor/__tests__/NodePickerDialog.test.tsx
+++ b/web/src/components/chain_editor/__tests__/NodePickerDialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import { NodePickerDialog } from "../NodePickerDialog";
+
+const mockMatchMedia = (coarse: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes("pointer: coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+const renderDialog = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <NodePickerDialog open onSelect={jest.fn()} onClose={jest.fn()} />
+    </ThemeProvider>
+  );
+
+describe("NodePickerDialog search focus", () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  it("focuses the search field on a fine pointer", () => {
+    mockMatchMedia(false);
+    renderDialog();
+    expect(screen.getByPlaceholderText("Search nodes...")).toHaveFocus();
+  });
+
+  it("leaves the search field unfocused on a coarse pointer", () => {
+    mockMatchMedia(true);
+    renderDialog();
+    expect(screen.getByPlaceholderText("Search nodes...")).not.toHaveFocus();
+  });
+});

--- a/web/src/components/chat/composer/MediaAspectRatioMenu.tsx
+++ b/web/src/components/chat/composer/MediaAspectRatioMenu.tsx
@@ -26,6 +26,7 @@ const styles = (theme: Theme) =>
   css({
     padding: theme.spacing(4, 4),
     minWidth: 480,
+    maxWidth: "100%",
     ".aspect-header": {
       color: theme.vars.palette.grey[400],
       textTransform: "uppercase",
@@ -79,6 +80,15 @@ const styles = (theme: Theme) =>
     },
     ".aspect-option.selected .aspect-label": {
       color: theme.vars.palette.primary.light
+    },
+    // Six 70px columns plus padding need ~520px, so on a phone the popover ran
+    // off the screen. Drop to three columns and trim the padding.
+    [theme.breakpoints.down("sm")]: {
+      minWidth: 0,
+      padding: theme.spacing(2, 2),
+      ".aspect-grid": {
+        gridTemplateColumns: "repeat(3, minmax(0, 1fr))"
+      }
     }
   });
 

--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import type { Theme } from "@mui/material/styles";
 import { useCallback, useMemo, memo } from "react";
 import {
@@ -263,10 +264,14 @@ const ChatView = ({
     const id = threadId ?? state.currentThreadId;
     return (id && state.todosByThread[id]) || NO_TODOS;
   });
-  const showTodoSidebar = todos.length > 0;
   const effectiveThreadId = useGlobalChatStore(
     (state) => threadId ?? state.currentThreadId
   );
+  // The two rails are 280px and 300px of fixed width. Below `md` they leave
+  // the conversation itself almost no room, so they drop out entirely on
+  // phones and narrow panels.
+  const railsFit = useMediaQuery(theme.breakpoints.up("md"));
+  const showTodoSidebar = railsFit && todos.length > 0;
 
   return (
     <div className="chat-view" css={cssStyles}>
@@ -320,7 +325,7 @@ const ChatView = ({
         )}
       </div>
       {showTodoSidebar && <TodoSidebar todos={todos} />}
-      {effectiveThreadId && (
+      {railsFit && effectiveThreadId && (
         <ThreadMemorySidebar threadId={effectiveThreadId} />
       )}
     </div>

--- a/web/src/components/chat/message/MediaOutputGroup.tsx
+++ b/web/src/components/chat/message/MediaOutputGroup.tsx
@@ -218,6 +218,13 @@ const styles = (theme: Theme) =>
     ".add-all-button": {
       opacity: 0.6,
       transition: `opacity ${MOTION.normal}`
+    },
+
+    // No hover on touch, so these would stay invisible while still catching
+    // taps over the media tiles.
+    "@media (hover: none)": {
+      ".add-to-canvas-button": { opacity: 1 },
+      ".add-all-button": { opacity: 1 }
     }
   });
 

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -54,6 +54,11 @@ const wrapperStyles = css({
   },
   "&:hover .add-to-canvas-button": {
     opacity: 1
+  },
+  // No hover on touch, so the button would stay invisible while still
+  // catching taps over the media.
+  "@media (hover: none)": {
+    ".add-to-canvas-button": { opacity: 1 }
   }
 });
 

--- a/web/src/components/chat/thread/ThreadList.styles.ts
+++ b/web/src/components/chat/thread/ThreadList.styles.ts
@@ -133,5 +133,13 @@ export const createStyles = (theme: Theme) =>
       },
 
       svg: { fontSize: "1.2em" }
+    },
+
+    // Without hover the delete button never appears, yet it still sits on top
+    // of the timestamp and swallows taps near the right edge of a row. Show it
+    // and drop the timestamp, matching what hovering does on a mouse.
+    "@media (hover: none)": {
+      ".delete-button": { opacity: 1 },
+      ".thread-time": { opacity: 0 }
     }
   });

--- a/web/src/components/color_picker/ColorPickerModal.tsx
+++ b/web/src/components/color_picker/ColorPickerModal.tsx
@@ -149,6 +149,36 @@ const styles = (theme: Theme) =>
     },
     ".footer-actions": {
       gap: getSpacingPx(SPACING.md)
+    },
+    // The 320px picker column left a phone-width dialog nothing for the tabs
+    // beside it. Stack the two sections and scroll the body instead.
+    [theme.breakpoints.down("sm")]: {
+      ".modal-content": {
+        width: "100%",
+        maxHeight: "100%",
+        borderRadius: 0,
+        border: "none"
+      },
+      ".modal-body": {
+        flexDirection: "column",
+        overflow: "auto"
+      },
+      ".picker-section": {
+        flex: "0 0 auto",
+        width: "100%",
+        borderRight: "none",
+        borderBottom: `1px solid ${theme.vars.palette.grey[800]}`,
+        padding: getSpacingPx(SPACING.lg),
+        overflow: "visible"
+      },
+      ".tabs-section": {
+        flex: "0 0 auto",
+        overflow: "visible"
+      },
+      ".tab-content": {
+        padding: getSpacingPx(SPACING.lg),
+        overflow: "visible"
+      }
     }
   });
 

--- a/web/src/components/common/LogsTable.tsx
+++ b/web/src/components/common/LogsTable.tsx
@@ -187,6 +187,12 @@ const tableStyles = (theme: Theme) =>
     ".list-container": {
       flex: 1,
       minHeight: 0
+    },
+
+    // Hover-revealed row details are unreachable on touch — show them.
+    "@media (hover: none)": {
+      ".row .copy-btn": { opacity: 1 },
+      ".timestamp": { opacity: 1 }
     }
   });
 

--- a/web/src/components/compositor/CompositorEditor.tsx
+++ b/web/src/components/compositor/CompositorEditor.tsx
@@ -63,7 +63,12 @@ const styles = (theme: Theme) =>
       width: "100%",
       height: "100%",
       display: "flex",
-      minHeight: 0
+      minHeight: 0,
+      // Below the panel width the stage would be squeezed to nothing, so the
+      // panel drops under the stage instead of docking beside it.
+      [theme.breakpoints.down("sm")]: {
+        flexDirection: "column"
+      }
     },
     ".stage-pane": {
       flex: "1 1 auto",
@@ -80,7 +85,13 @@ const styles = (theme: Theme) =>
       minHeight: 0,
       padding: theme.spacing(1),
       gap: theme.spacing(1),
-      overflowY: "auto"
+      overflowY: "auto",
+      [theme.breakpoints.down("sm")]: {
+        flex: "0 1 auto",
+        width: "100%",
+        borderLeft: "none",
+        borderTop: `1px solid ${theme.vars.palette.divider}`
+      }
     },
     ".size-row .field": {
       flex: 1,

--- a/web/src/components/dialogs/FileBrowserDialog.tsx
+++ b/web/src/components/dialogs/FileBrowserDialog.tsx
@@ -82,6 +82,17 @@ const styles = (theme: Theme) =>
       overflow: "hidden",
       backgroundColor: theme.vars.palette.background.paper
     },
+    ".search-wrap": {
+      width: 200,
+      flexShrink: 0
+    },
+    // On a phone the toolbar's fixed 200px search and the 250px folder tree
+    // left the file list a sliver. The search takes its own line and the tree
+    // steps aside — the breadcrumbs, the up button, and tapping a folder cover
+    // the same navigation.
+    [theme.breakpoints.down("sm")]: {
+      ".search-wrap": { width: "100%" }
+    },
     ".breadcrumbs": {
       flex: 1,
       minWidth: 0
@@ -635,6 +646,7 @@ function FileBrowserDialog({
           sx={{
             px: 2,
             py: 1,
+            flexWrap: "wrap",
             borderBottom: `1px solid ${theme.vars.palette.divider}`,
             backgroundColor: theme.vars.palette.background.default
           }}
@@ -680,7 +692,7 @@ function FileBrowserDialog({
             </FlexRow>
           )}
 
-          <div style={{ width: 200 }}>
+          <div className="search-wrap">
             <SearchInput
               value={searchQuery}
               onChange={handleSearchQueryChange}
@@ -701,7 +713,15 @@ function FileBrowserDialog({
           className="file-browser-content"
           sx={{ flex: 1, minHeight: 0, border: "none", borderRadius: 0 }}
         >
-          <FlexColumn className="left-panel" sx={{ width: 250, minWidth: 200, overflow: "hidden" }}>
+          <FlexColumn
+            className="left-panel"
+            sx={{
+              display: { xs: "none", sm: "flex" },
+              width: 250,
+              minWidth: 200,
+              overflow: "hidden"
+            }}
+          >
             <div className="folder-tree" ref={treeScrollRef}>
               <RichTreeView
                 items={treeItems}

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -123,6 +123,39 @@ const styles = (theme: Theme) =>
     },
     ".model-list-section": {
       marginBottom: theme.spacing(6)
+    },
+    // Phone width: the 300px category rail plus the 280px info rail leave the
+    // model list nothing to occupy, and the header row overflows sideways.
+    // Stack the rails, cap the category list, and drop the purely
+    // informational one.
+    [theme.breakpoints.down("sm")]: {
+      ".model-list-header": {
+        flexWrap: "wrap",
+        justifyContent: "flex-start",
+        padding: "0.75em 1em"
+      },
+      ".main": {
+        flexDirection: "column"
+      },
+      ".sidebar": {
+        width: "100%",
+        minWidth: 0,
+        maxWidth: "none",
+        height: "auto",
+        maxHeight: "35vh",
+        flexShrink: 0,
+        borderRight: "none",
+        borderBottom: `1px solid ${theme.vars.palette.divider}`
+      },
+      ".content": {
+        height: "auto",
+        flex: "1 1 auto",
+        minHeight: 0,
+        padding: "1em 0.75em 2em 0.75em"
+      },
+      ".right-sidebar": {
+        display: "none"
+      }
     }
   });
 

--- a/web/src/components/node/CommentNode.tsx
+++ b/web/src/components/node/CommentNode.tsx
@@ -125,6 +125,17 @@ const styles = (theme: Theme) =>
         opacity: 1
       }
     },
+    // Touch devices have no hover: the color picker would never appear, and
+    // the format toolbar only while the comment is being edited.
+    "@media (pointer: coarse)": {
+      ".color-picker-container": {
+        opacity: 1
+      },
+      "&.focused .format-toolbar-container": {
+        opacity: 1,
+        display: "flex"
+      }
+    },
     ".node-resize-handle": {
       opacity: 0.6,
       transition: `opacity ${MOTION.normal}`,

--- a/web/src/components/node/EditableTitle.tsx
+++ b/web/src/components/node/EditableTitle.tsx
@@ -199,6 +199,13 @@ const EditableTitle = memo(function EditableTitle({
 
     "&:hover .remove-title": {
       opacity: 1
+    },
+
+    // Touch devices have no hover; keep the remove button reachable.
+    "@media (pointer: coarse)": {
+      ".remove-title": {
+        opacity: 1
+      }
     }
   }), [theme]);
 

--- a/web/src/components/node/ImageView.tsx
+++ b/web/src/components/node/ImageView.tsx
@@ -28,6 +28,10 @@ const hoverStyles = css({
   },
   "&:hover .image-view-actions": {
     opacity: 1
+  },
+  // Touch devices have no hover; keep the copy/download/viewer buttons reachable.
+  "@media (pointer: coarse)": {
+    ".image-view-actions": { opacity: 1 }
   }
 });
 

--- a/web/src/components/node/NodeHistoryViewer.tsx
+++ b/web/src/components/node/NodeHistoryViewer.tsx
@@ -114,6 +114,10 @@ const styles = (theme: Theme) =>
     "&:hover .node-history-overlay, &:focus-within .node-history-overlay": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the history controls reachable.
+    "@media (pointer: coarse)": {
+      ".node-history-overlay": { opacity: 1 }
+    },
     ".overlay-cluster": {
       pointerEvents: "auto",
       display: "inline-flex",

--- a/web/src/components/node/OutputNode/OutputNode.tsx
+++ b/web/src/components/node/OutputNode/OutputNode.tsx
@@ -191,6 +191,12 @@ const styles = (theme: Theme) =>
       },
       "& .tile:hover .tile-actions": {
         opacity: 1
+      },
+      // Touch devices have no hover; keep the output action buttons reachable.
+      "@media (pointer: coarse)": {
+        ".actions": { opacity: 1 },
+        ".image-view-actions": { opacity: 1 },
+        ".tile-actions": { opacity: 1 }
       }
     },
     tableStyles(theme)

--- a/web/src/components/node/PreviewImageGrid.tsx
+++ b/web/src/components/node/PreviewImageGrid.tsx
@@ -233,6 +233,10 @@ const styles = (theme: Theme, gap: number) =>
     ".tile:hover .tile-actions": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the per-tile actions reachable.
+    "@media (pointer: coarse)": {
+      ".tile-actions": { opacity: 1 }
+    },
     ".tile-action-btn": {
       width: 24,
       height: 24,

--- a/web/src/components/node/PreviewNode/PreviewNode.tsx
+++ b/web/src/components/node/PreviewNode/PreviewNode.tsx
@@ -212,6 +212,10 @@ const styles = (theme: Theme) =>
         maxHeight: "500px",
         overflowY: "auto",
         padding: "1em"
+      },
+      // Touch devices have no hover; keep the preview action buttons reachable.
+      "@media (pointer: coarse)": {
+        ".actions": { opacity: 1 }
       }
     },
     tableStyles(theme)

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -99,6 +99,13 @@ const propertyInputContainerStyles = (theme: Theme) =>
       opacity: 1
     },
 
+    // Touch devices have no hover; keep the action icons and reset reachable.
+    "@media (pointer: coarse)": {
+      ".action-icons, .reset-button.is-active": {
+        opacity: 1
+      }
+    },
+
     ".action-icon": {
       fontSize: "var(--fontSizeBig)",
       cursor: "pointer",

--- a/web/src/components/node/output/DataframeRenderer.tsx
+++ b/web/src/components/node/output/DataframeRenderer.tsx
@@ -73,6 +73,10 @@ const styles = (theme: Theme) =>
     "&:hover .dataframe-action-buttons": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the dataframe actions reachable.
+    "@media (pointer: coarse)": {
+      ".dataframe-action-buttons": { opacity: 1 }
+    },
     ".dataframe-action-buttons .MuiIconButton-root": {
       padding: "0.25em",
       color: theme.vars.palette.primary.main,

--- a/web/src/components/node/output/styles.ts
+++ b/web/src/components/node/output/styles.ts
@@ -19,6 +19,10 @@ export const outputStyles = (theme: Theme, hasActions = true) =>
     "&:hover .actions": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the output action buttons reachable.
+    "@media (pointer: coarse)": {
+      ".actions": { opacity: 1 }
+    },
     ".content": {
       flex: 1,
       overflowY: "auto",

--- a/web/src/components/node_menu/FavoritesTiles.tsx
+++ b/web/src/components/node_menu/FavoritesTiles.tsx
@@ -123,6 +123,10 @@ const tileStyles = (theme: Theme) =>
     },
     ".favorite-tile:hover .unfavorite-btn": {
       opacity: 1
+    },
+    // Touch devices have no hover; keep the unfavorite button reachable.
+    "@media (pointer: coarse)": {
+      ".unfavorite-btn": { opacity: 1 }
     }
   });
 

--- a/web/src/components/node_menu/NodeLibraryRow.tsx
+++ b/web/src/components/node_menu/NodeLibraryRow.tsx
@@ -54,6 +54,10 @@ const rowStyles = (theme: Theme) =>
     },
     "&:hover .nl-fav, &:focus-within .nl-fav, &.is-favorite .nl-fav": {
       opacity: 1
+    },
+    // Touch devices have no hover; keep the favorite toggle reachable.
+    "@media (pointer: coarse)": {
+      ".nl-fav": { opacity: 1 }
     }
   });
 

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -203,7 +203,8 @@ const typeFilterChipsStyles = (theme: Theme) =>
       fontWeight: FONT_WEIGHT.semibold
     },
     ".filter-menu-content": {
-      minWidth: "390px",
+      // Clamped to the viewport: a flat 390px overflows a phone screen.
+      minWidth: "min(390px, calc(100vw - 32px))",
       maxWidth: "480px",
       padding: getSpacingPx(SPACING.xl)
     },

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -153,6 +153,10 @@ const styles = (theme: Theme) =>
       ".video-preview:hover .video-preview-actions": {
         opacity: 1
       },
+      // Touch devices have no hover; keep the video preview actions reachable.
+      "@media (pointer: coarse)": {
+        ".video-preview-actions": { opacity: 1 }
+      },
       ".video-preview-actions button": {
         width: 24,
         height: 24,

--- a/web/src/components/node_types/editing/CollectionBody.tsx
+++ b/web/src/components/node_types/editing/CollectionBody.tsx
@@ -145,6 +145,10 @@ const styles = (theme: Theme) =>
     ".col-tile:hover .col-remove, .col-tile:focus-within .col-remove": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the remove button reachable.
+    "@media (pointer: coarse)": {
+      ".col-remove": { opacity: 1 }
+    },
     ".col-empty": {
       gridColumn: "1 / -1",
       flex: 1,

--- a/web/src/components/node_types/editing/ListGeneratorBody.tsx
+++ b/web/src/components/node_types/editing/ListGeneratorBody.tsx
@@ -172,6 +172,10 @@ const styles = (theme: Theme) =>
     ".list-head:hover .list-actions, .list-head:focus-within .list-actions": {
       opacity: 1
     },
+    // Touch devices have no hover; keep the list actions reachable.
+    "@media (pointer: coarse)": {
+      ".list-actions": { opacity: 1 }
+    },
     ".list-chevron": {
       flexShrink: 0,
       fontSize: theme.fontSizeNormal,

--- a/web/src/components/node_types/editing/promptComposer/MentionAssetTile.tsx
+++ b/web/src/components/node_types/editing/promptComposer/MentionAssetTile.tsx
@@ -78,6 +78,10 @@ const styles = (theme: Theme) =>
     },
     "&:hover .thumb img": { transform: "scale(1.06)" },
     "&:hover .rename-button, &.selected .rename-button": { opacity: 1 },
+    // Touch devices have no hover; keep the rename button reachable.
+    "@media (pointer: coarse)": {
+      ".rename-button": { opacity: 1 }
+    },
     "&.selected": {
       borderColor: theme.vars.palette.primary.main,
       background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,

--- a/web/src/components/packages/PackageManager.tsx
+++ b/web/src/components/packages/PackageManager.tsx
@@ -227,7 +227,16 @@ function PackageManager() {
   }, [showSearch]);
 
   return (
-    <FlexRow sx={{ width: "100%", height: "100%", minHeight: 0 }}>
+    <Box
+      sx={{
+        display: "flex",
+        // The rail stacks above the list on a phone (see PackageRail).
+        flexDirection: { xs: "column", sm: "row" },
+        width: "100%",
+        height: "100%",
+        minHeight: 0
+      }}
+    >
       <PackageRail
         tab={tab}
         onTab={handleTab}
@@ -237,7 +246,10 @@ function PackageManager() {
       />
 
       <FlexColumn sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-        <FlexColumn gap={0} sx={{ flexShrink: 0, pt: 2.75, px: 3.75 }}>
+        <FlexColumn
+          gap={0}
+          sx={{ flexShrink: 0, pt: 2.75, px: { xs: 1.75, sm: 3.75 } }}
+        >
           {model.isSoftware && (
             <FlexRow
               gap={1.75}
@@ -313,7 +325,7 @@ function PackageManager() {
                       : `Update all (${model.bulkUpdate.count})`}
                   </EditorButton>
                 )}
-                <Box sx={{ width: 250 }}>
+                <Box sx={{ width: { xs: "100%", sm: 250 } }}>
                   <SearchInput
                     ref={searchRef}
                     value={q}
@@ -411,7 +423,7 @@ function PackageManager() {
           )}
         </FlexColumn>
       </FlexColumn>
-    </FlexRow>
+    </Box>
   );
 }
 

--- a/web/src/components/packages/PackageRail.tsx
+++ b/web/src/components/packages/PackageRail.tsx
@@ -39,11 +39,17 @@ const PackageRail = ({
   <FlexColumn
     gap={0.75}
     sx={(theme) => ({
-      width: 250,
+      // Phone width: the rail sits above the list as a full-width header
+      // instead of taking 250px of a 375px viewport.
+      width: { xs: "100%", sm: 250 },
       flexShrink: 0,
-      height: "100%",
+      height: { xs: "auto", sm: "100%" },
       p: 1.75,
-      borderRight: `1px solid ${theme.vars.palette.divider}`,
+      borderRight: { xs: "none", sm: `1px solid ${theme.vars.palette.divider}` },
+      borderBottom: {
+        xs: `1px solid ${theme.vars.palette.divider}`,
+        sm: "none"
+      },
       backgroundColor:
         theme.vars.palette.c_app_header ?? theme.vars.palette.background.default
     })}
@@ -66,6 +72,7 @@ const PackageRail = ({
       color="secondary"
       weight={600}
       sx={{
+        display: { xs: "none", sm: "block" },
         textTransform: "uppercase",
         letterSpacing: "0.09em",
         px: 1.25,
@@ -76,79 +83,93 @@ const PackageRail = ({
       Browse
     </Text>
 
-    {categories.map((c) => {
-      const active = c.id === activeCat;
-      return (
-        <Box
-          key={c.id}
-          component="button"
-          type="button"
-          onClick={() => onCat(c.id)}
-          aria-current={active ? "true" : undefined}
-          sx={(theme) => ({
-            position: "relative",
-            display: "flex",
-            alignItems: "center",
-            gap: 1.25,
-            width: "100%",
-            textAlign: "left",
-            padding: theme.spacing(SPACING.md, SPACING.lg, SPACING.md, SPACING.xl),
-            borderRadius: BORDER_RADIUS.lg,
-            border: "none",
-            cursor: "pointer",
-            backgroundColor: active
-              ? theme.vars.palette.action.selected
-              : "transparent",
-            transition: `background-color ${MOTION.fast}`,
-            "&:hover": {
+    {/* Column of categories on desktop, one scrollable row on a phone. */}
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "row", sm: "column" },
+        gap: 0.75,
+        minWidth: 0,
+        overflowX: { xs: "auto", sm: "visible" },
+        pt: { xs: 1, sm: 0 }
+      }}
+    >
+      {categories.map((c) => {
+        const active = c.id === activeCat;
+        return (
+          <Box
+            key={c.id}
+            component="button"
+            type="button"
+            onClick={() => onCat(c.id)}
+            aria-current={active ? "true" : undefined}
+            sx={(theme) => ({
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              gap: 1.25,
+              width: { xs: "auto", sm: "100%" },
+              flexShrink: 0,
+              whiteSpace: "nowrap",
+              textAlign: "left",
+              padding: theme.spacing(SPACING.md, SPACING.lg, SPACING.md, SPACING.xl),
+              borderRadius: BORDER_RADIUS.lg,
+              border: "none",
+              cursor: "pointer",
               backgroundColor: active
                 ? theme.vars.palette.action.selected
-                : theme.vars.palette.action.hover
-            },
-            "&:focus-visible": {
-              outline: `2px solid ${theme.vars.palette.primary.main}`,
-              outlineOffset: "-2px"
-            }
-          })}
-        >
-          {active && (
-            <Box
-              aria-hidden
-              sx={(theme) => ({
-                position: "absolute",
-                left: 4,
-                top: 9,
-                bottom: 9,
-                width: 3,
-                borderRadius: BORDER_RADIUS.sm,
-                backgroundColor: theme.vars.palette.primary.main
-              })}
-            />
-          )}
-          <Text
-            size="small"
-            sx={{ color: active ? "text.primary" : "text.secondary" }}
-          >
-            {c.label}
-          </Text>
-          <Box
-            sx={(theme) => ({
-              marginLeft: "auto",
-              fontFamily: theme.fontFamily2,
-              fontSize: "var(--fontSizeSmaller)",
-              fontWeight: 500,
-              color: theme.vars.palette.text.secondary,
-              backgroundColor: theme.vars.palette.action.selected,
-              py: SPACING.micro,
-              px: SPACING.md,
-              borderRadius: BORDER_RADIUS.sm
+                : "transparent",
+              transition: `background-color ${MOTION.fast}`,
+              "&:hover": {
+                backgroundColor: active
+                  ? theme.vars.palette.action.selected
+                  : theme.vars.palette.action.hover
+              },
+              "&:focus-visible": {
+                outline: `2px solid ${theme.vars.palette.primary.main}`,
+                outlineOffset: "-2px"
+              }
             })}
           >
-            {c.count}
+            {active && (
+              <Box
+                aria-hidden
+                sx={(theme) => ({
+                  position: "absolute",
+                  left: 4,
+                  top: 9,
+                  bottom: 9,
+                  width: 3,
+                  borderRadius: BORDER_RADIUS.sm,
+                  backgroundColor: theme.vars.palette.primary.main
+                })}
+              />
+            )}
+            <Text
+              size="small"
+              sx={{ color: active ? "text.primary" : "text.secondary" }}
+            >
+              {c.label}
+            </Text>
+            <Box
+              sx={(theme) => ({
+                marginLeft: { xs: 0, sm: "auto" },
+                fontFamily: theme.fontFamily2,
+                fontSize: "var(--fontSizeSmaller)",
+                fontWeight: 500,
+                color: theme.vars.palette.text.secondary,
+                backgroundColor: theme.vars.palette.action.selected,
+                py: SPACING.micro,
+                px: SPACING.md,
+                borderRadius: BORDER_RADIUS.sm
+              })}
+            >
+              {c.count}
+            </Box>
           </Box>
-        </Box>
-      );
-    })}
+        );
+      })}
+    </Box>
 
     <FlexRow sx={{ flex: 1 }} />
 
@@ -156,6 +177,7 @@ const PackageRail = ({
       size="small"
       color="secondary"
       sx={(theme) => ({
+        display: { xs: "none", sm: "block" },
         lineHeight: 1.5,
         p: 1.25,
         borderTop: `1px solid ${theme.vars.palette.divider}`

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -606,6 +606,7 @@ const MobilePanelLeft: React.FC<{
   onClose: () => void;
   onViewChange: (view: LeftPanelView) => void;
   handlePanelToggle: (view: LeftPanelView) => void;
+  showAppMenu?: boolean;
 }> = ({
   activeView,
   activeNodeCategory,
@@ -615,7 +616,8 @@ const MobilePanelLeft: React.FC<{
   onOpen,
   onClose,
   onViewChange,
-  handlePanelToggle
+  handlePanelToggle,
+  showAppMenu = false
 }) => {
   const theme = useTheme();
 
@@ -648,6 +650,10 @@ const MobilePanelLeft: React.FC<{
         ariaLabel="Workflows, sketches, timelines, and assets panel"
         headerExtras={
           <div css={mobileHeaderExtrasStyles(theme)}>
+            {/* The rail's app menu (Settings, Help, Models, Downloads, …) has
+              no other entry point on mobile — the vertical toolbar that carries
+              it on desktop isn't rendered here. */}
+            {showAppMenu && <RailAppMenu onAction={onClose} />}
             <Tooltip title="Workflows" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
               <ToolbarIconButton
                 className={`tab-button ${activeView === "workflows" ? "active" : ""}`}
@@ -846,6 +852,7 @@ const PanelLeft: React.FC = () => {
         onClose={handleMobileClose}
         onViewChange={onViewChange}
         handlePanelToggle={handlePanelToggle}
+        showAppMenu={isWorkspace}
       />
     );
   }

--- a/web/src/components/panels/QueueOverlay.tsx
+++ b/web/src/components/panels/QueueOverlay.tsx
@@ -10,7 +10,9 @@ import {
   Tooltip,
   MOTION,
   reducedMotion,
-  BORDER_RADIUS
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
 } from "../ui_primitives";
 import type { SxProps } from "@mui/material/styles";
 import LayersIcon from "@mui/icons-material/Layers";
@@ -336,6 +338,19 @@ const HeaderCount = ({
   </FlexRow>
 );
 
+// The 92px left inset clears the desktop rail, but 92 + 304 is wider than a
+// phone viewport, so the overlay used to hang off the right edge with its
+// expand and cancel controls out of reach. On mobile the rail is a floating
+// hamburger at left 8, so the overlay starts past it and runs to the margin.
+const mobileOverlayStyles = (theme: Theme) =>
+  css({
+    [theme.breakpoints.down("sm")]: {
+      left: "56px",
+      right: getSpacingPx(SPACING.md),
+      width: "auto"
+    }
+  });
+
 const overlayStyles = (theme: Theme) =>
   css({
     position: "fixed",
@@ -474,7 +489,7 @@ const QueueOverlay = memo(function QueueOverlay() {
   if (!expanded) {
     const single = running.length === 1 ? running[0] : null;
     return (
-      <Box css={overlayStyles(theme)} data-state={hasJobs ? "open" : "closed"}>
+      <Box css={[overlayStyles(theme), mobileOverlayStyles(theme)]} data-state={hasJobs ? "open" : "closed"}>
         <FlexColumn gap={1} sx={{ p: 1.5 }}>
           <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
             <Dot color={running.length ? "primary.main" : "grey.600"} />
@@ -515,7 +530,7 @@ const QueueOverlay = memo(function QueueOverlay() {
   }
 
   return (
-    <Box css={overlayStyles(theme)} data-state={hasJobs ? "open" : "closed"}>
+    <Box css={[overlayStyles(theme), mobileOverlayStyles(theme)]} data-state={hasJobs ? "open" : "closed"}>
       <FlexRow align="center" gap={1} sx={{ px: 2, py: 1.5, flex: "0 0 auto" }}>
         <LayersIcon sx={{ fontSize: 17, color: "text.secondary" }} />
         <Text size="normal" weight={600} sx={{ flex: 1 }}>

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -64,12 +64,21 @@ const menuStyles = () =>
     padding: `${getSpacingPx(SPACING.xs)} 0`
   });
 
+export interface RailAppMenuProps {
+  /**
+   * Called after an item opens something (a page tab, Help, Downloads). The
+   * mobile panel sheet uses it to dismiss itself so the destination isn't
+   * hidden behind it.
+   */
+  onAction?: () => void;
+}
+
 /**
  * The app menu docked at the top of the workspace rail. The logo opens a menu
  * carrying the global actions that used to live in the old header's right cluster:
  * Settings, Help, and Downloads (with live progress when active).
  */
-const RailAppMenu: React.FC = () => {
+const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
   const theme = useTheme();
   const navigate = useNavigate();
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -95,6 +104,11 @@ const RailAppMenu: React.FC = () => {
   useCombo(["Control", "/"], handleShowKeyboardShortcuts);
 
   const close = useCallback(() => setOpen(false), []);
+  // Closing after an item was picked, as opposed to dismissing the popover.
+  const finish = useCallback(() => {
+    setOpen(false);
+    onAction?.();
+  }, [onAction]);
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
 
   // Open an app page (Settings, Costs, …) as a workspace tab and focus the
@@ -108,15 +122,15 @@ const RailAppMenu: React.FC = () => {
         title: PAGE_TAB_TITLES[key]
       });
       navigate("/workspace");
-      close();
+      finish();
     },
-    [openTab, navigate, close]
+    [openTab, navigate, finish]
   );
 
   const goDashboard = useCallback(() => {
     navigate("/dashboard");
-    close();
-  }, [navigate, close]);
+    finish();
+  }, [navigate, finish]);
 
   const goExamples = useCallback(() => openPage("examples"), [openPage]);
   const goTutorials = useCallback(() => openPage("tutorials"), [openPage]);
@@ -130,8 +144,8 @@ const RailAppMenu: React.FC = () => {
 
   const openHelp = useCallback(() => {
     handleOpenHelp();
-    close();
-  }, [handleOpenHelp, close]);
+    finish();
+  }, [handleOpenHelp, finish]);
 
   const { downloads, openDownloadsDialog } = useModelDownloadStore(
     useShallow((state) => ({
@@ -153,8 +167,8 @@ const RailAppMenu: React.FC = () => {
 
   const openDownloads = useCallback(() => {
     openDownloadsDialog();
-    close();
-  }, [openDownloadsDialog, close]);
+    finish();
+  }, [openDownloadsDialog, finish]);
 
   return (
     <>

--- a/web/src/components/panels/__tests__/RailAppMenu.test.tsx
+++ b/web/src/components/panels/__tests__/RailAppMenu.test.tsx
@@ -42,10 +42,10 @@ jest.mock("../../../stores/ModelDownloadStore", () => ({
   useModelDownloadStore: () => ({ downloads: {}, openDialog: jest.fn() })
 }));
 
-const renderMenu = () =>
+const renderMenu = (onAction?: () => void) =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <RailAppMenu />
+      <RailAppMenu onAction={onAction} />
     </ThemeProvider>
   );
 
@@ -85,4 +85,26 @@ it("keeps Dashboard on its route (not a tab)", async () => {
 
   expect(useWorkspaceTabsStore.getState().tabs).toHaveLength(0);
   expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+});
+
+it("reports the pick to its host so the mobile sheet can dismiss", async () => {
+  const user = userEvent.setup();
+  const onAction = jest.fn();
+  renderMenu(onAction);
+
+  await user.click(screen.getByRole("button", { name: /open app menu/i }));
+  await user.click(screen.getByRole("menuitem", { name: /settings/i }));
+
+  expect(onAction).toHaveBeenCalledTimes(1);
+});
+
+it("does not report a dismissed menu as a pick", async () => {
+  const user = userEvent.setup();
+  const onAction = jest.fn();
+  renderMenu(onAction);
+
+  await user.click(screen.getByRole("button", { name: /open app menu/i }));
+  await user.keyboard("{Escape}");
+
+  expect(onAction).not.toHaveBeenCalled();
 });

--- a/web/src/components/properties/ImageSizePresetsMenu.tsx
+++ b/web/src/components/properties/ImageSizePresetsMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from "../ui_primitives";
 import Search from "@mui/icons-material/Search";
 import { IMAGE_SIZE_PRESETS, PresetOption } from "../../config/constants";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 
 interface ImageSizePresetsMenuProps {
   anchorEl: null | HTMLElement;
@@ -31,6 +32,8 @@ export const ImageSizePresetsMenu: React.FC<ImageSizePresetsMenuProps> = ({
   currentHeight
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
+  // Skipped on touch, where the virtual keyboard would cover the preset list.
+  const autoFocusEnabled = useAutoFocusEnabled();
 
   const handleClose = useCallback(() => {
     onClose();
@@ -117,7 +120,7 @@ export const ImageSizePresetsMenu: React.FC<ImageSizePresetsMenuProps> = ({
           value={searchQuery}
           onChange={handleSearchChange}
           onKeyDown={handleSearchKeyDown}
-          autoFocus
+          autoFocus={autoFocusEnabled}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -148,6 +148,10 @@ const PropertyDropzone = ({
       ".dropzone:hover .asset-actions": {
         opacity: 1
       },
+      // Touch devices have no hover; keep the asset actions reachable.
+      "@media (pointer: coarse)": {
+        ".asset-actions": { opacity: 1 }
+      },
       ".asset-action-button": {
         backgroundColor: theme.vars.palette.c_scrim,
         color: theme.vars.palette.grey[100],

--- a/web/src/components/properties/__tests__/ImageSizePresetsMenu.test.tsx
+++ b/web/src/components/properties/__tests__/ImageSizePresetsMenu.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import { ImageSizePresetsMenu } from "../ImageSizePresetsMenu";
+
+const mockMatchMedia = (coarse: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes("pointer: coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+const renderMenu = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ImageSizePresetsMenu
+        anchorEl={document.body}
+        open
+        onClose={jest.fn()}
+        onSelect={jest.fn()}
+        currentWidth={512}
+        currentHeight={512}
+      />
+    </ThemeProvider>
+  );
+
+describe("ImageSizePresetsMenu search focus", () => {
+  const original = window.matchMedia;
+  let focusSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // MUI's Menu moves focus to its list right after mount, so assert on the
+    // input's own focus call rather than the final activeElement.
+    focusSpy = jest.spyOn(HTMLInputElement.prototype, "focus");
+  });
+
+  afterEach(() => {
+    focusSpy.mockRestore();
+    window.matchMedia = original;
+  });
+
+  it("focuses the search field on a fine pointer", () => {
+    mockMatchMedia(false);
+    renderMenu();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("leaves the search field unfocused on a coarse pointer", () => {
+    mockMatchMedia(true);
+    renderMenu();
+    // The virtual keyboard would otherwise cover the preset list.
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/search/SearchInput.tsx
+++ b/web/src/components/search/SearchInput.tsx
@@ -9,6 +9,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import { useKeyPressedStore } from "../../stores/KeyPressedStore";
 import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 import { isMac } from "../../utils/platform";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import type { NodeMetadata } from "../../stores/ApiTypes";
 
 const styles = (theme: Theme) =>
@@ -145,6 +146,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
 }) => {
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
+  const autoFocusEnabled = useAutoFocusEnabled();
   const [localSearchTerm, setLocalSearchTerm] = useState(externalSearchTerm);
 
   // Debounced search - store handles search ID management internally
@@ -173,11 +175,13 @@ const SearchInput: React.FC<SearchInputProps> = ({
     inputRef.current?.focus();
   }, [resetSearch]);
 
+  // Skipped on touch, where the virtual keyboard would cover the menu that
+  // just opened.
   React.useEffect(() => {
-    if (focusSearchInput) {
+    if (focusSearchInput && autoFocusEnabled) {
       inputRef.current?.focus();
     }
-  }, [focusSearchInput]);
+  }, [focusSearchInput, autoFocusEnabled]);
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/web/src/components/search/__tests__/SearchInput.test.tsx
+++ b/web/src/components/search/__tests__/SearchInput.test.tsx
@@ -20,9 +20,31 @@ jest.mock("../../../stores/KeyPressedStore", () => ({
 const renderWithTheme = (ui: React.ReactElement) =>
   render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
 
+
+// `useAutoFocusEnabled` reads `(pointer: coarse)`; jsdom has no matchMedia.
+const mockMatchMedia = (coarse: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes("pointer: coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
 describe("SearchInput", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    mockMatchMedia(false);
+  });
+
   afterEach(() => {
     jest.useRealTimers();
+    window.matchMedia = originalMatchMedia;
   });
 
   it("lets the local draft lead while typing and debounces onSearchChange", () => {
@@ -95,5 +117,23 @@ describe("SearchInput", () => {
     fireEvent.click(screen.getByTestId("search-clear-btn"));
     expect(input.value).toBe("");
     expect(onSearchChange).toHaveBeenLastCalledWith("");
+  });
+
+  it("skips the mount focus on a coarse pointer", () => {
+    mockMatchMedia(true);
+    renderWithTheme(
+      <SearchInput onSearchChange={jest.fn()} searchTerm="" focusSearchInput />
+    );
+
+    expect(screen.getByTestId("search-input-field")).not.toHaveFocus();
+  });
+
+  it("focuses on mount on a fine pointer", () => {
+    mockMatchMedia(false);
+    renderWithTheme(
+      <SearchInput onSearchChange={jest.fn()} searchTerm="" focusSearchInput />
+    );
+
+    expect(screen.getByTestId("search-input-field")).toHaveFocus();
   });
 });

--- a/web/src/components/sketch/Inspector/CreateGeneratedLayerDialog.tsx
+++ b/web/src/components/sketch/Inspector/CreateGeneratedLayerDialog.tsx
@@ -29,6 +29,7 @@ import {
   Toast
 } from "../../ui_primitives";
 import { useCreateGeneratedLayer } from "../../../hooks/sketch/useCreateGeneratedLayer";
+import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 
 const IMAGE_OUTPUT_TYPES = new Set([
   "nodetool.output.ImageOutput",
@@ -52,7 +53,9 @@ const ROW_GAP_PX = 4;
 
 const dialogStyles = (theme: Theme) =>
   css({
-    minWidth: 560,
+    // Never wider than the viewport: the dialog is reachable on phones, where
+    // a hard 560px min forces the page to scroll sideways.
+    minWidth: "min(560px, 100vw - 32px)",
     maxWidth: 720
   });
 
@@ -130,6 +133,7 @@ const CreateGeneratedLayerDialogBody: React.FC<{
 }> = ({ onClose, onCreated }) => {
     const theme = useTheme();
     const [filter, setFilter] = useState("");
+    const autoFocusEnabled = useAutoFocusEnabled();
     const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(
       null
     );
@@ -244,8 +248,10 @@ const CreateGeneratedLayerDialogBody: React.FC<{
               Pick any workflow whose graph has an image output node.
             </Caption>
 
+            {/* autoFocus is skipped on touch, where the virtual keyboard
+                would cover the workflow list below. */}
             <TextInput
-              autoFocus
+              autoFocus={autoFocusEnabled}
               compact
               size="small"
               placeholder="Search workflows…"

--- a/web/src/components/timeline/AddClipMenu.tsx
+++ b/web/src/components/timeline/AddClipMenu.tsx
@@ -39,6 +39,7 @@ import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
 import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectGenJob";
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
+import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import ImageModelSelect from "../properties/ImageModelSelect";
 import VideoModelSelect from "../properties/VideoModelSelect";
 import TTSModelSelect from "../properties/TTSModelSelect";
@@ -93,7 +94,8 @@ const trackMediaType = (
 
 const menuStyles = (theme: Theme) =>
   css({
-    width: 360,
+    // A hard 360px overflows the narrowest phones once the padding is added.
+    width: "min(360px, calc(100vw - 32px))",
     padding: theme.spacing(1)
   });
 
@@ -309,6 +311,7 @@ export const AddClipMenu: React.FC<AddClipMenuProps> = memo(
     // ── Direct-gen prompt state ────────────────────────────────────────────
     const lastModel = useLastDirectGenModel(directGenKind ?? "image");
     const [prompt, setPrompt] = useState("");
+    const autoFocusEnabled = useAutoFocusEnabled();
     const [directProvider, setDirectProvider] = useState<string | undefined>(
       undefined
     );
@@ -564,6 +567,8 @@ export const AddClipMenu: React.FC<AddClipMenuProps> = memo(
               {directGenKind !== null && (
                 <>
                   <FlexColumn gap={0.5} data-testid="add-clip-prompt-section">
+                    {/* autoFocus is skipped on touch, where the virtual
+                        keyboard would cover the rest of the menu. */}
                     <TextInput
                       value={prompt}
                       onChange={(e) => setPrompt(e.target.value)}
@@ -579,7 +584,7 @@ export const AddClipMenu: React.FC<AddClipMenuProps> = memo(
                       minRows={2}
                       maxRows={5}
                       compact
-                      autoFocus
+                      autoFocus={autoFocusEnabled}
                       fullWidth
                       inputProps={{
                         "aria-label": "Prompt",

--- a/web/src/components/ui_primitives/HoverActionGroup.tsx
+++ b/web/src/components/ui_primitives/HoverActionGroup.tsx
@@ -69,6 +69,9 @@ export const HoverActionGroup: React.FC<HoverActionGroupProps> = memo(
       if (revealOnFocusWithin) {
         revealStyles["&:focus-within"] = { opacity: 1 };
       }
+      // A pointer that cannot hover never reveals the actions, leaving them
+      // invisible but still tappable. Show them outright instead.
+      revealStyles["@media (hover: none)"] = { opacity: 1 };
     }
 
     return (

--- a/web/src/components/ui_primitives/__tests__/HoverActionGroup.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/HoverActionGroup.test.tsx
@@ -35,6 +35,18 @@ describe("HoverActionGroup", () => {
     expect(box).toHaveStyle({ opacity: "1" });
   });
 
+  // A pointer without hover can never trigger the reveal, so the group must
+  // opt out of hiding entirely there.
+  it("reveals the actions where hover is unavailable", () => {
+    renderGroup();
+    // Emotion inserts through the CSSOM, so the <style> tags read as empty.
+    const sheets = Array.from(document.styleSheets)
+      .flatMap((sheet) => Array.from(sheet.cssRules))
+      .map((rule) => rule.cssText)
+      .join("");
+    expect(sheets).toMatch(/@media \(hover: none\) \{[^}]*opacity: 1/);
+  });
+
   it("applies configured transition duration", () => {
     const { container } = renderGroup({ transitionMs: 300 });
     const box = container.firstChild as HTMLElement;

--- a/web/src/components/widgets/ImageComparer.tsx
+++ b/web/src/components/widgets/ImageComparer.tsx
@@ -165,8 +165,10 @@ const ImageComparer: React.FC<ImageComparerProps> = ({
   const [loadedMetadataA, setLoadedMetadataA] = useState<ImageMetadata>({});
   const [loadedMetadataB, setLoadedMetadataB] = useState<ImageMetadata>({});
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+  // Pointer events, not mouse events: on touch the comparer was inert, since
+  // the divider only ever followed a mouse.
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
       if (!containerRef.current) {return;}
 
       const rect = containerRef.current.getBoundingClientRect();
@@ -184,13 +186,18 @@ const ImageComparer: React.FC<ImageComparerProps> = ({
     [mode]
   );
 
-  const handleMouseEnter = useCallback(() => {
+  const handlePointerEnter = useCallback(() => {
     setIsHovering(true);
   }, []);
 
-  const handleMouseLeave = useCallback(() => {
+  const handlePointerLeave = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     setIsHovering(false);
-    setPosition(50);
+    // A touch pointer "leaves" the moment the finger lifts. Recentering then
+    // would undo the comparison the user just dragged to, so only a mouse
+    // leaving resets it.
+    if (e.pointerType === "mouse") {
+      setPosition(50);
+    }
   }, []);
 
   const toggleMode = useCallback((e: React.MouseEvent) => {
@@ -241,6 +248,8 @@ const ImageComparer: React.FC<ImageComparerProps> = ({
   }, [mode, position]);
 
   const cursorStyle = mode === "horizontal" ? "ew-resize" : "ns-resize";
+  // Claim the drag axis for the divider; the other axis still scrolls the page.
+  const touchAction = mode === "horizontal" ? "pan-y" : "pan-x";
 
   const dividerStyle = useMemo(() => {
     if (mode === "horizontal") {
@@ -267,10 +276,10 @@ const ImageComparer: React.FC<ImageComparerProps> = ({
       <div
         ref={containerRef}
         className="comparer-container"
-        onMouseMove={handleMouseMove}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        style={{ cursor: cursorStyle }}
+        onPointerMove={handlePointerMove}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        style={{ cursor: cursorStyle, touchAction }}
       >
         {/* Image B (background - full image) */}
         <div className="image-layer image-b">

--- a/web/src/components/widgets/__tests__/ImageComparer.test.tsx
+++ b/web/src/components/widgets/__tests__/ImageComparer.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import ImageComparer from "../ImageComparer";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const renderComparer = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ImageComparer imageA="a.png" imageB="b.png" labelA="A" labelB="B" />
+    </ThemeProvider>
+  );
+
+const container = () =>
+  document.querySelector(".comparer-container") as HTMLElement;
+
+// jsdom has no PointerEvent, and fireEvent drops the properties it cannot set
+// on a plain Event, so build the event by hand. React derives enter/leave from
+// pointerover/pointerout.
+const POINTER_EVENT_NAME = {
+  enter: "pointerover",
+  leave: "pointerout",
+  move: "pointermove"
+} as const;
+
+const firePointer = (
+  el: HTMLElement,
+  kind: keyof typeof POINTER_EVENT_NAME,
+  init: { pointerType: string; clientX?: number; clientY?: number }
+) => {
+  const event = new MouseEvent(POINTER_EVENT_NAME[kind], {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0
+  });
+  Object.defineProperty(event, "pointerType", { value: init.pointerType });
+  fireEvent(el, event);
+};
+
+// jsdom reports a zero-sized box; give the container a real one so the
+// percentage math is meaningful.
+const stubRect = (el: HTMLElement) => {
+  el.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, width: 200, height: 100 }) as DOMRect;
+};
+
+describe("ImageComparer", () => {
+  it("moves the divider for a touch pointer", () => {
+    renderComparer();
+    const el = container();
+    stubRect(el);
+
+    firePointer(el, "enter", { pointerType: "touch" });
+    firePointer(el, "move", { pointerType: "touch", clientX: 50, clientY: 50 });
+
+    const divider = document.querySelector(".divider-line") as HTMLElement;
+    expect(divider).toBeInTheDocument();
+    expect(divider.style.left).toBe("25%");
+  });
+
+  it("keeps the dragged position after a touch lifts", () => {
+    renderComparer();
+    const el = container();
+    stubRect(el);
+
+    firePointer(el, "enter", { pointerType: "touch" });
+    firePointer(el, "move", { pointerType: "touch", clientX: 50, clientY: 50 });
+    firePointer(el, "leave", { pointerType: "touch" });
+
+    firePointer(el, "enter", { pointerType: "touch" });
+    const divider = document.querySelector(".divider-line") as HTMLElement;
+    expect(divider.style.left).toBe("25%");
+  });
+
+  it("recenters when a mouse leaves", () => {
+    renderComparer();
+    const el = container();
+    stubRect(el);
+
+    firePointer(el, "enter", { pointerType: "mouse" });
+    firePointer(el, "move", { pointerType: "mouse", clientX: 50, clientY: 50 });
+    firePointer(el, "leave", { pointerType: "mouse" });
+
+    firePointer(el, "enter", { pointerType: "mouse" });
+    const divider = document.querySelector(".divider-line") as HTMLElement;
+    expect(divider.style.left).toBe("50%");
+  });
+
+  it("switches the drag axis with the mode toggle", () => {
+    renderComparer();
+    const el = container();
+    stubRect(el);
+
+    fireEvent.click(screen.getByRole("button", { name: /switch to vertical/i }));
+
+    firePointer(el, "enter", { pointerType: "touch" });
+    firePointer(el, "move", { pointerType: "touch", clientX: 50, clientY: 25 });
+
+    const divider = document.querySelector(".divider-line") as HTMLElement;
+    expect(divider.style.top).toBe("25%");
+  });
+});


### PR DESCRIPTION
Follow-up to #4531, #4532, #4533 and #4534. Those four PRs each fixed one instance of a recurring mobile-web bug; this one sweeps the rest of `web/src/components/` for the same kinds.

The kinds, as the reference PRs define them:

1. **Auto-focus on touch** — `autoFocus` or a mount-time `.focus()` raises the virtual keyboard over the list the panel just opened to show. Gated on `useAutoFocusEnabled()`. Focus the user *did* ask for (rename fields, a Find bar, a tapped path input) is left alone.
2. **No way back from hidden chrome** — a panel hidden behind a keyboard shortcut, or pinned open with its toggle suppressed, on a device with neither a keyboard nor the room.
3. **Dead controls** — a handler that does not change what it claims to.
4. **Fixed widths** — hard pixel rails, popovers and dialogs that overflow a phone viewport.

A fifth kind fell out of the same lens: **controls revealed only by `:hover`**, which on a touch device stay invisible while remaining tappable — in one case an unlabelled destructive button sitting on top of a timestamp.

## Changes

**Reachability (kinds 2, 3 and hover)**

- `RailAppMenu` — Settings, Help, Downloads, Models, Packages, Collections, Costs, Tutorials, Examples, Entities, Workspaces, Dashboard — was rendered only by the desktop branch of `PanelLeft`. Mobile gets `MobilePanelLeft`, which has no vertical toolbar, and nothing else in the tree renders the menu: `OpenMenu`'s "+" only opens documents, `CommandMenu` is keyboard-only. **Every app page was unreachable on mobile web.** The sheet header now carries it, and picking an item dismisses the sheet.
- `ImageComparer` was wired to `onMouseMove/Enter/Leave`, so the divider never moved on touch — inert in the asset viewer, the compare dialog, the preview grid and `CompareImagesNode`. Now on pointer events, claiming only the drag axis so the page still scrolls; recenter-on-leave stays mouse-only, since a touch pointer leaves the instant the finger lifts.
- `HoverActionGroup`, the shared reveal primitive, left its children at `opacity: 0` forever on a coarse pointer. Fixed at the primitive, plus ~20 hand-rolled instances: image/output node copy-download-viewer buttons, preview and dataframe actions, property and asset icons, the comment color picker, history prev/next, node-library favorites, chat thread delete, add-to-canvas, log row copy.

**Layout (kind 4)** — the fullscreen Assets page pinned a 300px folder tree open *and* hid the toggle that would close it, leaving ~75px of grid at 375px. The chat rendered a 280px todo rail and a 300px memory rail beside the conversation. Models, Package Manager, the compositor and the color picker each docked a fixed rail. All now stack or step aside below `sm`. Six popovers and dialogs with hard 360–560px widths clamp to the viewport.

**Focus (kind 1)** — `SearchInput` (which defaulted `focusSearchInput` to true, covering the node menu and model-menu dialog), the chain-editor node picker, the sketch generated-layer filter, the timeline direct-gen prompt, and the image-size preset search.

## Testing

`npm run lint` and `npm run typecheck` clean; `npx jest` in `web/` green at **1028 suites / 12,193 tests**. New cases cover the two focus gates, the `HoverActionGroup` reveal, the `RailAppMenu` dismiss-on-pick (and *not* on Escape), the assets folder-pane fallback, and four for the comparer's pointer handling.

## Notes for the reviewer

- Kind 3 turned up only the one finding (`ImageComparer`) across the whole sweep — every other suspect toggle traced to real state.
- Deliberately **not** fixed, as layout reworks rather than contained bugs: the timeline editor's three-column middle row, and the Puck app builder / `AppBuilderShell`, which aren't phone-usable at any width.
- `styles/mobile.css` has a dead selector — `.mobile .floating-node-menu .type-filter-container` matches nothing, since that wrapper is a bare `<div>`. The intent to hide the node-menu type filters on phones is not in effect. Left alone; the popover width is clamped instead, so it's usable either way.