### PR TITLE
feat(evals): add task-planner and script-planner eval suites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,17 @@ npm run dev:nodetool -- eval graph-planner -p openai -m gpt-5.4-mini --json --ou
 npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8   # non-zero exit below threshold
 ```
 
+The other two planning modes have a suite each, scoring the plan without
+running it: **`task-planner`** (multi-task DAG quality — parallel width,
+decomposition size, tool routing, no synthesis task) and **`script-planner`**
+(orchestration-script authoring — concurrency primitives, real loops, budget
+guards, no prelude shadowing).
+
+```bash
+npm run dev:nodetool -- eval task-planner -p anthropic -m claude-sonnet-5
+npm run dev:nodetool -- eval script-planner -p openai -m gpt-5.4-mini
+```
+
 Alongside `graph-planner` (one-shot DSL) there are seven **tool-loop** suites
 that drive a real provider through the frontend `ui_*` tool contract against a
 headless bridge — no browser — and score the multi-turn tool-calling flow

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -389,6 +389,56 @@ npm run dev:nodetool -- eval graph-planner -p anthropic -m ... --min-success 0.8
 
 Harness tests (scripted provider, no network): `tests/graph-planner-eval.test.ts`.
 
+### Planning-mode eval suites (`task-planner`, `script-planner`)
+
+The graph-planner suite covers graph mode. The other two planning modes have a
+suite each, both scoring the *plan* statically — nothing is executed.
+
+**`task-planner`** runs `TaskPlanner.planMultiTask` and scores the committed
+`TaskPlan`. `PlanBuilder` already rejects structurally broken plans (duplicate
+step ids, dangling deps, cycles), so anything that comes back is valid by
+construction; what it cannot judge is quality, and that is the suite:
+parallel width, decomposition proportional to the objective, real dependencies
+modelled as dependencies, tool routing (`run_python` for arithmetic, not a
+reasoning step), the step-id prefix convention, and the prompt's hard rule that
+final synthesis belongs to the Compiler, not to an "assemble" task. Metrics per
+case: tasks, steps, parallel width, critical-path depth, planner tool calls,
+rejected `add_task`/`finish_plan` calls; aggregate adds a **clean rate** — the
+fraction of plans built without a single rejected call.
+
+**`script-planner`** runs `ScriptPlanner.plan` and scores the authored
+orchestration script by static analysis. `validateScript` already gates the
+submission (non-empty, calls `agent(`, has a `return`, compiles); the suite
+checks the control flow the objective demands — `parallel()`/`pipeline()` for
+independent work, a real `for`/`while` for unknown-size discovery, a
+`budget.remainingCalls()` guard on that loop, a `schema:` on the aggregating
+call — plus universal checks that the script does not shadow a prelude name
+(`agent`, `parallel`, `budget`, …), does not use `import`/`require` (no loader
+in the guest), and stays inside a character budget. Metrics: `agent()` call
+sites, script length, submit rounds, rejected submissions, one-shot rate.
+
+Cases + expectations live in `src/evals/{task,script}-planner-cases.ts`, the
+runners in `src/evals/{task,script}-planner-eval.ts`. Both offer the same
+never-executed tool library (`src/evals/planner-tools.ts`: `web_search`,
+`fetch_page`, `read_file`, `write_file`, `run_python`, `generate_image`) so the
+planner has something concrete to route work to.
+
+```bash
+npm run dev:nodetool -- eval task-planner --list
+npm run dev:nodetool -- eval task-planner -p anthropic -m claude-sonnet-5
+npm run dev:nodetool -- eval script-planner -p openai -m gpt-5.4-mini --min-success 0.8
+IS_SANDBOX=1 npm run dev:nodetool -- eval task-planner -p claude_agent_sdk -m sonnet --no-find-model
+```
+
+Harness tests (scripted provider, no network):
+`tests/task-planner-eval.test.ts`, `tests/script-planner-eval.test.ts`.
+
+**Cost reads `$0` on these two under `claude_agent_sdk`.** Both planners abort
+the provider loop from inside the accepting tool (`finish_plan` /
+`submit_script`), and the SDK only reports token usage on its terminal `result`
+message — which a cancelled query never emits. The run is not free; the usage
+is simply unobservable. Score, timing, and call counts are unaffected.
+
 ### Tool-loop eval suites (frontend `ui_*` surfaces)
 
 Where the graph-planner eval measures one-shot DSL authoring, the tool-loop

--- a/packages/agents/src/evals/planner-tools.ts
+++ b/packages/agents/src/evals/planner-tools.ts
@@ -1,0 +1,102 @@
+/**
+ * Declarative tool library shared by the planning eval suites.
+ *
+ * Both planner suites score a *plan*, never an execution, so these tools are
+ * never called — the planner only sees their names and descriptions and
+ * decides which step (or which `opts.tools` restriction) should use them.
+ * Calling one throws, which keeps a suite honest: a harness that accidentally
+ * starts executing plans fails loudly instead of silently scoring an
+ * execution.
+ *
+ * The set covers the interaction shapes a planner has to route between:
+ * retrieval (`web_search`, `fetch_page`), storage (`write_file`, `read_file`),
+ * deterministic compute (`run_python`), and media generation
+ * (`generate_image`).
+ */
+
+import type { ProcessingContext, JsonSchema } from "@nodetool-ai/runtime";
+import { Tool } from "../tools/base-tool.js";
+
+/** A tool the planner may reference by name but that is never executed. */
+class DeclarativeTool extends Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly jsonSchema: JsonSchema;
+
+  constructor(name: string, description: string, schema: JsonSchema) {
+    super();
+    this.name = name;
+    this.description = description;
+    this.jsonSchema = schema;
+  }
+
+  async process(
+    _context: ProcessingContext,
+    _params: Record<string, unknown>
+  ): Promise<unknown> {
+    throw new Error(
+      `${this.name} is a planning-eval placeholder and must never be executed`
+    );
+  }
+}
+
+const stringArg = (name: string, description: string): JsonSchema => ({
+  type: "object",
+  properties: { [name]: { type: "string", description } },
+  required: [name],
+  additionalProperties: false
+});
+
+/** Tool names the planning suites expose, in the order they are offered. */
+export const PLANNER_TOOL_NAMES = [
+  "web_search",
+  "fetch_page",
+  "read_file",
+  "write_file",
+  "run_python",
+  "generate_image"
+] as const;
+
+/** Fresh instances of the planning toolset (one set per eval case). */
+export function createPlannerTools(): Tool[] {
+  return [
+    new DeclarativeTool(
+      "web_search",
+      "Search the web and return a list of result titles, URLs, and snippets.",
+      stringArg("query", "Search query.")
+    ),
+    new DeclarativeTool(
+      "fetch_page",
+      "Fetch one URL and return its readable text content.",
+      stringArg("url", "Absolute URL to fetch.")
+    ),
+    new DeclarativeTool(
+      "read_file",
+      "Read a UTF-8 text file from the workspace.",
+      stringArg("path", "Workspace-relative path.")
+    ),
+    new DeclarativeTool(
+      "write_file",
+      "Write a UTF-8 text file to the workspace.",
+      {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative path." },
+          content: { type: "string", description: "File contents." }
+        },
+        required: ["path", "content"],
+        additionalProperties: false
+      }
+    ),
+    new DeclarativeTool(
+      "run_python",
+      "Run a Python snippet for deterministic computation and return its stdout.",
+      stringArg("code", "Python source to execute.")
+    ),
+    new DeclarativeTool(
+      "generate_image",
+      "Generate one image from a text prompt and return its asset reference.",
+      stringArg("prompt", "Image prompt.")
+    )
+  ];
+}

--- a/packages/agents/src/evals/script-planner-cases.ts
+++ b/packages/agents/src/evals/script-planner-cases.ts
@@ -1,0 +1,120 @@
+/**
+ * Built-in evaluation cases for ScriptPlanner (script mode) authoring.
+ *
+ * Each case is an objective whose *shape* demands a particular control flow —
+ * fan-out, a loop that runs until a condition holds, a budget-scaled sweep, a
+ * two-stage pipeline. The expectations check that the authored script actually
+ * uses it, rather than serializing everything or unrolling a loop by hand.
+ */
+
+export interface ScriptPlannerEvalExpectations {
+  /** Minimum `agent()` call sites in the source. */
+  minAgentCalls?: number;
+  /** Independent work must go through `parallel()` or `pipeline()`. */
+  requireConcurrency?: boolean;
+  /** Unknown-size work must use a real `for`/`while` loop. */
+  requireLoop?: boolean;
+  /** A loop must be guarded by `budget.remainingCalls()` / `spentUsd()`. */
+  requireBudgetGuard?: boolean;
+  /** Some `agent()` call must request a structured result via `schema:`. */
+  requireSchema?: boolean;
+  /** Regex sources; each must match the script source (case-insensitive). */
+  requiredPatterns?: string[];
+  /** Regex sources; none may match the script source. */
+  forbiddenPatterns?: string[];
+  /** The script is coordination logic — cap how long it may get. */
+  maxChars?: number;
+}
+
+export interface ScriptPlannerEvalCase {
+  id: string;
+  description: string;
+  objective: string;
+  inputs?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  /** Case needs configured model providers — skipped when there are none. */
+  needsModelProviders?: boolean;
+  expect: ScriptPlannerEvalExpectations;
+}
+
+export const SCRIPT_PLANNER_EVAL_CASES: readonly ScriptPlannerEvalCase[] = [
+  {
+    id: "fan-out-summaries",
+    description: "Independent per-item work must fan out, not serialize",
+    objective:
+      "Summarize each of these five product pages in two sentences: /pricing, /security, /integrations, /changelog, /about. The five summaries are independent of each other. Return all five.",
+    expect: {
+      minAgentCalls: 1,
+      requireConcurrency: true,
+      maxChars: 2500
+    }
+  },
+  {
+    id: "loop-until-enough",
+    description: "An unknown-size target needs a loop, not a fixed unroll",
+    objective:
+      "Find ten distinct, non-duplicate claims about the safety of lithium iron phosphate batteries. Each round of searching may turn up duplicates, so keep going until you have ten distinct claims. Return the ten claims.",
+    expect: {
+      minAgentCalls: 1,
+      requireLoop: true,
+      requireBudgetGuard: true,
+      requiredPatterns: ["web_search"],
+      maxChars: 3500
+    }
+  },
+  {
+    id: "two-stage-pipeline",
+    description: "Per-item find-then-verify should pipeline, not barrier",
+    objective:
+      "For each of these three claims, first gather supporting evidence, then have a second agent verify that evidence and rate it supported or refuted: 'coffee lowers blood pressure', 'the Sahara is expanding', 'octopuses have three hearts'. Each claim's verification only needs its own evidence. Return each claim with its rating.",
+    outputSchema: {
+      type: "object",
+      properties: {
+        claims: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              claim: { type: "string" },
+              rating: { type: "string" }
+            },
+            required: ["claim", "rating"]
+          }
+        }
+      },
+      required: ["claims"]
+    },
+    expect: {
+      minAgentCalls: 2,
+      requireConcurrency: true,
+      requireSchema: true,
+      maxChars: 3500
+    }
+  },
+  {
+    id: "budget-scaled-sweep",
+    description: "Fleet size must be derived from the budget, not hardcoded",
+    objective:
+      "Audit the input codebase summary for security issues. Run as many independent reviewer agents as the remaining budget allows — scale the fleet to the budget rather than picking a fixed number — then return the deduplicated issues.",
+    inputs: { summary: "A Fastify API with SQLite storage and JWT auth." },
+    expect: {
+      minAgentCalls: 1,
+      requireConcurrency: true,
+      requireBudgetGuard: true,
+      maxChars: 3500
+    }
+  },
+  {
+    id: "sequential-refinement",
+    description: "A genuine data dependency must stay sequential",
+    objective:
+      "Draft a product announcement for the input feature, then have a second agent rewrite the draft to be 30% shorter, then have a third agent write a one-line social post based on the shortened version. Each step needs the previous step's text. Return the final social post.",
+    inputs: { feature: "offline mode for the mobile app" },
+    expect: {
+      minAgentCalls: 3,
+      requiredPatterns: ["await agent"],
+      forbiddenPatterns: ["\\bparallel\\s*\\("],
+      maxChars: 2500
+    }
+  }
+];

--- a/packages/agents/src/evals/script-planner-eval.ts
+++ b/packages/agents/src/evals/script-planner-eval.ts
@@ -1,0 +1,426 @@
+/**
+ * ScriptPlanner (script mode) evaluation harness — provider-agnostic.
+ *
+ * Script mode is the third planning mode: instead of a DAG of tasks the model
+ * authors a JavaScript orchestration script that the {@link ScriptRunner}
+ * executes, with each `agent()` call spawning a real sub-agent. This suite
+ * scores the authored script the way the graph-planner suite scores an
+ * accepted graph — statically, without running it.
+ *
+ * `validateScript` already gates the submission (non-empty, calls `agent(`,
+ * has a `return`, compiles). What it cannot judge is whether the script uses
+ * the control flow the objective actually calls for: concurrency for
+ * independent work, a real loop for unknown-size discovery, a budget guard so
+ * the loop degrades instead of dying on the call cap, a schema on the final
+ * aggregation. Those are the expectations here.
+ *
+ * Scoring is structural (see {@link checkScriptExpectations}) — never an exact
+ * script, so many valid orchestrations pass.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import type { EvalCheck } from "./graph-planner-eval.js";
+import { ScriptPlanner, validateScript } from "../script-planner.js";
+import { SCRIPT_RESERVED_NAMES } from "../script-runner.js";
+import { createPlannerTools } from "./planner-tools.js";
+import {
+  SCRIPT_PLANNER_EVAL_CASES,
+  type ScriptPlannerEvalCase,
+  type ScriptPlannerEvalExpectations
+} from "./script-planner-cases.js";
+
+/** `agent(...)` calls, ignoring property accesses like `foo.agent(`. */
+const AGENT_CALL_RE = /(?<![\w.$])agent\s*\(/g;
+/** `parallel(` or `pipeline(` — the two concurrency primitives. */
+const CONCURRENCY_RE = /(?<![\w.$])(?:parallel|pipeline)\s*\(/;
+/** A real loop, not an array `.map`: the shape unknown-size discovery needs. */
+const LOOP_RE = /\b(?:while|for)\s*\(/;
+/** The guard that keeps a loop from dying on the lifetime call cap. */
+const BUDGET_GUARD_RE =
+  /budget\s*\.\s*(?:remainingCalls|agentCalls|spentUsd)\s*\(/;
+/** A schema passed to `agent()` — structured, validated sub-agent output. */
+const SCHEMA_OPT_RE = /\bschema\s*:/;
+/** Module syntax the sandbox has no loader for. */
+const MODULE_SYNTAX_RE = /(?:^|\n)\s*import\s|(?<![\w.$])require\s*\(/;
+
+export interface ScriptPlanCaseResult {
+  caseId: string;
+  description: string;
+  skipped: boolean;
+  /** The planner returned an accepted script. */
+  accepted: boolean;
+  score: number;
+  checks: EvalCheck[];
+  /** `agent()` call sites in the source (static count, not runtime calls). */
+  agentCalls: number;
+  chars: number;
+  /** `submit_script` calls — 1 means the model one-shotted the script. */
+  submitRounds: number;
+  /** Submissions the host validator rejected. */
+  validationFailures: number;
+  durationMs: number;
+  costUsd: number;
+  /** The accepted script, so a report can be inspected after the fact. */
+  script?: string;
+  error?: string;
+}
+
+export interface ScriptPlanEvalReport {
+  provider: string;
+  model: string;
+  startedAt: string;
+  cases: ScriptPlanCaseResult[];
+  summary: {
+    total: number;
+    skipped: number;
+    accepted: number;
+    /** accepted / (total - skipped) */
+    successRate: number;
+    /** Mean expectation score over non-skipped cases. */
+    meanScore: number;
+    /** Fraction of accepted scripts that passed validation on the first try. */
+    oneShotRate: number;
+    avgAgentCalls: number;
+    avgChars: number;
+    avgDurationMs: number;
+    totalCostUsd: number;
+  };
+}
+
+export interface RunScriptPlannerEvalOptions {
+  provider: BaseProvider;
+  model: string;
+  /** Configured providers; enables model-dependent cases (else they skip). */
+  providers?: Record<string, BaseProvider>;
+  /** Cases to run; defaults to the built-in suite. */
+  cases?: readonly ScriptPlannerEvalCase[];
+  signal?: AbortSignal;
+  /** Progress callback (one line per event, for CLI display). */
+  onEvent?: (line: string) => void;
+}
+
+/** Static count of `agent()` call sites in a script. */
+export function countAgentCalls(script: string): number {
+  return script.match(AGENT_CALL_RE)?.length ?? 0;
+}
+
+/**
+ * Score an accepted script against a case's expectations. Pure and fully
+ * unit-testable: takes the source text, never calls a provider and never
+ * executes the script.
+ */
+export function checkScriptExpectations(
+  script: string,
+  expect: ScriptPlannerEvalExpectations
+): EvalCheck[] {
+  const checks: EvalCheck[] = [];
+
+  if (expect.minAgentCalls !== undefined) {
+    const count = countAgentCalls(script);
+    checks.push({
+      name: `agentCalls>=${expect.minAgentCalls}`,
+      pass: count >= expect.minAgentCalls,
+      detail: `found ${count}`
+    });
+  }
+
+  if (expect.requireConcurrency) {
+    const pass = CONCURRENCY_RE.test(script);
+    checks.push({
+      name: "concurrency",
+      pass,
+      detail: pass
+        ? undefined
+        : "no parallel()/pipeline() — independent work is serialized"
+    });
+  }
+
+  if (expect.requireLoop) {
+    const pass = LOOP_RE.test(script);
+    checks.push({
+      name: "loop",
+      pass,
+      detail: pass
+        ? undefined
+        : "no for/while loop — unknown-size work was unrolled"
+    });
+  }
+
+  if (expect.requireBudgetGuard) {
+    const pass = BUDGET_GUARD_RE.test(script);
+    checks.push({
+      name: "budget-guard",
+      pass,
+      detail: pass
+        ? undefined
+        : "loop is not guarded by budget.remainingCalls()"
+    });
+  }
+
+  if (expect.requireSchema) {
+    const pass = SCHEMA_OPT_RE.test(script);
+    checks.push({
+      name: "schema",
+      pass,
+      detail: pass ? undefined : "no agent() call requests a structured result"
+    });
+  }
+
+  for (const pattern of expect.requiredPatterns ?? []) {
+    const pass = new RegExp(pattern, "i").test(script);
+    checks.push({
+      name: `has:${pattern}`,
+      pass,
+      detail: pass ? undefined : `script does not match /${pattern}/i`
+    });
+  }
+
+  for (const pattern of expect.forbiddenPatterns ?? []) {
+    const hit = new RegExp(pattern, "i").test(script);
+    checks.push({
+      name: `not:${pattern}`,
+      pass: !hit,
+      detail: hit ? `script matches forbidden /${pattern}/i` : undefined
+    });
+  }
+
+  if (expect.maxChars !== undefined) {
+    checks.push({
+      name: `chars<=${expect.maxChars}`,
+      pass: script.length <= expect.maxChars,
+      detail: `${script.length} chars`
+    });
+  }
+
+  // Universal: the host validator must still be satisfied. The planner gates
+  // on it too, so a failure here means an accepted script drifted from what
+  // the runner will take.
+  const errors = validateScript(script);
+  checks.push({
+    name: "validates",
+    pass: errors.length === 0,
+    detail: errors.length === 0 ? undefined : errors.join("; ")
+  });
+
+  // Universal: the prelude owns these names. Redeclaring one shadows the real
+  // bridge, and the script silently does nothing.
+  const shadowed = SCRIPT_RESERVED_NAMES.filter((name) =>
+    new RegExp(`\\b(?:const|let|var|function)\\s+${name}\\b`).test(script)
+  );
+  checks.push({
+    name: "no-shadowing",
+    pass: shadowed.length === 0,
+    detail:
+      shadowed.length === 0 ? undefined : `redeclares ${shadowed.join(", ")}`
+  });
+
+  // Universal: no module loader exists inside the QuickJS guest.
+  const usesModules = MODULE_SYNTAX_RE.test(script);
+  checks.push({
+    name: "no-imports",
+    pass: !usesModules,
+    detail: usesModules ? "script uses import/require" : undefined
+  });
+
+  return checks;
+}
+
+async function runCase(
+  evalCase: ScriptPlannerEvalCase,
+  opts: RunScriptPlannerEvalOptions
+): Promise<ScriptPlanCaseResult> {
+  let submitRounds = 0;
+  let validationFailures = 0;
+  const costBefore = opts.provider.getTotalCost();
+  const startedAt = Date.now();
+
+  const planner = new ScriptPlanner({
+    provider: opts.provider,
+    model: opts.model,
+    tools: createPlannerTools(),
+    outputSchema: evalCase.outputSchema,
+    inputs: evalCase.inputs,
+    signal: opts.signal
+  });
+
+  const context = new ProcessingContext({
+    jobId: `script-planner-eval-${randomUUID()}`,
+    userId: "eval-user"
+  });
+
+  let script: string | null = null;
+  let error: string | undefined;
+  try {
+    const gen = planner.plan(evalCase.objective, context);
+    let res = await gen.next();
+    while (!res.done) {
+      const m = res.value as { type?: string } & Record<string, unknown>;
+      if (m.type === "planning_update") {
+        if (m.phase === "generation" && m.status === "running") {
+          submitRounds++;
+          opts.onEvent?.("    [submit_script]");
+        } else if (m.phase === "validation" && m.status === "failed") {
+          validationFailures++;
+          opts.onEvent?.(`    [rejected] ${String(m.content ?? "")}`);
+        }
+      }
+      res = await gen.next();
+    }
+    script = res.value;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const costUsd = opts.provider.getTotalCost() - costBefore;
+
+  const checks: EvalCheck[] = [
+    { name: "accepted", pass: script !== null, detail: error }
+  ];
+  if (script) checks.push(...checkScriptExpectations(script, evalCase.expect));
+  const score = script
+    ? checks.filter((c) => c.pass).length / checks.length
+    : 0;
+
+  return {
+    caseId: evalCase.id,
+    description: evalCase.description,
+    skipped: false,
+    accepted: script !== null,
+    score,
+    checks,
+    agentCalls: script ? countAgentCalls(script) : 0,
+    chars: script?.length ?? 0,
+    submitRounds,
+    validationFailures,
+    durationMs,
+    costUsd,
+    script: script ?? undefined,
+    error
+  };
+}
+
+export async function runScriptPlannerEval(
+  opts: RunScriptPlannerEvalOptions
+): Promise<ScriptPlanEvalReport> {
+  const cases = opts.cases ?? SCRIPT_PLANNER_EVAL_CASES;
+  const hasModelProviders =
+    !!opts.providers && Object.keys(opts.providers).length > 0;
+  const results: ScriptPlanCaseResult[] = [];
+
+  for (const evalCase of cases) {
+    if (opts.signal?.aborted) break;
+    if (evalCase.needsModelProviders && !hasModelProviders) {
+      opts.onEvent?.(`- ${evalCase.id}: SKIPPED (no model providers)`);
+      results.push({
+        caseId: evalCase.id,
+        description: evalCase.description,
+        skipped: true,
+        accepted: false,
+        score: 0,
+        checks: [],
+        agentCalls: 0,
+        chars: 0,
+        submitRounds: 0,
+        validationFailures: 0,
+        durationMs: 0,
+        costUsd: 0
+      });
+      continue;
+    }
+
+    opts.onEvent?.(`- ${evalCase.id}: ${evalCase.description}`);
+    const result = await runCase(evalCase, opts);
+    const failed = result.checks.filter((c) => !c.pass);
+    opts.onEvent?.(
+      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+        `agents=${result.agentCalls} chars=${result.chars} ` +
+        `submits=${result.submitRounds} ${Math.round(result.durationMs / 1000)}s` +
+        (failed.length > 0
+          ? ` | failed: ${failed.map((c) => c.name).join(", ")}`
+          : "")
+    );
+    results.push(result);
+  }
+
+  const ran = results.filter((r) => !r.skipped);
+  const acceptedResults = ran.filter((r) => r.accepted);
+  const mean = (pick: (r: ScriptPlanCaseResult) => number): number =>
+    ran.length > 0 ? ran.reduce((a, r) => a + pick(r), 0) / ran.length : 0;
+
+  return {
+    provider: opts.provider.provider,
+    model: opts.model,
+    startedAt: new Date().toISOString(),
+    cases: results,
+    summary: {
+      total: results.length,
+      skipped: results.length - ran.length,
+      accepted: acceptedResults.length,
+      successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+      meanScore: mean((r) => r.score),
+      oneShotRate:
+        acceptedResults.length > 0
+          ? acceptedResults.filter((r) => r.validationFailures === 0).length /
+            acceptedResults.length
+          : 0,
+      avgAgentCalls: mean((r) => r.agentCalls),
+      avgChars: mean((r) => r.chars),
+      avgDurationMs: mean((r) => r.durationMs),
+      totalCostUsd: ran.reduce((a, r) => a + r.costUsd, 0)
+    }
+  };
+}
+
+/** Text summary table for terminal output. */
+export function formatScriptPlanReport(report: ScriptPlanEvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `ScriptPlanner eval — provider=${report.provider} model=${report.model}`
+  );
+  lines.push("");
+  const header = [
+    "case".padEnd(22),
+    "result".padEnd(7),
+    "score".padEnd(6),
+    "agents".padEnd(7),
+    "chars".padEnd(7),
+    "submits".padEnd(8),
+    "time".padEnd(7),
+    "cost"
+  ].join("");
+  lines.push(header);
+  lines.push("-".repeat(header.length));
+  for (const r of report.cases) {
+    lines.push(
+      [
+        r.caseId.padEnd(22),
+        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
+        String(r.agentCalls).padEnd(7),
+        String(r.chars).padEnd(7),
+        String(r.submitRounds).padEnd(8),
+        `${Math.round(r.durationMs / 1000)}s`.padEnd(7),
+        r.costUsd > 0 ? `$${r.costUsd.toFixed(4)}` : "-"
+      ].join("")
+    );
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      lines.push(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  const s = report.summary;
+  lines.push("");
+  lines.push(
+    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  mean score ${s.meanScore.toFixed(2)}` +
+      `  one-shot ${(s.oneShotRate * 100).toFixed(0)}%` +
+      `  avg agents ${s.avgAgentCalls.toFixed(1)}` +
+      `  avg chars ${Math.round(s.avgChars)}` +
+      `  avg time ${(s.avgDurationMs / 1000).toFixed(1)}s` +
+      (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +
+      (s.skipped > 0 ? `  (${s.skipped} skipped)` : "")
+  );
+  return lines.join("\n");
+}

--- a/packages/agents/src/evals/script-planner-eval.ts
+++ b/packages/agents/src/evals/script-planner-eval.ts
@@ -42,8 +42,12 @@ const BUDGET_GUARD_RE =
   /budget\s*\.\s*(?:remainingCalls|agentCalls|spentUsd)\s*\(/;
 /** A schema passed to `agent()` — structured, validated sub-agent output. */
 const SCHEMA_OPT_RE = /\bschema\s*:/;
-/** Module syntax the sandbox has no loader for. */
-const MODULE_SYNTAX_RE = /(?:^|\n)\s*import\s|(?<![\w.$])require\s*\(/;
+/**
+ * Module syntax the sandbox has no loader for. The leading run is horizontal
+ * whitespace only — `\s*` after a `\n` alternative would also match newlines,
+ * so the two overlap and a newline-heavy script backtracks polynomially.
+ */
+const MODULE_SYNTAX_RE = /^[ \t]*import\s|(?<![\w.$])require\s*\(/m;
 
 export interface ScriptPlanCaseResult {
   caseId: string;

--- a/packages/agents/src/evals/task-planner-cases.ts
+++ b/packages/agents/src/evals/task-planner-cases.ts
@@ -1,0 +1,147 @@
+/**
+ * Built-in evaluation cases for TaskPlanner multi-task (plan mode) planning.
+ *
+ * Each case is an objective plus machine-checkable expectations on the
+ * committed plan. `PlanBuilder` already guarantees the plan is structurally
+ * sound, so the expectations here target judgment calls it cannot make:
+ * how wide the plan opens, whether a genuine dependency is modelled as one,
+ * whether decomposition stays proportional to the work, and which tool a step
+ * routes to.
+ */
+
+export interface TaskPlannerEvalExpectations {
+  minTasks?: number;
+  maxTasks?: number;
+  minSteps?: number;
+  maxSteps?: number;
+  /** Cap on the widest task — the prompt's step-granularity rule. */
+  maxStepsPerTask?: number;
+  /** Tasks with an empty `dependsOn`; the plan's parallel width. */
+  minIndependentTasks?: number;
+  /** Tasks with a non-empty `dependsOn`; proves the DAG is not flat. */
+  minDependentTasks?: number;
+  /** No task may depend on another — the work is genuinely independent. */
+  requireFlat?: boolean;
+  /** Tool names some step must route to (via `tools` or its instructions). */
+  requiredTools?: string[];
+  /** Tool names no step may route to. */
+  forbiddenTools?: string[];
+  /** Regex sources; each must match the concatenated step instructions. */
+  requiredInstructionPatterns?: string[];
+  /** Opt out of the universal "no synthesis task" check. */
+  allowSynthesisTask?: boolean;
+}
+
+export interface TaskPlannerEvalCase {
+  id: string;
+  description: string;
+  objective: string;
+  inputs?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  /** Case needs configured model providers — skipped when there are none. */
+  needsModelProviders?: boolean;
+  expect: TaskPlannerEvalExpectations;
+}
+
+export const TASK_PLANNER_EVAL_CASES: readonly TaskPlannerEvalCase[] = [
+  {
+    id: "parallel-research",
+    description: "Three unrelated topics must become three concurrent tasks",
+    objective:
+      "Research three separate topics — retrieval-augmented generation, vector databases, and prompt caching. For each one, find recent sources and write down the key findings. The three topics are unrelated to each other.",
+    outputSchema: {
+      type: "object",
+      properties: { findings: { type: "string" } },
+      required: ["findings"]
+    },
+    expect: {
+      minTasks: 3,
+      minIndependentTasks: 3,
+      requireFlat: true,
+      requiredTools: ["web_search"],
+      maxStepsPerTask: 3
+    }
+  },
+  {
+    id: "real-dependency",
+    description:
+      "A genuine data dependency must be modelled as one, not flattened",
+    objective:
+      "Download the page at the input url, then extract every section heading from the downloaded text, and separately count how many words the page contains. The extraction and the word count both need the downloaded page.",
+    inputs: { url: "https://example.com/article" },
+    expect: {
+      minTasks: 3,
+      minDependentTasks: 2,
+      requiredTools: ["fetch_page"],
+      requiredInstructionPatterns: ["heading"]
+    }
+  },
+  {
+    id: "no-over-decomposition",
+    description: "A one-shot objective must not be split into a task graph",
+    objective:
+      "Write a single four-line poem about autumn rain. No research, no files, no images — just the poem.",
+    expect: {
+      maxTasks: 2,
+      maxSteps: 2,
+      forbiddenTools: ["web_search", "fetch_page", "generate_image"]
+    }
+  },
+  {
+    id: "deterministic-routing",
+    description:
+      "Arithmetic must be routed to run_python, not to a reasoning step",
+    objective:
+      "Compute the first 40 Fibonacci numbers and their sum exactly. This is deterministic computation — it must be executed as code, not reasoned out. Write the result to results.txt.",
+    expect: {
+      maxTasks: 3,
+      requiredTools: ["run_python", "write_file"],
+      forbiddenTools: ["web_search", "generate_image"]
+    }
+  },
+  {
+    id: "media-fanout",
+    description: "One image per scene, planned as concurrent generation tasks",
+    objective:
+      "Generate one illustration for each of these three scenes: a lighthouse at dawn, a market at noon, a harbour at night. Each illustration is independent of the others.",
+    needsModelProviders: true,
+    expect: {
+      minTasks: 3,
+      minIndependentTasks: 3,
+      requiredTools: ["generate_image"],
+      requiredInstructionPatterns: ["lighthouse", "harbour"]
+    }
+  },
+  {
+    id: "gather-not-assemble",
+    description:
+      "Under an output schema the plan must gather facts and leave assembly to the Compiler",
+    objective:
+      "Produce a competitive brief on three note-taking apps: Obsidian, Notion, and Logseq. Gather pricing, platform support, and the standout feature for each.",
+    outputSchema: {
+      type: "object",
+      properties: {
+        apps: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              pricing: { type: "string" },
+              platforms: { type: "string" },
+              standoutFeature: { type: "string" }
+            },
+            required: ["name", "pricing", "platforms", "standoutFeature"]
+          }
+        }
+      },
+      required: ["apps"]
+    },
+    expect: {
+      minTasks: 3,
+      minIndependentTasks: 3,
+      requiredTools: ["web_search"],
+      requiredInstructionPatterns: ["pricing"]
+    }
+  }
+];

--- a/packages/agents/src/evals/task-planner-eval.ts
+++ b/packages/agents/src/evals/task-planner-eval.ts
@@ -1,0 +1,480 @@
+/**
+ * TaskPlanner (plan mode) evaluation harness — provider-agnostic.
+ *
+ * Runs {@link TaskPlanner.planMultiTask} for each case and scores the resulting
+ * {@link TaskPlan}. `PlanBuilder` already rejects structurally broken plans —
+ * duplicate step ids, dangling dependencies, cycles — so a plan that comes back
+ * at all is valid by construction. What it cannot judge is plan *quality*, and
+ * that is what this suite measures: does the planner exploit parallelism, keep
+ * decomposition proportional to the objective, route work to the right tool,
+ * respect the step-granularity and id-prefix conventions, and leave final
+ * synthesis to the Compiler stage instead of planning an "assemble" task?
+ *
+ * Scoring is structural (see {@link checkTaskPlanExpectations}) — task/step
+ * counts, DAG shape, tool routing, instruction patterns — never an exact plan,
+ * so many valid decompositions pass.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import type { EvalCheck } from "./graph-planner-eval.js";
+import { TaskPlanner } from "../task-planner.js";
+import type { Task, TaskPlan } from "../types.js";
+import { createPlannerTools } from "./planner-tools.js";
+import {
+  TASK_PLANNER_EVAL_CASES,
+  type TaskPlannerEvalCase,
+  type TaskPlannerEvalExpectations
+} from "./task-planner-cases.js";
+
+/**
+ * Task titles and step instructions that mean "assemble the final answer".
+ * The planner prompt forbids such a task outright — the Compiler stage owns
+ * final synthesis and already has every `task_result` in memory.
+ */
+const SYNTHESIS_PATTERN =
+  /\b(aggregat\w*|synthesi[sz]\w*|assembl\w*|consolidat\w*|final report|final answer|combine (?:the )?results?|compile (?:the )?(?:results?|report|findings))\b/i;
+
+export interface TaskPlanCaseResult {
+  caseId: string;
+  description: string;
+  skipped: boolean;
+  /** The planner returned a committed plan. */
+  accepted: boolean;
+  score: number;
+  checks: EvalCheck[];
+  tasks: number;
+  steps: number;
+  /** Tasks with no `dependsOn` — how wide the plan opens. */
+  parallelWidth: number;
+  /** Longest chain of task dependencies (1 for a flat fan-out). */
+  criticalPath: number;
+  /** Planner tool calls by name (`add_task`, `remove_task`, `finish_plan`). */
+  toolCalls: Record<string, number>;
+  /** `add_task`/`finish_plan` calls the builder rejected. */
+  validationFailures: number;
+  durationMs: number;
+  costUsd: number;
+  error?: string;
+}
+
+export interface TaskPlanEvalReport {
+  provider: string;
+  model: string;
+  startedAt: string;
+  cases: TaskPlanCaseResult[];
+  summary: {
+    total: number;
+    skipped: number;
+    accepted: number;
+    /** accepted / (total - skipped) */
+    successRate: number;
+    /** Mean expectation score over non-skipped cases. */
+    meanScore: number;
+    /** Fraction of accepted plans built without a single rejected tool call. */
+    cleanRate: number;
+    avgTasks: number;
+    avgSteps: number;
+    avgParallelWidth: number;
+    avgDurationMs: number;
+    totalCostUsd: number;
+  };
+}
+
+export interface RunTaskPlannerEvalOptions {
+  provider: BaseProvider;
+  model: string;
+  /** Configured providers; enables model-dependent cases (else they skip). */
+  providers?: Record<string, BaseProvider>;
+  /** Cases to run; defaults to the built-in suite. */
+  cases?: readonly TaskPlannerEvalCase[];
+  /** Planning attempts per case. */
+  maxRetries?: number;
+  signal?: AbortSignal;
+  /** Progress callback (one line per event, for CLI display). */
+  onEvent?: (line: string) => void;
+}
+
+/** Every step in the plan, flattened. */
+function allSteps(plan: TaskPlan) {
+  return plan.tasks.flatMap((t) => t.steps);
+}
+
+/** Tool names any step explicitly restricted itself to. */
+function declaredStepTools(plan: TaskPlan): Set<string> {
+  const names = new Set<string>();
+  for (const step of allSteps(plan)) {
+    for (const tool of step.tools ?? []) names.add(tool);
+  }
+  return names;
+}
+
+/**
+ * Longest chain of task-level dependencies. 1 means a flat fan-out (every task
+ * independent); N means the plan serializes N stages.
+ */
+export function criticalPathDepth(tasks: readonly Task[]): number {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  const memo = new Map<string, number>();
+
+  const depth = (id: string, seen: Set<string>): number => {
+    const cached = memo.get(id);
+    if (cached !== undefined) return cached;
+    // The builder rejects cycles, but a defensive guard keeps the scorer total
+    // for hand-written plans in tests.
+    if (seen.has(id)) return 0;
+    const task = byId.get(id);
+    if (!task) return 0;
+    seen.add(id);
+    const parents = task.dependsOn ?? [];
+    const result =
+      parents.length === 0
+        ? 1
+        : 1 + Math.max(...parents.map((p) => depth(p, seen)));
+    seen.delete(id);
+    memo.set(id, result);
+    return result;
+  };
+
+  return tasks.length === 0
+    ? 0
+    : Math.max(...tasks.map((t) => depth(t.id, new Set())));
+}
+
+/**
+ * Score a committed plan against a case's expectations. Pure and fully
+ * unit-testable: takes a {@link TaskPlan}, never calls a provider.
+ */
+export function checkTaskPlanExpectations(
+  plan: TaskPlan,
+  expect: TaskPlannerEvalExpectations
+): EvalCheck[] {
+  const checks: EvalCheck[] = [];
+  const steps = allSteps(plan);
+  const independent = plan.tasks.filter(
+    (t) => !t.dependsOn || t.dependsOn.length === 0
+  );
+  const dependent = plan.tasks.filter((t) => (t.dependsOn?.length ?? 0) > 0);
+
+  const bound = (
+    name: string,
+    actual: number,
+    min: number | undefined,
+    max: number | undefined
+  ): void => {
+    if (min !== undefined) {
+      checks.push({
+        name: `${name}>=${min}`,
+        pass: actual >= min,
+        detail: `found ${actual}`
+      });
+    }
+    if (max !== undefined) {
+      checks.push({
+        name: `${name}<=${max}`,
+        pass: actual <= max,
+        detail: `found ${actual}`
+      });
+    }
+  };
+
+  bound("tasks", plan.tasks.length, expect.minTasks, expect.maxTasks);
+  bound("steps", steps.length, expect.minSteps, expect.maxSteps);
+  bound("parallel", independent.length, expect.minIndependentTasks, undefined);
+  bound("dependent", dependent.length, expect.minDependentTasks, undefined);
+
+  if (expect.maxStepsPerTask !== undefined) {
+    const worst = plan.tasks.reduce(
+      (acc, t) => (t.steps.length > acc.steps.length ? t : acc),
+      plan.tasks[0] ?? { id: "-", steps: [] as Task["steps"] }
+    );
+    checks.push({
+      name: `stepsPerTask<=${expect.maxStepsPerTask}`,
+      pass: worst.steps.length <= expect.maxStepsPerTask,
+      detail: `widest task '${worst.id}' has ${worst.steps.length}`
+    });
+  }
+
+  if (expect.requireFlat) {
+    const chained = dependent.map((t) => t.id);
+    checks.push({
+      name: "flat-fanout",
+      pass: chained.length === 0,
+      detail:
+        chained.length === 0
+          ? undefined
+          : `tasks with dependencies: ${chained.join(", ")}`
+    });
+  }
+
+  const stepTools = declaredStepTools(plan);
+  const instructions = steps.map((s) => s.instructions).join("\n");
+
+  for (const tool of expect.requiredTools ?? []) {
+    // A planner may route a tool either by restricting a step's toolset or by
+    // naming it in the instructions — the prompt teaches both, so accept both.
+    const pass =
+      stepTools.has(tool) || new RegExp(`\\b${tool}\\b`).test(instructions);
+    checks.push({
+      name: `tool:${tool}`,
+      pass,
+      detail: pass ? undefined : `no step routes work to ${tool}`
+    });
+  }
+
+  for (const tool of expect.forbiddenTools ?? []) {
+    const hit =
+      stepTools.has(tool) || new RegExp(`\\b${tool}\\b`).test(instructions);
+    checks.push({
+      name: `not-tool:${tool}`,
+      pass: !hit,
+      detail: hit ? `plan routes work to ${tool}` : undefined
+    });
+  }
+
+  for (const pattern of expect.requiredInstructionPatterns ?? []) {
+    const re = new RegExp(pattern, "i");
+    const pass = re.test(instructions);
+    checks.push({
+      name: `says:${pattern}`,
+      pass,
+      detail: pass ? undefined : `no step instruction matches /${pattern}/i`
+    });
+  }
+
+  // Universal: step ids must be prefixed with their task id. The builder only
+  // enforces global uniqueness; the prefix convention is what keeps ids
+  // readable and collision-free as a plan grows.
+  const unprefixed = plan.tasks.flatMap((t) =>
+    t.steps.filter((s) => !s.id.startsWith(t.id)).map((s) => `${t.id}/${s.id}`)
+  );
+  checks.push({
+    name: "step-ids-prefixed",
+    pass: unprefixed.length === 0,
+    detail:
+      unprefixed.length === 0
+        ? undefined
+        : `unprefixed: ${unprefixed.join(", ")}`
+  });
+
+  // Universal: final synthesis belongs to the Compiler stage, not the plan.
+  if (!expect.allowSynthesisTask) {
+    const offender =
+      plan.tasks.find((t) => SYNTHESIS_PATTERN.test(t.title))?.title ??
+      steps.find((s) => SYNTHESIS_PATTERN.test(s.instructions))?.id;
+    checks.push({
+      name: "no-synthesis-task",
+      pass: offender === undefined,
+      detail: offender ? `synthesis work planned in "${offender}"` : undefined
+    });
+  }
+
+  return checks;
+}
+
+async function runCase(
+  evalCase: TaskPlannerEvalCase,
+  opts: RunTaskPlannerEvalOptions
+): Promise<TaskPlanCaseResult> {
+  const toolCalls: Record<string, number> = {};
+  let validationFailures = 0;
+  const costBefore = opts.provider.getTotalCost();
+  const startedAt = Date.now();
+
+  const planner = new TaskPlanner({
+    provider: opts.provider,
+    model: opts.model,
+    tools: createPlannerTools(),
+    outputSchema: evalCase.outputSchema,
+    inputs: evalCase.inputs,
+    maxRetries: opts.maxRetries,
+    signal: opts.signal
+  });
+
+  const context = new ProcessingContext({
+    jobId: `task-planner-eval-${randomUUID()}`,
+    userId: "eval-user"
+  });
+
+  let plan: TaskPlan | null = null;
+  let error: string | undefined;
+  try {
+    const gen = planner.planMultiTask(evalCase.objective, context);
+    let res = await gen.next();
+    while (!res.done) {
+      const m = res.value as { type?: string } & Record<string, unknown>;
+      if (m.type === "tool_call_update") {
+        const name = String(m.name ?? "unknown");
+        toolCalls[name] = (toolCalls[name] ?? 0) + 1;
+        opts.onEvent?.(`    [tool] ${name}`);
+      } else if (m.type === "planning_update" && m.phase === "validation") {
+        validationFailures++;
+      }
+      res = await gen.next();
+    }
+    plan = res.value;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const costUsd = opts.provider.getTotalCost() - costBefore;
+
+  const checks: EvalCheck[] = [
+    { name: "planned", pass: plan !== null, detail: error }
+  ];
+  if (plan) checks.push(...checkTaskPlanExpectations(plan, evalCase.expect));
+  const score = plan ? checks.filter((c) => c.pass).length / checks.length : 0;
+
+  return {
+    caseId: evalCase.id,
+    description: evalCase.description,
+    skipped: false,
+    accepted: plan !== null,
+    score,
+    checks,
+    tasks: plan?.tasks.length ?? 0,
+    steps: plan ? allSteps(plan).length : 0,
+    parallelWidth: plan
+      ? plan.tasks.filter((t) => !t.dependsOn || t.dependsOn.length === 0)
+          .length
+      : 0,
+    criticalPath: plan ? criticalPathDepth(plan.tasks) : 0,
+    toolCalls,
+    validationFailures,
+    durationMs,
+    costUsd,
+    error
+  };
+}
+
+export async function runTaskPlannerEval(
+  opts: RunTaskPlannerEvalOptions
+): Promise<TaskPlanEvalReport> {
+  const cases = opts.cases ?? TASK_PLANNER_EVAL_CASES;
+  const hasModelProviders =
+    !!opts.providers && Object.keys(opts.providers).length > 0;
+  const results: TaskPlanCaseResult[] = [];
+
+  for (const evalCase of cases) {
+    if (opts.signal?.aborted) break;
+    if (evalCase.needsModelProviders && !hasModelProviders) {
+      opts.onEvent?.(`- ${evalCase.id}: SKIPPED (no model providers)`);
+      results.push({
+        caseId: evalCase.id,
+        description: evalCase.description,
+        skipped: true,
+        accepted: false,
+        score: 0,
+        checks: [],
+        tasks: 0,
+        steps: 0,
+        parallelWidth: 0,
+        criticalPath: 0,
+        toolCalls: {},
+        validationFailures: 0,
+        durationMs: 0,
+        costUsd: 0
+      });
+      continue;
+    }
+
+    opts.onEvent?.(`- ${evalCase.id}: ${evalCase.description}`);
+    const result = await runCase(evalCase, opts);
+    const failed = result.checks.filter((c) => !c.pass);
+    opts.onEvent?.(
+      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+        `tasks=${result.tasks} steps=${result.steps} ` +
+        `parallel=${result.parallelWidth} depth=${result.criticalPath} ` +
+        `${Math.round(result.durationMs / 1000)}s` +
+        (failed.length > 0
+          ? ` | failed: ${failed.map((c) => c.name).join(", ")}`
+          : "")
+    );
+    results.push(result);
+  }
+
+  const ran = results.filter((r) => !r.skipped);
+  const acceptedResults = ran.filter((r) => r.accepted);
+  const mean = (pick: (r: TaskPlanCaseResult) => number): number =>
+    ran.length > 0 ? ran.reduce((a, r) => a + pick(r), 0) / ran.length : 0;
+
+  return {
+    provider: opts.provider.provider,
+    model: opts.model,
+    startedAt: new Date().toISOString(),
+    cases: results,
+    summary: {
+      total: results.length,
+      skipped: results.length - ran.length,
+      accepted: acceptedResults.length,
+      successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+      meanScore: mean((r) => r.score),
+      cleanRate:
+        acceptedResults.length > 0
+          ? acceptedResults.filter((r) => r.validationFailures === 0).length /
+            acceptedResults.length
+          : 0,
+      avgTasks: mean((r) => r.tasks),
+      avgSteps: mean((r) => r.steps),
+      avgParallelWidth: mean((r) => r.parallelWidth),
+      avgDurationMs: mean((r) => r.durationMs),
+      totalCostUsd: ran.reduce((a, r) => a + r.costUsd, 0)
+    }
+  };
+}
+
+/** Text summary table for terminal output. */
+export function formatTaskPlanReport(report: TaskPlanEvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `TaskPlanner eval — provider=${report.provider} model=${report.model}`
+  );
+  lines.push("");
+  const header = [
+    "case".padEnd(22),
+    "result".padEnd(7),
+    "score".padEnd(6),
+    "tasks".padEnd(6),
+    "steps".padEnd(6),
+    "par".padEnd(4),
+    "depth".padEnd(6),
+    "time".padEnd(7),
+    "cost"
+  ].join("");
+  lines.push(header);
+  lines.push("-".repeat(header.length));
+  for (const r of report.cases) {
+    lines.push(
+      [
+        r.caseId.padEnd(22),
+        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
+        String(r.tasks).padEnd(6),
+        String(r.steps).padEnd(6),
+        String(r.parallelWidth).padEnd(4),
+        String(r.criticalPath).padEnd(6),
+        `${Math.round(r.durationMs / 1000)}s`.padEnd(7),
+        r.costUsd > 0 ? `$${r.costUsd.toFixed(4)}` : "-"
+      ].join("")
+    );
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      lines.push(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  const s = report.summary;
+  lines.push("");
+  lines.push(
+    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  mean score ${s.meanScore.toFixed(2)}` +
+      `  clean ${(s.cleanRate * 100).toFixed(0)}%` +
+      `  avg tasks ${s.avgTasks.toFixed(1)}` +
+      `  avg steps ${s.avgSteps.toFixed(1)}` +
+      `  avg parallel ${s.avgParallelWidth.toFixed(1)}` +
+      `  avg time ${(s.avgDurationMs / 1000).toFixed(1)}s` +
+      (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +
+      (s.skipped > 0 ? `  (${s.skipped} skipped)` : "")
+  );
+  return lines.join("\n");
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -507,6 +507,44 @@ export type {
   ToolRecorder
 } from "./evals/subtask-cases.js";
 
+// Planning-mode evaluation harnesses (TaskPlanner DAG, ScriptPlanner script)
+export {
+  runTaskPlannerEval,
+  formatTaskPlanReport,
+  checkTaskPlanExpectations,
+  criticalPathDepth
+} from "./evals/task-planner-eval.js";
+export type {
+  TaskPlanCaseResult,
+  TaskPlanEvalReport,
+  RunTaskPlannerEvalOptions
+} from "./evals/task-planner-eval.js";
+export { TASK_PLANNER_EVAL_CASES } from "./evals/task-planner-cases.js";
+export type {
+  TaskPlannerEvalCase,
+  TaskPlannerEvalExpectations
+} from "./evals/task-planner-cases.js";
+export {
+  runScriptPlannerEval,
+  formatScriptPlanReport,
+  checkScriptExpectations,
+  countAgentCalls
+} from "./evals/script-planner-eval.js";
+export type {
+  ScriptPlanCaseResult,
+  ScriptPlanEvalReport,
+  RunScriptPlannerEvalOptions
+} from "./evals/script-planner-eval.js";
+export { SCRIPT_PLANNER_EVAL_CASES } from "./evals/script-planner-cases.js";
+export type {
+  ScriptPlannerEvalCase,
+  ScriptPlannerEvalExpectations
+} from "./evals/script-planner-cases.js";
+export {
+  createPlannerTools,
+  PLANNER_TOOL_NAMES
+} from "./evals/planner-tools.js";
+
 // Graph-native planning & execution
 export { evaluateGraphDsl } from "./graph-dsl.js";
 export type { GraphDslResult, EvaluateGraphDslOptions } from "./graph-dsl.js";

--- a/packages/agents/tests/script-planner-eval.test.ts
+++ b/packages/agents/tests/script-planner-eval.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the ScriptPlanner eval harness
+ * (`src/evals/script-planner-*`): static script scoring, agent()-call
+ * counting, metrics from the planner message stream, skip logic, and report
+ * formatting — all with a scripted provider, no network.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runScriptPlannerEval,
+  formatScriptPlanReport,
+  checkScriptExpectations,
+  countAgentCalls,
+  SCRIPT_PLANNER_EVAL_CASES,
+  type ScriptPlannerEvalCase
+} from "../src/index.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+
+/** Provider replaying one scripted tool-call list per generateLoop call. */
+function createScriptedProvider(script: ToolCall[]): BaseProvider {
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const tc of script) {
+        if (args.signal?.aborted) break;
+        yield tc as unknown as ProviderStreamItem;
+        await toolMap
+          .get(tc.name)
+          ?.execute?.(tc.args as Record<string, unknown>);
+        if (args.signal?.aborted) break;
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+const FANOUT_SCRIPT = `const pages = ["/pricing", "/security", "/about"];
+const summaries = await parallel(pages.map((p) => () =>
+  agent(\`Summarize \${p} in two sentences.\`, { label: p })));
+return summaries.filter(Boolean);`;
+
+const submitScript = (script: string): ToolCall =>
+  ({
+    id: "call_submit",
+    name: "submit_script",
+    args: { script }
+  }) as unknown as ToolCall;
+
+describe("countAgentCalls", () => {
+  it("counts call sites and ignores property access", () => {
+    expect(countAgentCalls("await agent('a'); await agent('b');")).toBe(2);
+    expect(countAgentCalls("foo.agent(1); myagent(2);")).toBe(0);
+  });
+});
+
+describe("checkScriptExpectations", () => {
+  it("passes a concurrent fan-out script", () => {
+    const checks = checkScriptExpectations(FANOUT_SCRIPT, {
+      minAgentCalls: 1,
+      requireConcurrency: true,
+      maxChars: 2500
+    });
+    expect(checks.every((c) => c.pass)).toBe(true);
+  });
+
+  it("fails concurrency when independent work is serialized", () => {
+    const serial = `const a = await agent("one");
+const b = await agent("two");
+return [a, b];`;
+    const check = checkScriptExpectations(serial, {
+      requireConcurrency: true
+    }).find((c) => c.name === "concurrency");
+    expect(check?.pass).toBe(false);
+  });
+
+  it("distinguishes a real loop from an unrolled one", () => {
+    const unrolled = `const a = await agent("1"); const b = await agent("2"); return [a, b];`;
+    const looped = `const out = [];
+while (out.length < 10 && budget.remainingCalls() > 2) {
+  out.push(await agent("find one more claim"));
+}
+return out;`;
+    expect(
+      checkScriptExpectations(unrolled, {
+        requireLoop: true,
+        requireBudgetGuard: true
+      })
+        .filter((c) => ["loop", "budget-guard"].includes(c.name))
+        .every((c) => c.pass)
+    ).toBe(false);
+    expect(
+      checkScriptExpectations(looped, {
+        requireLoop: true,
+        requireBudgetGuard: true
+      })
+        .filter((c) => ["loop", "budget-guard"].includes(c.name))
+        .every((c) => c.pass)
+    ).toBe(true);
+  });
+
+  it("flags a script that shadows a prelude name", () => {
+    const shadowed = `const agent = async (p) => p;\nreturn await agent("x");`;
+    const check = checkScriptExpectations(shadowed, {}).find(
+      (c) => c.name === "no-shadowing"
+    );
+    expect(check?.pass).toBe(false);
+    expect(check?.detail).toContain("agent");
+  });
+
+  it("flags module syntax and a script the host validator rejects", () => {
+    const bad = `import fs from "node:fs";\nawait agent("x");`;
+    const checks = checkScriptExpectations(bad, {});
+    expect(checks.find((c) => c.name === "no-imports")?.pass).toBe(false);
+    // No return statement → the host validator rejects it too.
+    expect(checks.find((c) => c.name === "validates")?.pass).toBe(false);
+  });
+});
+
+describe("runScriptPlannerEval", () => {
+  const cases: ScriptPlannerEvalCase[] = [
+    {
+      id: "fan-out",
+      description: "independent work fans out",
+      objective: "Summarize three pages independently.",
+      expect: { minAgentCalls: 1, requireConcurrency: true }
+    },
+    {
+      id: "needs-models",
+      description: "skipped without providers",
+      objective: "Generate images.",
+      needsModelProviders: true,
+      expect: {}
+    }
+  ];
+
+  it("collects metrics, scores the script, and skips model-dependent cases", async () => {
+    const report = await runScriptPlannerEval({
+      provider: createScriptedProvider([submitScript(FANOUT_SCRIPT)]),
+      model: "test-model",
+      cases
+    });
+
+    const fanout = report.cases[0];
+    expect(fanout.accepted).toBe(true);
+    expect(fanout.score).toBe(1);
+    expect(fanout.agentCalls).toBe(1);
+    expect(fanout.submitRounds).toBe(1);
+    expect(fanout.validationFailures).toBe(0);
+    expect(fanout.script).toContain("parallel(");
+
+    expect(report.cases[1].skipped).toBe(true);
+    expect(report.summary.successRate).toBe(1);
+    expect(report.summary.oneShotRate).toBe(1);
+  });
+
+  it("counts a rejected submission and still accepts the fixed script", async () => {
+    const report = await runScriptPlannerEval({
+      // First submission never calls agent() → host validator rejects it.
+      provider: createScriptedProvider([
+        submitScript("return 42;"),
+        submitScript(FANOUT_SCRIPT)
+      ]),
+      model: "test-model",
+      cases: [cases[0]]
+    });
+
+    expect(report.cases[0].accepted).toBe(true);
+    expect(report.cases[0].validationFailures).toBe(1);
+    expect(report.cases[0].submitRounds).toBe(2);
+    expect(report.summary.oneShotRate).toBe(0);
+  });
+
+  it("scores a run that never produced a valid script as failed", async () => {
+    const report = await runScriptPlannerEval({
+      provider: createScriptedProvider([submitScript("return 42;")]),
+      model: "test-model",
+      cases: [cases[0]]
+    });
+    expect(report.cases[0].accepted).toBe(false);
+    expect(report.cases[0].score).toBe(0);
+    expect(formatScriptPlanReport(report)).toContain("ScriptPlanner eval");
+  });
+});
+
+describe("SCRIPT_PLANNER_EVAL_CASES", () => {
+  it("has unique ids and an expectation on every case", () => {
+    const ids = SCRIPT_PLANNER_EVAL_CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const c of SCRIPT_PLANNER_EVAL_CASES) {
+      expect(Object.keys(c.expect).length).toBeGreaterThan(0);
+      expect(c.objective.length).toBeGreaterThan(20);
+    }
+  });
+});

--- a/packages/agents/tests/task-planner-eval.test.ts
+++ b/packages/agents/tests/task-planner-eval.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for the TaskPlanner eval harness (`src/evals/task-planner-*`):
+ * plan-quality scoring, critical-path math, metrics collection from the
+ * planner message stream, skip logic, and report formatting — all with a
+ * scripted provider, no network.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runTaskPlannerEval,
+  formatTaskPlanReport,
+  checkTaskPlanExpectations,
+  criticalPathDepth,
+  TASK_PLANNER_EVAL_CASES,
+  type TaskPlannerEvalCase
+} from "../src/index.js";
+import type { Task, TaskPlan } from "../src/types.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+
+/** Provider replaying one scripted tool-call list per generateLoop call. */
+function createScriptedProvider(script: ToolCall[]): BaseProvider {
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const tc of script) {
+        if (args.signal?.aborted) break;
+        yield tc as unknown as ProviderStreamItem;
+        await toolMap
+          .get(tc.name)
+          ?.execute?.(tc.args as Record<string, unknown>);
+        if (args.signal?.aborted) break;
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+function task(id: string, stepIds: string[], extra: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    dependsOn: [],
+    steps: stepIds.map((sid) => ({
+      id: sid,
+      instructions: `do ${sid}`,
+      completed: false,
+      dependsOn: [],
+      logs: []
+    })),
+    ...extra
+  };
+}
+
+const flatPlan: TaskPlan = {
+  title: "flat",
+  tasks: [task("a", ["a_1"]), task("b", ["b_1"]), task("c", ["c_1"])]
+};
+
+describe("criticalPathDepth", () => {
+  it("is 1 for a flat fan-out and N for an N-stage chain", () => {
+    expect(criticalPathDepth(flatPlan.tasks)).toBe(1);
+    expect(
+      criticalPathDepth([
+        task("a", ["a_1"]),
+        task("b", ["b_1"], { dependsOn: ["a"] }),
+        task("c", ["c_1"], { dependsOn: ["b"] })
+      ])
+    ).toBe(3);
+  });
+
+  it("is 0 for an empty plan", () => {
+    expect(criticalPathDepth([])).toBe(0);
+  });
+});
+
+describe("checkTaskPlanExpectations", () => {
+  it("passes a wide flat plan against fan-out expectations", () => {
+    const checks = checkTaskPlanExpectations(flatPlan, {
+      minTasks: 3,
+      minIndependentTasks: 3,
+      requireFlat: true,
+      maxStepsPerTask: 2
+    });
+    expect(checks.every((c) => c.pass)).toBe(true);
+  });
+
+  it("fails requireFlat when a task carries a dependency", () => {
+    const chained: TaskPlan = {
+      title: "chained",
+      tasks: [task("a", ["a_1"]), task("b", ["b_1"], { dependsOn: ["a"] })]
+    };
+    const flat = checkTaskPlanExpectations(chained, { requireFlat: true }).find(
+      (c) => c.name === "flat-fanout"
+    );
+    expect(flat?.pass).toBe(false);
+    expect(flat?.detail).toContain("b");
+  });
+
+  it("accepts a tool routed via step.tools or via the instructions", () => {
+    const viaTools: TaskPlan = {
+      title: "t",
+      tasks: [
+        {
+          ...task("a", ["a_1"]),
+          steps: [
+            {
+              id: "a_1",
+              instructions: "look it up",
+              completed: false,
+              dependsOn: [],
+              tools: ["web_search"],
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+    const viaText: TaskPlan = {
+      title: "t",
+      tasks: [
+        {
+          ...task("a", ["a_1"]),
+          steps: [
+            {
+              id: "a_1",
+              instructions: "Use web_search to find sources.",
+              completed: false,
+              dependsOn: [],
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+    for (const plan of [viaTools, viaText]) {
+      const check = checkTaskPlanExpectations(plan, {
+        requiredTools: ["web_search"]
+      }).find((c) => c.name === "tool:web_search");
+      expect(check?.pass).toBe(true);
+    }
+  });
+
+  it("flags unprefixed step ids and a planned synthesis task", () => {
+    const sloppy: TaskPlan = {
+      title: "sloppy",
+      tasks: [
+        task("gather", ["s1"]),
+        { ...task("wrapup", ["wrapup_1"]), title: "Assemble the final report" }
+      ]
+    };
+    const checks = checkTaskPlanExpectations(sloppy, {});
+    expect(checks.find((c) => c.name === "step-ids-prefixed")?.pass).toBe(
+      false
+    );
+    expect(checks.find((c) => c.name === "no-synthesis-task")?.pass).toBe(
+      false
+    );
+  });
+
+  it("allows a synthesis task when the case opts in", () => {
+    const plan: TaskPlan = {
+      title: "s",
+      tasks: [{ ...task("final", ["final_1"]), title: "Combine the results" }]
+    };
+    const check = checkTaskPlanExpectations(plan, {
+      allowSynthesisTask: true
+    }).find((c) => c.name === "no-synthesis-task");
+    expect(check).toBeUndefined();
+  });
+});
+
+describe("runTaskPlannerEval", () => {
+  const cases: TaskPlannerEvalCase[] = [
+    {
+      id: "fanout",
+      description: "three independent tasks",
+      objective: "Research three topics.",
+      expect: { minTasks: 2, minIndependentTasks: 2, requireFlat: true }
+    },
+    {
+      id: "needs-models",
+      description: "skipped without providers",
+      objective: "Generate images.",
+      needsModelProviders: true,
+      expect: {}
+    }
+  ];
+
+  const addTask = (id: string, deps: string[] = []): ToolCall =>
+    ({
+      id: `call_${id}`,
+      name: "add_task",
+      args: {
+        id,
+        title: `Task ${id}`,
+        depends_on: deps,
+        steps: [
+          {
+            id: `${id}_1`,
+            instructions: `Use web_search for ${id}.`,
+            depends_on: []
+          }
+        ]
+      }
+    }) as unknown as ToolCall;
+
+  it("collects metrics, scores the plan, and skips model-dependent cases", async () => {
+    const provider = createScriptedProvider([
+      addTask("alpha"),
+      addTask("beta"),
+      {
+        id: "call_finish",
+        name: "finish_plan",
+        args: { title: "Research plan" }
+      } as unknown as ToolCall
+    ]);
+
+    const report = await runTaskPlannerEval({
+      provider,
+      model: "test-model",
+      cases
+    });
+
+    expect(report.provider).toBe("scripted");
+    const fanout = report.cases[0];
+    expect(fanout.accepted).toBe(true);
+    expect(fanout.tasks).toBe(2);
+    expect(fanout.steps).toBe(2);
+    expect(fanout.parallelWidth).toBe(2);
+    expect(fanout.criticalPath).toBe(1);
+    expect(fanout.toolCalls["add_task"]).toBe(2);
+    expect(fanout.validationFailures).toBe(0);
+    expect(fanout.score).toBe(1);
+
+    expect(report.cases[1].skipped).toBe(true);
+    expect(report.summary.successRate).toBe(1);
+    expect(report.summary.cleanRate).toBe(1);
+    expect(report.summary.avgTasks).toBe(2);
+  });
+
+  it("counts rejected add_task calls against the clean rate", async () => {
+    // The first add_task depends on a task that was never added → rejected.
+    const provider = createScriptedProvider([
+      addTask("alpha", ["missing"]),
+      addTask("alpha"),
+      addTask("beta"),
+      {
+        id: "call_finish",
+        name: "finish_plan",
+        args: { title: "Research plan" }
+      } as unknown as ToolCall
+    ]);
+
+    const report = await runTaskPlannerEval({
+      provider,
+      model: "test-model",
+      cases: [cases[0]]
+    });
+
+    expect(report.cases[0].accepted).toBe(true);
+    expect(report.cases[0].validationFailures).toBe(1);
+    expect(report.summary.cleanRate).toBe(0);
+  });
+
+  it("scores a never-committed plan as failed", async () => {
+    // No finish_plan → no committed plan.
+    const provider = createScriptedProvider([addTask("alpha")]);
+    const report = await runTaskPlannerEval({
+      provider,
+      model: "test-model",
+      cases: [cases[0]]
+    });
+    expect(report.cases[0].accepted).toBe(false);
+    expect(report.cases[0].score).toBe(0);
+    expect(report.summary.successRate).toBe(0);
+  });
+
+  it("formats a report with the failed checks inline", async () => {
+    const provider = createScriptedProvider([
+      addTask("alpha"),
+      {
+        id: "call_finish",
+        name: "finish_plan",
+        args: { title: "Research plan" }
+      } as unknown as ToolCall
+    ]);
+    const report = await runTaskPlannerEval({
+      provider,
+      model: "test-model",
+      cases: [cases[0]]
+    });
+    const text = formatTaskPlanReport(report);
+    expect(text).toContain("TaskPlanner eval");
+    expect(text).toContain("fanout");
+    // One task only → the minTasks>=2 check fails and is listed.
+    expect(text).toContain("✗ tasks>=2");
+  });
+});
+
+describe("TASK_PLANNER_EVAL_CASES", () => {
+  it("has unique ids and an expectation on every case", () => {
+    const ids = TASK_PLANNER_EVAL_CASES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const c of TASK_PLANNER_EVAL_CASES) {
+      expect(Object.keys(c.expect).length).toBeGreaterThan(0);
+      expect(c.objective.length).toBeGreaterThan(20);
+    }
+  });
+});

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -83,6 +83,24 @@ interface EvalSuite {
   run(deps: EvalRunDeps): Promise<EvalRunResult>;
 }
 
+/**
+ * Filter a suite's cases down to `--cases`, rejecting ids the suite doesn't
+ * have. Undefined ids run the whole suite.
+ */
+function selectCases<T extends { id: string }>(
+  all: readonly T[],
+  caseIds: string[] | undefined
+): readonly T[] {
+  if (!caseIds) return all;
+  const wanted = new Set(caseIds);
+  const picked = all.filter((c) => wanted.has(c.id));
+  const missing = [...wanted].filter((id) => !picked.some((c) => c.id === id));
+  if (missing.length > 0) {
+    throw new Error(`Unknown case ids: ${missing.join(", ")} (see --list)`);
+  }
+  return picked;
+}
+
 /** GraphPlanner one-shot DSL suite (`@nodetool-ai/agents`). */
 const graphPlannerSuite: EvalSuite = {
   id: "graph-planner",
@@ -100,17 +118,7 @@ const graphPlannerSuite: EvalSuite = {
     const { GRAPH_PLANNER_EVAL_CASES, runGraphPlannerEval, formatEvalReport } =
       await import("@nodetool-ai/agents");
 
-    let cases = GRAPH_PLANNER_EVAL_CASES;
-    if (deps.caseIds) {
-      const wanted = new Set(deps.caseIds);
-      cases = GRAPH_PLANNER_EVAL_CASES.filter((c) => wanted.has(c.id));
-      const missing = [...wanted].filter(
-        (id) => !cases.some((c) => c.id === id)
-      );
-      if (missing.length > 0) {
-        throw new Error(`Unknown case ids: ${missing.join(", ")} (see --list)`);
-      }
-    }
+    const cases = selectCases(GRAPH_PLANNER_EVAL_CASES, deps.caseIds);
 
     console.log(
       `Running ${cases.length} case(s) with ${deps.providerId}/${deps.model}` +
@@ -154,17 +162,7 @@ const subtaskSuite: EvalSuite = {
     const { SUBTASK_EVAL_CASES, runSubtaskEval, formatSubtaskReport } =
       await import("@nodetool-ai/agents");
 
-    let cases = SUBTASK_EVAL_CASES;
-    if (deps.caseIds) {
-      const wanted = new Set(deps.caseIds);
-      cases = SUBTASK_EVAL_CASES.filter((c) => wanted.has(c.id));
-      const missing = [...wanted].filter(
-        (id) => !cases.some((c) => c.id === id)
-      );
-      if (missing.length > 0) {
-        throw new Error(`Unknown case ids: ${missing.join(", ")} (see --list)`);
-      }
-    }
+    const cases = selectCases(SUBTASK_EVAL_CASES, deps.caseIds);
 
     console.log(
       `Running ${cases.length} subtask case(s) with ${deps.providerId}/${deps.model}` +
@@ -185,6 +183,89 @@ const subtaskSuite: EvalSuite = {
     return {
       report,
       formatted: formatSubtaskReport(report),
+      successRate: report.summary.successRate
+    };
+  }
+};
+
+/** TaskPlanner multi-task (plan mode) DAG-quality suite. */
+const taskPlannerSuite: EvalSuite = {
+  id: "task-planner",
+  description:
+    "Run the TaskPlanner (plan mode) eval suite — multi-task DAG quality: parallelism, decomposition size, tool routing — against a provider/model",
+  async listCases() {
+    const { TASK_PLANNER_EVAL_CASES } = await import("@nodetool-ai/agents");
+    return TASK_PLANNER_EVAL_CASES.map((c) => ({
+      id: c.id,
+      description: c.description,
+      needsModelProviders: c.needsModelProviders
+    }));
+  },
+  async run(deps) {
+    const {
+      TASK_PLANNER_EVAL_CASES,
+      runTaskPlannerEval,
+      formatTaskPlanReport
+    } = await import("@nodetool-ai/agents");
+
+    const cases = selectCases(TASK_PLANNER_EVAL_CASES, deps.caseIds);
+    console.log(
+      `Running ${cases.length} task-planner case(s) with ${deps.providerId}/${deps.model}`
+    );
+
+    const report = await runTaskPlannerEval({
+      provider: deps.provider,
+      model: deps.model,
+      providers: deps.providers,
+      cases,
+      maxRetries: deps.maxRetries,
+      onEvent: deps.onEvent
+    });
+
+    return {
+      report,
+      formatted: formatTaskPlanReport(report),
+      successRate: report.summary.successRate
+    };
+  }
+};
+
+/** ScriptPlanner (script mode) orchestration-script authoring suite. */
+const scriptPlannerSuite: EvalSuite = {
+  id: "script-planner",
+  description:
+    "Run the ScriptPlanner (script mode) eval suite — orchestration-script authoring: concurrency, loops, budget guards — against a provider/model",
+  async listCases() {
+    const { SCRIPT_PLANNER_EVAL_CASES } = await import("@nodetool-ai/agents");
+    return SCRIPT_PLANNER_EVAL_CASES.map((c) => ({
+      id: c.id,
+      description: c.description,
+      needsModelProviders: c.needsModelProviders
+    }));
+  },
+  async run(deps) {
+    const {
+      SCRIPT_PLANNER_EVAL_CASES,
+      runScriptPlannerEval,
+      formatScriptPlanReport
+    } = await import("@nodetool-ai/agents");
+
+    const cases = selectCases(SCRIPT_PLANNER_EVAL_CASES, deps.caseIds);
+    console.log(
+      `Running ${cases.length} script-planner case(s) with ${deps.providerId}/${deps.model}`
+    );
+
+    const report = await runScriptPlannerEval({
+      provider: deps.provider,
+      model: deps.model,
+      providers: deps.providers,
+      cases,
+      onEvent: deps.onEvent
+    });
+
+    return {
+      report,
+      formatted: formatScriptPlanReport(report),
       successRate: report.summary.successRate
     };
   }
@@ -238,20 +319,10 @@ function makeToolLoopSuite(
     async run(deps) {
       const mod = await import("@nodetool-ai/agents");
       const { runToolLoopEval, formatToolLoopReport } = mod;
-      let cases = pickCases(mod as unknown as Record<string, unknown>);
-
-      if (deps.caseIds) {
-        const wanted = new Set(deps.caseIds);
-        cases = cases.filter((c) => wanted.has(c.id));
-        const missing = [...wanted].filter(
-          (want) => !cases.some((c) => c.id === want)
-        );
-        if (missing.length > 0) {
-          throw new Error(
-            `Unknown case ids: ${missing.join(", ")} (see --list)`
-          );
-        }
-      }
+      const cases = selectCases(
+        pickCases(mod as unknown as Record<string, unknown>),
+        deps.caseIds
+      );
 
       console.log(
         `Running ${cases.length} ${id} case(s) with ${deps.providerId}/${deps.model}`
@@ -281,6 +352,8 @@ function makeToolLoopSuite(
 /** All evaluation suites exposed under `nodetool eval <suite>`. */
 export const EVAL_SUITES: readonly EvalSuite[] = [
   graphPlannerSuite,
+  taskPlannerSuite,
+  scriptPlannerSuite,
   subtaskSuite,
   makeToolLoopSuite(
     "tool-loop",


### PR DESCRIPTION
Plan mode and script mode were the two planning modes with no evaluation coverage: graph mode had `eval graph-planner`, the frontend surfaces had the tool-loop suites, and sub-agent execution had `eval subtask`.

## What's new

**`nodetool eval task-planner`** runs `TaskPlanner.planMultiTask` and scores the committed `TaskPlan`. `PlanBuilder` already rejects structurally broken plans (duplicate step ids, dangling deps, cycles), so anything that comes back is valid by construction — the suite scores what it cannot judge:

- parallel width and whether a genuine data dependency is modelled as one
- decomposition proportional to the objective (a four-line poem must not become a task graph)
- tool routing — arithmetic goes to `run_python`, not to a reasoning step
- the step-id prefix convention
- the prompt's hard rule that final synthesis belongs to the Compiler, not to an "assemble" task

Metrics: tasks, steps, parallel width, critical-path depth, planner tool calls, and a **clean rate** — plans built without a single rejected `add_task`/`finish_plan`.

**`nodetool eval script-planner`** runs `ScriptPlanner.plan` and scores the authored orchestration script statically. `validateScript` already gates submission (non-empty, calls `agent(`, has a `return`, compiles); the suite checks the control flow each objective demands — `parallel()`/`pipeline()` for independent work, a real `for`/`while` for unknown-size discovery, a `budget.remainingCalls()` guard on that loop, a `schema:` on the aggregating call — plus universal checks that the script doesn't shadow a prelude name (`agent`, `parallel`, `budget`, …) or use `import`/`require`, which the QuickJS guest has no loader for.

Metrics: `agent()` call sites, script length, submit rounds, rejected submissions, one-shot rate.

Both suites share `src/evals/planner-tools.ts` — `web_search`, `fetch_page`, `read_file`, `write_file`, `run_python`, `generate_image` — so the planner has concrete tools to route work to. They are never executed; calling one throws, so a harness that starts executing plans fails loudly instead of silently scoring an execution.

Also folds the four copies of the `--cases` id filter in `packages/cli/src/commands/eval.ts` into one `selectCases` helper.

## Results against the Claude Agent provider

`IS_SANDBOX=1 nodetool eval <suite> -p claude_agent_sdk -m sonnet --no-find-model`

```
TaskPlanner eval — provider=claude_agent_sdk model=sonnet
case                  result score tasks steps par depth time
parallel-research     pass   1.00  3     9     3   1     34s
real-dependency       pass   1.00  3     3     1   2     30s
no-over-decomposition pass   1.00  1     1     1   1     13s
deterministic-routing pass   1.00  1     2     1   1     18s
media-fanout          skip   -     0     0     0   0     0s
gather-not-assemble   pass   1.00  3     12    3   1     30s
success 5/5 (100%)  mean score 1.00  clean 100%  avg tasks 2.2  avg parallel 1.8
```

```
ScriptPlanner eval — provider=claude_agent_sdk model=sonnet
case                  result score agents chars  submits time
fan-out-summaries     pass   1.00  1      1316   1       43s
loop-until-enough     pass   0.89  5      5573   2       87s   ✗ chars<=3500
two-stage-pipeline    pass   1.00  2      1820   1       21s
budget-scaled-sweep   pass   0.88  2      10147  1       60s   ✗ chars<=3500
sequential-refinement pass   1.00  3      1573   1       16s
success 5/5 (100%)  mean score 0.95  one-shot 80%  avg agents 2.6  avg chars 4086
```

Two real findings: script mode runs long (a 10k-character coordination script for a fan-out sweep), and one submission was rejected for emitting `export` syntax before it self-corrected.

Cost reads `$0` on both suites under `claude_agent_sdk`. Both planners abort the provider loop from inside the accepting tool (`finish_plan` / `submit_script`), and the SDK reports token usage only on its terminal `result` message, which a cancelled query never emits. The run isn't free — the usage is unobservable. Documented in `packages/agents/CLAUDE.md`; score, timing, and call counts are unaffected.

## Tests

- `packages/agents/tests/task-planner-eval.test.ts` and `script-planner-eval.test.ts` — 22 tests, scripted provider, no network: scoring predicates, critical-path math, metrics from the planner message stream, skip logic, report formatting.
- Full `@nodetool-ai/agents` suite: 1639 passed.
- `typecheck` and `lint` clean for the touched packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxPEmoZoQ7ZaH6AsXEmCYR)_