### PR TITLE
marketing: plainer language sitewide, and a homepage that argues before it lists

### DIFF
--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -43,7 +43,7 @@
 - [FAQ hub](https://nodetool.ai/faq): all questions, grouped by category.
 - [What is NodeTool?](https://nodetool.ai/faq/what-is-nodetool)
 - [Is NodeTool open source?](https://nodetool.ai/faq/is-nodetool-open-source)
-- [What is BYOK, and what does it mean for me?](https://nodetool.ai/faq/what-is-byok)
+- [What does "bring your own keys" mean for me?](https://nodetool.ai/faq/what-is-byok)
 - [Does NodeTool mark up model pricing?](https://nodetool.ai/faq/does-nodetool-mark-up-model-pricing)
 - [Studio or Cloud — which should I use?](https://nodetool.ai/faq/studio-or-cloud)
 - [Which models are supported?](https://nodetool.ai/faq/which-models-are-supported)
@@ -53,7 +53,7 @@
 - [Is there an open source alternative to Figma Weave?](https://nodetool.ai/faq/open-source-figma-weave-alternative)
 - [What is a node-based workflow?](https://nodetool.ai/faq/what-is-a-node-based-workflow)
 - [What is a diffusion model?](https://nodetool.ai/faq/what-is-a-diffusion-model)
-- [What is RAG (retrieval-augmented generation)?](https://nodetool.ai/faq/what-is-rag)
+- [How can a model answer from my own documents?](https://nodetool.ai/faq/what-is-rag)
 - [What is a planning agent?](https://nodetool.ai/faq/what-is-a-planning-agent)
 
 ## Ideas

--- a/marketing/src/app/alternatives/[slug]/opengraph-image.tsx
+++ b/marketing/src/app/alternatives/[slug]/opengraph-image.tsx
@@ -18,7 +18,7 @@ export default async function Image({
   const name = c?.name ?? "your tools";
   return ogImage(
     `${name} alternatives`,
-    "The open source, BYOK canvas for image, video, audio, and text.",
+    "The open-source canvas for image, video, audio, and text, run with your own keys.",
     {
       image: c?.og.image ?? "screen_canvas.png",
       accent: c?.og.accent ?? "blue",

--- a/marketing/src/app/alternatives/[slug]/page.tsx
+++ b/marketing/src/app/alternatives/[slug]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   const c = getCompetitor(slug);
   if (!c) return {};
   const title = `${c.name} alternatives (${yearToken()}) — why teams choose NodeTool`;
-  const description = `${c.limitation} Compare NodeTool and other ${c.category.toLowerCase()} alternatives — open source, BYOK, one canvas for image, video, audio, and text.`;
+  const description = `${c.limitation} Compare NodeTool with other ${c.category.toLowerCase()} alternatives: open source, run with your own keys, one canvas for image, video, audio, and text.`;
   return {
     title,
     description,
@@ -131,9 +131,10 @@ export default async function AlternativesPage({
             Looking for a {c.name} alternative?
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            {c.limitation} If that&apos;s what has you looking, here are the
-            alternatives worth weighing — and why teams pick NodeTool, the open
-            source, BYOK canvas for image, video, audio, and text.
+            {c.limitation} If that is what brought you here, these are the
+            alternatives worth weighing, and why teams pick NodeTool: an
+            open-source canvas for image, video, audio, and text that runs on
+            your own keys.
           </p>
         </section>
 

--- a/marketing/src/app/apps/page.tsx
+++ b/marketing/src/app/apps/page.tsx
@@ -13,7 +13,7 @@ const BASE_URL = "https://nodetool.ai";
 export const metadata: Metadata = {
   title: "AI Mini Apps — NodeTool",
   description:
-    "Ready-to-use AI mini apps built with NodeTool's App Builder: type, click Run, get results. Every app runs on an editable visual workflow you own.",
+    "Ready-to-use AI mini apps built with NodeTool's app builder: fill in a field, press Run, and get your result. Each one is powered by a visual workflow you can open and change.",
   alternates: { canonical: `${BASE_URL}/apps` },
 };
 
@@ -82,10 +82,9 @@ export default function AppsHub() {
               AI apps anyone can use
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-400">
-              A mini app is a clean screen with a few inputs and a Run button —
-              no canvas, no nodes, no jargon. Each one ships with NodeTool,
-              drives one or more real workflows, and opens them on the canvas
-              whenever you&apos;re curious.
+              A mini app is a simple screen with a few fields and a Run button.
+              Each one comes with NodeTool and is powered by real workflows, which
+              you can open on the canvas whenever you want to see how they work.
             </p>
             <div className="mt-8">
               <SmartDownloadButton

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -56,7 +56,7 @@ const proPoints = [
   {
     icon: Zap,
     title: "Start in 30 seconds",
-    body: "Sign in, open a workflow, hit run. No installer, no drivers, nothing to set up — just a browser tab.",
+    body: "Sign in, open a workflow, and press run. No installer, no drivers, nothing to set up beyond a browser tab.",
   },
   {
     icon: Globe,
@@ -66,33 +66,33 @@ const proPoints = [
   {
     icon: Users,
     title: "Built for teams",
-    body: "Share workflows, hand off prompts, collaborate on agents. One workspace, many builders.",
+    body: "Share workflows, hand over prompts, and work on agents together in one shared workspace.",
   },
   {
     icon: KeyRound,
     title: "Bring your own keys",
-    body: "OpenAI, Anthropic, Gemini, Mistral, Groq, Replicate, FAL, ElevenLabs, HuggingFace — every cloud provider, billed to your account, not ours.",
+    body: "OpenAI, Anthropic, Gemini, Mistral, Groq, Replicate, FAL, ElevenLabs, and HuggingFace all bill your account directly, not ours.",
   },
   {
     icon: RefreshCcw,
     title: "Always on the latest version",
-    body: "We ship Cloud updates continuously — new nodes, new providers, and bug fixes, no update step on your side.",
+    body: "We release Cloud updates continuously: new building blocks, new providers, and fixes, with nothing for you to install.",
   },
   {
     icon: Cloud,
     title: "No GPU required",
-    body: "We run the servers and the storage. Heavy image and video jobs run at the providers you choose.",
+    body: "We run the servers and the storage, and demanding image and video work runs at the providers you choose.",
   },
 ];
 
 const consPoints = [
   {
     title: "Alpha — still early",
-    body: "Cloud is in active alpha. Expect breaking changes, missing polish, and occasional downtime. Uptime and support guarantees come with the full release.",
+    body: "Cloud is in active alpha. Expect changes that break things, rough edges, and occasional downtime. Uptime and support guarantees arrive with the full release.",
   },
   {
     title: "No local models",
-    body: "Cloud doesn't run Ollama or MLX models — those need access to your hardware. Use Studio if you want open models running on your own machine.",
+    body: "Cloud cannot run Ollama or MLX models, because those need direct access to your hardware. Use Studio if you want open models running on your own machine.",
   },
   {
     title: "Needs an internet connection",
@@ -100,7 +100,7 @@ const consPoints = [
   },
   {
     title: "Your data lives with us",
-    body: "Workflows and assets are stored encrypted in our managed storage. If you need data to never leave your device, Studio is the right choice — or self-host the same open-source code.",
+    body: "Workflows and files are stored encrypted on our servers. If your data must never leave your device, choose Studio, or host the same open-source code yourself.",
   },
 ];
 
@@ -220,9 +220,9 @@ export default function CloudPage() {
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
                   NodeTool Cloud is the hosted version of the same open-source
-                  platform. No install, no GPU, no driver setup — just sign in
-                  and start building. Bring your own API keys for every cloud
-                  provider you want to use.
+                  app. There is nothing to install and no hardware to set up:
+                  sign in and start building. Bring your own API keys for
+                  whichever providers you want to use.
                 </p>
                 <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4 text-sm text-amber-100/90 max-w-xl">
                   <strong className="text-amber-200">Heads up:</strong> Cloud is
@@ -303,8 +303,8 @@ export default function CloudPage() {
                 Zero setup. Anywhere. Always current.
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl">
-                Cloud removes the install, the GPU, and the upgrade chores —
-                while keeping you in control of your provider keys and your
+                Cloud takes away the install, the hardware, and the upgrades,
+                while leaving you in control of your provider keys and your
                 workflows.
               </p>
             </header>
@@ -345,8 +345,8 @@ export default function CloudPage() {
                   </h2>
                   <p className="mt-3 text-slate-300 max-w-2xl">
                     Cloud connects to OpenAI, Anthropic, Gemini, Mistral, Groq,
-                    Replicate, FAL, ElevenLabs, HuggingFace, and more — using
-                    keys you provide. No hidden fees, no resold credits.
+                    Replicate, FAL, ElevenLabs, HuggingFace, and more, using the
+                    keys you provide. No hidden fees and no resold credits.
                   </p>
                 </div>
               </div>
@@ -423,10 +423,10 @@ export default function CloudPage() {
                 Cloud is just our hosting of open-source code.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Every node, every provider, every line of code that powers
-                Cloud is on GitHub under AGPL-3.0. If you ever want to run it
-                yourself, everything we run is yours to run too — no lock-in,
-                no &ldquo;cloud-only&rdquo; features, no closed source layer.
+                Every building block, every provider, and every line of code
+                behind Cloud is on GitHub under AGPL-3.0. If you ever want to run
+                it yourself, everything we run is yours to run too. There are no
+                cloud-only features and nothing kept closed.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool"

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -28,19 +28,19 @@ const creativeFeatures = [
   {
     title: "Visual Workflow Canvas",
     description:
-      "Snap nodes into complete creative workflows — the whole process on one screen, from brief to render.",
+      "Snap blocks together into complete creative workflows, so the whole process sits on one screen, from brief to final render.",
     icon: Layers,
     image: "/screen_canvas.png",
     features: [
       "Infinite canvas",
-      "Watch every node run live",
-      "Reusable node groups",
+      "Watch every step run live",
+      "Reusable groups you can save",
     ],
   },
   {
     title: "Image generation & editing",
     description:
-      "Run Flux, Qwen-Image, Nano-Banana, Z-Image, gpt-image, and friends. Generate, mask, inpaint, outpaint, relight, and upscale — all on the canvas.",
+      "Run Flux, Qwen-Image, Nano-Banana, Z-Image, gpt-image, and the rest. Generate, mask, inpaint, outpaint, relight, and upscale, all on the canvas.",
     icon: Wand2,
     image: "/disaster_girl.mp4",
     features: ["Masks, inpaint, outpaint", "Multi-model support", "Batch processing"],
@@ -48,7 +48,7 @@ const creativeFeatures = [
   {
     title: "Video workflows",
     description:
-      "Wire Seedance, Kling, Veo, Runway, and Sora alongside your edit nodes. Generate, transform, and stitch — without exporting between tools.",
+      "Put Seedance, Kling, Veo, Runway, and Sora next to your editing steps. Generate, transform, and join clips without exporting between tools.",
     icon: Video,
     image: "/sora.mp4",
     features: [
@@ -60,7 +60,7 @@ const creativeFeatures = [
   {
     title: "Audio on the same surface",
     description:
-      "Compose with Suno, generate voice with ElevenLabs, transcribe with Whisper. Same canvas, same nodes, no extra tabs.",
+      "Write music with Suno, make voices with ElevenLabs, and turn speech into text with Whisper. Same canvas, no extra tabs.",
     icon: Music,
     image: "/suno.png",
     features: ["Stem separation", "Music generation", "Voice generation"],
@@ -138,8 +138,9 @@ export default function CreativesPage() {
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Every model. Your keys. Your canvas. Wire Seedance, Kling, Veo, Runway,
-                  Luma, Suno, and Flux on one open-source canvas — no marked-up credits, no lock-in.
+                  Every model. Your keys. Your canvas. Bring Seedance, Kling, Veo,
+                  Runway, Luma, Suno, and Flux together in one open-source workspace,
+                  with no marked-up credits and nothing locking you in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -405,8 +406,8 @@ export default function CreativesPage() {
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-                The same models the studios use — Seedance, Kling, Luma, Suno, Flux —
-                wired into one node-based canvas, with masks, inpaint, outpaint,
+                The same models the studios use, including Seedance, Kling, Luma,
+                Suno, and Flux, on one visual canvas with masks, inpaint, outpaint,
                 relight, upscale, and compositing built in.
               </p>
             </motion.div>
@@ -520,7 +521,7 @@ export default function CreativesPage() {
                 {
                   title: "Every model on one canvas",
                   description:
-                    "Seedance, Kling, Veo, Runway, Luma, Suno, ElevenLabs, Flux, Ideogram, and more — switch the moment a better one ships.",
+                    "Seedance, Kling, Veo, Runway, Luma, Suno, ElevenLabs, Flux, Ideogram, and more. Switch the moment a better one arrives.",
                   icon: Zap,
                   color: "text-amber-400",
                   bgColor: "bg-teal-500/10",
@@ -570,8 +571,8 @@ export default function CreativesPage() {
                 </span>
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-                Download NodeTool, plug in the providers you already pay for,
-                and start wiring your next piece on a canvas you actually own.
+                Download NodeTool, connect the providers you already pay for,
+                and start your next piece on a canvas you actually own.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool/releases"

--- a/marketing/src/app/faq/page.tsx
+++ b/marketing/src/app/faq/page.tsx
@@ -9,12 +9,12 @@ import { faqByCategory, faqEntries } from "@/data/faqEntries";
 export const metadata: Metadata = {
   title: "NodeTool FAQ — the open creative AI workspace",
   description:
-    "Answers about NodeTool: BYOK pricing, Studio vs Cloud, supported models, how it compares to other tools, and a short glossary of terms like BYOK, RAG, and diffusion models.",
+    "Answers about NodeTool: how pricing with your own API keys works, Studio compared with Cloud, which models are supported, how it compares with other tools, and a short glossary of common terms.",
   alternates: { canonical: "/faq" },
   openGraph: {
     title: "NodeTool FAQ",
     description:
-      "BYOK pricing, Studio vs Cloud, supported models, comparisons, and a short glossary.",
+      "Pricing with your own keys, Studio compared with Cloud, supported models, comparisons, and a short glossary.",
     url: "https://nodetool.ai/faq",
     type: "website",
   },
@@ -62,8 +62,8 @@ export default function FaqHubPage() {
             Frequently asked questions
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            What NodeTool is, how BYOK pricing works, Studio vs Cloud, which
-            models run, and a short glossary of the terms.
+            What NodeTool is, how pricing works when you use your own API keys,
+            how Studio and Cloud differ, which models run, and a short glossary.
           </p>
         </section>
 

--- a/marketing/src/app/features.tsx
+++ b/marketing/src/app/features.tsx
@@ -19,11 +19,11 @@ export type Feature = {
 
 export const features = [
   {
-    name: "🔗 Snap nodes together",
+    name: "🔗 Snap blocks together",
     description: (
       <>
-        Drag any model into your canvas — image, video, audio, text, agents,
-        or custom code. Connect with one click and run.
+        Drag any model onto your canvas: image, video, audio, text, agents, or
+        your own code. Connect them with one click and press run.
       </>
     ),
     icon: CodeBracketIcon,
@@ -36,9 +36,10 @@ export const features = [
     name: "☁️ Every model, your keys",
     description: (
       <>
-        One canvas, every major provider. Video with Seedance, Kling, Veo, and
-        Runway; music with Suno; images with Flux and Ideogram via FAL or KIE;
-        plus OpenAI, Anthropic, Gemini — and local models via MLX, Ollama, and GGUF.
+        One canvas, every major provider. Video from Seedance, Kling, Veo, and
+        Runway, music from Suno, images from Flux and Ideogram through FAL or
+        KIE, plus OpenAI, Anthropic, and Gemini. Local models run through MLX,
+        Ollama, and GGUF.
       </>
     ),
     icon: FolderIcon,
@@ -51,9 +52,9 @@ export const features = [
     name: "🚀 Deploy to RunPod",
     description: (
       <>
-        Ship workflows to RunPod with one command. GPU acceleration,
-        auto-scaling, multi-region, and custom Docker images — for workflows
-        that outgrow your laptop.
+        Send a workflow to RunPod with one command and it runs on rented GPUs,
+        adding capacity as demand rises. For work that has outgrown your
+        laptop.
       </>
     ),
     icon: CloudArrowUpIcon,
@@ -65,7 +66,7 @@ export const features = [
   {
     name: "💬 Chat interface",
     description:
-      "Trigger and re-run any workflow through a chat interface — same nodes, different surface.",
+      "Start and repeat any workflow from a chat window, using the same workflow behind the scenes.",
     icon: ChatBubbleBottomCenterTextIcon,
     href: "#",
     gif: "/chat.png",
@@ -75,7 +76,7 @@ export const features = [
   {
     name: "🤖 Agent nodes",
     description:
-      "Drop in a planning agent that calls models and tools to finish a multi-step task. Used as a node, not a separate framework.",
+      "Add an agent that plans a multi-step job and calls the models and tools it needs. It is a block on the canvas, not a separate system to learn.",
     icon: PuzzlePieceIcon,
     href: "#",
     gif: "/agents.png",
@@ -83,9 +84,9 @@ export const features = [
     height: 400,
   },
   {
-    name: "📁 Vector store & RAG",
+    name: "📁 Answers from your documents",
     description:
-      "Built-in SQLite-vec embedded vector store. Build assistants that know your documents — no extra database to run.",
+      "Store your documents inside NodeTool and build assistants that can answer from them. There is no separate database to set up.",
     icon: FolderIcon,
     href: "#",
     gif: "/vector-db.jpg",

--- a/marketing/src/app/ideas/page.tsx
+++ b/marketing/src/app/ideas/page.tsx
@@ -60,8 +60,8 @@ export default function IdeasHubPage() {
             AI workflow ideas
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            What to build on the canvas — grouped by category, drawn from the
-            example workflows that ship with NodeTool.
+            What to build on the canvas, grouped by category and drawn from the
+            example workflows included with NodeTool.
           </p>
         </section>
 

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -19,7 +19,7 @@ const jetBrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "NodeTool — The open creative AI workspace",
   description:
-    "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas you run on your machine or in the browser. Pay providers directly. No credits, no markup, no lock-in.",
+    "NodeTool is the open-source creative AI workspace. Every major model from every major provider runs on one visual canvas, using your own keys, on your machine or in your browser. You pay providers directly: no credits, no markup, no lock-in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "NodeTool — The open creative AI workspace",
     description:
-      "Every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text in one place. Open source. Your own keys. Provider prices.",
+      "Every major model from every major provider on one visual canvas, using your own keys. Image, video, audio, and text in one place. Open source, and you pay provider prices.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
@@ -67,7 +67,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool — The open creative AI workspace",
     description:
-      "Every model. Your keys. Your canvas. The open-source creative AI workspace — bring your own keys to every major provider and pay provider prices.",
+      "Every model. Your keys. Your canvas. The open-source creative AI workspace: bring your own keys to every major provider and pay their published prices.",
     images: ["/preview.png"],
   },
 };
@@ -94,7 +94,7 @@ export default function RootLayout({
               "@context": "https://schema.org",
               "@type": "SoftwareApplication",
               "name": "NodeTool",
-              "description": "NodeTool is the open-source creative AI workspace — every major model from every major provider, called with your own keys, wired into one node-based canvas. Image, video, audio, and text on one surface, with masks, inpaint, outpaint, relight, upscale, and compositing built in. Runs as a desktop app on macOS, Windows, and Linux, or in the browser via NodeTool Cloud.",
+              "description": "NodeTool is the open-source creative AI workspace. Every major model from every major provider runs on one visual canvas, using your own keys. Image, video, audio, and text sit side by side, with masks, inpaint, outpaint, relight, upscale, and compositing built in. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
               "applicationCategory": "MultimediaApplication",
               "applicationSubCategory": "Creative AI Workspace",
               "operatingSystem": "macOS, Windows, Linux",
@@ -113,15 +113,15 @@ export default function RootLayout({
               },
               "screenshot": "https://nodetool.ai/preview.png",
               "featureList": [
-                "Node-based creative canvas for image, video, audio, and text",
+                "One visual canvas for image, video, audio, and text",
                 "Bring your own keys to every major provider: FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, HuggingFace",
                 "Pay providers directly at provider prices, no credits, no markup",
                 "Editing tools built in: masks, inpaint, outpaint, relight, upscale, layers, compositing",
                 "The latest models under their real names: Flux, Seedance, Wan, Veo, Kling, Hailuo, Whisper, ElevenLabs, Suno",
                 "Run models locally via MLX, Ollama, llama.cpp, vLLM, and LM Studio",
                 "Two editions on one open-source codebase: Studio (desktop) and Cloud (browser)",
-                "Streaming execution with live output as nodes finish",
-                "Workflows, files, and keys belong to you — runs on your machine or browser",
+                "Results appear live as each step finishes",
+                "Workflows, files, and keys belong to you, on your machine or in your browser",
                 "AGPL-3.0 open source, self-host any time"
               ],
               "softwareRequirements": "Node.js 22+ (Python 3.11+ optional, for Python nodes)",
@@ -148,7 +148,7 @@ export default function RootLayout({
                 "https://github.com/nodetool-ai/nodetool",
                 "https://discord.gg/WmQTWZRcYE"
               ],
-              "description": "NodeTool builds the open creative AI workspace: a node-based canvas that connects every major model from every major provider with the user's own keys, available as a desktop app and as a browser-based managed edition."
+              "description": "NodeTool builds the open creative AI workspace: a visual canvas that connects every major model from every major provider using the user's own keys, available as a desktop app and as a hosted browser edition."
             })
           }}
         />
@@ -166,7 +166,7 @@ export default function RootLayout({
                   "name": "What is NodeTool?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool is the open-source creative AI workspace. Every major model from every major provider — FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more — is called with your own keys and wired into one node-based canvas. Image, video, audio, and text live on the same surface, with editing tools like masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. Runs as a desktop app on macOS, Windows, and Linux, or in the browser via NodeTool Cloud."
+                    "text": "NodeTool is the open-source creative AI workspace. Every major model from every major provider (FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more) runs on one visual canvas using your own keys. Image, video, audio, and text live side by side, with editing tools such as masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud."
                   }
                 },
                 {
@@ -174,7 +174,7 @@ export default function RootLayout({
                   "name": "How is NodeTool different from ComfyUI?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "ComfyUI is a Stable Diffusion power tool built for engineers. NodeTool is the full creative workspace — image, video, audio, and text on one canvas, with the editing tools creatives actually use. NodeTool also supports far more models across providers and media types, called with your own keys at provider prices."
+                    "text": "ComfyUI is a specialist image tool built for engineers. NodeTool is a complete creative workspace: image, video, audio, and text on one canvas, with the editing tools creatives actually use. It also covers far more models, across more providers and media types, using your own keys at provider prices."
                   }
                 },
                 {
@@ -182,7 +182,7 @@ export default function RootLayout({
                   "name": "How is NodeTool different from Figma Weave (formerly Weavy) or other closed SaaS canvases?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Closed canvases lock you into a credit system and a hand-picked list of models. NodeTool is open source. You bring your own API keys to every provider, pay providers directly at provider prices, and own your workflows and files. Cloud is just our managed hosting of the same open-source code you can run yourself."
+                    "text": "Closed tools tie you to a credit system and a hand-picked list of models. NodeTool is open source. You bring your own API keys to every provider, pay those providers directly at their published prices, and own your workflows and files. Cloud is simply our hosting of the same open-source code you can run yourself."
                   }
                 },
                 {
@@ -190,7 +190,7 @@ export default function RootLayout({
                   "name": "How does pricing work?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool Studio is free to download and use. NodeTool Cloud is a subscription for managed hosting. In both editions, you bring your own API keys to every provider and pay those providers directly at their list prices. NodeTool does not run models for you on its own servers, does not issue its own credits, and does not mark up model calls."
+                    "text": "NodeTool Studio is free to download and use. NodeTool Cloud is a subscription that covers hosting. In both, you bring your own API keys and pay each provider directly at their list prices. NodeTool does not run models on its own servers, does not issue its own credits, and does not add a markup."
                   }
                 },
                 {
@@ -198,7 +198,7 @@ export default function RootLayout({
                   "name": "What models does NodeTool support?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "The latest models, including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Models can also run on your own machine via MLX, Ollama, llama.cpp, vLLM, and LM Studio."
+                    "text": "The latest models, including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, reached through providers such as FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Models can also run on your own machine with MLX, Ollama, llama.cpp, vLLM, and LM Studio."
                   }
                 },
                 {
@@ -206,7 +206,7 @@ export default function RootLayout({
                   "name": "Who is NodeTool for?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Independent generative artists, motion designers, AI-native illustrators, technical art directors, ComfyUI power users frustrated with the UX, and small creative studios, brand teams, and post-production shops working with AI every day."
+                    "text": "Independent artists, motion designers, illustrators, and art directors, along with small creative studios, brand teams, and post-production houses that work with AI every day."
                   }
                 },
                 {
@@ -214,7 +214,7 @@ export default function RootLayout({
                   "name": "Is NodeTool open source?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. Both Studio and Cloud share the same AGPL-3.0 codebase. There is no closed-source layer and no \"pro tier\" hiding the good features. You can self-host any time."
+                    "text": "Yes. Studio and Cloud are built from the same AGPL-3.0 source. Nothing is held back for a paid tier, and you can host it yourself at any time."
                   }
                 }
               ]
@@ -231,7 +231,7 @@ export default function RootLayout({
               "@type": "VideoObject",
               "name": "NodeTool — the open creative AI workspace (demo)",
               "description":
-                "A walkthrough of NodeTool: wiring image, video, audio, and text models from every major provider into one node-based canvas, called with your own keys.",
+                "A walkthrough of NodeTool: connecting image, video, audio, and text models from every major provider on one visual canvas, using your own keys.",
               "thumbnailUrl": "https://nodetool.ai/preview.png",
               "contentUrl": "https://nodetool.ai/demo.mp4",
               "uploadDate": "2026-01-01",

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -27,19 +27,19 @@ const marketingBenefits = [
   {
     title: "Output at campaign volume",
     description:
-      "One workflow, run across every SKU, market, or audience segment. The cost that matters is cost-per-asset at scale, not the polish of a single hero shot.",
+      "Build one workflow and run it for every product, market, or audience. What matters at that scale is the cost of each asset, not the polish of a single hero shot.",
     icon: TrendingUp,
   },
   {
     title: "Every model, your keys",
     description:
-      "Flux, Veo, Kling, Seedance, Suno, ElevenLabs, and more, called with your own provider keys at list price. No credit packs, no per-seat markup.",
+      "Flux, Veo, Kling, Seedance, Suno, ElevenLabs, and more, all run with your own provider keys at list price. No credit packs and no per-seat markup.",
     icon: Zap,
   },
   {
     title: "Brand consistency, built in",
     description:
-      "Lock a palette, a voice, or a product shot into the workflow once. Every asset it produces inherits it — no manual re-briefing per output.",
+      "Set a palette, a tone of voice, or a product shot once, and every asset the workflow produces follows it. There is no need to re-brief for each output.",
     icon: Palette,
   },
 ];
@@ -60,13 +60,13 @@ const upcomingWorkflows = [
   {
     title: "Cold Outreach Co-Pilot",
     description:
-      "Research a prospect list and draft personalized outreach at volume, without losing the personal read.",
+      "Research a list of prospects and draft personalized outreach at volume, while it still reads as though a person wrote it.",
     icon: Mail,
   },
   {
     title: "Hook & Thumbnail Factory",
     description:
-      "Batch-generate and A/B-test video hooks and thumbnail concepts from a video title and description.",
+      "Generate video hooks and thumbnail ideas in batches from a title and description, then test them against each other.",
     icon: Youtube,
   },
 ];
@@ -138,9 +138,9 @@ export default function MarketingSegmentPage() {
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
                   Product videos, ad creative, social calendars, and brand
-                  assets from every major model, called with your own keys,
-                  on one node-based canvas. No marked-up credits, no lock-in
-                  — built for output volume, not one-off polish.
+                  assets from every major model, run with your own keys on one
+                  visual canvas. No marked-up credits, nothing locking you in,
+                  and built for steady output rather than one-off polish.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -254,12 +254,12 @@ export default function MarketingSegmentPage() {
                 </h3>
                 <p className="text-lg text-slate-400 leading-relaxed mb-6">
                   Turn a campaign brief and a single product photo into a
-                  cinematic 16:9 product video. Your inputs feed a prompt, an
-                  agent directs the shot, and a text-to-video model renders
-                  it, ready to re-run across every SKU in the line.
+                  cinematic 16:9 product video. Your inputs shape the prompt, an
+                  agent directs the shot, and a video model renders it, ready to
+                  run again for every product in the line.
                 </p>
                 <ul className="space-y-3 mb-8">
-                  {["Brief → Prompt → Agent → Text-to-Video", "Re-runnable per SKU or market", "Your own keys for every model in the workflow"].map(
+                  {["Brief, prompt, agent, then video", "Run it again per product or market", "Your own keys for every model in the workflow"].map(
                     (item) => (
                       <li key={item} className="flex items-center gap-3 text-slate-300">
                         <Check className="w-5 h-5 text-emerald-400" />
@@ -314,8 +314,9 @@ export default function MarketingSegmentPage() {
                 More marketing workflows on the way
               </h2>
               <p className="text-lg text-slate-400 leading-relaxed">
-                The Product Video Generator ships today. These are next up —
-                same pattern: brief in, campaign out.
+                The Product Video Generator is available today. These are next,
+                and they follow the same pattern: a brief goes in, a campaign
+                comes out.
               </p>
             </motion.div>
 
@@ -364,7 +365,7 @@ export default function MarketingSegmentPage() {
                 </span>
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-                Download NodeTool, plug in the providers you already pay for,
+                Download NodeTool, connect the providers you already pay for,
                 and build the workflow that produces your next campaign.
               </p>
               <SmartDownloadButton

--- a/marketing/src/app/models/[slug]/page.tsx
+++ b/marketing/src/app/models/[slug]/page.tsx
@@ -353,7 +353,7 @@ function ProviderTable({ model }: { model: ModelEntry }) {
               <tr className="bg-slate-900/60 text-sm">
                 <th className="px-5 py-4 font-medium text-slate-400">Provider</th>
                 <th className="px-5 py-4 font-medium text-slate-400">
-                  BYOK env var
+                  Setting for your key
                 </th>
               </tr>
             </thead>

--- a/marketing/src/app/models/page.tsx
+++ b/marketing/src/app/models/page.tsx
@@ -67,9 +67,9 @@ export default function ModelsHubPage() {
             Every top model, as a node
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            Image and video&apos;s best models — run each in a visual AI
-            workflow, chain them, and put any two through the same prompt.
-            Bring-your-own-key at provider prices.
+            The best image and video models available today. Run any of them in a
+            visual workflow, put them one after another, or give two the same
+            prompt and compare. You use your own keys at provider prices.
           </p>
         </section>
 

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -7,6 +7,7 @@ import { motion } from "framer-motion";
 import SiteHeader from "../components/SiteHeader";
 import SiteFooter from "../components/SiteFooter";
 import NodeToolHero from "../components/NodeToolHero";
+import StatusQuoSection from "../components/StatusQuoSection";
 import BuildRunDeploy from "../components/BuildRunDeploy";
 import OwnershipSection from "../components/OwnershipSection";
 import ModelSupportSection from "../components/ModelSupportSection";
@@ -249,6 +250,9 @@ export default function Home() {
           </div>
         </section>
 
+        {/* Name the pain before showing the fix — the demo answers this block */}
+        <StatusQuoSection />
+
         {/* Demo video — surface the product immediately after the hero */}
         <section id="demo-video" aria-label="NodeTool Demo" className="rhythm-section relative scroll-mt-24">
           <div className={`${sectionContainer}`}>
@@ -295,11 +299,20 @@ export default function Home() {
         {/* Concrete proof right after the mental model: a complete, runnable workflow */}
         <UseCasesShowcase />
 
+        {/* Position vs. the alternatives — answers the status-quo block up top */}
+        <ComparisonSection reducedMotion={reducedMotion} />
+
+        {/* Ownership — the core pillar, kept adjacent to the model story it explains */}
+        <OwnershipSection reducedMotion={reducedMotion} />
+        <ModelSupportSection reducedMotion={reducedMotion} />
+
+        {/* Cost transparency — the payoff of your own keys: real per-run cost */}
+        <CostDashboardSection />
+
+        {/* --- Secondary: what's inside, once the narrative has landed --- */}
+
         {/* What the canvas does */}
         <FeaturesSection />
-
-        {/* What's in the canvas */}
-        <NodeMenuSection />
 
         {/* Assemble the generated clips — built-in timeline editor */}
         <TimelineEditorSection />
@@ -307,22 +320,17 @@ export default function Home() {
         {/* Paint and generate on one canvas — built-in sketch editor (sibling to the timeline editor) */}
         <SketchEditorSection />
 
+        {/* What's in the canvas */}
+        <NodeMenuSection />
+
         {/* Asset Manager — companion to the canvas story */}
         <AssetManagerSection />
 
         {/* Alternate interface: drive workflows by chat (payoff after canvas) */}
         <ChatUISection />
 
-        {/* Position vs. the alternatives — sets up the BYOK / your-stack story that follows */}
-        <ComparisonSection reducedMotion={reducedMotion} />
-
-        {/* Ownership block — three adjacent sections that share the BYOK / your-stack story */}
-        <OwnershipSection reducedMotion={reducedMotion} />
-        <ModelSupportSection reducedMotion={reducedMotion} />
+        {/* Local model library — supports the "runs on your machine" claim above */}
         <ModelManagerSection />
-
-        {/* Cost transparency — the payoff of BYOK: pay providers directly, see every node's real cost */}
-        <CostDashboardSection />
 
         {/* Templates Gallery */}
         {/* <ExamplesGrid /> */}
@@ -387,8 +395,9 @@ export default function Home() {
               Put every model on one canvas.
             </h2>
             <p className="mt-4 text-lg text-slate-300">
-              Free, open source, and yours to run. Download Studio — or try
-              Cloud in the browser, nothing to install.
+              Start the next piece and finish it in the same place. Free, open
+              source, and yours to run: download Studio, or try Cloud in the
+              browser with nothing to install.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/pricing/page.tsx
+++ b/marketing/src/app/pricing/page.tsx
@@ -8,12 +8,12 @@ import { SmartDownloadButton } from "../SmartDownloadButton";
 export const metadata: Metadata = {
   title: "Pricing — free Studio, your own keys, pay providers directly | NodeTool",
   description:
-    "NodeTool Studio is free and open source. NodeTool Cloud is a subscription for managed hosting. In both, you bring your own API keys and pay providers their list prices — no credits, no markup.",
+    "NodeTool Studio is free and open source. NodeTool Cloud is a subscription that covers hosting. In both, you bring your own API keys and pay providers their list prices, with no credits and no markup.",
   alternates: { canonical: "/pricing" },
   openGraph: {
     title: "NodeTool Pricing — free Studio, your own keys to every provider",
     description:
-      "Studio is free and open source. Cloud is managed hosting. In both you bring your own keys: pay providers directly at their list prices, no credits, no markup.",
+      "Studio is free and open source. Cloud covers hosting. In both you bring your own keys and pay providers directly at their list prices, with no credits and no markup.",
     url: "https://nodetool.ai/pricing",
     type: "website",
   },
@@ -33,7 +33,7 @@ const offers = {
   "@type": "Product",
   name: "NodeTool",
   description:
-    "The open creative AI workspace. Studio (desktop) is free; Cloud is a managed subscription. In both you bring your own API keys.",
+    "The open creative AI workspace. Studio on the desktop is free, and Cloud is a hosted subscription. In both you bring your own API keys.",
   brand: { "@type": "Brand", name: "NodeTool" },
   offers: [
     {
@@ -48,7 +48,7 @@ const offers = {
       "@type": "Offer",
       name: "NodeTool Cloud",
       description:
-        "Managed hosting subscription (currently in alpha). Bring your own keys to every provider.",
+        "Hosted subscription, currently in alpha. Bring your own keys to every provider.",
       url: "https://nodetool.ai/cloud",
       availability: "https://schema.org/PreOrder",
     },
@@ -61,7 +61,7 @@ const editionRows: { label: string; studio: string | boolean; cloud: string | bo
   { label: "Bring your own API keys", studio: true, cloud: true },
   { label: "Pay providers directly (no markup)", studio: true, cloud: true },
   { label: "Local models (Ollama, MLX, llama.cpp)", studio: true, cloud: false },
-  { label: "Zero setup / no GPU needed", studio: false, cloud: true },
+  { label: "No setup and no graphics card needed", studio: false, cloud: true },
   { label: "Open source (AGPL-3.0)", studio: true, cloud: true },
   { label: "Self-host any time", studio: true, cloud: true },
 ];
@@ -102,9 +102,9 @@ export default function PricingPage() {
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
             NodeTool Studio is free and open source. NodeTool Cloud is a
-            subscription for managed hosting. In both editions you bring your own
-            API keys and pay each provider their list price — no credits, no
-            markup, no locked-down model list.
+            subscription that covers hosting. In both, you bring your own API keys
+            and pay each provider their list price. There are no credits, no
+            markup, and no restricted list of models.
           </p>
         </section>
 
@@ -122,7 +122,7 @@ export default function PricingPage() {
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
                   "Runs on macOS, Windows, and Linux",
-                  "Local models via Ollama, MLX, llama.cpp",
+                  "Local models through Ollama, MLX, and llama.cpp",
                   "Your own keys to every cloud provider",
                   "Your workflows and files stay on your machine",
                 ].map((f) => (
@@ -148,19 +148,19 @@ export default function PricingPage() {
                   Alpha
                 </span>
               </div>
-              <p className="mt-1 text-sm text-slate-400">Hosted · zero setup</p>
+              <p className="mt-1 text-sm text-slate-400">Hosted · nothing to install</p>
               <div className="mt-6 flex items-baseline gap-2">
                 <span className="text-4xl font-bold text-white">Subscription</span>
               </div>
               <p className="mt-1 text-sm text-slate-400">
-                Managed hosting of the same open-source app. Pricing will be
-                set at full release.
+                Hosting for the same open-source app. Pricing will be set at
+                full release.
               </p>
               <ul className="mt-6 space-y-3 text-sm text-slate-300">
                 {[
-                  "Runs in your browser — no install, no GPU",
+                  "Runs in your browser, with nothing to install",
                   "Your own keys to every cloud provider",
-                  "Same AGPL-3.0 codebase you can self-host",
+                  "The same AGPL-3.0 code you can host yourself",
                   "Pay providers directly at provider prices",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2">
@@ -214,15 +214,15 @@ export default function PricingPage() {
         <section aria-labelledby="byok-title" className="mx-auto mt-16 max-w-3xl px-6">
           <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
             <h2 id="byok-title" className="text-2xl font-semibold tracking-tight text-white">
-              How &ldquo;bring your own keys&rdquo; works
+              How bringing your own keys works
             </h2>
             <p className="mt-4 leading-relaxed text-slate-300">
-              You add your own API keys for the providers you use — FAL, KIE,
-              OpenAI, Anthropic, Gemini, Replicate, and the rest. Model calls go
-              to those providers and you pay them their published list prices.
-              NodeTool does not run models on its own servers, does not issue
-              its own credits, and does not mark up model calls. Your
-              Cloud subscription pays for hosting the workspace, nothing more.
+              You add your own API keys for the providers you use, such as FAL,
+              KIE, OpenAI, Anthropic, Gemini, and Replicate. Every request goes
+              straight to those providers and you pay them their published prices.
+              NodeTool does not run models on its own servers, does not issue its
+              own credits, and does not add a markup. A Cloud subscription pays for
+              hosting the workspace, nothing more.
             </p>
           </div>
         </section>

--- a/marketing/src/app/providers/[slug]/page.tsx
+++ b/marketing/src/app/providers/[slug]/page.tsx
@@ -260,8 +260,8 @@ function ProviderPage({ entry }: { entry: ProviderEntry }) {
               </div>
             </div>
             <p className="max-w-sm text-sm leading-relaxed text-slate-400">
-              Calls go straight to {entry.name} with your key at their list
-              price — NodeTool never proxies or marks up the request.
+              Requests go straight to {entry.name} with your key at their list
+              price. NodeTool never sits in the middle and never adds a markup.
             </p>
           </div>
         </section>

--- a/marketing/src/app/providers/page.tsx
+++ b/marketing/src/app/providers/page.tsx
@@ -67,11 +67,11 @@ export default function ProvidersHubPage() {
             Every provider, bring your own key
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            NodeTool integrates {providerEntries.length} model providers — media
-            aggregators serving {aggregatorModels.toLocaleString()}+ image,
-            video, audio, and 3D models, plus direct LLM and voice APIs. Every
-            one is a node on the canvas, called with your own key at the
-            provider&apos;s list price — no credits, no markup.
+            NodeTool connects to {providerEntries.length} model providers. Between
+            them they offer more than {aggregatorModels.toLocaleString()} image,
+            video, audio, and 3D models, alongside text and voice services. Each
+            provider is a block on the canvas that runs on your own key at the
+            provider&apos;s list price, with no credits and no markup.
           </p>
         </section>
 

--- a/marketing/src/app/showcase/page.tsx
+++ b/marketing/src/app/showcase/page.tsx
@@ -59,8 +59,9 @@ export default function ShowcaseHubPage() {
             Made with NodeTool
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            Images and video generated with NodeTool workflows. Pick any shot to
-            see the exact model, workflow, and prompt — then remix it in the app.
+            Images and video made with NodeTool workflows. Pick any shot to see
+            the exact model, workflow, and prompt behind it, then make your own
+            version in the app.
           </p>
         </section>
 

--- a/marketing/src/app/solutions/page.tsx
+++ b/marketing/src/app/solutions/page.tsx
@@ -48,8 +48,8 @@ export default function SolutionsHub() {
               What do you want to build?
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-400">
-              Outcome and audience landing pages — each with a runnable NodeTool workflow you can
-              open in Studio and make your own.
+              Pages grouped by what you want to make and who you are, each with a
+              NodeTool workflow you can open in Studio and adapt.
             </p>
           </div>
         </section>

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -60,47 +60,47 @@ const proPoints = [
   {
     icon: WifiOff,
     title: "Works fully offline",
-    body: "Once your local models are downloaded, disconnect the internet and keep building — travel, secure environments, air-gapped machines.",
+    body: "Once your local models are downloaded you can disconnect from the internet and keep working, whether you are travelling or on a machine with no network at all.",
   },
   {
     icon: Shield,
     title: "Your data never leaves the device",
-    body: "Workflows, assets, prompts, and model outputs stay on your disk. No telemetry — and no cloud round-trip unless you explicitly call a remote API.",
+    body: "Workflows, files, prompts, and results stay on your disk. Nothing is reported back to us, and nothing leaves the machine unless you call a remote provider on purpose.",
   },
   {
     icon: Cpu,
     title: "Run open models on your machine",
-    body: "Ollama, MLX (Apple Silicon), llama.cpp, Hugging Face — all wired into the same nodes. Pick any open model and pay no API fees.",
+    body: "Ollama, MLX for Apple Silicon, llama.cpp, and Hugging Face all work with the same building blocks. Pick any open model and pay no usage fees.",
   },
   {
     icon: Zap,
     title: "Use your GPU to the fullest",
-    body: "NVIDIA GPUs on Windows and Linux, Apple Silicon on macOS. Image, video, and audio nodes use your hardware directly.",
+    body: "NVIDIA graphics cards on Windows and Linux, Apple Silicon on macOS. Image, video, and audio work runs on your own hardware.",
   },
   {
     icon: HardDrive,
     title: "Own your model library",
-    body: "Built-in Model Manager downloads, organizes, and shares model files across workflows. Keep exactly the models you want.",
+    body: "The built-in model manager downloads and organizes model files and shares them across workflows, so you keep exactly the models you want.",
   },
   {
     icon: Code2,
     title: "Custom Python and TypeScript nodes",
-    body: "Drop in your own code, install Python packages in the bundled environment, or sandbox untrusted code in Docker.",
+    body: "Add your own code, install Python packages in the environment that ships with the app, or run code you do not trust inside Docker.",
   },
 ];
 
 const consPoints = [
   {
     title: "Hardware matters",
-    body: "Local models need RAM and ideally a GPU. We recommend 16GB+ RAM and 4GB+ of GPU memory for serious local-model work.",
+    body: "Local models need memory and ideally a graphics card. For serious local work we suggest 16GB or more of RAM and at least 4GB of graphics memory.",
   },
   {
     title: "You manage updates",
-    body: "When a new release ships, you install it. We sign and notarize builds for macOS/Windows so updates stay easy.",
+    body: "When a new release comes out, you install it. Builds are signed and notarized for macOS and Windows, so updating stays simple.",
   },
   {
     title: "Disk space",
-    body: "Local models are large — plan ~20GB for a small starter set, much more for video and image models.",
+    body: "Local models are large. Allow around 20GB for a small starter set, and considerably more for image and video models.",
   },
 ];
 
@@ -213,10 +213,10 @@ export default function StudioPage() {
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Studio is the desktop app for builders who want
-                  their models, data, and outputs to stay on their own machine.
-                  Run free local models with Ollama and MLX — and bring your
-                  own keys for any cloud provider when you need them.
+                  NodeTool Studio is the desktop app for people who want their
+                  models, data, and results to stay on their own machine. Run
+                  free local models with Ollama and MLX, and bring your own keys
+                  for a cloud provider whenever you need one.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton
@@ -281,7 +281,8 @@ export default function StudioPage() {
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl">
                 Everything Studio does, it can do without a network connection.
-                Your prompts, your files, and your models — all on your hardware.
+                Your prompts, your files, and your models all stay on your own
+                hardware.
               </p>
             </header>
 
@@ -324,8 +325,9 @@ export default function StudioPage() {
                 What Studio asks of you.
               </h2>
               <p className="mt-4 text-base text-slate-400 leading-relaxed max-w-2xl">
-                Running everything on your own machine means you take on a few
-                things the cloud would otherwise handle. If any of these feel heavy,{" "}
+                Running everything on your own machine means taking on a few jobs
+                the cloud would otherwise handle. If any of these feel like too
+                much,{" "}
                 <a
                   href="/cloud"
                   className="text-blue-300 hover:text-blue-200 underline underline-offset-2"
@@ -379,9 +381,9 @@ export default function StudioPage() {
                 100% open source. Always.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Studio is released under AGPL-3.0. Every node, every provider,
-                every line of the runtime is on GitHub. Audit it, fork it,
-                self-host it — there is no separate &ldquo;pro&rdquo; codebase.
+                Studio is released under AGPL-3.0. Every building block, every
+                provider, and every line that runs it is on GitHub. Read it, copy
+                it, or host it yourself. There is no separate paid version.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool"

--- a/marketing/src/app/tasks/page.tsx
+++ b/marketing/src/app/tasks/page.tsx
@@ -43,8 +43,8 @@ export default function TasksHub() {
               AI tasks, done on one canvas
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-400">
-              Pick a capability — the models that do it, the templates that wire it, and how to run
-              it yourself with your own keys.
+              Pick what you want to do, then see the models that do it, the templates
+              that put them together, and how to run it with your own keys.
             </p>
           </div>
         </section>

--- a/marketing/src/app/templates/page.tsx
+++ b/marketing/src/app/templates/page.tsx
@@ -13,7 +13,7 @@ const BASE_URL = "https://nodetool.ai";
 export const metadata: Metadata = {
   title: "AI Workflow Templates — NodeTool",
   description:
-    "Browse ready-to-run NodeTool AI workflow templates for image, video, audio, agents, and marketing. Open any one in Studio and run it with your own keys.",
+    "Browse ready-to-run NodeTool workflow templates for image, video, audio, agents, and marketing. Open any of them in Studio and run it with your own keys.",
   alternates: { canonical: `${BASE_URL}/templates` },
 };
 
@@ -87,8 +87,8 @@ export default function TemplatesHub() {
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-400">
               Ready-to-run NodeTool workflows for image, video, audio, agents,
-              and marketing. Open any one in Studio, connect your keys, and run
-              it — then rewire the nodes to make it yours.
+              and marketing. Open one in Studio, connect your keys, and run it,
+              then rearrange it to suit your own work.
             </p>
             <div className="mt-8">
               <SmartDownloadButton

--- a/marketing/src/app/useCases.tsx
+++ b/marketing/src/app/useCases.tsx
@@ -2,7 +2,7 @@ export const useCases = [
   {
     name: "AI Agents & Automation",
     description:
-      "Multi-step agents that plan, execute, and adapt.",
+      "Agents that plan a job, carry it out, and adjust as they go.",
     image: "/usecase_agents.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-blue-400",
@@ -12,7 +12,7 @@ export const useCases = [
   {
     name: "Document Intelligence",
     description:
-      "Index documents, search with AI, and answer questions. RAG made simple.",
+      "Add your documents, search them with AI, and get answers with sources.",
     image: "/usecase_documents.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-emerald-400",
@@ -22,7 +22,7 @@ export const useCases = [
   {
     name: "Image & Video Creation",
     description:
-      "Generate and transform media. Mix Flux, NanoBanana, and custom models.",
+      "Generate and edit media, mixing Flux, NanoBanana, and your own models.",
     image: "/usecase_media.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-pink-400",
@@ -32,7 +32,7 @@ export const useCases = [
   {
     name: "Data Processing",
     description:
-      "Transform data, extract insights, and automate reports.",
+      "Reshape data, pull out what matters, and produce reports automatically.",
     image: "/usecase_data.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-teal-400",
@@ -42,7 +42,7 @@ export const useCases = [
   {
     name: "Voice & Audio",
     description:
-      "Transcribe, analyze, and generate speech with Whisper.",
+      "Turn speech into text, analyze it, and generate new voice tracks.",
     image: "/usecase_audio.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-cyan-400",
@@ -52,7 +52,7 @@ export const useCases = [
   {
     name: "Smart Assistants",
     description:
-      "AI assistants that understand documents, emails, and notes.",
+      "Assistants that can read your documents, emails, and notes.",
     image: "/usecase_assistant.png",
     href: "https://docs.nodetool.ai/workflows/",
     iconColor: "text-amber-400",

--- a/marketing/src/components/AssetManagerSection.tsx
+++ b/marketing/src/components/AssetManagerSection.tsx
@@ -80,7 +80,7 @@ export default function AssetManagerSection() {
               {
                 icon: PhotoIcon,
                 title: "Import & organize",
-                body: "Drag and drop. Files auto-organize by type, project, or tags.",
+                body: "Drag and drop. Files sort themselves by type, project, or tag.",
               },
               {
                 icon: CubeTransparentIcon,
@@ -90,7 +90,7 @@ export default function AssetManagerSection() {
               {
                 icon: PuzzlePieceIcon,
                 title: "Use in workflows",
-                body: "Reference assets in your workflows—folders or single files.",
+                body: "Point any workflow at a single file or a whole folder.",
               },
             ].map(({ icon: Icon, title, body }) => (
               <div key={title} className="group">

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -45,17 +45,17 @@ export default function BuildRunDeploy() {
       <div className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
-          title="Wire your canvas"
+          title="Build your canvas"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="Drag in models, edits, and assets. Connect them. Every model from every provider lives on the same canvas."
+          description="Drag in models, edits, and files, then connect them. Every model from every provider sits on the same canvas."
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Render with your keys"
+          title="Run it with your own keys"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
           description="Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate. Pay providers directly. Watch results stream in."
@@ -179,10 +179,10 @@ function BuildVisual() {
 function RunVisual() {
   const lines = [
     "Workflow started",
-    "LLM response received",
+    "Text written",
     "Image generated",
-    "Data transformed",
-    "Workflow completed",
+    "Clip assembled",
+    "Workflow finished",
   ];
   return (
     <div className="grid grid-cols-[1fr_auto] gap-3">

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -68,7 +68,7 @@ export default function BuildRunDeploy() {
           title="Edit and finish"
           icon={<Wand2 className="h-6 w-6" />}
           accent="amber"
-          description="Drop the generated image or clip into the built-in editors. Crop, mask, cut, and arrange on the timeline — no export, no second app."
+          description="Send the image or clip straight into the built-in editors. Crop, mask, cut, and arrange on the timeline. Nothing to export, no second app to open."
         >
           <EditVisual />
         </Card>

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -47,7 +47,7 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Skip the canvas when you don&apos;t need it. Ask in plain English, the right workflow runs, results stream back inline.
+            Skip the canvas when you don&apos;t need it. Ask in plain English, the right workflow runs, and the results come back in the conversation.
           </motion.p>
         </div>
 

--- a/marketing/src/components/CommunitySection.tsx
+++ b/marketing/src/components/CommunitySection.tsx
@@ -18,7 +18,7 @@ const variants = {
         Made with <span className="text-blue-400">working creatives</span>
       </>
     ),
-    body: "NodeTool is AGPL-3.0 open source. Star the repo, jump into Discord, and trade workflows with other artists, motion designers, and studios using it for real work.",
+    body: "NodeTool is open source under AGPL-3.0. Star the project on GitHub, join us on Discord, and share workflows with the artists, motion designers, and studios already using it on real jobs.",
     card: "rounded-3xl border border-white/10 bg-slate-900/40 backdrop-blur-xl p-8 md:p-16 text-center overflow-hidden relative",
     topBar:
       "absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-blue-500 to-transparent opacity-50",
@@ -35,7 +35,7 @@ const variants = {
         </span>
       </>
     ),
-    body: "Trade workflows, swap prompts, and ship work with other working creatives. NodeTool is open source under AGPL-3.0.",
+    body: "Share workflows and prompts, and compare notes with other working creatives. NodeTool is open source under AGPL-3.0.",
     card: "rounded-3xl border border-white/10 bg-gradient-to-br from-rose-500/10 via-teal-500/10 to-cyan-500/10 backdrop-blur-xl p-8 md:p-16 text-center overflow-hidden relative",
     topBar:
       "absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-rose-500 via-teal-500 to-cyan-500 opacity-50",
@@ -48,7 +48,7 @@ const variants = {
         Made with <span className="text-amber-400">marketing teams</span>
       </>
     ),
-    body: "NodeTool is AGPL-3.0 open source. Star the repo, jump into Discord, and trade campaign workflows with other marketers running production at scale.",
+    body: "NodeTool is open source under AGPL-3.0. Star the project on GitHub, join us on Discord, and share campaign workflows with marketers producing at volume.",
     card: "rounded-3xl border border-white/10 bg-gradient-to-br from-amber-500/10 via-emerald-500/10 to-cyan-500/10 backdrop-blur-xl p-8 md:p-16 text-center overflow-hidden relative",
     topBar:
       "absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-amber-500 via-emerald-500 to-cyan-500 opacity-50",

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -14,7 +14,7 @@ export default function ComparisonSection({
     <section
       id="differences"
       aria-labelledby="differences-title"
-      className="relative py-24"
+      className="relative py-24 scroll-mt-24"
     >
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-8">
         <header className="scroll-fade mb-14 max-w-3xl">

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -47,19 +47,19 @@ export default function ComparisonSection({
         <div className="scroll-fade grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
             competitor="ComfyUI"
-            sentence="ComfyUI is a node editor for image-generation models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away."
+            sentence="ComfyUI is an editor for image models. NodeTool is the studio around it: image, video, music, and words on one canvas, with every major model a click away."
             reducedMotion={reducedMotion}
             delay={0}
           />
           <ComparisonCard
             competitor="Figma Weave / closed canvases"
-            sentence="Closed canvases lock you into a credit system and a hand-picked list of models. NodeTool is open source — every provider, your own keys, provider prices."
+            sentence="Closed tools tie you to a credit system and a hand-picked list of models. NodeTool is open source: every provider, your own keys, and the prices those providers publish."
             reducedMotion={reducedMotion}
             delay={0.05}
           />
           <ComparisonCard
             competitor="A dozen browser tabs"
-            sentence="Midjourney, Runway, Photoshop, ElevenLabs, Suno — each in its own tab, none of them talking to each other. NodeTool wires them into one canvas you can run, share, and re-run."
+            sentence="Midjourney, Runway, Photoshop, ElevenLabs, and Suno each sit in their own tab, and none of them talk to each other. NodeTool brings them onto one canvas you can run, share, and run again."
             reducedMotion={reducedMotion}
             delay={0.1}
           />
@@ -103,15 +103,15 @@ export default function ComparisonSection({
                 Every model. Your keys. Your canvas.
               </h3>
               <p className="text-slate-300 leading-relaxed mb-4 text-[1.025rem]">
-                Take Seedance, one of today&apos;s top video models. It&apos;s
-                available on FAL, Replicate, and KIE at different price points.
-                NodeTool lets you pick the cheapest. And when the next Veo or
-                Kling ships, it&apos;s one node swap away.
+                Take Seedance, one of today&apos;s best video models. It is sold
+                by FAL, Replicate, and KIE at different prices, and NodeTool
+                lets you pick the cheapest of the three. When the next Veo or
+                Kling arrives, you switch to it in one click.
               </p>
               <p className="text-slate-400 leading-relaxed text-[1.025rem]">
-                That&apos;s what not being tied to one vendor buys you: the
-                best model at the best price, every week — and nothing to lose
-                if your favorite tool gets acquired.
+                That is what staying independent buys you: the best model at the
+                best price each week, and nothing to lose if your favorite tool
+                is bought by someone else.
               </p>
             </div>
           </div>

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -102,9 +102,9 @@ export default function CostDashboardSection() {
             See what every run actually costs
           </h3>
           <p className="mt-4 text-lg leading-relaxed text-slate-300">
-            NodeTool tracks the cost of every node run and totals it by
-            workflow, provider, or model. You bring your own keys and pay
-            providers directly, so the numbers are the real ones.
+            NodeTool records what each step costs and adds it up by workflow,
+            provider, or model. Because you use your own keys and pay providers
+            directly, these are the amounts you are actually billed.
           </p>
         </div>
 
@@ -370,16 +370,16 @@ export default function CostDashboardSection() {
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
           {[
             {
-              title: "Cost per node",
-              body: "Every run priced on its own, grouped by node, workflow, provider, or model.",
+              title: "Cost per step",
+              body: "Every run is priced on its own and can be grouped by step, workflow, provider, or model.",
             },
             {
               title: "No markup",
-              body: "Pay OpenAI, fal.ai, and the rest directly with your own keys. NodeTool takes zero cut.",
+              body: "Pay OpenAI, fal.ai, and the rest directly with your own keys. NodeTool takes no cut.",
             },
             {
               title: "Export anytime",
-              body: "Pull the full breakdown to CSV for your own books, billing, or client invoices.",
+              body: "Download the full breakdown as a spreadsheet for your own books or client invoices.",
             },
           ].map(({ title, body }) => (
             <div key={title}>

--- a/marketing/src/components/DeploySection.tsx
+++ b/marketing/src/components/DeploySection.tsx
@@ -33,10 +33,10 @@ export default function DeploySection({
             </h2>
 
             <p className="text-lg text-slate-400 mb-8 leading-relaxed">
-              Same workflow runs locally or on a remote GPU with no rewrites.
-              NodeTool builds the container image and ships it to your provider
-              of choice—RunPod, Google Cloud Run, Fly.io, Railway, or your own
-              SSH host.
+              The same workflow runs on your machine or on a rented GPU, with
+              nothing to rewrite. NodeTool packages it and sends it to the host
+              you pick: RunPod, Google Cloud Run, Fly.io, Railway, or a server
+              of your own.
             </p>
 
             <div className="flex flex-col gap-6">
@@ -46,14 +46,14 @@ export default function DeploySection({
                 </div>
                 <div>
                   <h3 className="text-white font-semibold">
-                    One Command Deploy
+                    One command to go live
                   </h3>
                   <p className="text-slate-400 text-sm mt-1 leading-relaxed">
                     Run{" "}
                     <code className="bg-slate-800 px-1.5 py-0.5 rounded text-purple-300 text-xs font-mono border border-white/5">
                       nodetool deploy
                     </code>{" "}
-                    to push your workflow to the cloud.
+                    sends your workflow to the cloud.
                   </p>
                 </div>
               </div>
@@ -63,11 +63,11 @@ export default function DeploySection({
                   <Zap className="w-5 h-5 text-pink-400" />
                 </div>
                 <div>
-                  <h3 className="text-white font-semibold">Serverless-Ready</h3>
+                  <h3 className="text-white font-semibold">Pay only while it runs</h3>
                   <p className="text-slate-400 text-sm mt-1 leading-relaxed">
-                    Deploy to Google Cloud Run for native scale-to-zero, or to
-                    RunPod serverless endpoints—pay only when your workflow
-                    runs.
+                    On Google Cloud Run or RunPod, the workflow starts when a
+                    request comes in and shuts down when it is done, so you are
+                    billed only for the time it was working.
                   </p>
                 </div>
               </div>
@@ -135,11 +135,11 @@ export default function DeploySection({
                     </span>
                   </div>
                   <div className="text-slate-400 pt-2">
-                    [+] Building workflow graph...{" "}
+                    [+] Packaging workflow...{" "}
                     <span className="text-green-400">Done</span>
                   </div>
                   <div className="text-slate-400">
-                    [+] Provisioning GPU instance (RTX 4090)...{" "}
+                    [+] Starting GPU machine (RTX 4090)...{" "}
                     <span className="text-green-400">Done</span>
                   </div>
                   <div className="text-slate-400">
@@ -147,7 +147,7 @@ export default function DeploySection({
                     <span className="text-green-400">Done</span>
                   </div>
                   <div className="text-slate-400 pb-2">
-                    [+] Configuring endpoint...{" "}
+                    [+] Setting up the web address...{" "}
                     <span className="text-green-400">Done</span>
                   </div>
                   <div className="text-purple-400 pt-2 border-t border-white/5">

--- a/marketing/src/components/EditionsCompareSection.tsx
+++ b/marketing/src/components/EditionsCompareSection.tsx
@@ -34,7 +34,7 @@ const rows: Row[] = [
     cloud: { value: "None — sign in and start building", ok: true },
   },
   {
-    label: "Local LLMs (Ollama, MLX, GGUF)",
+    label: "Local models (Ollama, MLX, GGUF)",
     studio: { value: "Yes — runs entirely on your hardware", ok: true },
     cloud: { value: "Not available — cloud APIs only", ok: false },
   },
@@ -171,7 +171,7 @@ export default function EditionsCompareSection({
         <header className="mb-12 max-w-3xl">
           <div className="mb-3 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.18em] text-blue-300/80">
             <span className="h-px w-8 bg-amber-300/60" />
-            Two editions, one open-source codebase
+            Two ways to run it, one open-source project
           </div>
           <motion.h2
             id="editions-title"
@@ -192,10 +192,10 @@ export default function EditionsCompareSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
-            Same workflows, same nodes, same providers. Pick the runtime that
-            fits how you want to work — and switch any time. Both editions are
-            AGPL-3.0 open source; Cloud is just our managed hosting of the same
-            code you can run yourself.
+            Same workflows, same building blocks, same providers. Pick the one
+            that suits how you work, and switch whenever you like. Both are
+            AGPL-3.0 open source: Cloud is simply our hosting of the same code
+            you can run yourself.
           </motion.p>
         </header>
 
@@ -206,9 +206,9 @@ export default function EditionsCompareSection({
             <div className="p-5 space-y-4">
               <p className="text-sm text-slate-300 leading-relaxed">
                 <strong className="text-white">Best for:</strong> artists with
-                a capable GPU or Apple Silicon, large local model collections,
-                offline work, and anyone who wants every byte on their own
-                disk.
+                a good graphics card or an Apple Silicon Mac, big local model
+                collections, offline work, and anyone who wants everything kept
+                on their own disk.
               </p>
               <ul className="space-y-2.5">
                 {rows.map((r) => (
@@ -229,9 +229,9 @@ export default function EditionsCompareSection({
             <div className="p-5 space-y-4">
               <p className="text-sm text-slate-300 leading-relaxed">
                 <strong className="text-white">Best for:</strong> studios and
-                solo artists who want to start in seconds, work from any
-                device, and skip the GPU setup — while still bringing their
-                own keys to every provider.
+                solo artists who want to start in seconds, work from any device,
+                and skip the hardware setup, while still using their own keys
+                with every provider.
               </p>
               <ul className="space-y-2.5">
                 {rows.map((r) => (
@@ -256,8 +256,8 @@ export default function EditionsCompareSection({
           <a href="/studio" className="text-blue-300 hover:text-blue-200 underline underline-offset-2">
             Studio
           </a>{" "}
-          when you want full local control. Your workflows are portable between
-          both.
+          when you want everything on your own machine. Your workflows move freely
+          between the two.
         </p>
       </div>
     </section>

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -59,9 +59,8 @@ export default function FeaturesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Image, video, audio, and text on a single node-based canvas — with
-            the editing tools you rely on wired in right next to the model
-            calls.
+            Image, video, audio, and text on a single visual canvas, with the
+            editing tools you already rely on sitting right next to the models.
           </motion.p>
         </div>
 
@@ -114,16 +113,16 @@ export default function FeaturesSection({
             {
               title: "Edit where you generate",
               description:
-                "Mask, retouch, extend, relight, upscale, layer, and composite. The editing tools you reach for, wired into the same canvas as the model calls.",
+                "Mask, retouch, extend, relight, upscale, layer, and composite. The editing tools you reach for live on the same canvas as the models.",
               icon: MousePointer2,
               color: "text-blue-400",
               bg: "bg-blue-500/10",
               border: "border-blue-500/20",
             },
             {
-              title: "Watch every node render",
+              title: "Watch every step render",
               description:
-                "Outputs stream in as nodes finish. Inspect any frame, swap a model, re-run from that node down.",
+                "Results appear as each step finishes. Inspect any frame, swap a model, and re-run from that point on.",
               icon: Activity,
               color: "text-purple-400",
               bg: "bg-purple-500/10",
@@ -141,7 +140,7 @@ export default function FeaturesSection({
             {
               title: "Image, video, audio, text",
               description:
-                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, Suno — all of it on one canvas, under their real names. No renamed mystery models.",
+                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, and Suno, all on one canvas under their real names. You always know which model you are running.",
               icon: Layers,
               color: "text-orange-400",
               bg: "bg-orange-500/10",

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -61,6 +61,7 @@ export default function FeaturesSection({
           >
             Image, video, audio, and text on a single visual canvas, with the
             editing tools you already rely on sitting right next to the models.
+            You direct the whole piece instead of generating parts of it.
           </motion.p>
         </div>
 

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -98,7 +98,7 @@ export default function ModelSupportSection({
                     >
                         The newest models,{" "}
                         <span className="text-white">
-                            the day they ship.
+                            the day they arrive.
                         </span>
                     </motion.h2>
 
@@ -109,9 +109,9 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.25, delay: 0.05 }}
                         className="text-lg text-slate-400 leading-relaxed"
                     >
-                        Frontier image, video, audio, and language models from
-                        every major provider — or running on your own machine
-                        when you want them local.
+                        The leading image, video, audio, and language models from
+                        every major provider, or the same kind of models running
+                        on your own computer when you prefer that.
                     </motion.p>
                 </div>
 

--- a/marketing/src/components/NodeMenuSection.tsx
+++ b/marketing/src/components/NodeMenuSection.tsx
@@ -53,7 +53,7 @@ export default function NodeMenuSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Hundreds of nodes for models, data, and files — plus auto-generated nodes for every Replicate, FAL, and Kie.ai model.
+            Hundreds of ready-made blocks for models, data, and files, plus one for every model on Replicate, FAL, and Kie.ai.
           </motion.p>
         </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -34,10 +34,10 @@ export default function NodeToolHero() {
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            Make films, posters, product videos, and music on one node-based
-            canvas, with every major model from every major provider. Your own
-            keys, provider prices — and when the next model ships, you&apos;re
-            one node swap away.
+            Make films, posters, product videos, and music on a single visual
+            canvas, using every major model from every major provider. You bring
+            your own keys and pay provider prices. When a new model arrives, you
+            switch to it in one click.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -19,25 +19,26 @@ export default function NodeToolHero() {
         <div className="hero-rise lg:col-span-5">
           <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
             <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
-            Free &amp; Open Source
+            The open creative AI workspace &middot; Free &amp; open source
           </span>
 
           <h1
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            The open creative
+            One canvas.
+            <br />
+            Every model.
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              AI workspace.
+              Your keys.
             </span>
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            Make films, posters, product videos, and music on a single visual
-            canvas, using every major model from every major provider. You bring
-            your own keys and pay provider prices. When a new model arrives, you
-            switch to it in one click.
+            Make films, posters, product videos, and music without credit
+            systems, markups, or lock-in. Stay in one place from the first idea
+            to the final cut.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -19,26 +19,24 @@ export default function NodeToolHero() {
         <div className="hero-rise lg:col-span-5">
           <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
             <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
-            The open creative AI workspace &middot; Free &amp; open source
+            Free &amp; Open Source
           </span>
 
           <h1
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            One canvas.
-            <br />
-            Every model.
+            The open creative
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              Your keys.
+              AI workspace.
             </span>
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            Make films, posters, product videos, and music without credit
-            systems, markups, or lock-in. Stay in one place from the first idea
-            to the final cut.
+            Films, posters, product videos, and music, made start to finish on
+            one canvas. Every major model, your own keys, and no credits or
+            markups in between.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -57,11 +57,10 @@ export default function OwnershipSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Every closed AI tool ends the same way: a price hike, fewer
-            models, or an acquisition that quietly rewrites the roadmap.
-            NodeTool calls whatever models you choose, charges you what the
-            providers charge, and ships under a license that outlives whoever
-            built it.
+            Every closed AI tool ends the same way: a price rise, fewer models,
+            or an acquisition that quietly rewrites the roadmap. NodeTool runs
+            whichever models you choose, charges you what the providers charge,
+            and is released under a license that outlives whoever built it.
           </motion.p>
         </div>
 

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -12,17 +12,17 @@ const features = [
   },
   {
     title: "Provider prices, no credits",
-    body: "No proprietary tokens. No minimum top-up. You pay providers what they charge. The same Seedance call that costs $0.18 on KIE costs $0.18 in NodeTool.",
+    body: "No in-house credits and no minimum top-up. You pay providers exactly what they charge: a Seedance run that costs $0.18 on KIE costs $0.18 in NodeTool.",
     icon: Shield,
   },
   {
     title: "Open source, always",
-    body: "Both editions — Studio (desktop) and Cloud (hosted) — share the same AGPL-3.0 codebase. No closed-source layer, no “pro tier” hiding the good features. Self-host any time.",
+    body: "Studio on the desktop and Cloud in the browser are built from the same AGPL-3.0 source. Nothing is held back for a paid tier, and you can host it yourself at any time.",
     icon: Globe,
   },
   {
     title: "Run models on your own machine",
-    body: "MLX, Ollama, llama.cpp, vLLM, LM Studio — fully supported. Runs offline once models are downloaded. Local is a feature, not a religion.",
+    body: "MLX, Ollama, llama.cpp, vLLM, and LM Studio are supported by default. Once a model is downloaded, it keeps running with no internet connection.",
     icon: Cpu,
   },
 ];

--- a/marketing/src/components/ProvidersSection.tsx
+++ b/marketing/src/components/ProvidersSection.tsx
@@ -53,7 +53,7 @@ export default function ProvidersSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Bring your own API keys — no markup, no middleman.
+            Bring your own API keys. No markup, no middleman.
           </motion.p>
         </div>
 
@@ -70,7 +70,7 @@ export default function ProvidersSection({
               <div className="absolute inset-0 bg-gradient-to-tr from-blue-500/5 to-purple-500/5 pointer-events-none" />
               <Image
                 src="/screen_llms.png"
-                alt="List of available LLM providers"
+                alt="List of available model providers"
                 width={1400}
                 height={900}
                 className="w-full h-auto opacity-90 transition-opacity group-hover:opacity-100"
@@ -101,7 +101,7 @@ export default function ProvidersSection({
             },
             {
               title: "Mix and Match",
-              description: "Use different providers within a single workflow. Switch models with one click.",
+              description: "Use several providers in the same workflow, and switch models with one click.",
               icon: Zap,
               color: "text-purple-400",
               bg: "bg-purple-500/10",
@@ -109,7 +109,7 @@ export default function ProvidersSection({
             },
             {
               title: "No Middleman",
-              description: "Direct API calls from your machine. No markup, no tracking.",
+              description: "Requests go straight from your machine to the provider. No markup, no tracking.",
               icon: ShieldCheck,
               color: "text-emerald-400",
               bg: "bg-emerald-500/10",

--- a/marketing/src/components/StatusQuoSection.tsx
+++ b/marketing/src/components/StatusQuoSection.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { ArrowRight } from "lucide-react";
+
+/**
+ * The pain, stated once and briefly, between the hero and the demo.
+ *
+ * Deliberately low-chrome: no icon cards, no grid of features. It exists to
+ * name the reader's current workflow so the demo that follows lands harder.
+ */
+
+const frictions = [
+  {
+    where: "Five tabs",
+    what: "Midjourney for the still, Runway for the motion, ElevenLabs for the voice, Premiere to put it together.",
+  },
+  {
+    where: "Export, import, repeat",
+    what: "Every handoff costs you the thread — the prompt, the seed, the reason you made that choice.",
+  },
+  {
+    where: "Credits you bought in advance",
+    what: "Paid at a markup, spent on a list of models somebody else picked for you.",
+  },
+  {
+    where: "The tool you rely on gets acquired",
+    what: "Prices move, models disappear, and your work sits inside somebody else's roadmap.",
+  },
+];
+
+export default function StatusQuoSection() {
+  return (
+    <section
+      aria-labelledby="status-quo-title"
+      className="relative py-16 sm:py-20"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="rounded-2xl border border-slate-800/70 bg-slate-950/40 p-8 md:p-10">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,20rem)_1fr] lg:gap-12">
+            <div>
+              <div className="mb-3 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.18em] text-rose-300/80">
+                <span className="h-px w-8 bg-rose-400/50" />
+                The way it works today
+              </div>
+              <h2
+                id="status-quo-title"
+                className="text-2xl font-bold tracking-tight text-white md:text-3xl"
+              >
+                Making one piece
+                <br />
+                shouldn&apos;t take five tools.
+              </h2>
+              <p className="mt-4 text-slate-400 leading-relaxed">
+                Stop exporting. Start finishing.
+              </p>
+              <a
+                href="#differences"
+                className="mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-blue-300 transition-colors hover:text-blue-200 focus-ring"
+              >
+                See how NodeTool compares
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
+
+            <ul className="space-y-5">
+              {frictions.map((f) => (
+                <li
+                  key={f.where}
+                  className="flex gap-4 border-l border-slate-800 pl-5"
+                >
+                  <div>
+                    <div className="text-sm font-semibold text-slate-200">
+                      {f.where}
+                    </div>
+                    <p className="mt-1 text-sm leading-relaxed text-slate-400">
+                      {f.what}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/marketing/src/components/UseCasesSection.tsx
+++ b/marketing/src/components/UseCasesSection.tsx
@@ -43,7 +43,7 @@ export default function UseCasesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Image, video, audio, text, agents, RAG — all on the same canvas. Wire the models you want, switch when better ones ship.
+            Image, video, audio, text, agents, and answers drawn from your own documents, all on the same canvas. Choose the models you want and switch whenever a better one arrives.
           </motion.p>
         </div>
 

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -66,8 +66,8 @@ export default function UseCasesShowcase() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed"
           >
-            Real workflows you can open, run, and rewire. Each one is complete,
-            not a demo, and built from the same nodes you get on day one.
+            Real workflows you can open, run, and change. Each one is finished
+            work, not a demo, and built from the blocks you get on day one.
           </motion.p>
         </div>
 

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -66,8 +66,9 @@ export default function UseCasesShowcase() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed"
           >
-            Real workflows you can open, run, and change. Each one is finished
-            work, not a demo, and built from the blocks you get on day one.
+            Real workflows you can open, run, and change. Each one runs from the
+            brief to the finished piece without leaving the canvas, and every one
+            is built from the blocks you get on day one.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -45,7 +45,7 @@ export default function AgentBuildRunDeploy() {
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-3 relative z-10">
                     <Card
                         title="Write the brief"
-                        subtitle="Set the look, the mood, the deliverable. Wire in the image, video, and audio models you want the agent to direct — Flux, Seedance, Veo, Suno, ElevenLabs."
+                        subtitle="Set the look, the mood, and what you need delivered. Choose the image, video, and audio models the agent should direct: Flux, Seedance, Veo, Suno, ElevenLabs."
                         step={1}
                         accentColor="blue"
                     >
@@ -54,7 +54,7 @@ export default function AgentBuildRunDeploy() {
 
                     <Card
                         title="Watch it direct"
-                        subtitle="See the agent reason about the shot, choose the model, generate variants, and self-correct when a render misses the brief. Every decision is on screen."
+                        subtitle="See the agent think through the shot, choose a model, produce variations, and try again when a render misses the brief. Every decision is on screen."
                         step={2}
                         accentColor="purple"
                     >
@@ -63,7 +63,7 @@ export default function AgentBuildRunDeploy() {
 
                     <Card
                         title="Iterate the cut"
-                        subtitle="Tweak the prompt, swap a model, re-run a branch — or save the whole agent as a node and reuse it on the next campaign. Your taste, multiplied."
+                        subtitle="Adjust the prompt, swap a model, or re-run one part. You can also save the whole agent and use it again on the next campaign."
                         step={3}
                         accentColor="emerald"
                     >
@@ -357,7 +357,7 @@ function DeployGraphic() {
             {/* Success Toast */}
             <div className="absolute -bottom-2 bg-emerald-900/80 border border-emerald-500/30 text-emerald-200 text-xs px-3 py-1 rounded-full flex items-center gap-1.5 shadow-lg backdrop-blur-md animate-[bounce_3s_infinite]">
                 <div className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                Saved as reusable node
+                Saved for reuse
             </div>
         </div>
     );

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -25,21 +25,21 @@ export default function AgentFeaturesSection({
       icon: Brain,
       title: "Briefs become storyboards",
       description:
-        "Drop in a one-line prompt or a full mood board. The agent plans the shots, picks the model for each one, and lays out a board you can rearrange before a single render runs.",
+        "Give it a one-line prompt or a full mood board. The agent plans the shots, picks a model for each one, and lays out a board you can rearrange before anything is rendered.",
       color: "teal",
     },
     {
       icon: GitFork,
       title: "Batch variants in parallel",
       description:
-        "Need ten alts of the hero frame in five aspect ratios? The agent fans the work out across providers, runs them at the same time, and brings the cuts back ranked for review.",
+        "Need ten versions of the hero frame in five aspect ratios? The agent spreads the work across providers, runs them at the same time, and brings the results back ranked for review.",
       color: "blue",
     },
     {
       icon: Users,
       title: "A crew, not a single model",
       description:
-        "Run a director, a stylist, and a colorist as separate agents that hand off via a shared board. Each one gets the model and prompt that fits its job.",
+        "Run a director, a stylist, and a colorist as separate agents that hand work to each other on a shared board. Each gets the model and prompt that suits its job.",
       color: "cyan",
     },
     {
@@ -53,14 +53,14 @@ export default function AgentFeaturesSection({
       icon: Eye,
       title: "See every decision",
       description:
-        "Watch the agent reason about composition, swap models when a render misses, and log every prompt it tried. No black boxes when the deadline hits.",
+        "Watch the agent think through the composition, switch models when a render misses the mark, and record every prompt it tried. Nothing is hidden when the deadline is close.",
       color: "pink",
     },
     {
       icon: Sparkles,
       title: "Bottle your art direction",
       description:
-        "Lock down a style guide as a reusable skill — palette, lens, mood, prompt patterns — and every agent on your canvas picks it up automatically.",
+        "Save a style guide once (palette, lens, mood, and the prompts behind them) and every agent on your canvas follows it automatically.",
       color: "amber",
     },
   ];
@@ -106,9 +106,9 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Agents are nodes on the same canvas as your image, video, and audio
-            workflows — except these nodes have taste, a plan, and the ability to
-            self-correct when a render misses.
+            An agent sits on the same canvas as your image, video, and audio
+            work. The difference is that it arrives with a plan, an eye for the
+            brief, and the ability to try again when a render misses.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -118,8 +118,8 @@ export default function AgentIntegrationsSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            The same models the studios use — wired into agents that know when to
-            reach for them. Hand your agent a brief and it picks the right tool for
+            The same models the studios use, in the hands of agents that know when
+            to reach for them. Hand your agent a brief and it picks the right tool for
             the shot.
           </motion.p>
         </div>

--- a/marketing/src/components/agents/AgentUseCasesSection.tsx
+++ b/marketing/src/components/agents/AgentUseCasesSection.tsx
@@ -41,7 +41,7 @@ const useCases: UseCase[] = [
   {
     name: "Video Ad Director",
     description:
-      "An agent that storyboards a 15-second spot, picks Seedance for the hero shot and Kling for B-roll, animates the cuts, and drops a Suno track underneath. Bring your brief — it'll bring the cut.",
+      "An agent that storyboards a 15-second spot, picks Seedance for the hero shot and Kling for B-roll, animates the cuts, and lays a Suno track underneath. You bring the brief, it brings the cut.",
     icon: Film,
     iconBgFrom: "from-amber-600/20",
     iconBgTo: "to-rose-600/20",
@@ -59,7 +59,7 @@ const useCases: UseCase[] = [
   {
     name: "Batch Retouching Agent",
     description:
-      "Hand it a folder of raw shots. It color-matches to your reference, upscales, removes the bins in the background, and exports the keepers. Your repeatable retouching, run while you sleep.",
+      "Hand it a folder of raw shots. It matches color to your reference, upscales, removes the clutter in the background, and exports the keepers while you get on with something else.",
     icon: Camera,
     iconBgFrom: "from-emerald-600/20",
     iconBgTo: "to-teal-600/20",
@@ -77,7 +77,7 @@ const useCases: UseCase[] = [
   {
     name: "Variant Explorer",
     description:
-      "Ten alts of the hero frame in five aspect ratios, ranked by how on-brief they are. The agent fans out across providers, scores the results, and surfaces only the cuts worth your time.",
+      "Ten versions of the hero frame in five aspect ratios, ranked by how closely they match the brief. The agent works across providers, scores the results, and shows you only the ones worth your time.",
     icon: LayoutGrid,
     iconBgFrom: "from-indigo-600/20",
     iconBgTo: "to-cyan-600/20",
@@ -148,7 +148,7 @@ export default function AgentUseCasesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Open one, swap in your style guide, point it at the providers you already pay
+            Open one, add your style guide, point it at the providers you already pay
             for, and let it run while you direct. Starter workflows live in the{" "}
             <a
               href="https://github.com/nodetool-ai/nodetool/tree/main/examples"

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -130,7 +130,7 @@ export default function AgentsGraphHero() {
                         <div className="mt-8 flex items-center justify-center gap-6 text-sm text-slate-400 font-medium">
                             <span className="flex items-center gap-2"><Command className="w-4 h-4" /> Open Source</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
-                            <span>Your own keys — pay providers direct</span>
+                            <span>Your own keys, paid straight to the provider</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
                             <span>Watch every step</span>
                         </div>

--- a/marketing/src/data/competitorEntries.ts
+++ b/marketing/src/data/competitorEntries.ts
@@ -141,19 +141,19 @@ export const competitors: Competitor[] = [
     category: "Node editor",
     vsTitle: "NodeTool vs ComfyUI — the open creative AI workspace",
     vsDescription:
-      "ComfyUI is an engineer-first node editor for Stable Diffusion. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a far wider model roster across providers, and built-in editing tools — all BYOK at provider prices. Both are open source.",
+      "ComfyUI is an node editor built for engineers for Stable Diffusion. NodeTool is the studio around it: image, video, music, and text on one visual canvas, a far wider list of models across providers, and built-in editing tools — all your own keys at provider prices. Both are open source.",
     vsOgTitle: "NodeTool vs ComfyUI — the open creative AI workspace",
     vsOgDescription:
-      "Beyond diffusion images: NodeTool puts image, video, audio, and text on one node-based canvas with editing tools built in. Open source, BYOK, provider prices.",
+      "Beyond diffusion images: NodeTool puts image, video, audio, and text on one visual canvas with editing tools built in. Open source, your own keys, provider prices.",
     og: {
       image: "screen_canvas.png",
       accent: "blue",
       subtitle:
-        "The studio around the node editor — every modality, every provider.",
+        "The studio around the node editor — every medium, every provider.",
     },
     heroHeading: "The open creative AI workspace, not just a diffusion editor.",
     heroParagraph:
-      "ComfyUI is a node editor for Stable Diffusion, built with an engineer-first UX. NodeTool is the studio around it: image, video, music, and words on one canvas, a far wider model roster, and the editing tools creatives reach for — called with your own keys at provider prices. Both are node-based and open source.",
+      "ComfyUI is a node editor for Stable Diffusion, built with an an interface built for engineers. NodeTool is the studio around it: image, video, music, and words on one canvas, a far wider list of models, and the editing tools creatives reach for — called with your own keys at provider prices. Both are open source, and both work by connecting blocks on a canvas.",
     competitorTagline: "Node editor for diffusion images",
     competitorBullets: [
       "Deep control over Stable Diffusion pipelines",
@@ -166,12 +166,12 @@ export const competitors: Competitor[] = [
       "Image, video, audio, and text on one canvas",
       "Every major model from every major provider",
       "Editing tools: masks, inpaint, relight, layers",
-      "BYOK at provider prices — no credits, no markup",
+      "your own keys at provider prices — no credits, no markup",
     ],
     rows: [
-      { label: "Modalities", competitor: "Diffusion images", nodetool: "Image, video, audio, text" },
-      { label: "Model roster", competitor: "Stable Diffusion / diffusion", nodetool: "Every major provider & modality" },
-      { label: "BYOK / provider billing", competitor: false, nodetool: true },
+      { label: "Media types", competitor: "Diffusion images", nodetool: "Image, video, audio, text" },
+      { label: "Models", competitor: "Stable Diffusion / diffusion", nodetool: "Every major provider and media type" },
+      { label: "Your own API keys", competitor: false, nodetool: true },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
       { label: "Local models", competitor: true, nodetool: true },
       { label: "Desktop + browser", competitor: false, nodetool: true },
@@ -179,15 +179,15 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "One canvas for everything, not just images",
     explainerParagraph:
-      "If your work starts and ends with Stable Diffusion images, ComfyUI gives you fine-grained control. But most creative projects span modalities — image into video, voice and music into a cut, words into everything. NodeTool keeps all of it on one node-based canvas with masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. You call every major model with your own keys at provider prices, and run locally via Ollama, MLX, and llama.cpp.",
-    ctaHeading: "Open, multimodal, and yours.",
+      "If your work starts and ends with Stable Diffusion images, ComfyUI gives you fine-grained control. But most creative projects span more than one medium — image into video, voice and music into a cut, words into everything. NodeTool keeps all of it on one visual canvas with masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. You call every major model with your own keys at provider prices, and run locally via Ollama, MLX, and llama.cpp.",
+    ctaHeading: "Open, complete, and yours.",
     ctaParagraph:
       "Download Studio and build across image, video, audio, and text in one place.",
     faq: [
       {
         question: "What is the difference between NodeTool and ComfyUI?",
         answer:
-          "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an engineer-first UX. NodeTool is the studio around it: image, video, music, and text on one node-based canvas, a much wider model roster across providers and modalities, and editing tools creatives actually use — called with your own keys at provider prices. Both are node-based and open source.",
+          "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an an interface built for engineers. NodeTool is the studio around it: image, video, music, and text on one visual canvas, a much wider list of models across providers and media types, and editing tools creatives actually use — called with your own keys at provider prices. Both are open source, and both work by connecting blocks on a canvas.",
       },
       {
         question: "Is NodeTool open source like ComfyUI?",
@@ -202,7 +202,7 @@ export const competitors: Competitor[] = [
       {
         question: "How does NodeTool handle model pricing?",
         answer:
-          "NodeTool is BYOK — you bring your own API keys and pay each provider their list price. There are no credits, no markup, and no curated roster. You can also run local models with Ollama, MLX, or llama.cpp in the desktop app.",
+          "NodeTool runs on your own keys — you bring your own API keys and pay each provider their list price. There are no credits, no markup, and no hand-picked list of models. You can also run local models with Ollama, MLX, or llama.cpp in the desktop app.",
       },
     ],
     limitation:
@@ -214,38 +214,38 @@ export const competitors: Competitor[] = [
     footerName: "Weavy (Figma Weave)",
     theme: "blue",
     category: "Creative canvas",
-    vsTitle: "NodeTool vs Weavy (now Figma Weave) — open source, BYOK, no credits",
+    vsTitle: "NodeTool vs Weavy (now Figma Weave) — open source, your own keys, no credits",
     vsDescription:
-      "Weavy became Figma Weave after Figma acquired it in October 2025 — still a closed SaaS canvas with credits and a curated model roster. NodeTool is open source (AGPL-3.0) and BYOK: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same self-hostable code.",
-    vsOgTitle: "NodeTool vs Weavy (now Figma Weave) — open source, BYOK",
+      "Weavy became Figma Weave after Figma acquired it in October 2025 — still a closed SaaS canvas with credits and a curated list of models. NodeTool is open source (AGPL-3.0) and your own keys: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same self-hostable code.",
+    vsOgTitle: "NodeTool vs Weavy (now Figma Weave) — open source, your own keys",
     vsOgDescription:
-      "No credits, no curated roster, no lock-in. NodeTool is open source and BYOK: every provider at provider prices, with workflows and files you own.",
+      "No credits, no hand-picked list of models, no lock-in. NodeTool is open source and runs on your own keys: every provider at provider prices, with workflows and files you own.",
     og: {
       image: "screen_canvas.png",
       accent: "violet",
-      subtitle: "Open source and BYOK — no credits, no curated roster, no lock-in.",
+      subtitle: "Open source and your own keys — no credits, no hand-picked list of models, no lock-in.",
     },
-    heroHeading: "Open source and BYOK. No credits, no lock-in.",
+    heroHeading: "Open source and your own keys. No credits, no lock-in.",
     heroParagraph:
-      "Weavy is now Figma Weave — Figma acquired it in October 2025 — and it remains a closed SaaS canvas with a credit system and a curated model roster. NodeTool is open source and BYOK: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same open-source code you can self-host.",
+      "Weavy is now Figma Weave — Figma acquired it in October 2025 — and it remains a closed SaaS canvas with a credit system and a curated list of models. NodeTool is open source and runs on your own keys: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same open-source code you can self-host.",
     competitorTagline: "Closed SaaS canvas, now Figma Weave",
     competitorBullets: [
       "Credit system you top up and burn",
-      "Curated roster of supported models",
+      "A hand-picked list of supported models",
       "Closed source, hosted only",
       "Now part of Figma — roadmap follows the platform",
     ],
     competitorBulletTone: "negative",
-    nodetoolTagline: "Open source · BYOK",
+    nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
-      "BYOK — pay providers directly at list prices",
+      "your own keys — pay providers directly at list prices",
       "Every major model from every major provider",
       "Open source under AGPL-3.0, self-hostable",
       "You own your workflows and files",
     ],
     rows: [
-      { label: "Pricing model", competitor: "Credits", nodetool: "BYOK / provider prices" },
-      { label: "Model roster", competitor: "Curated roster", nodetool: "Every provider" },
+      { label: "Pricing model", competitor: "Credits", nodetool: "Your keys, provider prices" },
+      { label: "Models", competitor: "Hand-picked list", nodetool: "Every provider" },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0" },
       { label: "Self-host", competitor: false, nodetool: true },
       { label: "Data ownership", competitor: false, nodetool: true },
@@ -253,7 +253,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Pay providers, not credits — and keep your work",
     explainerParagraph:
-      "Credit systems and curated rosters decide which models you can use and what each call costs. NodeTool flips that: you add your own API keys and pay each provider their published list price. The whole workspace is open source under AGPL-3.0, so you can run it as a desktop app or self-host it, and your workflows and files stay yours. NodeTool Cloud is managed hosting of the same code.",
+      "Credit systems and hand-picked list of modelss decide which models you can use and what each call costs. NodeTool flips that: you add your own API keys and pay each provider their published list price. The whole workspace is open source under AGPL-3.0, so you can run it as a desktop app or self-host it, and your workflows and files stay yours. NodeTool Cloud is managed hosting of the same code.",
     ctaHeading: "Own your canvas.",
     ctaParagraph:
       "Download Studio and build with every provider, at provider prices.",
@@ -261,7 +261,7 @@ export const competitors: Competitor[] = [
       {
         question: "How is NodeTool different from Weavy?",
         answer:
-          "Weavy and similar closed SaaS canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK: every provider, your keys, provider prices, and you own your workflows and files. NodeTool Cloud is just managed hosting of the same open-source code you can self-host.",
+          "Weavy and similar closed SaaS canvases lock you into a credit system and a curated list of models. NodeTool is open source and runs on your own keys: every provider, your keys, provider prices, and you own your workflows and files. NodeTool Cloud is just managed hosting of the same open-source code you can self-host.",
       },
       {
         question: "What happened to Weavy?",
@@ -271,7 +271,7 @@ export const competitors: Competitor[] = [
       {
         question: "Does NodeTool use credits?",
         answer:
-          "No. NodeTool is BYOK — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no curated roster of models.",
+          "No. NodeTool runs on your own keys — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no hand-picked list of models of models.",
       },
       {
         question: "Can I self-host NodeTool?",
@@ -294,36 +294,36 @@ export const competitors: Competitor[] = [
     category: "Creative canvas",
     vsTitle: "NodeTool vs Figma Weave — the open-source alternative",
     vsDescription:
-      "Figma Weave (formerly Weavy) is a hosted AI canvas billed in its own AI credits, on its way into the Figma platform. NodeTool covers the same node-based media workflows as an open-source, BYOK workspace: every provider, your keys, provider prices, on your desktop or self-hosted — no credits, no ecosystem lock-in.",
+      "Figma Weave (formerly Weavy) is a hosted AI canvas billed in its own AI credits, on its way into the Figma platform. NodeTool covers the same visual media workflows as an open-source workspace that runs on your own keys: every provider, your keys, provider prices, on your desktop or self-hosted — no credits, no ecosystem lock-in.",
     vsOgTitle: "NodeTool vs Figma Weave — the open-source alternative",
     vsOgDescription:
-      "Same node-based media workflows, without the credits or the ecosystem. NodeTool is open source and BYOK: every provider at provider prices, workflows you own.",
+      "Same visual media workflows, without the credits or the ecosystem. NodeTool is open source and runs on your own keys: every provider at provider prices, workflows you own.",
     og: {
       image: "screen_canvas.png",
       accent: "violet",
-      subtitle: "The open-source, BYOK alternative to Figma Weave.",
+      subtitle: "The open-source, your own keys alternative to Figma Weave.",
     },
     heroHeading: "The open-source alternative to Figma Weave.",
     heroParagraph:
-      "Figma Weave — the canvas formerly known as Weavy — is a polished hosted tool with a curated frontier-model roster, billed in its own AI credits and moving deeper into the Figma platform. NodeTool covers the same node-based media workflows in the open: AGPL-3.0 source, BYOK at provider prices, a desktop app you can run offline with local models, and workflows and files that stay yours.",
+      "Figma Weave — the canvas formerly known as Weavy — is a polished hosted tool with a curated frontier-list of models, billed in its own AI credits and moving deeper into the Figma platform. NodeTool covers the same visual media workflows in the open: AGPL-3.0 source, your own keys at provider prices, a desktop app you can run offline with local models, and workflows and files that stay yours.",
     competitorTagline: "Hosted AI canvas in the Figma ecosystem",
     competitorBullets: [
       "Billed in Figma Weave AI credits",
-      "Curated model roster, chosen for you",
+      "Curated list of models, chosen for you",
       "Closed source, browser-only, no self-host",
       "Roadmap follows Figma's platform plans",
     ],
     competitorBulletTone: "negative",
-    nodetoolTagline: "Open source · BYOK",
+    nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
-      "BYOK — pay providers directly at list prices",
+      "your own keys — pay providers directly at list prices",
       "Every major model from every major provider",
       "Open source under AGPL-3.0 — desktop app or self-host",
       "Local models via Ollama, MLX, and llama.cpp",
     ],
     rows: [
-      { label: "Pricing model", competitor: "AI credits", nodetool: "BYOK / provider prices" },
-      { label: "Model roster", competitor: "Curated roster", nodetool: "Every provider" },
+      { label: "Pricing model", competitor: "AI credits", nodetool: "Your keys, provider prices" },
+      { label: "Models", competitor: "Hand-picked list", nodetool: "Every provider" },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0" },
       { label: "Free tier", competitor: true, nodetool: "Studio is free" },
       { label: "Self-host", competitor: false, nodetool: true },
@@ -332,10 +332,10 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Own the canvas, not a seat in an ecosystem",
     explainerParagraph:
-      "Acquisitions change products: pricing, model rosters, and roadmaps for Figma Weave now follow Figma's platform strategy, and your workflows live on their servers either way. NodeTool takes the opposite bet. The whole workspace is open source under AGPL-3.0, workflows are files you own, and models are called with your own API keys at each provider's published price — or run locally with Ollama, MLX, and llama.cpp. If the tool changes direction, you keep the code, the graphs, and the keys.",
+      "Acquisitions change products: pricing, list of modelss, and roadmaps for Figma Weave now follow Figma's platform strategy, and your workflows live on their servers either way. NodeTool takes the opposite bet. The whole workspace is open source under AGPL-3.0, workflows are files you own, and models are called with your own API keys at each provider's published price — or run locally with Ollama, MLX, and llama.cpp. If the tool changes direction, you keep the code, the graphs, and the keys.",
     ctaHeading: "Build on a canvas nobody can acquire.",
     ctaParagraph:
-      "Download Studio — open source, BYOK, every provider at provider prices.",
+      "Download Studio — open source, your own keys, every provider at provider prices.",
     faq: [
       {
         question: "Is Figma Weave the same as Weavy?",
@@ -345,17 +345,17 @@ export const competitors: Competitor[] = [
       {
         question: "Is there an open source alternative to Figma Weave?",
         answer:
-          "NodeTool is one: an open-source (AGPL-3.0) node-based canvas for image, video, audio, and text. It is BYOK — you call every major provider with your own keys at provider prices — and runs as a desktop app, in the browser, or self-hosted.",
+          "NodeTool is one: an open-source (AGPL-3.0) visual canvas for image, video, audio, and text. It runs on your own keys — you call every major provider with your own keys at provider prices — and runs as a desktop app, in the browser, or self-hosted.",
       },
       {
         question: "Does NodeTool use credits like Figma Weave?",
         answer:
-          "No. NodeTool is BYOK — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no curated roster. You can also run local models for no per-call cost at all.",
+          "No. NodeTool runs on your own keys — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no hand-picked list of models. You can also run local models for no per-call cost at all.",
       },
       {
         question: "When is Figma Weave the better pick?",
         answer:
-          "If your team already lives in Figma and wants a managed, hosted canvas with a curated roster and community workflows — and doesn't need self-hosting, local models, or BYOK pricing — Figma Weave is a polished choice. NodeTool is for teams that want the same workflows with open source, their own keys, and their own machines.",
+          "If your team already lives in Figma and wants a managed, hosted canvas with a hand-picked list of models and community workflows — and doesn't need self-hosting, local models, or pricing on your own keys — Figma Weave is a polished choice. NodeTool is for teams that want the same workflows with open source, their own keys, and their own machines.",
       },
     ],
     limitation:
@@ -366,13 +366,13 @@ export const competitors: Competitor[] = [
     slug: "langflow",
     name: "Langflow",
     theme: "blue",
-    category: "LLM app builder",
+    category: "Chatbot & agent builder",
     vsTitle: "NodeTool vs Langflow — agents plus native media generation",
     vsDescription:
-      "Langflow is a low-code builder for LLM apps: chatbots, RAG, agents. NodeTool covers the same agent and RAG ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas — open source, BYOK, local models included.",
+      "Langflow is a drag-and-drop builder for chatbot and agent apps, covering chat, document search, and agents. NodeTool covers the same agent and document-search ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas — open source, your own keys, local models included.",
     vsOgTitle: "NodeTool vs Langflow — agents plus native media generation",
     vsOgDescription:
-      "Both build agents and RAG pipelines. Only one renders image, video, and music natively on the same canvas. Open source, BYOK, local models.",
+      "Both build agents and document question-answering. Only one renders image, video, and music natively on the same canvas. Open source, your own keys, local models.",
     og: {
       image: "screen_workflow.png",
       accent: "emerald",
@@ -380,34 +380,34 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Agents that ship media, not just messages.",
     heroParagraph:
-      "Langflow is a low-code builder for LLM apps — chatbots, RAG, agents — rooted in Python and LangChain. NodeTool covers that same ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas. Open source, BYOK at provider prices, local models included.",
-    competitorTagline: "Low-code builder for LLM apps",
+      "Langflow is a drag-and-drop builder for chatbot and agent apps, covering chat, document search, and agents, rooted in Python and LangChain. NodeTool covers that same ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas. Open source, your own keys at provider prices, local models included.",
+    competitorTagline: "Drag-and-drop builder for chatbot and agent apps",
     competitorBullets: [
-      "Visual flows for chatbots, RAG, and agents",
+      "Visual flows for chatbots, document search, and agents",
       "Python-extensible, LangChain ecosystem",
       "Open source (MIT), self-hostable",
-      "Text and LLM pipelines first",
+      "Text workflows first",
     ],
     nodetoolTagline: "Agents plus native generation",
     nodetoolBullets: [
-      "Agents, RAG, and chat on the same canvas",
+      "Agents, document search, and chat on the same canvas",
       "Native image, video, and music generation nodes",
       "Editing tools: masks, inpaint, relight, layers",
-      "BYOK at provider prices — local models via Ollama, MLX, llama.cpp",
+      "your own keys at provider prices — local models via Ollama, MLX, llama.cpp",
     ],
     rows: [
-      { label: "Focus", competitor: "LLM apps: chat, RAG, agents", nodetool: "Agents + image, video, audio, text" },
+      { label: "Focus", competitor: "chatbot and agent apps: chat, document search, agents", nodetool: "Agents + image, video, audio, text" },
       { label: "Native media generation (image, video, music)", competitor: "Via external APIs", nodetool: "Built-in nodes" },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
-      { label: "Agents & RAG", competitor: true, nodetool: true },
-      { label: "Local models", competitor: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
-      { label: "BYOK / provider billing", competitor: true, nodetool: true },
+      { label: "Agents & document search", competitor: true, nodetool: true },
+      { label: "Local models", competitor: "Text models via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
+      { label: "Your own API keys", competitor: true, nodetool: true },
       { label: "Open source", competitor: "MIT", nodetool: "AGPL-3.0" },
       { label: "Desktop app", competitor: "macOS, Windows", nodetool: "macOS, Windows, Linux" },
     ],
     explainerHeading: "The pipeline and the picture, on one canvas",
     explainerParagraph:
-      "If your project ends at a chatbot or a RAG pipeline, Langflow is a solid choice — visual flows, Python extensibility, a mature LangChain ecosystem. But the moment an agent needs to produce something you can look at or listen to — a storyboard, a product video, a soundtrack — Langflow hands you an API key form and a blank HTTP node. NodeTool keeps going: generation nodes for image, video, and music from every major provider sit on the same canvas as your agents and retrieval, with masks, inpaint, relight, upscale, and layers built in. You bring your own keys and pay provider list prices — no credits, no markup — and run local models via Ollama, MLX, and llama.cpp on the desktop.",
+      "If your project ends at a chatbot or a document question-answering, Langflow is a solid choice — visual flows, Python extensibility, a mature LangChain ecosystem. But the moment an agent needs to produce something you can look at or listen to — a storyboard, a product video, a soundtrack — Langflow hands you an API key form and a blank HTTP node. NodeTool keeps going: generation nodes for image, video, and music from every major provider sit on the same canvas as your agents and retrieval, with masks, inpaint, relight, upscale, and layers built in. You bring your own keys and pay provider list prices — no credits, no markup — and run local models via Ollama, MLX, and llama.cpp on the desktop.",
     ctaHeading: "Build agents that make things.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents.",
@@ -415,12 +415,12 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Langflow?",
         answer:
-          "Langflow is a low-code visual builder for LLM applications — chatbots, RAG pipelines, and agents — rooted in the Python and LangChain ecosystem. NodeTool covers the same agent and RAG ground but treats media as a first-class output: image, video, and music generation run as native nodes on the same canvas, with editing tools like masks, inpaint, and layers built in. Both are open source and self-hostable.",
+          "Langflow is a drag-and-drop visual builder for chatbot and agent apps, covering chat, document question-answering, and agents, rooted in the Python and LangChain ecosystem. NodeTool covers the same agent and document-search ground but treats media as a built-in output: image, video, and music generation run as native nodes on the same canvas, with editing tools like masks, inpaint, and layers built in. Both are open source and self-hostable.",
       },
       {
         question: "Can Langflow generate images and video?",
         answer:
-          "Langflow is built for text and LLM workloads; generating media means wiring up external APIs yourself. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools — masks, inpaint, outpaint, relight, upscale, layers, and compositing.",
+          "Langflow is built for text and text work; generating media means wiring up external APIs yourself. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools — masks, inpaint, outpaint, relight, upscale, layers, and compositing.",
       },
       {
         question: "Is NodeTool open source like Langflow?",
@@ -430,7 +430,7 @@ export const competitors: Competitor[] = [
       {
         question: "Can I run local models in NodeTool?",
         answer:
-          "Yes. NodeTool runs local models via Ollama, MLX, and llama.cpp in the desktop app, and connects to every major cloud provider BYOK — your keys, provider list prices, no credits or markup.",
+          "Yes. NodeTool runs local models via Ollama, MLX, and llama.cpp in the desktop app, and connects to every major cloud provider with your own keys — your keys, provider list prices, no credits or markup.",
       },
     ],
     limitation:
@@ -443,10 +443,10 @@ export const competitors: Competitor[] = [
     category: "Workflow automation",
     vsTitle: "NodeTool vs n8n — when the workflow creates, not just connects",
     vsDescription:
-      "n8n moves data between hundreds of business apps. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas — open source under AGPL-3.0 (not fair-code), BYOK at provider prices, with a desktop app and local models.",
+      "n8n moves data between hundreds of business apps. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas — open source under AGPL-3.0 (not fair-code), your own keys at provider prices, with a desktop app and local models.",
     vsOgTitle: "NodeTool vs n8n — when the workflow creates, not just connects",
     vsOgDescription:
-      "n8n connects apps. NodeTool generates — image, video, music, and agents on one canvas. Open source (AGPL-3.0), BYOK, desktop app, local models.",
+      "n8n connects apps. NodeTool generates — image, video, music, and agents on one canvas. Open source (AGPL-3.0), your own keys, desktop app, local models.",
     og: {
       image: "screen_canvas.png",
       accent: "cyan",
@@ -454,20 +454,20 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Workflows that create, not just connect.",
     heroParagraph:
-      "n8n moves data between hundreds of business apps — schedules, retries, branching. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas. Open source under AGPL-3.0, BYOK at provider prices, with a desktop app and local models.",
+      "n8n moves data between hundreds of business apps — schedules, retries, branching. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas. Open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
     competitorTagline: "Workflow automation platform",
     competitorBullets: [
       "400+ integrations for business apps",
-      "Orchestration: schedules, retries, branching",
+      "Scheduling, retries, and branching",
       "AI agent nodes built on LangChain",
       "Fair-code: source-available, commercially restricted",
     ],
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
       "Native image, video, and music generation nodes",
-      "Agents and RAG on the same canvas as generation",
+      "Agents and document search on the same canvas as generation",
       "Open source under AGPL-3.0, desktop app included",
-      "BYOK at provider prices — no credits, no markup",
+      "your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Focus", competitor: "App-to-app automation", nodetool: "AI generation + agents" },
@@ -475,13 +475,13 @@ export const competitors: Competitor[] = [
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
       { label: "Business app connectors", competitor: "400+ integrations", nodetool: "AI-focused set" },
       { label: "License", competitor: "Sustainable Use (fair-code)", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Local models", competitor: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
-      { label: "Pricing model", competitor: "Per-execution plans (cloud)", nodetool: "BYOK / provider prices" },
+      { label: "Local models", competitor: "Text models via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
+      { label: "Pricing model", competitor: "Per-execution plans (cloud)", nodetool: "Your keys, provider prices" },
       { label: "Desktop app", competitor: false, nodetool: true },
     ],
     explainerHeading: "Plumbing is solved. Production isn't.",
     explainerParagraph:
-      "If the hard part of your workflow is moving records between Salesforce, Slack, and a spreadsheet on a schedule, n8n is built for exactly that. But when the workflow's output is the thing itself — a product video, a batch of campaign images, a soundtrack, an agent's research report — the generation can't live in a generic HTTP node. NodeTool makes it native: image, video, and music models from every major provider as first-class nodes, agents and retrieval on the same canvas, and editing tools — masks, inpaint, relight, upscale, layers — built in. It's open source under AGPL-3.0 rather than fair-code, runs as a desktop app on macOS, Windows, and Linux, and calls models with your own keys at provider list prices.",
+      "If the hard part of your workflow is moving records between Salesforce, Slack, and a spreadsheet on a schedule, n8n is built for exactly that. But when the workflow's output is the thing itself — a product video, a batch of campaign images, a soundtrack, an agent's research report — the generation can't live in a generic HTTP node. NodeTool makes it native: image, video, and music models from every major provider as built-in blocks, agents and retrieval on the same canvas, and editing tools — masks, inpaint, relight, upscale, layers — built in. It's open source under AGPL-3.0 rather than fair-code, runs as a desktop app on macOS, Windows, and Linux, and calls models with your own keys at provider list prices.",
     ctaHeading: "Make the workflow the studio.",
     ctaParagraph:
       "Download Studio and generate image, video, and music where your agents already work.",
@@ -489,7 +489,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and n8n?",
         answer:
-          "n8n is a workflow automation platform: it moves data between hundreds of business apps, with AI agent nodes built on LangChain. NodeTool is built for workflows where the AI work is the point — native image, video, and music generation, agents, and media editing tools on one node-based canvas. If the job is connecting Salesforce to Slack on a schedule, use n8n. If the job is producing something with AI, use NodeTool.",
+          "n8n is a workflow automation platform: it moves data between hundreds of business apps, with AI agent nodes built on LangChain. NodeTool is built for workflows where the AI work is the point — native image, video, and music generation, agents, and media editing tools on one visual canvas. If the job is connecting Salesforce to Slack on a schedule, use n8n. If the job is producing something with AI, use NodeTool.",
       },
       {
         question: "Is n8n open source?",
@@ -504,7 +504,7 @@ export const competitors: Competitor[] = [
       {
         question: "When should I pick n8n instead of NodeTool?",
         answer:
-          "When the hard part of your workflow is business-app plumbing: hundreds of connectors, schedules, retries, and branching between SaaS tools. That is what n8n is built for. NodeTool is the better fit when the workflow's output is AI-generated media or agent work, and you want local models, BYOK provider pricing, and a desktop app.",
+          "When the hard part of your workflow is business-app plumbing: hundreds of connectors, schedules, retries, and branching between SaaS tools. That is what n8n is built for. NodeTool is the better fit when the workflow's output is AI-generated media or agent work, and you want local models, provider pricing on your own keys, and a desktop app.",
       },
     ],
     limitation:
@@ -514,48 +514,48 @@ export const competitors: Competitor[] = [
     slug: "flowise",
     name: "Flowise",
     theme: "violet",
-    category: "LLM app builder",
-    vsTitle: "NodeTool vs Flowise — RAG chatbots plus native media generation",
+    category: "Chatbot & agent builder",
+    vsTitle: "NodeTool vs Flowise — chatbots that answer from your documents plus native media generation",
     vsDescription:
-      "Flowise is the fastest drag-and-drop path to a LangChain-based RAG chatbot. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — BYOK at provider prices, no hosted-credit tiers.",
-    vsOgTitle: "NodeTool vs Flowise — RAG chatbots plus native media generation",
+      "Flowise is the fastest drag-and-drop path to a LangChain-based chatbot that answers from your documents. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — your own keys at provider prices, no hosted-credit tiers.",
+    vsOgTitle: "NodeTool vs Flowise — chatbots that answer from your documents plus native media generation",
     vsOgDescription:
-      "Flowise builds RAG chatbots fast. NodeTool builds the chatbot and the image, video, and music pipeline around it — one canvas, BYOK.",
+      "Flowise builds chatbots that answer from your documents fast. NodeTool builds the chatbot and the image, video, and music pipeline around it — one canvas, your own keys.",
     og: {
       image: "screen_workflow.png",
       accent: "violet",
-      subtitle: "RAG chatbots plus native image, video, and music generation.",
+      subtitle: "chatbots that answer from your documents plus native image, video, and music generation.",
     },
     heroHeading: "The chatbot, plus everything it needs to produce.",
     heroParagraph:
-      "Flowise is the fastest drag-and-drop path to a LangChain RAG chatbot. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, BYOK at provider prices, with a desktop app and local models.",
+      "Flowise is the fastest drag-and-drop path to a LangChain chatbot that answers from your documents. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
     competitorTagline: "Drag-and-drop LangChain builder",
     competitorBullets: [
-      "Fastest path to a RAG chatbot",
+      "Fastest path to a chatbot that answers from your documents",
       "Vector store and LangChain node library",
       "Source-available under Apache 2.0",
       "Hosted cloud sold on usage-based credits",
     ],
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
-      "Agents, RAG, and native image/video/music generation",
+      "Agents, document search, and native image/video/music generation",
       "Built-in editing tools — masks, inpaint, relight, layers",
       "Open source under AGPL-3.0, desktop app included",
-      "BYOK at provider prices — no credits, no markup",
+      "your own keys at provider prices — no credits, no markup",
     ],
     rows: [
-      { label: "Focus", competitor: "LangChain chatbots & RAG", nodetool: "AI generation + agents" },
+      { label: "Focus", competitor: "LangChain chatbots & document search", nodetool: "AI generation + agents" },
       { label: "Native media generation (image, video, music)", competitor: "Via HTTP request nodes", nodetool: "Built-in nodes" },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
-      { label: "Vector store / RAG nodes", competitor: true, nodetool: true },
+      { label: "Vector store / document search nodes", competitor: true, nodetool: true },
       { label: "License", competitor: "Apache 2.0 (source-available)", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Local models", competitor: "LLMs via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
-      { label: "Pricing model", competitor: "Usage-based credits (cloud)", nodetool: "BYOK / provider prices" },
+      { label: "Local models", competitor: "Text models via Ollama", nodetool: "Ollama, MLX, llama.cpp" },
+      { label: "Pricing model", competitor: "Usage-based credits (cloud)", nodetool: "Your keys, provider prices" },
       { label: "Desktop app", competitor: false, nodetool: true },
     ],
     explainerHeading: "A chatbot is often just the front door.",
     explainerParagraph:
-      "Flowise is genuinely fast at what it's built for: wire a vector store, a retriever, and an LLM node into a working RAG chatbot in minutes. But the moment the workflow needs to produce something — a rendered image, a video cut, a voice line — that step lands in a generic HTTP node calling an external API by hand. In NodeTool, image, video, and music models from every major provider sit on the same canvas as the agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price, no credit tiers on top.",
+      "Flowise is genuinely fast at what it's built for: wire a vector store, a retriever, and an language model node into a working chatbot that answers from your documents in minutes. But the moment the workflow needs to produce something — a rendered image, a video cut, a voice line — that step lands in a generic HTTP node calling an external API by hand. In NodeTool, image, video, and music models from every major provider sit on the same canvas as the agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price, no credit tiers on top.",
     ctaHeading: "Build the chatbot. Ship the media too.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents and retrieval.",
@@ -563,73 +563,73 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Flowise?",
         answer:
-          "Flowise is a drag-and-drop builder for LangChain-based LLM apps — its fastest path is a RAG chatbot backed by a vector store. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation nodes, plus editing tools (masks, inpaint, relight, layers), on the same canvas. If the deliverable is a chatbot, Flowise gets there fastest. If the deliverable includes generated media, NodeTool is built for the whole pipeline.",
+          "Flowise is a drag-and-drop builder for LangChain-based chatbot and agent apps — its fastest path is a chatbot that answers from your documents backed by a vector store. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation nodes, plus editing tools (masks, inpaint, relight, layers), on the same canvas. If the deliverable is a chatbot, Flowise gets there fastest. If the deliverable includes generated media, NodeTool is built for the whole pipeline.",
       },
       {
         question: "Is Flowise open source?",
         answer:
-          "Flowise is source-available under the Apache 2.0 license, with a hosted Flowise Cloud sold on usage-based credit tiers. NodeTool is open source under AGPL-3.0 and BYOK: you connect your own provider keys and pay providers directly at their list prices, with no credit markup on either self-hosted or NodeTool Cloud usage.",
+          "Flowise is source-available under the Apache 2.0 license, with a hosted Flowise Cloud sold on usage-based credit tiers. NodeTool is open source under AGPL-3.0 and your own keys: you connect your own provider keys and pay providers directly at their list prices, with no credit markup on either self-hosted or NodeTool Cloud usage.",
       },
       {
         question: "Can Flowise generate images or video?",
         answer:
-          "Only by wiring a generic HTTP request node to an external API. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools, as first-class citizens on the same canvas as its agent and RAG nodes.",
+          "Only by wiring a generic HTTP request node to an external API. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools, as built-in blocks on the same canvas as its agent and document search nodes.",
       },
       {
         question: "When should I pick Flowise instead of NodeTool?",
         answer:
-          "When the job is strictly a LangChain-flavored chatbot or assistant over a document set, and you want the fastest drag-and-drop path to that specific shape. NodeTool is the better fit once the workflow also needs to produce image, video, or audio, or you want a desktop app with local-model support and BYOK pricing across everything, not just the LLM calls.",
+          "When the job is strictly a LangChain-flavored chatbot or assistant over a document set, and you want the fastest drag-and-drop path to that specific shape. NodeTool is the better fit once the workflow also needs to produce image, video, or audio, or you want a desktop app with local-model support and pricing on your own keys across everything, not just the language model calls.",
       },
     ],
     limitation:
-      "Flowise nails the LangChain RAG chatbot, but generating media drops you into a raw HTTP node, and its cloud is billed in credits.",
+      "Flowise nails the LangChain chatbot that answers from your documents, but generating media drops you into a raw HTTP node, and its cloud is billed in credits.",
   },
   {
     slug: "dify",
     name: "Dify",
     theme: "amber",
-    category: "LLM app builder",
-    vsTitle: "NodeTool vs Dify — an LLM app platform vs a media-generation canvas",
+    category: "Chatbot & agent builder",
+    vsTitle: "NodeTool vs Dify — a language model app platform vs a media-generation canvas",
     vsDescription:
-      "Dify is a strong LLM app platform: prompt orchestration, knowledge bases, and agent debugging for text-first products. NodeTool starts from the same agent and RAG ground, then puts native image, video, and music generation and editing tools on the same canvas — BYOK at provider prices, no vendor-hosted markup.",
-    vsOgTitle: "NodeTool vs Dify — an LLM app platform vs a media-generation canvas",
+      "Dify is a strong language model app platform: prompt management, knowledge bases, and agent debugging for text-first products. NodeTool starts from the same agent and document-search ground, then puts native image, video, and music generation and editing tools on the same canvas — your own keys at provider prices, no vendor-hosted markup.",
+    vsOgTitle: "NodeTool vs Dify — a language model app platform vs a media-generation canvas",
     vsOgDescription:
-      "Dify is built for text-first LLM apps. NodeTool adds native image, video, and music generation on the same canvas as agents and RAG — BYOK.",
+      "Dify is built for text-first chatbot and agent apps. NodeTool adds native image, video, and music generation on the same canvas as agents and document search — your own keys.",
     og: {
       image: "screen_llms.png",
       accent: "amber",
-      subtitle: "Agents and RAG, plus native image, video, and music generation.",
+      subtitle: "Agents and document search, plus native image, video, and music generation.",
     },
     heroHeading: "Text apps are the floor, not the ceiling.",
     heroParagraph:
-      "Dify is a strong platform for text-first LLM apps — prompt orchestration, knowledge bases, agent debugging. NodeTool starts from the same agent and RAG ground, then puts native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, BYOK at provider prices, with a desktop app and local models.",
-    competitorTagline: "LLM app development platform",
+      "Dify is a strong platform for text-first chatbot and agent apps — prompt management, knowledge bases, agent debugging. NodeTool starts from the same agent and document-search ground, then puts native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
+    competitorTagline: "language model app development platform",
     competitorBullets: [
-      "Prompt orchestration and app-store-style deployment",
+      "Prompt management and app-store-style deployment",
       "Built-in knowledge bases and agent debugging",
       "Modified Apache 2.0 license with commercial limits",
       "Cloud sold on seat/usage plans",
     ],
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
-      "Agents, RAG, and native image/video/music generation",
+      "Agents, document search, and native image/video/music generation",
       "Built-in editing tools — masks, inpaint, relight, layers",
       "Open source under AGPL-3.0, desktop app included",
-      "BYOK at provider prices — no credits, no markup",
+      "your own keys at provider prices — no credits, no markup",
     ],
     rows: [
-      { label: "Focus", competitor: "Text-first LLM apps & knowledge bases", nodetool: "AI generation + agents" },
+      { label: "Focus", competitor: "Text-first chatbot and agent apps & knowledge bases", nodetool: "AI generation + agents" },
       { label: "Native media generation (image, video, music)", competitor: "Via tool/plugin calls", nodetool: "Built-in nodes" },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
       { label: "Agent debugging & tracing", competitor: true, nodetool: true },
       { label: "License", competitor: "Modified Apache 2.0 (commercial limits)", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Local models", competitor: "LLMs via self-hosted endpoints", nodetool: "Ollama, MLX, llama.cpp" },
-      { label: "Pricing model", competitor: "Seat/usage plans (cloud)", nodetool: "BYOK / provider prices" },
+      { label: "Local models", competitor: "language models via self-hosted endpoints", nodetool: "Ollama, MLX, llama.cpp" },
+      { label: "Pricing model", competitor: "Seat/usage plans (cloud)", nodetool: "Your keys, provider prices" },
       { label: "Desktop app", competitor: false, nodetool: true },
     ],
     explainerHeading: "Great for the chatbot. Not built for the render.",
     explainerParagraph:
-      "Dify earns its reputation on debugging and knowledge-base tooling for text-first LLM apps — a support bot, an internal copilot, a document Q&A assistant. But when the deliverable includes a generated image, a video cut, or a synthesized voice line, that step has to leave the platform. NodeTool puts image, video, and music models from every major provider on the same canvas as its agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price.",
+      "Dify earns its reputation on debugging and knowledge-base tooling for text-first chatbot and agent apps — a support bot, an internal copilot, a document Q&A assistant. But when the deliverable includes a generated image, a video cut, or a synthesized voice line, that step has to leave the platform. NodeTool puts image, video, and music models from every major provider on the same canvas as its agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price.",
     ctaHeading: "Build past the chatbot.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents and knowledge base.",
@@ -637,26 +637,26 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Dify?",
         answer:
-          "Dify is an LLM app development platform focused on prompt orchestration, knowledge bases, and agent debugging for text-first products like chatbots and copilots. NodeTool covers the same agent and RAG ground on a node-based canvas, then adds native image, video, and music generation and editing tools — masks, inpaint, relight, layers — as first-class nodes, so a workflow can produce media, not just text and structured output.",
+          "Dify is a language model app development platform focused on prompt management, knowledge bases, and agent debugging for text-first products like chatbots and copilots. NodeTool covers the same agent and document-search ground on a visual canvas, then adds native image, video, and music generation and editing tools — masks, inpaint, relight, layers — as built-in blocks, so a workflow can produce media, not just text and structured output.",
       },
       {
         question: "Is Dify open source?",
         answer:
-          "Dify's source is published under a modified Apache 2.0 license that adds commercial-use conditions above certain usage thresholds — check Dify's own license file for the current terms before relying on it for a commercial deployment. NodeTool is open source under AGPL-3.0, an OSI-approved license, and is fully BYOK on both self-hosted and NodeTool Cloud deployments.",
+          "Dify's source is published under a modified Apache 2.0 license that adds commercial-use conditions above certain usage thresholds — check Dify's own license file for the current terms before relying on it for a commercial deployment. NodeTool is open source under AGPL-3.0, an OSI-approved license, and is fully your own keys on both self-hosted and NodeTool Cloud deployments.",
       },
       {
         question: "Can Dify generate images or video?",
         answer:
-          "Dify can call image-generation APIs through its tool/plugin system, but it is not built around media generation the way it is built around text and RAG. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools, on the same canvas as its agent and knowledge-base nodes.",
+          "Dify can call image-generation APIs through its tool/plugin system, but it is not built around media generation the way it is built around text and document search. NodeTool ships native generation nodes for image, video, and music across every major provider, plus built-in editing tools, on the same canvas as its agent and knowledge-base nodes.",
       },
       {
         question: "When should I pick Dify instead of NodeTool?",
         answer:
-          "When the product is a text-first LLM app — a support chatbot, an internal copilot, a knowledge-base assistant — and you want Dify's prompt-orchestration UI, built-in observability, and app-store-style deployment. NodeTool is the better fit when the workflow needs to produce image, video, or audio alongside the agent and RAG work, or when you want a desktop app with local-model support and BYOK pricing throughout.",
+          "When the product is a text-first language model app — a support chatbot, an internal copilot, a knowledge-base assistant — and you want Dify's prompt-management interface, built-in observability, and app-store-style deployment. NodeTool is the better fit when the workflow needs to produce image, video, or audio alongside the agent and document search work, or when you want a desktop app with local-model support and pricing on your own keys throughout.",
       },
     ],
     limitation:
-      "Dify is built around text-first LLM apps; media generation happens through plugins, and its license adds commercial limits.",
+      "Dify is built around text-first chatbot and agent apps; media generation happens through plugins, and its license adds commercial limits.",
   },
 
   // --- First wave of new competitors (drafted from the same pattern) ---
@@ -668,18 +668,18 @@ export const competitors: Competitor[] = [
     isNew: true,
     vsTitle: "NodeTool vs Flora — an open canvas you own",
     vsDescription:
-      "Flora is a polished, hosted infinite canvas for AI image and video, billed in credits. NodeTool is the open source, BYOK version of that idea: image, video, music, and text on one node-based canvas, every provider at list price, and workflows and files you keep. Both put creation on a canvas — only one is yours to self-host.",
+      "Flora is a polished, hosted infinite canvas for AI image and video, billed in credits. NodeTool is the open source, your own keys version of that idea: image, video, music, and text on one visual canvas, every provider at list price, and workflows and files you keep. Both put creation on a canvas — only one is yours to self-host.",
     vsOgTitle: "NodeTool vs Flora — an open canvas you own",
     vsOgDescription:
-      "Flora is a hosted, credit-based creative canvas. NodeTool is open source and BYOK — every provider at list price, workflows you own.",
+      "Flora is a hosted, credit-based creative canvas. NodeTool is open source and runs on your own keys — every provider at list price, workflows you own.",
     og: {
       image: "screen_canvas.png",
       accent: "rose",
-      subtitle: "A creative AI canvas that's open source and BYOK — not credit-metered.",
+      subtitle: "A creative AI canvas that's open source and runs on your own keys — not credit-metered.",
     },
     heroHeading: "The creative canvas, open source and yours.",
     heroParagraph:
-      "Flora is a beautifully designed hosted canvas for AI image and video, sold on credits. NodeTool is the open version of that idea: image, video, music, and text on one node-based canvas, every model called with your own keys at provider prices, and workflows and files you own and can self-host.",
+      "Flora is a beautifully designed hosted canvas for AI image and video, sold on credits. NodeTool is the open version of that idea: image, video, music, and text on one visual canvas, every model called with your own keys at provider prices, and workflows and files you own and can self-host.",
     competitorTagline: "Hosted infinite canvas",
     competitorBullets: [
       "Polished, purpose-built creative canvas UX",
@@ -688,25 +688,25 @@ export const competitors: Competitor[] = [
       "Billed in credits you top up",
     ],
     competitorBulletTone: "negative",
-    nodetoolTagline: "Open source · BYOK",
+    nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
       "Image, video, audio, and text on one canvas",
       "Every major model from every major provider",
       "Open source under AGPL-3.0, self-hostable",
-      "BYOK at provider prices — no credits, no markup",
+      "your own keys at provider prices — no credits, no markup",
     ],
     rows: [
-      { label: "Design / onboarding polish", competitor: "Purpose-built creative UX", nodetool: "Node-based, power-user first" },
-      { label: "Modalities", competitor: "Image, video", nodetool: "Image, video, audio, text" },
-      { label: "Model roster", competitor: "Curated roster", nodetool: "Every major provider" },
-      { label: "Pricing model", competitor: "Credits", nodetool: "BYOK / provider prices" },
+      { label: "Design / onboarding polish", competitor: "Purpose-built creative interface", nodetool: "A visual canvas built for depth" },
+      { label: "Media types", competitor: "Image, video", nodetool: "Image, video, audio, text" },
+      { label: "Models", competitor: "Hand-picked list", nodetool: "Every major provider" },
+      { label: "Pricing model", competitor: "Credits", nodetool: "Your keys, provider prices" },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0" },
       { label: "Self-host / data ownership", competitor: false, nodetool: true },
       { label: "Desktop app + local models", competitor: false, nodetool: true },
     ],
     explainerHeading: "A canvas you can take with you",
     explainerParagraph:
-      "Flora is genuinely pleasant to use — the onboarding and the canvas feel designed, and for a quick hosted image or video it's fast to reach for. But it's closed and credit-metered: the model roster is curated, each render burns credits, and your work lives on their platform. NodeTool trades some of that turnkey polish for control — image, video, music, and text on one canvas, every provider at list price with your own keys, local models via Ollama, MLX, and llama.cpp, and the whole thing open source under AGPL-3.0 so you can self-host it and keep your files.",
+      "Flora is genuinely pleasant to use — the onboarding and the canvas feel designed, and for a quick hosted image or video it's fast to reach for. But it's closed and credit-metered: the list of models is curated, each render burns credits, and your work lives on their platform. NodeTool trades some of that turnkey polish for control — image, video, music, and text on one canvas, every provider at list price with your own keys, local models via Ollama, MLX, and llama.cpp, and the whole thing open source under AGPL-3.0 so you can self-host it and keep your files.",
     ctaHeading: "Create on a canvas you own.",
     ctaParagraph:
       "Download Studio and build across image, video, audio, and text — your keys, your files.",
@@ -714,7 +714,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Flora?",
         answer:
-          "Flora is a hosted, closed-source creative canvas for AI image and video, billed in credits. NodeTool is an open source (AGPL-3.0), BYOK node-based canvas that spans image, video, audio, and text, connects to every major provider at list price, and can be self-hosted or run as a desktop app with local models.",
+          "Flora is a hosted, closed-source creative canvas for AI image and video, billed in credits. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys that spans image, video, audio, and text, connects to every major provider at list price, and can be self-hosted or run as a desktop app with local models.",
       },
       {
         question: "Is NodeTool a free alternative to Flora?",
@@ -738,18 +738,18 @@ export const competitors: Competitor[] = [
     isNew: true,
     vsTitle: "NodeTool vs Krea — real-time generation, or an open pipeline",
     vsDescription:
-      "Krea is a hosted studio known for real-time image generation and enhancement, sold on subscription and credits. NodeTool is an open source, BYOK canvas for the whole pipeline: image, video, music, and text on one graph, every provider at list price, self-hostable. Krea is faster to a single instant render; NodeTool is built to compose, edit, and own the result.",
+      "Krea is a hosted studio known for real-time image generation and enhancement, sold on subscription and credits. NodeTool is an open-source, bring-your-own-key canvas for the whole pipeline: image, video, music, and text on one graph, every provider at list price, self-hostable. Krea is faster to a single instant render; NodeTool is built to compose, edit, and own the result.",
     vsOgTitle: "NodeTool vs Krea — real-time generation, or an open pipeline",
     vsOgDescription:
-      "Krea shines at instant, real-time renders. NodeTool is the open, BYOK pipeline around them — image, video, music, and text on one canvas.",
+      "Krea shines at instant, real-time renders. NodeTool is the open, your own keys pipeline around them — image, video, music, and text on one canvas.",
     og: {
       image: "screen_canvas.png",
       accent: "cyan",
-      subtitle: "An open, BYOK canvas for the whole pipeline — not just instant renders.",
+      subtitle: "An open canvas that runs on your own keys, built for the whole process rather than one instant render.",
     },
     heroHeading: "Instant renders, or the whole pipeline?",
     heroParagraph:
-      "Krea is a hosted studio built around real-time image generation and enhancement, sold on subscription and credits. NodeTool is the open source, BYOK canvas around that: image, video, music, and text on one node-based graph, every model at provider prices, self-hostable, with editing built in.",
+      "Krea is a hosted studio built around real-time image generation and enhancement, sold on subscription and credits. NodeTool is the open-source, bring-your-own-key canvas around that: image, video, music, and text on one visual canvas, every model at provider prices, self-hostable, with editing built in.",
     competitorTagline: "Hosted real-time studio",
     competitorBullets: [
       "Real-time, instant image generation and enhance",
@@ -758,19 +758,19 @@ export const competitors: Competitor[] = [
       "Curated model selection",
     ],
     competitorBulletTone: "negative",
-    nodetoolTagline: "Open source · BYOK",
+    nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
       "Image, video, audio, and text on one canvas",
       "Compose and edit — masks, inpaint, relight, layers",
       "Every major model from every major provider",
-      "BYOK at provider prices — self-hostable, local models",
+      "your own keys at provider prices — self-hostable, local models",
     ],
     rows: [
       { label: "Real-time / instant generation", competitor: "Built-in, real-time", nodetool: "Batch & workflow, not real-time" },
-      { label: "Modalities", competitor: "Image, video", nodetool: "Image, video, audio, text" },
+      { label: "Media types", competitor: "Image, video", nodetool: "Image, video, audio, text" },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: "Enhance / upscale", nodetool: "Full editing on canvas" },
-      { label: "Model roster", competitor: "Curated roster", nodetool: "Every major provider" },
-      { label: "Pricing model", competitor: "Subscription + credits", nodetool: "BYOK / provider prices" },
+      { label: "Models", competitor: "Hand-picked list", nodetool: "Every major provider" },
+      { label: "Pricing model", competitor: "Subscription + credits", nodetool: "Your keys, provider prices" },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0" },
       { label: "Self-host + local models", competitor: false, nodetool: true },
     ],
@@ -784,34 +784,34 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Krea?",
         answer:
-          "Krea is a hosted, closed-source studio built around real-time image generation and enhancement, sold on subscription and credits. NodeTool is an open source (AGPL-3.0), BYOK node-based canvas for multi-step pipelines across image, video, audio, and text, with editing tools built in, every major provider at list price, and self-hosting plus local models.",
+          "Krea is a hosted, closed-source studio built around real-time image generation and enhancement, sold on subscription and credits. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys for multi-step pipelines across image, video, audio, and text, with editing tools built in, every major provider at list price, and self-hosting plus local models.",
       },
       {
         question: "Does NodeTool do real-time generation like Krea?",
         answer:
-          "Not in the same instant, interactive way — Krea is purpose-built for real-time renders. NodeTool is built for composing and editing workflows: you wire up multi-step pipelines across modalities and run them, rather than watching a single image resolve live.",
+          "Not in the same instant, interactive way — Krea is purpose-built for real-time renders. NodeTool is built for composing and editing workflows: you wire up multi-step pipelines across different media and run them, rather than watching a single image resolve live.",
       },
       {
         question: "Is NodeTool cheaper than Krea?",
         answer:
-          "NodeTool is BYOK — you pay each provider their list price with your own keys, with no subscription or credit markup, and Studio itself is free and open source. Whether that's cheaper depends on your usage, but there's no platform margin on top of the model cost.",
+          "NodeTool runs on your own keys — you pay each provider their list price with your own keys, with no subscription or credit markup, and Studio itself is free and open source. Whether that's cheaper depends on your usage, but there's no platform margin on top of the model cost.",
       },
     ],
     limitation:
-      "Krea is a closed, credit-based hosted studio focused on real-time renders — no self-hosting, no BYOK, and it's image/video only.",
+      "Krea is a closed, credit-based hosted studio focused on real-time renders — no self-hosting, no your own keys, and it's image/video only.",
   },
   {
     slug: "lm-studio",
     name: "LM Studio",
     theme: "emerald",
-    category: "Local LLM runtime",
+    category: "Local language model runtime",
     isNew: true,
-    vsTitle: "NodeTool vs LM Studio — local LLMs, plus everything after them",
+    vsTitle: "NodeTool vs LM Studio — local language models, plus everything after them",
     vsDescription:
-      "LM Studio is an excellent desktop app for running local GGUF LLMs with a chat UI and an OpenAI-compatible local server. NodeTool runs local models too — via Ollama, MLX, and llama.cpp — but on a node-based canvas that also generates image, video, and music and builds agents and RAG. For pure local-LLM chat and serving, LM Studio is more specialized; for building workflows around those models, NodeTool is the canvas.",
-    vsOgTitle: "NodeTool vs LM Studio — local LLMs, plus everything after them",
+      "LM Studio is an excellent desktop app for running local GGUF language models with a chat UI and an OpenAI-compatible local server. NodeTool runs local models too — via Ollama, MLX, and llama.cpp — but on a visual canvas that also generates image, video, and music and builds agents and document search. For pure local-language model chat and serving, LM Studio is more specialized; for building workflows around those models, NodeTool is the canvas.",
+    vsOgTitle: "NodeTool vs LM Studio — local language models, plus everything after them",
     vsOgDescription:
-      "LM Studio runs local LLMs beautifully. NodeTool runs local models too, then builds image, video, music, agents, and RAG around them.",
+      "LM Studio runs local language models beautifully. NodeTool runs local models too, then builds image, video, music, agents, and document search around them.",
     og: {
       image: "screen_llms.png",
       accent: "emerald",
@@ -819,46 +819,46 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Run local models — then build the workflow.",
     heroParagraph:
-      "LM Studio is a superb desktop runtime for local GGUF LLMs: a clean chat UI, a great model browser, and an OpenAI-compatible local server. NodeTool runs local models too — via Ollama, MLX, and llama.cpp — but on a node-based canvas that also generates image, video, and music and builds agents and RAG around them.",
-    competitorTagline: "Desktop local-LLM runtime",
+      "LM Studio is a superb desktop runtime for local GGUF language models: a clean chat UI, a great model browser, and an OpenAI-compatible local server. NodeTool runs local models too — via Ollama, MLX, and llama.cpp — but on a visual canvas that also generates image, video, and music and builds agents and document search around them.",
+    competitorTagline: "Desktop local-language model runtime",
     competitorBullets: [
-      "Polished model browser and one-click local LLMs",
+      "Polished model browser and one-click local language models",
       "OpenAI-compatible local server",
       "Great chat UI for a single model",
-      "Proprietary (free), text-LLM focused",
+      "Proprietary (free), text-language model focused",
     ],
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
       "Local models via Ollama, MLX, and llama.cpp",
       "Plus native image, video, and music generation",
-      "Agents, RAG, and multi-step workflows on one canvas",
-      "Open source under AGPL-3.0, BYOK for cloud models",
+      "Agents, document search, and multi-step workflows on one canvas",
+      "Open source under AGPL-3.0, your own keys for cloud models",
     ],
     rows: [
-      { label: "Local LLM chat & model browser", competitor: "Purpose-built, polished", nodetool: "Supported via Ollama/MLX/llama.cpp" },
+      { label: "Local language model chat & model browser", competitor: "Purpose-built, polished", nodetool: "Supported via Ollama/MLX/llama.cpp" },
       { label: "OpenAI-compatible local server", competitor: true, nodetool: "Via provider integrations" },
       { label: "Native media generation (image, video, music)", competitor: false, nodetool: true },
-      { label: "Agents, RAG, multi-step workflows", competitor: false, nodetool: true },
-      { label: "Cloud providers (BYOK)", competitor: false, nodetool: true },
+      { label: "Agents, document search, multi-step workflows", competitor: false, nodetool: true },
+      { label: "Cloud providers (your own keys)", competitor: false, nodetool: true },
       { label: "Source", competitor: "Proprietary (free)", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Node-based canvas", competitor: false, nodetool: true },
+      { label: "Visual canvas", competitor: false, nodetool: true },
     ],
     explainerHeading: "The runtime, and the workflow around it",
     explainerParagraph:
-      "For downloading a local model and chatting with it, LM Studio is excellent — the model browser is the best in class, and the OpenAI-compatible server makes it easy to point other tools at a local endpoint. If that's the whole job, LM Studio is more specialized than NodeTool and a great pick. But once you want the model to do something in a pipeline — retrieve from your documents, drive an agent, feed a prompt into image or video generation — you need a canvas. NodeTool runs the same class of local models via Ollama, MLX, and llama.cpp and puts them next to native generation nodes, agents, and RAG, open source and BYOK for any cloud models you add.",
+      "For downloading a local model and chatting with it, LM Studio is excellent — the model browser is the best in class, and the OpenAI-compatible server makes it easy to point other tools at a local endpoint. If that's the whole job, LM Studio is more specialized than NodeTool and a great pick. But once you want the model to do something in a pipeline — retrieve from your documents, drive an agent, feed a prompt into image or video generation — you need a canvas. NodeTool runs the same class of local models via Ollama, MLX, and llama.cpp and puts them next to native generation nodes, agents, and document search, open source and runs on your own keys for any cloud models you add.",
     ctaHeading: "From local chat to full workflow.",
     ctaParagraph:
-      "Download Studio and put your local models on a canvas with generation, agents, and RAG.",
+      "Download Studio and put your local models on a canvas with generation, agents, and document search.",
     faq: [
       {
         question: "What is the difference between NodeTool and LM Studio?",
         answer:
-          "LM Studio is a desktop app specialized in running local GGUF LLMs — model browser, chat UI, and an OpenAI-compatible local server. NodeTool is an open source node-based canvas that also runs local models (via Ollama, MLX, and llama.cpp) and additionally generates image, video, and music and builds agents and RAG workflows around them.",
+          "LM Studio is a desktop app specialized in running local GGUF language models — model browser, chat UI, and an OpenAI-compatible local server. NodeTool is an open source visual canvas that also runs local models (via Ollama, MLX, and llama.cpp) and additionally generates image, video, and music and builds agents and document search workflows around them.",
       },
       {
         question: "Should I use LM Studio or NodeTool for local models?",
         answer:
-          "If you mainly want to download a local LLM and chat with it, or serve it over an OpenAI-compatible endpoint, LM Studio is the more specialized tool. If you want to build workflows around local (and cloud) models — retrieval, agents, media generation — NodeTool is the canvas for that.",
+          "If you mainly want to download a local language model and chat with it, or serve it over an OpenAI-compatible endpoint, LM Studio is the more specialized tool. If you want to build workflows around local (and cloud) models — retrieval, agents, media generation — NodeTool is the canvas for that.",
       },
       {
         question: "Is NodeTool open source?",
@@ -867,54 +867,54 @@ export const competitors: Competitor[] = [
       },
     ],
     limitation:
-      "LM Studio is a specialized local-LLM runtime — no media generation, no agents or RAG workflows, and it's proprietary.",
+      "LM Studio is a specialized local-language model runtime — no media generation, no agents or document search workflows, and it's proprietary.",
   },
   {
     slug: "jan",
     name: "Jan",
     theme: "blue",
-    category: "Local LLM runtime",
+    category: "Local language model runtime",
     isNew: true,
     vsTitle: "NodeTool vs Jan — an open local chat app vs an open AI canvas",
     vsDescription:
-      "Jan is an open source, offline-first desktop app for chatting with local LLMs — a clean local ChatGPT alternative. NodeTool is open source too, but a node-based canvas: it runs local models and adds image, video, and music generation, agents, and RAG. Both are open and local-friendly; Jan is a focused chat app, NodeTool is the workflow builder around the models.",
+      "Jan is an open source, offline-first desktop app for chatting with local language models — a clean local ChatGPT alternative. NodeTool is open source too, but a visual canvas: it runs local models and adds image, video, and music generation, agents, and document search. Both are open and local-friendly; Jan is a focused chat app, NodeTool is the workflow builder around the models.",
     vsOgTitle: "NodeTool vs Jan — an open local chat app vs an open AI canvas",
     vsOgDescription:
-      "Jan is an open, offline-first local chat app. NodeTool is an open node-based canvas — local models plus generation, agents, and RAG.",
+      "Jan is an open, offline-first local chat app. NodeTool is an open visual canvas — local models plus generation, agents, and document search.",
     og: {
       image: "screen_chat.png",
       accent: "blue",
-      subtitle: "Open and local-first — plus generation, agents, and RAG on one canvas.",
+      subtitle: "Open and local-first — plus generation, agents, and document search on one canvas.",
     },
     heroHeading: "Open and local — plus everything past chat.",
     heroParagraph:
-      "Jan is an open source, offline-first desktop app for chatting with local LLMs — a clean, private local ChatGPT alternative. NodeTool is open source too, but a node-based canvas: it runs local models via Ollama, MLX, and llama.cpp and adds native image, video, and music generation, agents, and RAG on the same graph.",
+      "Jan is an open source, offline-first desktop app for chatting with local language models — a clean, private local ChatGPT alternative. NodeTool is open source too, but a visual canvas: it runs local models via Ollama, MLX, and llama.cpp and adds native image, video, and music generation, agents, and document search on the same graph.",
     competitorTagline: "Open source local chat app",
     competitorBullets: [
-      "Offline-first, private local LLM chat",
+      "Offline-first, private local language model chat",
       "Clean local ChatGPT-style UI",
       "Open source and self-hostable",
-      "Text and LLM chat focused",
+      "Text and language model chat focused",
     ],
     nodetoolTagline: "The open AI canvas",
     nodetoolBullets: [
       "Local models via Ollama, MLX, and llama.cpp",
       "Native image, video, and music generation",
-      "Agents, RAG, and multi-step workflows on one canvas",
-      "Open source under AGPL-3.0, BYOK for cloud models",
+      "Agents, document search, and multi-step workflows on one canvas",
+      "Open source under AGPL-3.0, your own keys for cloud models",
     ],
     rows: [
-      { label: "Local LLM chat", competitor: "Purpose-built, offline-first", nodetool: "Supported, plus workflows" },
+      { label: "Local language model chat", competitor: "Purpose-built, offline-first", nodetool: "Supported, plus workflows" },
       { label: "Offline / privacy focus", competitor: "Offline-first by design", nodetool: "Local models supported" },
       { label: "Native media generation (image, video, music)", competitor: false, nodetool: true },
-      { label: "Agents, RAG, multi-step workflows", competitor: false, nodetool: true },
-      { label: "Cloud providers (BYOK)", competitor: "Optional", nodetool: "Every major provider" },
+      { label: "Agents, document search, multi-step workflows", competitor: false, nodetool: true },
+      { label: "Cloud providers (your own keys)", competitor: "Optional", nodetool: "Every major provider" },
       { label: "Open source", competitor: true, nodetool: true },
-      { label: "Node-based canvas", competitor: false, nodetool: true },
+      { label: "Visual canvas", competitor: false, nodetool: true },
     ],
     explainerHeading: "A great chat app, or a whole canvas",
     explainerParagraph:
-      "Jan does one thing well and openly: private, offline-first chat with local models, with a UI that feels like a local ChatGPT. If that's what you want, Jan is a lovely, focused choice and fully open source. NodeTool aims wider: it runs the same local models via Ollama, MLX, and llama.cpp, but puts them on a node-based canvas alongside native image, video, and music generation, agents, and RAG — so a local model can drive a whole workflow, not just a chat window. Both are open source; the difference is scope.",
+      "Jan does one thing well and openly: private, offline-first chat with local models, with a UI that feels like a local ChatGPT. If that's what you want, Jan is a lovely, focused choice and fully open source. NodeTool aims wider: it runs the same local models via Ollama, MLX, and llama.cpp, but puts them on a visual canvas alongside native image, video, and music generation, agents, and document search — so a local model can drive a whole workflow, not just a chat window. Both are open source; the difference is scope.",
     ctaHeading: "Take local models past the chat window.",
     ctaParagraph:
       "Download Studio and build workflows around your local and cloud models.",
@@ -922,21 +922,21 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Jan?",
         answer:
-          "Jan is an open source, offline-first desktop app focused on chatting with local LLMs. NodeTool is an open source (AGPL-3.0) node-based canvas that runs local models too, and additionally generates image, video, and music and builds agents and RAG workflows around them.",
+          "Jan is an open source, offline-first desktop app focused on chatting with local language models. NodeTool is an open source (AGPL-3.0) visual canvas that runs local models too, and additionally generates image, video, and music and builds agents and document search workflows around them.",
       },
       {
         question: "Are both NodeTool and Jan open source?",
         answer:
-          "Yes. Jan is open source and offline-first; NodeTool is open source under AGPL-3.0 and runs as a desktop app on macOS, Windows, and Linux with local-model support plus BYOK cloud providers.",
+          "Yes. Jan is open source and offline-first; NodeTool is open source under AGPL-3.0 and runs as a desktop app on macOS, Windows, and Linux with local-model support plus your own keys cloud providers.",
       },
       {
         question: "Can NodeTool run fully offline like Jan?",
         answer:
-          "NodeTool can run local models via Ollama, MLX, and llama.cpp for offline LLM and media work. Cloud provider nodes need network access, but you choose which models are local and which are cloud.",
+          "NodeTool can run local models via Ollama, MLX, and llama.cpp for offline language model and media work. Cloud provider nodes need network access, but you choose which models are local and which are cloud.",
       },
     ],
     limitation:
-      "Jan is a focused local chat app — no media generation and no multi-step agent or RAG workflows.",
+      "Jan is a focused local chat app — no media generation and no multi-step agent or document search workflows.",
   },
   {
     slug: "lindy",
@@ -946,10 +946,10 @@ export const competitors: Competitor[] = [
     isNew: true,
     vsTitle: "NodeTool vs Lindy — business-ops agents vs an AI generation canvas",
     vsDescription:
-      "Lindy is a hosted no-code platform for AI assistants that automate business operations — email, scheduling, CRM. NodeTool is an open source, BYOK canvas where the AI work is the output: native image, video, and music generation, agents, and RAG. Lindy is built for ops plumbing; NodeTool is built to produce media and run creative agent workflows.",
+      "Lindy is a hosted platform that needs no code for AI assistants that automate business operations — email, scheduling, CRM. NodeTool is an open-source, bring-your-own-key canvas where the AI work is the output: native image, video, and music generation, agents, and document search. Lindy is built for ops plumbing; NodeTool is built to produce media and run creative agent workflows.",
     vsOgTitle: "NodeTool vs Lindy — business-ops agents vs an AI generation canvas",
     vsOgDescription:
-      "Lindy automates business ops with hosted agents. NodeTool is the open, BYOK canvas for AI generation, agents, and RAG.",
+      "Lindy automates business ops with hosted agents. NodeTool is the open canvas that runs on your own keys for AI generation, agents, and document search.",
     og: {
       image: "screen_workflow.png",
       accent: "violet",
@@ -957,10 +957,10 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Agents that produce, not just operate.",
     heroParagraph:
-      "Lindy is a polished hosted platform for no-code AI assistants that automate business operations — inbox, scheduling, CRM. NodeTool is an open source, BYOK canvas where the AI work is the deliverable: native image, video, and music generation, agents, and RAG on one node-based graph.",
+      "Lindy is a polished hosted platform for AI assistants built without code that automate business operations — inbox, scheduling, CRM. NodeTool is an open-source, bring-your-own-key canvas where the AI work is the deliverable: native image, video, and music generation, agents, and document search on one visual canvas.",
     competitorTagline: "Hosted business-ops agents",
     competitorBullets: [
-      "No-code assistants for ops automation",
+      "Assistants for operations work, built without code",
       "Deep business-app integrations",
       "Hosted, closed source",
       "Billed in tasks/credits + seats",
@@ -969,9 +969,9 @@ export const competitors: Competitor[] = [
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
       "Native image, video, and music generation",
-      "Agents and RAG on the same canvas as generation",
+      "Agents and document search on the same canvas as generation",
       "Open source under AGPL-3.0, desktop app included",
-      "BYOK at provider prices — local models supported",
+      "your own keys at provider prices — local models supported",
     ],
     rows: [
       { label: "Focus", competitor: "Business-ops automation", nodetool: "AI generation + agents" },
@@ -979,12 +979,12 @@ export const competitors: Competitor[] = [
       { label: "Native media generation (image, video, music)", competitor: false, nodetool: true },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Pricing model", competitor: "Tasks/credits + seats", nodetool: "BYOK / provider prices" },
+      { label: "Pricing model", competitor: "Tasks/credits + seats", nodetool: "Your keys, provider prices" },
       { label: "Desktop app + local models", competitor: false, nodetool: true },
     ],
     explainerHeading: "Ops plumbing, or creative production",
     explainerParagraph:
-      "Lindy is strong where its integrations are strong: wiring an assistant into your inbox, calendar, and CRM to handle repetitive operations, all no-code and hosted. If the job is ops automation across business apps, that prebuilt depth is a real advantage. NodeTool is built for a different job — producing things with AI. Image, video, and music models sit on the same canvas as agents and RAG, with editing tools built in, every call BYOK at provider prices, and the whole workspace open source under AGPL-3.0 with local-model support and a desktop app.",
+      "Lindy is strong where its integrations are strong: wiring an assistant into your inbox, calendar, and CRM to handle repetitive operations, all hosted and built without code. If the job is ops automation across business apps, that prebuilt depth is a real advantage. NodeTool is built for a different job — producing things with AI. Image, video, and music models sit on the same canvas as agents and document search, with editing tools built in, every call made with your own keys at provider prices, and the whole workspace open source under AGPL-3.0 with local-model support and a desktop app.",
     ctaHeading: "Put creation on the canvas.",
     ctaParagraph:
       "Download Studio and build agents that generate image, video, and music.",
@@ -992,7 +992,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Lindy?",
         answer:
-          "Lindy is a hosted, closed-source no-code platform for AI assistants that automate business operations like email, scheduling, and CRM. NodeTool is an open source (AGPL-3.0), BYOK node-based canvas focused on AI generation — image, video, and music — plus agents and RAG, with a desktop app and local-model support.",
+          "Lindy is a hosted, closed-source hosted platform for AI assistants that automate business operations like email, scheduling, and CRM. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
       },
       {
         question: "When should I pick Lindy instead of NodeTool?",
@@ -1000,9 +1000,9 @@ export const competitors: Competitor[] = [
           "When the job is automating business operations with deep prebuilt integrations into your inbox, calendar, and CRM. That's what Lindy is built for. NodeTool is the better fit when the workflow's output is AI-generated media or creative agent work.",
       },
       {
-        question: "Is NodeTool open source and BYOK?",
+        question: "Is NodeTool open source and runs on your own keys?",
         answer:
-          "Yes. NodeTool is open source under AGPL-3.0 and BYOK — you connect your own provider keys and pay list prices, with no per-task credits or platform markup, and you can run local models on your own hardware.",
+          "Yes. NodeTool is open source under AGPL-3.0 and your own keys — you connect your own provider keys and pay list prices, with no per-task credits or platform markup, and you can run local models on your own hardware.",
       },
     ],
     limitation:
@@ -1014,12 +1014,12 @@ export const competitors: Competitor[] = [
     theme: "amber",
     category: "Workflow automation",
     isNew: true,
-    vsTitle: "NodeTool vs Gumloop — no-code ops automation vs an AI generation canvas",
+    vsTitle: "NodeTool vs Gumloop — business automation vs an AI generation canvas",
     vsDescription:
-      "Gumloop is a hosted no-code platform for AI-powered business automation, with prebuilt nodes and integrations. NodeTool is an open source, BYOK canvas where the AI work is the point: native image, video, and music generation, agents, and RAG. Gumloop automates business processes; NodeTool produces media and runs creative workflows you can self-host.",
-    vsOgTitle: "NodeTool vs Gumloop — no-code ops automation vs an AI generation canvas",
+      "Gumloop is a hosted platform that needs no code for AI-powered business automation, with prebuilt nodes and integrations. NodeTool is an open-source, bring-your-own-key canvas where the AI work is the point: native image, video, and music generation, agents, and document search. Gumloop automates business processes; NodeTool produces media and runs creative workflows you can self-host.",
+    vsOgTitle: "NodeTool vs Gumloop — business automation vs an AI generation canvas",
     vsOgDescription:
-      "Gumloop automates business processes, hosted and no-code. NodeTool is the open, BYOK canvas for AI generation, agents, and RAG.",
+      "Gumloop automates business processes, hosted, with no code to write. NodeTool is the open canvas that runs on your own keys for AI generation, agents, and document search.",
     og: {
       image: "screen_workflow.png",
       accent: "amber",
@@ -1027,8 +1027,8 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Automation that generates, not just processes.",
     heroParagraph:
-      "Gumloop is a hosted no-code platform for AI-powered business automation, with a deep library of prebuilt nodes and integrations. NodeTool is an open source, BYOK canvas built for the case where the AI work is the deliverable: native image, video, and music generation, agents, and RAG on one node-based graph.",
-    competitorTagline: "Hosted no-code automation",
+      "Gumloop is a hosted platform that needs no code for AI-powered business automation, with a deep library of prebuilt nodes and integrations. NodeTool is an open-source, bring-your-own-key canvas built for the case where the AI work is the deliverable: native image, video, and music generation, agents, and document search on one visual canvas.",
+    competitorTagline: "Hosted automation, no code required",
     competitorBullets: [
       "Prebuilt nodes for business automation",
       "Broad SaaS integrations",
@@ -1039,9 +1039,9 @@ export const competitors: Competitor[] = [
     nodetoolTagline: "The AI-native canvas",
     nodetoolBullets: [
       "Native image, video, and music generation",
-      "Agents and RAG on the same canvas as generation",
+      "Agents and document search on the same canvas as generation",
       "Open source under AGPL-3.0, desktop app included",
-      "BYOK at provider prices — local models supported",
+      "your own keys at provider prices — local models supported",
     ],
     rows: [
       { label: "Focus", competitor: "Business-process automation", nodetool: "AI generation + agents" },
@@ -1049,12 +1049,12 @@ export const competitors: Competitor[] = [
       { label: "Native media generation (image, video, music)", competitor: false, nodetool: true },
       { label: "Editing tools (masks, inpaint, relight, layers)", competitor: false, nodetool: true },
       { label: "Source", competitor: "Closed", nodetool: "AGPL-3.0 (open source)" },
-      { label: "Pricing model", competitor: "Credits + seats", nodetool: "BYOK / provider prices" },
+      { label: "Pricing model", competitor: "Credits + seats", nodetool: "Your keys, provider prices" },
       { label: "Desktop app + local models", competitor: false, nodetool: true },
     ],
     explainerHeading: "Process automation, or media production",
     explainerParagraph:
-      "Gumloop is good at what it's built for: no-code automation of business processes, with prebuilt nodes and broad SaaS integrations that get an ops workflow running fast and hosted. If that's the job, its integration library is a real edge. NodeTool is built to produce, not just process — image, video, and music models on the same canvas as agents and RAG, editing tools built in, every call BYOK at provider prices, and the whole workspace open source under AGPL-3.0 with local models and a desktop app.",
+      "Gumloop is good at what it's built for: automating business processes without writing code, with prebuilt nodes and broad SaaS integrations that get an ops workflow running fast and hosted. If that's the job, its integration library is a real edge. NodeTool is built to produce, not just process — image, video, and music models on the same canvas as agents and document search, editing tools built in, every call made with your own keys at provider prices, and the whole workspace open source under AGPL-3.0 with local models and a desktop app.",
     ctaHeading: "Automate the creation itself.",
     ctaParagraph:
       "Download Studio and build workflows that generate image, video, and music.",
@@ -1062,17 +1062,17 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Gumloop?",
         answer:
-          "Gumloop is a hosted, closed-source no-code platform for AI-powered business-process automation with prebuilt nodes and SaaS integrations. NodeTool is an open source (AGPL-3.0), BYOK node-based canvas focused on AI generation — image, video, and music — plus agents and RAG, with a desktop app and local-model support.",
+          "Gumloop is a hosted, closed-source hosted platform for business-process automation with prebuilt nodes and SaaS integrations. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
       },
       {
         question: "When should I pick Gumloop instead of NodeTool?",
         answer:
-          "When the job is automating a business process across SaaS tools with prebuilt, no-code integrations. That's Gumloop's strength. NodeTool is the better fit when the workflow's output is AI-generated media or creative agent work you want to own and self-host.",
+          "When the job is automating a business process across SaaS tools with ready-made integrations that need no code. That's Gumloop's strength. NodeTool is the better fit when the workflow's output is AI-generated media or creative agent work you want to own and self-host.",
       },
       {
         question: "Is NodeTool open source and self-hostable?",
         answer:
-          "Yes. NodeTool is open source under AGPL-3.0, self-hostable, and BYOK — you pay providers directly at list prices with no credits or platform markup, and you can run local models on your own hardware.",
+          "Yes. NodeTool is open source under AGPL-3.0, self-hostable, and your own keys — you pay providers directly at list prices with no credits or platform markup, and you can run local models on your own hardware.",
       },
     ],
     limitation:
@@ -1116,8 +1116,8 @@ export function alternativesFor(slug: string): {
     name: "NodeTool",
     href: null,
     note: current
-      ? `Open source, BYOK canvas for image, video, audio, and text — the ${current.category.toLowerCase()} alternative you can self-host.`
-      : "Open source, BYOK canvas for image, video, audio, and text.",
+      ? `An open-source canvas for image, video, audio, and text that runs on your own keys — the ${current.category.toLowerCase()} alternative you can host yourself.`
+      : "An open-source canvas for image, video, audio, and text that runs on your own keys.",
     isNodetool: true,
   };
   const rivals = siblings(slug)
@@ -1147,7 +1147,7 @@ export const vsEntries: PageEntry[] = competitors.map((c) => ({
 export const alternativesEntries: PageEntry[] = competitors.map((c) => ({
   route: `/alternatives/${c.slug}`,
   title: `${c.name} alternatives (${YEAR}) — why teams choose NodeTool`,
-  description: `${c.limitation} Compare NodeTool and other ${c.category.toLowerCase()} alternatives — open source, BYOK, one canvas for image, video, audio, and text.`,
+  description: `${c.limitation} Compare NodeTool and other ${c.category.toLowerCase()} alternatives — open source, your own keys, one canvas for image, video, audio, and text.`,
   priority: c.isNew ? 0.55 : 0.6,
   changeFrequency: "monthly",
   indexable: true,

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -10,8 +10,8 @@ import type { PageEntry } from "./types";
  *      that renders `<FaqBlock surface="…" />` (see components/FaqBlock.tsx).
  *
  * The `surfaces` field is what wires a row onto those inline blocks. Glossary
- * terms ship here as the `glossary` category (What is BYOK / RAG / a node-based
- * workflow / a diffusion model) rather than duplicating the docs-site glossary
+ * terms ship here as the `glossary` category (node-based workflow, diffusion
+ * model, RAG, planning agent) rather than duplicating the docs-site glossary
  * wholesale — that would create cross-domain duplicate content between
  * nodetool.ai and docs.nodetool.ai.
  */
@@ -77,7 +77,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-nodetool",
     question: "What is NodeTool?",
     answerMd:
-      "NodeTool is the open creative AI workspace. Every major model from every major provider — FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more — wired into one node-based canvas you run on your own machine or in the browser. Image, video, music, and text live on the same canvas, alongside planning agents that run multi-step jobs.",
+      "NodeTool is the open creative AI workspace. Every major model from every major provider, including FAL, KIE, OpenAI, Anthropic, Gemini, and Replicate, sits on one visual canvas that you run on your own machine or in the browser. Image, video, music, and text share that canvas, alongside agents that carry out longer jobs step by step.",
     category: "general",
     relatedRoute: "/",
     surfaces: ["agents", "comparison"],
@@ -86,16 +86,16 @@ const seeds: FaqSeed[] = [
     slug: "is-nodetool-open-source",
     question: "Is NodeTool open source?",
     answerMd:
-      "Yes. The full codebase is **AGPL-3.0** on [GitHub](https://github.com/nodetool-ai/nodetool). Studio and Cloud share the same source — no closed-source layer, no \"pro\" tier hiding the good features. Self-host any time.",
+      "Yes. The whole project is **AGPL-3.0** on [GitHub](https://github.com/nodetool-ai/nodetool). Studio and Cloud are built from the same source, and nothing is held back for a paid tier. You can host it yourself at any time.",
     category: "general",
     relatedRoute: "/studio",
     surfaces: ["comparison"],
   },
   {
     slug: "what-is-byok",
-    question: "What is BYOK, and what does it mean for me?",
+    question: "What does \"bring your own keys\" mean for me?",
     answerMd:
-      "BYOK is **bring your own keys**. You connect your own provider accounts and pay each provider directly at their list price. NodeTool never marks up model calls, never issues proprietary credits, and never runs inference on its own servers. Your keys, your bill, your data.",
+      "It means you connect your own provider accounts and pay each provider directly at their list price. NodeTool never adds a markup, never sells its own credits, and never runs models on its own servers. Your keys, your bill, your data. You will sometimes see this written as **BYOK**.",
     category: "byok",
     relatedRoute: "/pricing",
     surfaces: ["agents", "comparison", "models"],
@@ -113,7 +113,7 @@ const seeds: FaqSeed[] = [
     slug: "studio-or-cloud",
     question: "Studio or Cloud — which should I use?",
     answerMd:
-      "Studio is the desktop app: free, open source, runs on your machine, and supports local models via MLX, Ollama, and GGUF. Cloud is the same workspace in the browser — zero setup, no GPU required, and your keys still go to providers directly. Same workflows either way.",
+      "Studio is the desktop app: free, open source, running on your machine, with support for local models through MLX, Ollama, and GGUF. Cloud is the same workspace in the browser, with nothing to install and no graphics card needed, and your keys still go straight to the providers. The workflows are the same either way.",
     category: "editions",
     relatedRoute: "/cloud",
     surfaces: [],
@@ -122,7 +122,7 @@ const seeds: FaqSeed[] = [
     slug: "which-models-are-supported",
     question: "Which models are supported?",
     answerMd:
-      "Frontier models including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno — called through providers like FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Local inference runs via MLX, Ollama, llama.cpp, vLLM, and LM Studio.",
+      "The leading models, including Flux, Seedance, Wan, Veo, Kling, Hailuo, Qwen Image, Whisper, ElevenLabs, and Suno, reached through providers such as FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, and HuggingFace. Models can also run on your own computer through MLX, Ollama, llama.cpp, vLLM, and LM Studio.",
     category: "models",
     relatedRoute: "/studio",
     surfaces: ["agents", "models"],
@@ -140,7 +140,7 @@ const seeds: FaqSeed[] = [
     slug: "how-is-nodetool-different-from-comfyui",
     question: "How is NodeTool different from ComfyUI?",
     answerMd:
-      "ComfyUI is a node editor for diffusion models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away, and editing tools — masks, inpaint, relight, layers — built in. Both are node-based and open source.",
+      "ComfyUI is an editor for image models. NodeTool is the studio around it: image, video, music, and words on one canvas, every major model a click away, and editing tools such as masks, inpaint, relight, and layers built in. Both are open source and both work by connecting blocks on a canvas.",
     category: "comparison",
     relatedRoute: "/vs/comfyui",
     surfaces: ["comparison"],
@@ -150,7 +150,7 @@ const seeds: FaqSeed[] = [
     question:
       "How is NodeTool different from Weavy (now Figma Weave) and other closed canvases?",
     answerMd:
-      "Closed canvases lock you into a credit system and a curated model roster. NodeTool is open source and BYOK. Your workflows, files, and keys belong to you, and you can switch providers the moment a better model ships.",
+      "Closed tools tie you to a credit system and a hand-picked list of models. NodeTool is open source and runs on your own provider keys. Your workflows, files, and keys belong to you, and you can switch providers the moment a better model appears.",
     category: "comparison",
     relatedRoute: "/vs/weavy",
     surfaces: ["comparison"],
@@ -159,7 +159,7 @@ const seeds: FaqSeed[] = [
     slug: "open-source-figma-weave-alternative",
     question: "Is there an open source alternative to Figma Weave?",
     answerMd:
-      "Yes. Figma Weave (formerly Weavy, acquired by Figma in October 2025) is closed source, hosted-only, and billed in its own AI credits. NodeTool covers the same node-based media workflows as an **AGPL-3.0** open-source workspace: image, video, audio, and text on one canvas, BYOK at provider prices, running as a desktop app, in the browser, or self-hosted.",
+      "Yes. Figma Weave (formerly Weavy, acquired by Figma in October 2025) is closed source, hosted only, and billed in its own AI credits. NodeTool covers the same kind of media work as an **AGPL-3.0** open-source workspace: image, video, audio, and text on one canvas, run with your own keys at provider prices, as a desktop app, in the browser, or on your own server.",
     category: "comparison",
     relatedRoute: "/vs/figma-weave",
     surfaces: ["comparison"],
@@ -169,7 +169,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-a-node-based-workflow",
     question: "What is a node-based workflow?",
     answerMd:
-      "A node-based workflow is a pipeline you build by connecting boxes (nodes) on a canvas instead of writing code. Each node does one thing — load an image, call a model, crop a video — and edges carry data from one node's output to the next node's input. The whole graph runs top to bottom, so you can see and rewire every step.",
+      "A node-based workflow is one you build by connecting boxes on a canvas instead of writing code. Each box does one thing, such as loading an image, running a model, or cropping a video, and the lines between them carry the result of one step into the next. The whole thing runs from start to finish, so you can watch every step and rearrange it whenever you like.",
     category: "glossary",
     relatedRoute: "/",
     surfaces: [],
@@ -178,16 +178,16 @@ const seeds: FaqSeed[] = [
     slug: "what-is-a-diffusion-model",
     question: "What is a diffusion model?",
     answerMd:
-      "A diffusion model generates images (or video, or audio) by starting from random noise and removing it step by step until a coherent result emerges, guided by your prompt. Flux, Stable Diffusion, and most image generators are diffusion models. In NodeTool you run them as nodes alongside everything else.",
+      "A diffusion model makes an image, video, or sound by starting from random noise and clearing it away step by step, guided by your prompt, until a clear result appears. Flux, Stable Diffusion, and most image generators work this way. In NodeTool you run them as blocks alongside everything else.",
     category: "glossary",
     relatedRoute: "/creatives",
     surfaces: [],
   },
   {
     slug: "what-is-rag",
-    question: "What is RAG (retrieval-augmented generation)?",
+    question: "How can a model answer from my own documents?",
     answerMd:
-      "RAG is **retrieval-augmented generation**: before a language model answers, it retrieves relevant chunks from your own documents and feeds them in as context, so the answer is grounded in your data instead of only the model's training. NodeTool has built-in vector search and document nodes to build RAG pipelines on the canvas.",
+      "Before the model answers, NodeTool searches your documents and passes the most relevant passages along with your question, so the answer comes from your material rather than the model's general training. The search and document blocks are built in, so you can put this together on the canvas. The technique is often called **RAG**, short for retrieval-augmented generation.",
     category: "glossary",
     relatedRoute: "/developers",
     surfaces: [],
@@ -196,7 +196,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-a-planning-agent",
     question: "What is a planning agent?",
     answerMd:
-      "A planning agent takes a goal, breaks it into steps, picks a model or tool for each step, and executes them in order — adjusting as it goes. In NodeTool an agent is a node on the canvas, so you can wire its output into the rest of your workflow.",
+      "A planning agent takes a goal, breaks it into steps, picks a model or tool for each step, and works through them in order, adjusting as it goes. In NodeTool an agent is a block on the canvas, so its results feed into the rest of your workflow.",
     category: "glossary",
     relatedRoute: "/agents",
     surfaces: ["agents"],
@@ -255,7 +255,7 @@ export const faqPageEntries: PageEntry[] = [
     route: FAQ_BASE,
     title: "NodeTool FAQ — open creative AI workspace",
     description:
-      "Answers about NodeTool: BYOK pricing, Studio vs Cloud, supported models, how it compares, and a short glossary.",
+      "Answers about NodeTool: pricing with your own keys, Studio compared with Cloud, supported models, comparisons, and a short glossary.",
     priority: 0.6,
     changeFrequency: "monthly",
     indexable: true,

--- a/marketing/src/data/landingEntries.ts
+++ b/marketing/src/data/landingEntries.ts
@@ -209,18 +209,18 @@ export const landingEntries: LandingEntry[] = [
     eyebrow: "For local-first builders",
     headline: "Local-First AI Workflows",
     subhead:
-      "Your models, your machine, your data. NodeTool Studio runs open-weight image, video, audio, and LLM workflows locally — no account to start, nothing sent to a server you don't control.",
+      "Your models, your machine, your data. NodeTool Studio runs image, video, audio, and text workflows on your own computer using open models. There is no account to create and nothing is sent to a server you do not control.",
     featuredTemplate: "image-enhance",
     highlights: [
       "Open-weight models on Apple Silicon, NVIDIA, or CPU",
       "No account required, nothing phones home",
-      "Add cloud APIs only when you want them — BYOK",
+      "Add cloud providers only when you want them, using your own keys",
     ],
     sections: ["features", "use-cases"],
     faqs: [
       {
         q: "Does NodeTool work fully offline?",
-        a: "Yes for local models. Download the weights once and run image, audio, and LLM workflows with no network. Cloud providers are opt-in per node.",
+        a: "Yes, with local models. Download them once and run image, audio, and text workflows with no internet connection. Cloud providers are only used where you choose to add them.",
       },
       {
         q: "What hardware do I need?",

--- a/marketing/src/data/providerEntries.ts
+++ b/marketing/src/data/providerEntries.ts
@@ -29,7 +29,7 @@ export type ProviderCategory = "aggregator" | "llm" | "media";
 
 export const CATEGORY_LABEL: Record<ProviderCategory, string> = {
   aggregator: "Model aggregators",
-  llm: "LLM & AI APIs",
+  llm: "Language & voice APIs",
   media: "Media & 3D",
 };
 
@@ -71,7 +71,7 @@ export interface ProviderEntry extends PageEntry {
   name: string;
   /** Provider home page. */
   url: string;
-  /** BYOK env var NodeTool reads. */
+  /** Environment variable NodeTool reads for your key. */
   byokEnv: string;
   /** Logo asset path under /public. */
   logo: string;
@@ -204,11 +204,11 @@ const aggregators: ProviderEntry[] = [
     byokEnv: "REPLICATE_API_TOKEN",
     accent: "blue",
     tagline:
-      "Run Replicate's image, video, and audio models in a visual AI workflow — hundreds of community and first-party models, BYOK at Replicate's list price.",
+      "Run Replicate's image, video, and audio models in a visual AI workflow — hundreds of community and first-party models, run with your own key at Replicate's list price.",
     blurb: [
       "Replicate hosts a large, fast-moving catalog of open and commercial models behind one API — image, video, and audio generators from FLUX and Stable Diffusion to Kling, Wan, and more. NodeTool surfaces each as a node you can drop onto the canvas.",
       "Chain Replicate models into a pipeline — prompt to image, image to video, transcript to speech — and the whole graph is reusable and shareable. Because every model is a node, comparing two Replicate models on the same prompt is a matter of wiring both into the same input.",
-      "Replicate is BYOK in NodeTool: set your `REPLICATE_API_TOKEN` and calls go straight to Replicate at their price. The model list below comes from the Replicate node manifest, so it tracks what the provider ships.",
+      "Replicate runs on your own key in NodeTool: set your `REPLICATE_API_TOKEN` and calls go straight to Replicate at their price. The model list below comes from the Replicate node manifest, so it tracks what the provider ships.",
     ],
     strengths: ["Image", "Video", "Audio"],
     faq: [
@@ -238,7 +238,7 @@ const aggregators: ProviderEntry[] = [
     blurb: [
       "Kie serves a curated set of top generative models — video (Veo, Kling, Seedance, Hailuo), image (Seedream, FLUX, GPT-Image), and audio including Suno music generation. NodeTool exposes each Kie model as its own node.",
       "Build a Kie pipeline on the canvas: write a prompt, generate an image, animate it, add a Suno soundtrack — one graph, edited freely and re-run on demand. Any Kie node can be swapped for a model on another provider without rewiring the rest.",
-      "Kie is BYOK: NodeTool calls it with your `KIE_API_KEY` at Kie's list price. The catalog below is generated from Kie's node manifest.",
+      "Kie runs on your own key: NodeTool calls it with your `KIE_API_KEY` at Kie's list price. The catalog below is generated from Kie's node manifest.",
     ],
     strengths: ["Video", "Image", "Audio"],
     faq: [
@@ -264,13 +264,13 @@ const aggregators: ProviderEntry[] = [
     byokEnv: "TOGETHER_API_KEY",
     accent: "cyan",
     tagline:
-      "Run Together AI's image and video models in a visual AI workflow — FLUX, Seedream, Kling, Veo and more, BYOK at Together's list price.",
+      "Run Together AI's image and video models in a visual AI workflow — FLUX, Seedream, Kling, Veo and more, run with your own key at Together's list price.",
     blurb: [
-      "Together AI runs a broad inference platform; NodeTool integrates its image and video generation models — FLUX, Seedream, and popular video models — as nodes on the canvas. (Together also serves open LLMs; those are reachable in chat via the Together provider id.)",
+      "Together AI hosts a wide range of models; NodeTool integrates its image and video generation models — FLUX, Seedream, and popular video models — as nodes on the canvas. (Together also serves open text models; those are reachable in chat via the Together provider id.)",
       "Drop a Together model into a graph, chain it with models from other providers, and share the whole pipeline as one file. Because each model is a node, putting two through the same prompt is a wiring change, not a rewrite.",
-      "Together is BYOK in NodeTool: set `TOGETHER_API_KEY` and calls go to Together at their price. The model list below is generated from Together's node manifest.",
+      "Together runs on your own key in NodeTool: set `TOGETHER_API_KEY` and calls go to Together at their price. The model list below is generated from Together's node manifest.",
     ],
-    strengths: ["Image", "Video", "LLMs"],
+    strengths: ["Image", "Video", "Text"],
     faq: [
       {
         q: "How do I connect Together AI?",
@@ -278,7 +278,7 @@ const aggregators: ProviderEntry[] = [
       },
       {
         q: "Which Together AI models does NodeTool support?",
-        a: "The image and video generation models are nodes (catalog below); Together's open-weight LLMs are available in chat and agent nodes via the Together provider.",
+        a: "The image and video generation models are nodes (catalog below); Together's open text models are available in chat and agent nodes via the Together provider.",
       },
       {
         q: "Is there a NodeTool fee on Together AI?",
@@ -296,9 +296,9 @@ const aggregators: ProviderEntry[] = [
     tagline:
       "Run AtlasCloud's chat, image and video models in a visual AI workflow — DeepSeek, Seedance, GPT-Image and more, called with your own key at AtlasCloud's price.",
     blurb: [
-      "AtlasCloud serves chat, image and video models through a single API. NodeTool exposes each image and video model as a node, and AtlasCloud's LLMs appear in the regular model picker alongside every other chat provider.",
+      "AtlasCloud serves chat, image and video models through a single API. NodeTool exposes each image and video model as a node, and AtlasCloud's text models appear in the regular model picker alongside every other chat provider.",
       "Wire an AtlasCloud image model into a video model, add an upscaler, and you have a repeatable pipeline you can re-run and share. Swapping AtlasCloud for another provider is a single node change.",
-      "AtlasCloud is BYOK: NodeTool calls it with your `ATLASCLOUD_API_KEY` at their list price. The catalog below comes from AtlasCloud's node manifest.",
+      "AtlasCloud runs on your own key: NodeTool calls it with your `ATLASCLOUD_API_KEY` at their list price. The catalog below comes from AtlasCloud's node manifest.",
     ],
     strengths: ["Chat", "Image", "Video"],
     faq: [
@@ -328,7 +328,7 @@ const aggregators: ProviderEntry[] = [
     blurb: [
       "Topaz Labs specializes in image and video enhancement — upscaling, denoising, and restoration. NodeTool integrates its models as nodes, so you can add a Topaz upscale step to the end of any generation pipeline.",
       "Generate an image or video with any provider, then route it through a Topaz node to sharpen and enlarge it — all in one graph. The pipeline is reusable and shareable as a single file.",
-      "Topaz is BYOK in NodeTool: set `TOPAZ_API_KEY` and calls go to Topaz at their price. The model list below is generated from Topaz's node manifest.",
+      "Topaz runs on your own key in NodeTool: set `TOPAZ_API_KEY` and calls go to Topaz at their price. The model list below is generated from Topaz's node manifest.",
     ],
     strengths: ["Image", "Video", "Upscaling"],
     faq: [
@@ -349,7 +349,7 @@ const aggregators: ProviderEntry[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Direct LLM & AI APIs (curated)
+// Direct language & voice APIs (curated)
 // ---------------------------------------------------------------------------
 
 const llmProviders: ProviderEntry[] = [
@@ -363,7 +363,7 @@ const llmProviders: ProviderEntry[] = [
     tagline:
       "Run Anthropic's Claude models in NodeTool chat and agent nodes — long-context reasoning, vision, and tool use, called with your own Anthropic key.",
     blurb: [
-      "Anthropic's Claude family is built for reliable reasoning, long context, and tool use. In NodeTool, Claude powers chat nodes, the planning agent, and any node that calls an LLM — wire it into a workflow to summarize, extract, route, or drive multi-step agents.",
+      "Anthropic's Claude family is built for reliable reasoning, long context, and tool use. In NodeTool, Claude powers chat nodes, the planning agent, and any node that calls a language model — wire it into a workflow to summarize, extract, route, or drive multi-step agents.",
       "Claude is bring-your-own-key: set `ANTHROPIC_API_KEY` and NodeTool calls Anthropic directly at their list price. Switching a workflow from Claude to another model is a single change on the node.",
     ],
     strengths: ["Reasoning", "Long context", "Vision", "Tools"],
@@ -371,12 +371,12 @@ const llmProviders: ProviderEntry[] = [
     highlights: [
       { name: "Claude Opus", desc: "Anthropic's most capable model for hard reasoning and agentic work.", kind: "Chat" },
       { name: "Claude Sonnet", desc: "Balanced speed and capability — the everyday workhorse.", kind: "Chat" },
-      { name: "Claude Haiku", desc: "Fast, low-cost model for high-volume and latency-sensitive tasks.", kind: "Chat" },
+      { name: "Claude Haiku", desc: "Fast, low-cost model for high-volume work where speed matters.", kind: "Chat" },
     ],
     faq: [
       {
         q: "How do I use Claude in NodeTool?",
-        a: "Add your `ANTHROPIC_API_KEY` in settings, then pick an Anthropic model on any chat, agent, or LLM node. NodeTool streams the response back onto the canvas.",
+        a: "Add your `ANTHROPIC_API_KEY` in settings, then pick an Anthropic model on any chat, agent, or text block. NodeTool streams the response back onto the canvas.",
       },
       {
         q: "Does NodeTool support Claude tool use and agents?",
@@ -407,7 +407,7 @@ const llmProviders: ProviderEntry[] = [
       { name: "GPT (flagship)", desc: "General-purpose chat and vision across the GPT series.", kind: "Chat" },
       { name: "Reasoning models", desc: "Step-by-step reasoning for math, code, and planning.", kind: "Reasoning" },
       { name: "GPT-Image", desc: "Text-to-image and image editing with strong prompt following.", kind: "Image" },
-      { name: "Whisper", desc: "Robust speech-to-text transcription.", kind: "Transcription" },
+      { name: "Whisper", desc: "Accurate speech-to-text transcription.", kind: "Transcription" },
     ],
     faq: [
       {
@@ -432,16 +432,16 @@ const llmProviders: ProviderEntry[] = [
     byokEnv: "GEMINI_API_KEY",
     accent: "blue",
     tagline:
-      "Run Google's Gemini models in NodeTool — long-context multimodal chat with image and audio understanding, called with your own Gemini API key.",
+      "Run Google's Gemini models in NodeTool — chat that reads long documents, images, and audio, called with your own Gemini API key.",
     blurb: [
-      "Google's Gemini models handle text, images, and audio in a single long-context window, which makes them a strong fit for document understanding, multimodal extraction, and agents. In NodeTool, Gemini is available on chat, agent, and LLM nodes.",
+      "Google's Gemini models handle text, images, and audio in a single long-context window, which suits document work, pulling details out of images, and agents. In NodeTool, Gemini is available on chat, agent, and text blocks.",
       "Gemini is bring-your-own-key: set `GEMINI_API_KEY` and NodeTool calls Google directly at list price. Related Google media models (Imagen, Veo) are also reachable through the media aggregators NodeTool integrates.",
     ],
-    strengths: ["Long context", "Multimodal", "Vision", "Tools"],
+    strengths: ["Long context", "Text, image & audio", "Vision", "Tools"],
     capabilities: ["Chat", "Vision", "Audio input", "Tool use", "Streaming"],
     highlights: [
-      { name: "Gemini Pro", desc: "Google's most capable multimodal model for complex tasks.", kind: "Chat" },
-      { name: "Gemini Flash", desc: "Fast, cost-efficient multimodal model for high volume.", kind: "Chat" },
+      { name: "Gemini Pro", desc: "Google's most capable model for complex work across text, images, and audio.", kind: "Chat" },
+      { name: "Gemini Flash", desc: "Fast, low-cost model for high volume across text, images, and audio.", kind: "Chat" },
       { name: "Imagen", desc: "Google's image generation model (via media providers).", kind: "Image" },
       { name: "Veo", desc: "Google's text-to-video model (via media providers).", kind: "Video" },
     ],
@@ -452,7 +452,7 @@ const llmProviders: ProviderEntry[] = [
       },
       {
         q: "Can Gemini read images and audio in NodeTool?",
-        a: "Yes — Gemini is multimodal, so you can wire images or audio into a Gemini node and prompt over them in one long-context call.",
+        a: "Yes. Gemini reads images and audio as well as text, so you can feed them into a Gemini block and ask questions about them in one go.",
       },
       {
         q: "What does Gemini cost in NodeTool?",
@@ -470,14 +470,14 @@ const llmProviders: ProviderEntry[] = [
     tagline:
       "Run xAI's Grok models in NodeTool chat and agent nodes — capable reasoning with tool use, called with your own xAI key.",
     blurb: [
-      "xAI's Grok models are general-purpose chat and reasoning models with tool-use support. In NodeTool, Grok slots into chat nodes, agents, and any LLM step in a workflow.",
+      "xAI's Grok models are general-purpose chat and reasoning models with tool-use support. In NodeTool, Grok slots into chat nodes, agents, and any text step in a workflow.",
       "Grok is bring-your-own-key: set `XAI_API_KEY` and NodeTool calls xAI directly at list price. Swap Grok for another model on the node whenever you want to compare.",
     ],
     strengths: ["Reasoning", "Tools", "Chat"],
     capabilities: ["Chat", "Reasoning", "Tool use", "Streaming"],
     highlights: [
       { name: "Grok (flagship)", desc: "xAI's most capable reasoning and chat model.", kind: "Chat" },
-      { name: "Grok (fast)", desc: "Lower-latency tier for high-volume chat.", kind: "Chat" },
+      { name: "Grok (fast)", desc: "Faster tier for high-volume chat.", kind: "Chat" },
     ],
     faq: [
       {
@@ -504,7 +504,7 @@ const llmProviders: ProviderEntry[] = [
     tagline:
       "Run Mistral's chat, vision, and code models in NodeTool — efficient open-weight and commercial models, called with your own Mistral key.",
     blurb: [
-      "Mistral AI ships a family of efficient models: general chat (Mistral Large and smaller tiers), Pixtral for vision, and Codestral for code. In NodeTool they power chat, agent, and LLM nodes.",
+      "Mistral AI ships a family of efficient models: general chat (Mistral Large and smaller tiers), Pixtral for vision, and Codestral for code. In NodeTool they power chat, agent, and text blocks.",
       "Mistral is bring-your-own-key: set `MISTRAL_API_KEY` and NodeTool calls Mistral directly at list price.",
     ],
     strengths: ["Efficient", "Vision", "Code"],
@@ -537,12 +537,12 @@ const llmProviders: ProviderEntry[] = [
     byokEnv: "GROQ_API_KEY",
     accent: "rose",
     tagline:
-      "Run open models on Groq's ultra-fast inference in NodeTool — very high tokens-per-second chat, called with your own Groq key.",
+      "Run open models on Groq's very fast servers in NodeTool — very high tokens-per-second chat, called with your own Groq key.",
     blurb: [
-      "Groq runs open-weight models (Llama and others) on custom LPU hardware for very low latency and high throughput. In NodeTool, Groq is the pick when a chat or agent step needs to be fast — the same open models, served quickly.",
+      "Groq runs open-weight models (Llama and others) on custom hardware built for speed. In NodeTool, Groq is the pick when a chat or agent step needs to be fast — the same open models, served quickly.",
       "Groq is bring-your-own-key: set `GROQ_API_KEY` and NodeTool calls Groq directly at list price.",
     ],
-    strengths: ["Fast inference", "Open models", "Low latency"],
+    strengths: ["Fast responses", "Open models", "Speed"],
     capabilities: ["Chat", "Tool use", "Streaming"],
     highlights: [
       { name: "Llama (Groq-served)", desc: "Meta's open Llama models at very high tokens/sec.", kind: "Chat" },
@@ -551,7 +551,7 @@ const llmProviders: ProviderEntry[] = [
     faq: [
       {
         q: "Why use Groq in NodeTool?",
-        a: "Speed. Groq serves open models with very low latency, which helps agent loops and high-volume chat nodes finish faster.",
+        a: "Speed. Groq serves open models very quickly, so agents and high-volume chat steps finish sooner.",
       },
       {
         q: "How do I connect Groq?",
@@ -573,7 +573,7 @@ const llmProviders: ProviderEntry[] = [
     tagline:
       "Run DeepSeek's chat and reasoning models in NodeTool — strong reasoning at low cost, called with your own DeepSeek key.",
     blurb: [
-      "DeepSeek's models are known for strong reasoning and coding at a low price point, with a dedicated reasoning variant. In NodeTool they power chat, agent, and LLM nodes.",
+      "DeepSeek's models are known for strong reasoning and coding at a low price point, with a dedicated reasoning variant. In NodeTool they power chat, agent, and text blocks.",
       "DeepSeek is bring-your-own-key: set `DEEPSEEK_API_KEY` and NodeTool calls DeepSeek directly at list price.",
     ],
     strengths: ["Reasoning", "Code", "Low cost"],
@@ -605,7 +605,7 @@ const llmProviders: ProviderEntry[] = [
     byokEnv: "COHERE_API_KEY",
     accent: "cyan",
     tagline:
-      "Run Cohere's Command, Embed, and Rerank models in NodeTool — chat plus best-in-class retrieval for RAG, called with your own Cohere key.",
+      "Run Cohere's Command, Embed, and Rerank models in NodeTool — chat plus document search that keeps answers grounded in your own material, called with your own Cohere key.",
     blurb: [
       "Cohere focuses on enterprise retrieval: Command for chat, Embed for embeddings, and Rerank for reordering search results. In NodeTool, that makes Cohere a natural backbone for RAG pipelines built on the vector store.",
       "Cohere is bring-your-own-key: set `COHERE_API_KEY` and NodeTool calls Cohere directly at list price.",
@@ -650,7 +650,7 @@ const llmProviders: ProviderEntry[] = [
     highlights: [
       { name: "Frontier chat models", desc: "Flagship models from major labs behind one endpoint.", kind: "Chat" },
       { name: "Open-weight models", desc: "A large catalog of open models across hosts.", kind: "Chat" },
-      { name: "Automatic routing", desc: "Fallback and price/latency routing across providers.", kind: "Routing" },
+      { name: "Automatic routing", desc: "Sends each request to the cheapest or fastest provider, with a fallback if one is down.", kind: "Routing" },
     ],
     faq: [
       {
@@ -675,15 +675,15 @@ const llmProviders: ProviderEntry[] = [
     byokEnv: "HF_TOKEN",
     accent: "amber",
     tagline:
-      "Run Hugging Face-hosted models in NodeTool — open models across text, image, and audio through Inference, called with your own HF token.",
+      "Run Hugging Face-hosted models in NodeTool — open models across text, image, and audio, called with your own Hugging Face token.",
     blurb: [
-      "Hugging Face hosts the open-model ecosystem and serves many of them through its Inference API and partner providers. In NodeTool, that opens a large set of open text, image, and audio models as nodes.",
+      "Hugging Face hosts most of the open models in circulation and serves many of them itself or through partner providers. In NodeTool that gives you a large set of open text, image, and audio models to work with.",
       "Hugging Face is bring-your-own-key: set `HF_TOKEN` and NodeTool calls Hugging Face directly at their price.",
     ],
     strengths: ["Open models", "Text", "Image", "Audio"],
     capabilities: ["Chat", "Image gen", "Audio", "Embeddings"],
     highlights: [
-      { name: "Open LLMs", desc: "Llama, Qwen, Mistral and more served via Inference.", kind: "Chat" },
+      { name: "Open text models", desc: "Llama, Qwen, Mistral, and more, hosted by Hugging Face.", kind: "Chat" },
       { name: "Open image models", desc: "FLUX, Stable Diffusion and other open generators.", kind: "Image" },
       { name: "Audio models", desc: "Open speech and audio models from the Hub.", kind: "Audio" },
     ],
@@ -694,7 +694,7 @@ const llmProviders: ProviderEntry[] = [
       },
       {
         q: "Which Hugging Face models are available?",
-        a: "Open models served through Hugging Face Inference and its partner providers — text, image, and audio.",
+        a: "Open text, image, and audio models served by Hugging Face and its partner providers.",
       },
       {
         q: "What does Hugging Face cost in NodeTool?",
@@ -710,12 +710,12 @@ const llmProviders: ProviderEntry[] = [
     byokEnv: "CEREBRAS_API_KEY",
     accent: "emerald",
     tagline:
-      "Run open models on Cerebras' wafer-scale inference in NodeTool — extreme tokens-per-second chat, called with your own Cerebras key.",
+      "Run open models on Cerebras hardware in NodeTool for exceptionally fast chat, called with your own Cerebras key.",
     blurb: [
-      "Cerebras serves open models on wafer-scale hardware for some of the fastest inference available. In NodeTool it's a low-latency backend for chat and agent nodes that run the same open models.",
+      "Cerebras serves open models on unusually large chips, which makes it one of the fastest options available. In NodeTool it is the quick choice for chat and agent steps running those same open models.",
       "Cerebras is bring-your-own-key: set `CEREBRAS_API_KEY` and NodeTool calls Cerebras directly at list price.",
     ],
-    strengths: ["Fastest inference", "Open models"],
+    strengths: ["Fastest responses", "Open models"],
     capabilities: ["Chat", "Tool use", "Streaming"],
     highlights: [
       { name: "Llama (Cerebras-served)", desc: "Open Llama models at extreme tokens/sec.", kind: "Chat" },
@@ -724,7 +724,7 @@ const llmProviders: ProviderEntry[] = [
     faq: [
       {
         q: "Why use Cerebras in NodeTool?",
-        a: "Latency. Cerebras serves open models extremely fast, which speeds up agent loops and interactive chat nodes.",
+        a: "Speed. Cerebras serves open models very quickly, which shortens agent runs and keeps chat responsive.",
       },
       {
         q: "How do I connect Cerebras?",
@@ -746,7 +746,7 @@ const llmProviders: ProviderEntry[] = [
     tagline:
       "Run Moonshot's Kimi models in NodeTool — long-context chat and agentic coding, called with your own Kimi key.",
     blurb: [
-      "Moonshot AI's Kimi models are known for very long context and strong agentic coding. NodeTool speaks to them through the Anthropic-compatible endpoint, so Kimi drives chat, agent, and LLM nodes.",
+      "Moonshot AI's Kimi models are known for very long context and strong agentic coding. NodeTool speaks to them through the Anthropic-compatible endpoint, so Kimi drives chat, agent, and text blocks.",
       "Moonshot is bring-your-own-key: set `KIMI_API_KEY` and NodeTool calls Moonshot directly at list price.",
     ],
     strengths: ["Long context", "Agentic", "Code"],

--- a/marketing/src/data/staticEntries.ts
+++ b/marketing/src/data/staticEntries.ts
@@ -18,7 +18,7 @@ export const staticEntries: PageEntry[] = [
   { route: "/cloud", title: "NodeTool Cloud", description: "Run NodeTool workflows in the cloud.", priority: 0.9, changeFrequency: "weekly", indexable: true },
   { route: "/pricing", title: "Pricing", description: "Free Studio, your own keys, pay providers directly.", priority: 0.8, changeFrequency: "weekly", indexable: true },
   { route: "/agents", title: "AI Agents", description: "Build planning agents on a visual canvas.", priority: 0.8, changeFrequency: "monthly", indexable: true },
-  { route: "/creatives", title: "For Creatives", description: "A node-based canvas for creative AI work.", priority: 0.8, changeFrequency: "monthly", indexable: true },
+  { route: "/creatives", title: "For Creatives", description: "A visual canvas for creative AI work.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   { route: "/developers", title: "For Developers", description: "Wire every major model into one canvas.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   { route: "/marketing", title: "For Marketing", description: "Produce campaign assets with AI workflows.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   // /vs/* and /alternatives/* come from the competitorEntries engine module.


### PR DESCRIPTION
Two passes over `marketing/`.

## 1. Reduce jargon sitewide

Insider shorthand replaced with the phrase a first-time visitor already understands, across the homepage sections, the Studio / Cloud / pricing / creatives / marketing pages, the hub pages, and the hand-written FAQ, provider, and comparison datasets.

| Was | Now |
|---|---|
| BYOK | "your own keys" (the FAQ row still names the acronym once, so the term is still findable) |
| RAG | "answers from your own documents" (same treatment in the glossary row) |
| LLM | "language model" / "text model" |
| node-based canvas | visual canvas |
| "one node swap away" | "you switch to it in one click" |
| inference, latency, throughput, multimodal, serverless, orchestration, roster, modalities, no-code/low-code | plain equivalents |
| frontier, robust, best-in-class, first-class | dropped |

FAQ slugs are unchanged, so no URLs move. `public/llms.txt` regenerated to match.

## 2. Homepage narrative

- **Hero.** "One canvas. Every model. Your keys." replaces the abstract "The open creative AI workspace" headline, which moves down to the eyebrow. The subhead now carries the outcome and the ownership claim instead of also trying to explain model swapping.
- **New `StatusQuoSection`** sits under the hero and names the reader's current workflow — five tabs, export/import, prepaid credits, the tool that gets acquired — then links to the comparison. Deliberately low-chrome: no icon-card grid, per the anti-references in `marketing/PRODUCT.md`.
- **Reordered** to hero → pain → demo → how it works → use cases → comparison → ownership → model support → cost, with the editors, node menu, asset manager, chat, and model manager moved below that. The argument runs before the feature tour.
- **Creative-flow language** where the product earns it: "Stop exporting. Start finishing.", directing the whole piece rather than generating parts of it, brief to finished piece without leaving the canvas.

## Not done

Adding real names, titles, or quotes to the "Made with working creatives" section — I have no real testimonials and won't invent them. Worth a follow-up if you can supply any.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean (only pre-existing `<img>` and `exhaustive-deps` warnings)
- `npm run build` succeeds, 292 static pages
- `npm run seo:check` passes after regenerating `llms.txt`
- Homepage rendered in Chromium and screenshotted; section order verified in the DOM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JceAzDMuFFkvak1MDGw8gi)_