### PR TITLE
refactor(web): design-token and accessibility cleanup across the UI

### DIFF
--- a/web/src/components/asset_viewer/LazyPDFViewer.tsx
+++ b/web/src/components/asset_viewer/LazyPDFViewer.tsx
@@ -2,7 +2,7 @@
 // it out of the initial bundle.
 
 import React, { Suspense, lazy } from "react";
-import { FlexColumn, Text, LoadingSpinner } from "../ui_primitives";
+import { FlexColumn, Text, LoadingSpinner, SPACING } from "../ui_primitives";
 import type { Asset } from "../../stores/ApiTypes";
 
 const PDFViewer = lazy(() =>
@@ -20,7 +20,7 @@ const PDFViewerLoadingFallback: React.FC = () => (
   <FlexColumn
     align="center"
     justify="center"
-    gap={2}
+    gap={SPACING.md}
     sx={{ height: "300px" }}
   >
     <LoadingSpinner size="medium" />

--- a/web/src/components/asset_viewer/Model3DViewer.tsx
+++ b/web/src/components/asset_viewer/Model3DViewer.tsx
@@ -668,7 +668,7 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
       >
         <FlexColumn className="canvas-container" fullWidth fullHeight>
           {isLoading && !loadError && (
-            <FlexColumn className="loading-overlay" align="center" gap={1}>
+            <FlexColumn className="loading-overlay" align="center" gap={SPACING.xs}>
               <LoadingSpinner size={compact ? "small" : "medium"} />
               {!compact && (
                 <Text size="small" color="secondary">
@@ -678,7 +678,7 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
             </FlexColumn>
           )}
           {loadError && (
-            <FlexColumn className="error-overlay" align="flex-start" gap={0.5}>
+            <FlexColumn className="error-overlay" align="flex-start" gap={SPACING.micro}>
               {loadError.split("\n").map((line, i) => (
                 <Text
                   key={`${i}:${line}`}
@@ -778,7 +778,7 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
         )}
 
         {!compact && (
-          <FlexRow className="controls-toolbar" gap={0.5} align="center">
+          <FlexRow className="controls-toolbar" gap={SPACING.micro} align="center">
             <ToolbarIconButton
               icon={<GridOnIcon fontSize="small" />}
               tooltip="Toggle Grid"

--- a/web/src/components/asset_viewer/PDFViewer.tsx
+++ b/web/src/components/asset_viewer/PDFViewer.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   ToolbarIconButton,
   BORDER_RADIUS,
+  SPACING,
   getSpacingPx,
   Z_INDEX
 } from "../ui_primitives";
@@ -227,7 +228,7 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ asset, url }) => {
         >
           {pageComponent}
         </Document>
-        <FlexRow className="page-controls" align="center" gap={1} sx={{ position: "sticky", bottom: "1em", background: theme.vars.palette.grey[600], padding: "0.8em 1em", borderRadius: BORDER_RADIUS.sm, zIndex: Z_INDEX.sticky, minWidth: "200px", userSelect: "none" }}>
+        <FlexRow className="page-controls" align="center" gap={SPACING.xs} sx={{ position: "sticky", bottom: "1em", background: theme.vars.palette.grey[600], padding: "0.8em 1em", borderRadius: BORDER_RADIUS.sm, zIndex: Z_INDEX.sticky, minWidth: "200px", userSelect: "none" }}>
           <ToolbarIconButton
             icon={<NavigateBefore />}
             tooltip="Previous page"

--- a/web/src/components/assets/AssetActionsMenu.tsx
+++ b/web/src/components/assets/AssetActionsMenu.tsx
@@ -159,21 +159,21 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
           display: "flex",
           flexWrap: "wrap",
           alignItems: "center",
-          columnGap: 2,
-          rowGap: 1,
-          px: 2,
-          py: 1
+          columnGap: SPACING.md,
+          rowGap: SPACING.xs,
+          px: SPACING.md,
+          py: SPACING.xs
         })
       }}
     >
       <FlexRow
         className="asset-menu-toolbar"
         align="center"
-        gap={0.75}
+        gap={SPACING.xs}
         wrap
         sx={{
-          px: 0.5,
-          py: 0.5,
+          px: SPACING.micro,
+          py: SPACING.micro,
           "& .MuiIconButton-root": { padding: SPACING.sm },
           "& .MuiSvgIcon-root": { fontSize: 16 }
         }}
@@ -199,14 +199,14 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
           active={typeFilterActive}
           sx={{
             borderRadius: BORDER_RADIUS.sm,
-            px: 0.5,
-            gap: 0.5,
+            px: SPACING.micro,
+            gap: SPACING.micro,
             fontSize: FONT_SIZE_SANS.label
           }}
         >
           <FlexRow
             align="center"
-            gap={0.5}
+            gap={SPACING.micro}
             sx={{ "& .MuiSvgIcon-root": { fontSize: 18 } }}
           >
             {TYPE_FILTER_ICONS[typeFilter]}
@@ -228,8 +228,12 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         )}
 
         {/* Actions: create & add assets */}
-        <FlexRow align="center" gap={0.5} sx={{ ml: "auto", pl: 0.5 }}>
-          <Divider orientation="vertical" flexItem sx={{ my: 0.5, mr: 0.5 }} />
+        <FlexRow align="center" gap={SPACING.micro} sx={{ ml: "auto", pl: SPACING.micro }}>
+          <Divider
+            orientation="vertical"
+            flexItem
+            sx={{ my: SPACING.micro, mr: SPACING.micro }}
+          />
           {!hideFolderControls && (
             <ToolbarIconButton
               icon={<CreateNewFolderIcon />}
@@ -253,7 +257,7 @@ const AssetActionsMenu: React.FC<AssetActionsMenuProps> = ({
         anchorEl={typeFilterAnchor}
         onClose={() => setTypeFilterAnchor(null)}
         placement="bottom-left"
-        paperSx={{ py: 0.5, minWidth: 160 }}
+        paperSx={{ py: SPACING.micro, minWidth: 160 }}
       >
         {TYPE_FILTERS.map((filter) => (
           <MenuItemPrimitive

--- a/web/src/components/assets/AssetCreateFolderConfirmation.tsx
+++ b/web/src/components/assets/AssetCreateFolderConfirmation.tsx
@@ -262,7 +262,7 @@ const AssetCreateFolderConfirmation: React.FC = () => {
 
         <FlexRow
           justify="flex-end"
-          gap={1}
+          gap={SPACING.xs}
           sx={{
             padding: ".5em 1em"
           }}

--- a/web/src/components/assets/AssetGrid.tsx
+++ b/web/src/components/assets/AssetGrid.tsx
@@ -116,7 +116,7 @@ const SelectedItemsInfo: React.FC<{
           tooltipPlacement="top"
           onClick={onClear}
           size="small"
-          sx={{ ml: 0.5, "& .MuiSvgIcon-root": { fontSize: 14 } }}
+          sx={{ ml: SPACING.micro, "& .MuiSvgIcon-root": { fontSize: 14 } }}
         />
       </div>
     </div>

--- a/web/src/components/assets/AssetListView.tsx
+++ b/web/src/components/assets/AssetListView.tsx
@@ -372,6 +372,7 @@ const AssetListView: React.FC<AssetListViewProps> = ({
           key={key}
           role="button"
           tabIndex={0}
+          aria-expanded={isExpanded}
           style={style}
           className="asset-content-type-header"
           onClick={(e) => {

--- a/web/src/components/assets/AssetMoveToFolderConfirmation.tsx
+++ b/web/src/components/assets/AssetMoveToFolderConfirmation.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { useCallback, useEffect, useState } from "react";
-import { Dialog, AlertBanner, EditorButton, FlexRow, FlexColumn } from "../ui_primitives";
+import { Dialog, AlertBanner, EditorButton, FlexRow, FlexColumn, SPACING } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import { getMousePosition } from "../../utils/MousePosition";
 import dialogStyles from "../../styles/DialogStyles";
@@ -75,7 +75,7 @@ const AssetMoveToFolderConfirmation: React.FC<
         </>
       }
       content={
-        <FlexColumn gap={2}>
+        <FlexColumn gap={SPACING.md}>
           {showAlert && (
             <AlertBanner severity="success" onClose={() => setShowAlert(null)}>
               {showAlert}

--- a/web/src/components/assets/AssetRenameConfirmation.tsx
+++ b/web/src/components/assets/AssetRenameConfirmation.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "@mui/material/styles";
-import { Text, Dialog, AlertBanner, EditorButton, FlexColumn, FlexRow, TextInput } from "../ui_primitives";
+import { Text, Dialog, AlertBanner, EditorButton, FlexColumn, FlexRow, TextInput, SPACING } from "../ui_primitives";
 import { getMousePosition } from "../../utils/MousePosition";
 import dialogStyles from "../../styles/DialogStyles";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
@@ -159,7 +159,7 @@ const AssetRenameConfirmation: React.FC<AssetRenameConfirmationProps> = (
               </span>
             }
             content={
-              <FlexColumn gap={2}>
+              <FlexColumn gap={SPACING.md}>
                 {showAlert && (
                   <AlertBanner
                     className="asset-rename-error-alert"
@@ -183,7 +183,7 @@ const AssetRenameConfirmation: React.FC<AssetRenameConfirmationProps> = (
                   autoCorrect="off"
                   spellCheck="false"
                 />
-                <FlexRow justify="flex-end" gap={1} fullWidth>
+                <FlexRow justify="flex-end" gap={SPACING.xs} fullWidth>
                   <EditorButton
                     className="asset-rename-cancel-button button-cancel"
                     onClick={handleClose}
@@ -198,7 +198,7 @@ const AssetRenameConfirmation: React.FC<AssetRenameConfirmationProps> = (
                   </EditorButton>
                 </FlexRow>
                 {assets && assets.length > 1 && (
-                  <FlexColumn className="asset-rename-notice-container" gap={0}>
+                  <FlexColumn className="asset-rename-notice-container" gap={SPACING.none}>
                     <Text className="asset-rename-notice notice" size="small">
                       <span>Multiple assets selected:</span> <br />
                       Names will be appended with a number.

--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -24,6 +24,7 @@ import {
   MOTION,
   reducedMotion,
   BORDER_RADIUS,
+  SPACING,
   Z_INDEX
 } from "../ui_primitives";
 //icons
@@ -653,8 +654,8 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
             />
           </>
         )}
-        <FlexRow className="asset-navigation" align="flex-end" justify="center" gap={1}>
-          <FlexRow className="prev-next-items left" align="center" justify="flex-end" gap={0.5}>
+        <FlexRow className="asset-navigation" align="flex-end" justify="center" gap={SPACING.xs}>
+          <FlexRow className="prev-next-items left" align="center" justify="flex-end" gap={SPACING.micro}>
             {displayPrevAssets?.map((asset, idx) => {
               const assetIndex = Math.max(
                 0,
@@ -701,7 +702,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
               showFiletype={true}
             />
           </FlexRow>
-          <FlexRow className="prev-next-items right" align="center" justify="flex-start" gap={0.5}>
+          <FlexRow className="prev-next-items right" align="center" justify="flex-start" gap={SPACING.micro}>
             {displayNextAssets?.map((asset, idx) => {
               const assetIndex = currentIndex + 1 + idx;
               const isCompareSelected = compareAssetA?.id === asset.id;
@@ -781,7 +782,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
       >
         {/* Compare mode instruction bar */}
         {compareMode && !compareAssetB && (
-          <FlexRow className="compare-mode-bar" gap={1} align="center">
+          <FlexRow className="compare-mode-bar" gap={SPACING.xs} align="center">
             <Text size="small">
               Select another image from the thumbnails below to compare
             </Text>
@@ -822,7 +823,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
         */}
         <FlexRow
           className="actions"
-          gap={1.5}
+          gap={SPACING.sm}
           align="center"
           sx={{ zIndex: Z_INDEX.tooltip }}
         >

--- a/web/src/components/assets/SaveToFolderMenu.tsx
+++ b/web/src/components/assets/SaveToFolderMenu.tsx
@@ -15,6 +15,7 @@ import {
   MOTION,
   BORDER_RADIUS,
   SPACING,
+  SPACING_PX,
   getSpacingPx
 } from "../ui_primitives";
 import { useFolderTree } from "../../serverState/useFolderTree";
@@ -45,7 +46,7 @@ const styles = (theme: Theme) =>
     ".folder-menu-item": {
       display: "flex",
       alignItems: "center",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       paddingTop: getSpacingPx(SPACING.sm),
       paddingBottom: getSpacingPx(SPACING.sm),
       paddingRight: getSpacingPx(SPACING.xl),
@@ -68,7 +69,7 @@ const styles = (theme: Theme) =>
     ".folder-menu-new-input": {
       display: "flex",
       alignItems: "center",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`
     }
   });
@@ -145,7 +146,7 @@ const SaveToFolderMenu: React.FC<SaveToFolderMenuProps> = ({
         className="folder-menu-item"
         role="menuitem"
         tabIndex={0}
-        style={{ paddingLeft: 12 + depth * 16 }}
+        style={{ paddingLeft: SPACING_PX.lg + depth * SPACING_PX.xl }}
         onClick={() => select(id)}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -243,7 +244,7 @@ const SaveToFolderMenu: React.FC<SaveToFolderMenuProps> = ({
               className="folder-menu-item"
               role="menuitem"
               tabIndex={0}
-              style={{ paddingLeft: 12 }}
+              style={{ paddingLeft: SPACING_PX.lg }}
               onClick={() => setCreating(true)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {

--- a/web/src/components/chat/composer/ChatComposer.styles.ts
+++ b/web/src/components/chat/composer/ChatComposer.styles.ts
@@ -41,8 +41,8 @@ export const createStyles = (theme: Theme) =>
         display: "flex",
         alignItems: "center",
         width: "100%",
-        paddingTop: "0px",
-        gap: theme.spacing(1),
+        paddingTop: 0,
+        gap: theme.spacing(SPACING.xs),
 
         ".chat-action-buttons": {
           marginLeft: "auto"

--- a/web/src/components/chat/feedback/LoadingIndicator.tsx
+++ b/web/src/components/chat/feedback/LoadingIndicator.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css, keyframes } from "@emotion/react";
 import React from "react";
-import { SPACING, getSpacingPx, MOTION } from "../../ui_primitives";
+import { SPACING, getSpacingPx, MOTION, BORDER_RADIUS } from "../../ui_primitives";
 
 const rotate = keyframes`
   0% { transform: rotate(0deg); }
@@ -49,6 +49,9 @@ const styles = {
     animation: ${rotate} ${MOTION.spin} infinite;
     transform-origin: 50% 50%;
     will-change: transform;
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   circle: css`
     fill: none;
@@ -58,6 +61,9 @@ const styles = {
     animation: ${dash} ${MOTION.pulse} infinite;
     opacity: 0.8;
     will-change: stroke-dasharray, stroke-dashoffset;
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   core: css`
     position: absolute;
@@ -67,10 +73,13 @@ const styles = {
     height: 6px;
     margin-left: -${getSpacingPx(SPACING.xs)};
     margin-top: -${getSpacingPx(SPACING.xs)};
-    border-radius: 50%;
+    border-radius: ${BORDER_RADIUS.circle};
     background: currentColor;
     animation: ${pulse} ${MOTION.pulse} infinite;
     will-change: transform, opacity;
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   wrapper: css`
     position: relative;

--- a/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
+++ b/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, memo } from "react";
 import Prism from "prismjs";
 import "../../../../prismGlobal";
 import DOMPurify from "dompurify";
-import { CopyButton, BORDER_RADIUS, FONT_SIZE_SANS, FONT_WEIGHT, SPACING, getSpacingPx } from "../../../ui_primitives";
+import { CopyButton, BORDER_RADIUS, FlexRow, FONT_SIZE_SANS, FONT_WEIGHT, SPACING, getSpacingPx } from "../../../ui_primitives";
 import { useIsDarkMode } from "../../../../hooks/useIsDarkMode";
 import {
   CodeThemeColors,
@@ -152,7 +152,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = memo(({
       <div css={cssStyles} className="code-block-container">
         <div className="code-block-header">
           <span className="code-block-language">{match ? match[1] : ""}</span>
-          <div style={{ display: "flex", gap: getSpacingPx(SPACING.md), alignItems: "center" }}>
+          <FlexRow gap={SPACING.md} align="center">
             {typeof onInsert === "function" && (
               <button
                 type="button"
@@ -173,7 +173,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = memo(({
               </button>
             )}
             <CopyButton value={codeContent} />
-          </div>
+          </FlexRow>
         </div>
         <div
           className="code-block-content"

--- a/web/src/components/collections/CollectionHeader.tsx
+++ b/web/src/components/collections/CollectionHeader.tsx
@@ -1,6 +1,15 @@
 import InfoIcon from "@mui/icons-material/Info";
 import { useState } from "react";
-import { FlexRow, FlexColumn, Text, Caption, Box, Popover } from "../ui_primitives";
+import {
+  FlexRow,
+  FlexColumn,
+  Text,
+  Caption,
+  Box,
+  Popover,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 
 const CollectionHeader = () => {
   const [formatInfoAnchor, setFormatInfoAnchor] = useState<HTMLElement | null>(
@@ -34,7 +43,13 @@ const CollectionHeader = () => {
             Collections are used to store and search documents. Following file
             formats are supported:
           </Caption>
-          <ul style={{ marginTop: 4, paddingLeft: 16, listStyle: "disc" }}>
+          <ul
+            style={{
+              marginTop: getSpacingPx(SPACING.xs),
+              paddingLeft: getSpacingPx(SPACING.xl),
+              listStyle: "disc"
+            }}
+          >
             <li>PDFs, PowerPoint, Word, Excel</li>
             <li>Text files, Markdown, HTML</li>
             <li>Images (text extraction with OCR)</li>

--- a/web/src/components/collections/CollectionItem.tsx
+++ b/web/src/components/collections/CollectionItem.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useMemo } from "react";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
-import { DeleteButton, FlexRow, FlexColumn, Text, Caption, Tooltip, LoadingSpinner, EditorButton, ProgressBar, MOTION, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../ui_primitives";
+import { DeleteButton, FlexRow, FlexColumn, Text, Caption, Tooltip, LoadingSpinner, EditorButton, ProgressBar, MOTION, BORDER_RADIUS, SPACING, Z_INDEX } from "../ui_primitives";
 import { CollectionResponse } from "../../stores/ApiTypes";
 import {
   UseMutationResult,
@@ -165,13 +165,6 @@ const CollectionItem = ({
     position: "relative"
   }), [dragOverCollection, collection.name]);
 
-  const containerStyle = useMemo(() => ({
-    display: "flex",
-    alignItems: "center",
-    gap: getSpacingPx(SPACING.lg),
-    width: "100%"
-  }), []);
-
   return (
     <FlexColumn
       onDrop={onDrop}
@@ -224,7 +217,7 @@ const CollectionItem = ({
           </Text>
         </FlexRow>
       )}
-      <div style={containerStyle}>
+      <FlexRow align="center" gap={SPACING.lg} fullWidth>
         <Tooltip title={`Collection: ${collection.name}`}>
           <Text
             weight={600}
@@ -242,9 +235,9 @@ const CollectionItem = ({
         {indexProgress?.collection === collection.name && (
           <IndexingProgress indexProgress={indexProgress} />
         )}
-      </div>
+      </FlexRow>
 
-      <div style={containerStyle}>
+      <FlexRow align="center" gap={SPACING.lg} fullWidth>
         <Tooltip title="Number of documents in this collection">
           <Text
             size="small"
@@ -312,7 +305,7 @@ const CollectionItem = ({
             </EditorButton>
           </Tooltip>
         )}
-      </div>
+      </FlexRow>
     </FlexColumn>
   );
 };

--- a/web/src/components/collections/EmptyCollectionState.tsx
+++ b/web/src/components/collections/EmptyCollectionState.tsx
@@ -1,4 +1,11 @@
-import { Text, FlexColumn, Divider, Box } from "../ui_primitives";
+import {
+  Text,
+  FlexColumn,
+  Divider,
+  Box,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 
 const EmptyCollectionState = () => {
   return (
@@ -24,7 +31,13 @@ const EmptyCollectionState = () => {
         </Text>
 
         <Text>With a collection, you can:</Text>
-        <ul style={{ paddingLeft: 16, marginBottom: 4, listStyle: "disc" }}>
+        <ul
+          style={{
+            paddingLeft: getSpacingPx(SPACING.xl),
+            marginBottom: getSpacingPx(SPACING.xs),
+            listStyle: "disc"
+          }}
+        >
           <li>Index text and images as vector embeddings</li>
           <li>Perform semantic similarity searches</li>
           <li>Filter search results using metadata</li>

--- a/web/src/components/color_picker/GradientBuilder.tsx
+++ b/web/src/components/color_picker/GradientBuilder.tsx
@@ -16,7 +16,7 @@ import {
   TextInput,
   ToggleGroup,
   ToggleOption,
-  Tooltip, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+  Tooltip, BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import {
   GradientValue,
   GradientStop,
@@ -51,11 +51,11 @@ const styles = (theme: Theme) =>
       border: `2px solid white`,
       boxShadow: "0 0 0 1px rgba(0,0,0,0.3)",
       "&:hover": {
-        zIndex: 10
+        zIndex: Z_INDEX.dropdown
       },
       "&.selected": {
         borderColor: theme.vars.palette.primary.main,
-        zIndex: 10
+        zIndex: Z_INDEX.dropdown
       }
     },
     ".css-output": {

--- a/web/src/components/costs/CostStatCard.tsx
+++ b/web/src/components/costs/CostStatCard.tsx
@@ -1,7 +1,14 @@
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
-import { Box, FlexRow, FlexColumn, Text, BORDER_RADIUS } from "../ui_primitives";
+import {
+  Box,
+  FlexRow,
+  FlexColumn,
+  Text,
+  BORDER_RADIUS,
+  SPACING
+} from "../ui_primitives";
 
 export interface CostStatCardProps {
   label: string;
@@ -37,7 +44,7 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
   const theme = useTheme();
   return (
     <FlexColumn
-      gap={1.5}
+      gap={SPACING.sm}
       sx={{
         flex: "1 1 0",
         minWidth: 200,
@@ -59,11 +66,10 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
         >
           {label}
         </Text>
-        <Box
+        <FlexRow
+          align="center"
+          justify="center"
           sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
             width: 26,
             height: 26,
             borderRadius: BORDER_RADIUS.lg,
@@ -72,10 +78,14 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
           }}
         >
           <Icon sx={{ fontSize: 15 }} />
-        </Box>
+        </FlexRow>
       </FlexRow>
 
-      <FlexRow gap={1} align={isLabel ? "flex-start" : "center"} sx={{ minWidth: 0 }}>
+      <FlexRow
+        gap={SPACING.xs}
+        align={isLabel ? "flex-start" : "center"}
+        sx={{ minWidth: 0 }}
+      >
         {valueDotColor && (
           <Box
             sx={{
@@ -84,7 +94,7 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
               borderRadius: BORDER_RADIUS.sm,
               backgroundColor: valueDotColor,
               flexShrink: 0,
-              mt: isLabel ? "8px" : 0
+              mt: isLabel ? SPACING.md : 0
             }}
           />
         )}
@@ -118,7 +128,12 @@ const CostStatCardInternal: React.FC<CostStatCardProps> = ({
         </Text>
       </FlexRow>
 
-      <FlexRow gap={1} align="center" sx={{ rowGap: 0.5 }} wrap>
+      <FlexRow
+        gap={SPACING.xs}
+        align="center"
+        sx={{ rowGap: SPACING.micro }}
+        wrap
+      >
         {badge}
         <Text size="small" color="secondary">
           {caption}

--- a/web/src/components/costs/CostsDashboard.tsx
+++ b/web/src/components/costs/CostsDashboard.tsx
@@ -632,14 +632,9 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
           }
         }}
       >
-        <Box
-          sx={{
-            display: "flex",
-            color: theme.vars.palette.text.secondary
-          }}
-        >
+        <FlexRow sx={{ color: theme.vars.palette.text.secondary }}>
           {icon}
-        </Box>
+        </FlexRow>
         {label}
         {count && (
           <Text

--- a/web/src/components/costs/CostsTable.tsx
+++ b/web/src/components/costs/CostsTable.tsx
@@ -92,12 +92,11 @@ const ExecutionRows: React.FC<{ rows: Execution[] }> = ({ rows }) => {
           }}
         >
           {/* node */}
-          <FlexRow gap={1.25} align="center" sx={{ minWidth: 0 }}>
-            <Box
+          <FlexRow gap={SPACING.sm} align="center" sx={{ minWidth: 0 }}>
+            <FlexRow
+              align="center"
+              justify="center"
               sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
                 width: 30,
                 height: 30,
                 borderRadius: BORDER_RADIUS.lg,
@@ -107,7 +106,7 @@ const ExecutionRows: React.FC<{ rows: Execution[] }> = ({ rows }) => {
               }}
             >
               <CostNodeIcon category={e.category} sx={{ fontSize: 16 }} />
-            </Box>
+            </FlexRow>
             <FlexColumn sx={{ minWidth: 0 }}>
               <Text
                 size="small"
@@ -345,14 +344,7 @@ const CostsTableInternal: React.FC<CostsTableProps> = ({
             <HeaderText align="right">Tokens (in/out)</HeaderText>
             <HeaderText align="right">Runtime</HeaderText>
             <HeaderText>Status</HeaderText>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "flex-end",
-                gap: getSpacingPx(SPACING.micro)
-              }}
-            >
+            <FlexRow align="center" justify="flex-end" gap={SPACING.micro}>
               <HeaderText align="right">When</HeaderText>
               <ArrowDropDownIcon
                 sx={{
@@ -360,7 +352,7 @@ const CostsTableInternal: React.FC<CostsTableProps> = ({
                   color: theme.vars.palette.text.secondary
                 }}
               />
-            </Box>
+            </FlexRow>
             <HeaderText align="right">Cost</HeaderText>
           </>
         ) : (

--- a/web/src/components/costs/SpendOverTimeChart.tsx
+++ b/web/src/components/costs/SpendOverTimeChart.tsx
@@ -184,8 +184,9 @@ const SpendOverTimeChartInternal: React.FC<SpendOverTimeChartProps> = ({
             const barPx = (visibleTotal / axisMax) * PLOT_HEIGHT;
             const isHovered = hovered === index;
             return (
-              <Box
+              <FlexColumn
                 key={index}
+                justify="flex-end"
                 onMouseEnter={() => setHovered(index)}
                 onMouseLeave={() => setHovered((h) => (h === index ? null : h))}
                 sx={{
@@ -193,9 +194,6 @@ const SpendOverTimeChartInternal: React.FC<SpendOverTimeChartProps> = ({
                   flex: "1 1 0",
                   maxWidth: 34,
                   height: PLOT_HEIGHT,
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "flex-end",
                   cursor: "default"
                 }}
               >
@@ -238,7 +236,7 @@ const SpendOverTimeChartInternal: React.FC<SpendOverTimeChartProps> = ({
                     isActive={isActive}
                   />
                 )}
-              </Box>
+              </FlexColumn>
             );
           })}
         </FlexRow>

--- a/web/src/components/hugging_face/ModelPackCard.tsx
+++ b/web/src/components/hugging_face/ModelPackCard.tsx
@@ -7,6 +7,7 @@ import {
   ToolbarIconButton,
   Chip,
   Box,
+  FlexRow,
   ProgressBar,
   Collapse,
   MOTION,
@@ -143,7 +144,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
       }}
     >
       <Box sx={{ p: 2, pb: 1 }}>
-        <Box display="flex" alignItems="flex-start" gap={2}>
+        <FlexRow align="flex-start" gap={2}>
           <InventoryIcon
             sx={{
               color: allDownloaded
@@ -154,7 +155,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
             }}
           />
           <Box flex={1}>
-            <Box display="flex" alignItems="center" gap={1} mb={0.5}>
+            <FlexRow align="center" gap={1} mb={0.5}>
               <Text size="normal" weight={600}>
                 {pack.title}
               </Text>
@@ -163,7 +164,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
                   sx={{ color: "var(--palette-success-main)", fontSize: 20 }}
                 />
               )}
-            </Box>
+            </FlexRow>
             <Text
               size="small"
               color="secondary"
@@ -171,7 +172,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
             >
               {pack.description}
             </Text>
-            <Box display="flex" gap={1} flexWrap="wrap">
+            <FlexRow gap={1} wrap>
               {pack.tags?.slice(0, 4).map((tag) => (
                 <Chip
                   key={tag}
@@ -201,9 +202,9 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
                   }}
                 />
               )}
-            </Box>
+            </FlexRow>
           </Box>
-        </Box>
+        </FlexRow>
 
         {isDownloading && (
           <Box mt={2}>
@@ -222,7 +223,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
         )}
       </Box>
 
-      <Box sx={{ px: 2, pb: 2, pt: 0, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <FlexRow align="center" justify="space-between" sx={{ px: 2, pb: 2, pt: 0 }}>
         <EditorButton
           variant={allDownloaded ? "outlined" : "contained"}
           size="small"
@@ -251,7 +252,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
           }}
           size="small"
         />
-      </Box>
+      </FlexRow>
 
       <Collapse in={expanded}>
         <Box px={2} pb={2}>

--- a/web/src/components/menus/SearchProviderSection.tsx
+++ b/web/src/components/menus/SearchProviderSection.tsx
@@ -122,12 +122,12 @@ const SearchProviderSection = memo(function SearchProviderSection({
             />
           )}
           <Text
+            size="small"
             sx={{
               color: hasAllCredentials ?
                 theme.palette.success.dark :
                 theme.palette.warning.dark,
-              margin: 0,
-              fontSize: "0.9em"
+              margin: 0
             }}
           >
             {hasAllCredentials
@@ -144,9 +144,7 @@ const SearchProviderSection = memo(function SearchProviderSection({
           style={{
             marginTop: "1.5em",
             padding: "1em",
-            backgroundColor: theme.palette.mode === "dark" ?
-              "rgba(255,255,255,0.05)" :
-              "rgba(0,0,0,0.02)",
+            backgroundColor: theme.vars.palette.c_overlay_subtle,
             borderLeft: `4px solid ${theme.palette.primary.main}`,
             borderRadius: BORDER_RADIUS.sm
           }}

--- a/web/src/components/model_editor/Model3DEditor.tsx
+++ b/web/src/components/model_editor/Model3DEditor.tsx
@@ -37,7 +37,7 @@ import {
   EditorButton,
   CloseButton,
   DownloadButton,
-  BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+  BORDER_RADIUS, SPACING, Z_INDEX, getSpacingPx } from "../ui_primitives";
 import SceneOutliner from "./SceneOutliner";
 import PropertiesPanel from "./PropertiesPanel";
 import Model3DChatPanel from "./Model3DChatPanel";
@@ -138,7 +138,7 @@ const styles = (theme: Theme) =>
       position: "absolute",
       top: "100%",
       left: 0,
-      zIndex: 50,
+      zIndex: Z_INDEX.dropdown,
       marginTop: getSpacingPx(SPACING.xs),
       padding: getSpacingPx(SPACING.xs),
       minWidth: "160px",
@@ -154,8 +154,8 @@ const styles = (theme: Theme) =>
     ".overlay": {
       position: "absolute",
       inset: 0,
-      zIndex: 100,
-      backgroundColor: "rgba(0,0,0,0.6)"
+      zIndex: Z_INDEX.overlay,
+      backgroundColor: theme.vars.palette.c_scrim
     },
     ".load-error": {
       position: "absolute",

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -204,13 +204,13 @@ function ModelList<TModel extends ModelSelectorModel>({
     ...badgeStyle,
     display: "inline-flex",
     alignItems: "center",
-    gap: 2
+    gap: getSpacingPx(SPACING.micro)
   }), [badgeStyle]);
 
   const secondaryTextStyle = useMemo<React.CSSProperties>(() => ({
     display: "flex",
     alignItems: "center",
-    gap: 4,
+    gap: getSpacingPx(SPACING.xs),
     fontSize: theme.vars.fontSizeSmaller,
     color: theme.vars.palette.text.secondary,
     overflow: "hidden",

--- a/web/src/components/model_menu/ProviderList.tsx
+++ b/web/src/components/model_menu/ProviderList.tsx
@@ -15,6 +15,8 @@ import {
   Tooltip,
   Box,
   BORDER_RADIUS,
+  SPACING,
+  getSpacingPx,
   List,
   ListItemButton,
   ListItemText
@@ -500,7 +502,7 @@ const horizontalListStyles = css({
   display: "flex",
   flexDirection: "row",
   alignItems: "stretch",
-  gap: 4,
+  gap: getSpacingPx(SPACING.xs),
   overflowX: "auto",
   overflowY: "hidden",
   paddingTop: 0,

--- a/web/src/components/node/EditableTitle.tsx
+++ b/web/src/components/node/EditableTitle.tsx
@@ -271,6 +271,7 @@ const EditableTitle = memo(function EditableTitle({
             className="remove-title"
             onClick={handleRemoveTitle}
             title="Remove note"
+            aria-label="Remove note"
           >
             <CloseIcon className="icon" />
           </button>

--- a/web/src/components/node/PreviewImageGrid.tsx
+++ b/web/src/components/node/PreviewImageGrid.tsx
@@ -51,6 +51,7 @@ const ImageTile = memo<ImageTileProps>(({
     <div
       role="button"
       tabIndex={0}
+      aria-label={`Image ${idx + 1}`}
       className={`tile ${isSelected ? "selected" : ""}`}
       onDoubleClick={() => {
         if (selectionMode) return;

--- a/web/src/components/node/SketchNode/SketchNode.tsx
+++ b/web/src/components/node/SketchNode/SketchNode.tsx
@@ -1380,6 +1380,7 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
             <div
               className="sketch-preview-wrap"
               role="button"
+              aria-label="Open sketch editor"
               tabIndex={0}
               onClick={handleOpenEditor}
               onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleOpenEditor(); } }}
@@ -1393,7 +1394,12 @@ const SketchNode: React.FC<SketchNodeProps> = (props) => {
                       alt="Image editor preview"
                     />
                     <div className="edit-overlay">
-                      <EditIcon sx={{ fontSize: 32, color: "white" }} />
+                      <EditIcon
+                        sx={{
+                          fontSize: 32,
+                          color: theme.vars.palette.common.white
+                        }}
+                      />
                       <span className="edit-overlay-label">Edit Sketch</span>
                     </div>
                   </>

--- a/web/src/components/node/SubgraphNode/SubgraphNode.tsx
+++ b/web/src/components/node/SubgraphNode/SubgraphNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useMemo } from "react";
 import { Node, NodeProps, NodeToolbar, Position } from "@xyflow/react";
-import { Box } from "../../ui_primitives";
+import { FlexColumn } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import { NodeData } from "../../../stores/NodeData";
 import { NodeHeader } from "../NodeHeader";
@@ -98,12 +98,10 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
   }
 
   return (
-    <Box
+    <FlexColumn
       className="subgraph-node"
       onDoubleClick={handleDoubleClick}
       sx={{
-        display: "flex",
-        flexDirection: "column",
         height: "100%",
         minHeight: 100,
         padding: "0 !important",
@@ -142,14 +140,12 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
         workflowId={workflow_id}
         status={statusValue}
       />
-      <Box
+      <FlexColumn
         className="node-content-container"
         sx={{
           flex: "1 1 auto",
           minHeight: 80,
-          width: "100%",
-          display: "flex",
-          flexDirection: "column"
+          width: "100%"
         }}
       >
         <SubgraphNodeContent
@@ -160,8 +156,8 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
           status={statusValue}
           workflowId={workflow_id}
         />
-      </Box>
-    </Box>
+      </FlexColumn>
+    </FlexColumn>
   );
 };
 

--- a/web/src/components/node/output/ToolCallRenderer.tsx
+++ b/web/src/components/node/output/ToolCallRenderer.tsx
@@ -133,6 +133,7 @@ export const ToolCallRenderer: React.FC<Props> = memo(({ chunk }) => {
         className="header"
         onClick={() => setOpen((v) => !v)}
         role="button"
+        aria-expanded={open}
         tabIndex={0}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/web/src/components/node_editor/FindInWorkflowDialog.tsx
+++ b/web/src/components/node_editor/FindInWorkflowDialog.tsx
@@ -361,7 +361,12 @@ const FindInWorkflowDialog: React.FC<FindInWorkflowDialogProps> = memo(
               onChange={handleInputChange}
             />
             {searchTerm && (
-              <button type="button" className="clear-button" onClick={handleClear}>
+              <button
+                type="button"
+                className="clear-button"
+                aria-label="Clear search"
+                onClick={handleClear}
+              >
                 <ClearIcon fontSize="small" />
               </button>
             )}
@@ -373,6 +378,7 @@ const FindInWorkflowDialog: React.FC<FindInWorkflowDialogProps> = memo(
               onClick={navigatePrevious}
               disabled={results.length === 0}
               title="Previous (Shift+Enter)"
+              aria-label="Previous match"
             >
               <ArrowUpwardIcon fontSize="small" />
             </button>
@@ -382,6 +388,7 @@ const FindInWorkflowDialog: React.FC<FindInWorkflowDialogProps> = memo(
               onClick={navigateNext}
               disabled={results.length === 0}
               title="Next (Enter)"
+              aria-label="Next match"
             >
               <ArrowDownwardIcon fontSize="small" />
             </button>

--- a/web/src/components/node_editor/NodeEditor.tsx
+++ b/web/src/components/node_editor/NodeEditor.tsx
@@ -7,7 +7,8 @@ import {
   Box,
   TextInput,
   BORDER_RADIUS,
-  Modal
+  Modal,
+  SPACING
 } from "../ui_primitives";
 // store
 import useNodeMenuStore from "../../stores/NodeMenuStore";
@@ -75,7 +76,7 @@ const NodeEditor: React.FC<NodeEditorProps> = ({ workflowId, active }) => {
       transform: "translateX(-50%)",
       width: "80vw",
       maxWidth: "1400px",
-      padding: 4,
+      padding: SPACING.xl,
       backgroundColor: theme.vars.palette.grey[800],
       boxShadow: 24,
       borderRadius: BORDER_RADIUS.lg,

--- a/web/src/components/node_editor/ViewportStatusIndicator.tsx
+++ b/web/src/components/node_editor/ViewportStatusIndicator.tsx
@@ -236,7 +236,7 @@ const ViewportStatusIndicator: React.FC<ViewportStatusIndicatorProps> = ({
             width: "1px",
             height: "16px",
             backgroundColor: theme.vars.palette.divider,
-            mx: 0.5
+            mx: SPACING.micro
           }}
         />
 
@@ -257,7 +257,7 @@ const ViewportStatusIndicator: React.FC<ViewportStatusIndicatorProps> = ({
         placement="top-center"
         paperSx={{
           minWidth: 120,
-          py: 0.5
+          py: SPACING.micro
         }}
       >
         <ListGroup compact flush>
@@ -268,8 +268,8 @@ const ViewportStatusIndicator: React.FC<ViewportStatusIndicatorProps> = ({
               data-preset={preset.toString()}
               selected={Math.abs(zoom - preset) < 0.01}
               sx={{
-                py: 0.5,
-                px: 2,
+                py: SPACING.micro,
+                px: SPACING.md,
                 "&.Mui-selected": {
                   backgroundColor: theme.vars.palette.action.selected,
                   "&:hover": {

--- a/web/src/components/node_menu/NodeItem.tsx
+++ b/web/src/components/node_menu/NodeItem.tsx
@@ -98,8 +98,8 @@ const NodeItem = memo(
                       textTransform: "uppercase",
                       bgcolor: "grey.700",
                       color: "grey.300",
-                      px: 1,
-                      py: 0.5,
+                      px: SPACING.xs,
+                      py: SPACING.micro,
                       borderRadius: BORDER_RADIUS.sm
                     }}
                   >
@@ -347,8 +347,8 @@ const NodeItem = memo(
                     textTransform: "uppercase",
                     bgcolor: `color-mix(in srgb, ${theme.vars.palette.warning.main} 20%, transparent)`,
                     color: theme.vars.palette.warning.main,
-                    px: 0.5,
-                    py: 0.5,
+                    px: SPACING.micro,
+                    py: SPACING.micro,
                     borderRadius: BORDER_RADIUS.sm,
                     whiteSpace: "nowrap",
                     flexShrink: 0
@@ -368,8 +368,8 @@ const NodeItem = memo(
                   letterSpacing: "0.03em",
                   bgcolor: `color-mix(in srgb, ${theme.vars.palette.info.main} 18%, transparent)`,
                   color: theme.vars.palette.info.main,
-                  px: 0.5,
-                  py: 0.5,
+                  px: SPACING.micro,
+                  py: SPACING.micro,
                   borderRadius: BORDER_RADIUS.sm,
                   whiteSpace: "nowrap",
                   flexShrink: 0

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -109,7 +109,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        padding: 2,
+        padding: getSpacingPx(SPACING.micro),
         border: "none",
         background: "transparent",
         borderRadius: BORDER_RADIUS.sm,

--- a/web/src/components/node_menu/SearchResultItem.tsx
+++ b/web/src/components/node_menu/SearchResultItem.tsx
@@ -471,6 +471,8 @@ const SearchResultItem = memo(
                 tabIndex={0}
                 onClick={handleToggleExpand}
                 onKeyDown={handleExpandKeyDown}
+                aria-expanded={isExpanded}
+                aria-label={isExpanded ? "Collapse details" : "Show details"}
                 title={isExpanded ? "Collapse details" : "Show details"}
               >
                 <ExpandMoreIcon />

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -488,7 +488,7 @@ const TypeFilterChips: React.FC<TypeFilterChipsProps> = memo(
                   sx: {
                     "& .MuiAutocomplete-option": {
                       minHeight: "30px",
-                      py: 0.5
+                      py: SPACING.micro
                     }
                   }
                 }
@@ -535,7 +535,7 @@ const TypeFilterChips: React.FC<TypeFilterChipsProps> = memo(
                   sx: {
                     "& .MuiAutocomplete-option": {
                       minHeight: "30px",
-                      py: 0.5
+                      py: SPACING.micro
                     }
                   }
                 }

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -38,6 +38,7 @@ import {
   VideoPlayer,
   BORDER_RADIUS,
   MOTION,
+  reducedMotion,
   Z_INDEX
 } from "../ui_primitives";
 import { NodeInputs } from "../node/NodeInputs";
@@ -148,7 +149,8 @@ const styles = (theme: Theme) =>
         display: "flex",
         gap: theme.spacing(0.5),
         opacity: 0,
-        transition: MOTION.opacity
+        transition: MOTION.opacity,
+        ...reducedMotion({ transition: MOTION.none })
       },
       ".video-preview:hover .video-preview-actions": {
         opacity: 1

--- a/web/src/components/node_types/PlaceholderNode.tsx
+++ b/web/src/components/node_types/PlaceholderNode.tsx
@@ -23,6 +23,7 @@ import {
   EditorButton,
   FlexColumn,
   MOTION,
+  reducedMotion,
   Text,
   Tooltip,
   BORDER_RADIUS,
@@ -93,6 +94,7 @@ const styles = (theme: Theme) =>
       border: `1px solid ${theme.vars.palette.action.selected}`,
       boxShadow: `0 6px 18px ${theme.vars.palette.c_scrim_soft}`,
       transition: `${MOTION.transform}, ${MOTION.shadow}, background-position ${MOTION.slow}`,
+      ...reducedMotion({ transition: MOTION.none }),
       overflow: "hidden",
       "&::before": {
         content: "''",
@@ -104,7 +106,8 @@ const styles = (theme: Theme) =>
         background:
           `linear-gradient(120deg, transparent, ${theme.vars.palette.c_overlay_strong}, transparent)`,
         transform: "skewX(-20deg)",
-        transition: `left ${MOTION.slow}`
+        transition: `left ${MOTION.slow}`,
+        ...reducedMotion({ transition: MOTION.none })
       },
       "&:hover": {
         transform: "translateY(-1px)",

--- a/web/src/components/node_types/editing/CollectionBody.tsx
+++ b/web/src/components/node_types/editing/CollectionBody.tsx
@@ -26,6 +26,7 @@ import {
   ToolbarIconButton,
   BORDER_RADIUS,
   MOTION,
+  reducedMotion,
   SPACING,
   thinScrollbarStyles
 } from "../../ui_primitives";
@@ -87,6 +88,7 @@ const styles = (theme: Theme) =>
       alignContent: "start",
       borderRadius: BORDER_RADIUS.sm,
       transition: MOTION.background,
+      ...reducedMotion({ transition: MOTION.none }),
       ...thinScrollbarStyles(theme)
     },
     "&.drag-over .col-grid": {
@@ -140,7 +142,8 @@ const styles = (theme: Theme) =>
       top: 2,
       right: 2,
       opacity: 0,
-      transition: MOTION.opacity
+      transition: MOTION.opacity,
+      ...reducedMotion({ transition: MOTION.none })
     },
     ".col-tile:hover .col-remove, .col-tile:focus-within .col-remove": {
       opacity: 1

--- a/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
+++ b/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
@@ -141,14 +141,14 @@ const styles = (theme: Theme) =>
         appearance: "none",
         width: 12,
         height: 12,
-        borderRadius: "50%",
+        borderRadius: BORDER_RADIUS.circle,
         backgroundColor: theme.vars.palette.primary.main,
         cursor: "pointer"
       },
       "&::-moz-range-thumb": {
         width: 12,
         height: 12,
-        borderRadius: "50%",
+        borderRadius: BORDER_RADIUS.circle,
         backgroundColor: theme.vars.palette.primary.main,
         border: "none",
         cursor: "pointer"

--- a/web/src/components/node_types/editing/LayerRow.tsx
+++ b/web/src/components/node_types/editing/LayerRow.tsx
@@ -20,7 +20,7 @@ import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { SelectField, StateIconButton, MOTION, BORDER_RADIUS } from "../../ui_primitives";
+import { SelectField, StateIconButton, MOTION, reducedMotion, BORDER_RADIUS } from "../../ui_primitives";
 import NumberInput from "../../inputs/NumberInput";
 
 import {
@@ -46,6 +46,7 @@ const styles = (theme: Theme) =>
       background: theme.vars.palette.grey[800],
       border: `1px solid ${theme.vars.palette.divider}`,
       transition: `background ${MOTION.fast}, border-color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
       "&:hover": {
         background: theme.vars.palette.action.hover
       },

--- a/web/src/components/node_types/editing/ListGeneratorBody.tsx
+++ b/web/src/components/node_types/editing/ListGeneratorBody.tsx
@@ -37,6 +37,7 @@ import {
   LoadingSpinner,
   BORDER_RADIUS,
   MOTION,
+  reducedMotion,
   FONT_WEIGHT,
   SPACING,
   thinScrollbarStyles
@@ -135,6 +136,7 @@ const styles = (theme: Theme) =>
       cursor: "pointer",
       userSelect: "none",
       transition: MOTION.background,
+      ...reducedMotion({ transition: MOTION.none }),
       "&:hover": {
         backgroundColor: theme.vars.palette.action.hover
       }
@@ -167,7 +169,8 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       opacity: 0,
-      transition: MOTION.opacity
+      transition: MOTION.opacity,
+      ...reducedMotion({ transition: MOTION.none })
     },
     ".list-head:hover .list-actions, .list-head:focus-within .list-actions": {
       opacity: 1
@@ -180,7 +183,8 @@ const styles = (theme: Theme) =>
       flexShrink: 0,
       fontSize: theme.fontSizeNormal,
       color: theme.vars.palette.text.secondary,
-      transition: MOTION.transform
+      transition: MOTION.transform,
+      ...reducedMotion({ transition: MOTION.none })
     },
     ".list-chevron.expanded": {
       transform: "rotate(90deg)"

--- a/web/src/components/node_types/editing/PainterBody.tsx
+++ b/web/src/components/node_types/editing/PainterBody.tsx
@@ -53,6 +53,7 @@ import {
   ToolbarIconButton,
   BORDER_RADIUS,
   MOTION,
+  reducedMotion,
   Z_INDEX
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
@@ -217,6 +218,7 @@ const styles = (theme: Theme) =>
         pointerEvents: "none",
         opacity: 0,
         transition: MOTION.opacity,
+        ...reducedMotion({ transition: MOTION.none }),
         // `will-change: transform` hints the browser to give this its own
         // GPU layer up front so per-move transform writes don't churn.
         willChange: "transform",

--- a/web/src/components/node_types/editing/promptComposer/EntityMentionChip.tsx
+++ b/web/src/components/node_types/editing/promptComposer/EntityMentionChip.tsx
@@ -38,7 +38,7 @@ const chipStyles = (theme: Theme) =>
       height: "1.5em",
       width: "1.5em",
       objectFit: "cover",
-      borderRadius: "50%"
+      borderRadius: BORDER_RADIUS.circle
     },
     "& .chip-label": {
       minWidth: 0,

--- a/web/src/components/node_types/editing/promptComposer/MentionEntityTile.tsx
+++ b/web/src/components/node_types/editing/promptComposer/MentionEntityTile.tsx
@@ -40,7 +40,7 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       width: 28,
       height: 28,
-      borderRadius: "50%",
+      borderRadius: BORDER_RADIUS.circle,
       objectFit: "cover",
       display: "block",
       background: theme.vars.palette.background.default
@@ -49,7 +49,7 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       width: 28,
       height: 28,
-      borderRadius: "50%",
+      borderRadius: BORDER_RADIUS.circle,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -6,6 +6,7 @@ import type { Theme } from "@mui/material/styles";
 import {
   Tooltip,
   Box,
+  FlexColumn,
   MOTION,
   BORDER_RADIUS,
   SPACING,
@@ -452,20 +453,18 @@ const PanelBodyContent = memo(function PanelBodyContent({
       return <LogPanel />;
     case "queue":
       return (
-        <Box
+        <FlexColumn
           className="queue-panel"
+          fullWidth
+          fullHeight
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            width: "100%",
-            height: "100%",
             overflow: "hidden",
             padding: "0 1em"
           }}
         >
           <PanelHeadline title="Queue" />
           <QueuePanel />
-        </Box>
+        </FlexColumn>
       );
     case "sandboxes":
       return sandboxesEnabled ? <SandboxesPanel /> : null;

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -367,6 +367,7 @@ const PanelContent = memo(function PanelContent({
                     onClick={handleFullscreenClick}
                     tabIndex={-1}
                     icon={<Fullscreen />}
+                    ariaLabel="Open the global asset library"
                   />
                 </Tooltip>
               }
@@ -396,6 +397,7 @@ const PanelContent = memo(function PanelContent({
                     onClick={handleFullscreenClick}
                     tabIndex={-1}
                     icon={<Fullscreen />}
+                    ariaLabel="Open library in full page"
                   />
                 </Tooltip>
               }

--- a/web/src/components/panels/TracePanel.tsx
+++ b/web/src/components/panels/TracePanel.tsx
@@ -189,6 +189,7 @@ const TraceRow = memo(function TraceRow({
         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleClick(); }}
         role="button"
         tabIndex={0}
+        aria-expanded={expanded}
       >
         <span className="trace-time">{formatRelativeTime(event.relativeMs)}</span>
         <span className="trace-icon">{EVENT_ICONS[event.type]}</span>

--- a/web/src/components/portal/DashboardFooter.tsx
+++ b/web/src/components/portal/DashboardFooter.tsx
@@ -8,13 +8,13 @@ import { SPACING, getSpacingPx } from "../ui_primitives";
 
 const styles = (theme: Theme) =>
   css({
-    marginTop: 8,
+    marginTop: getSpacingPx(SPACING.md),
     borderTop: `1px solid ${theme.vars.palette.divider}`,
     ".foot-wrap": {
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       flexWrap: "wrap",
       minHeight: 46,
       padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(10)}`, // was 10px 40px

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -29,11 +29,11 @@ const heroStyles = (theme: Theme) =>
     },
     ".hero-wrap": {
       position: "relative",
-      paddingTop: 8,
-      paddingBottom: 8,
+      paddingTop: getSpacingPx(SPACING.md),
+      paddingBottom: getSpacingPx(SPACING.md),
       [theme.breakpoints.down("sm")]: {
-        paddingTop: 8,
-        paddingBottom: 8
+        paddingTop: getSpacingPx(SPACING.md),
+        paddingBottom: getSpacingPx(SPACING.md)
       }
     },
     ".hero-composer": {
@@ -41,10 +41,10 @@ const heroStyles = (theme: Theme) =>
       maxWidth: 720
     },
     ".hero-foot": {
-      marginTop: 8,
+      marginTop: getSpacingPx(SPACING.md),
       display: "flex",
       alignItems: "center",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       flexWrap: "wrap"
     },
     ".hero-skip": {

--- a/web/src/components/portal/DashboardTemplates.tsx
+++ b/web/src/components/portal/DashboardTemplates.tsx
@@ -19,6 +19,7 @@ import {
   LoadingSpinner,
   MOTION,
   BORDER_RADIUS,
+  SPACING,
   getSpacingPx
 } from "../ui_primitives";
 import {
@@ -32,12 +33,12 @@ const MAX_VISIBLE = 8;
 
 const styles = (theme: Theme) =>
   css({
-    paddingTop: 8,
+    paddingTop: getSpacingPx(SPACING.md),
     ".cats": {
       display: "flex",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       flexWrap: "wrap",
-      marginBottom: 8
+      marginBottom: getSpacingPx(SPACING.md)
     },
     ".cat": {
       display: "inline-flex",
@@ -72,7 +73,7 @@ const styles = (theme: Theme) =>
     ".tpl-grid": {
       display: "grid",
       gridTemplateColumns: "repeat(4, 1fr)",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       [theme.breakpoints.down("lg")]: {
         gridTemplateColumns: "repeat(3, 1fr)"
       },
@@ -98,8 +99,8 @@ const fullPageStyles = css({
   flex: 1,
   minHeight: 0,
   overflowY: "auto",
-  paddingTop: 24,
-  paddingBottom: 32
+  paddingTop: getSpacingPx(SPACING.xxl),
+  paddingBottom: getSpacingPx(SPACING.xxxl)
 });
 
 interface DashboardTemplatesProps {

--- a/web/src/components/portal/DashboardTutorials.tsx
+++ b/web/src/components/portal/DashboardTutorials.tsx
@@ -6,15 +6,16 @@ import { memo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { TutorialCard } from "../tutorials/TutorialCard";
 import { TUTORIALS } from "../tutorials/tutorialsData";
+import { SPACING, getSpacingPx } from "../ui_primitives";
 import { wrapStyles, SectionHeader, SectionLink } from "./dashboardChrome";
 
 const gridStyles = (theme: Theme) =>
   css({
-    paddingTop: 8,
+    paddingTop: getSpacingPx(SPACING.md),
     ".tut-grid": {
       display: "grid",
       gridTemplateColumns: "repeat(3, 1fr)",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       [theme.breakpoints.down("md")]: {
         gridTemplateColumns: "repeat(2, 1fr)"
       },

--- a/web/src/components/portal/DashboardWorkflows.tsx
+++ b/web/src/components/portal/DashboardWorkflows.tsx
@@ -26,15 +26,15 @@ type ViewMode = "grid" | "list";
 
 const styles = (theme: Theme) =>
   css({
-    paddingTop: 8,
-    paddingBottom: 8,
+    paddingTop: getSpacingPx(SPACING.md),
+    paddingBottom: getSpacingPx(SPACING.md),
     ".viewtog": {
       display: "flex",
-      gap: 2,
+      gap: getSpacingPx(SPACING.micro),
       background: theme.vars.palette.c_node_bg,
       border: `1px solid ${theme.vars.palette.divider}`,
       borderRadius: BORDER_RADIUS.md,
-      padding: 2
+      padding: getSpacingPx(SPACING.micro)
     },
     ".viewtog button": {
       width: 28,
@@ -54,7 +54,7 @@ const styles = (theme: Theme) =>
     ".rec-grid": {
       display: "grid",
       gridTemplateColumns: "repeat(4, 1fr)",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       [theme.breakpoints.down("lg")]: {
         gridTemplateColumns: "repeat(3, 1fr)"
       },
@@ -68,7 +68,7 @@ const styles = (theme: Theme) =>
     ".rec-new": {
       display: "flex",
       flexDirection: "column",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       textAlign: "left",
       background: "transparent",
       border: "none",
@@ -105,7 +105,7 @@ const styles = (theme: Theme) =>
       fontFamily: theme.fontFamily2,
       fontSize: 12,
       color: theme.vars.palette.text.disabled,
-      marginTop: 2
+      marginTop: getSpacingPx(SPACING.micro)
     },
     ".rec-list": {
       height: 420,

--- a/web/src/components/portal/GettingStartedChecklist.tsx
+++ b/web/src/components/portal/GettingStartedChecklist.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
       textTransform: "uppercase" as const,
       letterSpacing: "0.08em",
       color: theme.vars.palette.text.disabled,
-      marginRight: 4
+      marginRight: getSpacingPx(SPACING.xs)
     },
     ".checklist-step": {
       display: "inline-flex",

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -54,7 +54,7 @@ const styles = (theme: Theme) =>
       overflowX: "hidden"
     },
     "main": {
-      paddingBottom: 8
+      paddingBottom: getSpacingPx(SPACING.md)
     },
 
     // Setup state (no provider configured yet)
@@ -65,7 +65,7 @@ const styles = (theme: Theme) =>
       alignItems: "center",
       justifyContent: "center",
       padding: `0 ${getSpacingPx(SPACING.xxl)}`,
-      paddingTop: 8
+      paddingTop: getSpacingPx(SPACING.md)
     },
     ".portal-setup-message": {
       maxWidth: 480,

--- a/web/src/components/portal/PortalSetupFlow.tsx
+++ b/web/src/components/portal/PortalSetupFlow.tsx
@@ -55,7 +55,7 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.c_white,
       display: "flex",
       alignItems: "center",
-      gap: 6,
+      gap: getSpacingPx(SPACING.sm),
     },
     ".portal-setup-recommended": {
       fontSize: 10,
@@ -84,7 +84,7 @@ const styles = (theme: Theme) =>
     ".portal-setup-key-help": {
       fontSize: 11,
       color: theme.vars.palette.c_gray4,
-      marginTop: 6,
+      marginTop: getSpacingPx(SPACING.sm),
       "& a": {
         color: theme.palette.primary.main,
         textDecoration: "none",
@@ -94,7 +94,7 @@ const styles = (theme: Theme) =>
     ".portal-setup-error": {
       fontSize: 11,
       color: theme.vars.palette.error.main,
-      marginTop: 6,
+      marginTop: getSpacingPx(SPACING.sm),
     },
     ".portal-setup-back": {
       display: "block",

--- a/web/src/components/portal/RecentWorkflowCard.tsx
+++ b/web/src/components/portal/RecentWorkflowCard.tsx
@@ -12,7 +12,7 @@ const styles = (theme: Theme) =>
   css({
     display: "flex",
     flexDirection: "column",
-    gap: 8,
+    gap: getSpacingPx(SPACING.md),
     textAlign: "left",
     background: "transparent",
     border: "none",

--- a/web/src/components/portal/WelcomeFlow.tsx
+++ b/web/src/components/portal/WelcomeFlow.tsx
@@ -74,7 +74,7 @@ const styles = (theme: Theme, fullWidth: boolean) =>
     ".welcome-grid": {
       display: "grid",
       gridTemplateColumns: "repeat(4, 1fr)",
-      gap: 8,
+      gap: getSpacingPx(SPACING.md),
       animation: `${rise} ${MOTION.slow} ${320}ms backwards`,
       [theme.breakpoints.down("md")]: {
         gridTemplateColumns: "repeat(2, 1fr)"

--- a/web/src/components/properties/BoolProperty.tsx
+++ b/web/src/components/properties/BoolProperty.tsx
@@ -3,6 +3,7 @@ import { PropertyProps } from "../node/PropertyInput";
 import { memo, useCallback } from "react";
 import isEqual from "../../utils/isEqual";
 import { NodeSwitch } from "../editor_ui";
+import { BORDER_RADIUS } from "../ui_primitives";
 
 const BoolProperty = (props: PropertyProps<boolean>) => {
   const { property, value, changed, onChange } = props;
@@ -22,7 +23,7 @@ const BoolProperty = (props: PropertyProps<boolean>) => {
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-start",
-        borderRadius: ".2em",
+        borderRadius: BORDER_RADIUS.xs,
       }}
     >
       <PropertyLabel

--- a/web/src/components/properties/LlamaModelSelect.tsx
+++ b/web/src/components/properties/LlamaModelSelect.tsx
@@ -7,7 +7,9 @@ import {
   LoadingSpinner,
   FlexRow,
   ListItemText,
-  ListItemIcon
+  ListItemIcon,
+  SPACING,
+  getSpacingPx
 } from "../ui_primitives";
 import CheckIcon from "@mui/icons-material/Check";
 import { useOllamaModels } from "../../hooks/useOllamaModels";
@@ -106,7 +108,7 @@ const LlamaModelSelect = ({ onChange, value }: LlamaModelSelectProps) => {
             <LoadingSpinner size="medium" />
           </FlexRow>
         ) : ollamaError ? (
-          <div style={{ padding: 8, maxWidth: 300 }}>
+          <div style={{ padding: getSpacingPx(SPACING.md), maxWidth: 300 }}>
             <Text size="small" color="error" sx={{ mb: 1 }}>
               Could not load Ollama models
             </Text>

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -381,6 +381,7 @@ const PropertyDropzone = ({
                   style={{ width: "100%", height: "20px" }}
                   onVolumeChange={handleVolumeChange}
                   src={uri as string}
+                  aria-label={filename || "Audio"}
                 >
                   Your browser does not support the audio element.
                 </audio>
@@ -408,6 +409,7 @@ const PropertyDropzone = ({
                   style={{ width: "100%", height: "auto" }}
                   controls
                   src={uri}
+                  aria-label={filename || "Video"}
                 >
                   Your browser does not support the video element.
                 </video>

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -370,6 +370,7 @@ const ScriptLineRow = ({
           <span>
             <ToolbarIconButton
               tooltip=""
+              ariaLabel="Voice line"
               disabled={readOnly || !voice}
               onClick={() => void onVoice()}
               icon={<GraphicEqIcon fontSize="small" />}

--- a/web/src/components/sketch/GeneratingLayerOverlay.tsx
+++ b/web/src/components/sketch/GeneratingLayerOverlay.tsx
@@ -98,7 +98,7 @@ const sparkleCss = css({
   position: "absolute",
   width: 6,
   height: 6,
-  borderRadius: "50%",
+  borderRadius: BORDER_RADIUS.circle,
   background:
     "radial-gradient(circle, #fff 0%, rgba(110, 231, 255, 0.9) 40%, transparent 70%)",
   animation: `${sparkleTwinkle} ${MOTION.pulse} infinite`,

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -259,9 +259,9 @@ const LayerItem: React.FC<LayerItemProps> = ({
             />
           )
         ) : (
-          <Box
+          <FlexRow
             className="layer-thumbnail-wrapper"
-            sx={{ position: "relative", display: "flex", flexShrink: 0 }}
+            sx={{ position: "relative", flexShrink: 0 }}
           >
             {thumbnailSrc ? (
               <img
@@ -296,7 +296,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
                 <MagicGenerationFill />
               </Box>
             )}
-          </Box>
+          </FlexRow>
         )}
 
         {!isGroup && (

--- a/web/src/components/textEditor/EditorVariablesPanel.tsx
+++ b/web/src/components/textEditor/EditorVariablesPanel.tsx
@@ -276,6 +276,7 @@ const EditorVariablesPanel = ({
                     autoFocus
                     value={draftValue}
                     placeholder="value"
+                    aria-label={`Value for ${variable.name}`}
                     onChange={(e) => setDraftValue(e.target.value)}
                     onClick={(e) => e.stopPropagation()}
                     onBlur={commitEdit}
@@ -302,6 +303,7 @@ const EditorVariablesPanel = ({
                 className="add-input"
                 value={addName}
                 placeholder="variable name"
+                aria-label="New variable name"
                 onChange={(e) =>
                   setAddName(e.target.value.replace(/[^\w]/g, ""))
                 }

--- a/web/src/components/textEditor/ToolbarPlugin.tsx
+++ b/web/src/components/textEditor/ToolbarPlugin.tsx
@@ -14,7 +14,7 @@ import {
   removeClassNamesFromElement
 } from "@lexical/utils";
 import { $patchStyleText } from "@lexical/selection";
-import { getSpacingPx, SPACING } from "../ui_primitives";
+import { BORDER_RADIUS, getSpacingPx, SPACING } from "../ui_primitives";
 import { copyAsMarkdown } from "./exportMarkdown";
 import { INSERT_HORIZONTAL_RULE_COMMAND } from "./horizontalRuleCommand";
 
@@ -23,15 +23,15 @@ const toolbarStyles = css`
   gap: ${getSpacingPx(SPACING.xs)};
   background-color: var(--palette-c_overlay_strong);
   padding: ${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)};
-  border-radius: 3px;
+  border-radius: ${BORDER_RADIUS.sm};
   button {
-    padding: ${getSpacingPx(0.5)} ${getSpacingPx(1.5)};
+    padding: ${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.sm)};
     min-width: 20px;
     font-size: var(--fontSizeSmall);
     border: none;
     line-height: 1.2em;
     background-color: transparent;
-    border-radius: 3px;
+    border-radius: ${BORDER_RADIUS.sm};
     color: black;
     cursor: pointer;
 

--- a/web/src/components/textEditor/codeHighlightStyles.ts
+++ b/web/src/components/textEditor/codeHighlightStyles.ts
@@ -1,4 +1,5 @@
 import type { Theme } from "@mui/material/styles";
+import { getSpacingPx, SPACING } from "../ui_primitives";
 
 // Returns CSS styles for Lexical code highlighting tokens using the provided theme.
 export const codeHighlightTokenStyles = (theme: Theme) => ({
@@ -6,10 +7,10 @@ export const codeHighlightTokenStyles = (theme: Theme) => ({
     backgroundColor: theme.vars.palette.grey[900],
     fontFamily: "JetBrains Mono, Consolas, 'Courier New', monospace",
     display: "block",
-    padding: "8px 12px",
+    padding: `${getSpacingPx(SPACING.md)} ${getSpacingPx(SPACING.lg)}`,
     lineHeight: "1.53",
     fontSize: "var(--fontSizeSmall)",
-    margin: "8px 0",
+    margin: `${getSpacingPx(SPACING.md)} 0`,
     borderRadius: "1em",
     tabSize: 2,
     overflow: "auto"

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -17,7 +17,6 @@ import {
   FlexColumn,
   Panel,
   Text,
-  Toast,
   SPACING,
   getSpacingPx,
   Z_INDEX,

--- a/web/src/components/timeline/ProjectSettingsDialog.tsx
+++ b/web/src/components/timeline/ProjectSettingsDialog.tsx
@@ -160,7 +160,7 @@ const ProjectSettingsDialogInternal: React.FC<ProjectSettingsDialogProps> = ({
       <FlexColumn gap={4} sx={{ py: 1 }}>
         {/* ── Canvas size ─────────────────────────────────────────── */}
         <FlexColumn gap={1.5}>
-          <Text size="small" sx={{ fontWeight: 600, mb: 1.5 }}>
+          <Text size="small" weight={600} sx={{ mb: 1.5 }}>
             Canvas size
           </Text>
           {/* Label hidden — the section header names it; an outlined variant
@@ -208,7 +208,7 @@ const ProjectSettingsDialogInternal: React.FC<ProjectSettingsDialogProps> = ({
 
         {/* ── Frame rate ──────────────────────────────────────────── */}
         <FlexColumn gap={1.5}>
-          <Text size="small" sx={{ fontWeight: 600, mb: 1.5 }}>
+          <Text size="small" weight={600} sx={{ mb: 1.5 }}>
             Frame rate
           </Text>
           <FlexRow gap={1.5} align="flex-start">

--- a/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackEffectsPanel.tsx
@@ -172,7 +172,7 @@ const addButtonStyles = (theme: Theme) =>
     border: "none",
     padding: theme.spacing(0.5, 1),
     borderRadius: BORDER_RADIUS.xs,
-    fontSize: theme.typography.caption.fontSize,
+    fontSize: FONT_SIZE_SANS.caption,
     cursor: "pointer",
     display: "inline-flex",
     alignItems: "center",
@@ -192,7 +192,7 @@ const paramLabelStyles = (theme: Theme) =>
   css({
     width: 70,
     flexShrink: 0,
-    fontSize: theme.typography.caption.fontSize,
+    fontSize: FONT_SIZE_SANS.caption,
     color: theme.vars.palette.text.secondary
   });
 
@@ -202,7 +202,7 @@ const paramValueStyles = (theme: Theme) =>
     flexShrink: 0,
     textAlign: "right",
     fontVariantNumeric: "tabular-nums",
-    fontSize: theme.typography.caption.fontSize,
+    fontSize: FONT_SIZE_SANS.caption,
     color: theme.vars.palette.text.primary
   });
 
@@ -462,7 +462,7 @@ const bandReadoutStyles = (theme: Theme, color: string) =>
     borderRadius: BORDER_RADIUS.xs,
     padding: theme.spacing(0.5, 1),
     background: theme.vars.palette.background.paper,
-    fontSize: theme.typography.caption.fontSize,
+    fontSize: FONT_SIZE_SANS.caption,
     display: "flex",
     flexDirection: "column",
     gap: 2
@@ -1735,7 +1735,7 @@ const ChromaKeyEditor: React.FC<
       <FlexRow gap={1} align="center">
         <span
           css={{
-            fontSize: theme.typography.caption.fontSize,
+            fontSize: FONT_SIZE_SANS.caption,
             color: theme.vars.palette.text.secondary,
             width: 70
           }}
@@ -1752,7 +1752,7 @@ const ChromaKeyEditor: React.FC<
         />
         <span
           css={{
-            fontSize: theme.typography.caption.fontSize,
+            fontSize: FONT_SIZE_SANS.caption,
             color: theme.vars.palette.text.primary,
             fontVariantNumeric: "tabular-nums"
           }}

--- a/web/src/components/timeline/preview/ClipTransformContextMenu.tsx
+++ b/web/src/components/timeline/preview/ClipTransformContextMenu.tsx
@@ -86,9 +86,9 @@ const ClipTransformContextMenu: React.FC<ClipTransformContextMenuProps> = ({
         py: 0.5
       }}
     >
-      <FlexRow align="center" sx={{ gap: 1, px: 2, py: 1, mb: 0.5 }}>
+      <FlexRow align="center" gap={1} sx={{ px: 2, py: 1, mb: 0.5 }}>
         <TransformIcon sx={{ fontSize: 16, color: "primary.light" }} />
-        <Text sx={{ fontSize: theme.fontSizeSmall, fontWeight: 600, color: "text.primary" }}>
+        <Text size="small" weight={600} sx={{ color: "text.primary" }}>
           Transform
         </Text>
       </FlexRow>

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -575,6 +575,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
           <button
             type="button"
             className={activeTab.mode === "view" ? "on" : ""}
+            aria-pressed={activeTab.mode === "view"}
             onClick={() => setMode(activeTab.id, "view")}
           >
             View
@@ -582,6 +583,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
           <button
             type="button"
             className={activeTab.mode === "edit" ? "on" : ""}
+            aria-pressed={activeTab.mode === "edit"}
             onClick={() => setMode(activeTab.id, "edit")}
           >
             Edit

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -450,6 +450,7 @@ const WorkspaceTree: React.FC = () => {
           <span
             className="breadcrumb-segment"
             role="button"
+            aria-label="Go to workspace root"
             tabIndex={0}
             onClick={() => setSelectedFilePath("")}
             onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { setSelectedFilePath(""); } }}


### PR DESCRIPTION
A cleanup sweep over the web component tree, run as 12 parallel passes each scoped to a disjoint directory. 76 files, +303/-218.

## What changed

**Accessibility**

Two real bugs, not just missing labels — `PanelLeft` (2 buttons) and `ScriptLineRow` rendered `aria-label=""` on icon-only buttons. `ToolbarIconButton` derives its accessible name from `tooltip`, and in these cases the tooltip lived on an outer `<Tooltip>` wrapper, so the primitive received an empty string. An empty accessible name is worse than none: screen readers announce the control as unlabeled rather than falling back to content. Fixed by passing `ariaLabel` explicitly.

The rest:
- Named the icon-only controls in `FindInWorkflowDialog`, `EditableTitle`, `SketchNode`, `PreviewImageGrid`
- `aria-expanded` on the collapsible rows in `AssetListView`, `SearchResultItem`, `TracePanel`, `ToolCallRenderer`
- Labeled the bare `<audio>`/`<video>` previews in `PropertyDropzone` and the variable inputs in `EditorVariablesPanel`
- `aria-pressed` on the `WorkspaceTabBar` view/edit toggle (state was previously conveyed only by a CSS class)
- `prefers-reduced-motion` overrides added to nine files that animate without one (WCAG 2.3.3) — 6 in `node_types`, 3 infinite keyframes in `chat/LoadingIndicator`

**Tokens**

Spacing, radius, and z-index literals replaced with `SPACING`, `BORDER_RADIUS`, `Z_INDEX`; scrim/overlay colors routed through `theme.vars`. A handful of genuine `Box sx={{display:"flex"}}` wrappers migrated to `FlexRow`/`FlexColumn`.

## Deliberate visual changes

Four values move by 1px. Each was off the scale CLAUDE.md mandates, so these are corrections rather than incidental drift — calling them out so they aren't mistaken for a pure no-op refactor:

- `AssetActionsMenu`: `gap={0.75}` (3px) → `SPACING.xs` (4px)
- `CostsTable`: `gap={1.25}` (5px) → `SPACING.sm` (6px)
- `TrackEffectsPanel`: 6 captions from MUI's `typography.caption` default (12px, not overridden in `ThemeNodetool`) → `FONT_SIZE_SANS.caption` (11px). The file already imported `FONT_SIZE_SANS` without using it — an incomplete earlier migration.

## Not done

Every pass independently reported the same blocker: the several hundred remaining `display: "flex"` occurrences live inside Emotion `css()` blocks keyed by class selector, not JSX `sx` props. Converting them means restructuring markup and breaking class-name selectors, so they're out of scope for a cleanup pass. This is the bulk of the 314-file gap in the STRATEGY.md audit table and needs a deliberate effort.

Also left alone, with reasons: `em`-based spacing and font sizes (relative units — snapping to the px grid changes rendered size), icon glyph `fontSize` values (explicitly exempt), color-as-data (syntax highlighting, 3D scene colors, brand palettes, `boxShadow`), and clickable `div`s missing keyboard handlers (adding handlers is a behavior change, not cleanup).

Notably, all 12 directories turned out to have **zero** raw MUI *component* imports already — the migration described in the audit table is further along than the doc suggests. The remaining debt is tokens, Emotion blocks, and a11y.

## Verification

- `tsc --noEmit` — clean (requires `npm run build:packages` first; without it 40 unrelated `@nodetool-ai/*` resolution errors appear)
- `oxlint src` — exit 0
- Jest — 1033 suites, 12,262 passed, 3 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdgrAoaeHQ7dnGJtsyMTtH)_