### PR TITLE
docs: lock pages horizontally, scroll wide tables in place

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -91,13 +91,23 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Lock the page horizontally. `clip` rather than `hidden` so the viewport
+   never becomes a scroll container — `hidden` leaks into a side-scroll on iOS
+   Safari, and it also turns the root into a scrollport, which breaks the
+   sticky header. Wide content (tables, code, diagrams) scrolls inside its own
+   box instead; see .table-scroll, pre, and .mermaid. */
+html,
+body {
+  overflow-x: clip;
+  max-width: 100%;
+}
+
 body {
   font-family: var(--font-body);
   font-size: 1rem;
   line-height: 1.7;
   color: var(--color-text-primary);
   background: var(--color-bg-primary);
-  overflow-x: hidden;
   position: relative;
 }
 
@@ -1287,6 +1297,9 @@ blockquote {
 /* === Content Area === */
 .content {
   flex: 1;
+  /* Flex items default to min-width: auto, which lets wide content push the
+     column past the viewport. Without this the whole page grows sideways. */
+  min-width: 0;
   padding: var(--spacing-2xl) var(--spacing-xl);
   max-width: 900px;
   margin: 0 auto;
@@ -1328,6 +1341,17 @@ blockquote {
 
 .page-content {
   margin-bottom: var(--spacing-3xl);
+  /* Long URLs and identifiers break instead of widening the page. */
+  overflow-wrap: break-word;
+}
+
+/* Inline code often holds an unbreakable path or env var name; break it rather
+   than let it stick out. `break-word` and not `anywhere` on purpose — the
+   latter also shrinks min-content width, which squeezes table columns into
+   shredded paths instead of letting a wide table scroll. Code inside <pre>
+   keeps its formatting and scrolls with the block. */
+.page-content :not(pre) > code {
+  overflow-wrap: break-word;
 }
 
 .page-content img {
@@ -1385,6 +1409,19 @@ blockquote {
   color: var(--color-accent-cyan);
 }
 
+/* Wide tables are the main thing that used to push docs pages sideways. They
+   get their own horizontal scroller (added by theme.js) so the page stays put.
+   The chrome — border, radius, background — moves to the wrapper so the
+   rounded corners clip the scrolling table. */
+.page-content .table-scroll {
+  overflow-x: auto;
+  max-width: 100%;
+  margin: var(--spacing-lg) 0;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
 .page-content table {
   width: 100%;
   border-collapse: collapse;
@@ -1392,7 +1429,32 @@ blockquote {
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  overflow: hidden;
+  /* Fallback for the moment before theme.js wraps the table, and for readers
+     with JS off: the table scrolls itself. `display: block` costs automatic
+     column sizing, so the wrapper above is the preferred path. */
+  display: block;
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.page-content .table-scroll:focus-visible {
+  outline: 2px solid var(--color-accent-cyan);
+  outline-offset: 2px;
+}
+
+.page-content .table-scroll > table {
+  display: table;
+  /* Fill the column when it fits, expand (and scroll) when it doesn't. */
+  width: auto;
+  min-width: 100%;
+  max-width: none;
+  overflow: visible;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
 }
 
 .page-content th,

--- a/docs/assets/js/theme.js
+++ b/docs/assets/js/theme.js
@@ -605,6 +605,56 @@
     });
   }
 
+  // --- Scrollable tables ------------------------------------------------------
+  // Reference tables are often wider than the content column. Give each one its
+  // own horizontal scroller so it scrolls instead of widening the page. The
+  // wrapper is focusable and labelled so keyboard and screen-reader users can
+  // reach the scrolled-off columns.
+  function initTableScroll() {
+    const wrappers = [];
+
+    document.querySelectorAll('.page-content table').forEach((table) => {
+      if (table.parentElement && table.parentElement.classList.contains('table-scroll')) return;
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'table-scroll';
+
+      const caption = table.querySelector('caption');
+      const firstHeader = table.querySelector('th');
+      const label = (caption && caption.textContent.trim()) || (firstHeader && firstHeader.textContent.trim());
+      wrapper.setAttribute('aria-label', label ? label + ' table' : 'Table');
+
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+      wrappers.push(wrapper);
+    });
+
+    if (!wrappers.length) return;
+
+    // Only a wrapper that actually scrolls becomes a tab stop — otherwise every
+    // table that fits would add a stop that goes nowhere. Which tables overflow
+    // depends on the viewport, so re-check on resize.
+    const syncFocusability = () => {
+      wrappers.forEach((wrapper) => {
+        if (wrapper.scrollWidth > wrapper.clientWidth) {
+          wrapper.setAttribute('tabindex', '0');
+          wrapper.setAttribute('role', 'region');
+        } else {
+          wrapper.removeAttribute('tabindex');
+          wrapper.removeAttribute('role');
+        }
+      });
+    };
+
+    syncFocusability();
+
+    let resizeTimer;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(syncFocusability, 150);
+    });
+  }
+
   // --- Init ------------------------------------------------------------------
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);
@@ -616,6 +666,7 @@
     initCollapsibleSections();
     setActiveLink();
     addCopyButtons();
+    initTableScroll();
     initCopyPageButton();
     initSmoothScroll();
     initReadingProgress();


### PR DESCRIPTION
Docs pages could be dragged sideways. Wide reference tables laid out past the content column and pushed the whole page with them.

## The problem

I built the site and audited 171 pages at 390 / 768 / 1280px with Playwright. **101 page/width combinations overflowed** — 96 at 390px, 4 at 768px, 1 at 1280px.

Isolating the outermost overflowing element on each page: **tables in 22 of 24 cases**, long unbreakable inline `<code>` in the rest. `/api-reference` was the worst — its 6-column table laid out at 976px inside a 335px content column, making the document 1001px wide against a 390px viewport.

`body { overflow-x: hidden }` was already there, but it is the wrong tool: it propagates to the viewport, so desktop Chrome *clipped* the wide columns instead of scrolling — the data was unreachable, not just ugly — and `overflow-x: hidden` on `body` leaks into a real side-scroll on iOS Safari, which is the drag you could feel.

## The fix

Wide content now scrolls inside its own box instead of moving the page.

- **`docs/assets/js/theme.js`** — wrap every `.page-content table` in a `.table-scroll` container. It becomes a labelled, focusable `role="region"` only when it actually overflows (so tables that fit don't add dead tab stops), and re-checks on resize.
- **`docs/assets/css/main.scss`**
  - `.table-scroll` carries the scroller plus the table's border/radius/background, so the rounded corners clip the scrolling table.
  - `.content` gets `min-width: 0` — as a flex item its default `min-width: auto` was letting wide content widen the column.
  - `overflow-wrap: break-word` on `.page-content` and inline code. Deliberately `break-word` and not `anywhere`: `anywhere` also shrinks min-content width, which squeezed table columns into shredded paths (`/v1/chat/completions` split across four lines) instead of letting a wide table scroll.
  - `overflow-x: clip` on `html, body` replaces `body { overflow-x: hidden }`. `clip` doesn't make the root a scrollport, so the sticky header and sidebar are unaffected, and it doesn't leak on iOS.
  - A `display: block` / `width: max-content` fallback on bare tables covers the moment before `theme.js` runs and readers with JS off.

## Verification

Playwright against a local Jekyll build, 171 pages × 3 widths (513 loads):

| Check | Before | After |
|---|---|---|
| Page/width combos overflowing | 101 | 0 |
| Pages that scroll horizontally on wheel input | — | 0 |
| Tables left unwrapped | — | 0 |

Also confirmed by hand: wide tables scroll internally and stay within the viewport at 390px; at 1280px tables that fit still fill the column; the sticky header holds at `top: 0` and the sidebar at `top: 70px` after scrolling, at both widths; vertical scrolling is unaffected.

No package or TypeScript code is touched — `docs/` is outside the eslint config's scope, so `lint`/`typecheck` are unaffected. `theme.js` passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JYDhaSjah5YDkUTBEXAAN

---
_Generated by [Claude Code](https://claude.ai/code/session_014JYDhaSjah5YDkUTBEXAAN)_