### PR TITLE
docs: rewrite the getting-started pages for newcomers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,17 @@
 ---
 layout: page
 title: "Quick Start"
-description: "Install NodeTool, run a template, ship a Mini-App."
+description: "Install NodeTool, run a ready-made example, change it, and turn it into a small app anyone can use."
 ---
 
-Install, open a template, run it, edit it, ship it. About 10 minutes, no account required.
+Install NodeTool, open a ready-made example, run it, change it, and turn it into
+a form anyone can use. About 10 minutes. No account required.
 
-Prefer to watch first? Here's a full workflow running on the canvas — see the
-[Tutorials](tutorials.md) page for all of them.
+This page assumes you have never used a tool like this. Every term is explained
+the first time it appears, and the [Glossary](glossary.md) covers the rest.
+
+Prefer to watch first? Here is a finished example running. The
+[Tutorials](tutorials.md) page has more.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/first-workflow.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/first-workflow.mp4' | relative_url }}" type="video/mp4">
@@ -15,112 +19,179 @@ Prefer to watch first? Here's a full workflow running on the canvas — see the
 
 ## Step 1 — Install
 
-### Requirements
+### Will it run on my computer?
 
-| Component | Minimum | Recommended |
+| | Minimum | Better |
 |-----------|---------|-------------|
-| **RAM** | 8 GB | 16 GB+ |
-| **Disk** | 10 GB free | 50 GB+ for models |
-| **GPU** | None | 8 GB+ VRAM for local inference |
-| **OS** | macOS 13+, Windows 10+, Ubuntu 22+ | Latest |
+| **Memory (RAM)** | 8 GB | 16 GB or more |
+| **Free disk space** | 10 GB | 50 GB if you download AI models |
+| **Graphics card (GPU)** | Not needed | 8 GB or more of video memory |
+| **Operating system** | macOS 13+, Windows 10+, Ubuntu 22+ | The latest version |
 
-No GPU? Use cloud providers with your keys. See [hardware notes](installation.md#what-different-tasks-need).
+A graphics card only matters if you want AI models to run on your own machine.
+Without one, NodeTool sends the work to an online AI service instead, and
+everything on this page still works. See the
+[hardware notes](installation.md#what-different-tasks-need).
 
-### Install
+### Install it
 
-1. Download from [nodetool.ai](https://nodetool.ai).
+1. Download NodeTool from [nodetool.ai](https://nodetool.ai).
 2. Run the installer.
-3. Launch. No setup wizard.
+3. Open the app. There is no setup wizard.
 
-Providers: open **Settings → Providers** and paste a key from [OpenAI](https://platform.openai.com), [Anthropic](https://www.anthropic.com), or [Google](https://ai.google.dev). One key is enough to run the templates below.
+Step-by-step instructions per operating system are on the
+[Installation](installation.md) page.
+
+### Connect it to an AI service
+
+NodeTool has no AI model built in. You point it at one, and the fastest way is
+an **API key**: a long password-like string you copy from an AI company's
+website. It lets NodeTool send requests on your account, and that company bills
+you for what you use.
+
+Open **Settings → Providers** and paste a key from
+[OpenAI](https://platform.openai.com),
+[Anthropic](https://www.anthropic.com), or
+[Google](https://ai.google.dev). One key is enough for the examples below.
+
+Want the AI to run on your own machine instead, with no account and no bill?
+That works too, and it needs a download of several gigabytes per model. See
+[Models & Providers](models-and-providers.md).
 
 ---
 
-## Step 2 — Run a workflow
+## Step 2 — Run a ready-made example
 
-Open a template from the Dashboard.
+Everything you build lives on a **canvas**: a large open work area where you
+place boxes and draw lines between them.
+
+- Each box is a **node**, and it does one job: write some text, make an image,
+  save a file.
+- A line carries the result of one node into the next one. Lines are also called
+  **connections**.
+- The whole picture, boxes and lines together, is a **workflow**.
+
+You don't have to build one yet. NodeTool ships with **templates**: finished
+workflows you can open and run as they are. Find them on the Dashboard, the
+screen you land on when the app opens.
 
 ### Movie Posters
 
-1. Dashboard → Templates → **Movie Posters**.
-2. The graph opens: inputs left, agent middle, image generator right, preview last.
-3. Fill the inputs:
+1. Go to Dashboard → Templates → **Movie Posters**.
+2. The workflow opens. Read it left to right: the boxes where you type go on the
+   left, the AI in the middle, the image maker next, and the finished picture on
+   the right.
+3. Type into the boxes on the left:
    - **Title**: Ocean Depths
    - **Genre**: Sci-Fi Thriller
    - **Audience**: Adults who love mystery
-4. Select a model for the Agent and List Generator (requires provider setup).
-5. Press <kbd>Ctrl/⌘ + Enter</kbd> to run.
+4. Two nodes, Agent and List Generator, ask you to pick a model. A **model** is
+   the specific AI you want to use, such as GPT-5 or Claude. Pick any one from
+   the dropdown. This is the step that needs the API key from above.
+5. Press <kbd>Ctrl/⌘ + Enter</kbd> to run it.
 
-Nodes light up as they process. Outputs stream into the Preview node on the right — that's your finished poster.
+Nodes light up one at a time as they work. Text and images appear inside the
+Preview node on the right as they are produced, so you can watch the poster
+being made instead of waiting for a finished file.
 
 ### Creative Story Ideas
 
 ![Editor](assets/screenshots/editor-empty-state.png)
 
-1. Dashboard → Templates → **Creative Story Ideas**.
-2. Set inputs:
+1. Go to Dashboard → Templates → **Creative Story Ideas**.
+2. Type into the boxes on the left:
    - **Genre**: Cyberpunk
    - **Character**: Rogue AI detective
    - **Setting**: Neon-lit underwater city
-3. Select a model for the Agent and List Generator (requires provider setup).
-4. Press <kbd>Ctrl/⌘ + Enter</kbd> to run.
+3. Pick a model for the Agent and List Generator nodes.
+4. Press <kbd>Ctrl/⌘ + Enter</kbd> to run it.
 
 ---
 
-## Step 3 — Edit
+## Step 3 — Change something
 
-The graph is yours to change. Edit, re-run, repeat — every run reflects the current graph.
+The template is now yours. Change it, run it again, and see what happens. Every
+run uses whatever is on the canvas at that moment, so there is nothing to
+rebuild or recompile.
 
-1. Change an input or swap a model, then press <kbd>Ctrl/⌘ + Enter</kbd> to re-run.
-2. Save your version with <kbd>Ctrl/⌘ + S</kbd>.
-3. Click a node to inspect it. Hover an edge to see the data flowing through. Press `Space`, search "Preview", drop one anywhere on the canvas to watch any value.
+1. Change one of your typed inputs, or pick a different model, then press
+   <kbd>Ctrl/⌘ + Enter</kbd> again.
+2. Press <kbd>Ctrl/⌘ + S</kbd> to save your version.
+3. Click a node to see its settings in the panel on the right. Hover over a line
+   to see the data passing through it.
+4. To watch any value anywhere in the workflow, press `Space` to open the node
+   list, search for "Preview", and drop one onto the canvas. Connect a line into
+   it and it will show whatever arrives.
 
-### Optional node packs
+### Finding more nodes
 
-NodeTool ships hundreds of nodes. To keep the node menu focused, advanced and niche namespaces — file system, databases, document conversion, web scraping, code execution, and more — are grouped into **optional packs**, and provider nodes follow your API keys.
+NodeTool comes with hundreds of nodes. Showing all of them at once would make
+the list unusable, so the more specialised ones are grouped into **packs** that
+start switched off. Turning a pack on adds its nodes to the list.
 
-Press `Space` to open the node menu, then click **Optional packs** at the bottom of the namespace list.
+Press `Space` to open the node list, then click **Optional packs** at the bottom
+of the category list.
 
 ![Optional node packs](assets/screenshots/node-menu-optional-packs.png)
 
-- **Categories** — turn on a group (Documents, Image & Graphics, Web & Scraping, …) to reveal its nodes in the menu. Search always finds every node, even when its pack is off — so hiding a pack only declutters browsing, it never hides a node from search.
-- **Providers** — a provider's nodes appear once you add its API key. The key is the switch: set it in **Settings → API Keys** (or use **Add API key** right here) and the provider's pack enables automatically, no restart. Locally-run packs like Transformers.js need no key, so they keep a manual toggle.
+- **Categories** — switch on a group (Documents, Image & Graphics, Web &
+  Scraping, and others) to show its nodes while browsing. Search always finds
+  every node, even in a pack that is switched off, so nothing is ever truly
+  hidden.
+- **Providers** — nodes for an AI company appear as soon as you add that
+  company's API key, in **Settings → API Keys** or with the **Add API key**
+  button right here. No restart needed. Packs that run on your own machine, like
+  Transformers.js, need no key and have a normal on/off switch.
 
-Opening a workflow that uses a node from a disabled pack enables that pack for you, so shared workflows just work.
+Opening a workflow that someone else made switches on any pack it needs, so
+shared workflows run without setup.
 
 ---
 
-## Step 4 — Build an app
+## Step 4 — Turn it into an app
 
-A Mini-App hides the graph and exposes inputs and outputs only — a form anyone can use without touching the canvas.
+A **Mini-App** is the same workflow with the boxes and lines hidden. What's left
+is a plain form: fill in the fields, press a button, get the result. Hand it to
+someone who should never have to look at a canvas.
 
 1. Open the workflow.
 2. Click **Mini-App** in the toolbar.
-3. Fill the inputs and run. Same workflow, no graph.
+3. Fill in the fields and run it. Same workflow underneath, no canvas.
 
-Custom UI? See [Mini Apps](mini-apps.md) for what apps solve and how they work,
-[Building Mini Apps](mini-apps-guide.md) for recipes, and
+To design the form yourself, see [Mini Apps](mini-apps.md) for what they are,
+[Building Mini Apps](mini-apps-guide.md) for worked examples, and
 [App Builder](app-builder.md) for the editor.
 
 ---
 
-## The bigger picture
+## What you just learned
 
-You just ran the loop NodeTool is built around: collect assets, build a workflow, generate outputs, and share them as a Mini-App. Two more editing surfaces plug into the same loop — the [Sketch Editor](sketch-editor.md) for layered still images and the [Video Editor](video-editor.md) for timelines — and everything they produce is an **asset** the others can read. All four surfaces share one asset store and the same model/provider system.
+The four steps above are the loop NodeTool is built around: gather your files,
+build a workflow, produce something, and share it as a Mini-App.
 
-See [Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together) for the full loop and diagram.
+Two other work areas plug into the same loop. The
+[Sketch Editor](sketch-editor.md) is for still images built from layers, the way
+Photoshop works. The [Video Editor](video-editor.md) is for arranging video and
+audio clips over time. Anything any of them produces is a file NodeTool calls an
+**asset**, and all four areas read and write the same set of assets, using the
+same AI services.
+
+[Key Concepts → How everything fits together](key-concepts.md#how-everything-fits-together)
+has the full picture with a diagram.
 
 ---
 
-## Next
+## Where to go next
 
-| Goal | Page |
+| If you want to | Read |
 |------|------|
-| How workflows work | [Key Concepts](key-concepts.md) |
-| Full interface | [User Interface](user-interface.md), [Workflow Editor](workflow-editor.md) |
-| More examples | [Gallery](workflows/), [Cookbook](cookbook.md) |
-| Models and providers | [Models & Providers](models-and-providers.md) |
-| Deploy | [Deployment](deployment.md) |
-| Stuck | [Troubleshooting](troubleshooting.md), [Debugging](workflow-debugging.md) |
+| Understand how workflows work | [Key Concepts](key-concepts.md) |
+| Learn the interface | [User Interface](user-interface.md), [Workflow Editor](workflow-editor.md) |
+| See more examples | [Gallery](workflows/), [Cookbook](cookbook.md) |
+| Choose AI models | [Models & Providers](models-and-providers.md) |
+| Look up a word | [Glossary](glossary.md) |
+| Put a workflow on a server | [Deployment](deployment.md) |
+| Fix something that broke | [Troubleshooting](troubleshooting.md), [Debugging](workflow-debugging.md) |
 
-[Discord](https://discord.gg/WmQTWZRcYE) · [GitHub](https://github.com/nodetool-ai/nodetool/issues) · [Glossary](glossary.md)
+Questions: [Discord](https://discord.gg/WmQTWZRcYE) ·
+[GitHub](https://github.com/nodetool-ai/nodetool/issues)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -106,12 +106,12 @@ How NodeTool runs your workflow – either in the same process, a separate subpr
 ## Infrastructure
 
 ### Server
-The background process that actually runs your workflows. Servers connect to the server and execute jobs.
+The background program that actually runs your workflows. The desktop app starts one on your own machine and talks to it; you never have to think about it unless you're hosting NodeTool for other people.
 
 *Technical: Process that runs workflows and exposes HTTP/WebSocket endpoints (via `nodetool serve`, optionally with `--host`/`--port`).*
 
 ### API Server
-The backend service that handles requests, manages workflows, and coordinates servers.
+The part of the server that answers requests from the app: saving and loading workflows, starting runs, returning results.
 
 *Technical: Node.js HTTP server (via `@nodetool-ai/websocket`) handling REST endpoints such as `/v1/chat/completions` and `/api/workflows`.*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,8 +120,8 @@ More patterns — pipelines, data, RAG, email — in the [Cookbook]({{ '/cookboo
 
 <ol class="step-sequence">
   <li><a href="{{ '/installation' | relative_url }}">Download NodeTool</a> for macOS, Windows, or Linux.</li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-2--run-a-workflow">Open a template, press Run.</a></li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-3--edit">Edit, re-run, ship as a Mini-App.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-2--run-a-ready-made-example">Open a template, press Run.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-3--change-something">Edit, re-run, ship as a Mini-App.</a></li>
 </ol>
 
 ## Explore

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,96 +1,130 @@
 ---
 layout: page
 title: "Install NodeTool on Windows, macOS, or Linux"
-description: "Download NodeTool for Windows, macOS, or Linux — dmg, exe, or AppImage. No setup wizard: Python, Conda, and AI engines install on demand as you need them."
+description: "Download NodeTool for Windows, macOS, or Linux — dmg, exe, or AppImage. No setup wizard: the extra pieces download only when a workflow needs them."
 ---
 
-NodeTool opens on first launch with no setup wizard. Python, Conda, and inference engines install on demand the first time you need them.
+Download, install, open. There is no setup wizard and nothing to configure
+first. The larger pieces some workflows need, such as AI models, download later
+and only when you actually use them.
 
 ---
 
-## Quick start
+## The short version
 
-1. Download from [nodetool.ai](https://nodetool.ai)
+1. Download NodeTool from [nodetool.ai](https://nodetool.ai)
 2. Run the installer
-3. Launch NodeTool
+3. Open NodeTool
 
-The download is a `.dmg` on macOS, `.exe` on Windows, and an AppImage on Linux — see [macOS](#macos), [Windows](#windows), and [Linux](#linux) below for the exact steps and platform notes.
+The file you get is a `.dmg` on macOS, an `.exe` on Windows, and an AppImage on
+Linux. Exact steps for each are below: [macOS](#macos), [Windows](#windows),
+[Linux](#linux).
 
-No local AI stack? Skip the download entirely: open **Settings → Providers** and add a key from [OpenAI](https://platform.openai.com), [Anthropic](https://www.anthropic.com), or [Google](https://ai.google.dev). See [Providers](providers.md).
+You don't need a fast computer. If you'd rather have an online AI service do the
+heavy work, skip every download on this page: open **Settings → Providers**
+and paste an API key from [OpenAI](https://platform.openai.com),
+[Anthropic](https://www.anthropic.com), or [Google](https://ai.google.dev). An
+**API key** is a password-like string from that company's website that lets
+NodeTool use your account there. See [Providers](providers.md).
 
 ---
 
 ## macOS
 
-1. Download the `.dmg` from [nodetool.ai](https://nodetool.ai). Separate builds ship for Apple Silicon (arm64) and Intel (x64) — pick the one matching your Mac (Apple menu → About This Mac).
-2. Open the DMG and drag Nodetool into Applications.
-3. Launch it from Applications. Release builds are code-signed and notarized, so Gatekeeper shouldn't block the first launch.
-4. Recording audio or video in a workflow prompts for microphone/camera permission the first time — approve it to use those nodes.
+1. Download the `.dmg` from [nodetool.ai](https://nodetool.ai). There are two
+   builds: one for Apple Silicon (arm64) and one for Intel (x64). To see which
+   Mac you have, open the Apple menu → About This Mac.
+2. Open the downloaded file and drag Nodetool into your Applications folder.
+3. Open it from Applications. Released builds are signed and approved by Apple,
+   so macOS should not warn you or block the first launch.
+4. If a workflow records audio or video, macOS asks once for microphone or
+   camera permission. Approve it or those nodes won't work.
 
-Apple Silicon Macs run local models through Apple's [MLX framework](models.md#mlx-framework-apple-silicon) automatically; no extra setup.
+On Apple Silicon Macs, AI models that run on your own machine use Apple's
+[MLX framework](models.md#mlx-framework-apple-silicon) automatically. Nothing to
+set up.
 
 ---
 
 ## Windows
 
-1. Download the installer (`Nodetool-Setup-<version>.exe`) from [nodetool.ai](https://nodetool.ai).
-2. Run it. You choose the install directory; the installer adds a desktop shortcut and launches NodeTool when it finishes.
-3. Approve the firewall prompt — NodeTool runs a local server on port 7777 that the UI connects to.
+1. Download the installer (`Nodetool-Setup-<version>.exe`) from
+   [nodetool.ai](https://nodetool.ai).
+2. Run it. You choose where it installs. It then adds a desktop shortcut and
+   opens NodeTool when it finishes.
+3. Approve the Windows firewall prompt. NodeTool runs a small server on your own
+   machine (on port 7777) that the app window talks to. Nothing is exposed to
+   the internet.
 
-The installer and app executable are code-signed. For local model acceleration, keep your NVIDIA driver current.
+Both the installer and the app are code-signed. If you want AI models to run on
+your own graphics card, keep your NVIDIA driver up to date.
 
 ---
 
 ## Linux
 
-1. Download the AppImage from [nodetool.ai](https://nodetool.ai) — it's the only Linux package NodeTool ships today.
-2. Make it executable and run it:
+1. Download the AppImage from [nodetool.ai](https://nodetool.ai). It is the only
+   Linux package NodeTool ships today.
+2. Mark it executable and run it:
    ```bash
    chmod +x Nodetool-*.AppImage
    ./Nodetool-*.AppImage
    ```
-3. There's no install step. The AppImage runs in place — move the file wherever you want it to live.
+3. There is no install step. An AppImage is a single self-contained file that
+   runs wherever you put it.
 
-Prefer Flatpak? The project publishes unsigned CI builds from every push to `main` — see [Flatpak CI Builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml) (not yet on Flathub).
+Prefer Flatpak? Unsigned builds are produced from every change to the project.
+See [Flatpak CI Builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml).
+They are not on Flathub yet.
 
 ---
 
-## What installs on demand
+## What downloads later
 
-The app itself is small. Everything else downloads the first time a workflow needs it:
+The app itself is small. These pieces arrive the first time a workflow needs
+them:
 
-- **Python and Conda** — installs when you run a workflow that uses a Python node (HuggingFace, MLX, Apple integrations). The backend's `PythonStdioBridge` spawns the Python worker only at that point; a workflow built entirely from TypeScript nodes never triggers it. One-time download, roughly 3-5 GB.
-- **Local inference engines** — Ollama and llama.cpp download when you install or run a model that needs them, from the **Models** panel.
-- **Model weights** — each model you install pulls its own weights, typically 4-20 GB depending on the model.
+- **Python and Conda** (about 3-5 GB, once) — some nodes are written in Python
+  rather than JavaScript, and they need this to run. It downloads the first time
+  you run a workflow containing one, such as a HuggingFace, MLX, or Apple
+  integration node. A workflow with no Python nodes never triggers it.
+- **Model runners** — Ollama and llama.cpp are the programs that run AI models
+  on your own machine. They download when you install or run a model that needs
+  one, from the **Models** panel.
+- **The models themselves** — usually 4-20 GB each, depending on the model.
 
-No GPU, or don't want the download? Use a cloud provider with your own API key instead (**Settings → Providers**). See [Providers](providers.md) and [Models & Providers](models-and-providers.md).
+No graphics card, or no room for the downloads? Use an online AI service with
+your own API key instead (**Settings → Providers**). See
+[Providers](providers.md) and [Models & Providers](models-and-providers.md).
 
-### What Different Tasks Need
+### What different tasks need
 
-Hardware maps to inference engine, not to a specific GPU model:
+What matters is the kind of hardware you have, not the exact model of graphics
+card:
 
-| Hardware | Engine | Good for |
+| Your hardware | What runs the model | Good for |
 |----------|--------|----------|
-| NVIDIA GPU | Nunchaku (4-bit diffusion), llama.cpp/GGUF | Image generation, quantized LLMs |
-| Apple Silicon | MLX | LLMs, vision models, Flux ported to MLX |
-| CPU only | llama.cpp, Transformers | Works, slower |
-| No GPU | Cloud providers (BYOK) | Every modality, no download |
+| NVIDIA graphics card | Nunchaku, llama.cpp/GGUF | Making images, running compressed language models |
+| Apple Silicon Mac | MLX | Language models, image understanding, Flux |
+| No graphics card, CPU only | llama.cpp, Transformers | Works, but slowly |
+| Anything, using an online service | The provider's servers | Every kind of task, nothing to download |
 
-See [Supported Models](models.md) for the full engine comparison.
+[Supported Models](models.md) compares all of them.
 
 ---
 
-## Alternative installs
+## Other ways to install
 
-Don't need the desktop app:
+If you don't want the desktop app:
 
-**CLI only** — install the standalone `nodetool` CLI without Electron:
+**Command line only** — install just the `nodetool` command, without the desktop
+app:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nodetool-ai/nodetool/main/install.sh | bash
 ```
 
-or through npm:
+or with npm:
 
 ```bash
 npm install -g @nodetool-ai/cli
@@ -99,16 +133,18 @@ nodetool serve
 
 See the [CLI Reference](cli.md).
 
-**Self-hosted server (Docker)** — run the backend on your own machine or a remote host:
+**On your own server (Docker)** — run NodeTool's backend on your machine or a
+remote host:
 
 ```bash
 cp .env.example .env
 docker compose up -d
 ```
 
-See [Self-Hosted Deployment](self-hosted-deployment.md) for auth modes, upgrades, and remote hosts, or the [Deployment Guide](deployment.md) for the full server/worker picture.
+See [Self-Hosted Deployment](self-hosted-deployment.md) for logins, upgrades,
+and remote hosts, or the [Deployment Guide](deployment.md) for the full picture.
 
-**From source** — for contributors:
+**From source code** — for people who want to change NodeTool itself:
 
 ```bash
 nvm use
@@ -117,23 +153,37 @@ npm run build:packages
 npm run dev
 ```
 
-Requires Node.js 22.22.1 (`.nvmrc`) and, for Python nodes, Python 3.11+ with conda. Full setup in the [repo README](https://github.com/nodetool-ai/nodetool#development-setup).
+Needs Node.js 22.22.1 (see `.nvmrc`) and, for Python nodes, Python 3.11+ with
+conda. Full setup in the
+[repo README](https://github.com/nodetool-ai/nodetool#development-setup).
 
 ---
 
-## Troubleshooting Installation
+## If installing goes wrong
 
-Most install problems are one of these. For workflow and runtime issues once NodeTool is running, see the [Troubleshooting Guide](troubleshooting.md).
+Most install problems are one of these four. For problems that show up once
+NodeTool is running, see [Troubleshooting](troubleshooting.md).
 
-**On-demand Python/Conda setup fails** — needs internet access and about 5 GB free disk space. Restart NodeTool; partial downloads resume automatically.
+**The Python download fails** — it needs an internet connection and about 5 GB
+of free disk space. Restart NodeTool; a partial download picks up where it left
+off.
 
-**GPU not detected** — check your driver with `nvidia-smi` in a terminal (the same check NodeTool's own Help → System Information dialog runs). No dedicated GPU? NodeTool falls back to CPU, or use a cloud provider instead.
+**NodeTool doesn't see my graphics card** — open a terminal and run
+`nvidia-smi`. That is the same check NodeTool runs in Help → System Information.
+If you have no dedicated graphics card, NodeTool falls back to the CPU, or you
+can use an online service instead.
 
-**Model download fails or stalls** — usually disk space or network. See [Model Download Troubleshooting](troubleshooting.md#issue-model-download-fails-or-stalls) for the full list: disk space, resuming, and HuggingFace rate limits.
+**A model download stalls or fails** — usually disk space or network.
+[Model Download Troubleshooting](troubleshooting.md#issue-model-download-fails-or-stalls)
+covers disk space, resuming, and HuggingFace download limits.
 
-**Can't connect to the local server** — approve the firewall prompt for NodeTool's local server (port 7777 by default). Running the self-hosted Docker image instead? See [Deployment Troubleshooting](troubleshooting.md#issue-deployment-fails-or-service-wont-start).
+**The app can't reach its own server** — approve the firewall prompt for
+NodeTool's local server on port 7777. Running the Docker version instead? See
+[Deployment Troubleshooting](troubleshooting.md#issue-deployment-fails-or-service-wont-start).
 
-**Still stuck** — ask in [Discord](https://discord.gg/WmQTWZRcYE) or file a [GitHub Issue](https://github.com/nodetool-ai/nodetool/issues). Include your OS and NodeTool version (Help → About).
+**Still stuck** — ask on [Discord](https://discord.gg/WmQTWZRcYE) or open a
+[GitHub Issue](https://github.com/nodetool-ai/nodetool/issues). Include your
+operating system and your NodeTool version (Help → About).
 
 ---
 
@@ -143,10 +193,13 @@ Most install problems are one of these. For workflow and runtime issues once Nod
 - **macOS** — drag Nodetool from Applications to the Trash.
 - **Linux** — delete the AppImage file.
 
-Settings live in `~/.config/nodetool/settings.yaml` (macOS/Linux) or `%APPDATA%\nodetool\settings.yaml` (Windows) — remove that folder too for a clean reset.
+Your settings live in `~/.config/nodetool/settings.yaml` (macOS and Linux) or
+`%APPDATA%\nodetool\settings.yaml` (Windows). Delete that folder too if you want
+to start completely fresh.
 
 ---
 
-## Next Steps
+## Next
 
-Ready to build your first workflow? See the [Getting Started guide](getting-started.md).
+You're installed. [Quick Start](getting-started.md) walks you through running
+your first workflow.

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -1,111 +1,149 @@
 ---
 layout: page
 title: "Key Concepts"
-description: "Core concepts behind NodeTool workflows, assets, sketches, and timelines."
+description: "The ideas behind NodeTool workflows, assets, sketches, and timelines, explained without jargon."
 ---
 
-The ideas you need to build on the canvas.
+The handful of ideas you need before building anything. No prior experience
+assumed. If you want a quick definition of a single word instead, the
+[Glossary](glossary.md) is faster.
 
 ---
 
 ## What NodeTool is
 
-A node-based canvas for creative AI. You wire **nodes** instead of writing code. Each node is a single operation: a model call, a transform, a tool.
+A visual way to use AI. Instead of writing code, you place boxes on a page and
+draw lines between them. Each box does one job, and the lines carry results from
+one box to the next.
 
-- **Your machine.** Local models run on your hardware. Outputs stay on disk.
-- **Your keys.** Cloud calls go directly to OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, and others. No credit markup.
-- **Mixed.** Local and cloud models in the same graph.
-- **Open.** AGPL-3.0. Self-host the same code we host.
+- **It runs on your computer.** Models that run locally use your own hardware,
+  and what they produce stays on your disk.
+- **You bring your own accounts.** When a workflow uses an online AI service
+  such as OpenAI, Anthropic, Gemini, FAL, KIE, or Replicate, the request goes
+  straight from your machine to that company and they bill you their normal
+  price. NodeTool adds nothing on top.
+- **You can mix the two.** One workflow can use a local model for one step and
+  an online service for the next.
+- **It's open source.** Licensed AGPL-3.0. The code we host is the code you can
+  run yourself.
 
 ---
 
-## Building blocks
+## The building blocks
 
 ### Nodes
 
-A **node** does one thing.
+A **node** is one box that does one thing.
 
-| Node | Does | Example |
+| Node | What it does | Example |
 |------|------|---------|
-| **Image Generator** | Image from text | "Sunset over mountains" → image |
-| **Agent** | Plans and executes a multi-step task | "Summarize this document" → structured summary |
-| **TextToSpeech** | Text → audio | Blog post → narration |
-| **Filter** | Drop items that don't match | Conditional branching |
+| **Image Generator** | Turns a description into a picture | "Sunset over mountains" → an image |
+| **Agent** | Works out the steps for a task and carries them out | "Summarize this document" → an organized summary |
+| **TextToSpeech** | Reads text aloud | A blog post → an audio file |
+| **Filter** | Throws away items that don't match a rule | Keep only the good results |
 
-Each node has inputs (left), outputs (right), and settings (right panel when selected).
+Every node takes things in on its left side, sends results out its right side,
+and has settings that appear in the panel on the right when you click it.
 
 ### Workflows
 
-A **workflow** is connected nodes. When you run it, inputs enter on the left, each node executes when its inputs are ready, results stream into preview and output nodes on the right.
+A **workflow** is a set of nodes joined by lines. When you run it, your input
+enters on the left, each node starts as soon as everything it needs has arrived,
+and results appear on the right as they are produced.
 
-Examples:
-- Prompt → image model → save
-- PDF → chunk → index → search → answer
-- Story → characters → portraits → video
+Examples of what a workflow can be:
 
-Workflows are the automation layer. Use them when you want a repeatable pipeline: generate media, transform files, call models, index documents, or prepare assets for another editor surface.
+- A description, into an image model, saved as a file.
+- A PDF, split into pieces, filed away, then searched to answer a question.
+- A story, turned into character descriptions, then portraits, then a video.
+
+Reach for a workflow when you want to do the same thing repeatedly: produce
+media, convert files, ask a model something, index documents, or prepare
+material for one of the other editors below.
 
 ### Connections
 
-Lines between ports. Types are checked — image outputs only connect to image inputs. Drag from an output port to an input port. Hover to inspect data in flight.
+The lines between nodes. Drag from a node's output on the right to another
+node's input on the left. NodeTool checks that the two ends match, so an image
+output only connects to an input that accepts images and you can't wire
+something nonsensical. Hover over a line to see what is passing through it.
 
 ### Assets
 
-An **asset** is a stored file: image, video, audio, PDF, text file, 3D model, or any other media a node can read or write. Assets live in the Asset Explorer and can be reused across workflows, sketches, timelines, and chats.
+An **asset** is any file NodeTool stores for you: an image, video, audio clip,
+PDF, text file, 3D model, or anything else a node can read or write. Assets live
+in the Asset Explorer and can be used again in any workflow, sketch, timeline,
+or chat.
 
-Assets are the shared material between surfaces:
+Assets are the common currency between the different editors:
 
-- Drop an image asset onto the workflow canvas to create an image input.
-- Save a workflow output as an asset so you can use it later.
-- Drag video, audio, or image assets onto a timeline as clips.
-- Open an image asset in the Sketch Editor for painting, masking, or layered edits.
-- Put document assets in collections for indexing and RAG.
+- Drag an image asset onto a workflow and it becomes an input.
+- Save a workflow's result as an asset to use later.
+- Drag video, audio, or images onto a timeline to become clips.
+- Open an image asset in the Sketch Editor to paint on it.
+- Group document assets into a collection so an AI can search them.
 
 ### Sketches
 
-A **sketch** is a layered image document. It is for painting, masking, retouching, compositing, and generating image layers in place.
+A **sketch** is an image made of stacked layers, the way Photoshop or GIMP work.
+Use it to paint, hide parts of an image, retouch, combine images, or have AI
+generate a layer in place.
 
-Sketches sit between manual editing and workflow automation:
+A sketch sits between editing by hand and automating with a workflow:
 
-- Start with a blank canvas or open an existing image asset.
-- Paint or build up layers by hand.
-- Bind a layer to an image workflow so it can regenerate when inputs change.
-- Render the sketch back into an image asset.
-- Use the rendered image in a workflow or timeline.
+- Start from a blank page or an image you already have.
+- Paint, or build the picture up in layers.
+- Attach a layer to an image workflow so it regenerates when its inputs change.
+- Flatten the sketch back into an ordinary image asset.
+- Use that image in a workflow or a timeline.
 
 ### Timelines
 
-A **timeline** is a multi-track media sequence. It holds clips arranged over time: video, audio, still images, overlays, and generated clips.
+A **timeline** arranges media over time on parallel tracks, the way a video
+editor does. It holds video, audio, still images, overlays, and clips generated
+by AI.
 
-Timelines are where outputs become finished media:
+Timelines are where results become finished media:
 
-- Drag existing assets into tracks as imported clips.
-- Add a generated clip backed by a workflow.
-- Trim, split, reorder, and layer clips.
-- Regenerate stale generated clips when the bound workflow or parameters change.
-- Export the sequence to a video asset.
+- Drag existing assets onto tracks.
+- Add a clip that is produced by a workflow.
+- Trim, split, reorder, and stack clips.
+- Regenerate a generated clip after you change its settings.
+- Export the whole sequence as a video asset.
 
 ### Agents
 
-An agent node takes a natural-language goal, breaks it into steps, and uses tools (web search, files, code) to finish. Use it when the path isn't fixed.
+An **agent** node takes a goal written in plain English, works out the steps
+itself, and uses tools such as web search, file access, or running code to get
+there. Use one when you can describe the outcome but not the exact steps. A
+normal node does one fixed thing; an agent decides what to do.
 
 ### Mini-Apps
 
-An app of its own: a form or dashboard that runs one or more workflows, with the graphs hidden. Created and opened from the Apps panel. Share with people who shouldn't have to read a node graph. See [Mini Apps](mini-apps.md).
+A **Mini-App** is a form or dashboard built on top of one or more workflows,
+with the nodes and lines hidden. Create and open them from the Apps panel. Give
+one to someone who should never have to look at a canvas. See
+[Mini Apps](mini-apps.md).
 
 ---
 
 ## How everything fits together
 
-NodeTool has one common loop:
+Most work in NodeTool follows one loop:
 
-1. **Collect or create assets.** Upload files, generate outputs from workflows, paint sketches, or export timelines.
-2. **Build workflows around them.** Workflows read assets, call models, transform media, and write new assets.
-3. **Edit the result in a surface built for the medium.** Use sketches for layered still images and timelines for time-based media.
-4. **Feed the edited result back into workflows.** A rendered sketch or exported timeline is just another asset.
-5. **Share the workflow or final output.** Keep the graph for repeatable work, expose it as a Mini-App, or publish the exported asset.
+1. **Get some material.** Upload files, produce them with a workflow, paint a
+   sketch, or export a timeline. All of it becomes assets.
+2. **Build a workflow around them.** It reads assets, calls models, converts
+   media, and writes new assets.
+3. **Polish the result in the right editor.** Sketches for still images,
+   timelines for anything with a duration.
+4. **Feed the polished result back in.** A flattened sketch or an exported video
+   is just another asset a workflow can read.
+5. **Share it.** Keep the workflow to run again, wrap it as a Mini-App, or
+   publish the finished file.
 
-The surfaces are separate because they solve different editing problems, but they share the same asset store and model/provider system.
+The editors are separate because painting an image and cutting a video are
+different problems, but they share one pool of assets and one set of AI services.
 
 {% mermaid %}
 graph LR
@@ -118,68 +156,76 @@ graph LR
     B --> F[Mini-App]
 {% endmermaid %}
 
-### Example: make a short product video
+### Worked example: a short product video
 
-1. Upload product photos as assets.
-2. Use a workflow to generate copy, background images, and voiceover.
-3. Open a hero image in a sketch to mask and retouch it.
-4. Drag the image, voiceover, and generated clips into a timeline.
-5. Bind one clip to an image-to-video workflow and regenerate until it fits.
-6. Export the timeline as the final video asset.
+1. Upload your product photos as assets.
+2. Run a workflow that writes the copy, makes background images, and records a
+   voiceover.
+3. Open the main photo in a sketch to touch it up and cut out the background.
+4. Drag the image, the voiceover, and the generated clips onto a timeline.
+5. Attach one clip to an image-to-video workflow and regenerate it until it
+   looks right.
+6. Export the timeline as your finished video.
 
 ---
 
 ## Models
 
-| Type | Output | Use |
+A **model** is a trained AI you call from a node. You don't train it; you use
+it.
+
+| Kind of model | Produces | Used for |
 |------|--------|-----|
 | Image | Pictures | Posters, concept art, mockups |
 | Video | Clips | Animation, motion |
-| Audio | Sound | Narration, music, SFX |
-| Text | Tokens | Scripts, summaries, analysis |
+| Audio | Sound | Narration, music, effects |
+| Text | Words | Scripts, summaries, analysis |
 
-### Local vs. cloud
+### On your machine, or online
 
-| | Local | Cloud |
+| | On your machine | Online service |
 |--|-------|-------|
-| Cost | Free after download | Provider's price, billed to your key |
-| Where | Your machine | Provider's servers |
-| Speed | Your hardware | Provider's hardware |
-| Internet | Offline OK | Required |
-| Setup | Download (4–20 GB each) | Paste API key |
+| Cost | Free once downloaded | The provider's price, billed to your account |
+| Where it runs | Your computer | Their servers |
+| Speed | Depends on your hardware | Depends on theirs |
+| Internet | Works offline | Required |
+| To set up | Download 4-20 GB per model | Paste an API key |
 
-Mix freely. Pick the best model for the job per node.
-
----
-
-## Glossary
-
-| Term | Meaning |
-|------|---------|
-| **Workflow** | Connected nodes |
-| **Node** | One operation |
-| **Edge / connection** | Data flow between nodes |
-| **Input / output** | Entry and exit ports |
-| **Preview** | Node that displays intermediate data |
-| **Run** | Execute the graph |
-| **Asset** | Stored file used by workflows, sketches, timelines, chats, or collections |
-| **Sketch** | Layered image document for painting, masking, compositing, and image generation |
-| **Timeline** | Multi-track sequence for arranging video, audio, image, and generated clips |
-| **Clip** | Media item placed on a timeline track |
-| **Generated clip / layer** | Timeline clip or sketch layer backed by a workflow or model call |
-| **Stale** | Generated output whose inputs, prompt, or bound workflow changed since the last generation |
-| **Model** | A trained network you call from a node |
-| **Provider** | Where the model runs (local, OpenAI, FAL, …) |
+You can mix them and choose per node, so an expensive online model can handle
+the one step that needs it while the rest runs locally.
 
 ---
 
-## How a run works
+## Words you'll see
+
+| Term | What it means |
+|------|------|
+| **Workflow** | Nodes joined by lines |
+| **Node** | One box that does one job |
+| **Edge / connection** | A line carrying data between nodes |
+| **Input / output** | Where data enters and leaves a node |
+| **Preview** | A node that displays whatever reaches it, for checking your work |
+| **Run** | Execute the workflow |
+| **Asset** | A stored file used by workflows, sketches, timelines, chats, or collections |
+| **Sketch** | A layered image document for painting, masking, and combining |
+| **Timeline** | Tracks for arranging video, audio, and images over time |
+| **Clip** | One piece of media placed on a timeline track |
+| **Generated clip / layer** | A clip or layer produced by a workflow instead of imported |
+| **Stale** | A generated result whose settings changed since it was last produced |
+| **Model** | The trained AI a node calls |
+| **Provider** | Whoever runs the model: your own machine, OpenAI, FAL, and so on |
+
+---
+
+## What happens when you press Run
 
 On <kbd>Ctrl/⌘ + Enter</kbd>:
 
-1. NodeTool walks the graph for dependencies.
-2. Each node runs the moment its inputs are ready. Independent nodes run in parallel.
-3. Results stream live into preview and output nodes.
+1. NodeTool reads the lines to work out which node depends on which.
+2. Each node starts the moment its inputs have arrived. Nodes that don't depend
+   on each other run at the same time.
+3. Results appear in preview and output nodes while they are still being
+   produced, rather than only at the end.
 
 {% mermaid %}
 graph LR
@@ -190,39 +236,48 @@ graph LR
     D --> F[Preview: Text]
 {% endmermaid %}
 
-The Agent runs first; Image Generator and Text Writer then run in parallel since both depend only on the Agent.
+Here the Agent goes first. Image Generator and Text Writer both wait only on the
+Agent, so once it finishes they run side by side.
 
-The graph is a DAG — data flows one way, no cycles. The runner schedules the order.
+Data always flows one way and a workflow can never loop back on itself. That
+restriction is what lets NodeTool figure out the running order for you, so you
+never specify it.
 
 ---
 
-## For developers
+## If you write code
 
-| Component | Role |
+Everything above is also available as a TypeScript API, so you can build and run
+the same workflows from code.
+
+| Piece | What it is |
 |-----------|------|
-| **Graph** | Nodes + connections. Build with `workflow(...)`, execute with `run(...)` or `runGraph(...)` (`@nodetool-ai/dsl` `packages/dsl/src/core.ts`). |
-| **DSL** | [TypeScript DSL](developer/ts-dsl-guide.md) (`@nodetool-ai/dsl`) — typed factories for building graphs in code. |
-| **WorkflowRunner** | The runner. Schedules nodes, manages GPU, streams progress. |
-| **ProcessingContext** | Runtime — user, auth, assets, cache (`@nodetool-ai/runtime`). |
+| **Graph** | Nodes plus connections. Build one with `workflow(...)`, run it with `run(...)` or `runGraph(...)` (`@nodetool-ai/dsl`, `packages/dsl/src/core.ts`). |
+| **DSL** | The [TypeScript DSL](developer/ts-dsl-guide.md) (`@nodetool-ai/dsl`), typed factory functions for building graphs in code. |
+| **WorkflowRunner** | Schedules the nodes, manages the GPU, streams progress back. |
+| **ProcessingContext** | Everything a running node can reach: user, auth, assets, cache (`@nodetool-ai/runtime`). |
 
-### Node type resolution
+### How a node type is found
 
-A workflow references nodes by type string (`package.Namespace.Class`). The runner resolves it via:
+A saved workflow refers to nodes by a type string (`package.Namespace.Class`).
+The runner resolves it in this order:
 
-1. In-memory registry (with and without trailing `Node`)
-2. Dynamic import by type path
-3. Installed packages registry
-4. Fallback match by class name
+1. The in-memory registry, with and without a trailing `Node`
+2. A dynamic import of the type path
+3. The installed packages registry
+4. A fallback match on class name
 
-Graphs load without pre-importing every node module.
+That is why loading a graph doesn't require importing every node module first.
 
-See the [Developer Guide](developer/) and [Custom Nodes](developer/custom-nodes-guide.md).
+See the [Developer Guide](developer/) and
+[Custom Nodes](developer/custom-nodes-guide.md).
 
 ---
 
 ## Next
 
-- [Getting Started](getting-started.md)
+- [Quick Start](getting-started.md) — run something in 10 minutes
+- [Glossary](glossary.md) — single-word definitions
 - [Workflow Editor](workflow-editor.md)
 - [Asset Management](asset-management.md)
 - [Sketch Editor](sketch-editor.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting Guide"
 description: "Debugging and fixing common NodeTool workflow issues."
 ---
 
-Step-by-step troubleshooting for common NodeTool issues. For installation-specific problems (GPU drivers, CUDA, platform issues), see [Installation Troubleshooting](installation.md#troubleshooting-installation).
+Step-by-step troubleshooting for common NodeTool issues. For installation-specific problems (GPU drivers, CUDA, platform issues), see [Installation Troubleshooting](installation.md#if-installing-goes-wrong).
 
 **Jump to:**
 - [Quick Diagnostic Checklist](#quick-diagnostic-checklist) — Start here
@@ -498,7 +498,7 @@ Include these details when asking for help:
 ## Related Documentation
 
 - [Workflow Debugging Guide](workflow-debugging.md) – Step-by-step debugging with Preview nodes and logs
-- [Installation Troubleshooting](installation.md#troubleshooting-installation) – Hardware, CUDA, and installation issues
+- [Installation Troubleshooting](installation.md#if-installing-goes-wrong) – Hardware, CUDA, and installation issues
 - [Getting Started](getting-started.md) – Basics of running workflows
 - [Workflow Editor](workflow-editor.md) – Using the visual editor
 - [Key Concepts](key-concepts.md) – Understanding nodes and connections

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,124 +1,132 @@
 ---
 layout: page
 title: "Tutorials"
-description: "Short, beginner-friendly video walkthroughs of NodeTool — build your first workflow, connect and run nodes, generate a list, ask the AI, combine inputs, summarize a document, describe an image, chat with an agent, and cut a scene on the timeline."
+description: "Short beginner video walkthroughs of NodeTool — build your first workflow, connect and run nodes, generate a list, ask the AI, combine inputs, summarize a document, describe an image, chat with an agent, and cut a scene on the timeline."
 ---
 
-Short, beginner-friendly walkthroughs. Each plays a real workflow on the canvas
-and zooms into every node so you can see what it does and what to fill in.
+Short walkthroughs for people starting from zero. Each one plays a real example
+and zooms in on every box so you can see what it does and what you type into it.
+
+New here? [Quick Start](getting-started.md) explains the words used below, and
+the [Glossary](glossary.md) defines them one by one.
 
 ## Build your first workflow
 
-A complete AI pipeline, end to end: type a prompt, an LLM rewrites it into
-something richer, and a Text To Image node turns it into a picture — all from
-connected nodes, no code.
+A complete example from start to finish: you type a short description, an AI
+rewrites it into something more detailed, and a Text To Image node turns that
+into a picture. No code, just connected boxes.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/first-workflow.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/first-workflow.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how nodes pass data through their handles, how to read live status
-(running rings, streaming text, the progress bar), and where generated output
-appears on the canvas.
+You'll see how a result passes from one box to the next, how to tell what is
+running (the spinning ring, text appearing as it's written, the progress bar),
+and where the finished picture shows up.
 
-## Connect & run
+## Connect and run
 
-The core loop, one step at a time. Add a node, wire its output into the next
-node's input, press Run, and read the result.
+The basic loop, one step at a time. Add a box, draw a line from its output into
+the next box's input, press Run, read the result.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/connect-run.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/connect-run.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn what inputs, outputs, and handles are, how to run a graph and watch
-nodes complete, and how to find a node's result in a Preview.
+You'll see what inputs and outputs are, what the small dots on the sides of a
+box are for, how to run everything and watch each box finish, and how to display
+a result in a Preview box.
 
 ## Generate a list
 
-One prompt, many results. A single LLM node turns a topic into a structured
-list, streaming each item as it arrives — the pattern behind batching and loops.
+One instruction, many answers. A single AI box turns a topic into a numbered
+list, showing each item the moment it arrives. This is the pattern behind
+anything that repeats a step over many items.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/list-generator.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/list-generator.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to drive an LLM node from an input, watch multi-item output
-stream in, and pass a list into the rest of a workflow.
+You'll see how to drive an AI box from something you typed, watch a multi-item
+answer arrive piece by piece, and pass the finished list on to the rest of the
+workflow.
 
 ## Ask the AI
 
-The simplest chat-style graph. Type a question, send it to an LLM node, and
-watch the answer stream in phrase by phrase before it lands in a Preview.
+The simplest example there is. Type a question, send it to an AI box, and watch
+the answer appear phrase by phrase before it lands in a Preview.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/ask-ai.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/ask-ai.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to feed a question into an LLM node, watch the answer stream as
-it generates, and reuse it downstream.
+You'll see how to feed a question into an AI box, watch the answer being
+written, and reuse it further along.
 
 ## Combine two inputs
 
-The first graph that branches in. Two text inputs flow into one Format Text node
-that fills a template, composing a single result from reusable parts.
+The first example where two lines meet. Two text boxes feed into one Format Text
+box that drops both into a sentence template, building one result from reusable
+parts.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/combine-inputs.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/combine-inputs.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to wire several inputs into one node, compose text with
-`{{ placeholders }}`, and build prompts from reusable parts.
+You'll see how to wire several inputs into one box, how to write a template with
+`{{ placeholders }}` in it, and how to assemble instructions from parts you can
+change independently.
 
 ## Summarize a document
 
-Long text in, key points out. A single Summarizer node condenses an article,
-transcript, or any block of text into a short summary, streaming it as it
-writes — the pattern behind the Meeting Transcript Summarizer example.
+Long text in, the key points out. A single Summarizer box condenses an article,
+a transcript, or any block of text into a short summary, writing it out as it
+goes. It's the same pattern the Meeting Transcript Summarizer example uses.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/summarize-text.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/summarize-text.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to feed a long passage into a Summarizer, watch the summary
-stream as it generates, and pass the result into the rest of a workflow.
+You'll see how to feed a long passage into a Summarizer, watch the summary being
+written, and pass the result on.
 
 ## Describe an image
 
-The first multimodal graph. Drop a picture into an Image Input, wire it into an
-Agent, and watch the model look at the image and describe it in words — the
-vision pattern behind captioning and alt-text workflows.
+The first example that mixes pictures and words. Drop a photo into an Image
+Input box, wire it into an Agent, and watch the AI look at the picture and
+describe it. This is how captions and alt text get generated.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/describe-image.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/describe-image.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to bring an image into a graph, send it to a vision model, and
-reuse the streamed description in any downstream text node.
+You'll see how to bring a picture into a workflow, send it to an AI that can
+see, and reuse the description in any box that takes text.
 
 ## Ask the chat agent
 
-A different surface: Chat. A question goes straight to the agent, which
-calls a web-search tool in the open — no hidden spinner — then streams its
-answer back token by token.
+A different part of the app: Chat. A question goes straight to the agent, which
+searches the web where you can watch it happen, then writes its answer back a
+few words at a time.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/chat-agent-qa.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/chat-agent-qa.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to send a message from Chat, watch a tool call run in
-the open, and read a streamed answer as it arrives.
+You'll see how to send a message from Chat, watch the agent use a tool in the
+open rather than behind a spinner, and read the answer as it arrives.
 
 ## Cut a scene together
 
-The timeline (video) editor: trim a clip, drag in another shot, drop in a
-caption that syncs word-by-word with the audio, then scrub the finished cut.
+The video editor: trim a clip, drag in a second shot, add a caption that lights
+up word by word in time with the audio, then play the finished cut.
 
 <video controls preload="metadata" poster="{{ '/assets/tutorials/timeline-trim-arrange.jpg' | relative_url }}">
   <source src="{{ '/assets/tutorials/timeline-trim-arrange.mp4' | relative_url }}" type="video/mp4">
 </video>
 
-You'll learn how to trim and arrange clips on real tracks, add a caption synced
-to the audio, and scrub and preview a cut without leaving the browser.
+You'll see how to trim and arrange clips on tracks, add a caption synced to the
+audio, and play back a cut without leaving the browser.
 
 ---
 


### PR DESCRIPTION
The four pages a first-time reader hits — Quick Start, Installation, Key Concepts, Tutorials — assumed the reader already knew what a canvas, node, graph, edge, handle, provider, API key, DAG, or asset was. Every one of those words appeared before it was ever defined.

Each is now explained where it first appears, and the ones that carried no meaning for a beginner are gone.

## What changed

**`getting-started.md` (Quick Start)** — introduces canvas, node, connection, and workflow before the first template instead of after. Says what an API key actually is and who bills you for it. Explains that a GPU is optional and why. Section titles now describe what the reader does ("Run a ready-made example", "Change something") rather than what the software calls it. "Optional node packs" becomes "Finding more nodes".

**`installation.md`** — plain-language platform steps. Explains why Windows shows a firewall prompt (a local server on 7777, nothing exposed), what Python/Conda and Ollama/llama.cpp are for and why they download late, and what an AppImage is. The hardware table now says "your hardware / what runs the model" instead of "hardware / engine". "Troubleshooting Installation" → "If installing goes wrong".

**`key-concepts.md`** — every building block rewritten for someone with no prior exposure. Connections explain type checking as "you can't wire something nonsensical". Sketches and timelines get an analogy each (Photoshop, a video editor). The DAG paragraph now says what the restriction buys the reader instead of naming it. The runner/DSL/type-resolution material moved under a clearly optional "If you write code" heading.

**`tutorials.md`** — drops "graph", "handles", "multimodal graph", and "token by token" for what the viewer actually sees on screen.

**`glossary.md`** — fixes one circular definition: "Servers connect to the server and execute jobs."

**`index.md`, `troubleshooting.md`** — updated to the three renamed anchors.

## Verification

- `bundle exec jekyll build` with `JEKYLL_ENV=production` — builds clean.
- `htmlproofer ./_site --disable-external --allow-hash-href --ignore-missing-alt --no-enforce-https` — 2277 internal links, 996 files of hashes, **0 failures**. This caught three inbound anchor links broken by the heading renames, which are fixed in the diff.
- Checked against [docs/WRITING_STYLE.md](https://github.com/nodetool-ai/nodetool/blob/main/docs/WRITING_STYLE.md): no forbidden expressions, no em-dash overuse in prose.

No code changes, so typecheck/lint/test are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwhPWeQT64Q4w3rrFEfjEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwhPWeQT64Q4w3rrFEfjEw)_