### PR TITLE
Support every Puck component across the mini app system

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -441,7 +441,10 @@ slot-valued props on Panel/Columns) headlessly — those live in `web/`
 (`puckDataOps.ts`), which a backend package can't import. Its operation,
 variable, resource, and binding-target tools call the shared doc-ops in
 `@nodetool-ai/app-runtime` (`src/doc-ops.ts`), the same module the browser
-handler calls, so that half of the contract cannot drift.
+handler calls, so that half of the contract cannot drift. The widget types it
+offers come from `WIDGET_CATALOG` in the same package — every widget the editor
+ships, with the fields each accepts — so `ui_app_list_component_types` reports
+the same catalog headlessly that the browser reads off the live Puck config.
 
 ```bash
 npm run dev:nodetool -- eval timeline-tools --list

--- a/packages/agents/src/evals/surfaces/app.ts
+++ b/packages/agents/src/evals/surfaces/app.ts
@@ -15,10 +15,10 @@
  *
  * What it does NOT fork is the tool *contract*: names, descriptions, and Zod
  * parameter shapes are copied verbatim from the builtin file — the single
- * source of truth the browser tools also expose. The widget catalog mirrors the
- * Puck config (`web/src/components/appbuilder/puck/config.tsx`): a representative
- * set of display / input / action / layout widgets, with the layout widgets
- * (Panel, Columns) carrying the same slot fields the real editor nests into.
+ * source of truth the browser tools also expose. Nor does it fork the widget
+ * catalog: types, labels, fields, and slots come from `WIDGET_CATALOG`, the
+ * same table the Puck config is checked against, so a model driving this bridge
+ * sees every widget the editor offers.
  */
 
 import { z } from "zod";
@@ -34,6 +34,9 @@ import {
   removeVariable,
   updateOperation,
   updateVariable,
+  widgetFields,
+  widgetSlots,
+  WIDGET_CATALOG,
   type AppDocMeta,
   type BindableWorkflow,
   type InputMapping,
@@ -53,61 +56,11 @@ import type {
   ToolLoopEvalCase
 } from "../tool-loop-eval.js";
 
-/** One widget type in the catalog: its fields and which of them are slots. */
-interface WidgetTypeDef {
-  label: string;
-  /** Field name → field kind (text, textarea, number, select, slot, ...). */
-  fields: Record<string, string>;
-}
-
-/**
- * The widget catalog: the full component set from the Puck config
- * (`web/src/components/appbuilder/puck/config.tsx`), kept 1:1 so a model
- * discovering types via `ui_app_list_component_types` sees the same catalog the
- * browser exposes. Only the type/label/field-kind metadata the `ui_app_*` tools
- * surface matters here — render functions and default props are the browser's
- * concern. Layout widgets (Panel/Columns) carry `slot` fields; nesting a widget
- * targets one of them. Keep this in sync when the frontend config's components
- * change.
- */
-const WIDGET_TYPES: Record<string, WidgetTypeDef> = {
-  // ── Display ──
-  Heading: { label: "Heading", fields: { text: "text", level: "select", binding: "custom" } },
-  Text: { label: "Text", fields: { text: "textarea", binding: "custom" } },
-  Markdown: { label: "Markdown", fields: { text: "textarea", binding: "custom" } },
-  Image: { label: "Image", fields: { binding: "custom", fit: "select", height: "number", placeholder: "text" } },
-  Audio: { label: "Audio", fields: { binding: "custom", placeholder: "text" } },
-  Video: { label: "Video", fields: { binding: "custom", height: "number", placeholder: "text" } },
-  Json: { label: "JSON", fields: { binding: "custom" } },
-  Output: { label: "Output", fields: { binding: "custom", placeholder: "text" } },
-  Progress: { label: "Progress", fields: { label: "text", binding: "custom" } },
-  // ── Inputs ──
-  WorkflowInput: { label: "Workflow Input", fields: { binding: "custom", events: "array" } },
-  TextInput: { label: "Text Input", fields: { binding: "custom", label: "text", placeholder: "text", multiline: "radio", events: "array" } },
-  NumberInput: { label: "Number Input", fields: { binding: "custom", label: "text", min: "number", max: "number", step: "number", events: "array" } },
-  Slider: { label: "Slider", fields: { binding: "custom", label: "text", min: "number", max: "number", step: "number", events: "array" } },
-  Switch: { label: "Switch", fields: { binding: "custom", label: "text", events: "array" } },
-  Select: { label: "Select", fields: { binding: "custom", label: "text", options: "array", events: "array" } },
-  ImageInput: { label: "Image Input", fields: { binding: "custom", label: "text", events: "array" } },
-  AudioInput: { label: "Audio Input", fields: { binding: "custom", label: "text", events: "array" } },
-  VideoInput: { label: "Video Input", fields: { binding: "custom", label: "text", events: "array" } },
-  DocumentInput: { label: "Document Input", fields: { binding: "custom", label: "text", events: "array" } },
-  ColorInput: { label: "Color Input", fields: { binding: "custom", label: "text", events: "array" } },
-  // ── Actions ──
-  Button: { label: "Button", fields: { label: "text", variant: "select", color: "select", events: "array" } },
-  // ── Layout ──
-  Container: { label: "Panel", fields: { title: "text", content: "slot" } },
-  Columns: { label: "Columns", fields: { gap: "number", left: "slot", right: "slot" } },
-  Divider: { label: "Divider", fields: {} }
-};
-
-/** Map of widget type → its slot field names (mirrors `getSlotFields`). */
-const SLOT_FIELDS: Record<string, string[]> = Object.fromEntries(
-  Object.entries(WIDGET_TYPES).map(([type, def]) => [
+/** The widget types the tools expose, with the fields each one accepts. */
+const WIDGET_TYPES = Object.fromEntries(
+  Object.entries(WIDGET_CATALOG).map(([type, descriptor]) => [
     type,
-    Object.entries(def.fields)
-      .filter(([, kind]) => kind === "slot")
-      .map(([name]) => name)
+    { label: descriptor.label, fields: widgetFields(type) }
   ])
 );
 
@@ -171,7 +124,7 @@ function slotArrays(
   node: ComponentNode
 ): { slot: string; items: ComponentNode[] }[] {
   const result: { slot: string; items: ComponentNode[] }[] = [];
-  for (const slot of SLOT_FIELDS[node.type] ?? []) {
+  for (const slot of widgetSlots(node.type)) {
     const value = node.props[slot];
     if (Array.isArray(value)) {
       result.push({ slot, items: value as ComponentNode[] });
@@ -391,8 +344,9 @@ export function createAppToolBridge(
         "name) or directly to any node property (props.binding = " +
         "'node:<nodeId>#<property>'), display widgets to Output nodes or " +
         "Variables, and other state to Variables. Add those nodes first with the " +
-        "workflow tools. To nest inside a Panel or Columns widget, pass parent_id " +
-        "(and slot: 'content' | 'left' | 'right').",
+        "workflow tools. To nest inside a layout widget, pass parent_id and the " +
+        "slot it holds children in: Panel and Accordion use 'content', Columns " +
+        "'left' | 'right', Tabs 'tab1' | 'tab2' | 'tab3'.",
       z.object({
         application_id: applicationIdParam,
         type: z
@@ -406,12 +360,18 @@ export function createAppToolBridge(
           .string()
           .nullable()
           .optional()
-          .describe("Id of a Panel/Columns widget in this app to nest inside."),
+          .describe(
+            "Id of a layout widget (Panel, Columns, Tabs, Accordion) in this app to nest inside."
+          ),
         slot: z
           .string()
           .nullable()
           .optional()
-          .describe("Slot of the parent: 'content', 'left', or 'right'."),
+          .describe(
+            "Slot of the parent: 'content' (Panel, Accordion), 'left' | 'right' " +
+              "(Columns), or 'tab1' | 'tab2' | 'tab3' (Tabs). Defaults to the " +
+              "parent's first slot."
+          ),
         index: z
           .number()
           .int()
@@ -421,7 +381,7 @@ export function createAppToolBridge(
       async ({ application_id: _app, type, props, parent_id, slot, index }) => {
         // The real tool/handler doesn't validate `type` — Puck inserts whatever
         // string it's given — so the bridge stays permissive too. An unknown
-        // type just has no slots (SLOT_FIELDS lookup defaults to []).
+        // type just has no slots (widgetSlots defaults to []).
         const id = nextId(type as string);
         const node: ComponentNode = {
           type: type as string,
@@ -441,7 +401,7 @@ export function createAppToolBridge(
         } else {
           content = mapTree(content, (n) => {
             if (n.props.id !== parentId) return n;
-            const slots = SLOT_FIELDS[n.type] ?? [];
+            const slots = widgetSlots(n.type);
             const targetSlot =
               wanted && slots.includes(wanted) ? wanted : slots[0];
             if (!targetSlot) return n;
@@ -912,7 +872,7 @@ const APP_SYSTEM_PROMPT = `You are an assistant building a mini web app in the A
 The app is a tree of widgets bound to one or more workflows. Every ui_app_* tool takes the \`application_id\` of the app you are editing — the id named in the objective, never a workflow id. Use the ui_app_* tools:
 - Call ui_app_get_snapshot first to see the placed widgets, the page title, and the available widget types.
 - Call ui_app_list_component_types to learn valid widget \`type\` values and their props.
-- Add widgets with ui_app_add_component. To nest inside a Panel (Container) or Columns widget, pass parent_id and slot ('content', 'left', or 'right').
+- Add widgets with ui_app_add_component. To nest inside a layout widget, pass parent_id and the slot it holds children in: Panel (Container) and Accordion use 'content', Columns 'left'/'right', Tabs 'tab1'/'tab2'/'tab3'.
 - Edit a widget's props with ui_app_update_component (its id cannot change); remove one with ui_app_remove_component.
 - Set the page title with ui_app_set_title.
 
@@ -1139,6 +1099,59 @@ export const APP_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<AppBridgeFinalState>
               s.components.some(
                 (c) =>
                   c.id === "switch-1" && c.props.binding === "var:dark_mode"
+              )
+          }
+        ]
+      }
+    },
+    {
+      // The widget the objective needs is only reachable if the model reads the
+      // catalog: Table and Tabs are not in the handful of types the tool
+      // descriptions name.
+      id: "tabbed-results",
+      description:
+        "Discover a display widget beyond the examples and nest it in a Tabs slot",
+      objective:
+        "Put a Table of the workflow's rows output in the first tab of the app's Tabs widget.",
+      createBridge: () =>
+        createAppToolBridge({
+          workflowId: "wf-app",
+          workflow: {
+            inputs: [],
+            outputs: [{ nodeId: "out-1", name: "rows", label: "Rows" }],
+            variables: []
+          },
+          components: [{ type: "Tabs", id: "tabs-1", props: { tab1Label: "Results" } }]
+        }),
+      systemPrompt: APP_SYSTEM_PROMPT,
+      userPrompt:
+        "Objective: App 'app-1' (application_id 'app-1') has a Tabs widget (id 'tabs-1') whose first tab is empty. " +
+        "The workflow emits a list of rows. Add a widget that shows those rows as a table inside the first tab, " +
+        "and bind it to the rows output — look the widget type and the binding token up with the tools rather than guessing.",
+      expect: {
+        requiredTools: ["ui_app_add_component"],
+        noErrorResults: true,
+        minToolCalls: 2,
+        maxToolCalls: 12,
+        finalState: [
+          {
+            name: "tableInFirstTab",
+            detail: "no Table widget nested in the Tabs widget's tab1 slot",
+            test: (s) =>
+              s.components.some(
+                (c) =>
+                  c.type === "Table" &&
+                  c.parentId === "tabs-1" &&
+                  c.slot === "tab1"
+              )
+          },
+          {
+            name: "tableBoundToRowsOutput",
+            detail: "the Table is not bound to op:main/out:out-1",
+            test: (s) =>
+              s.components.some(
+                (c) =>
+                  c.type === "Table" && c.props.binding === "op:main/out:out-1"
               )
           }
         ]

--- a/packages/agents/tests/app-tool-loop.test.ts
+++ b/packages/agents/tests/app-tool-loop.test.ts
@@ -12,6 +12,7 @@ import type {
   ProviderStreamItem,
   ProviderTool
 } from "@nodetool-ai/runtime";
+import { WIDGET_CATALOG } from "@nodetool-ai/app-runtime";
 import { runToolLoopEval } from "../src/evals/tool-loop-eval.js";
 import {
   createAppToolBridge,
@@ -131,6 +132,46 @@ describe("createAppToolBridge", () => {
       "left",
       "right"
     ]);
+  });
+
+  it("offers every widget in the shared catalog, not a subset", async () => {
+    // This list used to be a hand-copied subset, so a model driving the bridge
+    // never saw the widgets the editor had gained since (Table, Tabs, the
+    // resource widgets, …) and the eval scored a smaller surface than ships.
+    const bridge = createAppToolBridge();
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    const listed = (await byName["ui_app_list_component_types"].execute({
+      application_id: APP
+    })) as {
+      types: { type: string; label: string; fields: { name: string }[] }[];
+    };
+    expect(listed.types.map((t) => t.type).sort()).toEqual(
+      Object.keys(WIDGET_CATALOG).sort()
+    );
+    const table = listed.types.find((t) => t.type === "Table");
+    expect(table?.label).toBe("Table");
+    expect(table?.fields.map((f) => f.name)).toContain("binding");
+
+    const snap = (await byName["ui_app_get_snapshot"].execute({
+      application_id: APP
+    })) as { componentTypes: string[] };
+    expect(snap.componentTypes.sort()).toEqual(Object.keys(WIDGET_CATALOG).sort());
+  });
+
+  it("nests a widget inside the Tabs widget's slots", async () => {
+    const bridge = createAppToolBridge({
+      components: [{ type: "Tabs", id: "tabs-1" }]
+    });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    await byName["ui_app_add_component"].execute({
+      application_id: APP,
+      type: "Table",
+      parent_id: "tabs-1",
+      slot: "tab2"
+    });
+    const nested = bridge.finalState().components.find((c) => c.type === "Table");
+    expect(nested).toMatchObject({ parentId: "tabs-1", slot: "tab2" });
   });
 
   it("nests a widget inside a Panel's content slot", async () => {
@@ -624,6 +665,34 @@ describe("APP_TOOL_LOOP_CASES", () => {
       provider: createScriptedProvider(script),
       model: "test-model",
       cases: [APP_TOOL_LOOP_CASES[4]]
+    });
+    const r = report.cases[0];
+    expect(r.accepted).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("tabbed-results: nesting a Table in the Tabs widget's first tab passes", async () => {
+    const script: ScriptedCall[] = [
+      { name: "ui_app_list_component_types", args: { application_id: APP } },
+      {
+        name: "ui_app_get_binding_targets",
+        args: { application_id: APP }
+      },
+      {
+        name: "ui_app_add_component",
+        args: {
+          application_id: APP,
+          type: "Table",
+          parent_id: "tabs-1",
+          slot: "tab1",
+          props: { binding: "op:main/out:out-1" }
+        }
+      }
+    ];
+    const report = await runToolLoopEval({
+      provider: createScriptedProvider(script),
+      model: "test-model",
+      cases: [APP_TOOL_LOOP_CASES[5]]
     });
     const r = report.cases[0];
     expect(r.accepted).toBe(true);

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -10,6 +10,20 @@
 /** How a widget participates in the reactive layer. */
 export type WidgetBindingMode = "read" | "write" | "action" | "layout";
 
+/**
+ * Editor field kinds, matching Puck's field `type`. `custom` covers the binding,
+ * variable, condition, and resource pickers the editor renders itself.
+ */
+export type WidgetFieldKind =
+  | "text"
+  | "textarea"
+  | "number"
+  | "select"
+  | "radio"
+  | "array"
+  | "slot"
+  | "custom";
+
 export interface WidgetDescriptor {
   /** Palette label, matching the editor. */
   label: string;
@@ -23,134 +37,402 @@ export interface WidgetDescriptor {
   commits?: boolean;
   /** Props holding child widgets, for tree traversal. */
   slots?: ReadonlyArray<string>;
+  /**
+   * The widget's own editor fields, name → kind. The three logic props every
+   * widget shares are not listed here — `widgetFields` adds them.
+   */
+  fields: Readonly<Record<string, WidgetFieldKind>>;
+  /**
+   * True when the widget renders a value a `format` template can rewrite. Media
+   * and control widgets show no formattable text, so the editor omits the field.
+   */
+  format?: boolean;
 }
 
 export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   // Display
-  Heading: { label: "Heading", mode: "read" },
-  Text: { label: "Text", mode: "read" },
-  Markdown: { label: "Markdown", mode: "read" },
-  Image: { label: "Image", mode: "read" },
-  Audio: { label: "Audio", mode: "read" },
-  Video: { label: "Video", mode: "read" },
-  Json: { label: "JSON", mode: "read" },
+  Heading: {
+    label: "Heading",
+    mode: "read",
+    format: true,
+    fields: { text: "text", level: "select", binding: "custom" }
+  },
+  Text: {
+    label: "Text",
+    mode: "read",
+    format: true,
+    fields: { text: "textarea", binding: "custom" }
+  },
+  Markdown: {
+    label: "Markdown",
+    mode: "read",
+    format: true,
+    fields: { text: "textarea", binding: "custom" }
+  },
+  Image: {
+    label: "Image",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      fit: "select",
+      height: "number",
+      placeholder: "text"
+    }
+  },
+  Audio: {
+    label: "Audio",
+    mode: "read",
+    fields: { binding: "custom", placeholder: "text" }
+  },
+  Video: {
+    label: "Video",
+    mode: "read",
+    fields: { binding: "custom", height: "number", placeholder: "text" }
+  },
+  Json: { label: "JSON", mode: "read", format: true, fields: { binding: "custom" } },
   // Lays out an array value as rows — what a run that emits N results needs.
-  Table: { label: "Table", mode: "read" },
-  Output: { label: "Output", mode: "read" },
-  Progress: { label: "Progress", mode: "read" },
+  Table: {
+    label: "Table",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      label: "text",
+      maxHeight: "number",
+      placeholder: "text"
+    }
+  },
+  Output: {
+    label: "Output",
+    mode: "read",
+    format: true,
+    fields: { binding: "custom", placeholder: "text" }
+  },
+  Progress: {
+    label: "Progress",
+    mode: "read",
+    fields: { label: "text", binding: "custom" }
+  },
   // Reads a bound value as a message rather than as content: an error output,
   // a validation string, a status line the app wants to draw attention to.
-  Alert: { label: "Alert", mode: "read" },
-  CodeBlock: { label: "Code", mode: "read" },
+  Alert: {
+    label: "Alert",
+    mode: "read",
+    format: true,
+    fields: {
+      binding: "custom",
+      text: "textarea",
+      title: "text",
+      severity: "select"
+    }
+  },
+  CodeBlock: {
+    label: "Code",
+    mode: "read",
+    format: true,
+    fields: {
+      binding: "custom",
+      text: "textarea",
+      language: "text",
+      maxHeight: "number"
+    }
+  },
   // Lays out an array value as items; Table's sibling for values that have no
   // columns.
-  List: { label: "List", mode: "read" },
+  List: {
+    label: "List",
+    mode: "read",
+    format: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      ordered: "radio",
+      placeholder: "text"
+    }
+  },
   // An object value as label/value rows — what a single-result operation that
   // emits a record usually wants.
-  KeyValue: { label: "Key/Value", mode: "read" },
-  Stat: { label: "Stat", mode: "read" },
+  KeyValue: {
+    label: "Key/Value",
+    mode: "read",
+    fields: { binding: "custom", label: "text", placeholder: "text" }
+  },
+  Stat: {
+    label: "Stat",
+    mode: "read",
+    format: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      caption: "text",
+      placeholder: "text"
+    }
+  },
   // Offers the bound media/document ref as a file rather than rendering it.
-  Download: { label: "Download", mode: "read" },
+  Download: {
+    label: "Download",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      label: "text",
+      filename: "text",
+      placeholder: "text"
+    }
+  },
   // Inputs
   WorkflowInput: {
     label: "Workflow Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
-  TextInput: { label: "Text Input", mode: "write", trigger: "change", commits: true },
+  TextInput: {
+    label: "Text Input",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      placeholder: "text",
+      multiline: "radio",
+      events: "array"
+    }
+  },
   NumberInput: {
     label: "Number Input",
     mode: "write",
     trigger: "change",
-    commits: true
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      min: "number",
+      max: "number",
+      step: "number",
+      events: "array"
+    }
   },
-  Slider: { label: "Slider", mode: "write", trigger: "change", commits: true },
-  Switch: { label: "Switch", mode: "write", trigger: "change", commits: false },
-  Select: { label: "Select", mode: "write", trigger: "change", commits: false },
+  Slider: {
+    label: "Slider",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      min: "number",
+      max: "number",
+      step: "number",
+      events: "array"
+    }
+  },
+  Switch: {
+    label: "Switch",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
+  },
+  Select: {
+    label: "Select",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: {
+      binding: "custom",
+      label: "text",
+      options: "array",
+      events: "array"
+    }
+  },
   RadioGroup: {
     label: "Radio Group",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: {
+      binding: "custom",
+      label: "text",
+      options: "array",
+      row: "radio",
+      events: "array"
+    }
   },
   // Writes an array of the checked options, so it binds to a list-typed input.
   CheckboxGroup: {
     label: "Checkbox Group",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: {
+      binding: "custom",
+      label: "text",
+      options: "array",
+      row: "radio",
+      events: "array"
+    }
   },
   // A date control settles on blur, so "on release" pacing is meaningful.
   DateInput: {
     label: "Date Input",
     mode: "write",
     trigger: "change",
-    commits: true
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      withTime: "radio",
+      events: "array"
+    }
   },
   ImageInput: {
     label: "Image Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
   AudioInput: {
     label: "Audio Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
   VideoInput: {
     label: "Video Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
   DocumentInput: {
     label: "Document Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
   ColorInput: {
     label: "Color Input",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
   },
+  // Resource widgets address a collection through `resourceBindingId`, not the
+  // `binding` token the state widgets carry.
   ResourcePicker: {
     label: "Resource Picker",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: { resourceBindingId: "custom", label: "text" }
   },
   ResourceGallery: {
     label: "Resource Gallery",
     mode: "write",
     trigger: "change",
-    commits: false
+    commits: false,
+    fields: {
+      resourceBindingId: "custom",
+      label: "text",
+      tileSize: "number"
+    }
   },
   // Edits the bound document through the resource provider rather than app
   // state, so it emits no event of its own.
-  StoryboardSceneList: { label: "Storyboard Scenes", mode: "write" },
+  StoryboardSceneList: {
+    label: "Storyboard Scenes",
+    mode: "write",
+    fields: {
+      resourceBindingId: "custom",
+      label: "text",
+      allowRemove: "radio"
+    }
+  },
   // Actions
-  Button: { label: "Button", mode: "action", trigger: "click" },
+  Button: {
+    label: "Button",
+    mode: "action",
+    trigger: "click",
+    fields: {
+      label: "text",
+      variant: "select",
+      color: "select",
+      events: "array"
+    }
+  },
   // Layout
-  Container: { label: "Panel", mode: "layout", slots: ["content"] },
-  Columns: { label: "Columns", mode: "layout", slots: ["left", "right"] },
+  Container: {
+    label: "Panel",
+    mode: "layout",
+    slots: ["content"],
+    fields: { title: "text", content: "slot" }
+  },
+  Columns: {
+    label: "Columns",
+    mode: "layout",
+    slots: ["left", "right"],
+    fields: { gap: "number", left: "slot", right: "slot" }
+  },
   // Three fixed slots rather than a variable number: Puck fields are declared
   // statically, and three tabs cover what a mini app does without a nested
   // array-of-slots field the agent would have to reason about.
-  Tabs: { label: "Tabs", mode: "layout", slots: ["tab1", "tab2", "tab3"] },
-  Accordion: { label: "Accordion", mode: "layout", slots: ["content"] },
-  Spacer: { label: "Spacer", mode: "layout" },
-  Divider: { label: "Divider", mode: "layout" }
+  Tabs: {
+    label: "Tabs",
+    mode: "layout",
+    slots: ["tab1", "tab2", "tab3"],
+    fields: {
+      tab1Label: "text",
+      tab1: "slot",
+      tab2Label: "text",
+      tab2: "slot",
+      tab3Label: "text",
+      tab3: "slot"
+    }
+  },
+  Accordion: {
+    label: "Accordion",
+    mode: "layout",
+    slots: ["content"],
+    fields: { title: "text", defaultOpen: "radio", content: "slot" }
+  },
+  Spacer: { label: "Spacer", mode: "layout", fields: { height: "number" } },
+  Divider: { label: "Divider", mode: "layout", fields: {} }
 };
 
 export const widgetMode = (type: string): WidgetBindingMode | "unknown" =>
   WIDGET_CATALOG[type]?.mode ?? "unknown";
 
 export const isKnownWidget = (type: string): boolean => type in WIDGET_CATALOG;
+
+/**
+ * Every field a widget's inspector shows: its own, plus the logic props each
+ * non-layout widget shares. Layout widgets carry no bindings and no conditions,
+ * so nothing is appended to them.
+ *
+ * This is what `ui_app_list_component_types` reports, on both the browser
+ * surface and the headless eval bridge, so an agent sees one catalog.
+ */
+export const widgetFields = (
+  type: string
+): Readonly<Record<string, WidgetFieldKind>> => {
+  const descriptor = WIDGET_CATALOG[type];
+  if (!descriptor) return {};
+  if (descriptor.mode === "layout") return descriptor.fields;
+  return {
+    ...descriptor.fields,
+    visibleWhen: "custom",
+    disabledWhen: "custom",
+    ...(descriptor.format ? { format: "text" as const } : {})
+  };
+};
+
+/** Slot field names of a widget — the props children nest into. */
+export const widgetSlots = (type: string): ReadonlyArray<string> =>
+  WIDGET_CATALOG[type]?.slots ?? [];
 
 /** Props every widget accepts on top of its own fields. */
 export interface CommonWidgetProps {

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { WIDGET_CATALOG, isKnownWidget, widgetMode } from "../src/widgets.js";
+import {
+  WIDGET_CATALOG,
+  isKnownWidget,
+  widgetFields,
+  widgetMode,
+  widgetSlots
+} from "../src/widgets.js";
 
 describe("widget catalog", () => {
   it("covers every widget the editor palette offers", () => {
@@ -71,8 +77,52 @@ describe("widget catalog", () => {
 
 describe("Table", () => {
   it("is a read widget, so it binds an output slot", () => {
-    expect(WIDGET_CATALOG.Table).toEqual({ label: "Table", mode: "read" });
+    expect(WIDGET_CATALOG.Table.label).toBe("Table");
     expect(widgetMode("Table")).toBe("read");
     expect(isKnownWidget("Table")).toBe(true);
+  });
+});
+
+describe("widgetFields", () => {
+  it("appends the logic props every bindable widget carries", () => {
+    expect(widgetFields("Heading")).toEqual({
+      text: "text",
+      level: "select",
+      binding: "custom",
+      visibleWhen: "custom",
+      disabledWhen: "custom",
+      format: "text"
+    });
+  });
+
+  it("omits the format template on widgets that render no formattable value", () => {
+    // A media widget shows a ref, not text — a template has nothing to rewrite.
+    expect(widgetFields("Image").format).toBeUndefined();
+    expect(widgetFields("Image").visibleWhen).toBe("custom");
+    expect(widgetFields("Slider").format).toBeUndefined();
+  });
+
+  it("gives layout widgets their own fields only", () => {
+    expect(widgetFields("Columns")).toEqual({
+      gap: "number",
+      left: "slot",
+      right: "slot"
+    });
+    expect(widgetFields("Divider")).toEqual({});
+  });
+
+  it("declares fields for every widget in the catalog", () => {
+    for (const [type, descriptor] of Object.entries(WIDGET_CATALOG)) {
+      expect(descriptor.fields, type).toBeDefined();
+      // Slots are children props, so each one must be a declared slot field.
+      for (const slot of widgetSlots(type)) {
+        expect(descriptor.fields[slot], `${type}.${slot}`).toBe("slot");
+      }
+    }
+  });
+
+  it("reports no fields for an unknown type rather than throwing", () => {
+    expect(widgetFields("Bogus")).toEqual({});
+    expect(widgetSlots("Bogus")).toEqual([]);
   });
 });

--- a/packages/cli/src/app-debug/app-spec.ts
+++ b/packages/cli/src/app-debug/app-spec.ts
@@ -109,6 +109,13 @@ export function bindingScopeFor(io: AppIO, context?: AppContext): BindingScope {
   };
 }
 
+/**
+ * True for the widgets the catalog gives a `resourceBindingId` field — the ones
+ * that read a document collection through the resource provider.
+ */
+const usesResourceBinding = (type: string): boolean =>
+  WIDGET_CATALOG[type]?.fields.resourceBindingId !== undefined;
+
 const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
   mode === "write" ? "write" : mode === "read" ? "read" : "none";
 
@@ -223,6 +230,11 @@ export function parseAppSpec(
       const id = str(item.props.id) ?? `${item.type}-${widgets.length}`;
       const bindingMode = widgetMode(item.type);
       const binding = str(item.props.binding) || null;
+      // A resource widget addresses a collection, not app state, so it carries
+      // `resourceBindingId` where the state widgets carry `binding`.
+      const resourceBindingId = usesResourceBinding(item.type)
+        ? str(item.props.resourceBindingId) || null
+        : null;
       const ref: BindingRef | null = binding
         ? resolveBinding(binding, scope, modeToBindingMode(bindingMode))
         : bindingMode === "write"
@@ -238,6 +250,7 @@ export function parseAppSpec(
         ref,
         stateKey: ref ? stateKey(ref) : null,
         canonicalBinding: ref ? encodeBinding(ref) : null,
+        resourceBindingId,
         label: str(item.props.label) ?? str(item.props.text) ?? null,
         events: parseEvents(item.props.events),
         parentId,
@@ -398,8 +411,21 @@ export function validateApp(
           ? `${where}: bound to "${w.binding}" but the workflow has no input node or node property that resolves it.`
           : `${where}: bound to "${w.binding}" but the workflow has no output or variable with that name.`
       );
-    } else if (!w.binding && w.bindingMode === "write") {
+    } else if (!w.binding && w.bindingMode === "write" && !usesResourceBinding(w.type)) {
       warnings.push(`${where}: not bound to an input — its value stays local UI state.`);
+    }
+    // A resource widget with no collection behind it renders an empty picker
+    // the user can never choose from, which a run-only check never surfaces.
+    if (usesResourceBinding(w.type)) {
+      if (!w.resourceBindingId) {
+        errors.push(
+          `${where}: no resource binding selected — the widget has no collection to show. Add one with a resource binding.`
+        );
+      } else if (!resourceIds.has(w.resourceBindingId)) {
+        errors.push(
+          `${where}: bound to resource "${w.resourceBindingId}" but the app declares no such resource binding.`
+        );
+      }
     }
     // An explicit `op:<id>/…` token resolves on its own syntax, so a token
     // naming an operation the document never declared has to be caught here.

--- a/packages/cli/src/app-debug/types.ts
+++ b/packages/cli/src/app-debug/types.ts
@@ -50,6 +50,12 @@ export interface AppWidgetSpec {
   stateKey: string | null;
   /** {@link ref} re-encoded in ID form — what a migrated document should store. */
   canonicalBinding: string | null;
+  /**
+   * For a resource widget (picker, gallery, scene list), the resource binding
+   * it addresses. These widgets read a document collection instead of app
+   * state, so this is their binding rather than {@link binding}.
+   */
+  resourceBindingId: string | null;
   label: string | null;
   events: AppEventSpec[];
   parentId: string | null;

--- a/packages/cli/tests/app-debug-spec.test.ts
+++ b/packages/cli/tests/app-debug-spec.test.ts
@@ -246,6 +246,68 @@ describe("validateApp", () => {
     expect(warnings.join("\n")).toMatch(/constant with no value/);
   });
 
+  it("flags a resource widget whose collection the app never declares", () => {
+    const doc = {
+      schemaVersion: 3,
+      ui: { root: { props: {} }, content: [
+        widget("ResourceGallery", "ResourceGallery-1", {
+          resourceBindingId: "shots"
+        }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ], zones: {} },
+      operations: [],
+      variables: [],
+      resources: []
+    };
+    const { spec } = parseAppSpec(doc, io);
+    expect(spec?.widgets[0].resourceBindingId).toBe("shots");
+    const { errors, warnings } = validateApp(spec!, io);
+    expect(errors.join("\n")).toMatch(/no such resource binding/);
+    // Its value is not app state, so the local-UI-state warning must not fire.
+    expect(warnings.join("\n")).not.toMatch(/local UI state/);
+  });
+
+  it("flags a resource widget with no collection selected at all", () => {
+    const doc = {
+      schemaVersion: 3,
+      ui: { root: { props: {} }, content: [
+        widget("ResourcePicker", "ResourcePicker-1", { resourceBindingId: "" }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ], zones: {} },
+      operations: [],
+      variables: [],
+      resources: []
+    };
+    const { spec } = parseAppSpec(doc, io);
+    const { errors } = validateApp(spec!, io);
+    expect(errors.join("\n")).toMatch(/no resource binding selected/);
+  });
+
+  it("accepts a resource widget bound to a declared collection", () => {
+    const doc = {
+      schemaVersion: 3,
+      ui: { root: { props: {} }, content: [
+        widget("StoryboardSceneList", "StoryboardSceneList-1", {
+          resourceBindingId: "board"
+        }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ], zones: {} },
+      operations: [],
+      variables: [],
+      resources: [
+        {
+          id: "board",
+          name: "Board",
+          kind: "storyboard",
+          scope: { projectId: "p1" },
+          operations: []
+        }
+      ]
+    };
+    const { spec } = parseAppSpec(doc, io);
+    expect(validateApp(spec!, io).errors).toEqual([]);
+  });
+
   it("warns on an unbound write widget (local-only state)", () => {
     const { spec } = parseAppSpec(
       appDoc([

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -25,11 +25,16 @@ framework-independent core the web runtime, the CLI `app debug` harness, and the
   node in the graph editor does not break an app. Bare names still resolve —
   that is the legacy `workflow.app_doc` form, read on import only.
 - The **widget catalog** lives in `@nodetool-ai/app-runtime` (`src/widgets.ts`)
-  — one table the Puck config, the CLI `app debug` harness, the `app-tools`
-  evals, and the mobile renderer all read. A new widget is added there first,
-  then implemented in `puck/widgets.tsx` and in
-  `mobile/src/components/app_runtime/widgets.tsx`; a type missing from either
-  renderer shows as an unknown widget on that surface.
+  — one table carrying each type's label, binding mode, editor fields, and
+  slots, read by the CLI `app debug` harness, the `app-tools` eval bridge (what
+  `ui_app_list_component_types` reports headlessly), and the mobile renderer. A
+  new widget is added there first, then implemented in `puck/config.tsx` +
+  `puck/widgets.tsx` and in `mobile/src/components/app_runtime/widgets.tsx`; a
+  type missing from either renderer shows as an unknown widget on that surface.
+  The Puck config declares its own fields (it holds the render functions and
+  default props), so `puck/__tests__/configCatalog.test.ts` asserts the two
+  agree type for type and field for field — that test is what keeps the agent
+  from being offered a widget the editor cannot place, or the reverse.
 - **Widgets** bind one slot (read for displays, two-way for inputs) and emit
   **events** (`click` / `change`) that dispatch **actions** (`run`, `cancel`,
   `setVariable`, `toggleVariable`, `resourceCommand`, `openResource`). A `run`

--- a/web/src/components/appbuilder/puck/__tests__/configCatalog.test.ts
+++ b/web/src/components/appbuilder/puck/__tests__/configCatalog.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The Puck config and the shared widget catalog describe the same components.
+ *
+ * `WIDGET_CATALOG` is what the CLI `app debug` harness, the mobile renderer and
+ * the headless `app-tools` bridge read; this config is what the editor renders.
+ * When they drift, an agent is offered widgets the editor cannot place — or
+ * places widgets the harness rejects as unknown. This test is the only thing
+ * holding the two together, so it compares them field by field.
+ */
+import type { Config } from "@puckeditor/core";
+import { WIDGET_CATALOG, widgetFields } from "@nodetool-ai/app-runtime";
+
+import { appConfig } from "../config";
+
+const components = (appConfig as Config).components as Record<
+  string,
+  { label?: string; fields?: Record<string, { type?: string }> }
+>;
+
+const fieldKinds = (type: string): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(components[type].fields ?? {}).map(([name, field]) => [
+      name,
+      field?.type ?? "unknown"
+    ])
+  );
+
+describe("Puck config ↔ widget catalog", () => {
+  it("offers exactly the widget types the catalog declares", () => {
+    expect(Object.keys(components).sort()).toEqual(
+      Object.keys(WIDGET_CATALOG).sort()
+    );
+  });
+
+  it("puts every component in a palette category", () => {
+    const categorized = Object.values(appConfig.categories ?? {}).flatMap(
+      (category) => category?.components ?? []
+    );
+    expect([...categorized].sort()).toEqual(Object.keys(components).sort());
+  });
+
+  it.each(Object.keys(WIDGET_CATALOG))("matches the catalog for %s", (type) => {
+    expect(components[type].label).toBe(WIDGET_CATALOG[type].label);
+    expect(fieldKinds(type)).toEqual(widgetFields(type));
+  });
+
+  it("declares each layout widget's slots as slot fields", () => {
+    for (const [type, descriptor] of Object.entries(WIDGET_CATALOG)) {
+      const slots = Object.entries(fieldKinds(type))
+        .filter(([, kind]) => kind === "slot")
+        .map(([name]) => name);
+      expect(slots).toEqual([...(descriptor.slots ?? [])]);
+    }
+  });
+});

--- a/web/src/lib/tools/builtin/puck.ts
+++ b/web/src/lib/tools/builtin/puck.ts
@@ -59,8 +59,9 @@ FrontendToolRegistry.register({
     "name) or directly to any node property (props.binding = " +
     "'node:<nodeId>#<property>'), display widgets to Output nodes or " +
     "Variables, and other state to Variables. Add those nodes first with the " +
-    "workflow tools. To nest inside a Panel or Columns widget, pass parent_id " +
-    "(and slot: 'content' | 'left' | 'right').",
+    "workflow tools. To nest inside a layout widget, pass parent_id and the " +
+    "slot it holds children in: Panel and Accordion use 'content', Columns " +
+    "'left' | 'right', Tabs 'tab1' | 'tab2' | 'tab3'.",
   parameters: z.object({
     application_id: applicationIdParam,
     type: z
@@ -74,12 +75,18 @@ FrontendToolRegistry.register({
       .string()
       .nullable()
       .optional()
-      .describe("Id of a Panel/Columns widget in this app to nest inside."),
+      .describe(
+        "Id of a layout widget (Panel, Columns, Tabs, Accordion) in this app to nest inside."
+      ),
     slot: z
       .string()
       .nullable()
       .optional()
-      .describe("Slot of the parent: 'content', 'left', or 'right'."),
+      .describe(
+        "Slot of the parent: 'content' (Panel, Accordion), 'left' | 'right' " +
+          "(Columns), or 'tab1' | 'tab2' | 'tab3' (Tabs). Defaults to the " +
+          "parent's first slot."
+      ),
     index: z
       .number()
       .int()


### PR DESCRIPTION
## What

Every component the App Builder's Puck config ships is now supported everywhere the mini app system consumes a document — the shared catalog, the CLI `app debug` harness, the mobile renderer, and the agent's tool surface.

The gap was the agent's headless App Builder surface (`packages/agents/src/evals/surfaces/app.ts`), which kept a hand-copied widget table 16 types behind the editor. `Table`, `List`, `KeyValue`, `Stat`, `Alert`, `CodeBlock`, `Download`, `RadioGroup`, `CheckboxGroup`, `DateInput`, `ResourcePicker`, `ResourceGallery`, `StoryboardSceneList`, `Tabs`, `Accordion` and `Spacer` could be placed on the canvas but never appeared in `ui_app_list_component_types`, so a model driving the `app-tools` eval could not use them. The tool descriptions were behind too: they named the Panel/Columns slots only, so `Tabs` and `Accordion` were effectively un-nestable.

## Changes

- **`@nodetool-ai/app-runtime`** — `WIDGET_CATALOG` now carries each type's editor fields (name → Puck field kind) and whether it takes a `format` template, plus `widgetFields` / `widgetSlots` accessors. It was already the source of truth for mode, trigger and slots; it now covers what an agent needs to fill a widget in.
- **Eval bridge** — derives its types, labels, fields and slots from the catalog instead of its own copy. A new `tabbed-results` case scores discovering a widget beyond the ones the tool descriptions name (a `Table`) and nesting it in a `Tabs` slot.
- **Drift guard** — `web/src/components/appbuilder/puck/__tests__/configCatalog.test.ts` asserts the Puck config and the catalog agree type for type, label for label, and field for field, and that every component sits in a palette category. The config keeps its own field declarations (it holds the render functions and default props); this test is what stops the two from separating again.
- **Tool contract** — `ui_app_add_component` now documents the Tabs (`tab1`/`tab2`/`tab3`) and Accordion (`content`) slots alongside Panel and Columns, in the browser tool and its verbatim mirror in the bridge.
- **`nodetool app debug`** — validates a resource widget's `resourceBindingId` (unset, or naming a collection the app never declares) and no longer warns that a resource widget's value is "local UI state", which was never true of a widget that reads through the resource provider.

## Testing

- `packages/app-runtime`, `packages/agents`, `packages/cli` vitest suites — pass
- Full `web` jest suite (1032 files) — pass
- `npm run lint`, `npm run typecheck` (web + electron) — pass. Mobile typecheck can't run here: `mobile/` is not a root workspace and its `node_modules` is absent in this container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNf8TiKjZJ5VLvFKmVqmGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNf8TiKjZJ5VLvFKmVqmGz)_