### PR TITLE
fix(subgraph): restore the subgraph canvas; point the mini-app journey at the workspace

### DIFF
--- a/packages/websocket/src/screenshot-server.ts
+++ b/packages/websocket/src/screenshot-server.ts
@@ -21,6 +21,7 @@
 import {
   initTestDb,
   getDb,
+  Application,
   Workflow,
   Thread,
   Message,
@@ -173,7 +174,7 @@ const MINI_APP_DOC: Record<string, unknown> = {
     {
       id: "main",
       name: "Run",
-      workflowId: "",
+      workflowId: "wf-mini-app",
       inputs: {},
       outputs: {},
       policy: "replace"
@@ -182,6 +183,29 @@ const MINI_APP_DOC: Record<string, unknown> = {
   resources: [],
   variables: []
 };
+
+/**
+ * The mini app as its own `applications` row.
+ *
+ * An app used to be a workflow — its document lived on `workflow.app_doc` and
+ * ran at `/apps/<workflowId>`. Apps are their own resource now: they are opened
+ * as a workspace tab and their operations name the workflows they bind. The
+ * journey suite drives that surface, so the fixture is an application row whose
+ * one operation points at `wf-mini-app`.
+ */
+const MOCK_APPLICATIONS = [
+  {
+    id: "app-mini-app",
+    user_id: USER_ID,
+    project_id: "default",
+    name: "Echo Mini App",
+    description:
+      "Deterministic mini app used by the user-journey suite: echoes its input to an Output widget",
+    document: JSON.stringify(MINI_APP_DOC),
+    created_at: "2024-09-01T09:00:00Z",
+    updated_at: "2024-12-14T10:00:00Z"
+  }
+];
 
 // Use real node types registered by @nodetool-ai/base-nodes so the editor
 // renders nodes instead of crashing on unknown types.
@@ -1362,6 +1386,11 @@ async function seedDatabase(): Promise<void> {
     await Workflow.create(wf);
   }
 
+  // Applications
+  for (const app of MOCK_APPLICATIONS) {
+    await Application.create(app);
+  }
+
   // Threads
   for (const thread of MOCK_THREADS) {
     await Thread.create(thread);
@@ -1509,7 +1538,7 @@ async function seedDatabase(): Promise<void> {
   }
 
   console.log(
-    `[screenshot-server] Seeded ${MOCK_WORKFLOWS.length} workflows, ${MOCK_TEMPLATES.length} templates, ${MOCK_THREADS.length} threads, ${MOCK_MESSAGES.length} messages, ${MOCK_ASSETS.length} assets, 1 sketch document, 3 timeline sequences, ${demoSecrets.length} secrets`
+    `[screenshot-server] Seeded ${MOCK_WORKFLOWS.length} workflows, ${MOCK_TEMPLATES.length} templates, ${MOCK_APPLICATIONS.length} applications, ${MOCK_THREADS.length} threads, ${MOCK_MESSAGES.length} messages, ${MOCK_ASSETS.length} assets, 1 sketch document, 3 timeline sequences, ${demoSecrets.length} secrets`
   );
 }
 

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -638,15 +638,19 @@ const ReactFlowWrapper = ({
     (_event: ReactMouseEvent, node: Node) => {
       if (node.type !== SUBGRAPH_NODE_TYPE) return;
       const data = node.data as {
-        workflow_id?: string;
         title?: string;
         properties?: { graph?: { nodes?: unknown[]; edges?: unknown[] } };
       };
       const innerGraph = data.properties?.graph ?? { nodes: [], edges: [] };
       const key = useSubgraphTabsStore.getState().openTab({
-        workflowId: data.workflow_id ?? "",
+        // The canvas this node is on, not `data.workflow_id`: that is only
+        // stamped on nodes the store created, so a node loaded from a saved
+        // graph would key its tab off "" and the strip would never find it.
+        workflowId,
         nodeId: node.id,
-        label: data.title || "Subgraph",
+        // Same fallback chain as the node's own header, so the tab is labelled
+        // with what the user sees on the canvas.
+        label: data.title || getMetadata(SUBGRAPH_NODE_TYPE)?.title || "Subgraph",
         initialGraph: {
           nodes: Array.isArray(innerGraph.nodes) ? innerGraph.nodes : [],
           edges: Array.isArray(innerGraph.edges) ? innerGraph.edges : []
@@ -664,7 +668,7 @@ const ReactFlowWrapper = ({
         }));
       }
     },
-    [workflowManagerStore]
+    [workflowManagerStore, workflowId, getMetadata]
   );
 
   const handlePaneClickWithSuppress = useCallback(

--- a/web/src/components/node/SubgraphNode/SubgraphNode.tsx
+++ b/web/src/components/node/SubgraphNode/SubgraphNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import { Node, NodeProps, NodeToolbar, Position } from "@xyflow/react";
 import { Box } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
@@ -15,13 +15,10 @@ import { useNodes } from "../../../contexts/NodeContext";
 import useSelect from "../../../hooks/nodes/useSelect";
 import { useDelayedVisibility } from "../../../hooks/useDelayedVisibility";
 import { useNodeFocusStore } from "../../../stores/NodeFocusStore";
-import { useSubgraphTabsStore } from "../../../stores/SubgraphTabsStore";
 import { SubgraphNodeContent } from "./SubgraphNodeContent";
+import { SUBGRAPH_ACCENT_COLOR } from "../../../constants/nodeTypes";
 
 const TOOLBAR_SHOW_DELAY = 200;
-
-/** Accent color for SubgraphNode (violet — distinct from WorkflowNode's teal). */
-const SUBGRAPH_HEADER_COLOR = "#7C3AED";
 
 const Toolbar = memo(function Toolbar({
   id,
@@ -73,26 +70,6 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
     return data.title || metadata.title || "Subgraph";
   }, [metadata, data.title]);
 
-  const openSubgraphTab = useSubgraphTabsStore((state) => state.openTab);
-  const handleDoubleClick = useCallback(
-    (event?: React.MouseEvent) => {
-      event?.stopPropagation();
-      const innerGraph = (data.properties?.graph as
-        | { nodes?: unknown[]; edges?: unknown[] }
-        | undefined) ?? { nodes: [], edges: [] };
-      openSubgraphTab({
-        workflowId: workflow_id,
-        nodeId: id,
-        label: headerTitle,
-        initialGraph: {
-          nodes: Array.isArray(innerGraph.nodes) ? innerGraph.nodes : [],
-          edges: Array.isArray(innerGraph.edges) ? innerGraph.edges : []
-        }
-      });
-    },
-    [openSubgraphTab, workflow_id, id, headerTitle, data.properties?.graph]
-  );
-
   if (!metadata) {
     return null;
   }
@@ -100,18 +77,17 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
   return (
     <Box
       className="subgraph-node"
-      onDoubleClick={handleDoubleClick}
       sx={{
         display: "flex",
         flexDirection: "column",
         height: "100%",
         minHeight: 100,
         padding: "0 !important",
-        border: `1px solid ${SUBGRAPH_HEADER_COLOR}40`,
+        border: `1px solid ${SUBGRAPH_ACCENT_COLOR}40`,
         borderRadius: theme.rounded.node,
         backgroundColor: theme.vars.palette.c_node_bg,
         boxShadow: selected
-          ? `0 0 0 2px ${SUBGRAPH_HEADER_COLOR}, 0 1px 10px rgba(0,0,0,0.5)`
+          ? `0 0 0 2px ${SUBGRAPH_ACCENT_COLOR}, 0 1px 10px rgba(0,0,0,0.5)`
           : isFocused
           ? `0 0 0 2px ${theme.vars.palette.warning.main}`
           : "none",
@@ -119,7 +95,7 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
           ? `2px dashed ${theme.vars.palette.warning.main}`
           : "none",
         outlineOffset: "-2px",
-        "--node-primary-color": SUBGRAPH_HEADER_COLOR
+        "--node-primary-color": SUBGRAPH_ACCENT_COLOR
       }}
     >
       {selected && <Toolbar id={id} selected={selected} dragging={dragging} />}
@@ -128,11 +104,11 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
         id={id}
         selected={selected}
         data={data}
-        backgroundColor={SUBGRAPH_HEADER_COLOR}
+        backgroundColor={SUBGRAPH_ACCENT_COLOR}
         metadataTitle={headerTitle}
         hasParent={hasParent}
         iconType="workflow"
-        iconBaseColor={SUBGRAPH_HEADER_COLOR}
+        iconBaseColor={SUBGRAPH_ACCENT_COLOR}
         workflowId={workflow_id}
       />
       <NodeErrors id={id} workflow_id={workflow_id} />

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -163,8 +163,15 @@ const PanelRight: React.FC = () => {
       : BOTTOM_PANEL_HEADER_HEIGHT;
   const panelRightStyles = useMemo(() => styles(theme, bottomOffset, isVisible), [theme, bottomOffset, isVisible]);
 
+  const currentWorkflowId = useWorkflowManager(
+    (state) => state.currentWorkflowId
+  );
+  // Tab keys are `${workflowId}:${nodeId}`, nested ones `${parentKey}:${nodeId}`
+  // — so the prefix says whether the open subgraph belongs to the workflow on
+  // screen. Without it, switching workflow tabs leaves the inspector pointed at
+  // the other workflow's subgraph.
   const activeSubgraphTab = useSubgraphTabsStore((state) =>
-    state.activeKey
+    state.activeKey && state.activeKey.startsWith(`${currentWorkflowId}:`)
       ? state.tabs.find((t) => t.key === state.activeKey)
       : undefined
   );
@@ -174,10 +181,6 @@ const PanelRight: React.FC = () => {
       : undefined
   );
   const activeNodeStore = activeSubgraphTab?.store ?? workflowNodeStore;
-
-  const currentWorkflowId = useWorkflowManager(
-    (state) => state.currentWorkflowId
-  );
 
   const handleMobileSheetClose = useCallback(
     () => setVisibility(false),

--- a/web/src/components/workspace/SubgraphTabContent.tsx
+++ b/web/src/components/workspace/SubgraphTabContent.tsx
@@ -1,0 +1,177 @@
+import { memo, useEffect } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+
+import NodeEditor from "../node_editor/NodeEditor";
+import SubgraphTabStrip from "./SubgraphTabStrip";
+import { NodeContext } from "../../contexts/NodeContext";
+import {
+  useWorkflowManager,
+  useWorkflowManagerStore
+} from "../../contexts/WorkflowManagerContext";
+import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
+import { ConnectableNodesProvider } from "../../providers/ConnectableNodesProvider";
+import KeyboardProvider from "../KeyboardProvider";
+import NodeCreateBridge from "../editor/NodeCreateBridge";
+import {
+  useSubgraphTabsStore,
+  type SubgraphTab
+} from "../../stores/SubgraphTabsStore";
+import type { NodeStore } from "../../stores/NodeStore";
+
+/** How long the inner graph must be still before it is written back. */
+const WRITE_BACK_DEBOUNCE_MS = 300;
+
+interface SubgraphGraphSyncProps {
+  tab: SubgraphTab;
+  parentStore: NodeStore;
+}
+
+/**
+ * Writes the subgraph canvas back onto the SubgraphNode that owns it.
+ *
+ * The tab's `NodeStore` is seeded from `data.properties.graph` when the tab
+ * opens and is otherwise independent, so without this the inner graph would
+ * live only as long as the tab: edits would not save, would not run, and
+ * `SubgraphSync` would never see the new boundary ports.
+ *
+ * Debounced because a node drag updates the store on every pointer frame, and
+ * each write re-renders the parent canvas.
+ */
+const SubgraphGraphSync = memo(
+  ({ tab, parentStore }: SubgraphGraphSyncProps) => {
+    useEffect(() => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let pending = false;
+
+      const flush = () => {
+        clearTimeout(timer);
+        if (!pending) {
+          return;
+        }
+        pending = false;
+        const { nodes, edges } = tab.store.getState().getWorkflow().graph;
+        const node = parentStore.getState().findNode(tab.nodeId);
+        if (!node) {
+          return;
+        }
+        parentStore.getState().updateNodeData(tab.nodeId, {
+          properties: {
+            ...(node.data.properties ?? {}),
+            graph: { nodes, edges }
+          }
+        });
+      };
+
+      const unsubscribe = tab.store.subscribe((state, previous) => {
+        if (state.nodes === previous.nodes && state.edges === previous.edges) {
+          return;
+        }
+        pending = true;
+        clearTimeout(timer);
+        timer = setTimeout(flush, WRITE_BACK_DEBOUNCE_MS);
+      });
+
+      return () => {
+        unsubscribe();
+        // Flush rather than cancel: this unmounts when the tab is switched
+        // away from or closed, which is exactly when an edit made in the last
+        // few hundred milliseconds would otherwise be dropped.
+        flush();
+      };
+    }, [tab, parentStore]);
+
+    return null;
+  }
+);
+
+SubgraphGraphSync.displayName = "SubgraphGraphSync";
+
+interface SubgraphTabContentProps {
+  tab: SubgraphTab;
+}
+
+/**
+ * The editor canvas for one open subgraph.
+ *
+ * A second `NodeEditor` over the tab's own `NodeStore`, registered in the
+ * WorkflowManager under the tab's synthetic id so `ReactFlowWrapper` treats it
+ * as a workflow that already exists locally and skips the 404 fetch that id
+ * would otherwise trigger.
+ *
+ * Renders its own strip and, when one of its subgraphs is open, itself — a
+ * SubgraphNode created inside a subgraph opens the same way as one at the top
+ * level.
+ */
+const SubgraphTabContent = ({ tab }: SubgraphTabContentProps) => {
+  const workflowManagerStore = useWorkflowManagerStore();
+  const parentStore = useWorkflowManager((state) =>
+    state.getNodeStore(tab.workflowId)
+  );
+  const nested = useSubgraphTabsStore((state) =>
+    state.tabs.find(
+      (candidate) =>
+        candidate.key === state.activeKey && candidate.workflowId === tab.key
+    )
+  );
+
+  // Idempotent: `ReactFlowWrapper` registers the store synchronously when the
+  // tab opens, and this re-registers on remount (a tab switched away from and
+  // back, or StrictMode's double mount).
+  useEffect(() => {
+    workflowManagerStore.setState((state) =>
+      state.nodeStores[tab.key] === tab.store
+        ? state
+        : { nodeStores: { ...state.nodeStores, [tab.key]: tab.store } }
+    );
+  }, [workflowManagerStore, tab]);
+
+  return (
+    <NodeContext.Provider value={tab.store}>
+      <ReactFlowProvider>
+        <ContextMenuProvider>
+          <ConnectableNodesProvider>
+            <KeyboardProvider>
+              {parentStore && (
+                <SubgraphGraphSync tab={tab} parentStore={parentStore} />
+              )}
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  width: "100%",
+                  height: "100%"
+                }}
+              >
+                <SubgraphTabStrip
+                  hostId={tab.key}
+                  hostActiveKey={tab.key}
+                  hostLabel={tab.label}
+                />
+                <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+                  <div
+                    data-testid="subgraph-tab-content"
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      display: nested ? "none" : undefined
+                    }}
+                  >
+                    <NodeEditor workflowId={tab.key} active />
+                  </div>
+                  {nested && (
+                    <div style={{ position: "absolute", inset: 0 }}>
+                      <SubgraphTabContent tab={nested} />
+                    </div>
+                  )}
+                </div>
+              </div>
+              <NodeCreateBridge />
+            </KeyboardProvider>
+          </ConnectableNodesProvider>
+        </ContextMenuProvider>
+      </ReactFlowProvider>
+    </NodeContext.Provider>
+  );
+};
+
+export default memo(SubgraphTabContent);

--- a/web/src/components/workspace/SubgraphTabStrip.tsx
+++ b/web/src/components/workspace/SubgraphTabStrip.tsx
@@ -1,0 +1,153 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, type MouseEvent } from "react";
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { useWorkflowManagerStore } from "../../contexts/WorkflowManagerContext";
+import { useSubgraphTabsStore } from "../../stores/SubgraphTabsStore";
+import { SUBGRAPH_ACCENT_COLOR } from "../../constants/nodeTypes";
+import {
+  SPACING_PX,
+  TYPOGRAPHY,
+  BORDER_RADIUS,
+  MOTION,
+  reducedMotion
+} from "../ui_primitives";
+
+const styles = (theme: Theme) =>
+  css({
+    display: "flex",
+    alignItems: "center",
+    gap: SPACING_PX.xs,
+    padding: `0 ${SPACING_PX.sm}px`,
+    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    backgroundColor: theme.vars.palette.background.paper,
+    ".graph-tab": {
+      display: "flex",
+      alignItems: "center",
+      gap: SPACING_PX.xs,
+      padding: `${SPACING_PX.xs}px ${SPACING_PX.sm}px`,
+      border: "none",
+      borderBottom: "2px solid transparent",
+      background: "none",
+      color: theme.vars.palette.text.secondary,
+      ...TYPOGRAPHY.sans.label,
+      cursor: "pointer",
+      transition: MOTION.fast,
+      "&:hover": { color: theme.vars.palette.text.primary },
+      "&.active": {
+        color: theme.vars.palette.text.primary,
+        // Violet, matching the SubgraphNode accent, so a subgraph canvas is
+        // never mistaken for the parent workflow's.
+        borderBottomColor: SUBGRAPH_ACCENT_COLOR
+      },
+      ...reducedMotion({ transition: MOTION.none })
+    },
+    // The host's own tab is not a subgraph tab — it carries neither the
+    // `subgraph-tab` class nor a close control.
+    ".parent-tab.active": {
+      borderBottomColor: theme.vars.palette.primary.main
+    },
+    ".close-icon": {
+      width: 14,
+      height: 14,
+      borderRadius: BORDER_RADIUS.sm,
+      "&:hover": { color: theme.vars.palette.error.main }
+    }
+  });
+
+interface SubgraphTabStripProps {
+  /** The canvas these tabs belong to: a workflow id, or a subgraph tab key. */
+  hostId: string;
+  /**
+   * The `activeKey` that means "show the host itself" — `null` for a workflow
+   * (no subgraph active), the host's own key for a nested subgraph.
+   */
+  hostActiveKey: string | null;
+  /** Label for the host's own tab. */
+  hostLabel: string;
+}
+
+/**
+ * Tabs for the subgraphs opened from one canvas, plus that canvas itself.
+ *
+ * Subgraph tabs are scoped to their parent workflow and hold a live in-memory
+ * `NodeStore`, so they are not workspace tabs: those persist to localStorage
+ * and would restore pointing at a store that no longer exists. The strip sits
+ * inside the workflow's own editor surface instead, and closing the workflow
+ * takes its subgraph tabs with it (`WorkflowManagerStore.removeWorkflow`).
+ */
+const SubgraphTabStrip = ({
+  hostId,
+  hostActiveKey,
+  hostLabel
+}: SubgraphTabStripProps) => {
+  const theme = useTheme();
+  const workflowManagerStore = useWorkflowManagerStore();
+  const tabs = useSubgraphTabsStore((state) => state.tabs);
+  const activeKey = useSubgraphTabsStore((state) => state.activeKey);
+  const setActive = useSubgraphTabsStore((state) => state.setActive);
+  const closeTab = useSubgraphTabsStore((state) => state.closeTab);
+
+  const handleClose = useCallback(
+    (event: MouseEvent<Element>, key: string) => {
+      // The close icon sits inside the tab button; without this the click also
+      // selects the tab it just removed.
+      event.stopPropagation();
+      closeTab(key);
+      // Drop the synthetic workflow the subgraph canvas was registered under,
+      // so reopening the tab rebuilds it from the parent node's graph rather
+      // than resurrecting the stale store.
+      workflowManagerStore.setState((state) => {
+        const nodeStores = { ...state.nodeStores };
+        delete nodeStores[key];
+        return { nodeStores };
+      });
+    },
+    [closeTab, workflowManagerStore]
+  );
+
+  const ownTabs = tabs.filter((tab) => tab.workflowId === hostId);
+  if (ownTabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div css={styles(theme)} role="tablist">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeKey === hostActiveKey}
+        className={`graph-tab parent-tab ${
+          activeKey === hostActiveKey ? "active" : ""
+        }`}
+        onClick={() => setActive(hostActiveKey)}
+      >
+        {hostLabel}
+      </button>
+      {ownTabs.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          role="tab"
+          aria-selected={activeKey === tab.key}
+          className={`graph-tab subgraph-tab ${
+            activeKey === tab.key ? "active" : ""
+          }`}
+          onClick={() => setActive(tab.key)}
+        >
+          {tab.label}
+          <CloseIcon
+            className="close-icon"
+            aria-label={`Close ${tab.label}`}
+            onClick={(event) => handleClose(event, tab.key)}
+          />
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default memo(SubgraphTabStrip);

--- a/web/src/components/workspace/WorkflowEditorSurface.tsx
+++ b/web/src/components/workspace/WorkflowEditorSurface.tsx
@@ -17,6 +17,9 @@ import QueueOverlay from "../panels/QueueOverlay";
 import StatusMessage from "../panels/StatusMessage";
 import NodeCreateBridge from "../editor/NodeCreateBridge";
 import WorkflowChainSurface from "./WorkflowChainSurface";
+import SubgraphTabStrip from "./SubgraphTabStrip";
+import SubgraphTabContent from "./SubgraphTabContent";
+import { useSubgraphTabsStore } from "../../stores/SubgraphTabsStore";
 import { useSettingsStore } from "../../stores/SettingsStore";
 import { FlexColumn, LoadingSpinner } from "../ui_primitives";
 
@@ -48,6 +51,13 @@ const WorkflowEditorSurface = ({
     (state) => state.settings.editorViewMode
   );
   const [missing, setMissing] = useState(false);
+  // Only this workflow's subgraph tabs may take over its canvas — another
+  // workflow tab's open subgraph must not hijack this one.
+  const activeSubgraph = useSubgraphTabsStore((state) =>
+    state.tabs.find(
+      (tab) => tab.key === state.activeKey && tab.workflowId === workflowId
+    )
+  );
 
   useEffect(() => {
     if (nodeStore) {
@@ -104,6 +114,11 @@ const WorkflowEditorSurface = ({
                   <StatusMessage />
                 </div>
               )}
+              <SubgraphTabStrip
+                hostId={workflowId}
+                hostActiveKey={null}
+                hostLabel="Workflow"
+              />
               <div
                 style={{
                   flex: 1,
@@ -120,11 +135,19 @@ const WorkflowEditorSurface = ({
                   style={{
                     width: "100%",
                     height: "100%",
-                    display: showChain ? "none" : undefined
+                    display: showChain || activeSubgraph ? "none" : undefined
                   }}
                 >
                   <NodeEditor workflowId={workflowId} active={active} />
                 </div>
+                {/* A subgraph takes over the canvas the same way the chain view
+                    does, and for the same reason: the parent editor stays
+                    mounted underneath so returning to it keeps its viewport. */}
+                {activeSubgraph && !showChain && (
+                  <div style={{ position: "absolute", inset: 0 }}>
+                    <SubgraphTabContent tab={activeSubgraph} />
+                  </div>
+                )}
                 {showChain && (
                   <div
                     style={{

--- a/web/src/constants/nodeTypes.ts
+++ b/web/src/constants/nodeTypes.ts
@@ -19,6 +19,13 @@ export const COLLECTION_NODE_TYPE = "nodetool.control.Collection";
 export const WORKFLOW_NODE_TYPE = "nodetool.workflows.workflow_node.Workflow";
 export const SUBGRAPH_NODE_TYPE = "nodetool.workflows.subgraph.Subgraph";
 
+/**
+ * Accent for everything subgraph — the node's header and the tab that opens its
+ * canvas. Violet, distinct from WorkflowNode's teal, so a subgraph canvas is
+ * never mistaken for the parent workflow's.
+ */
+export const SUBGRAPH_ACCENT_COLOR = "#7C3AED";
+
 // --- Special editor nodes --------------------------------------------------
 export const SKETCH_NODE_TYPE = "nodetool.constant.Sketch";
 export const CODE_NODE_TYPE = "nodetool.code.Code";

--- a/web/tests/journeys/README.md
+++ b/web/tests/journeys/README.md
@@ -75,12 +75,6 @@ mutate it — adding nodes, sending messages. Assert against a measured baseline
 
 ## Known gaps
 
-- Three subgraph tests are `test.fixme`. Creating a SubgraphNode works and
-  double-clicking it does call `SubgraphTabsStore.openTab`, but the workspace
-  shell renders no subgraph tab strip and no subgraph canvas — the store is read
-  only by `PanelRight`. The tests assert on `.subgraph-tab`, which no longer
-  exists in the app. They stay as fixme because they describe the surface that
-  has to come back.
 - Editing a node's property on the canvas is not covered. Clicks near the left
   icon rail get intercepted, and stray keystrokes land on canvas shortcuts
   (typing `b` bypasses the selected node). The mini-app journey covers

--- a/web/tests/journeys/README.md
+++ b/web/tests/journeys/README.md
@@ -43,9 +43,14 @@ Seeded in `screenshot-server.ts`:
 
 | Id | What it is |
 | --- | --- |
-| `wf-mini-app` | `StringInput → Output` echo graph plus an app document (input, Run button, Output widget). Used by the mini-app journey. |
+| `wf-mini-app` | `StringInput → Output` echo graph. The workflow the mini app's one operation binds. |
+| `app-mini-app` | The `applications` row built on that graph — an app document with an input, a Run button and an Output widget. Used by the mini-app journey. |
 | `wf-editor-journey` | The same graph in a separate row, so the editor journey's edits can't disturb the mini-app journey. |
 | `thread-story` | Chat thread with existing messages. |
+
+An app is its own resource, not a workflow with an `app_doc`: there is no
+standalone `/apps/<id>` route. The mini-app journey opens the app the way a user
+does — the editor's left rail, Apps, the app, then the tab's Run toggle.
 
 The echo graph is deliberately trivial: both nodes are structural, so the value
 the UI shows after a run is genuinely the value that travelled through the
@@ -70,11 +75,12 @@ mutate it — adding nodes, sending messages. Assert against a measured baseline
 
 ## Known gaps
 
-- Three subgraph tests are `test.fixme`. Creating a SubgraphNode works;
-  double-clicking it never opens its tab. Reproduced against both the hermetic
-  backend and real providers, so it is a product bug, not a harness one. The
-  spec previously lived at `tests/subgraph-e2e.spec.ts` where no CI workflow ran
-  it, which is why it went unnoticed.
+- Three subgraph tests are `test.fixme`. Creating a SubgraphNode works and
+  double-clicking it does call `SubgraphTabsStore.openTab`, but the workspace
+  shell renders no subgraph tab strip and no subgraph canvas — the store is read
+  only by `PanelRight`. The tests assert on `.subgraph-tab`, which no longer
+  exists in the app. They stay as fixme because they describe the surface that
+  has to come back.
 - Editing a node's property on the canvas is not covered. Clicks near the left
   icon rail get intercepted, and stray keystrokes land on canvas shortcuts
   (typing `b` bypasses the selected node). The mini-app journey covers

--- a/web/tests/journeys/fixtures.ts
+++ b/web/tests/journeys/fixtures.ts
@@ -19,8 +19,12 @@ import {
 
 /** Ids seeded by `packages/websocket/src/screenshot-server.ts`. */
 export const FIXTURES = {
-  /** Two-node echo graph + app document. Used by the mini-app journey. */
+  /** Two-node echo graph. The workflow the mini app's operation binds. */
   miniApp: "wf-mini-app",
+  /** The `applications` row built on that graph. Used by the mini-app journey. */
+  miniAppId: "app-mini-app",
+  /** Its display name — how a user picks it out of the Apps panel. */
+  miniAppName: "Echo Mini App",
   /** Same graph, separate row — the editor journey mutates this one. */
   editorGraph: "wf-editor-journey",
   /** Seeded thread with existing messages. */

--- a/web/tests/journeys/library.spec.ts
+++ b/web/tests/journeys/library.spec.ts
@@ -87,17 +87,16 @@ test.describe("Asset browser", () => {
 });
 
 test.describe("Fixture wiring", () => {
-  test("the seeded mini-app workflow is served with its app document", async ({
+  test("the mini app's workflow is served with its echo graph", async ({
     request
   }) => {
-    // Guards the fixture the mini-app journey depends on: if `app_doc` ever
-    // stops being persisted, this fails with a clear cause instead of the
-    // mini-app spec failing on a missing Run button.
+    // Guards the workflow half of the fixture the mini-app journey depends on:
+    // if the echo graph ever loses a node, this fails with a clear cause
+    // instead of the mini-app spec failing on an Output that stays empty.
     const res = await request.get(`/api/workflows/${FIXTURES.miniApp}`);
     expect(res.ok()).toBe(true);
 
     const workflow = await res.json();
-    expect(workflow.app_doc, "mini-app fixture lost its app_doc").toBeTruthy();
     expect(workflow.graph.nodes).toHaveLength(2);
   });
 });

--- a/web/tests/journeys/mini-app.spec.ts
+++ b/web/tests/journeys/mini-app.spec.ts
@@ -1,14 +1,14 @@
 /**
  * Journey: open a mini app, run it, read the result.
  *
- * Covers the app runtime and the streaming fold: the Puck document's widgets
- * bind to the workflow's inputs and outputs, the Run button triggers a job, and
- * the streamed messages fold back into the Output widget's value.
+ * Covers the app runtime and the streaming fold: the app document's widgets
+ * bind to its operation's inputs and outputs, the Run button triggers a job,
+ * and the streamed messages fold back into the Output widget's value.
  *
- * The `wf-mini-app` fixture is a `StringInput → Output` echo, so the assertion
- * is exact — the text typed into the input is the text the Output widget must
- * display. Nothing in that path is faked, which makes this the strongest
- * end-to-end signal in the suite.
+ * The `app-mini-app` fixture binds `wf-mini-app`, a `StringInput → Output`
+ * echo, so the assertion is exact — the text typed into the input is the text
+ * the Output widget must display. Nothing in that path is faked, which makes
+ * this the strongest end-to-end signal in the suite.
  */
 
 import { test, expect, FIXTURES } from "./fixtures";
@@ -17,7 +17,7 @@ import { MiniAppPage } from "./pages";
 test.describe("Mini app", () => {
   test("renders the app document's widgets", async ({ page, pageErrors }) => {
     const app = new MiniAppPage(page);
-    await app.open(FIXTURES.miniApp);
+    await app.open(FIXTURES.miniAppName);
 
     await expect(app.runButton()).toBeVisible();
     await expect(app.promptInput().first()).toBeVisible();
@@ -27,7 +27,7 @@ test.describe("Mini app", () => {
 
   test("runs with the seeded input value", async ({ page }) => {
     const app = new MiniAppPage(page);
-    await app.open(FIXTURES.miniApp);
+    await app.open(FIXTURES.miniAppName);
 
     await app.run();
 
@@ -36,7 +36,7 @@ test.describe("Mini app", () => {
 
   test("runs with a value the user typed", async ({ page }) => {
     const app = new MiniAppPage(page);
-    await app.open(FIXTURES.miniApp);
+    await app.open(FIXTURES.miniAppName);
 
     // Distinct from the seeded default, so a stale or ignored param fails
     // instead of passing on the old value.

--- a/web/tests/journeys/pages.ts
+++ b/web/tests/journeys/pages.ts
@@ -117,12 +117,31 @@ export class ChatPage {
   }
 }
 
-/** A mini app rendered by the app runtime at `/apps/<id>`. */
+/**
+ * A mini app, opened the way a user opens one.
+ *
+ * An app is its own resource: there is no standalone `/apps/<id>` route any
+ * more. A user reaches one from the editor's left rail — Apps → the app — which
+ * opens it as a workspace tab in Design mode, then switches that tab to Run.
+ */
 export class MiniAppPage {
   constructor(private readonly page: Page) {}
 
-  async open(workflowId: string): Promise<void> {
-    await goto(this.page, `/apps/${workflowId}`);
+  /** Open the app named `appName` and switch its tab to Run. */
+  async open(appName: string): Promise<void> {
+    await goto(this.page, "/workspace");
+    await this.page.getByRole("button", { name: "Apps" }).first().click();
+    await this.page
+      .getByRole("button", { name: appName })
+      .first()
+      .click({ timeout: 30_000 });
+
+    // The tab opens in Design mode; Run is the surface a user runs the app on.
+    await this.page
+      .getByRole("button", { name: "Run", exact: true })
+      .first()
+      .click({ timeout: 30_000 });
+
     await this.runButton().waitFor({ state: "visible", timeout: 30_000 });
   }
 

--- a/web/tests/journeys/subgraph.spec.ts
+++ b/web/tests/journeys/subgraph.spec.ts
@@ -123,16 +123,18 @@ test.describe("Subgraph feature", () => {
   });
 
   /**
-   * PRE-EXISTING FAILURE — not caused by moving this spec into the journey
-   * suite. Creating a SubgraphNode works (the test above passes), but
-   * double-clicking it never opens a `.subgraph-tab`, so every test that
-   * depends on the tab opening times out. Reproduced identically against both
-   * the hermetic backend and real providers (`NODETOOL_FAKE_PROVIDERS=0`).
+   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
+   * (the test above passes) and double-clicking it does call
+   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
+   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
+   * `PanelRight`, to pick which store the inspector shows. There is no
+   * `.subgraph-tab` element in the app, so this test and the two below assert
+   * against markup that does not exist.
    *
-   * This spec previously lived at `tests/subgraph-e2e.spec.ts`, where no CI
-   * workflow ran it — which is why the regression went unnoticed. Marked fixme
-   * so the nightly journey run stays meaningful; remove once the tab-opening
-   * path is fixed.
+   * Kept as fixme rather than deleted: the store, the open path and the
+   * inspector wiring are all still there, so these describe the surface that
+   * has to come back. Remove the fixme once the workspace shell hosts subgraph
+   * tabs again.
    */
   test.fixme("opens a violet-accented tab when double-clicked", async ({ page }) => {
     await gotoEditor(page);
@@ -205,16 +207,18 @@ test.describe("Subgraph feature", () => {
   });
 
   /**
-   * PRE-EXISTING FAILURE — not caused by moving this spec into the journey
-   * suite. Creating a SubgraphNode works (the test above passes), but
-   * double-clicking it never opens a `.subgraph-tab`, so every test that
-   * depends on the tab opening times out. Reproduced identically against both
-   * the hermetic backend and real providers (`NODETOOL_FAKE_PROVIDERS=0`).
+   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
+   * (the test above passes) and double-clicking it does call
+   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
+   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
+   * `PanelRight`, to pick which store the inspector shows. There is no
+   * `.subgraph-tab` element in the app, so this test and the two below assert
+   * against markup that does not exist.
    *
-   * This spec previously lived at `tests/subgraph-e2e.spec.ts`, where no CI
-   * workflow ran it — which is why the regression went unnoticed. Marked fixme
-   * so the nightly journey run stays meaningful; remove once the tab-opening
-   * path is fixed.
+   * Kept as fixme rather than deleted: the store, the open path and the
+   * inspector wiring are all still there, so these describe the surface that
+   * has to come back. Remove the fixme once the workspace shell hosts subgraph
+   * tabs again.
    */
   test.fixme("subgraph canvas accepts new nodes via pane context menu", async ({
     page
@@ -307,16 +311,18 @@ test.describe("Subgraph feature", () => {
   });
 
   /**
-   * PRE-EXISTING FAILURE — not caused by moving this spec into the journey
-   * suite. Creating a SubgraphNode works (the test above passes), but
-   * double-clicking it never opens a `.subgraph-tab`, so every test that
-   * depends on the tab opening times out. Reproduced identically against both
-   * the hermetic backend and real providers (`NODETOOL_FAKE_PROVIDERS=0`).
+   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
+   * (the test above passes) and double-clicking it does call
+   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
+   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
+   * `PanelRight`, to pick which store the inspector shows. There is no
+   * `.subgraph-tab` element in the app, so this test and the two below assert
+   * against markup that does not exist.
    *
-   * This spec previously lived at `tests/subgraph-e2e.spec.ts`, where no CI
-   * workflow ran it — which is why the regression went unnoticed. Marked fixme
-   * so the nightly journey run stays meaningful; remove once the tab-opening
-   * path is fixed.
+   * Kept as fixme rather than deleted: the store, the open path and the
+   * inspector wiring are all still there, so these describe the surface that
+   * has to come back. Remove the fixme once the workspace shell hosts subgraph
+   * tabs again.
    */
   test.fixme("switches back to parent workflow tab and closes subgraph tab", async ({
     page

--- a/web/tests/journeys/subgraph.spec.ts
+++ b/web/tests/journeys/subgraph.spec.ts
@@ -3,12 +3,13 @@
  *
  * Exercises the full UI flow:
  *  - Add Subgraph via pane context menu
- *  - Verify the SubgraphNode appears on the canvas with the violet accent
- *  - Double-click to open it in a tab
- *  - Verify the tab chrome (violet border) appears
- *  - Switch back to the parent workflow tab
- *  - Close the subgraph tab; verify cleanup
- *  - Group existing nodes via NodeContextMenu and verify a subgraph is formed
+ *  - Double-click it to open its canvas in a tab
+ *  - Edit that canvas, and switch and close the tab
+ *  - Confirm the edit landed on the parent node rather than dying with the tab
+ *
+ * The last one is the assertion that matters: a subgraph tab holds its own
+ * NodeStore, so a canvas that renders and edits perfectly can still lose every
+ * change the moment the tab closes.
  *
  * Runs against the real backend started by `tests/globalSetup.ts`.
  */
@@ -93,6 +94,48 @@ const openPaneContextMenu = async (page: Page): Promise<void> => {
   }
 };
 
+/**
+ * Open the first SubgraphNode's canvas by double-clicking it, as a user would.
+ *
+ * A real double-click, not a synthetic dispatch: React Flow's
+ * `onNodeDoubleClick` is what opens the tab, and it is the handler that
+ * registers the subgraph's NodeStore.
+ */
+const openSubgraphTab = async (page: Page): Promise<void> => {
+  await page.locator(".subgraph-node").first().dblclick();
+  await page
+    .locator(".subgraph-tab.active")
+    .first()
+    .waitFor({ state: "visible", timeout: 5000 });
+};
+
+/**
+ * Add a String Input node to the open subgraph canvas via its pane menu.
+ *
+ * The subgraph canvas overlays the parent one, so a real right-click at the
+ * centre of the editor area lands on the subgraph's pane.
+ */
+const addStringInputToSubgraph = async (page: Page): Promise<void> => {
+  await page.mouse.move(960, 540);
+  await page.mouse.click(960, 540, { button: "right" });
+
+  await page
+    .locator(".pane-context-menu")
+    .first()
+    .waitFor({ state: "visible", timeout: 5000 });
+
+  await page
+    .locator(".pane-context-menu")
+    .getByText("Add Input Node", { exact: false })
+    .first()
+    .click();
+  await page
+    .locator(".pane-submenu")
+    .getByText("String", { exact: true })
+    .first()
+    .click();
+};
+
 const clickAddSubgraph = async (page: Page): Promise<void> => {
   // Locate the "Add Subgraph" item by visible text within the open pane menu.
   const item = page
@@ -122,21 +165,7 @@ test.describe("Subgraph feature", () => {
     expect(after).toBe(1);
   });
 
-  /**
-   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
-   * (the test above passes) and double-clicking it does call
-   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
-   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
-   * `PanelRight`, to pick which store the inspector shows. There is no
-   * `.subgraph-tab` element in the app, so this test and the two below assert
-   * against markup that does not exist.
-   *
-   * Kept as fixme rather than deleted: the store, the open path and the
-   * inspector wiring are all still there, so these describe the surface that
-   * has to come back. Remove the fixme once the workspace shell hosts subgraph
-   * tabs again.
-   */
-  test.fixme("opens a violet-accented tab when double-clicked", async ({ page }) => {
+  test("opens a violet-accented tab when double-clicked", async ({ page }) => {
     await gotoEditor(page);
 
     await openPaneContextMenu(page);
@@ -147,43 +176,7 @@ test.describe("Subgraph feature", () => {
 
     expect(await page.locator(".subgraph-tab").count()).toBe(0);
 
-    // Get the subgraph node's React Flow id (data-id attribute) and dispatch
-    // a synthetic dblclick on the actual .react-flow__node wrapper so React
-    // Flow's onNodeDoubleClick handler picks it up.
-    const fired = await page.evaluate(() => {
-      const node = document.querySelector(".subgraph-node");
-      const wrapper = node?.closest(".react-flow__node") as HTMLElement | null;
-      if (!wrapper) return false;
-      const rect = wrapper.getBoundingClientRect();
-      const eventInit = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        clientX: rect.left + rect.width / 2,
-        clientY: rect.top + rect.height / 2,
-        button: 0,
-        buttons: 0,
-        detail: 2
-      };
-      wrapper.dispatchEvent(new MouseEvent("mousedown", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("mouseup", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("click", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("dblclick", eventInit));
-      return true;
-    });
-    expect(fired).toBe(true);
-
-    await page.waitForFunction(
-      () => document.querySelectorAll(".subgraph-tab").length > 0,
-      undefined,
-      { timeout: 5000 }
-    );
-
-    await page.waitForFunction(
-      () => document.querySelectorAll(".subgraph-tab.active").length > 0,
-      undefined,
-      { timeout: 5000 }
-    );
+    await openSubgraphTab(page);
 
     // The subgraph tab's canvas must actually mount a ReactFlow viewport —
     // not the "Workflow not found" error state from a failed useWorkflow
@@ -206,21 +199,7 @@ test.describe("Subgraph feature", () => {
     expect(paneCount).toBeGreaterThan(0);
   });
 
-  /**
-   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
-   * (the test above passes) and double-clicking it does call
-   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
-   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
-   * `PanelRight`, to pick which store the inspector shows. There is no
-   * `.subgraph-tab` element in the app, so this test and the two below assert
-   * against markup that does not exist.
-   *
-   * Kept as fixme rather than deleted: the store, the open path and the
-   * inspector wiring are all still there, so these describe the surface that
-   * has to come back. Remove the fixme once the workspace shell hosts subgraph
-   * tabs again.
-   */
-  test.fixme("subgraph canvas accepts new nodes via pane context menu", async ({
+  test("subgraph canvas accepts new nodes via pane context menu", async ({
     page
   }) => {
     await gotoEditor(page);
@@ -230,33 +209,7 @@ test.describe("Subgraph feature", () => {
     const subgraphNode = page.locator(".subgraph-node").first();
     await subgraphNode.waitFor({ state: "attached", timeout: 5000 });
 
-    // Open the subgraph in a tab.
-    await page.evaluate(() => {
-      const node = document.querySelector(".subgraph-node");
-      const wrapper = node?.closest(".react-flow__node") as HTMLElement | null;
-      if (!wrapper) return;
-      const rect = wrapper.getBoundingClientRect();
-      const eventInit = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        clientX: rect.left + rect.width / 2,
-        clientY: rect.top + rect.height / 2,
-        button: 0,
-        buttons: 0,
-        detail: 2
-      };
-      wrapper.dispatchEvent(new MouseEvent("mousedown", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("mouseup", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("click", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("dblclick", eventInit));
-    });
-
-    await page.waitForFunction(
-      () => document.querySelectorAll(".subgraph-tab.active").length > 0,
-      undefined,
-      { timeout: 5000 }
-    );
+    await openSubgraphTab(page);
     await page.waitForSelector(".react-flow__viewport", {
       state: "attached",
       timeout: 10_000
@@ -274,28 +227,7 @@ test.describe("Subgraph feature", () => {
       );
     });
 
-    // Right-click on the subgraph pane via real mouse. The
-    // SubgraphTabContent Box covers the editor area with zIndex above the
-    // (invisible) parent canvas, so this lands on the subgraph pane.
-    await page.mouse.move(960, 540);
-    await page.mouse.click(960, 540, { button: "right" });
-
-    await page
-      .locator(".pane-context-menu")
-      .first()
-      .waitFor({ state: "visible", timeout: 5000 });
-
-    // Click "Add Input Node" → "String" inside the now-open menu.
-    await page
-      .locator(".pane-context-menu")
-      .getByText("Add Input Node", { exact: false })
-      .first()
-      .click();
-    await page
-      .locator(".pane-submenu")
-      .getByText("String", { exact: true })
-      .first()
-      .click();
+    await addStringInputToSubgraph(page);
 
     // The node count inside the subgraph canvas should increase by one.
     await page.waitForFunction(
@@ -310,21 +242,7 @@ test.describe("Subgraph feature", () => {
     );
   });
 
-  /**
-   * UNIMPLEMENTED SURFACE, not a broken one. Creating a SubgraphNode works
-   * (the test above passes) and double-clicking it does call
-   * `SubgraphTabsStore.openTab`, but the workspace shell renders no subgraph
-   * tab strip and no subgraph canvas: `SubgraphTabsStore.tabs` is read only by
-   * `PanelRight`, to pick which store the inspector shows. There is no
-   * `.subgraph-tab` element in the app, so this test and the two below assert
-   * against markup that does not exist.
-   *
-   * Kept as fixme rather than deleted: the store, the open path and the
-   * inspector wiring are all still there, so these describe the surface that
-   * has to come back. Remove the fixme once the workspace shell hosts subgraph
-   * tabs again.
-   */
-  test.fixme("switches back to parent workflow tab and closes subgraph tab", async ({
+  test("switches back to parent workflow tab and closes subgraph tab", async ({
     page
   }) => {
     await gotoEditor(page);
@@ -334,49 +252,47 @@ test.describe("Subgraph feature", () => {
     const subgraphNode = page.locator(".subgraph-node").first();
     await subgraphNode.waitFor({ state: "attached", timeout: 5000 });
 
-    // Open the subgraph tab via JS dispatch (same as test 2).
-    await page.evaluate(() => {
-      const node = document.querySelector(".subgraph-node");
-      const wrapper = node?.closest(".react-flow__node") as HTMLElement | null;
-      if (!wrapper) return;
-      const rect = wrapper.getBoundingClientRect();
-      const eventInit = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        clientX: rect.left + rect.width / 2,
-        clientY: rect.top + rect.height / 2,
-        button: 0,
-        buttons: 0,
-        detail: 2
-      };
-      wrapper.dispatchEvent(new MouseEvent("mousedown", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("mouseup", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("click", eventInit));
-      wrapper.dispatchEvent(new MouseEvent("dblclick", eventInit));
-    });
+    await openSubgraphTab(page);
 
-    await page.waitForFunction(
-      () => document.querySelectorAll(".subgraph-tab").length > 0,
-      undefined,
-      { timeout: 5000 }
-    );
+    // Back to the parent canvas: the subgraph tab stays open, the parent
+    // graph is what the canvas shows again.
+    await page.locator(".parent-tab").first().click();
+    await expect(page.locator(".subgraph-tab.active")).toHaveCount(0);
+    await expect(page.locator(".subgraph-node").first()).toBeVisible();
 
-    // Close the subgraph tab via the close icon. The close-icon is an SVG
-    // element so we dispatch a synthetic click that bubbles through React.
-    await page.evaluate(() => {
-      const tab = document.querySelector(".subgraph-tab");
-      const close = tab?.querySelector(".close-icon");
-      if (!close) return;
-      close.dispatchEvent(
-        new MouseEvent("click", { bubbles: true, cancelable: true })
-      );
-    });
+    await page.locator(".subgraph-tab .close-icon").first().click();
 
-    await page.waitForFunction(
-      () => document.querySelectorAll(".subgraph-tab").length === 0,
-      undefined,
-      { timeout: 5000 }
-    );
+    // The strip disappears with its last subgraph tab.
+    await expect(page.locator(".subgraph-tab")).toHaveCount(0);
+  });
+
+  test("keeps subgraph edits on the parent node", async ({ page }) => {
+    await gotoEditor(page);
+
+    await openPaneContextMenu(page);
+    await clickAddSubgraph(page);
+    await page
+      .locator(".subgraph-node")
+      .first()
+      .waitFor({ state: "attached", timeout: 5000 });
+
+    const handlesBefore = await page
+      .locator(".subgraph-node .react-flow__handle")
+      .count();
+
+    await openSubgraphTab(page);
+    await addStringInputToSubgraph(page);
+
+    // Back on the parent canvas the SubgraphNode must expose the new boundary
+    // port. That only happens if the inner graph was written back onto the
+    // node — SubgraphSync derives the node's ports from `properties.graph`, so
+    // a canvas whose edits never leave the tab would show no new handle.
+    await page.locator(".parent-tab").first().click();
+    await expect
+      .poll(
+        () => page.locator(".subgraph-node .react-flow__handle").count(),
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(handlesBefore);
   });
 });


### PR DESCRIPTION
Two commits: the journey-suite repair, then the subgraph bug it surfaced.

---

## 1. Mini-app journey pointed at a route that no longer exists

`MiniAppPage.open()` navigated to `/apps/<workflowId>`. An app is its own resource now (`applications` table, opened as a workspace tab), so all three mini-app tests booted into the error boundary and timed out after 30s. The nightly last ran green before the apps work landed, and it's `continue-on-error: true`, so nothing flagged it.

- **Fixture** — `screenshot-server.ts` seeds an `applications` row (`app-mini-app`) whose one operation binds the existing `wf-mini-app` echo graph. That operation's `workflowId` had been left `""`.
- **Page object** — opens the app the way a user does: left rail → Apps → the app → the tab's Run toggle. Spec assertions untouched, so the journey still proves value-in → kernel → value-out with nothing faked.
- **Fixture-wiring test** — asserted on `workflow.app_doc`, which the app layer no longer reads. Now guards the echo graph the operation actually runs.

## 2. Subgraphs: double-clicking a SubgraphNode did nothing

Three separate faults, and only the first was visible.

**No surface.** `SubgraphTabsStore` was read by exactly one component — `PanelRight`, to pick the inspector's store. Nothing rendered a tab strip or a subgraph canvas, so `openTab` mutated state nobody displayed. Added `SubgraphTabStrip` and `SubgraphTabContent` (a second `NodeEditor` over the tab's own store), hosted by `WorkflowEditorSurface` the same way the chain view is — overlaid, parent editor left mounted so returning keeps its viewport. `SubgraphTabContent` renders itself for a subgraph opened inside a subgraph.

Subgraph tabs stay out of `WorkspaceTabsStore` deliberately: that persists to localStorage, and a restored tab would point at a `NodeStore` that no longer exists.

**The wrong handler won.** `SubgraphNode` and `ReactFlowWrapper` both handled the double click. The node's called `stopPropagation`, so it always won — and it was the one that did *not* register the tab's store in the WorkflowManager, which the canvas needs to skip a 404 fetch for the synthetic id. Deleted it. That surviving handler also keyed the tab off `data.workflow_id`, only stamped on nodes the store created, so a node loaded from a saved graph keyed its tab off `""`; it now uses the canvas's own workflow id.

**Edits died with the tab.** The tab's store is seeded from `properties.graph` and nothing wrote back, so a subgraph edited perfectly still saved nothing and `SubgraphSync` never saw the new boundary ports. Added `SubgraphGraphSync` — debounced against drag frames, flushed on unmount, since cancelling there would drop any edit from the last 300ms, which is exactly when the user switches or closes the tab.

Also scoped the inspector to the workflow on screen; it followed `activeKey` globally, so switching workflow tabs left it on the other one's subgraph.

## Tests

The three `test.fixme` specs are re-enabled and now drive a real double-click instead of dispatching synthetic mouse events. A fifth covers the write-back: add an Input inside the subgraph, return to the parent, assert the SubgraphNode grew the port. **That test caught the flush bug** — the first implementation cancelled the pending write on unmount, so switching tabs quickly lost the edit.

```
Journeys:  20 passed, 0 skipped, 0 failed
Jest:      3043 passed (node, stores, panels, workspace)
```

`npm run lint` and web/electron typecheck clean. Mobile typecheck fails in this sandbox on uninstalled Expo deps — pre-existing and unrelated; CI's typecheck job covers it.