### PR TITLE
Bolt: Optimize table row deletion performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,6 @@
 ## 2024-12-05 - O(N*E) bottleneck in WebSocket runner output processing
 **Learning:** Found an O(N*E) bottleneck in `packages/websocket/src/unified-websocket-runner.ts` inside `_streamJobMessagesInner` where `graphNodes.find((n) => n.id === nodeId)` was called for every output/node update message processed. Since `graphNodes` can be large and the runner streams many updates per job, this caused unnecessary CPU time.
 **Action:** Replaced the O(N) `.find()` lookup inside the message streaming loop with an O(1) `Map` lookup by extracting `graphNodes` into a pre-computed map before the loop.
+## 2026-05-25 - O(N*M) lookup optimization in TableActions
+**Learning:** Found an O(N*M) performance bottleneck in `web/src/components/node/DataTable/TableActions.tsx` where `selectedRows.some()` was called inside `data.filter()` during row deletion. For large tables with many selected rows, this nested loop blocks the UI thread.
+**Action:** Replaced `.some()` with a pre-initialized `Set` of selected row indices and used `.has()` for O(1) lookups, reducing time complexity from O(N*M) to O(N+M) and improving deletion speed for large selections.

--- a/web/src/components/node/DataTable/TableActions.tsx
+++ b/web/src/components/node/DataTable/TableActions.tsx
@@ -153,10 +153,11 @@ const TableActions: React.FC<TableActionsProps> = memo(({
 
   const handleDeleteRows = useCallback(() => {
     if (Array.isArray(data)) {
+      const selectedIndices = new Set(
+        selectedRows.map((row) => row.getData().rownum)
+      );
       const filtered = (data as CellValue[]).filter((_, index) => {
-        return !selectedRows.some(
-          (selectedRow) => selectedRow.getData().rownum === index
-        );
+        return !selectedIndices.has(index);
       });
       onChangeRows(filtered);
     } else {


### PR DESCRIPTION
## What
Refactored `handleDeleteRows` in `TableActions.tsx` to use a `Set` for indexing selected rows.

## Why
When performing a deletion on a data table, the previous logic iterated through every `data` item and executed a nested `Array.some()` call across `selectedRows` to check if the current `index` was being deleted. This resulted in an $O(N \times M)$ operation, creating noticeable main-thread lag when working with large dataframes (e.g. thousands of rows) where numerous rows were selected.

## Impact
Time complexity of the filtering pass drops from $O(N \times M)$ to $O(N + M)$. The `selectedRows` list is evaluated only once to populate an $O(1)$ lookup `Set`. This drastically reduces JavaScript function call overhead and stops large dataset operations from locking up the UI.

## Verification
- Verified $O(N \times M)$ pattern in code inspection.
- Ran tests across the `web` workspace via `npm run test` and `npm run lint`.
- Successfully validated changes and tracked learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [987808923652853319](https://jules.google.com/task/987808923652853319) started by @georgi*