### PR TITLE
Sketch: collapse the editor chrome to one bar

### DIFF
--- a/web/src/components/chat/composer/imageModelOptions.tsx
+++ b/web/src/components/chat/composer/imageModelOptions.tsx
@@ -4,7 +4,7 @@
  *
  * The image counterpart to `videoModelOptions`: one source of truth for the
  * surfaces that generate images (the media chat composer, {@link MediaChatComposer},
- * and the sketch connected-mode prompt bar), so the two present identical,
+ * and the sketch generate popover), so the two present identical,
  * model-constrained options and can't drift apart.
  */
 

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -65,7 +65,6 @@ import {
   useSketchIsMobile
 } from "./hooks";
 import {
-  ConnectedModePromptBar,
   ConnectedStatusBar,
   ConnectedToolbar,
   ConnectedToolTopBar,
@@ -190,9 +189,13 @@ export interface SketchEditorProps {
   onExportMask?: (dataUrl: string | null) => void;
   /** When true, window keyboard shortcuts for the editor are disabled (e.g. shortcuts help open). */
   suspendKeyboardShortcuts?: boolean;
-  /** Document-level actions rendered at the trailing edge of the top mode bar
-   * (e.g. Save/Done when embedded in an asset tab). */
+  /** Compact document actions rendered inline at the trailing edge of the tool
+   * bar (e.g. Save/Done when embedded in an asset tab). Keep to one or two
+   * buttons — the bar shares its row with the tool settings. */
   headerActions?: React.ReactNode;
+  /** Document actions appended to the tool bar's overflow menu. Receives the
+   * menu's close callback. */
+  menuItems?: (close: () => void) => React.ReactNode;
 }
 
 const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
@@ -205,7 +208,8 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
       onExportImage,
       onExportMask,
       suspendKeyboardShortcuts,
-      headerActions
+      headerActions,
+      menuItems
     },
     ref
   ) {
@@ -233,7 +237,7 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
     // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
     // the next time the viewport shrinks back to mobile. Also keep the two
     // mobile bottom sheets mutually exclusive: when the Assistant opens (its
-    // toggle lives in the prompt bar), close the panels sheet so two stacked
+    // toggle lives in the tool bar menu), close the panels sheet so two stacked
     // SwipeableDrawer modals never fight over focus/scroll.
     useEffect(() => {
       if (!mobilePanelsOpen) {
@@ -433,10 +437,6 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
 
     return (
       <FlexColumn className="sketch-editor" css={styles(theme)} gap={0}>
-        {/* Top mode / prompt bar — full editor width above the 3-column body.
-          Renders nothing without a bound document (in-node modal). */}
-        <ConnectedModePromptBar trailingActions={headerActions} />
-
         <FlexRow
           className="sketch-editor__body"
           sx={{ flex: 1, minHeight: 0, width: "100%", overflow: "hidden" }}
@@ -549,6 +549,8 @@ const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
                 onCropCancelPreview={
                   session.canvasActions.handleCropCancelPreview
                 }
+                headerActions={headerActions}
+                menuItems={menuItems}
               />
             </Container>
 

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -194,8 +194,9 @@ export interface SketchEditorProps {
    * buttons — the bar shares its row with the tool settings. */
   headerActions?: React.ReactNode;
   /** Document actions appended to the tool bar's overflow menu. Receives the
-   * menu's close callback. */
-  menuItems?: (close: () => void) => React.ReactNode;
+   * menu's close callback, and returns an array — MUI's Menu rejects a
+   * Fragment child. */
+  menuItems?: (close: () => void) => React.ReactNode[];
 }
 
 const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(

--- a/web/src/components/sketch/SketchToolTopBar.tsx
+++ b/web/src/components/sketch/SketchToolTopBar.tsx
@@ -11,17 +11,9 @@ import { css } from "@emotion/react";
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
-import FitScreenIcon from "@mui/icons-material/FitScreen";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import {
-  EditorButton,
-  FlexRow,
-  IconButton,
-  Text,
-  Tooltip
-} from "../ui_primitives";
+import { FlexRow, IconButton, Text, Tooltip } from "../ui_primitives";
 import { getToolSettingsLabel } from "./tool-settings-panels/getToolSettingsLabel";
 import {
   SketchTool,
@@ -134,14 +126,12 @@ export interface SketchToolTopBarProps {
   onCancelSegmentation?: () => void;
   onClearSegmentPrompts?: () => void;
   onCheckSegmentModel?: () => void;
-  /** Collapse the left tool rail + right panels for a chrome-less canvas. */
-  onTogglePanelsHidden?: () => void;
   /** When true, only the tool header and global actions render. */
   settingsCollapsed?: boolean;
   /** Toggles `settingsCollapsed`; the caret is omitted when not supplied. */
   onToggleSettingsCollapsed?: () => void;
-  /** Fit the document to the canvas viewport (zoom-to-fit, centered). */
-  onFit?: () => void;
+  /** Editor-wide actions pinned to the trailing edge of the bar. */
+  trailingActions?: React.ReactNode;
 }
 
 const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
@@ -203,8 +193,7 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
   onCancelSegmentation,
   onClearSegmentPrompts,
   onCheckSegmentModel,
-  onTogglePanelsHidden,
-  onFit,
+  trailingActions,
   settingsCollapsed = false,
   onToggleSettingsCollapsed
 }) => {
@@ -319,45 +308,7 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
         />
       )}
 
-      {(onFit || onTogglePanelsHidden) && (
-        <FlexRow
-          align="center"
-          gap={0.5}
-          className="tool-top-bar__global-actions"
-          sx={{ ml: "auto", flexShrink: 0 }}
-        >
-          {onFit && (
-            <Tooltip title="Fit canvas to the viewport">
-              <span>
-                <EditorButton
-                  variant="text"
-                  size="small"
-                  onClick={onFit}
-                  startIcon={<FitScreenIcon fontSize="small" />}
-                  data-testid="sketch-fit-view"
-                >
-                  Fit
-                </EditorButton>
-              </span>
-            </Tooltip>
-          )}
-          {onTogglePanelsHidden && (
-            <Tooltip title="Hide panels — press Tab, or tap the corner button, to restore">
-              <span>
-                <EditorButton
-                  variant="text"
-                  size="small"
-                  onClick={onTogglePanelsHidden}
-                  startIcon={<ViewSidebarOutlinedIcon fontSize="small" />}
-                  data-testid="sketch-hide-panels"
-                >
-                  Hide panels
-                </EditorButton>
-              </span>
-            </Tooltip>
-          )}
-        </FlexRow>
-      )}
+      {trailingActions}
     </FlexRow>
   );
 };

--- a/web/src/components/sketch/StandaloneSketchEditor.tsx
+++ b/web/src/components/sketch/StandaloneSketchEditor.tsx
@@ -29,7 +29,14 @@ import AddPhotoAlternateOutlinedIcon from "@mui/icons-material/AddPhotoAlternate
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { EmptyState, EditorButton, FlexColumn, FlexRow, LoadingSpinner } from "../ui_primitives";
+import {
+  EditorMenuItem,
+  EmptyState,
+  FlexColumn,
+  ListItemIcon,
+  ListItemText,
+  LoadingSpinner
+} from "../ui_primitives";
 import SketchEditor, { type SketchEditorHandle } from "./SketchEditor";
 import SaveToFolderMenu from "../assets/SaveToFolderMenu";
 import { trpc } from "../../trpc/client";
@@ -58,7 +65,7 @@ const centered = { flex: 1, width: "100%", height: "100%" } as const;
 
 interface StandaloneSketchEditorProps {
   documentId: string;
-  /** Actions rendered at the trailing edge of the editor's top mode bar. */
+  /** Compact actions rendered inline at the trailing edge of the tool bar. */
   headerActions?: React.ReactNode;
   /**
    * Whether this editor is the focused/visible surface. Drives which instance
@@ -77,6 +84,15 @@ const StandaloneSketchEditorBody: React.FC<StandaloneSketchEditorProps> = memo(
     const { saveAsAsset, saving: savingAsAsset } = useSaveSketchAsAsset();
     const [saveAsAssetAnchor, setSaveAsAssetAnchor] =
       useState<HTMLElement | null>(null);
+    // Closes the tool bar's overflow menu once the folder popover is done —
+    // the popover is anchored to a menu item, so the menu has to outlive it.
+    const closeMenuRef = useRef<(() => void) | null>(null);
+
+    const closeSaveAsAsset = useCallback(() => {
+      setSaveAsAssetAnchor(null);
+      closeMenuRef.current?.();
+      closeMenuRef.current = null;
+    }, []);
 
     const documentQuery = trpc.sketch.get.useQuery(
       { id: documentId },
@@ -147,41 +163,53 @@ const StandaloneSketchEditorBody: React.FC<StandaloneSketchEditorProps> = memo(
       editorRef.current?.exportPng();
     };
 
-    const documentActions = (
-      <FlexRow gap={2} align="center" sx={{ flexShrink: 0 }}>
-        <EditorButton
-          size="small"
-          variant="outlined"
-          onClick={handleSave}
+    // Document actions live in the tool bar's overflow menu so the editor
+    // chrome stays one slim row. "Save as Asset" opens a folder popover
+    // anchored to its own menu item, so it leaves the menu open and closes
+    // both once a folder is chosen.
+    const documentMenuItems = (close: () => void) => (
+      <>
+        <EditorMenuItem
+          onClick={() => {
+            close();
+            handleSave();
+          }}
           disabled={saving}
-          startIcon={<SaveOutlinedIcon fontSize="small" />}
           data-testid="sketch-save-document"
-          sx={{ height: 34 }}
         >
-          {saving ? "Saving…" : "Save"}
-        </EditorButton>
-        <EditorButton
-          size="small"
-          variant="outlined"
-          onClick={(e) => setSaveAsAssetAnchor(e.currentTarget)}
+          <ListItemIcon>
+            <SaveOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{saving ? "Saving…" : "Save"}</ListItemText>
+        </EditorMenuItem>
+        <EditorMenuItem
+          onClick={(e) => {
+            closeMenuRef.current = close;
+            setSaveAsAssetAnchor(e.currentTarget);
+          }}
           disabled={savingAsAsset}
-          startIcon={<AddPhotoAlternateOutlinedIcon fontSize="small" />}
           data-testid="sketch-save-as-asset"
-          sx={{ height: 34 }}
         >
-          {savingAsAsset ? "Saving…" : "Save as Asset"}
-        </EditorButton>
-        <EditorButton
-          size="small"
-          variant="outlined"
-          onClick={handleExportPng}
-          startIcon={<FileDownloadOutlinedIcon fontSize="small" />}
+          <ListItemIcon>
+            <AddPhotoAlternateOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>
+            {savingAsAsset ? "Saving…" : "Save as Asset"}
+          </ListItemText>
+        </EditorMenuItem>
+        <EditorMenuItem
+          onClick={() => {
+            close();
+            handleExportPng();
+          }}
           data-testid="sketch-export-png"
-          sx={{ height: 34 }}
         >
-          Export PNG
-        </EditorButton>
-      </FlexRow>
+          <ListItemIcon>
+            <FileDownloadOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Export PNG</ListItemText>
+        </EditorMenuItem>
+      </>
     );
 
     // Show the spinner until we've captured a seed for this documentId.
@@ -213,21 +241,13 @@ const StandaloneSketchEditorBody: React.FC<StandaloneSketchEditorProps> = memo(
           documentId={documentId}
           initialDocument={seed.document}
           initialEditorState={initialEditorState ?? undefined}
-          headerActions={
-            headerActions ? (
-              <>
-                {documentActions}
-                {headerActions}
-              </>
-            ) : (
-              documentActions
-            )
-          }
+          headerActions={headerActions}
+          menuItems={documentMenuItems}
         />
         <SaveToFolderMenu
           anchorEl={saveAsAssetAnchor}
           open={!!saveAsAssetAnchor}
-          onClose={() => setSaveAsAssetAnchor(null)}
+          onClose={closeSaveAsAsset}
           onSelectFolder={(folderId) => void saveAsAsset(folderId)}
         />
       </div>

--- a/web/src/components/sketch/StandaloneSketchEditor.tsx
+++ b/web/src/components/sketch/StandaloneSketchEditor.tsx
@@ -167,50 +167,51 @@ const StandaloneSketchEditorBody: React.FC<StandaloneSketchEditorProps> = memo(
     // chrome stays one slim row. "Save as Asset" opens a folder popover
     // anchored to its own menu item, so it leaves the menu open and closes
     // both once a folder is chosen.
-    const documentMenuItems = (close: () => void) => (
-      <>
-        <EditorMenuItem
-          onClick={() => {
-            close();
-            handleSave();
-          }}
-          disabled={saving}
-          data-testid="sketch-save-document"
-        >
-          <ListItemIcon>
-            <SaveOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>{saving ? "Saving…" : "Save"}</ListItemText>
-        </EditorMenuItem>
-        <EditorMenuItem
-          onClick={(e) => {
-            closeMenuRef.current = close;
-            setSaveAsAssetAnchor(e.currentTarget);
-          }}
-          disabled={savingAsAsset}
-          data-testid="sketch-save-as-asset"
-        >
-          <ListItemIcon>
-            <AddPhotoAlternateOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>
-            {savingAsAsset ? "Saving…" : "Save as Asset"}
-          </ListItemText>
-        </EditorMenuItem>
-        <EditorMenuItem
-          onClick={() => {
-            close();
-            handleExportPng();
-          }}
-          data-testid="sketch-export-png"
-        >
-          <ListItemIcon>
-            <FileDownloadOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Export PNG</ListItemText>
-        </EditorMenuItem>
-      </>
-    );
+    const documentMenuItems = (close: () => void) => [
+      <EditorMenuItem
+        key="save"
+        onClick={() => {
+          close();
+          handleSave();
+        }}
+        disabled={saving}
+        data-testid="sketch-save-document"
+      >
+        <ListItemIcon>
+          <SaveOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>{saving ? "Saving…" : "Save"}</ListItemText>
+      </EditorMenuItem>,
+      <EditorMenuItem
+        key="save-as-asset"
+        onClick={(e) => {
+          closeMenuRef.current = close;
+          setSaveAsAssetAnchor(e.currentTarget);
+        }}
+        disabled={savingAsAsset}
+        data-testid="sketch-save-as-asset"
+      >
+        <ListItemIcon>
+          <AddPhotoAlternateOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>
+          {savingAsAsset ? "Saving…" : "Save as Asset"}
+        </ListItemText>
+      </EditorMenuItem>,
+      <EditorMenuItem
+        key="export-png"
+        onClick={() => {
+          close();
+          handleExportPng();
+        }}
+        data-testid="sketch-export-png"
+      >
+        <ListItemIcon>
+          <FileDownloadOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Export PNG</ListItemText>
+      </EditorMenuItem>
+    ];
 
     // Show the spinner until we've captured a seed for this documentId.
     // Using `seed` (not the live query state) keeps the canvas mounted across

--- a/web/src/components/sketch/__tests__/ConnectedGeneratePopover.test.tsx
+++ b/web/src/components/sketch/__tests__/ConnectedGeneratePopover.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /**
- * Tests for the top prompt bar: the visibility gate (bound document) and that
+ * Tests for the generate popover: the visibility gate (bound document) and that
  * submitting creates a text-to-image layer and runs the direct-gen job for
  * full-frame generation.
  */
@@ -12,8 +12,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
 
-import { ConnectedModePromptBar } from "../editor-shell/ConnectedModePromptBar";
-import { useSketchStore } from "../state";
+import { ConnectedGeneratePopover } from "../editor-shell/ConnectedGeneratePopover";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 
 // Heavy model picker — stub to keep model-fetching deps out of jsdom.
@@ -28,25 +27,29 @@ jest.mock("../../../hooks/sketch/useDirectGenJob", () => ({
 }));
 
 // useMediaOptions fetches per-model constraints via TanStack Query; these tests
-// don't render a QueryClientProvider, so stub it (the bar falls back to the full
-// static option lists, which is what these assertions expect).
+// don't render a QueryClientProvider, so stub it (the form falls back to the
+// full static option lists, which is what these assertions expect).
 jest.mock("../../../hooks/useModelsByProvider", () => ({
   __esModule: true,
   useMediaOptions: () => ({ data: undefined })
 }));
 
-function renderBar() {
+function renderForm(open = true) {
   // The app theme mock carries the custom palette (Paper.overlay etc.)
   // the primitives style against; a bare createTheme lacks it.
   const theme = mockTheme;
   return render(
     <ThemeProvider theme={theme}>
-      <ConnectedModePromptBar />
+      <ConnectedGeneratePopover
+        open={open}
+        anchorEl={null}
+        onClose={jest.fn()}
+      />
     </ThemeProvider>
   );
 }
 
-/** Seed a direct-gen binding so the bar's model picker starts populated. */
+/** Seed a direct-gen binding so the form's model picker starts populated. */
 function seedModel(): void {
   useSketchSessionStore.getState().upsertBinding({
     layerId: "seed-binding",
@@ -62,37 +65,32 @@ function seedModel(): void {
 
 beforeEach(() => {
   mockStart.mockReset();
-  useSketchStore.setState((s) => ({
-    ...s,
-    panelsHidden: false
-  }));
   useSketchSessionStore.setState({ documentId: null, name: "", bindings: {} });
 });
 
-describe("<ConnectedModePromptBar />", () => {
+describe("<ConnectedGeneratePopover />", () => {
   it("renders nothing without a bound document", () => {
-    const { queryByTestId } = renderBar();
-    expect(queryByTestId("sketch-mode-prompt-bar")).toBeNull();
+    const { queryByTestId } = renderForm();
+    expect(queryByTestId("sketch-generate-form")).toBeNull();
   });
 
-  it("renders nothing when panels are hidden (chrome-less canvas)", () => {
+  it("renders nothing while closed", () => {
     useSketchSessionStore.setState({ documentId: "doc-1" });
-    useSketchStore.setState((s) => ({ ...s, panelsHidden: true }));
-    const { queryByTestId } = renderBar();
-    expect(queryByTestId("sketch-mode-prompt-bar")).toBeNull();
+    const { queryByTestId } = renderForm(false);
+    expect(queryByTestId("sketch-generate-form")).toBeNull();
   });
 
-  it("renders the bar and submit with a bound document", () => {
+  it("renders the form and submit with a bound document", () => {
     useSketchSessionStore.setState({ documentId: "doc-1", name: "portrait" });
-    const { getByTestId } = renderBar();
-    expect(getByTestId("sketch-mode-prompt-bar")).toBeTruthy();
+    const { getByTestId } = renderForm();
+    expect(getByTestId("sketch-generate-form")).toBeTruthy();
     expect(getByTestId("sketch-gen-submit")).toBeTruthy();
   });
 
   it("keeps submit disabled until a prompt is typed", () => {
     useSketchSessionStore.setState({ documentId: "doc-1" });
     seedModel();
-    const { getByTestId, getByPlaceholderText } = renderBar();
+    const { getByTestId, getByPlaceholderText } = renderForm();
     expect(getByTestId("sketch-gen-submit")).toBeDisabled();
     fireEvent.change(getByPlaceholderText("Describe the image…"), {
       target: { value: "a red fox" }
@@ -103,7 +101,7 @@ describe("<ConnectedModePromptBar />", () => {
   it("runs the direct-gen job on Generate submit", async () => {
     useSketchSessionStore.setState({ documentId: "doc-1" });
     seedModel();
-    const { getByTestId, getByPlaceholderText } = renderBar();
+    const { getByTestId, getByPlaceholderText } = renderForm();
     fireEvent.change(getByPlaceholderText("Describe the image…"), {
       target: { value: "a red fox" }
     });

--- a/web/src/components/sketch/__tests__/editorActionsMenu.test.tsx
+++ b/web/src/components/sketch/__tests__/editorActionsMenu.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * The tool bar's overflow menu: the editor-wide entries render, host-supplied
+ * entries are appended, and nothing trips MUI's "Menu doesn't accept a Fragment
+ * as a child" warning (the page-load smoke test fails on any console error).
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import { ConnectedEditorActions } from "../editor-shell/ConnectedEditorActions";
+import { EditorMenuItem } from "../../ui_primitives";
+import { useSketchStore } from "../state";
+
+function renderActions(menuItems?: (close: () => void) => React.ReactNode[]) {
+  return render(
+    <ThemeProvider theme={createTheme({ cssVariables: true })}>
+      <ConnectedEditorActions menuItems={menuItems} />
+    </ThemeProvider>
+  );
+}
+
+describe("editor actions menu", () => {
+  it("opens the menu with the editor-wide entries", async () => {
+    const user = userEvent.setup();
+    renderActions();
+
+    await user.click(screen.getByTestId("sketch-editor-menu"));
+
+    expect(screen.getByTestId("sketch-assistant-toggle")).toBeTruthy();
+    expect(screen.getByTestId("sketch-fit-view")).toBeTruthy();
+    await user.click(screen.getByTestId("sketch-hide-panels"));
+    expect(useSketchStore.getState().panelsHidden).toBe(true);
+    useSketchStore.setState((s) => ({ ...s, panelsHidden: false }));
+  });
+
+  it("appends host entries without a Fragment child warning", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const user = userEvent.setup();
+    const onHostAction = jest.fn();
+
+    renderActions((close) => [
+      <EditorMenuItem
+        key="host"
+        onClick={() => {
+          close();
+          onHostAction();
+        }}
+        data-testid="host-action"
+      >
+        Host action
+      </EditorMenuItem>
+    ]);
+
+    await user.click(screen.getByTestId("sketch-editor-menu"));
+    await user.click(screen.getByTestId("host-action"));
+
+    expect(onHostAction).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
@@ -1,0 +1,198 @@
+/**
+ * ConnectedEditorActions — the trailing action cluster of the tool bar.
+ *
+ * Two controls only, so the editor's chrome stays one slim row: a Generate
+ * button that opens the text-to-image form in a popover, and an overflow menu
+ * holding the editor-wide actions (assistant panel, fit, hide panels) plus any
+ * document actions the host surface contributes via `menuItems`.
+ *
+ * Editor-shell convention: narrow store selectors only; the fit computation
+ * reads and writes through getState() so the cluster gains no subscriptions on
+ * the document or viewport.
+ */
+
+import React, { memo, useCallback, useRef, useState } from "react";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import FitScreenIcon from "@mui/icons-material/FitScreen";
+import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
+import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
+
+import {
+  Divider,
+  EditorButton,
+  EditorMenu,
+  EditorMenuItem,
+  FlexRow,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { useSketchStore, SKETCH_ZOOM_MIN, SKETCH_ZOOM_MAX } from "../state";
+import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
+import { ConnectedGeneratePopover } from "./ConnectedGeneratePopover";
+
+export interface ConnectedEditorActionsProps {
+  /** Compact buttons rendered inline before the menu (e.g. the asset tab's
+   * Save to image / Done). Keep to one or two — everything else belongs in
+   * `menuItems`. */
+  inlineActions?: React.ReactNode;
+  /** Host-supplied menu entries appended to the overflow menu. Receives the
+   * menu's close callback so an item can dismiss it (or keep it open while a
+   * follow-up popover of its own is anchored inside). */
+  menuItems?: (close: () => void) => React.ReactNode;
+}
+
+/** Zoom the document to fit the canvas region, with a small margin. */
+function fitToViewport(): void {
+  const root = globalThis.document;
+  const region = root?.querySelector(".sketch-editor__canvas-region");
+  if (!region) {
+    return;
+  }
+  const rect = (region as HTMLElement).getBoundingClientRect();
+  const store = useSketchStore.getState();
+  const { width: docW, height: docH } = store.document.canvas;
+  if (rect.width <= 0 || rect.height <= 0 || docW <= 0 || docH <= 0) {
+    return;
+  }
+  const FIT_MARGIN = 0.9;
+  const raw = Math.min(rect.width / docW, rect.height / docH) * FIT_MARGIN;
+  const scale = Math.max(SKETCH_ZOOM_MIN, Math.min(SKETCH_ZOOM_MAX, raw));
+  store.setZoom(scale);
+  store.setPan({ x: 0, y: 0 });
+}
+
+export const ConnectedEditorActions = memo(function ConnectedEditorActions({
+  inlineActions,
+  menuItems
+}: ConnectedEditorActionsProps) {
+  const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
+  const toggleAssistantPanel = useSketchStore((s) => s.toggleAssistantPanel);
+  const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
+
+  const documentId = useSketchSessionStore((s) => s.documentId);
+
+  const generateAnchorRef = useRef<HTMLButtonElement>(null);
+  const [generateOpen, setGenerateOpen] = useState(false);
+  // The form fetches model options and holds the direct-gen job, so it stays
+  // unmounted until first opened — then stays mounted so a half-typed prompt
+  // survives closing the popover.
+  const [generateMounted, setGenerateMounted] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const closeMenu = useCallback(() => setMenuAnchor(null), []);
+
+  const handleAssistant = useCallback(() => {
+    closeMenu();
+    toggleAssistantPanel();
+  }, [closeMenu, toggleAssistantPanel]);
+
+  const handleFit = useCallback(() => {
+    closeMenu();
+    fitToViewport();
+  }, [closeMenu]);
+
+  const handleHidePanels = useCallback(() => {
+    closeMenu();
+    togglePanelsHidden();
+  }, [closeMenu, togglePanelsHidden]);
+
+  return (
+    <FlexRow
+      align="center"
+      gap={0.5}
+      className="tool-top-bar__global-actions"
+      sx={{ ml: "auto", flexShrink: 0 }}
+    >
+      {inlineActions}
+
+      {documentId && (
+        <>
+          <Tooltip title="Generate an image from a prompt">
+            <span>
+              <EditorButton
+                ref={generateAnchorRef}
+                variant="text"
+                size="small"
+                onClick={() => {
+                  setGenerateMounted(true);
+                  setGenerateOpen(true);
+                }}
+                startIcon={<AutoAwesomeIcon fontSize="small" />}
+                data-testid="sketch-open-generate"
+              >
+                Generate
+              </EditorButton>
+            </span>
+          </Tooltip>
+          {generateMounted && (
+            <ConnectedGeneratePopover
+              open={generateOpen}
+              anchorEl={generateAnchorRef.current}
+              onClose={() => setGenerateOpen(false)}
+            />
+          )}
+        </>
+      )}
+
+      <Tooltip title="Editor actions">
+        <IconButton
+          size="small"
+          onClick={(e) => setMenuAnchor(e.currentTarget)}
+          aria-label="Editor actions"
+          aria-haspopup="menu"
+          data-testid="sketch-editor-menu"
+        >
+          <MoreVertIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      <EditorMenu
+        anchorEl={menuAnchor}
+        open={!!menuAnchor}
+        onClose={closeMenu}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        paperSx={{ borderRadius: BORDER_RADIUS.lg, minWidth: 220 }}
+      >
+        <EditorMenuItem
+          onClick={handleAssistant}
+          selected={assistantPanelOpen}
+          data-testid="sketch-assistant-toggle"
+        >
+          <ListItemIcon>
+            <SmartToyOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>
+            {assistantPanelOpen ? "Hide Assistant" : "Assistant"}
+          </ListItemText>
+        </EditorMenuItem>
+
+        <EditorMenuItem onClick={handleFit} data-testid="sketch-fit-view">
+          <ListItemIcon>
+            <FitScreenIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Fit to viewport</ListItemText>
+        </EditorMenuItem>
+
+        <EditorMenuItem
+          onClick={handleHidePanels}
+          data-testid="sketch-hide-panels"
+        >
+          <ListItemIcon>
+            <ViewSidebarOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Hide panels</ListItemText>
+        </EditorMenuItem>
+
+        {menuItems ? <Divider /> : null}
+        {menuItems?.(closeMenu)}
+      </EditorMenu>
+    </FlexRow>
+  );
+});
+
+export default ConnectedEditorActions;

--- a/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
@@ -41,8 +41,9 @@ export interface ConnectedEditorActionsProps {
   inlineActions?: React.ReactNode;
   /** Host-supplied menu entries appended to the overflow menu. Receives the
    * menu's close callback so an item can dismiss it (or keep it open while a
-   * follow-up popover of its own is anchored inside). */
-  menuItems?: (close: () => void) => React.ReactNode;
+   * follow-up popover of its own is anchored inside). Returns an array — MUI's
+   * Menu rejects a Fragment child. */
+  menuItems?: (close: () => void) => React.ReactNode[];
 }
 
 /** Zoom the document to fit the canvas region, with a small margin. */
@@ -188,7 +189,7 @@ export const ConnectedEditorActions = memo(function ConnectedEditorActions({
           <ListItemText>Hide panels</ListItemText>
         </EditorMenuItem>
 
-        {menuItems ? <Divider /> : null}
+        {menuItems ? <Divider key="host-divider" /> : null}
         {menuItems?.(closeMenu)}
       </EditorMenu>
     </FlexRow>

--- a/web/src/components/sketch/editor-shell/ConnectedGeneratePopover.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedGeneratePopover.tsx
@@ -1,13 +1,16 @@
 /**
- * ConnectedModePromptBar — the top prompt bar of the image editor.
+ * ConnectedGeneratePopover — the image editor's text-to-image form.
  *
- * Drives full-frame text-to-image generation: document name + dimensions, a
- * prompt input, a model selector, and a Generate action that creates a new
- * text-to-image layer and runs it via useDirectGenJob. Selection-driven
- * inpainting lives in the floating SelectionActionBar instead.
+ * Drives full-frame text-to-image generation: a prompt input, model selector,
+ * size chips, and a Generate action that creates a new text-to-image layer and
+ * runs it via useDirectGenJob. Selection-driven inpainting lives in the
+ * floating SelectionActionBar instead.
+ *
+ * The form lives in a popover opened from the tool bar's Generate button, so
+ * the editor's chrome stays a single slim row.
  *
  * Follows the editor-shell convention: narrow store selectors only, actions
- * pulled via getState() inside handlers so the bar never re-renders on
+ * pulled via getState() inside handlers so the form never re-renders on
  * unrelated store churn. Renders nothing without a bound document (the in-node
  * sketch modal has no session, same gate as SelectionActionBar).
  */
@@ -28,10 +31,13 @@ import ImageIcon from "@mui/icons-material/Image";
 
 import {
   EditorButton,
+  FlexColumn,
   FlexRow,
   LoadingSpinner,
+  Popover,
   TextInput,
-  Toast
+  Toast,
+  BORDER_RADIUS
 } from "../../ui_primitives";
 import MediaControlChip from "../../chat/composer/MediaControlChip";
 import MediaAspectRatioMenu from "../../chat/composer/MediaAspectRatioMenu";
@@ -51,7 +57,7 @@ import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
 import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 import { SKETCH_SPACING } from "../sketchStyles";
 
-/** Most recent direct-gen binding's model, to seed the bar's picker. */
+/** Most recent direct-gen binding's model, to seed the form's picker. */
 function seedModelFromBindings(): { model: string; provider: string } {
   const bindings = Object.values(useSketchSessionStore.getState().bindings);
   const last = bindings
@@ -71,20 +77,19 @@ function uniqueLayerName(base: string): string {
   return `${base} ${n}`;
 }
 
-interface ConnectedModePromptBarProps {
-  /** Document-level actions rendered at the trailing edge of the bar (e.g.
-   * Save/Done when the editor is embedded in an asset tab). */
-  trailingActions?: React.ReactNode;
+interface ConnectedGeneratePopoverProps {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
 }
 
-const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
-  trailingActions
+const ConnectedGeneratePopoverInner: React.FC<ConnectedGeneratePopoverProps> = ({
+  open,
+  anchorEl,
+  onClose
 }) => {
   const theme = useTheme();
 
-  const panelsHidden = useSketchStore((s) => s.panelsHidden);
-  const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
-  const toggleAssistantPanel = useSketchStore((s) => s.toggleAssistantPanel);
   const docW = useSketchStore((s) => s.document.canvas.width);
   const docH = useSketchStore((s) => s.document.canvas.height);
 
@@ -219,167 +224,135 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
 
   const actionDisabled = generating || !prompt.trim() || !model;
 
-  // Hide with the rest of the chrome on Tab (panelsHidden = chrome-less canvas),
-  // matching ConnectedToolTopBar. No bound document → no session to act on.
-  if (!documentId || panelsHidden) {
+  // No bound document → no session to act on (the in-node sketch modal).
+  if (!documentId) {
     return null;
   }
 
   return (
     <>
-      <FlexRow
-        className="sketch-mode-prompt-bar"
-        data-testid="sketch-mode-prompt-bar"
-        align="center"
-        gap={1}
-        sx={{
-          flexShrink: 0,
-          width: "100%",
-          // The prompt bar is the editor's hero input, so it carries more
-          // height than the utility tool-options bar below it. Generous
-          // vertical room keeps the controls from feeling crammed.
-          minHeight: 56,
-          // On narrow screens the prompt + model/size chips + actions can't fit
-          // on one line, so wrap them (prompt takes the first row via flex:1,
-          // controls flow onto the next) instead of overflowing off-screen.
-          flexWrap: "wrap",
-          rowGap: SKETCH_SPACING.md,
-          padding: `${SKETCH_SPACING.lg} ${SKETCH_SPACING.xl}`,
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={onClose}
+        placement="bottom-right"
+        paperSx={{
+          width: 340,
           backgroundColor: theme.vars.palette.grey[900],
-          borderBottom: `1px solid ${theme.vars.palette.grey[800]}`
+          border: `1px solid ${theme.vars.palette.grey[800]}`,
+          borderRadius: BORDER_RADIUS.sm
         }}
       >
-        {/* Prompt — grows to fill */}
-        <TextInput
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Describe the image…"
-          compact
-          fullWidth
-          inputProps={{
-            "aria-label": "Generation prompt",
-            "data-testid": "sketch-gen-prompt"
-          }}
-          onKeyDown={(e) => {
-            if (
-              e.key === "Enter" &&
-              !e.shiftKey &&
-              !actionDisabled &&
-              !e.nativeEvent.isComposing &&
-              e.nativeEvent.keyCode !== 229
-            ) {
-              e.preventDefault();
-              void handleGenerate();
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <AutoAwesomeIcon
-                  fontSize="small"
-                  sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
-                />
+        <FlexColumn
+          className="sketch-generate-form"
+          data-testid="sketch-generate-form"
+          gap={1}
+          sx={{ padding: SKETCH_SPACING.lg }}
+        >
+          <TextInput
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Describe the image…"
+            autoFocus
+            multiline
+            minRows={2}
+            maxRows={6}
+            fullWidth
+            inputProps={{
+              "aria-label": "Generation prompt",
+              "data-testid": "sketch-gen-prompt"
+            }}
+            onKeyDown={(e) => {
+              if (
+                e.key === "Enter" &&
+                !e.shiftKey &&
+                !actionDisabled &&
+                !e.nativeEvent.isComposing &&
+                e.nativeEvent.keyCode !== 229
+              ) {
+                e.preventDefault();
+                void handleGenerate();
+              }
+            }}
+          />
+
+          <FlexRow align="center" gap={1} sx={{ flexWrap: "wrap" }}>
+            {/* Model selector — same chip + dialog as the media composer */}
+            <MediaControlChip
+              ref={imageModelAnchorRef}
+              icon={<ImageIcon fontSize="small" />}
+              label={modelName || "Select Model"}
+              active={imageModelOpen}
+              onClick={() => setImageModelOpen(true)}
+              truncate
+              showChevron={false}
+            />
+            {imageModelOpen && (
+              <ImageModelMenuDialog
+                open
+                anchorEl={imageModelAnchorRef.current}
+                onClose={() => setImageModelOpen(false)}
+                onModelChange={handlePickImageModel}
+                task="text_to_image"
+              />
+            )}
+
+            {/* Resolution */}
+            <MediaControlChip
+              icon={<ResolutionIcon fontSize="small" />}
+              label={resolution}
+              active={!!resolutionAnchor}
+              onClick={(e) => setResolutionAnchor(e.currentTarget)}
+              showChevron={false}
+            />
+            <MediaOptionMenu
+              anchorEl={resolutionAnchor}
+              open={!!resolutionAnchor}
+              onClose={() => setResolutionAnchor(null)}
+              header="Resolution"
+              value={resolution}
+              options={resolutionOptions}
+              onChange={handleResolutionChange}
+            />
+
+            {/* Aspect ratio */}
+            <MediaControlChip
+              icon={<AspectRatioIcon fontSize="small" />}
+              label={aspectRatio}
+              active={!!aspectAnchor}
+              onClick={(e) => setAspectAnchor(e.currentTarget)}
+              showChevron={false}
+            />
+            <MediaAspectRatioMenu
+              anchorEl={aspectAnchor}
+              open={!!aspectAnchor}
+              onClose={() => setAspectAnchor(null)}
+              value={aspectRatio}
+              options={aspectOptions}
+              onChange={handleAspectChange}
+            />
+          </FlexRow>
+
+          {/* Primary action — full-frame text-to-image */}
+          <EditorButton
+            variant="contained"
+            size="small"
+            disabled={actionDisabled}
+            onClick={() => void handleGenerate()}
+            startIcon={
+              generating ? (
+                <LoadingSpinner inline size={14} color="inherit" />
+              ) : (
+                <AutoAwesomeIcon fontSize="small" />
               )
             }
-          }}
-          sx={{
-            flex: 1,
-            minWidth: 160,
-            // Match the control/button height so the row aligns.
-            "& .MuiOutlinedInput-root": { height: 34 }
-          }}
-        />
-
-        {/* Model selector — same chip + dialog as the media composer */}
-        <MediaControlChip
-          ref={imageModelAnchorRef}
-          icon={<ImageIcon fontSize="small" />}
-          label={modelName || "Select Model"}
-          active={imageModelOpen}
-          onClick={() => setImageModelOpen(true)}
-          truncate
-          showChevron={false}
-        />
-        {imageModelOpen && (
-          <ImageModelMenuDialog
-            open
-            anchorEl={imageModelAnchorRef.current}
-            onClose={() => setImageModelOpen(false)}
-            onModelChange={handlePickImageModel}
-            task="text_to_image"
-          />
-        )}
-
-        {/* Resolution */}
-        <MediaControlChip
-          icon={<ResolutionIcon fontSize="small" />}
-          label={resolution}
-          active={!!resolutionAnchor}
-          onClick={(e) => setResolutionAnchor(e.currentTarget)}
-          showChevron={false}
-        />
-        <MediaOptionMenu
-          anchorEl={resolutionAnchor}
-          open={!!resolutionAnchor}
-          onClose={() => setResolutionAnchor(null)}
-          header="Resolution"
-          value={resolution}
-          options={resolutionOptions}
-          onChange={handleResolutionChange}
-        />
-
-        {/* Aspect ratio */}
-        <MediaControlChip
-          icon={<AspectRatioIcon fontSize="small" />}
-          label={aspectRatio}
-          active={!!aspectAnchor}
-          onClick={(e) => setAspectAnchor(e.currentTarget)}
-          showChevron={false}
-        />
-        <MediaAspectRatioMenu
-          anchorEl={aspectAnchor}
-          open={!!aspectAnchor}
-          onClose={() => setAspectAnchor(null)}
-          value={aspectRatio}
-          options={aspectOptions}
-          onChange={handleAspectChange}
-        />
-
-        {/* Primary action — full-frame text-to-image */}
-        <EditorButton
-          variant="contained"
-          size="small"
-          disabled={actionDisabled}
-          onClick={() => void handleGenerate()}
-          startIcon={
-            generating ? (
-              <LoadingSpinner inline size={14} color="inherit" />
-            ) : (
-              <AutoAwesomeIcon fontSize="small" />
-            )
-          }
-          data-testid="sketch-gen-submit"
-          sx={{ flexShrink: 0, height: 34 }}
-        >
-          Generate
-        </EditorButton>
-
-        {/* Assistant toggle — opens the right-side AI chat panel that drives
-            the editor through the ui_sketch_* agent tools. */}
-        <EditorButton
-          variant={assistantPanelOpen ? "contained" : "outlined"}
-          size="small"
-          onClick={toggleAssistantPanel}
-          startIcon={<AutoAwesomeIcon fontSize="small" />}
-          aria-pressed={assistantPanelOpen}
-          data-testid="sketch-assistant-toggle"
-          sx={{ flexShrink: 0, height: 34 }}
-        >
-          Assistant
-        </EditorButton>
-
-        {trailingActions}
-      </FlexRow>
+            data-testid="sketch-gen-submit"
+            sx={{ alignSelf: "flex-end", height: 34 }}
+          >
+            Generate
+          </EditorButton>
+        </FlexColumn>
+      </Popover>
 
       <Toast
         open={error !== null}
@@ -393,7 +366,7 @@ const ConnectedModePromptBarInner: React.FC<ConnectedModePromptBarProps> = ({
   );
 };
 
-export const ConnectedModePromptBar = memo(ConnectedModePromptBarInner);
-ConnectedModePromptBar.displayName = "ConnectedModePromptBar";
+export const ConnectedGeneratePopover = memo(ConnectedGeneratePopoverInner);
+ConnectedGeneratePopover.displayName = "ConnectedGeneratePopover";
 
-export default ConnectedModePromptBar;
+export default ConnectedGeneratePopover;

--- a/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
@@ -42,7 +42,7 @@ export interface ConnectedToolTopBarProps {
   /** Compact host actions rendered inline at the trailing edge. */
   headerActions?: React.ReactNode;
   /** Host actions appended to the bar's overflow menu. */
-  menuItems?: (close: () => void) => React.ReactNode;
+  menuItems?: (close: () => void) => React.ReactNode[];
 }
 
 export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(

--- a/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedToolTopBar.tsx
@@ -6,9 +6,10 @@
  * Action callbacks that depend on document are passed in as props; their
  * individual references are stable via `useCallback`.
  */
-import React, { memo, useCallback, useEffect } from "react";
+import React, { memo, useEffect } from "react";
 import SketchToolTopBar from "../SketchToolTopBar";
-import { useSketchStore, SKETCH_ZOOM_MIN, SKETCH_ZOOM_MAX } from "../state";
+import { ConnectedEditorActions } from "./ConnectedEditorActions";
+import { useSketchStore } from "../state";
 import {
   useResolvedToolSettings,
   useSketchIsMobile,
@@ -38,6 +39,10 @@ export interface ConnectedToolTopBarProps {
   onCropCanvasToSelection: () => void;
   onCropCommit: () => void;
   onCropCancelPreview: () => void;
+  /** Compact host actions rendered inline at the trailing edge. */
+  headerActions?: React.ReactNode;
+  /** Host actions appended to the bar's overflow menu. */
+  menuItems?: (close: () => void) => React.ReactNode;
 }
 
 export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
@@ -46,7 +51,6 @@ export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
   const activeTool = useSketchStore((s) => s.activeTool);
   const cropPreviewBounds = useSketchStore((s) => s.cropPreviewBounds);
   const panelsHidden = useSketchStore((s) => s.panelsHidden);
-  const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
   const hasActiveSelection = useSketchStore((s) => s.hasActiveSelection);
   const toolSettingsCollapsed = useSketchStore((s) => s.toolSettingsCollapsed);
   const toggleToolSettingsCollapsed = useSketchStore(
@@ -89,28 +93,6 @@ export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
     smoothCurrentSelectionBorders,
     convertSelectionToBorderOutline
   } = useToolChromeActions();
-
-  // Fit-to-viewport: measure the canvas region (one-off, on click — not a hot
-  // path), scale the document to fit with a small margin, and recenter. Reads
-  // doc dims + sets zoom/pan via getState() so the bar gains no subscriptions.
-  const handleFit = useCallback(() => {
-    const root = globalThis.document;
-    const region = root?.querySelector(".sketch-editor__canvas-region");
-    if (!region) {
-      return;
-    }
-    const rect = (region as HTMLElement).getBoundingClientRect();
-    const store = useSketchStore.getState();
-    const { width: docW, height: docH } = store.document.canvas;
-    if (rect.width <= 0 || rect.height <= 0 || docW <= 0 || docH <= 0) {
-      return;
-    }
-    const FIT_MARGIN = 0.9;
-    const raw = Math.min(rect.width / docW, rect.height / docH) * FIT_MARGIN;
-    const scale = Math.max(SKETCH_ZOOM_MIN, Math.min(SKETCH_ZOOM_MAX, raw));
-    store.setZoom(scale);
-    store.setPan({ x: 0, y: 0 });
-  }, []);
 
   if (panelsHidden) {
     return null;
@@ -180,8 +162,12 @@ export const ConnectedToolTopBar = memo(function ConnectedToolTopBar(
       onCancelSegmentation={props.segmentation.cancelSegmentation}
       onClearSegmentPrompts={props.onClearSegmentPrompts}
       onCheckSegmentModel={props.segmentation.checkModel}
-      onTogglePanelsHidden={togglePanelsHidden}
-      onFit={handleFit}
+      trailingActions={
+        <ConnectedEditorActions
+          inlineActions={props.headerActions}
+          menuItems={props.menuItems}
+        />
+      }
       settingsCollapsed={toolSettingsCollapsed}
       onToggleSettingsCollapsed={toggleToolSettingsCollapsed}
     />

--- a/web/src/components/sketch/editor-shell/index.ts
+++ b/web/src/components/sketch/editor-shell/index.ts
@@ -7,7 +7,8 @@
  * subscriber wiring.
  *
  * ## Re-exported components
- * - ConnectedModePromptBar
+ * - ConnectedEditorActions
+ * - ConnectedGeneratePopover
  * - ConnectedStatusBar
  * - ConnectedToolbar
  * - ConnectedToolTopBar
@@ -17,7 +18,9 @@
  * - SketchCanvasPane
  */
 
-export { ConnectedModePromptBar } from "./ConnectedModePromptBar";
+export { ConnectedEditorActions } from "./ConnectedEditorActions";
+export type { ConnectedEditorActionsProps } from "./ConnectedEditorActions";
+export { ConnectedGeneratePopover } from "./ConnectedGeneratePopover";
 export { ConnectedStatusBar } from "./ConnectedStatusBar";
 export { ConnectedToolbar } from "./ConnectedToolbar";
 export { ConnectedToolTopBar } from "./ConnectedToolTopBar";

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -6,7 +6,7 @@
  * clip onto the first unlocked video track at the playhead (creating a video
  * track if the sequence has none). Generation starts immediately.
  *
- * Layout mirrors the image editor's prompt bar (`ConnectedModePromptBar`) and
+ * Layout mirrors the image editor's generate form (`ConnectedGeneratePopover`) and
  * the media chat composer: a prompt that grows to fill, then the model + setting
  * chips, then the primary Generate action. The model / duration / resolution /
  * aspect controls are the shared `MediaControlChip` + option menus, so options

--- a/web/src/components/workspace/ImageSketchEditor.tsx
+++ b/web/src/components/workspace/ImageSketchEditor.tsx
@@ -20,7 +20,7 @@ interface ImageSketchEditorProps {
  * Edit-mode body for the workspace image tab: the sketch editor embedded inline
  * on the asset's backing sketch document (created and linked on first edit).
  * "Save to image" renders the composite back into the asset; "Done" returns the
- * tab to view mode. Both live in the editor's top mode bar. The sketch document
+ * tab to view mode. Both live in the editor's tool bar. The sketch document
  * autosaves independently.
  */
 const ImageSketchEditor = ({ asset, onClose }: ImageSketchEditorProps) => {


### PR DESCRIPTION
The image editor stacked a full-width text-to-image form above the tool bar, plus Save / Save as Asset / Export PNG / Assistant / Fit / Hide panels as labelled buttons — three rows of chrome before the canvas, which on a phone left barely any canvas.

## Changes

- **`ConnectedGeneratePopover`** (was `ConnectedModePromptBar`) — the same prompt / model / resolution / aspect / Generate form, now in a popover opened from a single **Generate** button in the tool bar. It mounts on first open and stays mounted, so a half-typed prompt survives closing the popover.
- **`ConnectedEditorActions`** — the tool bar's trailing cluster: the Generate button plus an overflow menu holding Assistant, Fit to viewport, Hide panels, and whatever the host surface contributes. The Generate button is hidden without a bound document (the in-node modal), same gate the prompt bar had.
- **`SketchToolTopBar`** drops its `onFit` / `onTogglePanelsHidden` buttons for a generic `trailingActions` slot; the fit computation moved into `ConnectedEditorActions`.
- **`SketchEditor`** gains a `menuItems?: (close) => ReactNode` prop for host actions. `StandaloneSketchEditor` uses it for Save / Save as Asset / Export PNG. "Save as Asset" deliberately leaves the menu open — its folder popover is anchored to the menu item, and closing the folder popover closes both.
- The asset tab's Save to image / Done stay inline via `headerActions`, now rendered in the tool bar.

Net effect: one slim bar above the canvas instead of three rows.

## Verification

- `tsc --noEmit` — clean for the touched areas (the repo's unbuilt-package errors are pre-existing).
- `oxlint` — no new findings.
- `jest src/components/sketch` — 114 suites, 1955 tests pass. The prompt-bar test moved to `ConnectedGeneratePopover.test.tsx` and covers the popover's closed state alongside the existing gate and submit assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_014utvxyk1ZhJi5SmLeFadFq)_