### PR TITLE
Expose the script planner as a chat tool

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -375,6 +375,11 @@ export {
   DEFAULT_MAX_AGENT_CALLS
 } from "./script-runner.js";
 export type { ScriptRunnerOptions } from "./script-runner.js";
+export {
+  PlanOrchestrationScriptTool,
+  DEFAULT_TOOL_MAX_AGENT_CALLS
+} from "./tools/plan-orchestration-script-tool.js";
+export type { PlanOrchestrationScriptToolOptions } from "./tools/plan-orchestration-script-tool.js";
 
 // GraphPlanner evaluation harness
 export {

--- a/packages/agents/src/tools/plan-orchestration-script-tool.ts
+++ b/packages/agents/src/tools/plan-orchestration-script-tool.ts
@@ -1,0 +1,231 @@
+/**
+ * `plan_orchestration_script` — the {@link ScriptPlanner} exposed as a chat
+ * tool, the code-shaped counterpart to `plan_workflow_graph`.
+ *
+ * The LLM hands over an objective; the planner authors a JavaScript
+ * orchestration script against the {@link ScriptRunner} guest API, and the
+ * runner executes it — every `agent()` call in the script becomes a real
+ * sub-agent running on the caller's toolset. Planning and execution events are
+ * forwarded upward tagged with `parent_tool_call_id`, so the chat UI streams
+ * the planner's progress and each sub-agent's work under this tool's card.
+ *
+ * Sub-agent tools are the *gated* parent toolset, so anything with side
+ * effects still goes through the permission gate; the orchestration call
+ * itself has none.
+ */
+
+import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createLogger } from "@nodetool-ai/config";
+import { Tool } from "./base-tool.js";
+import { TOOL_CALL_ID_FIELD } from "./subtask-fields.js";
+import { ScriptPlanner } from "../script-planner.js";
+import { ScriptRunner } from "../script-runner.js";
+
+const log = createLogger("nodetool.agents.plan-orchestration-script-tool");
+
+/** Agent-call ceiling for a chat-initiated script. Well under ScriptRunner's own default. */
+export const DEFAULT_TOOL_MAX_AGENT_CALLS = 20;
+
+const CANCELLED = "Orchestration was cancelled.";
+
+export interface PlanOrchestrationScriptToolOptions {
+  provider: BaseProvider;
+  model: string;
+  /**
+   * Tools sub-agents may use. Called lazily on each invocation so a
+   * dynamically-mutated toolbelt is observed, mirroring `run_subtask`.
+   */
+  parentTools?: () => Tool[];
+  /**
+   * Forwards planner and sub-agent events to the client. Events arrive tagged
+   * with `parent_tool_call_id` so the UI can nest them under this tool's card.
+   */
+  forwardMessage?: (msg: ProcessingMessage) => Promise<void> | void;
+  /**
+   * Resolves the abort signal for the *current* chat turn. Read lazily on each
+   * call: the tool outlives a single turn, and each turn installs a fresh
+   * controller, so a captured signal would go stale after the first Stop.
+   */
+  signal?: () => AbortSignal | undefined;
+  /** Lifetime cap on `agent()` calls per script. Defaults to 20. */
+  maxAgentCalls?: number;
+  /** Concurrent `agent()` calls beyond this queue. Defaults to ScriptRunner's. */
+  maxConcurrentAgents?: number;
+}
+
+const DESCRIPTION = [
+  "Plan and run an orchestration script for a multi-step objective. The",
+  "backend ScriptPlanner writes ONE JavaScript script that coordinates",
+  "sub-agents (`agent()`, `parallel()`, `pipeline()`, `budget`), and the",
+  "sandboxed ScriptRunner executes it — each `agent()` call is a real",
+  "sub-agent with this session's tools. Returns the script and its return",
+  "value; progress streams to the user.",
+  "",
+  "Use this over repeated `run_subtask` calls when the work needs control",
+  "flow a flat list of subtasks cannot express: fan-out over an unknown-size",
+  "list, loop-until-done, per-item pipelines, or budget-scaled depth. Set",
+  "`execute: false` to review the script without running it."
+].join("\n");
+
+export class PlanOrchestrationScriptTool extends Tool {
+  readonly name = "plan_orchestration_script";
+  readonly needsToolCallId = true;
+  readonly description = DESCRIPTION;
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      objective: {
+        type: "string" as const,
+        description:
+          "Natural-language description of what the orchestration should " +
+          "accomplish. Self-contained — sub-agents see nothing else."
+      },
+      inputs: {
+        type: "object" as const,
+        description:
+          "Values the script can read via `inputs`, keyed by name. Inline " +
+          "anything the sub-agents need here rather than assuming context."
+      },
+      output_schema: {
+        type: "object" as const,
+        description:
+          "JSON schema the final deliverable must match. Omit for free text."
+      },
+      execute: {
+        type: "boolean" as const,
+        description:
+          "Run the script after planning it. Default true; set false to " +
+          "review the script first.",
+        default: true
+      }
+    },
+    required: ["objective"]
+  };
+
+  constructor(private readonly opts: PlanOrchestrationScriptToolOptions) {
+    super();
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const objective =
+      typeof params["objective"] === "string"
+        ? params["objective"].slice(0, 80)
+        : "objective";
+    return `Orchestrating: ${objective}`;
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const objective =
+      typeof params["objective"] === "string" ? params["objective"].trim() : "";
+    if (!objective) {
+      return {
+        error: "`objective` is required and must be a non-empty string."
+      };
+    }
+
+    const parentToolCallId =
+      typeof params[TOOL_CALL_ID_FIELD] === "string"
+        ? (params[TOOL_CALL_ID_FIELD] as string)
+        : null;
+    const forward = async (msg: ProcessingMessage): Promise<void> => {
+      if (!this.opts.forwardMessage) return;
+      const tagged = {
+        ...(msg as unknown as Record<string, unknown>),
+        parent_tool_call_id: parentToolCallId
+      } as unknown as ProcessingMessage;
+      try {
+        await this.opts.forwardMessage(tagged);
+      } catch {
+        // A broken forwarder must not kill the run — the model still gets the
+        // script and result from the tool return below.
+      }
+    };
+
+    const signal = this.opts.signal?.();
+    if (signal?.aborted) return { error: CANCELLED };
+
+    const inputs =
+      params["inputs"] && typeof params["inputs"] === "object"
+        ? (params["inputs"] as Record<string, unknown>)
+        : {};
+    const outputSchema =
+      params["output_schema"] && typeof params["output_schema"] === "object"
+        ? (params["output_schema"] as Record<string, unknown>)
+        : undefined;
+    const tools = this.opts.parentTools?.() ?? [];
+
+    const planner = new ScriptPlanner({
+      provider: this.opts.provider,
+      model: this.opts.model,
+      tools,
+      outputSchema,
+      inputs,
+      threadId: context.threadId ?? undefined,
+      signal
+    });
+
+    let script: string | null = null;
+    const planGen = planner.plan(objective, context);
+    let next = await planGen.next();
+    while (!next.done) {
+      // The planner's own abort stops its LLM loop, but a tool call already in
+      // flight still resolves — stop driving the generator so a Stop ends the
+      // turn promptly instead of after the current round.
+      if (signal?.aborted) {
+        await planGen.return(null);
+        return { error: CANCELLED };
+      }
+      await forward(next.value);
+      next = await planGen.next();
+    }
+    script = next.value;
+
+    if (signal?.aborted) return { error: CANCELLED };
+    if (!script) {
+      return {
+        error:
+          "ScriptPlanner failed to produce a valid orchestration script. " +
+          "Sharpen the objective (name the concrete steps and deliverable) " +
+          "and retry."
+      };
+    }
+
+    if (params["execute"] === false) {
+      return { script, executed: false };
+    }
+
+    const runner = new ScriptRunner({
+      provider: this.opts.provider,
+      model: this.opts.model,
+      context,
+      tools,
+      inputs,
+      signal,
+      maxAgentCalls: this.opts.maxAgentCalls ?? DEFAULT_TOOL_MAX_AGENT_CALLS,
+      maxConcurrentAgents: this.opts.maxConcurrentAgents
+    });
+
+    const runGen = runner.execute(script);
+    try {
+      let step = await runGen.next();
+      while (!step.done) {
+        if (signal?.aborted) {
+          await runGen.return(null);
+          return { script, error: CANCELLED };
+        }
+        await forward(step.value);
+        step = await runGen.next();
+      }
+      log.info("Orchestration script executed", { chars: script.length });
+      return { script, executed: true, result: step.value ?? null };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      log.warn("Orchestration script failed", { error: message });
+      return { script, executed: true, error: message };
+    }
+  }
+}

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -122,6 +122,10 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // plan_workflow_graph only builds and returns a graph — saving it goes
   // through the gated `create_workflow`.
   plan_workflow_graph: "read",
+  // plan_orchestration_script runs its script in the QuickJS sandbox; the
+  // sub-agents it spawns get the gated parent toolset, so every side effect
+  // is still approved at the individual tool call.
+  plan_orchestration_script: "read",
   // run_search spawns a read-only child loop (read_file/glob/grep/
   // list_directory/memory_read only); the call itself has no side effects, so
   // it always runs ungated.

--- a/packages/agents/tests/plan-orchestration-script-tool.test.ts
+++ b/packages/agents/tests/plan-orchestration-script-tool.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `plan_orchestration_script` exposes ScriptPlanner + ScriptRunner as a chat
+ * tool. It must stream planner and sub-agent events upward tagged with the
+ * parent tool call id, run the planned script, and end promptly on Stop.
+ */
+import { describe, it, expect } from "vitest";
+import { PlanOrchestrationScriptTool } from "../src/tools/plan-orchestration-script-tool.js";
+import { TOOL_CALL_ID_FIELD } from "../src/tools/subtask-fields.js";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const ECHO_SCHEMA = {
+  type: "object",
+  properties: { echo: { type: "string" } },
+  required: ["echo"]
+};
+
+const SCRIPT = `const a = await agent("planned prompt", { schema: ${JSON.stringify(
+  ECHO_SCHEMA
+)} });
+return a.echo;`;
+
+/**
+ * Provider serving both roles: `submit_script` calls (planner) get
+ * `plannerScript`; sub-agent loops finish via `finish_step`, echoing the
+ * step objective.
+ */
+function createProvider(
+  plannerScript: string | null,
+  onPlan?: () => void
+): BaseProvider {
+  let calls = 0;
+  return {
+    provider: "scripted",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      messages: Array<{ role: string; content: unknown }>;
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      calls++;
+      const submit = args.tools?.find((t) => t.name === "submit_script");
+      if (submit) {
+        onPlan?.();
+        if (plannerScript !== null && !args.signal?.aborted) {
+          const tc: ToolCall = {
+            id: `plan_${calls}`,
+            name: "submit_script",
+            args: { script: plannerScript }
+          };
+          yield tc;
+          const content = await submit.execute?.(tc.args as never);
+          yield {
+            type: "message",
+            message: {
+              role: "tool",
+              toolCallId: tc.id,
+              content: String(content)
+            }
+          };
+        }
+        yield { type: "chunk", content: "", done: true };
+        return;
+      }
+
+      const system = String(args.messages[0]?.content ?? "");
+      const objective = /# Objective\n(.*)/.exec(system)?.[1] ?? "?";
+      const finish = args.tools?.find((t) => t.name === "finish_step");
+      const tc: ToolCall = {
+        id: `exec_${calls}`,
+        name: "finish_step",
+        args: { result: { echo: objective } }
+      };
+      yield tc;
+      const content = await finish?.execute?.(tc.args as never);
+      yield {
+        type: "message",
+        message: {
+          role: "tool",
+          toolCallId: tc.id,
+          content:
+            typeof content === "string" ? content : JSON.stringify(content)
+        }
+      };
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+describe("PlanOrchestrationScriptTool", () => {
+  it("rejects an empty objective without calling the planner", async () => {
+    let planned = false;
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT, () => {
+        planned = true;
+      }),
+      model: "test-model"
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "   " }
+    )) as { error?: string };
+
+    expect(result.error).toMatch(/objective/);
+    expect(planned).toBe(false);
+  });
+
+  it("returns the script without running it when execute is false", async () => {
+    let subAgentRan = false;
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT),
+      model: "test-model",
+      parentTools: () => {
+        subAgentRan = true;
+        return [];
+      }
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "echo something", execute: false }
+    )) as { script?: string; executed?: boolean; result?: unknown };
+
+    expect(result.script).toBe(SCRIPT);
+    expect(result.executed).toBe(false);
+    expect(result.result).toBeUndefined();
+    // parentTools is read once for the planner's prompt, never for a run.
+    expect(subAgentRan).toBe(true);
+  });
+
+  it("runs the planned script and returns its value", async () => {
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT),
+      model: "test-model"
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "echo something" }
+    )) as { script?: string; executed?: boolean; result?: unknown };
+
+    expect(result.executed).toBe(true);
+    expect(result.result).toBe("planned prompt");
+  });
+
+  it("forwards planner and sub-agent events tagged with the parent call id", async () => {
+    const forwarded: ProcessingMessage[] = [];
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT),
+      model: "test-model",
+      forwardMessage: (msg) => {
+        forwarded.push(msg);
+      }
+    });
+
+    await tool.process(createMockContext() as ProcessingContext, {
+      objective: "echo something",
+      [TOOL_CALL_ID_FIELD]: "tc_parent"
+    });
+
+    const types = forwarded.map((m) => m.type);
+    expect(types).toContain("planning_update");
+    expect(types).toContain("log_update");
+    expect(types).toContain("step_result");
+    for (const msg of forwarded) {
+      expect(
+        (msg as unknown as Record<string, unknown>)["parent_tool_call_id"]
+      ).toBe("tc_parent");
+    }
+  });
+
+  it("reports the planner failing to produce a valid script", async () => {
+    const tool = new PlanOrchestrationScriptTool({
+      // No agent() call — fails validation, and the stub never retries.
+      provider: createProvider("return 1;"),
+      model: "test-model"
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "nothing works" }
+    )) as { error?: string; script?: string };
+
+    expect(result.error).toMatch(/ScriptPlanner failed/);
+    expect(result.script).toBeUndefined();
+  });
+
+  it("returns cancelled without invoking the planner when already aborted", async () => {
+    let planned = false;
+    const controller = new AbortController();
+    controller.abort();
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT, () => {
+        planned = true;
+      }),
+      model: "test-model",
+      signal: () => controller.signal
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "echo something" }
+    )) as { error?: string };
+
+    expect(result.error).toBe("Orchestration was cancelled.");
+    expect(planned).toBe(false);
+  });
+
+  it("stops driving the planner when the turn aborts mid-plan", async () => {
+    const controller = new AbortController();
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT),
+      model: "test-model",
+      signal: () => controller.signal,
+      // Abort on the planner's first progress event, the way Stop mid-plan does.
+      forwardMessage: () => {
+        controller.abort();
+      }
+    });
+
+    const result = (await tool.process(
+      createMockContext() as ProcessingContext,
+      { objective: "echo something" }
+    )) as { error?: string; script?: string };
+
+    expect(result.error).toBe("Orchestration was cancelled.");
+    expect(result.script).toBeUndefined();
+  });
+
+  it("reads the signal per call, so a later turn is not stuck on a stale abort", async () => {
+    const stale = new AbortController();
+    stale.abort();
+    let current = stale;
+    const tool = new PlanOrchestrationScriptTool({
+      provider: createProvider(SCRIPT),
+      model: "test-model",
+      signal: () => current.signal
+    });
+    const ctx = createMockContext() as ProcessingContext;
+
+    const cancelled = (await tool.process(ctx, { objective: "first" })) as {
+      error?: string;
+    };
+    expect(cancelled.error).toBe("Orchestration was cancelled.");
+
+    current = new AbortController();
+    const fresh = (await tool.process(ctx, { objective: "second" })) as {
+      result?: unknown;
+    };
+    expect(fresh.result).toBe("planned prompt");
+  });
+});

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -105,7 +105,8 @@ import { Tool } from "@nodetool-ai/agents";
 import {
   RunSubtaskTool,
   RunSearchTool,
-  PlanWorkflowGraphTool
+  PlanWorkflowGraphTool,
+  PlanOrchestrationScriptTool
 } from "@nodetool-ai/agents";
 import {
   ToolSearchTool,
@@ -1160,10 +1161,16 @@ const CHAT_AGENT_SYSTEM_PROMPT = `You are NodeTool's chat assistant. Reply in cl
   read each other's results; sequence dependent work across turns.
 - Subtasks can themselves call \`run_subtask\` (bounded recursion). Don't
   decompose work that you could just do directly.
+- When the shape of the work needs control flow a flat list of subtasks
+  cannot express — fan-out over a list whose size you learn at runtime,
+  loop-until-done, per-item pipelines, budget-scaled depth — call
+  \`plan_orchestration_script\` instead. It writes ONE JavaScript script
+  coordinating sub-agents (\`agent\`, \`parallel\`, \`pipeline\`, \`budget\`)
+  and runs it; progress streams to the user.
 
 # Your toolbelt
 You start with a resident core, always available without loading:
-- Delegation: \`run_subtask\` (and \`run_search\`).
+- Delegation: \`run_subtask\`, \`plan_orchestration_script\` (and \`run_search\`).
 - Nodes and workflows: \`run_node\`, \`run_workflow\`, \`search_nodes\`,
   \`list_nodes\`, \`get_node_info\`, \`list_workflows\`, \`get_workflow\`.
 - Workflow building: \`plan_workflow_graph\`, \`validate_workflow\`,
@@ -1272,6 +1279,7 @@ const RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   // Delegation primitives.
   "run_subtask",
   "run_search",
+  "plan_orchestration_script",
   // Node + workflow discovery and execution — the bread-and-butter toolbelt.
   "search_nodes",
   "get_node_info",
@@ -4443,6 +4451,20 @@ export class UnifiedWebSocketRunner {
           model,
           parentTools: () => baseTools,
           forwardMessage: forwardSubtaskMessage
+        })
+      );
+
+      // Code-shaped orchestration: the ScriptPlanner writes a script, the
+      // ScriptRunner executes it, and every `agent()` call inside runs on the
+      // same gated toolset as a subtask. Shares the subtask forwarder so
+      // planner progress and sub-agent events nest under this tool's card.
+      serverTools.unshift(
+        new PlanOrchestrationScriptTool({
+          provider,
+          model,
+          parentTools: () => baseTools,
+          forwardMessage: forwardSubtaskMessage,
+          signal: () => this.chatAbort?.signal
         })
       );
 

--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -99,6 +99,99 @@ describe("chatProtocol", () => {
     });
   });
 
+  // Server-side planners (plan_workflow_graph, plan_orchestration_script)
+  // forward progress as bare events, not agent_execution messages. Without a
+  // dispatch branch they were dropped and the user saw a silent "Thinking…"
+  // for the whole plan.
+  describe("planner progress events", () => {
+    const makeState = () => ({
+      status: "streaming",
+      currentThreadId: "thread-1",
+      threads: {
+        "thread-1": {
+          id: "thread-1",
+          title: "T",
+          updated_at: new Date().toISOString()
+        }
+      },
+      threadRuntime: {
+        "thread-1": {
+          status: "streaming",
+          statusMessage: null,
+          progress: { current: 0, total: 0 },
+          error: null,
+          planningUpdate: null,
+          taskUpdate: null,
+          logUpdate: null,
+          runningToolCallId: null,
+          toolMessage: null,
+          sendMessageTimeoutId: null
+        }
+      },
+      lastTaskUpdatesByThread: {},
+      messageCache: { "thread-1": [] },
+      selectedModel: { provider: "", id: "" },
+      summarizeThread: jest.fn(),
+      updateThreadTitle: jest.fn()
+    });
+
+    const dispatch = async (payload: any) => {
+      let capturedState: any = makeState();
+      const set = jest.fn((updater) => {
+        capturedState = {
+          ...capturedState,
+          ...(typeof updater === "function" ? updater(capturedState) : updater)
+        };
+      });
+      await handleChatWebSocketMessage(payload, set, () => capturedState);
+      return capturedState;
+    };
+
+    it("routes planning_update to the thread runtime", async () => {
+      const state = await dispatch({
+        type: "planning_update",
+        thread_id: "thread-1",
+        phase: "generation",
+        status: "running",
+        content: "Writing orchestration script..."
+      });
+
+      expect(state.threadRuntime["thread-1"].planningUpdate).toMatchObject({
+        phase: "generation",
+        content: "Writing orchestration script..."
+      });
+    });
+
+    it("routes log_update to the thread runtime", async () => {
+      const state = await dispatch({
+        type: "log_update",
+        thread_id: "thread-1",
+        content: "Executing orchestration script...",
+        severity: "info"
+      });
+
+      expect(state.threadRuntime["thread-1"].logUpdate).toMatchObject({
+        content: "Executing orchestration script..."
+      });
+    });
+
+    it("routes task_update to the thread runtime and the last-update map", async () => {
+      const state = await dispatch({
+        type: "task_update",
+        thread_id: "thread-1",
+        event: "task_created",
+        task: { id: "t1", title: "Research", steps: [] }
+      });
+
+      expect(state.threadRuntime["thread-1"].taskUpdate).toMatchObject({
+        event: "task_created"
+      });
+      expect(state.lastTaskUpdatesByThread["thread-1"]).toMatchObject({
+        event: "task_created"
+      });
+    });
+  });
+
   describe("title generation", () => {
     it("generates title from first user message when first assistant chunk completes", async () => {
       let capturedState: any = {

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -124,6 +124,7 @@ export type MsgpackData =
   | TaskUpdate
   | TodoUpdate
   | PlanningUpdate
+  | LogUpdate
   | OutputUpdate
   | StepResult
   | WorkflowCreatedUpdate
@@ -1355,6 +1356,28 @@ export async function handleChatWebSocketMessage(
     applyReducer(applyOutputUpdate, data);
   } else if (data.type === "tool_call_update") {
     applyReducer(applyToolCallUpdate, data);
+  } else if (data.type === "planning_update") {
+    // Server-side planners (plan_workflow_graph, plan_orchestration_script)
+    // forward their progress as bare events rather than agent_execution
+    // messages, so drive the thread runtime directly.
+    if (tid) {
+      set((state) => threadRuntimeUpdate(state, tid, { planningUpdate: data }));
+    }
+  } else if (data.type === "task_update") {
+    if (tid) {
+      const taskUpdate = data;
+      set((state) => ({
+        ...threadRuntimeUpdate(state, tid, { taskUpdate }),
+        lastTaskUpdatesByThread: {
+          ...state.lastTaskUpdatesByThread,
+          [tid]: taskUpdate
+        }
+      }));
+    }
+  } else if (data.type === "log_update") {
+    if (tid) {
+      set((state) => threadRuntimeUpdate(state, tid, { logUpdate: data }));
+    }
   } else if (data.type === "todo_update") {
     if (tid) {
       set((state) => ({


### PR DESCRIPTION
`plan_orchestration_script` is the code-shaped counterpart to `plan_workflow_graph`: the backend `ScriptPlanner` writes one JavaScript orchestration script against the `ScriptRunner` guest API (`agent`, `parallel`, `pipeline`, `budget`), and `ScriptRunner` executes it in the QuickJS sandbox. Each `agent()` call becomes a real sub-agent running on this session's toolset.

## What changed

**New tool** — `packages/agents/src/tools/plan-orchestration-script-tool.ts`
- Params: `objective` (required), `inputs`, `output_schema`, `execute` (default `true`; set `false` to review the script without running it).
- Returns `{ script, executed, result }`, or `{ script, error }` when the script throws.
- Sub-agents get the *gated* parent toolset, so every side effect still goes through the permission gate. The orchestration call itself has none, so it's classified `read` — the same reasoning as `run_subtask`.
- Agent-call budget capped at 20 per script (`ScriptRunner`'s own default is 100).
- Cancellation mirrors `plan_workflow_graph`: the abort signal is read lazily per call, and a Stop mid-plan or mid-run stops driving the generator instead of waiting out the current round.

**Wiring** — `packages/websocket/src/unified-websocket-runner.ts`
- Registered alongside `run_subtask`, sharing its forwarder and lazy `baseTools` snapshot.
- Added to the resident tool set (no `ToolSearch` round-trip) and to the chat system prompt as the escalation from `run_subtask` when the work needs control flow a flat list of subtasks can't express — fan-out over a runtime-sized list, loop-until-done, per-item pipelines, budget-scaled depth.

**Streaming fix** — `web/src/core/chat/chatProtocol.ts`

Planner events forward tagged with `parent_tool_call_id`, but the web chat client had no dispatch branch for `planning_update`, `task_update`, or `log_update` — they were silently dropped, so a planner running as a tool showed nothing but "Thinking…" for its whole run. They now route to the thread runtime and render through the existing `PlanningUpdateDisplay` / `TaskUpdateDisplay` / log row. This fixes streaming for `plan_workflow_graph` too, which had the same gap.

## Testing

- New `packages/agents/tests/plan-orchestration-script-tool.test.ts` (8 cases): empty objective, plan-only, plan-and-run, event forwarding with the parent call id, planner failure, and the three cancellation paths.
- New cases in `web/src/core/chat/__tests__/chatProtocol.test.ts` for the three dispatch branches.
- `npm run lint` clean; `typecheck` passes for web and electron (mobile fails only on uninstalled Expo deps, pre-existing in this sandbox); agents (1647), websocket (1938), and the full web suite (12277) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtD2gRsDjE48f5hqpcoePE)_