### PR TITLE
fix(web): keyboard access, silent failures, and off-grid spacing

### DIFF
--- a/web/src/components/asset_viewer/Model3DViewer.tsx
+++ b/web/src/components/asset_viewer/Model3DViewer.tsx
@@ -814,6 +814,7 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
                 value={lightingPreset}
                 onChange={handleLightingChange}
                 variant="outlined"
+                aria-label="Lighting preset"
                 IconComponent={LightModeIcon}
               >
                 {LIGHTING_PRESETS.map((preset) => (
@@ -829,6 +830,7 @@ const Model3DViewer: React.FC<Model3DViewerProps> = ({
                 value={backgroundColor}
                 onChange={handleBackgroundChange}
                 variant="outlined"
+                aria-label="Background color"
               >
                 {BACKGROUND_COLORS.map((bg) => (
                   <MenuItem key={bg.value} value={bg.value}>

--- a/web/src/components/assets/AssetDeleteConfirmation.tsx
+++ b/web/src/components/assets/AssetDeleteConfirmation.tsx
@@ -10,6 +10,7 @@ import { useAssets } from "../../serverState/useAssets";
 import AssetTree from "./AssetTree";
 import { Asset } from "../../stores/ApiTypes";
 import { useAuth } from "../../stores/useAuth";
+import { useNotificationStore } from "../../stores/NotificationStore";
 import {
   Dialog,
   DialogActionButtons,
@@ -50,6 +51,9 @@ const AssetDeleteConfirmation: React.FC<AssetDeleteConfirmationProps> = ({
   const selectedAssets = useAssetGridStore((state) => state.selectedAssets);
   const user = useAuth((state) => state.user);
   const queryClient = useQueryClient();
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
 
   useEffect(() => {
     if (!dialogOpen) {return;} // Only process when dialog is actually open
@@ -119,14 +123,38 @@ const AssetDeleteConfirmation: React.FC<AssetDeleteConfirmationProps> = ({
       // Invalidate all asset queries (including workflow-specific ones)
       await queryClient.invalidateQueries({ queryKey: ["assets"] });
       await refetchAssetsAndFolders();
+      const parts = [
+        folderCount > 0
+          ? `${folderCount} folder${folderCount !== 1 ? "s" : ""}`
+          : null,
+        fileCount > 0 ? `${fileCount} file${fileCount !== 1 ? "s" : ""}` : null
+      ].filter((part): part is string => part !== null);
+      addNotification({
+        type: "success",
+        alert: true,
+        content: `Deleted ${parts.join(" and ") || "selection"}`
+      });
     } catch (error) {
-      if (error instanceof Error) {
-        console.error("Execute deletion error:", error.message);
-      }
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Could not delete: ${
+          error instanceof Error ? error.message : "unknown error"
+        }`
+      });
     } finally {
       setIsLoading(false);
     }
-  }, [mutation, assets, setDialogOpen, refetchAssetsAndFolders, queryClient]);
+  }, [
+    mutation,
+    assets,
+    setDialogOpen,
+    refetchAssetsAndFolders,
+    queryClient,
+    addNotification,
+    folderCount,
+    fileCount
+  ]);
 
   const getDialogTitle = () => {
     if (isAssetTreeLoading && folderCount > 0) {

--- a/web/src/components/assets/AssetItem.tsx
+++ b/web/src/components/assets/AssetItem.tsx
@@ -227,7 +227,7 @@ const styles = (theme: Theme) =>
       height: "2em",
       margin: "0.1em",
       padding: "0 0.1em",
-      borderRadius: "0em !important",
+      borderRadius: "0 !important",
       backgroundColor: "transparent"
     },
     ".asset-delete": {

--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -755,6 +755,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
         fullWidth
         open={open}
         onClose={handleClose}
+        aria-label="Asset viewer"
         slotProps={{
           // Override the primitive's default glass/rounded/bordered paper so the
           // viewer is a true edge-to-edge fullscreen surface with no top gap.

--- a/web/src/components/assets/BreadcrumbNav.tsx
+++ b/web/src/components/assets/BreadcrumbNav.tsx
@@ -26,6 +26,10 @@ const styles = (theme: Theme) =>
       alignItems: "center",
       gap: "0.1em",
       cursor: "pointer",
+      background: "none",
+      border: "none",
+      padding: 0,
+      fontFamily: "inherit",
       color: theme.vars.palette.grey[400],
       fontSize: theme.fontSizeSmall,
       whiteSpace: "nowrap",
@@ -138,14 +142,28 @@ const BreadcrumbNav: React.FC = () => {
             {index > 0 && (
               <NavigateNextIcon className="breadcrumb-separator" />
             )}
-            <Text
-              className={`breadcrumb-item ${isLast ? "current" : ""}`}
-              onClick={() => !isLast && handleClick(crumb.id)}
-              component="span"
-            >
-              {isRoot && <HomeIcon className="breadcrumb-home" />}
-              {!isRoot && crumb.name}
-            </Text>
+            {isLast ? (
+              <Text
+                className="breadcrumb-item current"
+                component="span"
+                aria-current="page"
+                aria-label={isRoot ? "Home" : crumb.name}
+              >
+                {isRoot && <HomeIcon className="breadcrumb-home" />}
+                {!isRoot && crumb.name}
+              </Text>
+            ) : (
+              <Text
+                className="breadcrumb-item"
+                component="button"
+                type="button"
+                onClick={() => handleClick(crumb.id)}
+                aria-label={isRoot ? "Home" : crumb.name}
+              >
+                {isRoot && <HomeIcon className="breadcrumb-home" />}
+                {!isRoot && crumb.name}
+              </Text>
+            )}
           </React.Fragment>
         );
       })}

--- a/web/src/components/assets/ImageCompareDialog.tsx
+++ b/web/src/components/assets/ImageCompareDialog.tsx
@@ -95,6 +95,7 @@ const ImageCompareDialog: React.FC = () => {
       fullWidth
       open={compareAssets !== null}
       onClose={closeCompareView}
+      aria-label="Compare images"
     >
       <div className="compare-container">
         <div className="actions">

--- a/web/src/components/chain_editor/ChainNodeCard.tsx
+++ b/web/src/components/chain_editor/ChainNodeCard.tsx
@@ -15,7 +15,8 @@ import {
   Divider,
   ToolbarIconButton,
   Box,
-  reducedMotion
+  reducedMotion,
+  activateOnKey
 } from "../ui_primitives";
 import { PREVIEW_NODE_TYPE } from "../../constants/nodeTypes";
 import { getOutputFromResult } from "../node/outputResult";
@@ -160,6 +161,11 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = memo(function ChainNo
         align="center"
         padding={2}
         onClick={onToggleExpanded}
+        onKeyDown={activateOnKey(onToggleExpanded)}
+        role="button"
+        tabIndex={0}
+        aria-expanded={node.expanded}
+        aria-label={node.metadata.title}
         sx={{ cursor: "pointer", "&:hover": { backgroundColor: theme.vars.palette.action.hover } }}
       >
         <Box

--- a/web/src/components/chain_editor/InputMappingSelector.tsx
+++ b/web/src/components/chain_editor/InputMappingSelector.tsx
@@ -20,7 +20,8 @@ import {
   ListItemIcon,
   FlexRow,
   FlexColumn,
-  Text
+  Text,
+  activateOnKey
 } from "../ui_primitives";
 import InputOutlinedIcon from "@mui/icons-material/InputOutlined";
 import CheckIcon from "@mui/icons-material/Check";
@@ -63,7 +64,10 @@ export const InputMappingSelector: React.FC<InputMappingSelectorProps> = ({
   const mappedCount = Object.keys(inputMappings).length;
 
   const handleOpenPicker = useCallback(
-    (inputName: string, event: React.MouseEvent<HTMLElement>) => {
+    (
+      inputName: string,
+      event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+    ) => {
       setActiveInput(inputName);
       setAnchorEl(event.currentTarget);
     },
@@ -140,6 +144,13 @@ export const InputMappingSelector: React.FC<InputMappingSelectorProps> = ({
             <Box
               key={prop.name}
               onClick={(e) => handleOpenPicker(prop.name, e)}
+              onKeyDown={activateOnKey<HTMLDivElement>((e) =>
+                handleOpenPicker(prop.name, e)
+              )}
+              role="button"
+              tabIndex={0}
+              aria-haspopup="menu"
+              aria-label={`Source for input ${prop.name}`}
               sx={{
                 display: "flex",
                 alignItems: "center",

--- a/web/src/components/chain_editor/OutputSelector.tsx
+++ b/web/src/components/chain_editor/OutputSelector.tsx
@@ -9,7 +9,8 @@ import {
   MOTION,
   BORDER_RADIUS,
   ListItemIcon,
-  ListItemText
+  ListItemText,
+  activateOnKey
 } from "../ui_primitives";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import CheckIcon from "@mui/icons-material/Check";
@@ -39,6 +40,14 @@ export const OutputSelector: React.FC<OutputSelectorProps> = React.memo(function
     <>
       <Box
         onClick={(e) => setAnchorEl(e.currentTarget)}
+        onKeyDown={activateOnKey<HTMLDivElement>((e) =>
+          setAnchorEl(e.currentTarget)
+        )}
+        role="button"
+        tabIndex={0}
+        aria-haspopup="menu"
+        aria-expanded={Boolean(anchorEl)}
+        aria-label="Select output"
         sx={{
           display: "inline-flex",
           alignItems: "center",

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -902,8 +902,13 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
             {onStop && (
               <Text
                 size="small"
+                component="button"
+                type="button"
                 sx={{
                   ml: "auto",
+                  background: "none",
+                  border: "none",
+                  padding: 0,
                   cursor: "pointer",
                   color: "primary.main"
                 }}
@@ -914,8 +919,13 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
             )}
             <Text
               size="small"
+              component="button"
+              type="button"
               sx={{
                 ml: onStop ? 0 : "auto",
+                background: "none",
+                border: "none",
+                padding: 0,
                 cursor: "pointer",
                 color: "error.main"
               }}

--- a/web/src/components/chat/sidebar/ThreadMemorySidebar.tsx
+++ b/web/src/components/chat/sidebar/ThreadMemorySidebar.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 import {
   FlexColumn,
   FlexRow,
@@ -18,6 +18,8 @@ import {
 import type { Image } from "../../../stores/ApiTypes";
 import { useAsset } from "../../../serverState/useAsset";
 import { trpc, type RouterOutputs } from "../../../trpc/client";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+import ConfirmDialog from "../../dialogs/ConfirmDialog";
 
 export const THREAD_MEMORY_SIDEBAR_WIDTH = 300;
 /** Asset thumbnail edge (px), on the 4px grid — a fixed component dimension. */
@@ -123,8 +125,11 @@ function resourceLabel(resource: Resource): string {
   return `${resource.type}: ${base}`;
 }
 
-const MemoryCard: React.FC<{ memory: Memory; onDelete: (id: string) => void }> =
-  memo(({ memory, onDelete }) => {
+const MemoryCard: React.FC<{
+  memory: Memory;
+  onDelete: (id: string) => void;
+  deleteDisabled: boolean;
+}> = memo(({ memory, onDelete, deleteDisabled }) => {
     const imageAssets = memory.resources.filter(isImageAsset);
     const otherResources = memory.resources.filter((r) => !isImageAsset(r));
     return (
@@ -142,6 +147,7 @@ const MemoryCard: React.FC<{ memory: Memory; onDelete: (id: string) => void }> =
             <DeleteButton
               tooltip="Delete memory"
               onClick={() => onDelete(memory.id)}
+              disabled={deleteDisabled}
             />
           </span>
         </FlexRow>
@@ -180,6 +186,10 @@ export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
     const theme = useTheme();
     const cssStyles = useMemo(() => styles(theme), [theme]);
     const utils = trpc.useUtils();
+    const addNotification = useNotificationStore(
+      (state) => state.addNotification
+    );
+    const [memoryToDelete, setMemoryToDelete] = useState<string | null>(null);
 
     const { data } = trpc.threadMemories.list.useQuery(
       { thread_id: threadId },
@@ -191,7 +201,15 @@ export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
       }
     );
     const deleteMemory = trpc.threadMemories.delete.useMutation({
-      onSuccess: () => utils.threadMemories.list.invalidate({ thread_id: threadId })
+      onSuccess: () =>
+        utils.threadMemories.list.invalidate({ thread_id: threadId }),
+      onError: (error) => {
+        addNotification({
+          type: "error",
+          alert: true,
+          content: `Could not delete memory: ${error.message}`
+        });
+      }
     });
 
     const memories = data?.memories ?? [];
@@ -226,12 +244,26 @@ export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
                 <MemoryCard
                   key={memory.id}
                   memory={memory}
-                  onDelete={(id) => deleteMemory.mutate({ id })}
+                  onDelete={setMemoryToDelete}
+                  deleteDisabled={deleteMemory.isPending}
                 />
               ))}
             </FlexColumn>
           )}
         </ScrollArea>
+        <ConfirmDialog
+          open={memoryToDelete !== null}
+          onClose={() => setMemoryToDelete(null)}
+          onConfirm={() => {
+            if (memoryToDelete) {
+              deleteMemory.mutate({ id: memoryToDelete });
+            }
+          }}
+          title="Delete memory"
+          content="Delete this memory? This cannot be undone."
+          confirmText="Delete"
+          cancelText="Cancel"
+        />
       </aside>
     );
   }

--- a/web/src/components/collections/CollectionHeader.tsx
+++ b/web/src/components/collections/CollectionHeader.tsx
@@ -8,7 +8,8 @@ import {
   Box,
   Popover,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  activateOnKey
 } from "../ui_primitives";
 
 const CollectionHeader = () => {
@@ -26,6 +27,13 @@ const CollectionHeader = () => {
           "&:hover": { color: "primary.main" }
         }}
         onClick={(e) => setFormatInfoAnchor(e.currentTarget)}
+        onKeyDown={activateOnKey<HTMLDivElement>((e) =>
+          setFormatInfoAnchor(e.currentTarget)
+        )}
+        role="button"
+        tabIndex={0}
+        aria-haspopup="dialog"
+        aria-expanded={Boolean(formatInfoAnchor)}
       >
         <InfoIcon sx={{ fontSize: "var(--fontSizeNormal)" }} />
         <Text size="small" weight={600}>

--- a/web/src/components/collections/CollectionItem.tsx
+++ b/web/src/components/collections/CollectionItem.tsx
@@ -2,11 +2,7 @@ import React, { memo, useCallback, useMemo } from "react";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { DeleteButton, FlexRow, FlexColumn, Text, Caption, Tooltip, LoadingSpinner, EditorButton, ProgressBar, MOTION, BORDER_RADIUS, SPACING, Z_INDEX } from "../ui_primitives";
 import { CollectionResponse } from "../../stores/ApiTypes";
-import {
-  UseMutationResult,
-  useMutation,
-  useQueryClient
-} from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import WorkflowSelect from "./WorkflowSelect";
 import { useState } from "react";
 import { trpcClient } from "../../trpc/client";
@@ -25,7 +21,8 @@ interface CollectionItemProps {
   onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragOver: (e: React.DragEvent<HTMLDivElement>, collection: string) => void;
   onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
-  deleteMutation: UseMutationResult<void, Error, string>;
+  /** Name of the collection whose deletion is in flight, if any. */
+  deletingCollection: string | null;
 }
 
 const IndexingProgress = memo(function IndexingProgress({
@@ -83,8 +80,9 @@ const CollectionItem = ({
   onDrop,
   onDragOver,
   onDragLeave,
-  deleteMutation
+  deletingCollection
 }: CollectionItemProps) => {
+  const isDeleting = deletingCollection !== null;
   const addNotification = useNotificationStore((state) => state.addNotification);
   const queryClient = useQueryClient();
   const [isEditingWorkflow, setIsEditingWorkflow] = useState(false);
@@ -174,14 +172,13 @@ const CollectionItem = ({
       gap={2}
     >
       <FlexRow justify="flex-end" sx={{ position: "absolute", top: 8, right: 8 }}>
-        {deleteMutation.isPending &&
-          deleteMutation.variables === collection.name ? (
+        {deletingCollection === collection.name ? (
           <LoadingSpinner size={20} inline />
         ) : (
           <DeleteButton
             onClick={handleDeleteClick}
             tooltip="Delete this collection"
-            disabled={deleteMutation.isPending}
+            disabled={isDeleting}
             sx={{ mt: -10 }}
             nodrag={false}
           />

--- a/web/src/components/collections/CollectionList.tsx
+++ b/web/src/components/collections/CollectionList.tsx
@@ -4,7 +4,6 @@ import AddIcon from "@mui/icons-material/Add";
 import CollectionHeader from "./CollectionHeader";
 import EmptyCollectionState from "./EmptyCollectionState";
 import CollectionItem from "./CollectionItem";
-import type { UseMutationResult } from "@tanstack/react-query";
 import { useCollectionStore } from "../../stores/CollectionStore";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -29,6 +28,7 @@ const CollectionList = () => {
     isLoading,
     error,
     deleteTarget,
+    deletingCollection,
     showForm,
     dragOverCollection,
     indexProgress,
@@ -47,6 +47,7 @@ const CollectionList = () => {
     isLoading: state.isLoading,
     error: state.error,
     deleteTarget: state.deleteTarget,
+    deletingCollection: state.deletingCollection,
     showForm: state.showForm,
     dragOverCollection: state.dragOverCollection,
     indexProgress: state.indexProgress,
@@ -172,26 +173,7 @@ const CollectionList = () => {
                     onDrop={dropHandlers[collection.name]}
                     onDragOver={handleDragOver}
                     onDragLeave={handleDragLeave}
-                    deleteMutation={
-                      {
-                        isPending: false,
-                        mutate: () => { },
-                        mutateAsync: async () => Promise.resolve(),
-                        reset: () => { },
-                        context: undefined,
-                        data: undefined,
-                        error: null,
-                        failureCount: 0,
-                        failureReason: null,
-                        isError: false,
-                        isIdle: true,
-                        isPaused: false,
-                        isSuccess: false,
-                        status: "idle",
-                        submittedAt: 0,
-                        variables: undefined
-                      } as UseMutationResult<void, Error, string>
-                    }
+                    deletingCollection={deletingCollection}
                   />
                 ))}
               </ListGroup>

--- a/web/src/components/color_picker/ColorInputs.tsx
+++ b/web/src/components/color_picker/ColorInputs.tsx
@@ -90,6 +90,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
                   <InputAdornment position="start">#</InputAdornment>
                 )
               }}
+              inputProps={{ "aria-label": "Hex color" }}
               placeholder="FFFFFF"
             />
             <TextInput
@@ -103,7 +104,7 @@ const ColorInputs: React.FC<ColorInputsProps> = memo(({
                   <InputAdornment position="end">%</InputAdornment>
                 )
               }}
-              inputProps={{ min: 0, max: 100 }}
+              inputProps={{ min: 0, max: 100, "aria-label": "Alpha (percent)" }}
               style={widthStyle}
             />
           </div>

--- a/web/src/components/color_picker/ColorPickerModal.tsx
+++ b/web/src/components/color_picker/ColorPickerModal.tsx
@@ -5,7 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import ReactDOM from "react-dom";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Text, Caption, Tooltip, FlexRow, FlexColumn, EditorButton, TabGroup, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { Text, Caption, Tooltip, FlexRow, FlexColumn, EditorButton, TabGroup, BORDER_RADIUS, SPACING, getSpacingPx, activateOnKey } from "../ui_primitives";
 import type { TabItem } from "../ui_primitives";
 import { CloseButton } from "../ui_primitives";
 import CheckIcon from "@mui/icons-material/Check";
@@ -433,7 +433,11 @@ const ColorPickerModal: React.FC<ColorPickerModalProps> = ({
                     className="preview-swatch"
                     align="center"
                     justify="center"
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Copy hex value"
                     onClick={handleCopyHex}
+                    onKeyDown={activateOnKey(handleCopyHex)}
                   >
                     <div className="preview-swatch-bg" />
                     <div

--- a/web/src/components/common/LogsTable.tsx
+++ b/web/src/components/common/LogsTable.tsx
@@ -331,9 +331,16 @@ const RowItem = memo(({
                   </pre>
                   <FlexRow justify="flex-end" sx={{ mt: 1, pt: 1, borderTop: 1, borderColor: "divider" }}>
                     <Text
-                      component="span"
+                      component="button"
+                      type="button"
                       size="small"
-                      sx={{ cursor: "pointer", color: "primary.main" }}
+                      sx={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        cursor: "pointer",
+                        color: "primary.main"
+                      }}
                       onClick={handleClose}
                     >
                       Close

--- a/web/src/components/content/Help/Help.tsx
+++ b/web/src/components/content/Help/Help.tsx
@@ -222,6 +222,7 @@ const Help = ({
       onClose={handleClose}
       fullWidth
       maxWidth="lg"
+      aria-label="Help"
     >
         <div css={helpStyles(theme)}>
           <div className="help">

--- a/web/src/components/dashboard/SandboxesPanel.tsx
+++ b/web/src/components/dashboard/SandboxesPanel.tsx
@@ -16,7 +16,9 @@ import {
   getSpacingPx
 } from "../ui_primitives";
 import PanelToolbar from "../panels/PanelToolbar";
+import ConfirmDialog from "../dialogs/ConfirmDialog";
 import { trpc } from "../../trpc/client";
+import { useNotificationStore } from "../../stores/NotificationStore";
 
 interface SandboxStatus {
   container_id: string;
@@ -86,7 +88,11 @@ function isSafeVncUrl(url: string): boolean {
 const SandboxesPanel: React.FC = () => {
   const theme = useTheme();
   const [selectedSandboxId, setSelectedSandboxId] = useState<string | null>(null);
+  const [sandboxToKill, setSandboxToKill] = useState<SandboxStatus | null>(null);
   const vncIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
 
   const enterVncFullscreen = useCallback(() => {
     const el = vncIframeRef.current;
@@ -106,20 +112,33 @@ const SandboxesPanel: React.FC = () => {
   const sandboxesQuery = trpc.sandboxes.list.useQuery(undefined, {
     refetchInterval: SANDBOX_LIST_REFETCH_INTERVAL_MS
   });
+  const notifyActionFailed = useCallback(
+    (action: string, error: { message: string }) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Could not ${action} sandbox: ${error.message}`
+      });
+    },
+    [addNotification]
+  );
   const pauseSandbox = trpc.sandboxes.pause.useMutation({
     onSuccess: async () => {
       await sandboxesQuery.refetch();
-    }
+    },
+    onError: (error) => notifyActionFailed("pause", error)
   });
   const resumeSandbox = trpc.sandboxes.resume.useMutation({
     onSuccess: async () => {
       await sandboxesQuery.refetch();
-    }
+    },
+    onError: (error) => notifyActionFailed("resume", error)
   });
   const killSandbox = trpc.sandboxes.kill.useMutation({
     onSuccess: async () => {
       await sandboxesQuery.refetch();
-    }
+    },
+    onError: (error) => notifyActionFailed("kill", error)
   });
 
   const sandboxes = sandboxesQuery.data ?? EMPTY_SANDBOXES;
@@ -197,7 +216,16 @@ const SandboxesPanel: React.FC = () => {
                       align="center"
                       justify="space-between"
                       sx={{ cursor: "pointer" }}
+                      role="button"
+                      tabIndex={0}
+                      aria-pressed={isSelected}
                       onClick={() => setSelectedSandboxId(sandbox.container_id)}
+                      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          setSelectedSandboxId(sandbox.container_id);
+                        }
+                      }}
                     >
                       <FlexColumn gap={0.5}>
                         <Text size="normal" weight={600}>
@@ -248,9 +276,7 @@ const SandboxesPanel: React.FC = () => {
                         density="compact"
                         variant="outlined"
                         disabled={actionPending}
-                        onClick={() =>
-                          killSandbox.mutate({ container_id: sandbox.container_id })
-                        }
+                        onClick={() => setSandboxToKill(sandbox)}
                       >
                         Kill
                       </EditorButton>
@@ -354,6 +380,19 @@ const SandboxesPanel: React.FC = () => {
           </FlexColumn>
         )}
       </FlexColumn>
+      <ConfirmDialog
+        open={sandboxToKill !== null}
+        onClose={() => setSandboxToKill(null)}
+        onConfirm={() => {
+          if (sandboxToKill) {
+            killSandbox.mutate({ container_id: sandboxToKill.container_id });
+          }
+        }}
+        title="Kill sandbox"
+        content={`Kill "${sandboxToKill?.name ?? ""}"? The container is destroyed and cannot be resumed.`}
+        confirmText="Kill"
+        cancelText="Cancel"
+      />
     </FlexColumn>
   );
 };

--- a/web/src/components/execution/ExecutionTree.tsx
+++ b/web/src/components/execution/ExecutionTree.tsx
@@ -18,11 +18,12 @@ import AutorenewRoundedIcon from "@mui/icons-material/AutorenewRounded";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
 import {
-  FlexRow,
-  FlexColumn,
   BORDER_RADIUS,
+  FlexColumn,
+  FlexRow,
   MOTION,
   reducedMotion,
+  SPACING,
   Z_INDEX
 } from "../ui_primitives";
 import type {
@@ -215,7 +216,7 @@ const treeStyles = (theme: Theme) =>
     ".tl-content": {
       flex: 1,
       minWidth: 0,
-      paddingBottom: theme.spacing(2.5)
+      paddingBottom: theme.spacing(SPACING.lg)
     },
 
     ".tl-item.last > .tl-content": {
@@ -315,7 +316,7 @@ const treeStyles = (theme: Theme) =>
     },
 
     ".tl-detail": {
-      marginTop: theme.spacing(0.25),
+      marginTop: theme.spacing(SPACING.micro),
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
       lineHeight: 1.6,
@@ -372,7 +373,7 @@ const treeStyles = (theme: Theme) =>
     ".tl-inspector-section": {
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.25)
+      gap: theme.spacing(SPACING.micro)
     },
 
     ".tl-inspector-label": {
@@ -408,7 +409,7 @@ const treeStyles = (theme: Theme) =>
     ".tl-inspector-tool": {
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.25),
+      gap: theme.spacing(SPACING.micro),
       padding: theme.spacing(0.5, 0),
       borderTop: `1px dashed ${theme.vars.palette.divider}`,
       "&:first-of-type": { borderTop: "none" }

--- a/web/src/components/hugging_face/model_list/ModelListItem.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListItem.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import React, { useMemo, useState, useCallback, memo } from "react";
-import { Chip, FlexRow, Tooltip, Text, Box, TextLink, SPACING, getSpacingPx } from "../../ui_primitives";
+import { Chip, FlexRow, Tooltip, Text, Box, TextLink, SPACING, getSpacingPx, activateOnKey } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import { ModelComponentProps } from "../ModelUtils";
@@ -97,6 +97,10 @@ const ModelListItem: React.FC<
         model.downloaded ? "downloaded " : ""
       }${selectable ? "selectable" : ""}`}
       onClick={selectable ? handleRowClick : undefined}
+      onKeyDown={selectable ? activateOnKey(() => onSelect?.()) : undefined}
+      role={selectable ? "button" : undefined}
+      tabIndex={selectable ? 0 : undefined}
+      aria-label={selectable ? model.id : undefined}
       sx={selectable ? { cursor: "pointer" } : undefined}
     >
       <div className="model-content">

--- a/web/src/components/inputs/ColorPicker.tsx
+++ b/web/src/components/inputs/ColorPicker.tsx
@@ -154,6 +154,8 @@ const ColorPicker: React.FC<ColorPickerProps> = ({
       >
         <Button
           className="open-colors-button"
+          aria-label="Choose color"
+          aria-haspopup="dialog"
           onClick={handleClick}
           style={{
             color: "white",
@@ -198,6 +200,9 @@ const ColorPicker: React.FC<ColorPickerProps> = ({
                 border: cellColor === null ? "2px dashed gray" : "none",
                 backgroundColor: cellColor || "transparent"
               }}
+              aria-label={
+                cellColor === null ? "No color" : `Color ${cellColor}`
+              }
               onClick={handleColorCellButtonClick}
             />
           ))}

--- a/web/src/components/inputs/SliderBasic.tsx
+++ b/web/src/components/inputs/SliderBasic.tsx
@@ -18,14 +18,14 @@ const sliderBasicStyles = (theme: Theme) =>
     },
     ".MuiSlider-rail": {
       backgroundColor: theme.vars.palette.grey[500],
-      borderRadius: "0px",
+      borderRadius: 0,
       height: "5px"
     },
     ".MuiSlider-track": {
       height: "5px",
       opacity: "1",
       left: "0",
-      borderRadius: "0px"
+      borderRadius: 0
     },
     ".MuiSlider-thumb": {
       backgroundColor: theme.vars.palette.grey[200],

--- a/web/src/components/menus/AboutMenu.tsx
+++ b/web/src/components/menus/AboutMenu.tsx
@@ -379,8 +379,13 @@ Ollama: ${systemInfo.ollamaInstalled ? systemInfo.ollamaVersion || "Installed" :
         <Box sx={{ marginTop: "1.5em", marginBottom: "1em" }}>
           <Text
             size="small"
+            component="button"
+            type="button"
             onClick={handleCopyAll}
             sx={{
+              background: "none",
+              border: "none",
+              padding: 0,
               color: "var(--palette-primary-main)",
               cursor: "pointer",
               display: "inline-flex",

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -777,6 +777,7 @@ const CommandMenu: React.FC<CommandMenuProps> = ({
       onClose={() => setOpen(false)}
       className="command-menu-dialog"
       css={styles()}
+      aria-label="Command menu"
     >
       <Command label="Command Menu" className="command-menu">
         <CommandInput

--- a/web/src/components/menus/FoldersSettingsMenu.tsx
+++ b/web/src/components/menus/FoldersSettingsMenu.tsx
@@ -130,6 +130,13 @@ const FoldersSettings = () => {
     }) => updateSettings(settings, secrets),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+    onError: (error: Error) => {
+      addNotification({
+        content: `Could not save folder settings: ${error.message}`,
+        type: "error",
+        alert: true
+      });
     }
   });
 
@@ -282,6 +289,7 @@ const FoldersSettings = () => {
                   onClick={handleSave}
                   color="primary"
                   className="save-button"
+                  disabled={updateSettingsMutation.isPending}
                 />
               </div>
             </>

--- a/web/src/components/menus/RemoteSettingsMenu.tsx
+++ b/web/src/components/menus/RemoteSettingsMenu.tsx
@@ -441,6 +441,13 @@ const RemoteSettings = () => {
           queryClient.invalidateQueries({ queryKey: [key] });
         }
       }
+    },
+    onError: (error: Error) => {
+      addNotification({
+        content: `Could not save settings: ${error.message}`,
+        type: "error",
+        alert: true
+      });
     }
   });
 
@@ -540,6 +547,7 @@ const RemoteSettings = () => {
                   onClick={handleSave}
                   className="save-button"
                   startIcon={<SaveIcon />}
+                  disabled={updateSettingsMutation.isPending}
                 >
                   SAVE SETTINGS
                 </EditorButton>

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -481,8 +481,13 @@ function ModelList<TModel extends ModelSelectorModel>({
                 Download a local model or add an API key for a cloud provider to get going.
                 {" "}
                 <Box
-                  component="span"
+                  component="button"
+                  type="button"
                   sx={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    font: "inherit",
                     color: "primary.main",
                     cursor: "pointer",
                     textDecoration: "underline",
@@ -506,8 +511,13 @@ function ModelList<TModel extends ModelSelectorModel>({
               <>
                 Enable a provider in the left sidebar or add an API key in{" "}
                 <Box
-                  component="span"
+                  component="button"
+                  type="button"
                   sx={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    font: "inherit",
                     color: "primary.main",
                     cursor: "pointer",
                     textDecoration: "underline",

--- a/web/src/components/model_menu/shared/RecommendedDownloadRow.tsx
+++ b/web/src/components/model_menu/shared/RecommendedDownloadRow.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   Tooltip,
   EditorButton,
-  LoadingSpinner, BORDER_RADIUS } from "../../ui_primitives";
+  LoadingSpinner, BORDER_RADIUS, activateOnKey } from "../../ui_primitives";
 import type { UnifiedModel } from "../../../stores/ApiTypes";
 import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
 import { DownloadProgress } from "../../hugging_face/DownloadProgress";
@@ -81,6 +81,10 @@ const RecommendedDownloadRow: React.FC<RecommendedDownloadRowProps> = ({
         align="center"
         gap={1.5}
         onClick={downloaded ? onSelect : undefined}
+        onKeyDown={downloaded ? activateOnKey(onSelect) : undefined}
+        role={downloaded ? "button" : undefined}
+        tabIndex={downloaded ? 0 : undefined}
+        aria-label={downloaded ? `Use ${model.id}` : undefined}
         sx={{
           px: 1.5,
           height: "100%",

--- a/web/src/components/node/AddDynamicOutputDialog.tsx
+++ b/web/src/components/node/AddDynamicOutputDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogActions,
   MenuItem
 } from "../ui_primitives";
-import { useCallback, useState, memo } from "react";
+import { useCallback, useState, memo, useId } from "react";
 import { TypeMetadata } from "../../stores/ApiTypes";
 import { validateIdentifierName } from "../../utils/identifierValidation";
 
@@ -33,6 +33,7 @@ const AddDynamicOutputDialog: React.FC<AddDynamicOutputDialogProps> = ({
   onClose,
   onAdd
 }) => {
+  const titleId = useId();
   const [name, setName] = useState("");
   const [type, setType] = useState("str");
   const [nameError, setNameError] = useState<string | undefined>();
@@ -61,8 +62,14 @@ const AddDynamicOutputDialog: React.FC<AddDynamicOutputDialogProps> = ({
   }, [name, type, onAdd, reset, onClose]);
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Add Output</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+      aria-labelledby={titleId}
+    >
+      <DialogTitle id={titleId}>Add Output</DialogTitle>
       <DialogContent>
         <FlexRow css={css({ gap: 8, marginTop: 8 })}>
           <TextField

--- a/web/src/components/node/NodeLogs.tsx
+++ b/web/src/components/node/NodeLogs.tsx
@@ -2,7 +2,15 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useRef, useEffect, useCallback, useState, useMemo } from "react";
+import {
+  memo,
+  useRef,
+  useEffect,
+  useCallback,
+  useState,
+  useMemo,
+  useId
+} from "react";
 
 import useLogsStore, { nodeLogKey } from "../../stores/LogStore";
 import isEqual from "../../utils/isEqual";
@@ -56,6 +64,7 @@ const styles = (theme: Theme) =>
 export const NodeLogsDialog: React.FC<NodeLogsDialogProps> = memo(
   ({ id, workflowId, open, onClose }) => {
     const theme = useTheme();
+    const titleId = useId();
     const logsRef = useRef<HTMLDivElement>(null);
     // O(1) lookup via pre-keyed map instead of filtering the full logs array.
     const logs = useLogsStore(
@@ -126,6 +135,7 @@ export const NodeLogsDialog: React.FC<NodeLogsDialogProps> = memo(
       <Dialog
         open={open}
         onClose={onClose}
+        aria-labelledby={titleId}
         fullWidth
         maxWidth="md"
         slotProps={{
@@ -146,7 +156,7 @@ export const NodeLogsDialog: React.FC<NodeLogsDialogProps> = memo(
           }
         }}
       >
-        <DialogTitle className="dialog-title">
+        <DialogTitle className="dialog-title" id={titleId}>
           <FlexRow gap={1} align="center">
             <Text size="normal" weight={600} component="h6">
               Node Logs

--- a/web/src/components/node/NodePropertyForm.tsx
+++ b/web/src/components/node/NodePropertyForm.tsx
@@ -12,7 +12,7 @@ import {
   DialogActions
 } from "../ui_primitives";
 import Add from "@mui/icons-material/Add";
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, memo, useId } from "react";
 import { useTheme } from "@mui/material/styles";
 import isEqual from "../../utils/isEqual";
 import { useDynamicOutput } from "../../hooks/nodes/useDynamicOutput";
@@ -39,6 +39,7 @@ const NodePropertyForm: React.FC<NodePropertyFormProps> = ({
 }) => {
   const theme = useTheme();
   const { handleAddOutput } = useDynamicOutput(id, dynamicOutputs);
+  const inputDialogTitleId = useId();
   const [showOutputDialog, setShowOutputDialog] = useState(false);
   const [showInputDialog, setShowInputDialog] = useState(false);
   const [newInputName, setNewInputName] = useState("");
@@ -138,6 +139,7 @@ const NodePropertyForm: React.FC<NodePropertyFormProps> = ({
         onClose={handleHideInputDialog}
         maxWidth="xs"
         fullWidth
+        aria-labelledby={inputDialogTitleId}
         sx={{
           "& .MuiDialog-paper": {
             borderRadius: BORDER_RADIUS.xl,
@@ -145,7 +147,7 @@ const NodePropertyForm: React.FC<NodePropertyFormProps> = ({
           }
         }}
       >
-        <DialogTitle>Add Input</DialogTitle>
+        <DialogTitle id={inputDialogTitleId}>Add Input</DialogTitle>
         <DialogContent>
           <FlexRow css={css({ gap: 8, marginTop: 8 })}>
             <TextField

--- a/web/src/components/node/PreviewImageGrid.tsx
+++ b/web/src/components/node/PreviewImageGrid.tsx
@@ -586,6 +586,7 @@ const PreviewImageGrid: React.FC<PreviewImageGridProps> = ({
           open={compareDialogOpen}
           onClose={handleCloseCompare}
           maxWidth={false}
+          aria-label="Compare outputs"
         >
           <Box sx={{ width: "90vw", height: "90vh", position: "relative" }}>
             <ToolbarIconButton

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -563,6 +563,7 @@ const PropertyInput: React.FC<PropertyInputProps> = ({
         <span className="inspector-reset-tooltip" style={INLINE_FLEX_STYLE}>
           <ToolbarIconButton
             className={`inspector-reset-button${isChanged ? " is-changed" : ""}`}
+            ariaLabel="Reset to default"
             onClick={handleResetToDefault}
             disabled={!isChanged}
             size="small"

--- a/web/src/components/node_editor/NodeEditor.tsx
+++ b/web/src/components/node_editor/NodeEditor.tsx
@@ -242,6 +242,7 @@ const NodeEditor: React.FC<NodeEditorProps> = ({ workflowId, active }) => {
                   }
                 }}
                 closeAfterTransition
+                aria-label="Keyboard shortcuts"
               >
                 <Box
                   sx={shortcutsModalSx}

--- a/web/src/components/node_editor/QuickAddNodeDialog.tsx
+++ b/web/src/components/node_editor/QuickAddNodeDialog.tsx
@@ -273,7 +273,12 @@ const QuickAddNodeDialog: React.FC<QuickAddNodeDialogProps> = ({
   }, [open, moveSelectionUp, moveSelectionDown, handleSelectNode, handleClose]);
 
   return (
-    <Dialog open={open} onClose={handleClose} className="quick-add-node-dialog">
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      className="quick-add-node-dialog"
+      aria-label="Quick add node"
+    >
       <div css={cssStyles}>
         <Command label="Quick Add Node" className="command-menu" shouldFilter={false}>
           <div className="command-input">

--- a/web/src/components/node_menu/FavoritesTiles.tsx
+++ b/web/src/components/node_menu/FavoritesTiles.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { EmptyState, Tooltip, Text, ToolbarIconButton, thinScrollbarStyles, Box, MOTION, BORDER_RADIUS, FONT_WEIGHT, SPACING, getSpacingPx } from "../ui_primitives";
@@ -16,6 +16,7 @@ import usePendingNodeCreateStore from "../../stores/PendingNodeCreateStore";
 import { serializeDragData } from "../../lib/dragdrop";
 import { useDragDropStore } from "../../lib/dragdrop/store";
 import { useFavoriteNodesStore } from "../../stores/FavoriteNodesStore";
+import ConfirmDialog from "../dialogs/ConfirmDialog";
 
 const tooltipHintStyle: CSSProperties = {
   fontSize: "var(--fontSizeSmaller)",
@@ -258,6 +259,8 @@ const FavoritesTiles = memo(function FavoritesTiles({
     [removeFavorite, addNotification]
   );
 
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+
   const handleClearFavorites = useCallback(() => {
     clearFavorites();
   }, [clearFavorites]);
@@ -310,7 +313,7 @@ const FavoritesTiles = memo(function FavoritesTiles({
             tooltipPlacement="top"
             size="small"
             className="clear-button"
-            onClick={handleClearFavorites}
+            onClick={() => setClearConfirmOpen(true)}
             aria-label="Clear all favorites"
           />
         </div>
@@ -370,6 +373,17 @@ const FavoritesTiles = memo(function FavoritesTiles({
           );
         })}
       </div>
+      <ConfirmDialog
+        open={clearConfirmOpen}
+        onClose={() => setClearConfirmOpen(false)}
+        onConfirm={handleClearFavorites}
+        title="Clear all favorites?"
+        content={`This removes all ${favorites.length} favorite nodes. This cannot be undone.`}
+        confirmText="Clear favorites"
+        cancelText="Cancel"
+        notificationMessage="Favorites cleared"
+        notificationType="success"
+      />
     </Box>
   );
 });

--- a/web/src/components/node_menu/NodeInfo.tsx
+++ b/web/src/components/node_menu/NodeInfo.tsx
@@ -65,7 +65,7 @@ const nodeInfoStyles = (theme: Theme) =>
       display: "inline-flex",
       alignItems: "center",
       padding: "0.25em 0.5em",
-      borderRadius: "0.25em",
+      borderRadius: BORDER_RADIUS.sm,
       height: "1.5em"
     },
     ".replicate-status.online": {

--- a/web/src/components/node_menu/RecentNodesTiles.tsx
+++ b/web/src/components/node_menu/RecentNodesTiles.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { DragEvent as ReactDragEvent } from "react";
@@ -16,6 +16,7 @@ import usePendingNodeCreateStore from "../../stores/PendingNodeCreateStore";
 import { serializeDragData } from "../../lib/dragdrop";
 import { useDragDropStore } from "../../lib/dragdrop/store";
 import { useRecentNodesStore } from "../../stores/RecentNodesStore";
+import ConfirmDialog from "../dialogs/ConfirmDialog";
 import { QUICK_ACTION_BUTTONS } from "./QuickActionTiles.constants";
 import { colorForType } from "../../config/data_types";
 import { IconForType } from "../../config/IconForType";
@@ -264,6 +265,8 @@ const RecentNodesTiles = memo(function RecentNodesTiles() {
     [getMetadata, requestCreate]
   );
 
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+
   const handleClearRecent = useCallback(() => {
     clearRecentNodes();
   }, [clearRecentNodes]);
@@ -312,7 +315,7 @@ const RecentNodesTiles = memo(function RecentNodesTiles() {
           tooltipPlacement="top"
           size="small"
           className="clear-button"
-          onClick={handleClearRecent}
+          onClick={() => setClearConfirmOpen(true)}
           aria-label="Clear recent nodes"
         />
       </div>
@@ -371,6 +374,17 @@ const RecentNodesTiles = memo(function RecentNodesTiles() {
           );
         })}
       </div>
+      <ConfirmDialog
+        open={clearConfirmOpen}
+        onClose={() => setClearConfirmOpen(false)}
+        onConfirm={handleClearRecent}
+        title="Clear recent nodes?"
+        content="This clears your recently used nodes list. This cannot be undone."
+        confirmText="Clear recent"
+        cancelText="Cancel"
+        notificationMessage="Recent nodes cleared"
+        notificationType="success"
+      />
     </div>
   );
 });

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -145,8 +145,8 @@ const typeFilterChipsStyles = (theme: Theme) =>
         paddingInline: theme.spacing(0.5)
       },
       "& .MuiChip-icon": {
-        marginLeft: theme.spacing(0.75),
-        marginRight: theme.spacing(0.25),
+        marginLeft: theme.spacing(SPACING.xs),
+        marginRight: theme.spacing(SPACING.micro),
         display: "inline-flex",
         alignItems: "center"
       },

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -27,10 +27,13 @@ import type * as monaco from "monaco-editor";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 
 import {
-  FlexColumn,
+  BORDER_RADIUS,
   CopyButton,
+  FlexColumn,
   LoadingSpinner,
-  ToolbarIconButton, BORDER_RADIUS } from "../ui_primitives";
+  SPACING,
+  ToolbarIconButton
+} from "../ui_primitives";
 import { editorClassNames, cn } from "../editor_ui";
 import HandleColumn from "../node/HandleColumn";
 import { NodeInputs } from "../node/NodeInputs";
@@ -139,7 +142,7 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.text.secondary
     },
     ".editor-placeholder": {
-      padding: theme.spacing(0.75),
+      padding: theme.spacing(SPACING.xs),
       fontFamily: "monospace",
       whiteSpace: "pre-wrap",
       overflow: "hidden",
@@ -148,7 +151,7 @@ const styles = (theme: Theme) =>
     },
     ".io-hint": {
       flex: "0 0 auto",
-      padding: `${theme.spacing(0.25)} ${theme.spacing(0.5)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(0.5)}`,
       fontFamily: theme.fontFamily1,
       fontSize: theme.fontSizeSmaller,
       lineHeight: 1.4,

--- a/web/src/components/node_types/ContentCardBody.tsx
+++ b/web/src/components/node_types/ContentCardBody.tsx
@@ -31,14 +31,15 @@ import LayersIcon from "@mui/icons-material/Layers";
 import DownloadIcon from "@mui/icons-material/Download";
 import AddIcon from "@mui/icons-material/Add";
 import {
+  BORDER_RADIUS,
   CheckerDropzone,
   DynamicInputButton,
   FlexColumn,
-  ToolbarIconButton,
-  VideoPlayer,
-  BORDER_RADIUS,
   MOTION,
   reducedMotion,
+  SPACING,
+  ToolbarIconButton,
+  VideoPlayer,
   Z_INDEX
 } from "../ui_primitives";
 import { NodeInputs } from "../node/NodeInputs";
@@ -162,7 +163,7 @@ const styles = (theme: Theme) =>
       ".video-preview-actions button": {
         width: 24,
         height: 24,
-        padding: theme.spacing(0.25),
+        padding: theme.spacing(SPACING.micro),
         backgroundColor: theme.vars.palette.c_scrim,
         color: theme.vars.palette.grey[0],
         borderRadius: BORDER_RADIUS.sm,

--- a/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
+++ b/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
@@ -38,9 +38,10 @@ import VolumeOffIcon from "@mui/icons-material/VolumeOff";
 import DownloadIcon from "@mui/icons-material/Download";
 
 import {
+  BORDER_RADIUS,
   CheckerDropzone,
-  ToolbarIconButton,
-  BORDER_RADIUS
+  SPACING,
+  ToolbarIconButton
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import NumberInput from "../../inputs/NumberInput";
@@ -136,7 +137,7 @@ const styles = (theme: Theme) =>
       background: theme.vars.palette.grey[700],
       borderRadius: BORDER_RADIUS.xs,
       cursor: "pointer",
-      margin: `${theme.spacing(0.25)} 0`,
+      margin: `${theme.spacing(SPACING.micro)} 0`,
       "&::-webkit-slider-thumb": {
         appearance: "none",
         width: 12,
@@ -179,20 +180,20 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      gap: theme.spacing(0.25)
+      gap: theme.spacing(SPACING.micro)
     },
     ".transport-actions": {
       flex: "0 0 auto",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.25)
+      gap: theme.spacing(SPACING.micro)
     },
     ".footer": {
       flex: "0 0 auto",
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(1),
-      paddingTop: theme.spacing(0.25)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".field": {
       display: "flex",
@@ -215,7 +216,7 @@ const styles = (theme: Theme) =>
       fontSize: theme.fontSizeSmall,
       fontVariantNumeric: "tabular-nums",
       color: theme.vars.palette.grey[100],
-      padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       borderRadius: BORDER_RADIUS.sm,
       backgroundColor: theme.vars.palette.grey[800]
     },

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionChip.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionChip.tsx
@@ -8,7 +8,7 @@ import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import MovieIcon from "@mui/icons-material/Movie";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 
-import { BORDER_RADIUS, Tooltip } from "../../../ui_primitives";
+import { BORDER_RADIUS, SPACING, Tooltip } from "../../../ui_primitives";
 import { useAssetById } from "../../../../serverState/useAssetById";
 import { assetMediaKind, parseAssetUri } from "./promptTokens";
 
@@ -55,8 +55,8 @@ const previewCardStyles = (theme: Theme) =>
   css({
     display: "flex",
     flexDirection: "column",
-    gap: theme.spacing(0.75),
-    padding: theme.spacing(0.75),
+    gap: theme.spacing(SPACING.xs),
+    padding: theme.spacing(SPACING.xs),
     background: theme.vars.palette.background.paper,
     border: `1px solid ${theme.vars.palette.divider}`,
     borderRadius: BORDER_RADIUS.lg,

--- a/web/src/components/node_types/editing/promptComposer/AssetMentionMenu.tsx
+++ b/web/src/components/node_types/editing/promptComposer/AssetMentionMenu.tsx
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { BORDER_RADIUS, Z_INDEX } from "../../../ui_primitives";
+import { BORDER_RADIUS, SPACING, Z_INDEX } from "../../../ui_primitives";
 import type { Asset } from "../../../../stores/ApiTypes";
 import type { Entity } from "@nodetool-ai/protocol";
 import { MentionAssetTile } from "./MentionAssetTile";
@@ -68,7 +68,7 @@ export const assetMentionMenuStyles = (theme: Theme) =>
       flexWrap: "wrap",
       alignItems: "center",
       gap: theme.spacing(0.5),
-      padding: theme.spacing(0.75),
+      padding: theme.spacing(SPACING.xs),
       maxHeight: 96,
       overflowY: "auto",
       borderBottom: `1px solid ${theme.vars.palette.divider}`

--- a/web/src/components/node_types/editing/promptComposer/EntityMentionChip.tsx
+++ b/web/src/components/node_types/editing/promptComposer/EntityMentionChip.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import type { EntityKind } from "@nodetool-ai/protocol";
 
-import { BORDER_RADIUS, Tooltip } from "../../../ui_primitives";
+import { BORDER_RADIUS, SPACING, Tooltip } from "../../../ui_primitives";
 import { useAssetById } from "../../../../serverState/useAssetById";
 import { readEntityMarker } from "../../../../serverState/useEntities";
 import { ENTITY_KIND_ICON } from "../../../entities/entityKind";
@@ -54,8 +54,8 @@ const previewCardStyles = (theme: Theme) =>
   css({
     display: "flex",
     flexDirection: "column",
-    gap: theme.spacing(0.75),
-    padding: theme.spacing(0.75),
+    gap: theme.spacing(SPACING.xs),
+    padding: theme.spacing(SPACING.xs),
     background: theme.vars.palette.background.paper,
     border: `1px solid ${theme.vars.palette.divider}`,
     borderRadius: BORDER_RADIUS.lg,

--- a/web/src/components/node_types/editing/promptComposer/MentionAssetTile.tsx
+++ b/web/src/components/node_types/editing/promptComposer/MentionAssetTile.tsx
@@ -60,7 +60,7 @@ const styles = (theme: Theme) =>
     width: TILE_WIDTH,
     display: "flex",
     flexDirection: "column",
-    gap: theme.spacing(0.75),
+    gap: theme.spacing(SPACING.xs),
     padding: theme.spacing(0.5),
     borderRadius: BORDER_RADIUS.md,
     border: "1px solid transparent",

--- a/web/src/components/node_types/editing/promptComposer/MentionEntityTile.tsx
+++ b/web/src/components/node_types/editing/promptComposer/MentionEntityTile.tsx
@@ -12,14 +12,19 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import type { Entity } from "@nodetool-ai/protocol";
 
-import { BORDER_RADIUS, MOTION, reducedMotion } from "../../../ui_primitives";
+import {
+  BORDER_RADIUS,
+  MOTION,
+  reducedMotion,
+  SPACING
+} from "../../../ui_primitives";
 import { ENTITY_KIND_COLOR, ENTITY_KIND_ICON } from "../../../entities/entityKind";
 
 const styles = (theme: Theme) =>
   css({
     display: "inline-flex",
     alignItems: "center",
-    gap: theme.spacing(0.75),
+    gap: theme.spacing(SPACING.xs),
     padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
     borderRadius: BORDER_RADIUS.xl,
     border: "1px solid transparent",

--- a/web/src/components/panels/ConversationOverlay.tsx
+++ b/web/src/components/panels/ConversationOverlay.tsx
@@ -27,6 +27,7 @@ import useGlobalChatStore, {
   useThreadsQuery
 } from "../../stores/GlobalChatStore";
 import useCanvasChatDockStore from "../../stores/CanvasChatDockStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
 import { useCanvasDockResize } from "../../hooks/handlers/useCanvasDockResize";
 import ChatThreadView from "../chat/thread/ChatThreadView";
 import ThreadList from "../chat/thread/ThreadList";
@@ -297,6 +298,10 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
   const status: ThreadStatus =
     rawStatus === "stopping" ? "connected" : (rawStatus as ThreadStatus);
 
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
   const handleNewConversation = useCallback(async () => {
     try {
       const id = await createNewThread();
@@ -319,9 +324,13 @@ const ConversationOverlay: React.FC<ConversationOverlayProps> = ({
     (id: string) => {
       deleteThread(id).catch((err) => {
         console.error("Failed to delete conversation:", err);
+        addNotification({
+          type: "error",
+          content: "Could not delete the conversation. Please try again."
+        });
       });
     },
-    [deleteThread]
+    [deleteThread, addNotification]
   );
 
   const handleExpand = useCallback(() => {

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -167,7 +167,7 @@ const styles = (
 
       "& .MuiIconButton-root, .MuiButton-root": {
         padding: `${theme.spacing(1)}`,
-        margin: `0 ${theme.spacing(0.75)}`,
+        margin: `0 ${theme.spacing(SPACING.xs)}`,
         borderRadius: BORDER_RADIUS.lg,
         backgroundColor: "transparent",
         transition: `${MOTION.background}, color ${MOTION.fast}`,

--- a/web/src/components/panels/QueueOverlay.tsx
+++ b/web/src/components/panels/QueueOverlay.tsx
@@ -29,6 +29,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Job } from "../../stores/ApiTypes";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useWorkflowRunsStore from "../../stores/WorkflowRunsStore";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 
 const RUNNING = new Set(["running", "suspended", "paused"]);
 const QUEUED = new Set(["queued", "scheduled", "starting"]);
@@ -436,7 +437,7 @@ const QueueOverlay = memo(function QueueOverlay() {
       try {
         await trpcClient.jobs.cancel.mutate({ id });
       } catch (err) {
-        console.error("Failed to cancel job:", err);
+        notifyMutationError("cancel the job", err);
       } finally {
         queryClient.invalidateQueries({ queryKey: ["jobs"] });
       }

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -40,7 +40,7 @@ const logoButtonStyles = (theme: Theme) =>
     justifyContent: "center",
     width: "40px",
     height: "34px",
-    margin: `0 ${theme.spacing(0.625)}`,
+    margin: `0 ${theme.spacing(SPACING.micro)}`,
     padding: 0,
     border: "none",
     borderRadius: BORDER_RADIUS.lg,

--- a/web/src/components/panels/jobs/JobItem.tsx
+++ b/web/src/components/panels/jobs/JobItem.tsx
@@ -25,6 +25,7 @@ import { useJobAssets } from "../../../serverState/useJobAssets";
 import { trpcClient } from "../../../trpc/client";
 import { useQueryClient } from "@tanstack/react-query";
 import isEqual from "../../../utils/isEqual";
+import { notifyMutationError } from "../../../utils/notifyMutationError";
 
 const formatDuration = (ms: number): string => {
   if (ms < 0) {
@@ -180,10 +181,28 @@ const AssetThumb = memo(function AssetThumb({ asset }: { asset: Asset }) {
     [asset.get_url]
   );
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== "Enter" && e.key !== " ") {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (asset.get_url) {
+        window.open(asset.get_url, "_blank", "noopener,noreferrer");
+      }
+    },
+    [asset.get_url]
+  );
+
   return (
     <Tooltip title={asset.name || asset.content_type}>
       <Box
+        role="button"
+        tabIndex={0}
+        aria-label="Open job output"
         onClick={handleOpen}
+        onKeyDown={handleKeyDown}
         sx={{
           width: TILE_SIZE,
           height: TILE_SIZE,
@@ -239,7 +258,20 @@ const JobItem = ({ job }: { job: Job }) => {
     return () => clearInterval(interval);
   }, [job.started_at, job.status]);
 
-  const handleClick = () => navigate(`/editor/${job.workflow_id}`);
+  const handleClick = useCallback(
+    () => navigate(`/editor/${job.workflow_id}`),
+    [navigate, job.workflow_id]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick]
+  );
 
   const handleStop = useCallback(
     async (e: React.MouseEvent) => {
@@ -260,7 +292,7 @@ const JobItem = ({ job }: { job: Job }) => {
           runnerState.cancel();
         }
       } catch (err) {
-        console.error("Failed to cancel job:", err);
+        notifyMutationError("cancel the job", err);
       } finally {
         queryClient.invalidateQueries({ queryKey: ["jobs"] });
         setCancelling(false);
@@ -322,7 +354,10 @@ const JobItem = ({ job }: { job: Job }) => {
     <FlexRow
       align="center"
       gap={1}
+      role="button"
+      tabIndex={0}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       sx={{
         px: 1,
         py: 1,

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -52,7 +52,7 @@ const heroStyles = (theme: Theme) =>
       alignItems: "center",
       gap: `${theme.spacing(1)}`,
       height: 34,
-      padding: `0 ${theme.spacing(1.75)}`,
+      padding: `0 ${theme.spacing(SPACING.md)}`,
       borderRadius: BORDER_RADIUS.md,
       background: "transparent",
       color: theme.vars.palette.text.primary,

--- a/web/src/components/portal/DashboardTemplates.tsx
+++ b/web/src/components/portal/DashboardTemplates.tsx
@@ -43,9 +43,9 @@ const styles = (theme: Theme) =>
     ".cat": {
       display: "inline-flex",
       alignItems: "center",
-      gap: `${theme.spacing(0.75)}`,
+      gap: `${theme.spacing(SPACING.xs)}`,
       height: 30,
-      padding: `0 ${theme.spacing(1.75)}`,
+      padding: `0 ${theme.spacing(SPACING.md)}`,
       borderRadius: BORDER_RADIUS.pill,
       fontSize: "var(--fontSizeSmall)",
       background: "transparent",

--- a/web/src/components/portal/PortalSetupFlow.tsx
+++ b/web/src/components/portal/PortalSetupFlow.tsx
@@ -20,7 +20,7 @@ const styles = (theme: Theme) =>
     ".portal-setup-providers": {
       display: "flex",
       flexDirection: "column",
-      gap: `${theme.spacing(0.75)}`,
+      gap: `${theme.spacing(SPACING.xs)}`,
     },
     ".portal-setup-provider": {
       display: "flex",
@@ -29,7 +29,7 @@ const styles = (theme: Theme) =>
       background: theme.vars.palette.c_gray1,
       border: `1px solid ${theme.vars.palette.c_gray2}`,
       borderRadius: BORDER_RADIUS.lg,
-      padding: `${theme.spacing(1.5)} ${theme.spacing(1.75)}`,
+      padding: `${theme.spacing(1.5)} ${theme.spacing(SPACING.md)}`,
       cursor: "pointer",
       transition: `border-color ${MOTION.fast}`,
       "&:hover": {
@@ -120,7 +120,7 @@ const styles = (theme: Theme) =>
     ".portal-setup-ollama-status": {
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.c_gray5,
-      marginTop: `${theme.spacing(0.75)}`,
+      marginTop: `${theme.spacing(SPACING.xs)}`,
       padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
       background: theme.vars.palette.c_gray1,
       borderRadius: BORDER_RADIUS.lg,

--- a/web/src/components/portal/RecentWorkflowCard.tsx
+++ b/web/src/components/portal/RecentWorkflowCard.tsx
@@ -44,13 +44,13 @@ const styles = (theme: Theme) =>
       left: `${theme.spacing(1)}`,
       display: "inline-flex",
       alignItems: "center",
-      gap: `${theme.spacing(0.75)}`,
+      gap: `${theme.spacing(SPACING.xs)}`,
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.text.secondary,
-      padding: `${theme.spacing(0.25)} ${theme.spacing(0.875)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       background: theme.vars.palette.c_scrim,
-      borderRadius: `${theme.spacing(0.5)}`
+      borderRadius: BORDER_RADIUS.xs
     },
     ".rmeta": { padding: `0 ${getSpacingPx(SPACING.micro)}` },
     ".rname": {
@@ -64,7 +64,7 @@ const styles = (theme: Theme) =>
     ".redit": {
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.text.disabled,
-      marginTop: `${theme.spacing(0.25)}`
+      marginTop: `${theme.spacing(SPACING.micro)}`
     }
   });
 

--- a/web/src/components/portal/WelcomeFlow.tsx
+++ b/web/src/components/portal/WelcomeFlow.tsx
@@ -118,7 +118,7 @@ const styles = (theme: Theme, fullWidth: boolean) =>
       color: theme.vars.palette.text.primary
     },
     ".welcome-card-blurb": {
-      marginTop: `${theme.spacing(0.25)}`,
+      marginTop: `${theme.spacing(SPACING.micro)}`,
       marginBottom: `${theme.spacing(1)}`,
       fontSize: "var(--fontSizeSmall)",
       lineHeight: 1.45,
@@ -127,7 +127,7 @@ const styles = (theme: Theme, fullWidth: boolean) =>
     ".welcome-card-node": {
       display: "inline-flex",
       alignItems: "center",
-      padding: `${theme.spacing(0.25)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(1)}`,
       borderRadius: BORDER_RADIUS.pill,
       background: theme.vars.palette.action.selected,
       color: theme.vars.palette.text.secondary,
@@ -145,7 +145,7 @@ const styles = (theme: Theme, fullWidth: boolean) =>
     ".welcome-skip": {
       background: "none",
       border: "none",
-      padding: `${theme.spacing(0.75)} ${theme.spacing(1.25)}`,
+      padding: `${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.sm)}`,
       borderRadius: BORDER_RADIUS.sm,
       fontSize: "var(--fontSizeSmall)",
       color: theme.vars.palette.text.secondary,

--- a/web/src/components/portal/dashboardChrome.tsx
+++ b/web/src/components/portal/dashboardChrome.tsx
@@ -78,7 +78,7 @@ const searchStyles = (theme: Theme) =>
     alignItems: "center",
     gap: `${theme.spacing(1)}`,
     height: 32,
-    padding: `0 ${theme.spacing(1.375)}`,
+    padding: `0 ${theme.spacing(SPACING.sm)}`,
     background: theme.vars.palette.c_node_bg,
     border: `1px solid ${theme.vars.palette.divider}`,
     borderRadius: BORDER_RADIUS.sm,
@@ -103,7 +103,7 @@ const searchStyles = (theme: Theme) =>
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.text.secondary,
-      padding: `${theme.spacing(0.125)} ${theme.spacing(0.75)}`,
+      padding: `${theme.spacing(SPACING.none)} ${theme.spacing(SPACING.xs)}`,
       border: `1px solid ${theme.vars.palette.divider}`,
       borderRadius: BORDER_RADIUS.xs,
       lineHeight: 1.4
@@ -208,7 +208,7 @@ const linkStyles = (theme: Theme) =>
   css({
     display: "inline-flex",
     alignItems: "center",
-    gap: `${theme.spacing(0.75)}`,
+    gap: `${theme.spacing(SPACING.xs)}`,
     fontSize: "var(--fontSizeSmall)",
     color: theme.vars.palette.primary.main,
     background: "none",

--- a/web/src/components/script/ScriptListPanel.tsx
+++ b/web/src/components/script/ScriptListPanel.tsx
@@ -27,6 +27,7 @@ import {
 import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
@@ -239,7 +240,7 @@ export const CreateScriptButton = memo(function CreateScriptButton() {
       }
       setVisibility(false);
     } catch (error) {
-      console.error("Failed to create script", error);
+      notifyMutationError("create the script", error);
     }
   }, [createScript, location.pathname, navigate, openTab, setVisibility]);
 
@@ -375,7 +376,7 @@ const ScriptListPanel = () => {
           document: source.document
         });
       } catch (error) {
-        console.error("Failed to duplicate script", error);
+        notifyMutationError("duplicate the script", error);
       }
     },
     [utils, createScript, updateScript]

--- a/web/src/components/sketch/ColorPickerPopover.tsx
+++ b/web/src/components/sketch/ColorPickerPopover.tsx
@@ -44,6 +44,13 @@ import { SKETCH_FONT, SKETCH_SPACING, SKETCH_Z_INDEX, SKETCH_COLORS, SKETCH_TOOL
 const SV_SIZE = 160;
 const HUE_HEIGHT = 12;
 
+const RGB_LABELS = { r: "Red", g: "Green", b: "Blue" } as const;
+const HSL_LABELS = {
+  h: "Hue (degrees)",
+  s: "Saturation (percent)",
+  l: "Lightness (percent)"
+} as const;
+
 interface ColorPickerPopoverProps {
   anchorEl: HTMLElement | null;
   color: string;
@@ -339,7 +346,7 @@ const ColorPickerPopover: React.FC<ColorPickerPopoverProps> = ({
           size="small"
           value={fgHex6}
           onChange={(e) => handleHex(e.target.value)}
-          inputProps={{ maxLength: 7 }}
+          inputProps={{ maxLength: 7, "aria-label": "Hex color" }}
           sx={{
             "& .MuiInputBase-root": { fontSize: SKETCH_FONT.sm, height: "22px" },
             "& .MuiInputBase-input": { padding: `${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.xs)}`, textAlign: "center" }
@@ -357,7 +364,11 @@ const ColorPickerPopover: React.FC<ColorPickerPopoverProps> = ({
                 type="number"
                 value={ch === "r" ? r : ch === "g" ? g : b}
                 onChange={(e) => handleRgb(ch, e.target.value)}
-                inputProps={{ min: 0, max: 255 }}
+                inputProps={{
+                  min: 0,
+                  max: 255,
+                  "aria-label": RGB_LABELS[ch]
+                }}
                 sx={numSx}
               />
             </FlexColumn>
@@ -377,7 +388,11 @@ const ColorPickerPopover: React.FC<ColorPickerPopoverProps> = ({
                 type="number"
                 value={ch === "h" ? hsl.h : ch === "s" ? hsl.s : hsl.l}
                 onChange={(e) => handleHsl(ch, e.target.value)}
-                inputProps={{ min: 0, max: ch === "h" ? 360 : 100 }}
+                inputProps={{
+                  min: 0,
+                  max: ch === "h" ? 360 : 100,
+                  "aria-label": HSL_LABELS[ch]
+                }}
                 sx={numSx}
               />
             </FlexColumn>

--- a/web/src/components/sketch/SketchCanvasSizePanel.tsx
+++ b/web/src/components/sketch/SketchCanvasSizePanel.tsx
@@ -256,6 +256,7 @@ const SketchCanvasSizePanel: React.FC<SketchCanvasSizePanelProps> = ({
       <Select
         size="small"
         displayEmpty
+        aria-label="Canvas size preset"
         value=""
         onChange={(e) => {
           const preset = CANVAS_PRESETS.find(

--- a/web/src/components/sketch/SketchLayersPanel.tsx
+++ b/web/src/components/sketch/SketchLayersPanel.tsx
@@ -1339,6 +1339,7 @@ const SketchLayersPanel: React.FC<SketchLayersPanelProps> = ({
             sx={{ px: getSpacingPx(SPACING.sm) }}
           >
             <Select
+              aria-label="Layer blend mode"
               value={coerceBlendMode(activeLayer.blendMode)}
               onChange={(e) =>
                 onLayerBlendModeChange(

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -27,6 +27,7 @@ import {
 import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
@@ -332,7 +333,7 @@ export const CreateSketchButton = memo(function CreateSketchButton() {
       }
       setVisibility(false);
     } catch (error) {
-      console.error("Failed to create sketch", error);
+      notifyMutationError("create the sketch", error);
     }
   }, [createSketch, location.pathname, navigate, openTab, setVisibility]);
 
@@ -481,7 +482,7 @@ const SketchListPanel = () => {
           document: source.document
         });
       } catch (error) {
-        console.error("Failed to duplicate sketch", error);
+        notifyMutationError("duplicate the sketch", error);
       }
     },
     [utils, createSketch, updateSketch]

--- a/web/src/components/sketch/tool-settings-panels/geometryEffectsPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/geometryEffectsPanels.tsx
@@ -7,7 +7,8 @@ import {
   getSpacingPx,
   Checkbox,
   FormControlLabel,
-  Slider
+  Slider,
+  activateOnKey
 } from "../../ui_primitives";
 import {
   BlurSettings,
@@ -223,10 +224,18 @@ export const GradientSettingsPanel = memo(function GradientSettingsPanel({
         <Text className="setting-label">Start</Text>
         <Box
           sx={{ ...colorSwatchSx }}
+          role="button"
+          tabIndex={0}
+          aria-label="Gradient start color"
+          aria-haspopup="dialog"
           onClick={(e) => {
             setStartInitial(settings.startColor);
             setStartAnchor(e.currentTarget);
           }}
+          onKeyDown={activateOnKey<HTMLDivElement>((e) => {
+            setStartInitial(settings.startColor);
+            setStartAnchor(e.currentTarget);
+          })}
         >
           <Box
             sx={{
@@ -241,10 +250,18 @@ export const GradientSettingsPanel = memo(function GradientSettingsPanel({
         <Text className="setting-label">End</Text>
         <Box
           sx={{ ...colorSwatchSx }}
+          role="button"
+          tabIndex={0}
+          aria-label="Gradient end color"
+          aria-haspopup="dialog"
           onClick={(e) => {
             setEndInitial(settings.endColor);
             setEndAnchor(e.currentTarget);
           }}
+          onKeyDown={activateOnKey<HTMLDivElement>((e) => {
+            setEndInitial(settings.endColor);
+            setEndAnchor(e.currentTarget);
+          })}
         >
           <Box
             sx={{

--- a/web/src/components/storyboard/StoryboardListPanel.tsx
+++ b/web/src/components/storyboard/StoryboardListPanel.tsx
@@ -30,6 +30,7 @@ import {
 import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
@@ -242,7 +243,7 @@ export const CreateStoryboardButton = memo(function CreateStoryboardButton() {
       }
       setVisibility(false);
     } catch (error) {
-      console.error("Failed to create storyboard", error);
+      notifyMutationError("create the storyboard", error);
     }
   }, [createStoryboard, location.pathname, navigate, openTab, setVisibility]);
 
@@ -378,7 +379,7 @@ const StoryboardListPanel = () => {
           document: source.document
         });
       } catch (error) {
-        console.error("Failed to duplicate storyboard", error);
+        notifyMutationError("duplicate the storyboard", error);
       }
     },
     [utils, createStoryboard, updateStoryboard]

--- a/web/src/components/storyboard/StoryboardSidebar.tsx
+++ b/web/src/components/storyboard/StoryboardSidebar.tsx
@@ -35,6 +35,7 @@ import {
 } from "../../hooks/storyboard/useStoryboards";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { tabId, useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 
 interface StoryboardSidebarProps {
   /** Board shown in the surface this sidebar belongs to. */
@@ -114,7 +115,7 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
       });
       openBoard(created.id, created.name);
     } catch (error) {
-      console.error("Failed to create storyboard", error);
+      notifyMutationError("create the storyboard", error);
     }
   }, [createStoryboard, openBoard]);
 
@@ -156,7 +157,7 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
       {isLoading ? (
         <LoadingSpinner size={20} />
       ) : (
-        <FlexColumn gap={0.5}>
+        <FlexColumn gap={0.5} role="listbox" aria-label="Storyboards">
           {(boards ?? []).map((board) => (
             <FlexRow
               key={board.id}
@@ -164,7 +165,16 @@ const StoryboardSidebarInner: React.FC<StoryboardSidebarProps> = ({
               justify="space-between"
               gap={1}
               className={`board-row${board.id === activeBoardId ? " active" : ""}`}
+              role="option"
+              aria-selected={board.id === activeBoardId}
+              tabIndex={0}
               onClick={() => openBoard(board.id, board.name)}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openBoard(board.id, board.name);
+                }
+              }}
             >
               <FlexColumn gap={0} sx={{ minWidth: 0 }}>
                 <Text size="small" truncate>

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -28,6 +28,7 @@ import {
 import { trpc } from "../../trpc/client";
 import { groupByDate } from "../../utils/groupByDate";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
+import { notifyMutationError } from "../../utils/notifyMutationError";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import {
@@ -328,7 +329,7 @@ export const CreateTimelineButton = memo(function CreateTimelineButton() {
       }
       setVisibility(false);
     } catch (error) {
-      console.error("Failed to create timeline", error);
+      notifyMutationError("create the timeline", error);
     }
   }, [createTimeline, location.pathname, navigate, openTab, setVisibility]);
 
@@ -487,7 +488,7 @@ const TimelineListPanel = () => {
           }
         });
       } catch (error) {
-        console.error("Failed to duplicate timeline", error);
+        notifyMutationError("duplicate the timeline", error);
       }
     },
     [utils, createTimeline, updateTimeline]

--- a/web/src/components/tutorials/TutorialCard.tsx
+++ b/web/src/components/tutorials/TutorialCard.tsx
@@ -88,7 +88,7 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
       display: "flex",
       flexDirection: "column",
       gap: 4,
-      padding: `${theme.spacing(1.25)} ${theme.spacing(1.5)}`
+      padding: `${theme.spacing(SPACING.sm)} ${theme.spacing(1.5)}`
     },
     ".level": {
       alignSelf: "flex-start",

--- a/web/src/components/tutorials/TutorialsPage.tsx
+++ b/web/src/components/tutorials/TutorialsPage.tsx
@@ -8,11 +8,12 @@ import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import Logo from "../Logo";
 import {
-  VideoPlayer,
-  EditorButton,
-  MOTION,
   BORDER_RADIUS,
-  getSpacingPx
+  EditorButton,
+  getSpacingPx,
+  MOTION,
+  SPACING,
+  VideoPlayer
 } from "../ui_primitives";
 import { TutorialCard } from "./TutorialCard";
 import { TUTORIALS, getTutorial } from "./tutorialsData";
@@ -103,7 +104,7 @@ const styles = (theme: Theme) =>
     ".tut-meta": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(1.25),
+      gap: theme.spacing(SPACING.sm),
       marginTop: getSpacingPx(5)
     },
     ".tut-meta .pill": {

--- a/web/src/components/ui_primitives/Card.tsx
+++ b/web/src/components/ui_primitives/Card.tsx
@@ -9,6 +9,7 @@ import React, { memo, forwardRef } from "react";
 import { Box, BoxProps } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { MOTION } from "./tokens";
+import { activateOnKey } from "./keyboardActivation";
 
 export interface CardProps extends BoxProps {
   /** Padding size variant */
@@ -94,6 +95,13 @@ const CardInternal = forwardRef<HTMLDivElement, CardProps>(({
     <Box
       ref={ref}
       onClick={clickable ? onClick : undefined}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={
+        clickable
+          ? activateOnKey<HTMLDivElement>((event) => event.currentTarget.click())
+          : undefined
+      }
       sx={{
         padding: theme.spacing(paddingValue),
         backgroundColor: theme.vars.palette.background.paper,

--- a/web/src/components/ui_primitives/Dialog.tsx
+++ b/web/src/components/ui_primitives/Dialog.tsx
@@ -33,7 +33,7 @@
  * </Dialog>
  */
 
-import React, { forwardRef, memo, ReactNode } from "react";
+import React, { forwardRef, memo, ReactNode, useId } from "react";
 import {
   Dialog as MuiDialog,
   DialogProps as MuiDialogProps,
@@ -160,6 +160,7 @@ export const Dialog = memo(
       ref
     ) => {
       const theme = useTheme();
+      const titleId = useId();
 
       const shouldShowActions = showActions || !!onConfirm;
 
@@ -201,7 +202,7 @@ export const Dialog = memo(
           onClose={onClose}
           css={dialogStyles(theme)}
           className={`dialog ${className ?? ""}`}
-          aria-labelledby={title ? "dialog-title" : undefined}
+          aria-labelledby={title ? titleId : undefined}
           slotProps={{
             backdrop: {
               style: {
@@ -222,7 +223,7 @@ export const Dialog = memo(
           {...dialogProps}
         >
           {title && (
-            <DialogTitle className="dialog-title" id="dialog-title">
+            <DialogTitle className="dialog-title" id={titleId}>
               {titleIsString ? (
                 <PanelHeadline
                   title={title as string}

--- a/web/src/components/ui_primitives/Text.tsx
+++ b/web/src/components/ui_primitives/Text.tsx
@@ -34,6 +34,8 @@ export interface TextProps extends Omit<TypographyProps, 'variant'> {
   target?: string;
   /** Link rel attribute */
   rel?: string;
+  /** Button type, for `component="button"` usage */
+  type?: "button" | "submit" | "reset";
 }
 
 /**

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -252,6 +252,9 @@ export {
   reducedMotion
 } from "./tokens";
 
+// Keyboard activation for non-native-button click targets
+export { activateOnKey } from "./keyboardActivation";
+
 // Keyboard shortcuts display
 export { KeyboardShortcutCard } from "./KeyboardShortcutCard";
 export type { KeyboardShortcutCardProps, ShortcutItem } from "./KeyboardShortcutCard";

--- a/web/src/components/ui_primitives/keyboardActivation.ts
+++ b/web/src/components/ui_primitives/keyboardActivation.ts
@@ -1,0 +1,34 @@
+/**
+ * Keyboard activation helper
+ *
+ * Elements that carry an `onClick` but aren't native buttons need Enter/Space
+ * to activate them (WCAG 2.1.1). Pair this with `role="button"` and
+ * `tabIndex={0}`.
+ */
+
+import type React from "react";
+
+/**
+ * Builds an `onKeyDown` handler that runs `activate` on Enter and Space,
+ * mirroring native button behavior. Space is prevented so the page doesn't
+ * scroll; keys arriving from a nested focusable child are ignored so an inner
+ * control doesn't also trigger its container.
+ *
+ * @example
+ * <Box
+ *   role="button"
+ *   tabIndex={0}
+ *   onClick={open}
+ *   onKeyDown={activateOnKey(open)}
+ * />
+ */
+export const activateOnKey =
+  <T extends HTMLElement = HTMLElement>(
+    activate?: (event: React.KeyboardEvent<T>) => void
+  ): React.KeyboardEventHandler<T> =>
+  (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    if (event.target !== event.currentTarget) return;
+    event.preventDefault();
+    activate?.(event);
+  };

--- a/web/src/components/video/VideoRecorder.tsx
+++ b/web/src/components/video/VideoRecorder.tsx
@@ -227,7 +227,7 @@ const VideoRecorder = (props: VideoRecorderProps) => {
                 backgroundColor: "var(--palette-warning-main)",
                 color: "var(--palette-grey-900)",
                 padding: ".2em 0.5em",
-                borderRadius: "0.2em",
+                borderRadius: BORDER_RADIUS.xs,
                 zIndex: Z_INDEX.overlay,
                 top: "0.5em",
                 left: "0.5em"

--- a/web/src/components/workflows/WorkflowCard.tsx
+++ b/web/src/components/workflows/WorkflowCard.tsx
@@ -11,7 +11,8 @@ import {
   SPACING,
   getSpacingPx,
   Fade,
-  Z_INDEX
+  Z_INDEX,
+  activateOnKey
 } from "../ui_primitives";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
@@ -326,7 +327,11 @@ const WorkflowCard = ({
       <Box
         css={cardStyles(theme)}
         className={isLoading ? "loading" : ""}
+        role="button"
+        tabIndex={0}
+        aria-label={workflow.name}
         onClick={handleClick}
+        onKeyDown={activateOnKey(handleClick)}
       >
         {isLoading && (
           <Fade in={true}>

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -27,6 +27,7 @@ import { useCreateStoryboard } from "../../hooks/storyboard/useStoryboards";
 import { useCreateApplication } from "../../hooks/useApplications";
 import { useCreateScript } from "../../hooks/script/useScripts";
 import { useAssetStore } from "../../stores/AssetStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
 import {
@@ -147,7 +148,12 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const [assetQuery, setAssetQuery] = useState("");
   const [wfFilter, setWfFilter] = useState("");
   const [chatFilter, setChatFilter] = useState("");
+  /** Label of the "New X" creator currently in flight, if any. */
+  const [creating, setCreating] = useState<string | null>(null);
 
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const createNew = useWorkflowManager((state) => state.createNew);
   const createNewThread = useGlobalChatStore((state) => state.createNewThread);
@@ -166,35 +172,63 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
     onClose();
   }, [onClose]);
 
-  const handleNew = useCallback(async () => {
-    const workflow = await createNew();
-    openTab({
-      type: "workflow",
-      ref: workflow.id,
-      mode: "edit",
-      title: workflow.name
-    });
-    close();
-  }, [createNew, openTab, close]);
+  /**
+   * Run one of the "New X" creators: block re-entry while it is in flight,
+   * close the menu on success, and surface a failure as a toast instead of a
+   * dead click.
+   */
+  const runCreate = useCallback(
+    async (label: string, create: () => Promise<void>) => {
+      setCreating(label);
+      try {
+        await create();
+        close();
+      } catch (error) {
+        addNotification({
+          type: "error",
+          alert: true,
+          content: `Could not create ${label}: ${
+            error instanceof Error ? error.message : "unknown error"
+          }`
+        });
+      } finally {
+        setCreating(null);
+      }
+    },
+    [addNotification, close]
+  );
 
-  const handleNewImage = useCallback(async () => {
-    try {
-      const asset = await createAsset(await createBlankImageFile());
-      openTab({
-        type: "image",
-        ref: asset.id,
-        mode: "edit",
-        title: asset.name || "Untitled image"
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create image", error);
-    }
-  }, [createAsset, openTab, close]);
+  const handleNew = useCallback(
+    () =>
+      runCreate("workflow", async () => {
+        const workflow = await createNew();
+        openTab({
+          type: "workflow",
+          ref: workflow.id,
+          mode: "edit",
+          title: workflow.name
+        });
+      }),
+    [runCreate, createNew, openTab]
+  );
+
+  const handleNewImage = useCallback(
+    () =>
+      runCreate("image", async () => {
+        const asset = await createAsset(await createBlankImageFile());
+        openTab({
+          type: "image",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || "Untitled image"
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
 
   const handleNewText = useCallback(
-    async (template: TextFileTemplate) => {
-      try {
+    (template: TextFileTemplate) =>
+      runCreate("text file", async () => {
         const asset = await createAsset(
           new File([template.content], template.filename, {
             type: template.mimeType
@@ -206,116 +240,106 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           mode: "edit",
           title: asset.name || template.filename
         });
-        close();
-      } catch (error) {
-        console.error("Failed to create text file", error);
-      }
-    },
-    [createAsset, openTab, close]
+      }),
+    [runCreate, createAsset, openTab]
   );
 
-  const handleNewVideo = useCallback(async () => {
-    try {
-      const sequence = await createTimeline.mutateAsync({
-        name: "Untitled video",
-        projectId: "default"
-      });
-      openTab({
-        type: "timeline",
-        ref: sequence.id,
-        mode: "edit",
-        title: sequence.name || "Untitled video"
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create video", error);
-    }
-  }, [createTimeline, openTab, close]);
+  const handleNewVideo = useCallback(
+    () =>
+      runCreate("video", async () => {
+        const sequence = await createTimeline.mutateAsync({
+          name: "Untitled video",
+          projectId: "default"
+        });
+        openTab({
+          type: "timeline",
+          ref: sequence.id,
+          mode: "edit",
+          title: sequence.name || "Untitled video"
+        });
+      }),
+    [runCreate, createTimeline, openTab]
+  );
 
-  const handleNewStoryboard = useCallback(async () => {
-    try {
-      const created = await createStoryboard.mutateAsync({
-        name: "Untitled storyboard",
-        projectId: "default"
-      });
-      openTab({
-        type: "storyboard",
-        ref: created.id,
-        mode: "edit",
-        title: created.name
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create storyboard", error);
-    }
-  }, [createStoryboard, openTab, close]);
+  const handleNewStoryboard = useCallback(
+    () =>
+      runCreate("storyboard", async () => {
+        const created = await createStoryboard.mutateAsync({
+          name: "Untitled storyboard",
+          projectId: "default"
+        });
+        openTab({
+          type: "storyboard",
+          ref: created.id,
+          mode: "edit",
+          title: created.name
+        });
+      }),
+    [runCreate, createStoryboard, openTab]
+  );
 
-  const handleNewApp = useCallback(async () => {
-    try {
-      const created = await createApplication.mutateAsync({
-        name: "Untitled app",
-        description: "",
-        projectId: "default"
-      });
-      openTab({
-        type: "application",
-        ref: created.id,
-        mode: "edit",
-        title: created.name
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create app", error);
-    }
-  }, [createApplication, openTab, close]);
+  const handleNewApp = useCallback(
+    () =>
+      runCreate("app", async () => {
+        const created = await createApplication.mutateAsync({
+          name: "Untitled app",
+          description: "",
+          projectId: "default"
+        });
+        openTab({
+          type: "application",
+          ref: created.id,
+          mode: "edit",
+          title: created.name
+        });
+      }),
+    [runCreate, createApplication, openTab]
+  );
 
-  const handleNewScript = useCallback(async () => {
-    try {
-      const created = await createScript.mutateAsync({
-        name: "Untitled script",
-        projectId: "default"
-      });
-      openTab({
-        type: "script",
-        ref: created.id,
-        mode: "edit",
-        title: created.name
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create script", error);
-    }
-  }, [createScript, openTab, close]);
+  const handleNewScript = useCallback(
+    () =>
+      runCreate("script", async () => {
+        const created = await createScript.mutateAsync({
+          name: "Untitled script",
+          projectId: "default"
+        });
+        openTab({
+          type: "script",
+          ref: created.id,
+          mode: "edit",
+          title: created.name
+        });
+      }),
+    [runCreate, createScript, openTab]
+  );
 
-  const handleNewChat = useCallback(async () => {
-    try {
-      const threadId = await createNewThread();
-      openTab({
-        type: "chat",
-        ref: threadId,
-        mode: "view",
-        title: "New chat"
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create chat", error);
-    }
-  }, [createNewThread, openTab, close]);
+  const handleNewChat = useCallback(
+    () =>
+      runCreate("chat", async () => {
+        const threadId = await createNewThread();
+        openTab({
+          type: "chat",
+          ref: threadId,
+          mode: "view",
+          title: "New chat"
+        });
+      }),
+    [runCreate, createNewThread, openTab]
+  );
 
-  const handleNewModel = useCallback(async () => {
-    try {
-      const asset = await createAsset(await createBlankModelFile());
-      openTab({
-        type: "model3d",
-        ref: asset.id,
-        mode: "edit",
-        title: asset.name || "Untitled model"
-      });
-      close();
-    } catch (error) {
-      console.error("Failed to create 3D model", error);
-    }
-  }, [createAsset, openTab, close]);
+  const handleNewModel = useCallback(
+    () =>
+      runCreate("3D model", async () => {
+        const asset = await createAsset(await createBlankModelFile());
+        openTab({
+          type: "model3d",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || "Untitled model"
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
 
   const { data: workflowList, isLoading: workflowsLoading } =
     useQuery<WorkflowList>({
@@ -422,47 +446,56 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               label="New workflow"
               icon={<AddRoundedIcon fontSize="small" />}
               onClick={() => void handleNew()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New text file…"
               icon={<ArticleOutlinedIcon fontSize="small" />}
               hasSubmenu
               onClick={() => setView("texts")}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New image"
               icon={<ImageOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewImage()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New video"
               icon={<MovieOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewVideo()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New storyboard"
               icon={<DashboardOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewStoryboard()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New app"
               icon={<DashboardCustomizeOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewApp()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New script"
               icon={<RecordVoiceOverOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewScript()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New 3D model"
               icon={<ViewInArOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewModel()}
+              disabled={creating !== null}
             />
             <MenuItemPrimitive
               label="New chat"
               icon={<ForumOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewChat()}
+              disabled={creating !== null}
               dividerAfter
             />
             <MenuItemPrimitive
@@ -496,6 +529,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                 key={template.filename}
                 label={template.label}
                 onClick={() => void handleNewText(template)}
+                disabled={creating !== null}
               />
             ))}
           </>

--- a/web/src/components/workspaces/WorkspaceSelect.tsx
+++ b/web/src/components/workspaces/WorkspaceSelect.tsx
@@ -260,6 +260,7 @@ const WorkspaceSelect: React.FC<WorkspaceSelectProps> = memo(
         <FormControl fullWidth={fullWidth} css={cssStyles}>
           <Select
             className={`workspace-select${compact ? " compact" : ""}`}
+            aria-label="Workspace"
             value={value || ""}
             onChange={handleChange}
             disabled={disabled || createMutation.isPending}

--- a/web/src/stores/CollectionStore.ts
+++ b/web/src/stores/CollectionStore.ts
@@ -4,6 +4,7 @@ import { restFetch } from "../lib/rest-fetch";
 import { CollectionList as CollectionListType } from "./ApiTypes";
 import { trpcClient } from "../trpc/client";
 import { queryClient } from "../queryClient";
+import { useNotificationStore } from "./NotificationStore";
 
 interface IndexResponseData {
   path: string;
@@ -27,6 +28,8 @@ interface CollectionStore {
   isLoading: boolean;
   error: string | null;
   deleteTarget: string | null;
+  /** Name of the collection whose deletion is in flight, if any. */
+  deletingCollection: string | null;
   showForm: boolean;
   dragOverCollection: string | null;
   indexProgress: IndexProgressState | null;
@@ -67,6 +70,7 @@ export const useCollectionStore = create<CollectionStore>()(
       isLoading: false,
       error: null,
       deleteTarget: null,
+      deletingCollection: null,
       showForm: false,
       dragOverCollection: null,
       indexProgress: null,
@@ -110,9 +114,27 @@ export const useCollectionStore = create<CollectionStore>()(
 
       confirmDelete: async () => {
         const deleteTarget = get().deleteTarget;
-        if (deleteTarget) {
+        if (!deleteTarget) {return;}
+        const addNotification = useNotificationStore.getState().addNotification;
+        set({ deletingCollection: deleteTarget });
+        try {
           await get().deleteCollection(deleteTarget);
           set({ deleteTarget: null });
+          addNotification({
+            type: "success",
+            alert: true,
+            content: `Deleted collection "${deleteTarget}"`
+          });
+        } catch (err) {
+          addNotification({
+            type: "error",
+            alert: true,
+            content: `Could not delete collection "${deleteTarget}": ${
+              err instanceof Error ? err.message : "unknown error"
+            }`
+          });
+        } finally {
+          set({ deletingCollection: null });
         }
       },
 

--- a/web/src/utils/notifyMutationError.ts
+++ b/web/src/utils/notifyMutationError.ts
@@ -1,0 +1,17 @@
+import { useNotificationStore } from "../stores/NotificationStore";
+
+/**
+ * Report a failed mutation to the user instead of only logging it.
+ *
+ * `label` names the action in lowercase, verb-first form — e.g.
+ * "create the timeline" produces "Could not create the timeline. Please try
+ * again."
+ */
+export const notifyMutationError = (label: string, error: unknown): void => {
+  console.error(`Failed to ${label}`, error);
+  useNotificationStore.getState().addNotification({
+    type: "error",
+    content: `Could not ${label}. Please try again.`,
+    alert: true
+  });
+};


### PR DESCRIPTION
Three UI/UX passes over the web app, found by surveying for issues the existing lint rules can't catch. 81 files, +783/-294.

## Accessibility

- **Mouse-only controls are now keyboard-operable.** 21 elements carried `onClick` on a non-interactive node and had no keyboard path. `ui_primitives/Card.tsx` is the widest fix — every `clickable` Card in the app inherited the gap. Role and `tabIndex` stay conditional on `clickable`, so non-clickable Cards do not become focusable.
- New `activateOnKey` helper handles Enter/Space. It ignores keys bubbling from a nested focusable child, so an inner control can't also trigger its container.
- **Named previously unlabeled controls**: color swatch grids (a whole grid of unnamed buttons), the inspector reset button, breadcrumb home, gradient endpoints, and five unlabeled `Select`s.
- **Dialogs**: seven had no accessible name; three rendered a visible `DialogTitle` that was never wired to `aria-labelledby` (MUI does not do this automatically).
- **Bug**: `Dialog` built `aria-labelledby` from the hardcoded literal id `"dialog-title"`, so two titled dialogs mounted at once produced duplicate DOM ids and a mis-pointed reference. Now generated with `useId`.
- Added a `type` prop to `Text` for `component="button"` usage, so a text-styled action renders as a real button without risking form submission. `TextProps` already declared `href`/`target`/`rel` for anchor usage — this closes the matching gap.

## Feedback on failure

25 catch blocks logged to the console and told the user nothing.

- **`OpenMenu.tsx`** — the app's main creation surface — accounted for nine. One was an outright unhandled rejection that left the menu open with no tab and no message. Creators now report failures and are disabled while in flight, so a double click can't create duplicate resources.
- **Settings saves** (folders, remote) defined `onSuccess` but no `onError`, so a dropped save was completely silent. These are API/provider settings.
- **Destructive actions given confirmation**: sandbox kill (irreversible, previously unconfirmed), clear favorites, clear recent nodes, thread-memory delete.
- `notifyMutationError` covers the four near-identical list panels (timeline, sketch, storyboard, script) that shared the same eight silent paths.

## Dead UI

- `CollectionList` passed a **stubbed mutation object** (`isPending: false`, `mutate: () => {}`) to `CollectionItem`, so its delete spinner and disabled button could never activate — real deletion ran through the store. Now tracked as store state with the existing UI wired to it.
- `CollectionStore.confirmDelete` could reject uncaught, closing the dialog with the collection still present.

## Design tokens

- Replaced 43 off-grid `theme.spacing()` calls across 23 files. The token linters only flag raw px literals, but the theme base is 4px (`ThemeNodetool.tsx:91`), so `spacing(0.75)` emitted an off-grid 3px. Values snap to the nearest step; **deltas are at most 1px**.
- Fixed `em`-unit radii and one case of a spacing token used as a border radius.

## Verification

- `typecheck` clean (pre-existing unbuilt-package errors in untouched files aside)
- `lint` clean, including the custom design-token linters
- **1033 suites / 12,262 tests pass**

## Deliberately out of scope

Flagged during the survey but larger than a quick pass, so left alone: migrating `SketchModal`'s 7 IconButtons and the `Tabs`→`TabGroup` swaps (both hand-roll ARIA wiring and custom indicator styling — higher risk than reward), and a shared `copyToClipboard` util for six log-only clipboard failures. `ChatThreadView`'s font-relative bubble radius was left as-is since it's visually load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wy1PNBcPxp83Tow6jUREHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy1PNBcPxp83Tow6jUREHN)_