### PR TITLE
ci(mobile): add the TestFlight dev-build path for managed devices

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -23,6 +23,7 @@ on:
           [
             development,
             development-simulator,
+            development-testflight,
             preview,
             preview-simulator,
             production
@@ -32,7 +33,8 @@ on:
         type: boolean
         default: false
       submit:
-        description: Submit the finished build to the stores (production only)
+        description: Submit the finished build (production → App Store,
+          development-testflight → TestFlight)
         type: boolean
         default: false
   push:
@@ -150,7 +152,7 @@ jobs:
           # login can mint those the first time, so CI can never recover on its
           # own — say what to do instead of leaving the raw EAS message.
           if [ "$status" -ne 0 ] && grep -qi "couldn't find any credentials" build.err; then
-            echo "::error::No iOS credentials on the Expo servers for profile '$PROFILE'. Run 'cd mobile && npx eas-cli credentials --platform ios' once from a machine signed in to the Apple Developer account (an ad-hoc profile also needs each test device's UDID registered). To smoke-test without an Apple account, use the 'preview-simulator' profile or build '--platform android'."
+            echo "::error::No iOS credentials on the Expo servers for profile '$PROFILE'. Run 'cd mobile && npx eas-cli credentials --platform ios' once from a machine signed in to the Apple Developer account (an ad-hoc profile also needs each test device's UDID registered). If the test device refuses the profile rather than the build failing to make one — a phone under MDM — ad-hoc is what is blocked: build 'development-testflight' and install from TestFlight instead. To smoke-test without an Apple account, use 'preview-simulator' or build '--platform android'."
           fi
           exit "$status"
 
@@ -175,13 +177,17 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       # `--latest` picks the build this job just queued, since the wait above
-      # means it is the newest one for the profile.
+      # means it is the newest one for the profile. Only the two profiles that
+      # produce a store-signed binary have a matching `submit` profile in
+      # eas.json; an internal-distribution build has nowhere to be submitted.
       - name: Submit
-        if: (github.event_name == 'push' || inputs.submit) && env.PROFILE == 'production'
+        if: >-
+          (github.event_name == 'push' || inputs.submit) &&
+          (env.PROFILE == 'production' || env.PROFILE == 'development-testflight')
         working-directory: mobile
         run: |
           eas submit \
             --non-interactive \
             --platform "$PLATFORM" \
-            --profile production \
+            --profile "$PROFILE" \
             --latest

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -1,16 +1,21 @@
 name: Expo preview (mobile)
 
 # Publishes the PR's JS bundle as an EAS Update and comments a QR code on the
-# pull request. Scanning it with Expo Go runs that PR's code on a phone.
+# pull request. Scanning it opens that PR's code in the development build.
 #
-# This is the signing-free way to test on iOS: Expo Go is an ordinary App Store
-# app, so it installs on managed devices that refuse the ad-hoc provisioning
-# profiles an EAS internal-distribution build needs (see eas-build.yml). It
-# publishes a bundle rather than building a binary, so it costs no build credits
-# and finishes in a couple of minutes.
+# The QR targets a dev build rather than Expo Go, because Expo Go cannot run
+# this app at all: it ships a fixed set of native modules, and app.json's
+# plugins include three that are not in it (@react-native-google-signin,
+# @sentry/react-native, expo-speech-recognition). The App Store build of Expo
+# Go is also pinned to an older SDK than this project targets.
 #
-# The limit is the flip side: Expo Go ships a fixed set of native modules, so a
-# PR that adds or changes native code needs a real build, not an update.
+# Install the dev client once from the `development-testflight` profile (see
+# eas-build.yml), and from then on every PR is a QR scan away — publishing a
+# bundle costs no build credits and takes a couple of minutes, where a rebuild
+# would mean a queue wait and a new TestFlight submission.
+#
+# The limit is the flip side: an update only carries JS. A PR that adds or
+# changes native code needs a new build of the client itself.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -75,6 +80,6 @@ jobs:
         with:
           working-directory: mobile
           command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}
-          qr-target: expo-go
+          qr-target: dev-build
           comment: true
           github-token: ${{ github.token }}

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -80,6 +80,9 @@ jobs:
         with:
           working-directory: mobile
           command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}
-          qr-target: dev-build
+          # `dev-client`, not the `dev-build` the action's own docs name: its
+          # input validation accepts only "expo-go" or "dev-client", and its
+          # error message misreports the second as "dev-build".
+          qr-target: dev-client
           comment: true
           github-token: ${{ github.token }}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -66,7 +66,14 @@ Then:
 - Press `i` to open in iOS Simulator (macOS only)
 - Press `a` to open in Android Emulator
 - Press `w` to open in web browser
-- Scan the QR code with Expo Go app on your phone
+- Scan the QR code with a **development build** on your phone (see
+  [Testing a PR on a phone](#testing-a-pr-on-a-phone))
+
+Not Expo Go: it ships a fixed set of native modules, and this app's plugins
+include three that are not among them —
+`@react-native-google-signin/google-signin`, `@sentry/react-native`, and
+`expo-speech-recognition`. Sign-in and speech fail there even when the bundle
+loads.
 
 ### Platform-specific
 
@@ -170,22 +177,50 @@ consistency:
 Builds run on **EAS Build** (Expo's cloud build service) against the EAS project
 declared in `app.json` (`extra.eas.projectId`, owner `mgeorgi`).
 
-### Testing a PR on a phone without signing it
+### Testing a PR on a phone
 
 `.github/workflows/expo-preview.yml` publishes every PR that touches `mobile/`
 as an **EAS Update** and comments a QR code on the pull request. Scan it with
-**Expo Go** to run that PR's code on a device.
-
-This is the way onto an iOS device that a company-managed phone allows: Expo Go
-is an ordinary App Store app, so it installs where an EAS
-internal-distribution build cannot — those need an ad-hoc provisioning profile,
-which embeds an allow-list of device UDIDs and which MDM policies routinely
-block. Publishing a bundle also costs no build credits and takes a couple of
-minutes instead of a queue wait.
-
-The tradeoff: Expo Go ships a fixed set of native modules, so a PR that adds or
-changes native code needs a real build. Updates are keyed to the PR's head ref
+the development build to run that PR's code on a device — no rebuild, no queue
+wait, no build credits. Updates are keyed to the PR's head ref
 (`eas update --branch`), so each PR gets its own channel.
+
+The tradeoff: an update carries only JS. A PR that adds or changes native code
+needs a new build of the client itself.
+
+Install the client once, from the `development-testflight` profile.
+
+#### Why TestFlight, and not Expo Go or an internal build
+
+Two doors are shut on a company-managed iPhone, and TestFlight is the one that
+is open:
+
+- **Expo Go** ships a fixed set of native modules. This app's plugins include
+  three that are not among them (`@react-native-google-signin/google-signin`,
+  `@sentry/react-native`, `expo-speech-recognition`), so sign-in and speech
+  fail there whatever the SDK. The App Store build of Expo Go is also pinned to
+  an older SDK than this project targets — only the newest build is installable
+  on a physical iPhone, and newer ones wait on Apple review.
+- **EAS internal distribution** signs with an ad-hoc provisioning profile,
+  which embeds an allow-list of device UDIDs. MDM policies routinely refuse
+  those profiles, and no credential setup changes that.
+- **TestFlight** is ordinary App Store distribution: no UDID allow-list, and
+  managed devices accept it. A development build sent there keeps every native
+  module the app actually uses.
+
+Building it needs iOS credentials on the Expo servers, which is a one-time
+interactive step (see [Troubleshooting](#troubleshooting-builds)). Unlike the
+ad-hoc case it is a _distribution_ certificate, so nothing has to be installed
+on the test device.
+
+```bash
+# One-time: build the client and send it to TestFlight, then install from
+# TestFlight on the phone.
+npm run eas -- build --profile development-testflight --platform ios --auto-submit
+```
+
+From CI: Actions → _EAS Build (mobile)_ → _Run workflow_ →
+profile `development-testflight`, with `wait` and `submit` checked.
 
 ### From CI (preferred)
 
@@ -223,13 +258,14 @@ Anything the scripts don't cover goes through the CLI directly, e.g.
 `eas.json` profiles all extend `base`, which pins Node to 22.22.1 so cloud
 builds use the same version as the repo (`.nvmrc`):
 
-| Profile                 | Use                                                       |
-| ----------------------- | --------------------------------------------------------- |
-| `development`           | Dev client on a physical device, internal distribution    |
-| `development-simulator` | Same, but an iOS Simulator build                          |
-| `preview`               | Testing builds — Android APK you can sideload             |
-| `preview-simulator`     | Same, but an iOS Simulator build — needs no Apple account |
-| `production`            | Store builds — Android AAB, version auto-incremented      |
+| Profile                  | Use                                                                         |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `development`            | Dev client on a physical device, internal distribution                      |
+| `development-simulator`  | Same, but an iOS Simulator build                                            |
+| `development-testflight` | Dev client signed for the store — the TestFlight path onto a managed device |
+| `preview`                | Testing builds — Android APK you can sideload                               |
+| `preview-simulator`      | Same, but an iOS Simulator build — needs no Apple account                   |
+| `production`             | Store builds — Android AAB, version auto-incremented                        |
 
 `cli.appVersionSource` is `remote`, so EAS owns the build number; the
 `production` profile increments it on every build.
@@ -263,9 +299,13 @@ eas build --platform ios --local
 
   An ad-hoc profile only installs on devices whose UDID is registered
   (`npx eas-cli device:create`), and adding a device means rebuilding. Once the
-  credentials exist, `--non-interactive` CI builds reuse them. To smoke-test
-  iOS without an Apple Developer account, build the `preview-simulator` profile
-  — a Simulator build needs no signing at all.
+  credentials exist, `--non-interactive` CI builds reuse them.
+
+  If the device refuses the profile rather than the build failing to make one —
+  a managed phone under MDM — no credential setup will help; ad-hoc is what is
+  being blocked. Use `development-testflight` instead. To smoke-test iOS
+  without an Apple Developer account at all, build `preview-simulator`; a
+  Simulator build needs no signing.
 
 - **Build failures**: Check the build logs in Expo dashboard
 - **Timeouts**: Larger apps may need increased build timeout settings

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -18,6 +18,18 @@
         "simulator": true
       }
     },
+    "development-testflight": {
+      "extends": "development",
+      "distribution": "store",
+      "autoIncrement": true,
+      "channel": "development",
+      "ios": {
+        "buildConfiguration": "Release"
+      },
+      "android": {
+        "buildType": "app-bundle"
+      }
+    },
     "preview": {
       "extends": "base",
       "distribution": "internal",
@@ -40,6 +52,7 @@
     }
   },
   "submit": {
+    "development-testflight": {},
     "production": {}
   }
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -25,6 +25,7 @@
         "expo-audio": "~56.0.13",
         "expo-clipboard": "~56.0.3",
         "expo-constants": "~56.0.20",
+        "expo-dev-client": "~56.0.24",
         "expo-document-picker": "~56.0.4",
         "expo-file-system": "~56.0.8",
         "expo-haptics": "~56.0.3",
@@ -6330,6 +6331,59 @@
       },
       "engines": {
         "node": ">=20.12.0"
+      }
+    },
+    "node_modules/expo-dev-client": {
+      "version": "56.0.24",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-56.0.24.tgz",
+      "integrity": "sha512-Nc5EKGiq7fVP60ONHiXVh4jTNHQbajbYwGA69Ahm02hKBp27CBnGkOxHp04hkgbcN6JLD8F1Y+W8SjXb0ioUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "~56.0.25",
+        "expo-dev-menu": "~56.0.21",
+        "expo-dev-menu-interface": "~56.0.0",
+        "expo-manifests": "~56.0.4",
+        "expo-updates-interface": "~56.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "56.0.25",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-56.0.25.tgz",
+      "integrity": "sha512-oTFCHGpy4I1+7dd58ltNOrwKTLkYATtaRHURhZgcvJRddsFF+OMcBJbJTB6CJu5DlFyHtwVd9nNlZuo49xClWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^56.0.2",
+        "expo-dev-menu": "~56.0.21",
+        "expo-manifests": "~56.0.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-56.0.21.tgz",
+      "integrity": "sha512-+WSpwdT8iPAwygpuJX3qiF8q/9S9/5doRYzwBI/+eBdUY6YhLt69ajlndf6gid+IdbGDS3kgTfqB++XQ8rE6mg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-56.0.1.tgz",
+      "integrity": "sha512-odATx0ZL/Kis10sKSBiKiGQxAB6coSi/KQtKcMhnQVNno6FkRh5/4e5BqcEvpq2rNMTiQp4ytNAQHtdwbPXvGA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-document-picker": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -39,6 +39,7 @@
     "expo-audio": "~56.0.13",
     "expo-clipboard": "~56.0.3",
     "expo-constants": "~56.0.20",
+    "expo-dev-client": "~56.0.24",
     "expo-document-picker": "~56.0.4",
     "expo-file-system": "~56.0.8",
     "expo-haptics": "~56.0.3",


### PR DESCRIPTION
Follow-up to #4530. That PR's Expo Go preview path turned out not to work for this app — this replaces it with one that does.

## Why Expo Go can't work here

Two independent reasons, either one fatal:

- **Native modules.** Expo Go ships a fixed set of them, and `app.json`'s plugins include three that aren't among them: `@react-native-google-signin/google-signin`, `@sentry/react-native`, `expo-speech-recognition`. Sign-in and speech fail there whatever the SDK — and sign-in gates the app.
- **SDK pin.** Per [Expo's May 2026 changelog](https://expo.dev/changelog/expo-go-and-app-store-may-2026), the App Store build of Expo Go is pinned to SDK 54 while SDK 55 waits on Apple review; this project is on SDK 56. Only the newest build is installable on a physical iPhone.

Downgrading the SDK wouldn't help — the native-module problem is version-independent — and it would mean `react-native` 0.85.3 → 0.81.5 plus a different Expo package-versioning generation (`expo-video` ~56.1.4 → ~3.0.16, `expo-audio` ~56.0.13 → ~1.1.1, and so on).

## Why TestFlight

It's the one open door onto a company-managed iPhone. Ordinary App Store distribution: no ad-hoc provisioning profile, so no UDID allow-list for MDM to refuse. And a **development build** sent there keeps every native module the app actually uses, so the fast JS loop still works — `eas update` publishes, the client picks it up.

## Changes

- **`development-testflight` profile** — dev client with `distribution: store`, `buildConfiguration: Release` (TestFlight won't take a Debug build), and `autoIncrement` (it rejects duplicate build numbers). Plus a matching `submit` profile.
- **Submit step** now runs for it, and submits with the *selected* profile instead of hardcoding `production`. Guarded to the two profiles that produce a store-signed binary — an internal-distribution build has nowhere to be submitted.
- **Preview workflow** QR retargeted to `dev-build`. `runtimeVersion` stays: a dev build wants it, and it was Expo Go that couldn't load an update carrying one. (That was a real defect in #4530 — the QR it posted wouldn't have loaded in Expo Go even on a matching SDK.)
- **`expo-dev-client` installed** — `developmentClient: true` needs it, and the pre-existing `development` profile was already missing it.
- **README** — corrected the "scan the QR code with Expo Go" instruction, wrong since those plugins landed; documented why TestFlight rather than the two closed doors; updated the credentials troubleshooting entry to distinguish *can't create a profile* from *the device refuses it*.

## One-time setup this still needs

```bash
cd mobile
npx eas-cli credentials --platform ios   # signed in to the Apple Developer account
npm run eas -- build --profile development-testflight --platform ios --auto-submit
```

Then install from TestFlight on the phone. Unlike the ad-hoc case this is a *distribution* certificate, so nothing gets installed on the test device. After that, every PR is a QR scan away.

## Testing

- `expo export --platform ios` builds; **66 suites / 916 tests pass** after adding `expo-dev-client`.
- Resolved the `development-testflight` inheritance chain and asserted the merged result: `developmentClient: true`, `distribution: store` overriding the parent's `internal`, Release config, autoIncrement, and a matching submit profile.
- `expo config --type prebuild --json` resolves; both workflow YAMLs parse after edits; Prettier clean on every touched file; `npm run lint` shows only a pre-existing warning in an untouched file.

Not exercised: a real EAS build or TestFlight submission — both cost credits, need the Apple credentials above, and are `workflow_dispatch`-only. The submit profiles are `{}`, matching the existing `production` one, so App Store Connect resolution goes through the server-stored ASC key; if that turns out to need an explicit `ascAppId`, it'll surface on the first submit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpEA69uhqxWFsvccUnj6yr)_