### PR TITLE
docs, marketing: refresh the model lineups (Claude 5 family, GPT-5.6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ npm run chat -- [flags]
 ```bash
 # Interactive agent chat
 npm run dev:chat -- --agent --provider openai --model gpt-5.4-mini
-npm run dev:chat -- --agent --provider anthropic --model claude-sonnet-4-6
+npm run dev:chat -- --agent --provider anthropic --model claude-sonnet-5
 
 # Piped input (non-interactive)
 echo "research 5 AI topics" | npm run dev:chat -- --agent --provider openai --model gpt-5.4-mini
@@ -198,7 +198,7 @@ Chat flags:
                          moonshot, minimax, cerebras, together, openrouter,
                          huggingface, replicate, kie, aki, ollama, lmstudio
                          (any registry provider id also works, e.g. vllm, llama_cpp)
--m, --model <id>         Model ID (e.g. claude-sonnet-4-6, gpt-5.4-mini)
+-m, --model <id>         Model ID (e.g. claude-sonnet-5, gpt-5.4-mini)
 -w, --workspace <path>   Workspace directory for file tools
 --tools <list>           Comma-separated tool names
 -u, --url <ws-url>       Connect to WebSocket server instead of local provider
@@ -435,7 +435,7 @@ and cost. Cases and expectations live in
 
 ```bash
 npm run dev:nodetool -- eval graph-planner --list                     # show cases
-npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval graph-planner -p ollama -m qwen-3.5:4b --cases summarize,branch-both-paths
 npm run dev:nodetool -- eval graph-planner -p openai -m gpt-5.4-mini --json --out report.json
 npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8   # non-zero exit below threshold
@@ -451,7 +451,7 @@ metrics, and `--min-success` CI gate as `graph-planner`. Details:
 
 ```bash
 npm run dev:nodetool -- eval timeline-tools --list
-npm run dev:nodetool -- eval script-tools -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval script-tools -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval sketch-tools -p ollama -m qwen-3.5:4b --min-success 0.8
 ```
 
@@ -661,7 +661,7 @@ Each line in the file is one span:
   "status": { "code": "OK" },
   "attributes": {
     "agent.objective": "...", "agent.kind": "plan",
-    "agent.provider": "anthropic", "agent.model": "claude-sonnet-4-6",
+    "agent.provider": "anthropic", "agent.model": "claude-sonnet-5",
     "gen_ai.usage.input_tokens": 150, "gen_ai.usage.output_tokens": 80
   },
   "events": [],

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ npm install -g @nodetool-ai/cli
 nodetool serve
 
 # Interactive chat with agent mode
-nodetool-chat --agent --provider anthropic --model claude-sonnet-4-6
+nodetool-chat --agent --provider anthropic --model claude-sonnet-5
 
 # Run a TypeScript DSL workflow
 nodetool workflows run my-workflow.ts

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -371,7 +371,7 @@ const agent = new Agent({
   name: "researcher",
   objective: "Research TypeScript ORMs and write a comparison report",
   provider: openaiProvider,
-  model: "gpt-4o",
+  model: "gpt-5.6",
   tools: [new GoogleSearchTool(), new BrowserTool(), new WriteFileTool()],
   workspace: "/tmp/research-output",
   maxSteps: 10,
@@ -398,7 +398,7 @@ const agent = new Agent({
   name: "extractor",
   objective: "Extract all email addresses from this text: ...",
   provider: openaiProvider,
-  model: "gpt-4o",
+  model: "gpt-5.6",
   tools: [],
   outputSchema: {
     type: "object",
@@ -424,7 +424,7 @@ const { emails } = agent.getResults() as { emails: string[] };
 | `name` | required | Agent identifier |
 | `objective` | required | Goal to achieve |
 | `provider` | required | LLM provider instance (`BaseProvider`) |
-| `model` | required | Model ID (e.g. `"gpt-4o"`) |
+| `model` | required | Model ID (e.g. `"gpt-5.6"`) |
 | `planningModel` | same as `model` | Alternative model for the planning phase |
 | `reasoningModel` | same as `model` | Alternative model for reasoning-heavy steps |
 | `tools` | `[]` | Array of `Tool` instances |

--- a/docs/AGENT_CLI_QUICKREF.md
+++ b/docs/AGENT_CLI_QUICKREF.md
@@ -72,7 +72,7 @@ system_prompt: |
   Answer questions clearly and concisely.
 model:
   provider: openai
-  id: gpt-4o-mini
+  id: gpt-5-mini
 tools:
   - read_file
   - write_file
@@ -100,10 +100,10 @@ max_steps: 10
 
 | Task Type | Planning Model | Main Model |
 |-----------|----------------|------------|
-| Analytical | gpt-4o-mini | gpt-4o |
-| General | gpt-4o-mini | gpt-4o |
-| Creative | gpt-4o-mini | gemini-3.5-flash |
-| Code | gpt-4o-mini | claude-sonnet-4-6 |
+| Analytical | gpt-5-mini | claude-opus-5 |
+| General | gpt-5-mini | gpt-5.6 |
+| Creative | gpt-5-mini | gemini-3.5-flash |
+| Code | gpt-5-mini | claude-sonnet-5 |
 
 ## Environment Variables
 
@@ -147,7 +147,7 @@ done
 | Config errors | Run `nodetool agent test agent.yaml` to validate provider, model, and tools |
 | Tool not found | Check the tool name against the available tools list (unknown names are ignored with a warning) |
 | Rate limiting | Use a local model (`ollama`) |
-| Slow planning | Use a faster planning model (`gpt-4o-mini`) |
+| Slow planning | Use a faster planning model (`gpt-5-mini`) |
 
 ## Links
 

--- a/docs/agent-cli.md
+++ b/docs/agent-cli.md
@@ -95,15 +95,15 @@ objective: Research the latest AI trends
 # Model configuration
 model:
   provider: openai     # AI provider
-  id: gpt-4o           # Model identifier
-  name: GPT-4o         # Display name (optional)
+  id: gpt-5.6           # Model identifier
+  name: GPT-5.6         # Display name (optional)
 
 # Planning agent (optional)
 planning_agent:
   enabled: true        # set false to plan with the main model instead
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 # Available tools
 tools:
@@ -148,8 +148,8 @@ workspace:
 ```yaml
 model:
   provider: openai        # Provider name
-  id: gpt-4o              # Model ID
-  name: GPT-4o            # Display name (optional)
+  id: gpt-5.6              # Model ID
+  name: GPT-5.6            # Display name (optional)
 ```
 
 Supported providers include:
@@ -327,7 +327,7 @@ system_prompt: |
 
 ### Model Selection
 
-- **Planning model**: Use a fast, cost-effective model (`gpt-4o-mini`, a small Claude model)
+- **Planning model**: Use a fast, cost-effective model (`gpt-5-mini`, a small Claude model)
 - **Main model**: Use a stronger model for the actual reasoning
 - **Code tasks**: Models with large context windows
 
@@ -360,7 +360,7 @@ planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 ```
 
 ### Use a local model to avoid rate limits

--- a/docs/agent-config-schema.md
+++ b/docs/agent-config-schema.md
@@ -142,13 +142,13 @@ model:
 # OpenAI
 model:
   provider: openai
-  id: gpt-4o
-  name: GPT-4o
+  id: gpt-5.6
+  name: GPT-5.6
 
 # Anthropic
 model:
   provider: anthropic
-  id: claude-sonnet-4-6
+  id: claude-sonnet-5
   name: Claude Sonnet
 
 # Gemini (google / googleai are aliases for gemini)
@@ -183,16 +183,16 @@ planning_agent:
 **Best practices:**
 - Use fast, cost-effective models for planning
 - The planning model can differ from the main model
-- Recommended: `gpt-4o-mini`, a small Claude model, or a Gemini Flash model
+- Recommended: `gpt-5-mini`, a small Claude model, or a Gemini Flash model
 
 **Examples:**
 ```yaml
-# Use GPT-4o Mini for cost-effective planning
+# Use GPT-5 Mini for cost-effective planning
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 # Disable the separate planning model; plan with the main model
 planning_agent:
@@ -391,15 +391,15 @@ system_prompt: |
 
 model:
   provider: openai
-  id: gpt-4o
-  name: GPT-4o
+  id: gpt-5.6
+  name: GPT-5.6
 
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
-    name: GPT-4o Mini
+    id: gpt-5-mini
+    name: GPT-5 Mini
 
 tools:
   - google_search
@@ -443,7 +443,7 @@ If upgrading from older configuration formats:
 ```yaml
 agent:
   name: my-agent
-  model: gpt-4o
+  model: gpt-5.6
   tools: [search, browser]
 ```
 
@@ -452,12 +452,12 @@ agent:
 name: my-agent
 model:
   provider: openai
-  id: gpt-4o
+  id: gpt-5.6
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 tools:
   - google_search
   - browser

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -118,7 +118,7 @@ curl -X POST "http://localhost:7777/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{
-    "model": "gpt-4",
+    "model": "gpt-5.6",
     "messages": [
       {"role": "user", "content": "Explain quantum computing in simple terms"}
     ]
@@ -131,7 +131,7 @@ Response:
   "id": "chatcmpl-abc123",
   "object": "chat.completion",
   "created": 1699000000,
-  "model": "gpt-4",
+  "model": "gpt-5.6",
   "choices": [
     {
       "index": 0,
@@ -158,7 +158,7 @@ curl -X POST "http://localhost:7777/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{
-    "model": "gpt-4",
+    "model": "gpt-5.6",
     "messages": [
       {"role": "user", "content": "Write a haiku about programming"}
     ],
@@ -191,9 +191,9 @@ Response:
 {
   "object": "list",
   "data": [
-    {"id": "gpt-4", "object": "model", "owned_by": "openai"},
-    {"id": "gpt-3.5-turbo", "object": "model", "owned_by": "openai"},
-    {"id": "claude-3-opus", "object": "model", "owned_by": "anthropic"},
+    {"id": "gpt-5.6", "object": "model", "owned_by": "openai"},
+    {"id": "gpt-5-mini", "object": "model", "owned_by": "openai"},
+    {"id": "claude-opus-5", "object": "model", "owned_by": "anthropic"},
     {"id": "gpt-oss:20b", "object": "model", "owned_by": "ollama"}
   ]
 }
@@ -300,7 +300,7 @@ const openai = new OpenAI({
 });
 
 const completion = await openai.chat.completions.create({
-  model: 'gpt-4',
+  model: 'gpt-5.6',
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 
@@ -338,7 +338,7 @@ from openai import OpenAI
 
 client = OpenAI(api_key=TOKEN, base_url=f"{BASE_URL}/v1")
 completion = client.chat.completions.create(
-    model="gpt-4",
+    model="gpt-5.6",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(completion.choices[0].message.content)

--- a/docs/chat-api.md
+++ b/docs/chat-api.md
@@ -32,7 +32,7 @@ is optional for development.
 
 ```json
 {
-  "model": "gpt-4",
+  "model": "gpt-5.6",
   "messages": [
     {"role": "user", "content": "Hello, how are you?"}
   ],
@@ -53,7 +53,7 @@ client = openai.OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-4",
+    model="gpt-5.6",
     messages=[
         {"role": "user", "content": "Hello, how are you?"}
     ],
@@ -98,7 +98,7 @@ const socket = new WebSocket("ws://localhost:7777/ws?api_key=YOUR_KEY");
 const message = {
   role: "user",
   content: "Hello world",
-  model: "gpt-3.5-turbo" // or any supported model
+  model: "gpt-5-mini" // or any supported model
 };
 
 socket.onmessage = async (event) => {

--- a/docs/chat-cli.md
+++ b/docs/chat-cli.md
@@ -20,7 +20,7 @@ Run `nodetool chat` from your shell. The current provider and model are shown in
 nodetool chat
 
 # Override provider and model
-nodetool chat --provider anthropic --model claude-sonnet-4-6
+nodetool chat --provider anthropic --model claude-sonnet-5
 
 # Set the workspace directory (defaults to the current directory)
 nodetool chat --workspace /path/to/project

--- a/docs/chat-server.md
+++ b/docs/chat-server.md
@@ -35,7 +35,7 @@ The server provides:
 curl http://localhost:7777/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-4o",
+    "model": "gpt-5.6",
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
@@ -56,7 +56,7 @@ const response = await fetch("http://localhost:7777/v1/chat/completions", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
-    model: "gpt-4o",
+    model: "gpt-5.6",
     messages: [{ role: "user", content: "Hello, AI!" }],
     stream: true
   })

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,7 +213,7 @@ Starts an interactive TUI chat session.
 nodetool chat
 
 # Chat with a specific provider and model
-nodetool chat --provider anthropic --model claude-sonnet-4-6
+nodetool chat --provider anthropic --model claude-sonnet-5
 
 # Connect to a running server
 nodetool chat --url ws://localhost:7777/ws

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -34,7 +34,7 @@ Creative AI is a tab graveyard:
 
 One canvas, every model, your keys:
 
-**One canvas for every modality.** Wire Flux to GPT-5 to ElevenLabs to Wan in a single graph. Outputs flow as typed edges — image, audio, text, embeddings — not pasted strings.
+**One canvas for every modality.** Wire Flux to GPT-5.6 to ElevenLabs to Wan in a single graph. Outputs flow as typed edges — image, audio, text, embeddings — not pasted strings.
 
 **BYOK to every provider.** OpenAI, Anthropic, Gemini, Replicate, FAL, Kie, ElevenLabs, MiniMax, HuggingFace. Pay them directly. No credit markup, no provider lock-in.
 

--- a/docs/developer/providers/anthropic.md
+++ b/docs/developer/providers/anthropic.md
@@ -73,8 +73,10 @@ This shape is not valid for every current model. The provider uses adaptive
 thinking for models that require it. Anthropic's
 [extended thinking guide](https://platform.claude.com/docs/en/build-with-claude/extended-thinking)
 requires adaptive configuration for Claude Fable 5, Claude Mythos 5 and
-Preview, Claude Opus 4.8 and 4.7, and Claude Sonnet 5. Sonnet 5 enables adaptive
-thinking by default; Fable and Mythos do not allow thinking to be disabled.
+Preview, Claude Opus 5, Claude Opus 4.8 and 4.7, and Claude Sonnet 5. Opus 5 and
+Sonnet 5 enable adaptive thinking by default; Opus 5 only accepts disabled
+thinking at effort `high` or lower, and Fable and Mythos do not allow thinking to
+be disabled at all.
 Manual `budget_tokens` is deprecated but still accepted for Claude Opus 4.6 and
 Claude Sonnet 4.6. Claude Haiku 4.5 also accepts manual thinking. Manual budgets
 must be at least 1,024 tokens and less than `max_tokens`.

--- a/docs/developer/providers/openai.md
+++ b/docs/developer/providers/openai.md
@@ -17,7 +17,7 @@ The provider is registered under `PROVIDER_IDS.OPENAI = "openai"` in
 
 | Model type | What to do |
 |---|---|
-| Chat / LLM (e.g. `gpt-5`, `o3`) | Nothing — the list is fetched live from `https://api.openai.com/v1/models` |
+| Chat / LLM (e.g. `gpt-5.6`) | Nothing — the list is fetched live from `https://api.openai.com/v1/models` and filtered to the gpt-5 family |
 | Image (e.g. `gpt-image-3`) | Add one entry to `getAvailableImageModels()` (~line 249) and one pricing entry if quality-based |
 | Video (e.g. `sora-3`) | Add one entry to `getAvailableVideoModels()` (~line 232) |
 | TTS / ASR / Embedding | Add one entry to the matching static getter |
@@ -41,36 +41,52 @@ The provider is registered under `PROVIDER_IDS.OPENAI = "openai"` in
 
 ### Chat / LLM models — dynamic
 
-`getAvailableLanguageModels()` (line 178) makes a live `GET` request to
-`https://api.openai.com/v1/models` using the stored API key, then maps every
-returned `id` to a `LanguageModel` object:
+`getAvailableLanguageModels()` makes a live `GET` request to
+`https://api.openai.com/v1/models` using the stored API key, then maps the
+returned ids to `LanguageModel` objects:
 
 ```typescript
-// openai-provider.ts lines 178–203
 async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+  const isOpenAI = this.provider === PROVIDER_IDS.OPENAI;
   const response = await this._fetch("https://api.openai.com/v1/models", {
     headers: { Authorization: `Bearer ${this.apiKey}` }
   });
-  if (!response.ok) return [];
+  if (!response.ok) return isOpenAI ? OPENAI_FALLBACK_MODELS : [];
   const payload = await response.json() as { data?: Array<{ id?: string }> };
-  return (payload.data ?? [])
-    .filter((row): row is { id: string } => typeof row.id === "string")
-    .map((row) => ({ id: row.id, name: row.id, provider: "openai" }));
+  const models = (payload.data ?? [])
+    .filter((row): row is { id: string } => typeof row.id === "string" && row.id.length > 0)
+    .filter((row) => !isOpenAI || isOpenAIResponsesModel(row.id))
+    .map((row) => ({ id: row.id, name: row.id, provider: this.provider }));
+  return models.length === 0 && isOpenAI ? OPENAI_FALLBACK_MODELS : models;
 }
 ```
 
-A new chat model released by OpenAI appears in NodeTool automatically the next
-time the model list is refreshed — no code change needed.
+Two filters shape the result. `isOpenAIResponsesModel()` keeps only the gpt-5
+family — everything older (`gpt-4o`, `gpt-4.1`, the o-series) is retired on the
+`openai` provider, and audio/realtime/transcribe variants are excluded because
+the Responses API doesn't serve them. OpenAI-compatible subclasses set their own
+provider id, skip the filter, and keep their full catalog.
 
-**Tool support** is controlled by `hasToolSupport()` (line 174):
+When the request fails or returns nothing, the provider falls back to
+`OPENAI_FALLBACK_MODELS`: `gpt-5.6` (plus `-sol`, `-terra`, `-luna`), `gpt-5.5`,
+`gpt-5.5-pro`, `gpt-5.4` with its `-pro`/`-mini`/`-nano` tiers, and `gpt-5`,
+`gpt-5-mini`, `gpt-5-nano`. Add new releases there so they show up before a
+successful live fetch.
+
+A new gpt-5-family chat model released by OpenAI appears in NodeTool
+automatically the next time the model list is refreshed — no code change needed.
+
+**Tool support** is controlled by `hasToolSupport()`:
 
 ```typescript
 async hasToolSupport(model: string): Promise<boolean> {
+  if (this.usesResponsesApi(model)) return true;
   return !(model.startsWith("o1") || model.startsWith("o3"));
 }
 ```
 
-If a new model needs to opt out of tool use, add its prefix here.
+Responses-API models always support tools. If a Chat Completions model on a
+compatible subclass needs to opt out, add its prefix here.
 
 ### Image, video, TTS, ASR, and embedding models — static
 

--- a/docs/examples/agents/README.md
+++ b/docs/examples/agents/README.md
@@ -100,13 +100,13 @@ system_prompt: |
 
 model:
   provider: openai
-  id: gpt-4o
+  id: gpt-5.6
 
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 tools:
   - write_file
@@ -134,11 +134,11 @@ max_steps: 10
 - Set expectations for output format and quality
 
 **Model Selection:**
-- **Planning model**: Use a fast, cost-effective model (gpt-4o-mini)
+- **Planning model**: Use a fast, cost-effective model (gpt-5-mini)
 - **Main model**: Match the model to task complexity
-  - Simple tasks: gpt-4o-mini, gemini-3.5-flash
-  - Complex reasoning: gpt-4o, claude-sonnet-4-6
-  - Code tasks: claude-sonnet-4-6 (large context)
+  - Simple tasks: gpt-5-mini, gemini-3.5-flash
+  - Complex reasoning: claude-opus-5, gpt-5.6
+  - Code tasks: claude-sonnet-5 (1M context)
 
 **Tool Configuration:**
 - Start minimal (read_file, write_file)
@@ -215,7 +215,7 @@ model:
 planning_agent:
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 ```
 
 ## Contributing

--- a/docs/examples/agents/code-assistant.yaml
+++ b/docs/examples/agents/code-assistant.yaml
@@ -27,13 +27,13 @@ system_prompt: |
 
 model:
   provider: anthropic
-  id: claude-3-5-sonnet-20241022
+  id: claude-sonnet-5
 
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 tools:
   - write_file

--- a/docs/examples/agents/content-creator.yaml
+++ b/docs/examples/agents/content-creator.yaml
@@ -33,7 +33,7 @@ planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 tools:
   - google_search

--- a/docs/examples/agents/minimal.yaml
+++ b/docs/examples/agents/minimal.yaml
@@ -9,7 +9,7 @@ system_prompt: |
 
 model:
   provider: openai
-  id: gpt-4o-mini
+  id: gpt-5-mini
 
 planning_agent:
   enabled: true

--- a/docs/examples/agents/research-agent.yaml
+++ b/docs/examples/agents/research-agent.yaml
@@ -20,13 +20,13 @@ system_prompt: |
 
 model:
   provider: openai
-  id: gpt-4o
+  id: gpt-5.6
 
 planning_agent:
   enabled: true
   model:
     provider: openai
-    id: gpt-4o-mini
+    id: gpt-5-mini
 
 tools:
   - google_search

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,7 +86,7 @@ screen you land on when the app opens.
    - **Genre**: Sci-Fi Thriller
    - **Audience**: Adults who love mystery
 4. Two nodes, Agent and List Generator, ask you to pick a model. A **model** is
-   the specific AI you want to use, such as GPT-5 or Claude. Pick any one from
+   the specific AI you want to use, such as GPT-5.6 or Claude Opus 5. Pick any one from
    the dropdown. This is the step that needs the API key from above.
 5. Press <kbd>Ctrl/⌘ + Enter</kbd> to run it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ story. [See all use cases →]({{ '/use-cases' | relative_url }})
 
 ## What you can do
 
-* **Mix models from every vendor** — Wire Flux next to GPT-5 next to ElevenLabs in one graph. Pick the best model per step, not per project.
+* **Mix models from every vendor** — Wire Flux next to GPT-5.6 next to ElevenLabs in one graph. Pick the best model per step, not per project.
 * **Run frontier models locally** — Ollama, MLX, and GGUF on your hardware. Works offline. Files never leave your disk.
 * **Bring your own keys** — Pay OpenAI, Anthropic, Gemini, Replicate, FAL, and ElevenLabs directly. No credit markup, no provider tax.
 * **Ship a workflow as a Mini-App** — Hide the graph, expose just inputs and outputs. Share a link, no install required.

--- a/docs/models-and-providers.md
+++ b/docs/models-and-providers.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Models & Providers"
-description: "Every AI model NodeTool runs — GPT-5, Claude, Gemini, Grok, DeepSeek, Llama; FLUX, Nano Banana, Seedream, Ideogram; Sora 2, Veo 3.1, Kling, Wan, Seedance; ElevenLabs, Suno, Whisper — across 30+ providers, local or cloud, bring-your-own-key."
+description: "Every AI model NodeTool runs — GPT-5.6, Claude Opus 5, Gemini, Grok, DeepSeek, Llama; FLUX, Nano Banana, Seedream, Ideogram; Sora 2, Veo 3.1, Kling, Wan, Seedance; ElevenLabs, Suno, Whisper — across 30+ providers, local or cloud, bring-your-own-key."
 ---
 
 > **Overview / start here.** For the full catalog of model families see [Supported Models](models.md); for connecting and configuring each provider see [Providers](providers.md); for the desktop download panel see [Models Manager](models-manager.md).
@@ -42,12 +42,12 @@ Chat models are fetched live from each provider's API, so a provider's list alwa
 
 ### Text & chat models (LLMs)
 
-The generic `nodetool.agents.Agent` and chat nodes route to whichever provider owns the model you pick. Swap `claude-opus` for `gpt-5` or `gemini-3.1-pro-preview` without changing the rest of the graph.
+The generic `nodetool.agents.Agent` and chat nodes route to whichever provider owns the model you pick. Swap `claude-opus-5` for `gpt-5.6` or `gemini-3.1-pro-preview` without changing the rest of the graph.
 
 | Provider | Model families |
 |---|---|
-| <img src="assets/icons/openai.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> OpenAI | GPT-5, GPT-5 mini, GPT-5 nano, GPT-4.1, GPT-4o, o-series reasoning models |
-| <img src="assets/icons/anthropic.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> Anthropic | Claude Opus 4.x, Claude Sonnet 4.x, Claude Haiku 4.x, Claude 3.5/3.7 Sonnet |
+| <img src="assets/icons/openai.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> OpenAI | GPT-5.6 (plus the Sol, Terra, and Luna variants), GPT-5.5, GPT-5.5 Pro, GPT-5.4 with its Pro/mini/nano tiers, GPT-5, GPT-5 mini, GPT-5 nano |
+| <img src="assets/icons/anthropic.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> Anthropic | Claude Fable 5, Claude Opus 5, Claude Sonnet 5, Claude Opus 4.8/4.7/4.6, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | <img src="assets/icons/gemini.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> Google Gemini | Gemini 3.5 Flash, Gemini 3.1 Pro, Gemini 3.1 Flash-Lite, Gemini 2.5 Pro |
 | <img src="assets/icons/xai.svg" width="16" height="16" style="vertical-align: middle;" alt="" /> xAI | Grok 4, Grok 3, Grok Code |
 | DeepSeek | DeepSeek-V3, DeepSeek-R1 (reasoning) |
@@ -60,7 +60,7 @@ The generic `nodetool.agents.Agent` and chat nodes route to whichever provider o
 | OpenRouter | 300+ models proxied through one key (Claude, GPT, Gemini, Llama, Qwen, DeepSeek, …) |
 | Together AI | Llama, Qwen, DeepSeek, Mixtral, GLM, Kimi, and more open models |
 | Evolink | GPT, Claude, Gemini, DeepSeek through one gateway key |
-| kie.ai | GPT-5.5, Claude Opus/Sonnet/Haiku 4.x, Gemini 3.1 Pro (chat gateway) |
+| kie.ai | GPT-5.5, Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5, Gemini 3.1 Pro, Gemini 3 Flash (chat gateway) |
 | Codex (OpenAI OAuth) | GPT chat models via your ChatGPT/Codex login |
 | Claude Agent SDK | Claude via your local `claude` CLI subscription |
 | Ollama · vLLM · LM Studio · llama.cpp | Any local open-weight model — Llama, Qwen, Gemma, DeepSeek, Mistral, Phi, GPT-OSS |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -51,7 +51,7 @@ Checked against each provider's implementation in `packages/runtime/src/provider
 | Meshy AI | | | | | | | ✅ |
 | Rodin AI | | | | | | | ✅ |
 
-¹ Chat only for a short gateway list (GPT-5.5, Claude Opus/Sonnet/Haiku 4.x, Gemini 3.1 Pro) — most kie.ai models are image, video, or audio.
+¹ Chat only for a short gateway list (GPT-5.5, Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5, Gemini 3.1 Pro, Gemini 3 Flash) — most kie.ai models are image, video, or audio.
 ² Text-to-video only; no image-to-video.
 ³ Via a dedicated Speech-to-Text node, not the generic ASR picker.
 ⁴ Upscale and enhancement, not text-to-image generation.
@@ -126,7 +126,7 @@ Evolink is an OpenAI/Anthropic-compatible gateway: one key for GPT, Claude, Gemi
 
 ## kie.ai
 
-kie.ai is a multi-model aggregator: manifest-driven image, video, TTS, and music models (Seedance, Runway, Wan, Kling, FLUX.2, Suno, and more), plus chat for a short list of gateway models (GPT-5.5, Claude Opus/Sonnet/Haiku 4.x, Gemini 3.1 Pro). One key covers all of it, often at a lower price than the upstream provider directly. Cloud only, keyed by `KIE_API_KEY`. See the [KIE provider guide](developer/providers/kie.md).
+kie.ai is a multi-model aggregator: manifest-driven image, video, TTS, and music models (Seedance, Runway, Wan, Kling, FLUX.2, Suno, and more), plus chat for a short list of gateway models (GPT-5.5, Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5, Gemini 3.1 Pro, Gemini 3 Flash). One key covers all of it, often at a lower price than the upstream provider directly. Cloud only, keyed by `KIE_API_KEY`. See the [KIE provider guide](developer/providers/kie.md).
 
 ## AKI
 

--- a/docs/workflow-debugging.md
+++ b/docs/workflow-debugging.md
@@ -116,7 +116,7 @@ Every NodeTool workflow is stored as JSON. Inspecting this JSON can help debug c
       "type": "nodetool.agents.Agent",
       "data": {
         "prompt": "...",
-        "model": { "provider": "openai", "id": "gpt-4" }
+        "model": { "provider": "openai", "id": "gpt-5.6" }
       },
       "position": { "x": 300, "y": 100 }
     }
@@ -186,7 +186,7 @@ Error: Required input 'prompt' is not connected
 → Connect something to the `prompt` input, or set a default value
 
 ```
-Error: Model not found: 'gpt-4'
+Error: Model not found: 'gpt-5.6'
 ```
 → Check API key configuration in Settings → Providers
 

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -48,11 +48,12 @@ const cloudProviders = [
 // Perishable by design: stale names here directly undercut the
 // "swap models the day they launch" pitch — review on every release cycle.
 const frontierModels = [
-    { name: "Claude Opus 4.8", color: "text-amber-400" },
-    { name: "Claude Sonnet 4.6", color: "text-amber-400" },
-    { name: "Claude Haiku 4.5", color: "text-amber-400" },
-    { name: "Gemini 3 Pro", color: "text-blue-400" },
-    { name: "Gemini 3 Flash", color: "text-blue-400" },
+    { name: "GPT-5.6", color: "text-emerald-400" },
+    { name: "Claude Fable 5", color: "text-amber-400" },
+    { name: "Claude Opus 5", color: "text-amber-400" },
+    { name: "Claude Sonnet 5", color: "text-amber-400" },
+    { name: "Gemini 3.5 Flash", color: "text-blue-400" },
+    { name: "Gemini 3.1 Pro", color: "text-blue-400" },
     { name: "Qwen Image", color: "text-sky-400" },
     { name: "Veo 3.1", color: "text-blue-400" },
     { name: "Kling 3", color: "text-cyan-400" },

--- a/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
+++ b/marketing/src/components/developers/DeveloperIntegrationsSection.tsx
@@ -19,7 +19,7 @@ const integrations = [
     category: "Language Models",
     icon: Bot,
     color: "text-blue-400",
-    items: ["OpenAI GPT-5.5", "Claude Opus 4.8", "Gemini 3 Pro", "Ollama", "Llama", "Mistral", "Qwen"],
+    items: ["OpenAI GPT-5.6", "Claude Opus 5", "Gemini 3.5 Flash", "Ollama", "Llama", "Mistral", "Qwen"],
   },
   {
     category: "Image Generation",

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -114,7 +114,7 @@ Primitive globals pass by value (no sync).
 nodetool-chat --agent
 
 # With specific provider and model
-nodetool-chat --agent --provider anthropic --model claude-sonnet-4-6
+nodetool-chat --agent --provider anthropic --model claude-sonnet-5
 
 # With workspace directory
 nodetool-chat --agent --workspace /path/to/project
@@ -150,7 +150,7 @@ const agent = new Agent({
   name: "my-agent",
   objective: "Research and summarize AI trends",
   provider,          // BaseProvider instance
-  model: "claude-sonnet-4-6",
+  model: "claude-sonnet-5",
   tools: [readFileTool, writeFileTool, searchTool],
   outputSchema: {    // Optional: structured output
     type: "object",
@@ -381,7 +381,7 @@ averages). Run it against any registered provider:
 
 ```bash
 npm run dev:nodetool -- eval graph-planner --list
-npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval graph-planner -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval graph-planner -p ollama -m qwen-3.5:4b --cases summarize
 npm run dev:nodetool -- eval graph-planner -p openai -m gpt-5.4-mini --json --out report.json
 npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8  # CI gate
@@ -445,7 +445,7 @@ handler calls, so that half of the contract cannot drift.
 
 ```bash
 npm run dev:nodetool -- eval timeline-tools --list
-npm run dev:nodetool -- eval script-tools -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval script-tools -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval sketch-tools -p ollama -m qwen-3.5:4b --cases compose-layers
 npm run dev:nodetool -- eval model3d-tools -p openai -m gpt-5.4-mini --min-success 0.8  # CI gate
 ```
@@ -497,7 +497,7 @@ Cases + tools live in `src/evals/subtask-cases.ts`, the runner in
 
 ```bash
 npm run dev:nodetool -- eval subtask --list
-npm run dev:nodetool -- eval subtask -p anthropic -m claude-sonnet-4-6
+npm run dev:nodetool -- eval subtask -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval subtask -p openai -m gpt-5.4-mini --cases all-tools
 IS_SANDBOX=1 npm run dev:nodetool -- eval subtask \
   -p claude_agent_sdk -m sonnet --max-iterations 40 --no-find-model
@@ -641,7 +641,7 @@ Use separate models for planning vs execution to optimize cost/quality:
 ```typescript
 const agent = new Agent({
   model: "claude-haiku-4-5",           // Fast/cheap for step execution
-  planningModel: "claude-sonnet-4-6",  // Better for plan decomposition
+  planningModel: "claude-sonnet-5",  // Better for plan decomposition
   reasoningModel: "claude-opus-4-6",   // Best for complex reasoning
   ...
 });

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -29,7 +29,7 @@ import { processChat } from "@nodetool-ai/chat";
 await processChat({
   userInput: "Summarize the attached report",
   messages,
-  model: "claude-sonnet-4-6",
+  model: "claude-sonnet-5",
   provider,
   context,
   tools,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,7 +59,7 @@ Server-calling commands accept `--api-url <url>` (default `http://localhost:7777
 
 ```bash
 nodetool-chat                           # Saved / auto-detected settings
-nodetool-chat --provider anthropic --model claude-sonnet-4-6
+nodetool-chat --provider anthropic --model claude-sonnet-5
 nodetool-chat --agent                   # Start in agent mode
 nodetool-chat --workspace /path/to/dir  # Set the workspace for file tools
 nodetool-chat --url ws://localhost:7777/ws   # Connect to a running server


### PR DESCRIPTION
The model listings on the docs and marketing pages had drifted behind what the providers actually serve. Anthropic's row stopped at Claude Opus 4.x and still named retired Claude 3.5/3.7 Sonnet; OpenAI's row listed `gpt-4o`, `gpt-4.1`, and the o-series, which the `openai` provider retired when it moved to the gpt-5 family on the Responses API.

## What changed

**Model lineups**
- Anthropic listings now name Claude Fable 5, Claude Opus 5, and Claude Sonnet 5 alongside the 4.x models still served.
- OpenAI listings now name GPT-5.6 (with the Sol/Terra/Luna variants), GPT-5.5 and 5.5 Pro, and the GPT-5.4 Pro/mini/nano tiers — matching `OPENAI_FALLBACK_MODELS` in `openai-provider.ts`.
- Gemini entries on the marketing pages use the ids the provider actually exposes (Gemini 3.5 Flash, Gemini 3.1 Pro) instead of "Gemini 3 Pro/Flash".
- kie.ai's chat gateway is spelled out per model, matching the ids hardcoded in `kie-provider.ts`, and picks up Gemini 3 Flash, which was missing.

**Provider guides**
- `docs/developer/providers/openai.md` described `getAvailableLanguageModels()` as returning every id from `/v1/models`. It now documents the `isOpenAIResponsesModel()` gpt-5-only filter, the exemption for OpenAI-compatible subclasses, and the `OPENAI_FALLBACK_MODELS` list to extend on a new release. The `hasToolSupport()` snippet was also stale.
- `docs/developer/providers/anthropic.md` gains Claude Opus 5's thinking rules: adaptive by default, disabled thinking accepted only at effort `high` or lower.

**Examples**
- Agent YAMLs, CLI invocations, and OpenAI-compatible API snippets that used `gpt-4o`, `gpt-4o-mini`, `gpt-4`, `gpt-3.5-turbo`, `claude-3-5-sonnet-20241022`, or `claude-sonnet-4-6` now use models the providers serve. The retired OpenAI ids were the load-bearing ones — those examples would fail against the current provider.

## Files touched

Marketing: `ModelSupportSection.tsx`, `DeveloperIntegrationsSection.tsx` (string lists only).
Docs: `models-and-providers.md`, `providers.md`, both provider guides, the agent CLI/config/example docs, and the API reference snippets. Plus the CLI examples in `README.md`, `CLAUDE.md`, and two package READMEs, so the model ids stay consistent repo-wide.

Left alone deliberately: `providerEntries.ts` (version-free by design — "Claude Opus", "Claude Sonnet"), the use-case pages (they describe a specific template's node config), and `gpt-4o-mini-tts` (still a real OpenAI TTS model).

## Testing

Prose and string-literal changes only — no logic touched. `npm run typecheck` in `marketing/` fails in this environment because `marketing/node_modules` isn't installed (it is not a root workspace); that is pre-existing and unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164nt3Jrq8BLptGYHt7v7wG

---
_Generated by [Claude Code](https://claude.ai/code/session_0164nt3Jrq8BLptGYHt7v7wG)_