### PR TITLE
Fill out the mini app widget catalog and make app data editable by hand

### DIFF
--- a/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Native parity for the widgets added beyond the original catalog. A type the
+ * web builder can place but this renderer does not know falls through to the
+ * unknown-widget hint, so each one is checked against a real document.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+import ApplicationAppView from "../ApplicationAppView";
+
+/** A document with one widget bound to a variable holding `value`. */
+const appDoc = (
+  type: string,
+  props: Record<string, unknown>,
+  value?: unknown
+) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Catalog" } },
+    content: [{ type, props: { id: `${type}-1`, ...props } }],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-catalog",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    {
+      id: "data",
+      name: "data",
+      scope: "instance",
+      persist: false,
+      default: value,
+    },
+  ],
+});
+
+const makeWorkflow = (id: string): Workflow =>
+  ({
+    id,
+    name: "Catalog",
+    description: "",
+    graph: { nodes: [], edges: [] },
+  }) as unknown as Workflow;
+
+const renderApp = (id: string, doc: unknown) =>
+  render(
+    <ApplicationAppView
+      document={parseApplicationDocument(doc) as ApplicationDocument}
+      workflow={makeWorkflow(id)}
+    />
+  );
+
+describe("added catalog widgets on mobile", () => {
+  it("renders an Alert from its binding", async () => {
+    renderApp(
+      "wf-alert",
+      appDoc(
+        "Alert",
+        { binding: "var:data", severity: "error", title: "Failed" },
+        "Model refused"
+      )
+    );
+    expect(await screen.findByText("Model refused")).toBeTruthy();
+    expect(screen.getByText("Failed")).toBeTruthy();
+  });
+
+  it("renders a List of a bound array", async () => {
+    renderApp(
+      "wf-list",
+      appDoc("List", { binding: "var:data" }, ["alpha", "beta"])
+    );
+    expect(await screen.findByText("alpha")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+  });
+
+  it("renders Key/Value rows for a bound record", async () => {
+    renderApp(
+      "wf-kv",
+      appDoc("KeyValue", { binding: "var:data" }, { model: "sonnet" })
+    );
+    expect(await screen.findByText("model")).toBeTruthy();
+    expect(screen.getByText("sonnet")).toBeTruthy();
+  });
+
+  it("renders a Stat and its caption", async () => {
+    renderApp(
+      "wf-stat",
+      appDoc("Stat", { binding: "var:data", label: "Score", caption: "so far" }, 42)
+    );
+    expect(await screen.findByText("42")).toBeTruthy();
+    expect(screen.getByText("so far")).toBeTruthy();
+  });
+
+  it("renders a Code block", async () => {
+    renderApp(
+      "wf-code",
+      appDoc("CodeBlock", { binding: "var:data" }, "print('hi')")
+    );
+    expect(await screen.findByText("print('hi')")).toBeTruthy();
+  });
+
+  it("offers a Download once the binding carries a file", async () => {
+    renderApp(
+      "wf-download",
+      appDoc("Download", { binding: "var:data", label: "Get it" }, {
+        type: "document",
+        uri: "https://example.test/report.pdf",
+      })
+    );
+    expect(await screen.findByText("Get it")).toBeTruthy();
+  });
+
+  it("renders the option groups as chips", async () => {
+    renderApp(
+      "wf-radio",
+      appDoc("RadioGroup", {
+        binding: "var:data",
+        label: "Colour",
+        options: [{ value: "Red" }, { value: "Blue" }],
+      })
+    );
+    expect(await screen.findByText("Red")).toBeTruthy();
+    expect(screen.getByText("Blue")).toBeTruthy();
+  });
+
+  it("shows only the active tab's contents", async () => {
+    renderApp("wf-tabs", {
+      schemaVersion: 3,
+      ui: {
+        root: { props: {} },
+        content: [
+          {
+            type: "Tabs",
+            props: {
+              id: "tabs-1",
+              tab1Label: "One",
+              tab2Label: "Two",
+              tab1: [{ type: "Text", props: { id: "t1", text: "first pane" } }],
+              tab2: [{ type: "Text", props: { id: "t2", text: "second pane" } }],
+            },
+          },
+        ],
+        zones: {},
+      },
+      operations: [],
+      resources: [],
+      variables: [],
+    });
+    expect(await screen.findByText("One")).toBeTruthy();
+    expect(screen.getByText("Two")).toBeTruthy();
+    // Both panes stay mounted; only the inactive one is hidden.
+    expect(screen.getByText("first pane")).toBeTruthy();
+  });
+
+  it("renders an Accordion's slot", async () => {
+    renderApp("wf-accordion", {
+      schemaVersion: 3,
+      ui: {
+        root: { props: {} },
+        content: [
+          {
+            type: "Accordion",
+            props: {
+              id: "acc-1",
+              title: "Advanced",
+              defaultOpen: true,
+              content: [{ type: "Text", props: { id: "t1", text: "inner" } }],
+            },
+          },
+        ],
+        zones: {},
+      },
+      operations: [],
+      resources: [],
+      variables: [],
+    });
+    expect(await screen.findByText("Advanced")).toBeTruthy();
+    expect(screen.getByText("inner")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -13,6 +13,8 @@ import React, { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Image,
+  Linking,
+  Platform,
   ScrollView,
   StyleSheet,
   Switch,
@@ -310,8 +312,6 @@ const ProgressWidget: React.FC<WidgetProps> = (widget) => {
   );
 };
 
-// ── Inputs ──────────────────────────────────────────────────────────────────
-
 const FieldLabel: React.FC<{ text: string; colors: ThemeColors }> = ({
   text,
   colors,
@@ -319,6 +319,167 @@ const FieldLabel: React.FC<{ text: string; colors: ThemeColors }> = ({
   text ? (
     <Text style={[styles.label, { color: colors.text }]}>{text}</Text>
   ) : null;
+
+/** A bound value shown as a message. Empty binding renders nothing. */
+const AlertWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const text = widget.formattedValue ?? (str(value) || str(widget.props.text));
+  if (!text) {return null;}
+  const severity = str(widget.props.severity) || "info";
+  const tint =
+    severity === "error"
+      ? colors.error
+      : severity === "warning"
+        ? colors.warning
+        : severity === "success"
+          ? colors.success
+          : colors.primary;
+  const title = str(widget.props.title);
+  return (
+    <View style={[styles.alert, { borderColor: tint }]}>
+      {title ? (
+        <Text style={[styles.label, { color: tint }]}>{title}</Text>
+      ) : null}
+      <Text style={[styles.body, { color: colors.text }]}>{text}</Text>
+    </View>
+  );
+};
+
+const CodeBlockWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const text =
+    widget.formattedValue ??
+    (value != null
+      ? asItems(value).map(cellText).join("\n")
+      : str(widget.props.text));
+  if (!text) {return null;}
+  return (
+    <ScrollView
+      horizontal
+      style={[styles.code, { backgroundColor: colors.inputBg }]}
+    >
+      <Text style={[styles.codeText, { color: colors.text }]}>{text}</Text>
+    </ScrollView>
+  );
+};
+
+const ListWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const items = (
+    widget.formattedValue ? [widget.formattedValue] : asItems(value)
+  ).filter((item) => item != null && item !== "");
+  if (items.length === 0) {
+    const placeholder = str(widget.props.placeholder);
+    return placeholder ? (
+      <Placeholder text={placeholder} colors={colors} />
+    ) : null;
+  }
+  const ordered = widget.props.ordered === true;
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      {items.map((item, index) => (
+        <View key={index} style={styles.listItem}>
+          <Text style={[styles.body, { color: colors.textTertiary }]}>
+            {ordered ? `${index + 1}.` : "•"}
+          </Text>
+          <Text style={[styles.body, styles.flex, { color: colors.text }]}>
+            {cellText(item)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const KeyValueWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const entries = isRow(value)
+    ? Object.entries(value)
+    : value == null || value === ""
+      ? []
+      : ([["value", value]] as [string, unknown][]);
+  if (entries.length === 0) {
+    const placeholder = str(widget.props.placeholder);
+    return placeholder ? (
+      <Placeholder text={placeholder} colors={colors} />
+    ) : null;
+  }
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      {entries.map(([key, entry]) => (
+        <View
+          key={key}
+          style={[styles.row, styles.kvRow, { borderColor: colors.borderLight }]}
+        >
+          <Text style={[styles.hint, { color: colors.textTertiary }]}>{key}</Text>
+          <Text style={[styles.body, styles.kvValue, { color: colors.text }]}>
+            {cellText(entry)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const StatWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const shown =
+    widget.formattedValue ?? (value != null && value !== "" ? str(value) : "");
+  const caption = str(widget.props.caption);
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <Text style={[styles.stat, { color: colors.text }]}>
+        {shown || str(widget.props.placeholder) || "—"}
+      </Text>
+      {caption ? (
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          {caption}
+        </Text>
+      ) : null}
+    </View>
+  );
+};
+
+/** Hands the bound file to the OS rather than rendering it inline. */
+const DownloadWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const uri = mediaUri(asItems(value)[0]);
+  if (!uri) {
+    const placeholder = str(widget.props.placeholder);
+    return placeholder ? (
+      <Placeholder text={placeholder} colors={colors} />
+    ) : null;
+  }
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      disabled={widget.disabled}
+      onPress={() => {
+        void Linking.openURL(uri);
+      }}
+      style={[
+        styles.button,
+        styles.secondaryButton,
+        { borderColor: colors.primary },
+      ]}
+    >
+      <Text style={[styles.buttonText, { color: colors.primary }]}>
+        {str(widget.props.label) || "Download"}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+// ── Inputs ──────────────────────────────────────────────────────────────────
 
 const TextInputWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
@@ -516,6 +677,153 @@ const SelectWidget: React.FC<WidgetProps> = (widget) => {
           })}
         </View>
       </ScrollView>
+    </View>
+  );
+};
+
+/** The author's option list, tolerating both `["a"]` and `[{ value: "a" }]`. */
+const useOptionValues = (raw: unknown): string[] =>
+  useMemo(() => {
+    if (!Array.isArray(raw)) {return [] as string[];}
+    return raw
+      .map((option) =>
+        typeof option === "string"
+          ? option
+          : str((option as Record<string, unknown>)?.value)
+      )
+      .filter((option) => option.length > 0);
+  }, [raw]);
+
+/** Chips rather than native radios: one tap target, and it matches Select. */
+const RadioGroupWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const options = useOptionValues(widget.props.options);
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <View style={styles.chipWrap}>
+        {options.map((option) => {
+          const selected = str(value) === option;
+          return (
+            <TouchableOpacity
+              key={option}
+              accessibilityRole="radio"
+              accessibilityState={{ selected }}
+              disabled={widget.disabled}
+              onPress={() => {
+                setValue(option);
+                emit("change");
+              }}
+              style={[
+                styles.chip,
+                {
+                  backgroundColor: selected ? colors.primary : colors.inputBg,
+                  borderColor: selected ? colors.primary : colors.border,
+                },
+              ]}
+            >
+              <Text
+                style={{ color: selected ? colors.textOnPrimary : colors.text }}
+              >
+                {option}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+/** Writes the checked options as an array, in the option list's own order. */
+const CheckboxGroupWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const options = useOptionValues(widget.props.options);
+  const selected = Array.isArray(value) ? value.map(str) : [];
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <View style={styles.chipWrap}>
+        {options.map((option) => {
+          const checked = selected.includes(option);
+          return (
+            <TouchableOpacity
+              key={option}
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked }}
+              disabled={widget.disabled}
+              onPress={() => {
+                setValue(
+                  options.filter((o) =>
+                    o === option ? !checked : selected.includes(o)
+                  )
+                );
+                emit("change");
+              }}
+              style={[
+                styles.chip,
+                {
+                  backgroundColor: checked ? colors.primary : colors.inputBg,
+                  borderColor: checked ? colors.primary : colors.border,
+                },
+              ]}
+            >
+              <Text
+                style={{ color: checked ? colors.textOnPrimary : colors.text }}
+              >
+                {option}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+/**
+ * A typed field rather than a native picker: the document stores the same
+ * `YYYY-MM-DD` string the web `<input type="date">` writes, and pulling in a
+ * date-picker dependency to produce it would not change what the app sees.
+ */
+const DateInputWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const withTime = widget.props.withTime === true;
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.inputBg,
+            color: colors.text,
+            borderColor: colors.border,
+          },
+        ]}
+        editable={!widget.disabled}
+        value={str(value)}
+        autoCapitalize="none"
+        placeholder={withTime ? "YYYY-MM-DDTHH:MM" : "YYYY-MM-DD"}
+        placeholderTextColor={colors.textTertiary}
+        onChangeText={(text) => {
+          setValue(text === "" ? null : text);
+          emit("change");
+        }}
+        onBlur={() => emit("change", "commit")}
+      />
     </View>
   );
 };
@@ -779,6 +1087,97 @@ const DividerWidget: React.FC = () => {
   return <View style={[styles.divider, { backgroundColor: colors.border }]} />;
 };
 
+const SpacerWidget: React.FC<WidgetProps> = (widget) => (
+  <View style={{ height: numOr(widget.props.height, 24) }} />
+);
+
+/** Tabs with a blank label are dropped, matching the web renderer. */
+const TabsWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const panes = (["tab1", "tab2", "tab3"] as const)
+    .map((key) => ({
+      key,
+      label: str(widget.props[`${key}Label`]),
+      nodes: slotNodes(widget.props[key]),
+    }))
+    .filter((pane) => pane.label.trim().length > 0);
+  const [active, setActive] = useState<string>("tab1");
+  const current = panes.some((pane) => pane.key === active)
+    ? active
+    : panes[0]?.key;
+
+  if (panes.length === 0) {return null;}
+  return (
+    <View style={styles.field}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={styles.chipRow}>
+          {panes.map((pane) => {
+            const selected = pane.key === current;
+            return (
+              <TouchableOpacity
+                key={pane.key}
+                accessibilityRole="tab"
+                accessibilityState={{ selected }}
+                onPress={() => setActive(pane.key)}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: selected ? colors.primary : colors.inputBg,
+                    borderColor: selected ? colors.primary : colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={{
+                    color: selected ? colors.textOnPrimary : colors.text,
+                  }}
+                >
+                  {pane.label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+      {panes.map((pane) =>
+        // Hidden rather than unmounted, so a widget's view state and any run it
+        // started survive switching tabs — same as the web renderer.
+        <View key={pane.key} style={pane.key === current ? undefined : styles.hidden}>
+          <ComponentList nodes={pane.nodes} />
+        </View>
+      )}
+    </View>
+  );
+};
+
+const AccordionWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const [open, setOpen] = useState(widget.props.defaultOpen !== false);
+  return (
+    <View
+      style={[
+        styles.panel,
+        { backgroundColor: colors.cardBg, borderColor: colors.borderLight },
+      ]}
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        onPress={() => setOpen((prev) => !prev)}
+        style={styles.row}
+      >
+        <Text style={[styles.panelTitle, { color: colors.text }]}>
+          {str(widget.props.title) || "Section"}
+        </Text>
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          {open ? "−" : "+"}
+        </Text>
+      </TouchableOpacity>
+      {open ? <ComponentList nodes={slotNodes(widget.props.content)} /> : null}
+    </View>
+  );
+};
+
 const UnknownWidget: React.FC<{ label: string }> = ({ label }) => {
   const { colors } = useTheme();
   return (
@@ -809,12 +1208,21 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Output: MediaOutputWidget,
   Table: TableWidget,
   Progress: ProgressWidget,
+  Alert: AlertWidget,
+  CodeBlock: CodeBlockWidget,
+  List: ListWidget,
+  KeyValue: KeyValueWidget,
+  Stat: StatWidget,
+  Download: DownloadWidget,
   WorkflowInput: WorkflowInputWidget,
   TextInput: TextInputWidget,
   NumberInput: NumberInputWidget,
   Slider: SliderWidget,
   Switch: SwitchWidget,
   Select: SelectWidget,
+  RadioGroup: RadioGroupWidget,
+  CheckboxGroup: CheckboxGroupWidget,
+  DateInput: DateInputWidget,
   ColorInput: ColorInputWidget,
   ImageInput: (props) => <MediaInputWidget {...props} kind="image" />,
   AudioInput: (props) => <MediaInputWidget {...props} kind="audio" />,
@@ -824,7 +1232,10 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Button: ButtonWidget,
   Container: ContainerWidget,
   Columns: ColumnsWidget,
+  Tabs: TabsWidget,
+  Accordion: AccordionWidget,
   Divider: DividerWidget as React.FC<WidgetProps>,
+  Spacer: SpacerWidget,
 };
 
 /**
@@ -1011,5 +1422,45 @@ const styles = StyleSheet.create({
   },
   divider: {
     height: StyleSheet.hairlineWidth,
+  },
+  hidden: {
+    display: "none",
+  },
+  chipWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  alert: {
+    gap: 4,
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  code: {
+    padding: 12,
+    borderRadius: 10,
+  },
+  codeText: {
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+    fontSize: 13,
+  },
+  listItem: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  kvRow: {
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    alignItems: "flex-start",
+  },
+  kvValue: {
+    flexShrink: 1,
+    textAlign: "right",
+  },
+  stat: {
+    fontSize: 30,
+    fontWeight: "700",
+    letterSpacing: -0.5,
   },
 });

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -38,6 +38,19 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   Table: { label: "Table", mode: "read" },
   Output: { label: "Output", mode: "read" },
   Progress: { label: "Progress", mode: "read" },
+  // Reads a bound value as a message rather than as content: an error output,
+  // a validation string, a status line the app wants to draw attention to.
+  Alert: { label: "Alert", mode: "read" },
+  CodeBlock: { label: "Code", mode: "read" },
+  // Lays out an array value as items; Table's sibling for values that have no
+  // columns.
+  List: { label: "List", mode: "read" },
+  // An object value as label/value rows — what a single-result operation that
+  // emits a record usually wants.
+  KeyValue: { label: "Key/Value", mode: "read" },
+  Stat: { label: "Stat", mode: "read" },
+  // Offers the bound media/document ref as a file rather than rendering it.
+  Download: { label: "Download", mode: "read" },
   // Inputs
   WorkflowInput: {
     label: "Workflow Input",
@@ -55,6 +68,26 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   Slider: { label: "Slider", mode: "write", trigger: "change", commits: true },
   Switch: { label: "Switch", mode: "write", trigger: "change", commits: false },
   Select: { label: "Select", mode: "write", trigger: "change", commits: false },
+  RadioGroup: {
+    label: "Radio Group",
+    mode: "write",
+    trigger: "change",
+    commits: false
+  },
+  // Writes an array of the checked options, so it binds to a list-typed input.
+  CheckboxGroup: {
+    label: "Checkbox Group",
+    mode: "write",
+    trigger: "change",
+    commits: false
+  },
+  // A date control settles on blur, so "on release" pacing is meaningful.
+  DateInput: {
+    label: "Date Input",
+    mode: "write",
+    trigger: "change",
+    commits: true
+  },
   ImageInput: {
     label: "Image Input",
     mode: "write",
@@ -105,6 +138,12 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   // Layout
   Container: { label: "Panel", mode: "layout", slots: ["content"] },
   Columns: { label: "Columns", mode: "layout", slots: ["left", "right"] },
+  // Three fixed slots rather than a variable number: Puck fields are declared
+  // statically, and three tabs cover what a mini app does without a nested
+  // array-of-slots field the agent would have to reason about.
+  Tabs: { label: "Tabs", mode: "layout", slots: ["tab1", "tab2", "tab3"] },
+  Accordion: { label: "Accordion", mode: "layout", slots: ["content"] },
+  Spacer: { label: "Spacer", mode: "layout" },
   Divider: { label: "Divider", mode: "layout" }
 };
 

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -46,7 +46,26 @@ describe("widget catalog", () => {
   it("declares the slots layout widgets nest children in", () => {
     expect(WIDGET_CATALOG.Columns.slots).toEqual(["left", "right"]);
     expect(WIDGET_CATALOG.Container.slots).toEqual(["content"]);
+    expect(WIDGET_CATALOG.Tabs.slots).toEqual(["tab1", "tab2", "tab3"]);
+    expect(WIDGET_CATALOG.Accordion.slots).toEqual(["content"]);
     expect(WIDGET_CATALOG.Divider.slots).toBeUndefined();
+    expect(WIDGET_CATALOG.Spacer.slots).toBeUndefined();
+  });
+
+  it("groups the multi-option and date inputs with the other write widgets", () => {
+    for (const type of ["RadioGroup", "CheckboxGroup", "DateInput"]) {
+      expect(widgetMode(type)).toBe("write");
+      expect(WIDGET_CATALOG[type].trigger).toBe("change");
+    }
+    // Only the date field settles on blur, so only it can pace "on release".
+    expect(WIDGET_CATALOG.DateInput.commits).toBe(true);
+    expect(WIDGET_CATALOG.RadioGroup.commits).toBe(false);
+  });
+
+  it("keeps the added display widgets read-only", () => {
+    for (const type of ["Alert", "CodeBlock", "List", "KeyValue", "Stat", "Download"]) {
+      expect(widgetMode(type)).toBe("read");
+    }
   });
 });
 

--- a/web/src/components/appbuilder/AppBuilderShell.tsx
+++ b/web/src/components/appbuilder/AppBuilderShell.tsx
@@ -9,6 +9,7 @@ import FrontendToolRuntimeSync from "../panels/FrontendToolRuntimeSync";
 import { createEmptyData, type AppDocument } from "./appData";
 import PuckAppEditor from "./puck/PuckAppEditor";
 import AppBuilderAgentPanel from "./AppBuilderAgentPanel";
+import AppDataPanel from "./AppDataPanel";
 
 export interface AppBuilderShellProps {
   /**
@@ -32,6 +33,17 @@ export interface AppBuilderShellProps {
   onSave: (document: AppDocument) => void;
   onClose?: () => void;
 }
+
+/** Shared framing for the panels that dock beside the canvas. */
+const sidePanelSx = {
+  width: { xs: "min(100vw, 360px)", lg: 420 },
+  flexShrink: 0,
+  height: "100%",
+  borderLeft: "1px solid",
+  borderColor: "divider",
+  overflow: "hidden",
+  borderTopLeftRadius: BORDER_RADIUS.lg
+} as const;
 
 /**
  * The builder's editing surface, independent of where the document is stored.
@@ -74,6 +86,8 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
   }));
   const [agentOpen, setAgentOpen] = useState(false);
   const toggleAgent = useCallback(() => setAgentOpen((open) => !open), []);
+  const [dataOpen, setDataOpen] = useState(false);
+  const toggleData = useCallback(() => setDataOpen((open) => !open), []);
 
   // Point the agent's workflow tools at the graph this app runs.
   useEffect(() => {
@@ -123,21 +137,23 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
             onToggleAgent={agentWorkflowId ? toggleAgent : undefined}
             meta={meta}
             onMetaChange={setMeta}
+            dataOpen={dataOpen}
+            onToggleData={toggleData}
           />
         </Box>
       </FlexColumn>
+      {dataOpen && (
+        <Box sx={sidePanelSx}>
+          <AppDataPanel
+            meta={meta}
+            onChange={setMeta}
+            workflowId={workflow.id}
+            workflowName={workflow.name}
+          />
+        </Box>
+      )}
       {agentOpen && agentWorkflowId && (
-        <Box
-          sx={{
-            width: { xs: "min(100vw, 360px)", lg: 420 },
-            flexShrink: 0,
-            height: "100%",
-            borderLeft: "1px solid",
-            borderColor: "divider",
-            overflow: "hidden",
-            borderTopLeftRadius: BORDER_RADIUS.lg
-          }}
-        >
+        <Box sx={sidePanelSx}>
           <AppBuilderAgentPanel
             applicationId={applicationId}
             workflowId={agentWorkflowId}

--- a/web/src/components/appbuilder/AppDataPanel.tsx
+++ b/web/src/components/appbuilder/AppDataPanel.tsx
@@ -1,0 +1,437 @@
+/**
+ * The half of an application document Puck does not own: its operations,
+ * variables, and resource bindings.
+ *
+ * Until this existed the three lists were reachable only through the agent's
+ * `ui_app_*` tools, so declaring a variable or binding a second workflow meant
+ * asking the agent to do it. Every edit goes through app-runtime's `doc-ops`,
+ * the same pure functions the agent tools and the CLI harness call, so both
+ * paths produce identical documents.
+ */
+import React, { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import AddIcon from "@mui/icons-material/Add";
+import {
+  addOperation,
+  addResource,
+  declareVariable,
+  removeOperation,
+  removeResource,
+  removeVariable,
+  updateOperation,
+  updateVariable,
+  type AppDocMeta,
+  type OperationBinding,
+  type OperationPolicy,
+  type ResourceBinding,
+  type ResourceKind,
+  type VariableDeclaration
+} from "@nodetool-ai/app-runtime";
+
+import { trpcClient } from "../../trpc/client";
+import {
+  Box,
+  Caption,
+  Card,
+  CollapsibleSection,
+  DeleteButton,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LabeledSwitch,
+  ScrollArea,
+  SelectField,
+  Text,
+  TextInput,
+  BORDER_RADIUS,
+  SPACING
+} from "../ui_primitives";
+
+export interface AppDataPanelProps {
+  meta: AppDocMeta;
+  onChange: (next: AppDocMeta) => void;
+  /** The workflow the builder opened with — the default for a new operation. */
+  workflowId: string;
+  workflowName?: string;
+}
+
+const POLICY_OPTIONS = [
+  { label: "Replace running", value: "replace" },
+  { label: "Queue behind", value: "queue" },
+  { label: "Run in parallel", value: "parallel" }
+];
+
+const SCOPE_OPTIONS = [
+  { label: "This session", value: "instance" },
+  { label: "Per user", value: "user" }
+];
+
+/**
+ * The node-SDK type names a variable may declare. A variable is a typed slot,
+ * not a free-form bag, so the list is closed — anything richer is a node.
+ */
+const TYPE_OPTIONS = [
+  { label: "Any", value: "" },
+  { label: "Text", value: "str" },
+  { label: "Number", value: "float" },
+  { label: "Integer", value: "int" },
+  { label: "True/false", value: "bool" },
+  { label: "List", value: "list" },
+  { label: "Record", value: "dict" }
+];
+
+const RESOURCE_KIND_OPTIONS: { label: string; value: ResourceKind }[] = [
+  { label: "Asset", value: "asset" },
+  { label: "Timeline", value: "timeline" },
+  { label: "Storyboard", value: "storyboard" },
+  { label: "Sketch", value: "sketch" }
+];
+
+/** A row in one of the three lists: a bordered card with a delete affordance. */
+const EntryCard: React.FC<{
+  title: string;
+  subtitle?: string;
+  onDelete: () => void;
+  deleteLabel: string;
+  children: React.ReactNode;
+}> = ({ title, subtitle, onDelete, deleteLabel, children }) => (
+  <Card
+    variant="outlined"
+    padding="none"
+    sx={{ p: SPACING.md, borderRadius: BORDER_RADIUS.md }}
+  >
+    <FlexColumn gap={SPACING.sm} fullWidth>
+      <FlexRow align="center" justify="space-between" gap={SPACING.sm} fullWidth>
+        <Box sx={{ minWidth: 0 }}>
+          <Text size="small" weight={600} truncate>
+            {title}
+          </Text>
+          {subtitle ? (
+            <Caption color="secondary" sx={{ display: "block" }}>
+              {subtitle}
+            </Caption>
+          ) : null}
+        </Box>
+        <DeleteButton onClick={onDelete} tooltip={deleteLabel} />
+      </FlexRow>
+      {children}
+    </FlexColumn>
+  </Card>
+);
+
+const OperationRow: React.FC<{
+  operation: OperationBinding;
+  workflowOptions: { label: string; value: string }[];
+  onPatch: (patch: Partial<OperationBinding>) => void;
+  onRemove: () => void;
+}> = ({ operation, workflowOptions, onPatch, onRemove }) => {
+  // A release pins a workflow this app can no longer list (deleted, or owned
+  // elsewhere); keep it selectable rather than silently switching the binding.
+  const options = workflowOptions.some((o) => o.value === operation.workflowId)
+    ? workflowOptions
+    : [
+        { label: operation.workflowId, value: operation.workflowId },
+        ...workflowOptions
+      ];
+  return (
+    <EntryCard
+      title={operation.name || operation.id}
+      subtitle={`id: ${operation.id}`}
+      onDelete={onRemove}
+      deleteLabel={`Remove operation ${operation.name || operation.id}`}
+    >
+      <TextInput
+        label="Name"
+        value={operation.name}
+        size="small"
+        fullWidth
+        onChange={(e) => onPatch({ name: e.target.value })}
+      />
+      <SelectField
+        label="Workflow"
+        value={operation.workflowId}
+        options={options}
+        onChange={(value) => onPatch({ workflowId: value })}
+      />
+      <SelectField
+        label="While one is running"
+        value={operation.policy}
+        options={POLICY_OPTIONS}
+        onChange={(value) => onPatch({ policy: value as OperationPolicy })}
+      />
+      <TextInput
+        label="Timeout (ms)"
+        type="number"
+        value={operation.timeoutMs == null ? "" : String(operation.timeoutMs)}
+        size="small"
+        fullWidth
+        onChange={(e) =>
+          onPatch({
+            timeoutMs: e.target.value === "" ? undefined : Number(e.target.value)
+          })
+        }
+      />
+    </EntryCard>
+  );
+};
+
+const VariableRow: React.FC<{
+  variable: VariableDeclaration;
+  onPatch: (patch: Partial<VariableDeclaration>) => void;
+  onRemove: () => void;
+}> = ({ variable, onPatch, onRemove }) => (
+  <EntryCard
+    title={variable.name || variable.id}
+    subtitle={`var:${variable.id}`}
+    onDelete={onRemove}
+    deleteLabel={`Remove variable ${variable.name || variable.id}`}
+  >
+    <TextInput
+      label="Name"
+      value={variable.name}
+      size="small"
+      fullWidth
+      onChange={(e) => onPatch({ name: e.target.value })}
+    />
+    <SelectField
+      label="Type"
+      value={variable.type?.type ?? ""}
+      options={TYPE_OPTIONS}
+      onChange={(value) => onPatch({ type: value ? { type: value } : null })}
+    />
+    <TextInput
+      label="Default"
+      value={variable.default == null ? "" : String(variable.default)}
+      size="small"
+      fullWidth
+      onChange={(e) =>
+        onPatch({ default: e.target.value === "" ? undefined : e.target.value })
+      }
+    />
+    <SelectField
+      label="Scope"
+      value={variable.scope}
+      options={SCOPE_OPTIONS}
+      onChange={(value) => onPatch({ scope: value as "instance" | "user" })}
+    />
+    <LabeledSwitch
+      // The label associates through `htmlFor`, so the control needs an id.
+      id={`persist-${variable.id}`}
+      label="Remember between visits"
+      checked={variable.persist}
+      // doc-ops downgrades persist on an instance-scoped variable, so the
+      // control says why it will not stick rather than letting it flip back.
+      disabled={variable.scope !== "user"}
+      onChange={(checked) => onPatch({ persist: checked })}
+    />
+    {variable.scope !== "user" ? (
+      <Caption color="secondary">Only per-user variables can be remembered.</Caption>
+    ) : null}
+  </EntryCard>
+);
+
+const ResourceRow: React.FC<{
+  resource: ResourceBinding;
+  onRemove: () => void;
+}> = ({ resource, onRemove }) => (
+  <EntryCard
+    title={resource.name || resource.id}
+    subtitle={`${resource.kind} · ${
+      resource.scope.fixedId
+        ? `pinned ${resource.scope.fixedId}`
+        : `project ${resource.scope.projectId}`
+    }`}
+    onDelete={onRemove}
+    deleteLabel={`Remove resource ${resource.name || resource.id}`}
+  >
+    <Caption color="secondary">
+      Allows: {resource.operations.join(", ")}
+    </Caption>
+  </EntryCard>
+);
+
+/** The "add a resource binding" form — the one entry that needs a scope up front. */
+const AddResourceForm: React.FC<{ onAdd: (input: {
+  name: string;
+  kind: ResourceKind;
+  projectId: string;
+}) => void }> = ({ onAdd }) => {
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<ResourceKind>("asset");
+  const [projectId, setProjectId] = useState("");
+
+  const submit = useCallback(() => {
+    if (!projectId.trim()) return;
+    onAdd({ name: name.trim() || kind, kind, projectId: projectId.trim() });
+    setName("");
+    setProjectId("");
+  }, [kind, name, onAdd, projectId]);
+
+  return (
+    <FlexColumn gap={SPACING.sm} fullWidth>
+      <TextInput
+        label="Name"
+        value={name}
+        size="small"
+        fullWidth
+        onChange={(e) => setName(e.target.value)}
+      />
+      <SelectField
+        label="Kind"
+        value={kind}
+        options={RESOURCE_KIND_OPTIONS}
+        onChange={(value) => setKind(value as ResourceKind)}
+      />
+      <TextInput
+        label="Project id"
+        value={projectId}
+        size="small"
+        fullWidth
+        onChange={(e) => setProjectId(e.target.value)}
+      />
+      <EditorButton
+        size="small"
+        variant="outlined"
+        startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+        disabled={!projectId.trim()}
+        onClick={submit}
+      >
+        Add resource
+      </EditorButton>
+    </FlexColumn>
+  );
+};
+
+const AppDataPanel: React.FC<AppDataPanelProps> = ({
+  meta,
+  onChange,
+  workflowId,
+  workflowName
+}) => {
+  const { data: workflows } = useQuery({
+    queryKey: ["workflows", "app-data-panel"],
+    queryFn: () => trpcClient.workflows.list.query({ limit: 200 }),
+    staleTime: 60_000
+  });
+
+  const workflowOptions = useMemo(() => {
+    const listed = (workflows?.workflows ?? []).map((workflow) => ({
+      label: workflow.name || workflow.id,
+      value: workflow.id
+    }));
+    if (!workflowId || listed.some((o) => o.value === workflowId)) return listed;
+    return [{ label: workflowName || workflowId, value: workflowId }, ...listed];
+  }, [workflowId, workflowName, workflows]);
+
+  const addOp = useCallback(() => {
+    if (!workflowId) return;
+    onChange(
+      addOperation(meta, {
+        name: `Operation ${meta.operations.length + 1}`,
+        workflowId
+      }).meta
+    );
+  }, [meta, onChange, workflowId]);
+
+  const addVar = useCallback(() => {
+    onChange(
+      declareVariable(meta, {
+        name: `variable_${meta.variables.length + 1}`,
+        scope: "instance"
+      }).meta
+    );
+  }, [meta, onChange]);
+
+  const addRes = useCallback(
+    (input: { name: string; kind: ResourceKind; projectId: string }) => {
+      onChange(
+        addResource(meta, {
+          name: input.name,
+          kind: input.kind,
+          scope: { projectId: input.projectId }
+        }).meta
+      );
+    },
+    [meta, onChange]
+  );
+
+  return (
+    <ScrollArea fullHeight>
+      <FlexColumn gap={SPACING.lg} padding={SPACING.lg} fullWidth>
+        <CollapsibleSection title="Operations" defaultOpen compact>
+          <FlexColumn gap={SPACING.md} fullWidth>
+            <Caption color="secondary">
+              The workflows this app runs. A Run action names one of these.
+            </Caption>
+            {meta.operations.map((operation) => (
+              <OperationRow
+                key={operation.id}
+                operation={operation}
+                workflowOptions={workflowOptions}
+                onPatch={(patch) =>
+                  onChange(updateOperation(meta, operation.id, patch).meta)
+                }
+                onRemove={() =>
+                  onChange(removeOperation(meta, operation.id).meta)
+                }
+              />
+            ))}
+            <EditorButton
+              size="small"
+              variant="outlined"
+              startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+              disabled={!workflowId}
+              onClick={addOp}
+            >
+              Add operation
+            </EditorButton>
+          </FlexColumn>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Variables" defaultOpen compact>
+          <FlexColumn gap={SPACING.md} fullWidth>
+            <Caption color="secondary">
+              App state widgets read and write, and operation outputs can land in.
+            </Caption>
+            {meta.variables.map((variable) => (
+              <VariableRow
+                key={variable.id}
+                variable={variable}
+                onPatch={(patch) =>
+                  onChange(updateVariable(meta, variable.id, patch).meta)
+                }
+                onRemove={() => onChange(removeVariable(meta, variable.id).meta)}
+              />
+            ))}
+            <EditorButton
+              size="small"
+              variant="outlined"
+              startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+              onClick={addVar}
+            >
+              Add variable
+            </EditorButton>
+          </FlexColumn>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Resources" compact>
+          <FlexColumn gap={SPACING.md} fullWidth>
+            <Caption color="secondary">
+              Document collections a picker or gallery widget can browse.
+            </Caption>
+            {meta.resources.map((resource) => (
+              <ResourceRow
+                key={resource.id}
+                resource={resource}
+                onRemove={() => onChange(removeResource(meta, resource.id).meta)}
+              />
+            ))}
+            <AddResourceForm onAdd={addRes} />
+          </FlexColumn>
+        </CollapsibleSection>
+      </FlexColumn>
+    </ScrollArea>
+  );
+};
+
+export default AppDataPanel;

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -24,6 +24,12 @@ framework-independent core the web runtime, the CLI `app debug` harness, and the
   `op:main/out:<nodeId>`, `var:<id>`, `view:<componentId>#<prop>`). Renaming a
   node in the graph editor does not break an app. Bare names still resolve —
   that is the legacy `workflow.app_doc` form, read on import only.
+- The **widget catalog** lives in `@nodetool-ai/app-runtime` (`src/widgets.ts`)
+  — one table the Puck config, the CLI `app debug` harness, the `app-tools`
+  evals, and the mobile renderer all read. A new widget is added there first,
+  then implemented in `puck/widgets.tsx` and in
+  `mobile/src/components/app_runtime/widgets.tsx`; a type missing from either
+  renderer shows as an unknown widget on that surface.
 - **Widgets** bind one slot (read for displays, two-way for inputs) and emit
   **events** (`click` / `change`) that dispatch **actions** (`run`, `cancel`,
   `setVariable`, `toggleVariable`, `resourceCommand`, `openResource`). A `run`
@@ -93,6 +99,11 @@ the existing worker path.
   - `BuilderWorkflowContext.tsx` — supplies the bindable surface to fields.
   - `PuckAppEditor.tsx` — the `<Puck>` editor wrapper.
 - `AppRuntimeView.tsx` — the live `<Render>` wrapper (used by app mode).
+- `AppDataPanel.tsx` — the operations/variables/resources editor that docks
+  beside the canvas (the **App Data** toggle in the editor header). Every edit
+  goes through app-runtime's `doc-ops`, the same pure functions the agent's
+  `ui_app_*` tools call, so hand edits and agent edits produce identical
+  documents.
 - `AppBuilderShell.tsx` — the editing surface, independent of storage: it seeds
   Puck from a document, holds the operations/resources/variables beside it, and
   emits the **whole** document on save.

--- a/web/src/components/appbuilder/__tests__/AppDataPanel.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppDataPanel.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * The panel that makes operations, variables, and resources editable by hand
+ * rather than only through the agent's `ui_app_*` tools.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { EMPTY_DOC_META, type AppDocMeta } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import AppDataPanel from "../AppDataPanel";
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    workflows: {
+      list: {
+        query: jest.fn().mockResolvedValue({
+          workflows: [
+            { id: "wf1", name: "Summarize" },
+            { id: "wf2", name: "Translate" }
+          ]
+        })
+      }
+    }
+  }
+}));
+
+const renderPanel = (meta: AppDocMeta = EMPTY_DOC_META) => {
+  const onChange = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={mockTheme}>
+        <AppDataPanel
+          meta={meta}
+          onChange={onChange}
+          workflowId="wf1"
+          workflowName="Summarize"
+        />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+  return { onChange };
+};
+
+const withVariable = (
+  overrides: Partial<AppDocMeta["variables"][number]> = {}
+): AppDocMeta => ({
+  ...EMPTY_DOC_META,
+  variables: [
+    {
+      id: "tone",
+      name: "tone",
+      type: null,
+      scope: "instance",
+      persist: false,
+      ...overrides
+    }
+  ]
+});
+
+describe("AppDataPanel", () => {
+  it("adds an operation bound to the builder's workflow", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPanel();
+    await user.click(screen.getByRole("button", { name: /add operation/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operations: [expect.objectContaining({ workflowId: "wf1" })]
+      })
+    );
+  });
+
+  it("declares a variable", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPanel();
+    await user.click(screen.getByRole("button", { name: /add variable/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: [expect.objectContaining({ id: "variable_1" })]
+      })
+    );
+  });
+
+  it("removes a variable", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPanel(withVariable());
+    await user.click(
+      screen.getByRole("button", { name: "Remove variable tone" })
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: [] })
+    );
+  });
+
+  it("changes an operation's run policy", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPanel({
+      ...EMPTY_DOC_META,
+      operations: [
+        {
+          id: "main",
+          name: "Main",
+          workflowId: "wf1",
+          inputs: {},
+          outputs: {},
+          policy: "replace"
+        }
+      ]
+    });
+    await user.click(screen.getByRole("combobox", { name: /while one is running/i }));
+    await user.click(screen.getByRole("option", { name: /queue behind/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operations: [expect.objectContaining({ policy: "queue" })]
+      })
+    );
+  });
+
+  it("only offers persistence on a per-user variable", async () => {
+    renderPanel(withVariable({ scope: "instance" }));
+    expect(
+      screen.getByRole("switch", { name: /remember between visits/i })
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/only per-user variables can be remembered/i)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps an operation's workflow selectable when the list does not carry it", async () => {
+    renderPanel({
+      ...EMPTY_DOC_META,
+      operations: [
+        {
+          id: "main",
+          name: "Main",
+          workflowId: "wf-gone",
+          inputs: {},
+          outputs: {},
+          policy: "replace"
+        }
+      ]
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: /workflow/i })).toHaveTextContent(
+        "wf-gone"
+      )
+    );
+  });
+
+  it("requires a project id before a resource can be added", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPanel();
+    await user.click(screen.getByRole("button", { name: /^resources$/i }));
+    const add = screen.getByRole("button", { name: /add resource/i });
+    expect(add).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/project id/i), "proj1");
+    await user.click(add);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resources: [
+          expect.objectContaining({ kind: "asset", scope: { projectId: "proj1" } })
+        ]
+      })
+    );
+  });
+});

--- a/web/src/components/appbuilder/puck/PuckAppEditor.tsx
+++ b/web/src/components/appbuilder/puck/PuckAppEditor.tsx
@@ -10,6 +10,7 @@ import SaveIcon from "@mui/icons-material/Save";
 import PhoneIphoneIcon from "@mui/icons-material/PhoneIphone";
 import TabletMacIcon from "@mui/icons-material/TabletMac";
 import AspectRatioIcon from "@mui/icons-material/AspectRatio";
+import TuneIcon from "@mui/icons-material/Tune";
 
 import { Workflow } from "../../../stores/ApiTypes";
 import { NodeContext } from "../../../contexts/NodeContext";
@@ -49,6 +50,8 @@ interface PuckAppEditorProps {
    */
   meta?: AppDocMeta;
   onMetaChange?: (next: AppDocMeta) => void;
+  dataOpen?: boolean;
+  onToggleData?: () => void;
 }
 
 /**
@@ -163,7 +166,9 @@ const PuckAppEditor: React.FC<PuckAppEditorProps> = ({
   agentOpen = false,
   onToggleAgent,
   meta = EMPTY_DOC_META,
-  onMetaChange
+  onMetaChange,
+  dataOpen = false,
+  onToggleData
 }) => {
   const workflowState = useMemo(
     () => extractWorkflowState(workflow, meta.resources),
@@ -194,6 +199,17 @@ const PuckAppEditor: React.FC<PuckAppEditorProps> = ({
           />
           <PreviewWidthToggle value={previewWidth} onChange={setPreviewWidth} />
           <GenerateFromWorkflowButton workflow={workflow} />
+          {onToggleData && (
+            <EditorButton
+              size="small"
+              variant={dataOpen ? "contained" : "text"}
+              startIcon={<TuneIcon sx={{ fontSize: 16 }} />}
+              onClick={onToggleData}
+              aria-pressed={dataOpen}
+            >
+              App Data
+            </EditorButton>
+          )}
           {onToggleAgent && (
             <EditorButton
               size="small"
@@ -230,7 +246,9 @@ const PuckAppEditor: React.FC<PuckAppEditorProps> = ({
       previewWidth,
       meta,
       handleMetaChange,
-      workflowState
+      workflowState,
+      dataOpen,
+      onToggleData
     ]
   );
 

--- a/web/src/components/appbuilder/puck/__tests__/catalogWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/catalogWidgets.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * The widgets added beyond the original catalog: the display forms that shape a
+ * bound value (Alert, List, Key/Value, Stat, Download), the multi-option
+ * inputs, and the layout widgets that hold slots.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime, INPUT_KEY, OUTPUT_KEY } from "../../__tests__/testRuntime";
+import {
+  AccordionWidget,
+  AlertWidget,
+  CheckboxGroupWidget,
+  DownloadWidget,
+  KeyValueWidget,
+  ListWidget,
+  RadioGroupWidget,
+  StatWidget,
+  TabsWidget
+} from "../widgets";
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const runtime = makeTestRuntime(initial);
+  const { wrapper: Wrapper } = runtime;
+  return {
+    ...runtime,
+    ...render(
+      <ThemeProvider theme={mockTheme}>
+        <Wrapper>{element}</Wrapper>
+      </ThemeProvider>
+    )
+  };
+};
+
+const withOutput = (value: unknown): Partial<AppInstanceState> => ({
+  outputs: {
+    [OUTPUT_KEY]: { value, invocationId: "j1", status: "done", revision: 1 }
+  }
+});
+
+const OPTIONS = [{ value: "Red" }, { value: "Blue" }];
+
+/** The runtime stores an input as a cell; tests care about the value in it. */
+const inputValue = (state: AppInstanceState): unknown =>
+  state.inputs[INPUT_KEY]?.value;
+
+const withInput = (value: unknown): Partial<AppInstanceState> => ({
+  inputs: { [INPUT_KEY]: { value, dirty: true, revision: 1 } }
+});
+
+/** A slot, as Puck hands one to a layout widget's render function. */
+const slot = (text: string) => () => <div>{text}</div>;
+
+describe("AlertWidget", () => {
+  it("renders the bound value as the message", () => {
+    renderWidget(
+      <AlertWidget id="a1" binding="result" severity="error" title="Failed" />,
+      withOutput("Model refused")
+    );
+    expect(screen.getByText("Model refused")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("renders nothing until the binding has a value", () => {
+    const { container } = renderWidget(<AlertWidget id="a1" binding="result" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("ListWidget", () => {
+  it("renders an array binding as items", () => {
+    renderWidget(<ListWidget id="l1" binding="result" />, withOutput(["a", "b"]));
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("falls back to the placeholder when the binding is empty", () => {
+    renderWidget(<ListWidget id="l1" binding="result" placeholder="Nothing" />);
+    expect(screen.getByText("Nothing")).toBeInTheDocument();
+  });
+});
+
+describe("KeyValueWidget", () => {
+  it("renders an object binding as label/value rows", () => {
+    renderWidget(
+      <KeyValueWidget id="k1" binding="result" />,
+      withOutput({ model: "sonnet", tokens: 42 })
+    );
+    expect(screen.getByText("model")).toBeInTheDocument();
+    expect(screen.getByText("sonnet")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders a non-object binding as a single row", () => {
+    renderWidget(<KeyValueWidget id="k1" binding="result" />, withOutput("solo"));
+    expect(screen.getByText("value")).toBeInTheDocument();
+    expect(screen.getByText("solo")).toBeInTheDocument();
+  });
+});
+
+describe("StatWidget", () => {
+  it("shows the bound value, and the placeholder when there is none", () => {
+    const { unmount } = renderWidget(
+      <StatWidget id="s1" binding="result" label="Score" />,
+      withOutput(99)
+    );
+    expect(screen.getByText("99")).toBeInTheDocument();
+    unmount();
+
+    renderWidget(<StatWidget id="s1" binding="result" placeholder="—" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("DownloadWidget", () => {
+  it("links to the bound file", () => {
+    renderWidget(
+      <DownloadWidget id="d1" binding="result" label="Get it" />,
+      withOutput({ type: "document", uri: "https://example.test/report.pdf" })
+    );
+    expect(screen.getByRole("link", { name: "Get it" })).toHaveAttribute(
+      "href",
+      "https://example.test/report.pdf"
+    );
+  });
+
+  it("shows the placeholder before a run produces anything", () => {
+    renderWidget(
+      <DownloadWidget id="d1" binding="result" placeholder="Not yet" />
+    );
+    expect(screen.getByText("Not yet")).toBeInTheDocument();
+  });
+});
+
+describe("RadioGroupWidget", () => {
+  it("writes the picked option to its binding", async () => {
+    const user = userEvent.setup();
+    const { store } = renderWidget(
+      <RadioGroupWidget id="r1" binding="prompt" options={OPTIONS} />
+    );
+    await user.click(screen.getByRole("radio", { name: "Blue" }));
+    expect(inputValue(store.getState())).toBe("Blue");
+  });
+});
+
+describe("CheckboxGroupWidget", () => {
+  it("writes the checked options as an array in option order", async () => {
+    const user = userEvent.setup();
+    const { store } = renderWidget(
+      <CheckboxGroupWidget id="c1" binding="prompt" options={OPTIONS} />
+    );
+    await user.click(screen.getByRole("checkbox", { name: "Blue" }));
+    expect(inputValue(store.getState())).toEqual(["Blue"]);
+    await user.click(screen.getByRole("checkbox", { name: "Red" }));
+    expect(inputValue(store.getState())).toEqual(["Red", "Blue"]);
+  });
+
+  it("unchecks an option without dropping the others", async () => {
+    const user = userEvent.setup();
+    const { store } = renderWidget(
+      <CheckboxGroupWidget id="c1" binding="prompt" options={OPTIONS} />,
+      withInput(["Red", "Blue"])
+    );
+    await user.click(screen.getByRole("checkbox", { name: "Red" }));
+    expect(inputValue(store.getState())).toEqual(["Blue"]);
+  });
+});
+
+describe("TabsWidget", () => {
+  it("shows the first named tab and switches on click", async () => {
+    const user = userEvent.setup();
+    renderWidget(
+      <TabsWidget
+        tab1Label="One"
+        tab2Label="Two"
+        tab1={slot("first pane")}
+        tab2={slot("second pane")}
+      />
+    );
+    expect(screen.getByText("first pane")).toBeVisible();
+    expect(screen.getByText("second pane")).not.toBeVisible();
+
+    await user.click(screen.getByRole("tab", { name: "Two" }));
+    expect(screen.getByText("second pane")).toBeVisible();
+    expect(screen.getByText("first pane")).not.toBeVisible();
+  });
+
+  it("drops tabs whose label is blank", () => {
+    renderWidget(
+      <TabsWidget tab1Label="One" tab2Label="" tab1={slot("only pane")} />
+    );
+    expect(screen.getAllByRole("tab")).toHaveLength(1);
+  });
+});
+
+describe("AccordionWidget", () => {
+  it("renders its slot under the title", () => {
+    renderWidget(
+      <AccordionWidget title="Advanced" content={slot("inner")} defaultOpen />
+    );
+    expect(screen.getByText("Advanced")).toBeInTheDocument();
+    expect(screen.getByText("inner")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -31,7 +31,19 @@ import {
   ButtonWidget,
   ContainerWidget,
   ColumnsWidget,
-  DividerWidget
+  DividerWidget,
+  AlertWidget,
+  CodeBlockWidget,
+  ListWidget,
+  KeyValueWidget,
+  StatWidget,
+  DownloadWidget,
+  RadioGroupWidget,
+  CheckboxGroupWidget,
+  DateInputWidget,
+  TabsWidget,
+  AccordionWidget,
+  SpacerWidget
 } from "./widgets";
 import { ResourcePickerWidget } from "./ResourcePickerWidget";
 import { ResourceGalleryWidget } from "./ResourceGalleryWidget";
@@ -233,6 +245,9 @@ export const appConfig: Config = {
         "Slider",
         "Switch",
         "Select",
+        "RadioGroup",
+        "CheckboxGroup",
+        "DateInput",
         "ResourcePicker",
         "ResourceGallery",
         "StoryboardSceneList",
@@ -255,11 +270,27 @@ export const appConfig: Config = {
         "Video",
         "Json",
         "Table",
+        "List",
+        "KeyValue",
         "Output",
-        "Progress"
+        "Progress",
+        "Stat",
+        "Alert",
+        "CodeBlock",
+        "Download"
       ]
     },
-    layout: { title: "Layout", components: ["Container", "Columns", "Divider"] }
+    layout: {
+      title: "Layout",
+      components: [
+        "Container",
+        "Columns",
+        "Tabs",
+        "Accordion",
+        "Divider",
+        "Spacer"
+      ]
+    }
   },
   components: {
     // ── Display ──
@@ -380,6 +411,97 @@ export const appConfig: Config = {
       defaultProps: { label: "" },
       render: withConditions((props) => <ProgressWidget {...props} />)
     },
+    List: {
+      label: "List",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        ordered: {
+          type: "radio",
+          label: "Numbered",
+          options: [
+            { label: "No", value: false },
+            { label: "Yes", value: true }
+          ]
+        },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields()
+      },
+      defaultProps: { label: "", ordered: false, placeholder: "No items yet" },
+      render: withConditions((props) => <ListWidget {...props} />)
+    },
+    KeyValue: {
+      label: "Key/Value",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { label: "", placeholder: "No values yet" },
+      render: withConditions((props) => <KeyValueWidget {...props} />)
+    },
+    Stat: {
+      label: "Stat",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        caption: { type: "text", label: "Caption" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields()
+      },
+      defaultProps: { label: "Total", caption: "", placeholder: "—" },
+      render: withConditions((props) => <StatWidget {...props} />)
+    },
+    Alert: {
+      label: "Alert",
+      fields: {
+        binding: bindingField("read"),
+        text: { type: "textarea", label: "Text" },
+        title: { type: "text", label: "Title" },
+        severity: {
+          type: "select",
+          label: "Severity",
+          options: [
+            { label: "Info", value: "info" },
+            { label: "Success", value: "success" },
+            { label: "Warning", value: "warning" },
+            { label: "Error", value: "error" }
+          ]
+        },
+        ...conditionalFields()
+      },
+      defaultProps: { text: "", title: "", severity: "info" },
+      render: withConditions((props) => <AlertWidget {...props} />)
+    },
+    CodeBlock: {
+      label: "Code",
+      fields: {
+        binding: bindingField("read"),
+        text: { type: "textarea", label: "Code" },
+        language: { type: "text", label: "Language label" },
+        maxHeight: { type: "number", label: "Max height (px)" },
+        ...conditionalFields()
+      },
+      defaultProps: { text: "", language: "" },
+      render: withConditions((props) => <CodeBlockWidget {...props} />)
+    },
+    Download: {
+      label: "Download",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        filename: { type: "text", label: "File name" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "Download",
+        filename: "",
+        placeholder: "Nothing to download yet"
+      },
+      render: withConditions((props) => <DownloadWidget {...props} />)
+    },
     // ── Inputs ──
     WorkflowInput: {
       label: "Workflow Input",
@@ -465,6 +587,73 @@ export const appConfig: Config = {
         options: [{ value: "Option A" }, { value: "Option B" }]
       },
       render: withConditions((props) => <SelectWidget {...props} />)
+    },
+    RadioGroup: {
+      label: "Radio Group",
+      fields: {
+        binding: bindingField("write"),
+        label: { type: "text", label: "Label" },
+        options: optionsField,
+        row: {
+          type: "radio",
+          label: "Layout",
+          options: [
+            { label: "Stacked", value: false },
+            { label: "Inline", value: true }
+          ]
+        },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "Choose",
+        row: false,
+        options: [{ value: "Option A" }, { value: "Option B" }]
+      },
+      render: withConditions((props) => <RadioGroupWidget {...props} />)
+    },
+    CheckboxGroup: {
+      label: "Checkbox Group",
+      fields: {
+        binding: bindingField("write"),
+        label: { type: "text", label: "Label" },
+        options: optionsField,
+        row: {
+          type: "radio",
+          label: "Layout",
+          options: [
+            { label: "Stacked", value: false },
+            { label: "Inline", value: true }
+          ]
+        },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "Select any",
+        row: false,
+        options: [{ value: "Option A" }, { value: "Option B" }]
+      },
+      render: withConditions((props) => <CheckboxGroupWidget {...props} />)
+    },
+    DateInput: {
+      label: "Date Input",
+      fields: {
+        binding: bindingField("write"),
+        label: { type: "text", label: "Label" },
+        withTime: {
+          type: "radio",
+          label: "Include time",
+          options: [
+            { label: "No", value: false },
+            { label: "Yes", value: true }
+          ]
+        },
+        events: eventsField("change"),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { label: "Date", withTime: false },
+      render: withConditions((props) => <DateInputWidget {...props} />)
     },
     ResourcePicker: {
       label: "Resource Picker",
@@ -572,11 +761,69 @@ export const appConfig: Config = {
         <ColumnsWidget gap={gap} left={left} right={right} />
       )
     },
+    Tabs: {
+      label: "Tabs",
+      fields: {
+        tab1Label: { type: "text", label: "Tab 1" },
+        tab1: { type: "slot" },
+        tab2Label: { type: "text", label: "Tab 2" },
+        tab2: { type: "slot" },
+        tab3Label: { type: "text", label: "Tab 3 (optional)" },
+        tab3: { type: "slot" }
+      },
+      defaultProps: {
+        tab1Label: "First",
+        tab2Label: "Second",
+        tab3Label: "",
+        tab1: [],
+        tab2: [],
+        tab3: []
+      },
+      render: ({ tab1Label, tab2Label, tab3Label, tab1, tab2, tab3 }) => (
+        <TabsWidget
+          tab1Label={tab1Label}
+          tab2Label={tab2Label}
+          tab3Label={tab3Label}
+          tab1={tab1}
+          tab2={tab2}
+          tab3={tab3}
+        />
+      )
+    },
+    Accordion: {
+      label: "Accordion",
+      fields: {
+        title: { type: "text", label: "Title" },
+        defaultOpen: {
+          type: "radio",
+          label: "Open by default",
+          options: [
+            { label: "Yes", value: true },
+            { label: "No", value: false }
+          ]
+        },
+        content: { type: "slot" }
+      },
+      defaultProps: { title: "Section", defaultOpen: true, content: [] },
+      render: ({ title, defaultOpen, content }) => (
+        <AccordionWidget
+          title={title}
+          defaultOpen={defaultOpen}
+          content={content}
+        />
+      )
+    },
     Divider: {
       label: "Divider",
       fields: {},
       defaultProps: {},
       render: () => <DividerWidget />
+    },
+    Spacer: {
+      label: "Spacer",
+      fields: { height: { type: "number", label: "Height (px)" } },
+      defaultProps: { height: 24 },
+      render: ({ height }) => <SpacerWidget height={height} />
     }
   }
 };

--- a/web/src/components/appbuilder/puck/widgets.tsx
+++ b/web/src/components/appbuilder/puck/widgets.tsx
@@ -11,14 +11,23 @@ import {
   SelectField,
   LabeledSwitch,
   EditorButton,
+  AlertBanner,
+  Checkbox,
+  CollapsibleSection,
+  TabGroup,
+  Label,
   Box,
   FlexColumn,
+  FlexRow,
   Card,
   DataTable,
   Divider,
   ProgressBar,
   Caption,
   SectionHeader,
+  FormGroup,
+  Radio,
+  RadioSet,
   BORDER_RADIUS,
   MOTION,
   SPACING,
@@ -494,6 +503,234 @@ export const ProgressWidget: React.FC<WidgetCommon & { label?: string }> = (
   );
 };
 
+/**
+ * A bound value shown as a message: an error output, a validation string, a
+ * status line. Renders nothing when the binding is empty, so pairing it with an
+ * error output gives an alert that appears only when the run fails.
+ */
+export const AlertWidget: React.FC<WidgetCommon & {
+  text?: string;
+  severity?: string;
+  title?: string;
+}> = (props) => {
+  const { value, designMode } = useBinding(props, "read");
+  const text =
+    props.formattedValue ?? (value != null ? str(value) : props.text ?? "");
+  if (!text && !designMode) return null;
+  const severity = (props.severity ?? "info") as
+    | "info"
+    | "success"
+    | "warning"
+    | "error";
+  return (
+    <AlertBanner
+      severity={severity}
+      variant="outlined"
+      title={props.title || undefined}
+      sx={{ width: "100%" }}
+    >
+      {text || "Alert"}
+    </AlertBanner>
+  );
+};
+
+export const CodeBlockWidget: React.FC<WidgetCommon & {
+  text?: string;
+  language?: string;
+  maxHeight?: number;
+}> = (props) => {
+  const { value } = useBinding(props, "read");
+  const parts = props.formattedValue
+    ? [props.formattedValue]
+    : value != null
+      ? asItems(value).map((item) =>
+          typeof item === "object" && item !== null
+            ? JSON.stringify(item, null, 2)
+            : str(item)
+        )
+      : [props.text ?? ""];
+  const text = parts.join("\n");
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.language ? (
+        <Caption color="secondary">{props.language}</Caption>
+      ) : null}
+      <Box
+        component="pre"
+        sx={{
+          m: 0,
+          width: "100%",
+          overflow: "auto",
+          maxHeight: props.maxHeight || undefined,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          fontFamily: "var(--fontFamily2, monospace)",
+          fontSize: "var(--fontSizeSmaller)",
+          backgroundColor: "action.hover",
+          borderRadius: BORDER_RADIUS.md,
+          p: SPACING.md
+        }}
+      >
+        {text}
+      </Box>
+    </FlexColumn>
+  );
+};
+
+/**
+ * An array binding as items. Table's sibling: Table wants rows with columns,
+ * this wants a value whose parts have no shared shape — a list of strings, a
+ * stream of results.
+ */
+export const ListWidget: React.FC<WidgetCommon & {
+  label?: string;
+  ordered?: boolean;
+  placeholder?: string;
+}> = (props) => {
+  const { value } = useBinding(props, "read");
+  const items = (
+    props.formattedValue ? [props.formattedValue] : asItems(value)
+  ).filter((item) => item != null && item !== "");
+  if (items.length === 0) {
+    return (
+      <Caption color="secondary">{props.placeholder ?? "No items yet"}</Caption>
+    );
+  }
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <Box
+        component={props.ordered ? "ol" : "ul"}
+        sx={{
+          m: 0,
+          pl: SPACING.xl,
+          display: "flex",
+          flexDirection: "column",
+          gap: SPACING.xs
+        }}
+      >
+        {items.map((item, index) => (
+          <Box component="li" key={index}>
+            <Text size="normal" sx={{ whiteSpace: "pre-wrap" }}>
+              {typeof item === "object" ? JSON.stringify(item) : str(item)}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+    </FlexColumn>
+  );
+};
+
+/**
+ * An object binding as label/value rows — the shape a single-result operation
+ * that emits a record has. A non-object value renders as one row.
+ */
+export const KeyValueWidget: React.FC<WidgetCommon & {
+  label?: string;
+  placeholder?: string;
+}> = (props) => {
+  const { value } = useBinding(props, "read");
+  const entries =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? Object.entries(value as Record<string, unknown>)
+      : value == null || value === ""
+        ? []
+        : [["value", value] as [string, unknown]];
+  if (entries.length === 0) {
+    return (
+      <Caption color="secondary">
+        {props.placeholder ?? "No values yet"}
+      </Caption>
+    );
+  }
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <FlexColumn gap={0} fullWidth>
+        {entries.map(([key, entry], index) => (
+          <FlexRow
+            key={key}
+            gap={SPACING.md}
+            justify="space-between"
+            align="flex-start"
+            fullWidth
+            sx={{
+              py: SPACING.sm,
+              ...(index > 0 ? { borderTop: "1px solid" } : {}),
+              borderColor: "divider"
+            }}
+          >
+            <Caption color="secondary">{key}</Caption>
+            <Text size="normal" sx={{ textAlign: "right", wordBreak: "break-word" }}>
+              {typeof entry === "object" && entry !== null
+                ? JSON.stringify(entry)
+                : str(entry)}
+            </Text>
+          </FlexRow>
+        ))}
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+/** One number the app wants read at a glance, with its label and a caption. */
+export const StatWidget: React.FC<WidgetCommon & {
+  label?: string;
+  caption?: string;
+  placeholder?: string;
+}> = (props) => {
+  const { value } = useBinding(props, "read");
+  const shown =
+    props.formattedValue ?? (value != null && value !== "" ? str(value) : "");
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <Text size="giant" weight={600}>
+        {shown || props.placeholder || "—"}
+      </Text>
+      {props.caption ? (
+        <Caption color="secondary">{props.caption}</Caption>
+      ) : null}
+    </FlexColumn>
+  );
+};
+
+/**
+ * Offers the bound value as a file instead of rendering it — the way to get a
+ * generated document, audio track, or dataset out of an app.
+ */
+export const DownloadWidget: React.FC<WidgetCommon & {
+  label?: string;
+  filename?: string;
+  placeholder?: string;
+}> = (props) => {
+  const { value, designMode } = useBinding(props, "read");
+  const href = resolveImageSrc(asItems(value)[0]);
+  if (!href && !designMode) {
+    return (
+      <Caption color="secondary">
+        {props.placeholder ?? "Nothing to download yet"}
+      </Caption>
+    );
+  }
+  return (
+    <EditorButton
+      size="medium"
+      variant="outlined"
+      density="normal"
+      href={href ?? undefined}
+      disabled={!href}
+      // A cross-origin href ignores `download` and navigates instead; opening
+      // in a new tab keeps the app's own page intact either way.
+      target="_blank"
+      rel="noopener"
+      download={props.filename || ""}
+    >
+      {props.label ?? "Download"}
+    </EditorButton>
+  );
+};
+
 // ── Input widgets ───────────────────────────────────────────────────────────
 
 export const TextInputWidget: React.FC<WidgetCommon & {
@@ -596,16 +833,22 @@ export const SwitchWidget: React.FC<WidgetCommon & { label?: string }> = (
   );
 };
 
+/** The author's option list, tolerating both `["a"]` and `[{ value: "a" }]`. */
+const optionValues = (options: unknown): string[] =>
+  Array.isArray(options)
+    ? options
+        .map((o) =>
+          typeof o === "string" ? o : (o as { value?: unknown } | null)?.value
+        )
+        .filter((o): o is string => typeof o === "string" && o.length > 0)
+    : [];
+
 export const SelectWidget: React.FC<WidgetCommon & {
   label?: string;
   options?: { value: string }[];
 }> = (props) => {
   const { value, setValue, emit } = useBinding(props, "write");
-  const options = Array.isArray(props.options)
-    ? props.options
-        .map((o) => (typeof o === "string" ? o : o?.value))
-        .filter((o): o is string => typeof o === "string" && o.length > 0)
-    : [];
+  const options = optionValues(props.options);
   return (
     <SelectField
       label={props.label ?? ""}
@@ -615,6 +858,94 @@ export const SelectWidget: React.FC<WidgetCommon & {
         setValue(v);
         emit("change");
       }}
+    />
+  );
+};
+
+export const RadioGroupWidget: React.FC<WidgetCommon & {
+  label?: string;
+  row?: boolean;
+  options?: { value: string }[];
+}> = (props) => {
+  const { value, setValue, emit } = useBinding(props, "write");
+  const options = optionValues(props.options);
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      {props.label ? <Label>{props.label}</Label> : null}
+      <RadioSet
+        row={Boolean(props.row)}
+        value={str(value)}
+        onChange={(_event, next) => {
+          setValue(next);
+          emit("change");
+        }}
+      >
+        {options.map((option) => (
+          <Radio key={option} value={option} label={option} size="small" compact />
+        ))}
+      </RadioSet>
+    </FlexColumn>
+  );
+};
+
+/**
+ * Writes the checked options as an array, so it binds to a list-typed input
+ * rather than to a scalar one.
+ */
+export const CheckboxGroupWidget: React.FC<WidgetCommon & {
+  label?: string;
+  row?: boolean;
+  options?: { value: string }[];
+}> = (props) => {
+  const { value, setValue, emit } = useBinding(props, "write");
+  const options = optionValues(props.options);
+  const selected = Array.isArray(value) ? value.map(str) : [];
+  const toggle = (option: string, checked: boolean) => {
+    // Rebuild from the option order rather than appending, so the written
+    // array reads the same way the control does.
+    const next = options.filter((o) =>
+      o === option ? checked : selected.includes(o)
+    );
+    setValue(next);
+    emit("change");
+  };
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      {props.label ? <Label>{props.label}</Label> : null}
+      <FormGroup row={Boolean(props.row)}>
+        {options.map((option) => (
+          <Checkbox
+            key={option}
+            label={option}
+            size="small"
+            compact
+            checked={selected.includes(option)}
+            onChange={(_event, checked) => toggle(option, checked)}
+          />
+        ))}
+      </FormGroup>
+    </FlexColumn>
+  );
+};
+
+export const DateInputWidget: React.FC<WidgetCommon & {
+  label?: string;
+  withTime?: boolean;
+}> = (props) => {
+  const { value, setValue, emit } = useBinding(props, "write");
+  return (
+    <TextInput
+      label={props.label ?? ""}
+      type={props.withTime ? "datetime-local" : "date"}
+      value={str(value)}
+      size="small"
+      fullWidth
+      InputLabelProps={{ shrink: true }}
+      onChange={(e) => {
+        setValue(e.target.value === "" ? null : e.target.value);
+        emit("change");
+      }}
+      onBlur={() => emit("change", "commit")}
     />
   );
 };
@@ -755,4 +1086,78 @@ export const DividerWidget: React.FC = () => (
   <Box sx={{ width: "100%", py: SPACING.xs }}>
     <Divider />
   </Box>
+);
+
+export const SpacerWidget: React.FC<{ height?: number }> = ({ height }) => (
+  <Box sx={{ width: "100%", height: numOr(height, SPACING_PX.xl) }} />
+);
+
+/**
+ * Three fixed slots, because Puck fields are declared statically. A tab with a
+ * blank label is dropped, so an app that wants two tabs just leaves the third
+ * label empty.
+ */
+export const TabsWidget: React.FC<{
+  tab1Label?: string;
+  tab2Label?: string;
+  tab3Label?: string;
+  tab1?: SlotComponent;
+  tab2?: SlotComponent;
+  tab3?: SlotComponent;
+}> = ({ tab1Label, tab2Label, tab3Label, tab1, tab2, tab3 }) => {
+  const panes = [
+    { value: "tab1", label: tab1Label, Slot: tab1 },
+    { value: "tab2", label: tab2Label, Slot: tab2 },
+    { value: "tab3", label: tab3Label, Slot: tab3 }
+  ].filter((pane) => (pane.label ?? "").trim().length > 0);
+  const [active, setActive] = React.useState("tab1");
+  // The author can empty a label at any time; fall back rather than render
+  // a tab strip with nothing selected.
+  const current = panes.some((pane) => pane.value === active)
+    ? active
+    : panes[0]?.value;
+
+  if (panes.length === 0) {
+    return <Caption color="secondary">Name a tab to show its content</Caption>;
+  }
+  return (
+    <FlexColumn gap={SPACING.lg} fullWidth>
+      <TabGroup
+        size="small"
+        value={current ?? "tab1"}
+        onChange={setActive}
+        tabs={panes.map((pane) => ({
+          value: pane.value,
+          label: pane.label ?? pane.value
+        }))}
+      />
+      {panes.map(({ value, Slot }) =>
+        // Slots stay mounted so a widget's view state and any run it started
+        // survive switching tabs; only the inactive ones are hidden.
+        Slot ? (
+          <Box
+            key={value}
+            hidden={value !== current}
+            sx={{ width: "100%", ...(value !== current && { display: "none" }) }}
+          >
+            <Slot style={slotStack} />
+          </Box>
+        ) : null
+      )}
+    </FlexColumn>
+  );
+};
+
+export const AccordionWidget: React.FC<{
+  title?: string;
+  defaultOpen?: boolean;
+  content?: SlotComponent;
+}> = ({ title, defaultOpen, content: Content }) => (
+  <CollapsibleSection
+    title={title || "Section"}
+    defaultOpen={defaultOpen !== false}
+    compact
+  >
+    {Content ? <Content style={slotStack} /> : null}
+  </CollapsibleSection>
 );

--- a/web/src/components/editor_ui/EditorButton.tsx
+++ b/web/src/components/editor_ui/EditorButton.tsx
@@ -31,6 +31,8 @@ export interface EditorButtonProps extends Omit<ButtonProps, "size"> {
   href?: string;
   target?: string;
   rel?: string;
+  /** Saves the href instead of navigating to it; "" keeps the server's name. */
+  download?: string;
 }
 
 /**

--- a/web/src/components/ui_primitives/Radio.tsx
+++ b/web/src/components/ui_primitives/Radio.tsx
@@ -1,0 +1,87 @@
+/**
+ * Radio Component
+ *
+ * A semantic wrapper around MUI Radio with label support, matching Checkbox.
+ * Used for one-of-many selections; wrap several in `RadioSet`.
+ */
+
+import React, { forwardRef, memo } from "react";
+import {
+  Radio as MuiRadio,
+  RadioProps as MuiRadioProps,
+  RadioGroup as MuiRadioGroup,
+  RadioGroupProps as MuiRadioGroupProps,
+  FormControlLabel,
+  FormControlLabelProps
+} from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+export interface RadioProps extends Omit<MuiRadioProps, "size"> {
+  /** Label text displayed next to the radio */
+  label?: React.ReactNode;
+  /** Size variant */
+  size?: "small" | "medium";
+  /** Compact mode reduces padding */
+  compact?: boolean;
+  /** Props forwarded to the FormControlLabel wrapper (only when label is provided) */
+  labelProps?: Partial<Omit<FormControlLabelProps, "control" | "label">>;
+}
+
+/**
+ * Radio - A themed radio button with optional label
+ *
+ * @example
+ * <Radio label="Fast" value="fast" checked={mode === "fast"} onChange={pick} />
+ */
+const RadioInternal = forwardRef<HTMLButtonElement, RadioProps>(
+  (
+    { label, size = "medium", compact = false, labelProps, sx, ...props },
+    ref
+  ) => {
+    const theme = useTheme();
+
+    const radio = (
+      <MuiRadio
+        ref={ref}
+        size={size}
+        sx={{
+          ...(compact && {
+            padding: theme.spacing(0.5)
+          }),
+          ...sx
+        }}
+        {...props}
+      />
+    );
+
+    if (label) {
+      return (
+        <FormControlLabel
+          control={radio}
+          label={label}
+          {...labelProps}
+          sx={{
+            ...(compact && {
+              marginLeft: -0.5,
+              "& .MuiFormControlLabel-label": {
+                fontSize: theme.fontSizeSmall
+              }
+            }),
+            ...labelProps?.sx
+          }}
+        />
+      );
+    }
+
+    return radio;
+  }
+);
+
+export const Radio = memo(RadioInternal);
+Radio.displayName = "Radio";
+
+export type RadioSetProps = MuiRadioGroupProps;
+
+/** The group wrapper that gives a set of `Radio`s one name and one value. */
+export const RadioSet = memo(MuiRadioGroup);
+RadioSet.displayName = "RadioSet";

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -334,6 +334,8 @@ export type { MobileBottomSheetProps } from "./MobileBottomSheet";
 
 export { Checkbox } from "./Checkbox";
 export type { CheckboxProps } from "./Checkbox";
+export { Radio, RadioSet } from "./Radio";
+export type { RadioProps, RadioSetProps } from "./Radio";
 
 export { ContextMenu } from "./ContextMenu";
 export type { ContextMenuProps } from "./ContextMenu";


### PR DESCRIPTION
Two gaps in the mini app builder: the widget palette stopped short of what apps actually need, and the non-UI half of an application document — its operations, variables, and resource bindings — had no human-facing editor at all. `AppBuilderShell` held `meta` in state, but the only thing that could write it was `PuckAgentBinder`, so declaring a variable or binding a second workflow meant asking the agent to do it.

## Widgets

Twelve new types, each declared once in `@nodetool-ai/app-runtime`'s `WIDGET_CATALOG` and implemented in both renderers (`web/src/components/appbuilder/puck/widgets.tsx` and `mobile/src/components/app_runtime/widgets.tsx`):

| Category | Widgets |
| --- | --- |
| Display | `Alert`, `CodeBlock`, `List`, `KeyValue`, `Stat`, `Download` |
| Inputs | `RadioGroup`, `CheckboxGroup`, `DateInput` |
| Layout | `Tabs`, `Accordion`, `Spacer` |

Notes on the ones with behaviour worth calling out:

- **Alert** renders nothing until its binding carries a value, so pairing it with an error output gives an alert that appears only when a run fails.
- **CheckboxGroup** writes the checked options as an array, rebuilt in the option list's own order rather than in click order, so it binds to a list-typed input.
- **Tabs** has three fixed slots (Puck fields are declared statically). A tab with a blank label is dropped. Every pane stays mounted and inactive ones are hidden — on both web and mobile — so a widget's view state and any run it started survive a tab switch.
- **Download** hands the bound ref to the browser as a file; on mobile it opens through `Linking`.
- **DateInput** is the one new control that settles on blur, so it is the only one that declares `commits: true` and can pace an action "on release".

Because the catalog is the shared contract, the CLI `app debug` harness and the `app-tools` evals pick these up without a second list to keep in step — that hand-copied list falling behind is what `WIDGET_CATALOG` was introduced to stop.

## App Data panel

`AppDataPanel.tsx` docks beside the canvas behind an **App Data** toggle in the editor header, listing the document's operations, variables, and resources with add/edit/remove for each:

- **Operations** — name, workflow (picked from the workflow list, keeping a pinned id selectable when the list no longer carries it), run policy, timeout.
- **Variables** — name, type, default, scope, and persistence. The persist switch is disabled on an instance-scoped variable and says why, rather than letting it flip back when `doc-ops` downgrades it.
- **Resources** — kind and project scope, with the add button gated on a scope being supplied.

Every edit calls app-runtime's `doc-ops` — the same pure functions the agent's `ui_app_*` tools call — so hand edits and agent edits produce identical documents.

## Primitives

Adds a `Radio`/`RadioSet` primitive mirroring the existing `Checkbox`, and a `download` prop on `EditorButton` alongside its `href`/`target`/`rel`, so the new widgets stay off raw MUI.

## Verification

- `npm run typecheck` — passes (web, electron, mobile)
- `npm run lint` — passes; no new warnings
- `npm run test` — passes
- New coverage: 15 web widget tests, 9 mobile parity tests, 7 panel tests, plus catalog assertions in `packages/app-runtime`

---
_Generated by [Claude Code](https://claude.ai/code/session_011YCbTTYFEbgnvQjYPm2rgj)_