### PR TITLE
Full-screen model menu on mobile

### DIFF
--- a/mobile/src/components/graph_editor/ModelSelectModal.tsx
+++ b/mobile/src/components/graph_editor/ModelSelectModal.tsx
@@ -188,7 +188,7 @@ export const ModelSelectModal: React.FC<ModelSelectModalProps> = ({
     <Modal
       visible={visible}
       animationType="slide"
-      presentationStyle="pageSheet"
+      presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -494,6 +494,20 @@ const listStyles = css({
   maxHeight: "calc(100% - 20px)"
 });
 
+// Horizontal strip used on narrow screens, where an 88px sidebar would eat a
+// quarter of the viewport.
+const horizontalListStyles = css({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "stretch",
+  gap: 4,
+  overflowX: "auto",
+  overflowY: "hidden",
+  paddingTop: 0,
+  paddingBottom: 0,
+  "& > *": { flexShrink: 0 }
+});
+
 type ProviderStoreHook = <Selected>(
   selector: (state: {
     selectedProvider: string | null;
@@ -509,6 +523,8 @@ export interface ProviderListProps {
   storeHook?: ProviderStoreHook;
   forceUnselect?: boolean;
   iconOnly?: boolean;
+  /** "horizontal" lays the providers out as a scrolling strip (mobile). */
+  orientation?: "vertical" | "horizontal";
 }
 
 const ProviderList: React.FC<ProviderListProps> = ({
@@ -517,7 +533,8 @@ const ProviderList: React.FC<ProviderListProps> = ({
   isError,
   storeHook = useLanguageModelMenuStore,
   forceUnselect = false,
-  iconOnly = false
+  iconOnly = false,
+  orientation = "vertical"
 }) => {
   const theme = useTheme();
   const selected = storeHook((s) => s.selectedProvider);
@@ -534,6 +551,9 @@ const ProviderList: React.FC<ProviderListProps> = ({
   const { isApiKeySet } = useSecrets();
 
   const isDarkMode = useIsDarkMode();
+  const isHorizontal = orientation === "horizontal";
+  const tooltipPlacement = isHorizontal ? "bottom" : "right";
+  const itemMinWidth = isHorizontal ? 76 : undefined;
 
   // Sort providers: enabled first (alphabetical), then disabled (alphabetical)
   const sortedProviders = React.useMemo(() => {
@@ -620,8 +640,8 @@ const ProviderList: React.FC<ProviderListProps> = ({
   return (
     <List
       dense
-      css={listStyles}
-      className="model-menu__providers-list"
+      css={isHorizontal ? horizontalListStyles : listStyles}
+      className={`model-menu__providers-list ${isHorizontal ? "is-horizontal" : ""}`}
       sx={{ fontSize: (theme: Theme) => theme.vars.fontSizeSmall, px: iconOnly ? 0.5 : 0 }}
     >
       {isLoading && (
@@ -644,6 +664,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
           justifyContent: iconOnly ? "center" : "flex-start",
           px: iconOnly ? 0 : 2,
           minHeight: iconOnly ? 52 : "auto",
+          minWidth: itemMinWidth,
           borderRadius: iconOnly ? 1 : 0
         }}
       >
@@ -651,7 +672,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
           <Tooltip
             className="model-menu__all-providers-tooltip"
             title="All providers"
-            placement="right"
+            placement={tooltipPlacement}
           >
             <FlexColumn align="center" gap={0.5} sx={{ py: 0.5 }}>
               <FormatListBulletedIcon className="model-menu__all-providers-icon" />
@@ -774,6 +795,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                   justifyContent: iconOnly ? "center" : "flex-start",
                   px: iconOnly ? 0 : 2,
                   minHeight: iconOnly ? 68 : "auto",
+                  minWidth: itemMinWidth,
                   borderRadius: iconOnly ? 1 : 0
                 }}
               >
@@ -781,7 +803,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                   <Tooltip
                     className="model-menu__provider-icon-tooltip"
                     title={providerLabel}
-                    placement="right"
+                    placement={tooltipPlacement}
                   >
                     <FlexColumn align="center" gap={0.5} sx={{ py: 0.5 }}>
                       <FlexRow

--- a/web/src/components/model_menu/__tests__/ModelMenuDialogBase.mobile.test.tsx
+++ b/web/src/components/model_menu/__tests__/ModelMenuDialogBase.mobile.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import mockTheme from "../../../__mocks__/themeMock";
+import ModelMenuDialogBase from "../shared/ModelMenuDialogBase";
+import { useLanguageModelMenuStore } from "../../../stores/ModelMenuStore";
+import type { LanguageModel } from "../../../stores/ApiTypes";
+
+const MOBILE_WIDTH_QUERY = /max-width/;
+
+/** Drive MUI's useMediaQuery: only max-width queries match on "mobile". */
+const setViewport = (mobile: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: mobile && MOBILE_WIDTH_QUERY.test(query),
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+const models: LanguageModel[] = [
+  { type: "language_model", id: "gpt-4o", name: "GPT-4o", provider: "openai" }
+];
+
+const renderMenu = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ThemeProvider theme={mockTheme}>
+          <ModelMenuDialogBase<LanguageModel>
+            open
+            onClose={jest.fn()}
+            title="Select Language Model"
+            modelData={{ models, isLoading: false, error: null }}
+            storeHook={useLanguageModelMenuStore}
+          />
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe("ModelMenuDialogBase responsive layout", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("fills the viewport and offers a close button on mobile", () => {
+    setViewport(true);
+    renderMenu();
+
+    expect(screen.getByText("Select Language Model")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+
+    const paper = document.querySelector(".MuiPopover-paper") as HTMLElement;
+    expect(paper.style.width).toBe("100vw");
+    expect(paper.style.height).toBe("100dvh");
+
+    expect(
+      document.querySelector(".model-menu__providers-list.is-horizontal")
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the anchored popover and vertical provider rail on desktop", () => {
+    setViewport(false);
+    renderMenu();
+
+    expect(screen.queryByText("Select Language Model")).not.toBeInTheDocument();
+
+    const paper = document.querySelector(".MuiPopover-paper") as HTMLElement;
+    expect(paper.style.width).toBe("600px");
+
+    expect(
+      document.querySelector(".model-menu__providers-list.is-horizontal")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
+++ b/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "@mui/material/styles";
 import React, { useCallback, useMemo, useState } from "react";
 import { isProduction } from "../../../lib/env";
 import type { PopoverOrigin } from "@mui/material";
+import { useMediaQuery } from "@mui/material";
 import {
   Tooltip,
   Caption,
@@ -14,14 +15,14 @@ import {
   Box,
   Collapse,
   BORDER_RADIUS,
-  ListItemText,
-  ListItemIcon,
   List,
   ListItemButton,
-  Popover
+  Popover,
+  Text
 } from "../../ui_primitives";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import CloseIcon from "@mui/icons-material/Close";
 
 import StarIcon from "@mui/icons-material/Star"; // Favorite
 import HistoryIcon from "@mui/icons-material/History"; // Recent
@@ -83,13 +84,76 @@ export interface ModelMenuBaseProps<TModel extends ModelSelectorModel> {
   modelType?: string;
 }
 
+interface QuickViewButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  horizontal: boolean;
+  onClick: () => void;
+}
+
+/** Favorites / Recent entry in the model menu's provider rail. */
+const QuickViewButton: React.FC<QuickViewButtonProps> = ({
+  icon,
+  label,
+  active,
+  horizontal,
+  onClick
+}) => (
+  <ListItemButton
+    disableRipple
+    selected={active}
+    onClick={onClick}
+    sx={{
+      py: 1,
+      px: 0,
+      borderRadius: BORDER_RADIUS.xs,
+      justifyContent: "center",
+      minHeight: 40,
+      minWidth: horizontal ? 76 : undefined
+    }}
+  >
+    <Tooltip title={label} placement={horizontal ? "bottom" : "right"}>
+      <FlexColumn align="center" gap={0.5}>
+        <FlexRow
+          align="center"
+          justify="center"
+          sx={{
+            width: 36,
+            height: 36,
+            borderRadius: BORDER_RADIUS.circle,
+            bgcolor: active ? "primary.main" : "action.selected",
+            border: (t) =>
+              `1px solid ${active ? "transparent" : t.vars.palette.divider}`,
+            color: active ? "primary.contrastText" : "text.primary"
+          }}
+        >
+          {icon}
+        </FlexRow>
+        {horizontal && (
+          <Caption
+            sx={{
+              maxWidth: 76,
+              textAlign: "center",
+              lineHeight: 1.15,
+              fontSize: "var(--fontSizeSmaller)"
+            }}
+          >
+            {label}
+          </Caption>
+        )}
+      </FlexColumn>
+    </Tooltip>
+  </ListItemButton>
+);
+
 function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
   open,
   onClose,
   anchorEl,
   modelData,
   onModelChange,
-  title: _title = "Select Model",
+  title = "Select Model",
   searchPlaceholder = "Search models...",
   storeHook,
   recommendedModels = [],
@@ -100,6 +164,9 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
 
   const isError = !!fetchedError;
   const theme = useTheme();
+  // Below `sm` the 600x560 popover no longer fits, so the menu takes over the
+  // whole viewport and the provider rail becomes a horizontal strip.
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const setSearch = storeHook((s) => s.setSearch);
   const search = storeHook((s) => s.search);
@@ -116,8 +183,6 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
   const cachePending = useHfCacheStatusStore((s) => s.pending);
   const cacheVersion = useHfCacheStatusStore((s) => s.version);
   const ensureStatuses = useHfCacheStatusStore((s) => s.ensureStatuses);
-
-  const isIconOnly = true;
 
   const { providers: providersFromModels, filteredModels, favoriteModels, recentModels } =
     useModelMenuData<TModel>(models || [], storeHook);
@@ -373,10 +438,169 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
     }
   }, [open, updatePosition, setSearch]);
 
+  const quickViews = (
+    <List
+      dense
+      className="model-menu__quick-views"
+      sx={{
+        py: isMobile ? 0 : 1,
+        px: 0.5,
+        // Keep the icons aligned with the provider icons when the provider
+        // list shows a scrollbar.
+        pr: isMobile ? 0.5 : 1.5,
+        width: isMobile ? "auto" : "100%",
+        display: "flex",
+        flexDirection: isMobile ? "row" : "column",
+        gap: 0.5,
+        flexShrink: 0
+      }}
+    >
+      <QuickViewButton
+        icon={
+          <StarIcon
+            fontSize="small"
+            sx={{ fontSize: "var(--fontSizeBig)", color: "inherit" }}
+          />
+        }
+        label="Favorites"
+        active={customView === "favorites"}
+        horizontal={isMobile}
+        onClick={handleSetFavoritesView}
+      />
+      <QuickViewButton
+        icon={
+          <HistoryIcon
+            fontSize="small"
+            sx={{ fontSize: "var(--fontSizeBig)", color: "inherit" }}
+          />
+        }
+        label="Recent"
+        active={customView === "recent"}
+        horizontal={isMobile}
+        onClick={handleSetRecentView}
+      />
+    </List>
+  );
+
+  const providerRail = (
+    <Box
+      sx={
+        isMobile
+          ? { flex: 1, minWidth: 0, overflow: "hidden" }
+          : { flex: 1, overflow: "hidden", width: "100%" }
+      }
+      onClickCapture={() => {
+        // If user clicks anywhere in provider list, we assume they want to stick to filtered view
+        if (customView) {
+          setCustomView(null);
+        }
+      }}
+    >
+      <ProviderList
+        providers={providers}
+        isLoading={!!isLoading}
+        isError={!!isError}
+        storeHook={storeHook}
+        forceUnselect={!!customView}
+        iconOnly
+        orientation={isMobile ? "horizontal" : "vertical"}
+      />
+    </Box>
+  );
+
+  const modelPane = (
+    <FlexColumn
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        bgcolor: "background.paper"
+      }}
+    >
+      {modelPacks.length > 0 && (
+        <Box
+          sx={{
+            px: 2,
+            pt: 1.5,
+            maxHeight: 180,
+            overflowY: "auto",
+            flexShrink: 0,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          {modelPacks.map((pack) => (
+            <ModelPackCard
+              key={pack.id}
+              pack={pack}
+              onDownloadAll={handleDownloadAllFromPack}
+            />
+          ))}
+        </Box>
+      )}
+      <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+        <ModelList<TModel>
+          models={filteredModelsAdvanced}
+          onSelect={handleSelectModel}
+          searchTerm={search}
+          hasDownloads={hasDownloads}
+          activeIndex={activeIndex}
+          downloadModels={downloadModels}
+          onDownloadSelect={handleSelectRecommended}
+          onDownloadStart={handleStartDownload}
+          modelType={modelType}
+        />
+      </Box>
+    </FlexColumn>
+  );
+
+  // Mobile stacks the rail above the list; desktop keeps it as a left sidebar.
+  const body = isMobile ? (
+    <FlexColumn sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+      <FlexRow
+        align="stretch"
+        sx={{
+          flexShrink: 0,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`,
+          bgcolor: theme.vars.palette.background.default
+        }}
+      >
+        {quickViews}
+        <Divider
+          orientation="vertical"
+          flexItem
+          sx={{ my: 1, opacity: 0.6 }}
+        />
+        {providerRail}
+      </FlexRow>
+      {modelPane}
+    </FlexColumn>
+  ) : (
+    <FlexRow sx={{ flex: 1, overflow: "hidden" }}>
+      <FlexColumn
+        sx={{
+          width: 88,
+          flexShrink: 0,
+          borderRight: `1px solid ${theme.vars.palette.divider}`,
+          bgcolor: theme.vars.palette.background.default,
+          alignItems: "center"
+        }}
+      >
+        {quickViews}
+        <Divider sx={{ mx: 2, mb: 1, opacity: 0.6 }} />
+        {providerRail}
+      </FlexColumn>
+      {modelPane}
+    </FlexRow>
+  );
+
   return (
     <Popover
       open={open}
       anchorEl={anchorEl}
+      // Full-screen on mobile: detach from the anchor so the paper fills the
+      // modal root instead of being positioned next to the trigger.
+      anchorReference={isMobile ? "none" : "anchorEl"}
+      marginThreshold={isMobile ? 0 : undefined}
       onClose={onClose}
       anchorOrigin={positionConfig.anchorOrigin}
       transformOrigin={positionConfig.transformOrigin}
@@ -385,22 +609,53 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
         paper: {
           elevation: 24,
           style: {
-            width: "600px",
-            height: "560px",
-            maxHeight: "90vh",
+            width: isMobile ? "100vw" : "600px",
+            height: isMobile ? "100dvh" : "560px",
+            maxHeight: isMobile ? "100dvh" : "90vh",
             maxWidth: "100vw",
-            borderRadius: theme.vars.rounded.dialog,
+            borderRadius: isMobile ? 0 : theme.vars.rounded.dialog,
             background: theme.vars.palette.background.paper,
-            border: `1px solid ${theme.vars.palette.divider}`,
+            border: isMobile
+              ? "none"
+              : `1px solid ${theme.vars.palette.divider}`,
             display: "flex",
             flexDirection: "column",
-            overflow: "hidden"
+            overflow: "hidden",
+            paddingTop: isMobile ? "env(safe-area-inset-top, 0px)" : undefined,
+            paddingBottom: isMobile
+              ? "env(safe-area-inset-bottom, 0px)"
+              : undefined
           }
         }
       }}
     >
+      {isMobile && (
+        <FlexRow
+          gap={1}
+          align="center"
+          justify="space-between"
+          sx={{
+            px: 2,
+            py: 1.5,
+            flexShrink: 0,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          <Text weight={600} truncate>
+            {title}
+          </Text>
+          <ToolbarIconButton
+            icon={<CloseIcon fontSize="small" />}
+            tooltip="Close"
+            onClick={onClose}
+            size="small"
+            nodrag={false}
+          />
+        </FlexRow>
+      )}
+
       <FlexRow
-        gap={2}
+        gap={isMobile ? 1 : 2}
         align="center"
         sx={{
           p: 1.5,
@@ -410,14 +665,15 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
           background: theme.vars.palette.background.paper
         }}
       >
-        <FlexRow gap={2} align="center" sx={{ flex: 1 }}>
+        <FlexRow gap={isMobile ? 1 : 2} align="center" sx={{ flex: 1 }}>
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <SearchInput
               onSearchChange={setSearch}
               placeholder={searchPlaceholder}
               debounceTime={150}
-              focusSearchInput
-              focusOnTyping
+              // Autofocusing on mobile raises the keyboard over the list.
+              focusSearchInput={!isMobile}
+              focusOnTyping={!isMobile}
               onPressArrowDown={handleArrowDown}
               onPressArrowUp={handleArrowUp}
               onPressEnter={handleEnter}
@@ -486,260 +742,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
         </FlexRow>
       </Collapse>
 
-      <FlexRow sx={{ flex: 1, overflow: "hidden" }}>
-        <FlexColumn
-          sx={{
-            width: isIconOnly ? 88 : 200,
-            flexShrink: 0,
-            borderRight: `1px solid ${theme.vars.palette.divider}`,
-            bgcolor: theme.vars.palette.background.default,
-            alignItems: isIconOnly ? "center" : "stretch"
-          }}
-        >
-          <List
-            dense
-            sx={{
-              py: 1,
-              width: "100%",
-              px: isIconOnly ? 0.5 : 0,
-              // Keep top icon-only actions aligned with provider icons when provider list shows a vertical scrollbar.
-              pr: isIconOnly ? 1.5 : 0
-            }}
-          >
-            <ListItemButton
-              disableRipple
-              selected={customView === "favorites"}
-              onClick={handleSetFavoritesView}
-              sx={{
-                py: isIconOnly ? 1 : 0.5,
-                borderRadius: BORDER_RADIUS.xs,
-                mx: 0,
-                mb: 0.5,
-                justifyContent: isIconOnly ? "center" : "flex-start",
-                minHeight: isIconOnly ? 40 : "auto",
-                px: isIconOnly ? 0 : 2
-              }}
-            >
-              {isIconOnly ? (
-                <Tooltip title="Favorites" placement="right">
-                  <FlexRow
-                    align="center"
-                    justify="center"
-                    sx={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: BORDER_RADIUS.circle,
-                      bgcolor:
-                        customView === "favorites"
-                          ? "primary.main"
-                          : "action.selected",
-                      border: `1px solid ${customView === "favorites" ? "transparent" : theme.vars.palette.divider}`
-                    }}
-                  >
-                    <StarIcon
-                      fontSize="small"
-                      sx={{
-                        fontSize: "var(--fontSizeBig)",
-                        color:
-                          customView === "favorites"
-                            ? "primary.contrastText"
-                            : "text.primary"
-                      }}
-                    />
-                  </FlexRow>
-                </Tooltip>
-              ) : (
-                <>
-                  <ListItemIcon sx={{ minWidth: 36 }}>
-                    <FlexRow
-                      align="center"
-                      justify="center"
-                      sx={{
-                        width: 28,
-                        height: 28,
-                        borderRadius: BORDER_RADIUS.sm,
-                        bgcolor: "rgba(0,0,0,0.04)"
-                      }}
-                    >
-                      <StarIcon
-                        fontSize="small"
-                        sx={{
-                          fontSize: "var(--fontSizeBig)",
-                          color:
-                            customView === "favorites"
-                              ? "primary.main"
-                              : "text.secondary"
-                        }}
-                      />
-                    </FlexRow>
-                  </ListItemIcon>
-                  <ListItemText
-                    primary="Favorites"
-                    primaryTypographyProps={{
-                      fontSize: "var(--fontSizeNormal)",
-                      fontWeight: customView === "favorites" ? 600 : 400
-                    }}
-                  />
-                </>
-              )}
-            </ListItemButton>
-            <ListItemButton
-              disableRipple
-              selected={customView === "recent"}
-              onClick={handleSetRecentView}
-              sx={{
-                py: isIconOnly ? 1 : 0.5,
-                borderRadius: BORDER_RADIUS.xs,
-                mx: 0,
-                justifyContent: isIconOnly ? "center" : "flex-start",
-                minHeight: isIconOnly ? 40 : "auto",
-                px: isIconOnly ? 0 : 2
-              }}
-            >
-              {isIconOnly ? (
-                <Tooltip title="Recent" placement="right">
-                  <FlexRow
-                    align="center"
-                    justify="center"
-                    sx={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: BORDER_RADIUS.circle,
-                      bgcolor:
-                        customView === "recent"
-                          ? "primary.main"
-                          : "action.selected",
-                      border: `1px solid ${customView === "recent" ? "transparent" : theme.vars.palette.divider}`
-                    }}
-                  >
-                    <HistoryIcon
-                      fontSize="small"
-                      sx={{
-                        fontSize: "var(--fontSizeBig)",
-                        color:
-                          customView === "recent"
-                            ? "primary.contrastText"
-                            : "text.primary"
-                      }}
-                    />
-                  </FlexRow>
-                </Tooltip>
-              ) : (
-                <>
-                  <ListItemIcon sx={{ minWidth: 36 }}>
-                    <FlexRow
-                      align="center"
-                      justify="center"
-                      sx={{
-                        width: 28,
-                        height: 28,
-                        borderRadius: BORDER_RADIUS.sm,
-                        bgcolor: "rgba(0,0,0,0.04)"
-                      }}
-                    >
-                      <HistoryIcon
-                        fontSize="small"
-                        sx={{
-                          fontSize: "var(--fontSizeBig)",
-                          color:
-                            customView === "recent"
-                              ? "primary.main"
-                              : "text.secondary"
-                        }}
-                      />
-                    </FlexRow>
-                  </ListItemIcon>
-                  <ListItemText
-                    primary="Recent"
-                    primaryTypographyProps={{
-                      fontSize: "var(--fontSizeNormal)",
-                      fontWeight: customView === "recent" ? 600 : 400
-                    }}
-                  />
-                </>
-              )}
-            </ListItemButton>
-          </List>
-
-          <Divider sx={{ mx: 2, mb: 1, opacity: 0.6 }} />
-
-          {!isIconOnly && (
-            <Box
-              sx={{
-                px: 2,
-                pb: 0.5,
-                fontSize: "var(--fontSizeSmall)",
-                fontWeight: 600,
-                color: "text.secondary",
-                textTransform: "uppercase",
-                letterSpacing: 0.5
-              }}
-            >
-              Providers
-            </Box>
-          )}
-          <Box
-            sx={{ flex: 1, overflow: "hidden", width: "100%" }}
-            onClickCapture={() => {
-              // If user clicks anywhere in provider list, we assume they want to stick to filtered view
-              if (customView) {
-                setCustomView(null);
-              }
-            }}
-          >
-            <ProviderList
-              providers={providers}
-              isLoading={!!isLoading}
-              isError={!!isError}
-              storeHook={storeHook}
-              forceUnselect={!!customView}
-              iconOnly={isIconOnly}
-            />
-          </Box>
-        </FlexColumn>
-
-        <FlexColumn
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            bgcolor: "background.paper"
-          }}
-        >
-          {modelPacks.length > 0 && (
-            <Box
-              sx={{
-                px: 2,
-                pt: 1.5,
-                maxHeight: 180,
-                overflowY: "auto",
-                flexShrink: 0,
-                borderBottom: `1px solid ${theme.vars.palette.divider}`
-              }}
-            >
-              {modelPacks.map((pack) => (
-                <ModelPackCard
-                  key={pack.id}
-                  pack={pack}
-                  onDownloadAll={handleDownloadAllFromPack}
-                />
-              ))}
-            </Box>
-          )}
-          <Box sx={{ flex: 1, overflow: "hidden" }}>
-            <ModelList<TModel>
-              models={filteredModelsAdvanced}
-              onSelect={handleSelectModel}
-              searchTerm={search}
-              hasDownloads={hasDownloads}
-              activeIndex={activeIndex}
-              downloadModels={downloadModels}
-              onDownloadSelect={handleSelectRecommended}
-              onDownloadStart={handleStartDownload}
-              modelType={modelType}
-            />
-          </Box>
-        </FlexColumn>
-      </FlexRow>
+      {body}
     </Popover>
   );
 }


### PR DESCRIPTION
## What

The model select popover was a fixed 600×560 panel anchored to its trigger. On a phone that overflows the viewport, and an 88px provider sidebar sits next to a model list with no room left.

Below the `sm` breakpoint the menu now takes over the screen:

- The popover detaches from its anchor (`anchorReference="none"`) and the paper is `100vw` / `100dvh`, square corners, with `env(safe-area-inset-*)` padding.
- A title bar with a close button appears — a full-bleed paper covers the backdrop, so tap-to-dismiss is gone and needs a replacement. This also gives the previously-unused `title` prop a job.
- The provider rail moves from a left sidebar to a horizontal scrolling strip above the list (`ProviderList` gained an `orientation` prop), so the full width goes to model rows. Provider icons keep their labels; Favorites/Recent gain labels in this layout.
- Search no longer autofocuses, where it would raise the keyboard over the list. The search-row gap tightens so the refresh and filter buttons don't crowd out the input.

Desktop layout is unchanged.

All ten model menu dialogs (language, image, video, TTS, ASR, music, embedding, HuggingFace, transformers.js, 3D) render through `ModelMenuDialogBase`, so they all get this.

Also: `mobile/`'s React Native `ModelSelectModal` documents itself as full screen but used `presentationStyle="pageSheet"` — switched to `fullScreen`.

## Refactor along the way

`ModelMenuDialogBase` carried a `const isIconOnly = true` with dead `!isIconOnly` branches for the Favorites/Recent buttons. Those are gone; the two buttons are now one `QuickViewButton` component shared by both layouts.

## Testing

- New `ModelMenuDialogBase.mobile.test.tsx` covers both layouts: full-viewport paper + close button + horizontal rail on mobile, anchored 600px paper + vertical rail on desktop.
- `npx jest src/components/model_menu` — 6 passed.
- `npm run lint` (web) — no errors.
- `tsc --noEmit` — no errors in the touched files.

Mobile typecheck could not run in this environment (`mobile/` deps are not installed and it is not a root workspace); the RN change is a one-word literal in `presentationStyle`.

## Not covered

Verified via unit tests and code review, not in a real browser at phone width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1u5zpSh2EnaE6rLqE5aQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1u5zpSh2EnaE6rLqE5aQ6)_