### PR TITLE
refactor(web): drop forwardRef wrappers, ref is a prop in React 19

### DIFF
--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -424,7 +424,7 @@ Just start typing what you want!
 
 ## Next Steps
 
-- **[Workflow Editor deep dive](workflow-editor.md)** – Master the canvas
+- **[Workflow Editor](workflow-editor.md)** – Master the canvas
 - **[Editor Panels](editor-panels.md)** – Left, right, bottom, and floating panels
 - **[Tips & Tricks](tips-and-tricks.md)** – Power user secrets
 - **[Cookbook](cookbook.md)** – Learn workflow patterns

--- a/packages/base-nodes/nodetool/examples/nodetool-base/README_EXAMPLES.md
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/README_EXAMPLES.md
@@ -206,7 +206,7 @@ Recommended order for learning:
 - **API Calls**: Consider rate limiting for LLM calls
 - **Large Files**: Process in chunks for video/audio
 - **Async Operations**: Use async/await for parallel execution
-- **Caching**: Leverage ChromaDB for semantic caching
+- **Caching**: Use ChromaDB for semantic caching
 
 ## Troubleshooting
 

--- a/web/src/components/chat/composer/MediaControlChip.tsx
+++ b/web/src/components/chat/composer/MediaControlChip.tsx
@@ -1,8 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, {
-  forwardRef,
-  memo
-} from "react";
+import React, { memo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -37,9 +34,18 @@ interface MediaControlChipProps {
   truncate?: boolean;
   /** Max width in px when truncating. Defaults to 200. */
   maxWidth?: number;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const createStyles = (theme: Theme, size: "sm" | "md", emphasis: "default" | "primary", active: boolean, truncate: boolean, iconOnly: boolean, maxWidth: number) =>
+const createStyles = (
+  theme: Theme,
+  size: "sm" | "md",
+  emphasis: "default" | "primary",
+  active: boolean,
+  truncate: boolean,
+  iconOnly: boolean,
+  maxWidth: number
+) =>
   css({
     display: "inline-flex",
     alignItems: "center",
@@ -101,72 +107,71 @@ const createStyles = (theme: Theme, size: "sm" | "md", emphasis: "default" | "pr
  * (mode selector, model chip, resolution chip, aspect ratio, duration, etc.).
  * Matches the pill shape shown in the reference screenshots.
  */
-const MediaControlChip = memo(
-  forwardRef<HTMLButtonElement, MediaControlChipProps>(
-    (
-      {
-        icon,
-        label,
-        title,
-        active = false,
-        showChevron = true,
-        onClick,
-        disabled = false,
-        size = "md",
-        className,
-        emphasis = "default",
-        truncate = false,
-        maxWidth = 200
-      },
-      ref
-    ) => {
-      const theme = useTheme();
-      const hasLabel =
-        label !== undefined && label !== null && label !== "";
-      return (
-        <button
-          ref={ref}
-          type="button"
-          title={title}
-          aria-label={!hasLabel ? title : undefined}
-          className={`media-control-chip${className ? ` ${className}` : ""}${active ? " active" : ""}`}
-          css={createStyles(theme, size, emphasis, active, truncate, !hasLabel, maxWidth)}
-          onClick={onClick}
-          disabled={disabled}
-          aria-pressed={active || undefined}
-        >
-          <FlexRow align="center" gap={hasLabel ? 1 : 0}>
-            {icon && <span className="media-chip-icon">{icon}</span>}
-            {hasLabel && (
-              <Text
-                component="span"
-                size="small"
-                weight={500}
-                sx={{
-                  color: "inherit",
-                  lineHeight: 1.2,
-                  ...(truncate && {
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap"
-                  })
-                }}
-              >
-                {label}
-              </Text>
-            )}
-            {showChevron && (
-              <span className="media-chip-chevron">
-                <ExpandLessIcon />
-              </span>
-            )}
-          </FlexRow>
-        </button>
-      );
-    }
-  )
-);
-
-MediaControlChip.displayName = "MediaControlChip";
+const MediaControlChip = memo(function MediaControlChip({
+  icon,
+  label,
+  title,
+  active = false,
+  showChevron = true,
+  onClick,
+  disabled = false,
+  size = "md",
+  className,
+  emphasis = "default",
+  truncate = false,
+  maxWidth = 200,
+  ref
+}: MediaControlChipProps) {
+  const theme = useTheme();
+  const hasLabel = label !== undefined && label !== null && label !== "";
+  return (
+    <button
+      ref={ref}
+      type="button"
+      title={title}
+      aria-label={!hasLabel ? title : undefined}
+      className={`media-control-chip${className ? ` ${className}` : ""}${active ? " active" : ""}`}
+      css={createStyles(
+        theme,
+        size,
+        emphasis,
+        active,
+        truncate,
+        !hasLabel,
+        maxWidth
+      )}
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active || undefined}
+    >
+      <FlexRow align="center" gap={hasLabel ? 1 : 0}>
+        {icon && <span className="media-chip-icon">{icon}</span>}
+        {hasLabel && (
+          <Text
+            component="span"
+            size="small"
+            weight={500}
+            sx={{
+              color: "inherit",
+              lineHeight: 1.2,
+              ...(truncate && {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap"
+              })
+            }}
+          >
+            {label}
+          </Text>
+        )}
+        {showChevron && (
+          <span className="media-chip-chevron">
+            <ExpandLessIcon />
+          </span>
+        )}
+      </FlexRow>
+    </button>
+  );
+});
 
 export default MediaControlChip;

--- a/web/src/components/chat/composer/MessageInput.tsx
+++ b/web/src/components/chat/composer/MessageInput.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useEffect, useRef, useCallback, memo, useLayoutEffect } from "react";
+import React, {
+  useEffect,
+  useRef,
+  useCallback,
+  memo,
+  useLayoutEffect
+} from "react";
 import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 
 interface MessageInputProps {
@@ -7,77 +13,79 @@ interface MessageInputProps {
   onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   disabled: boolean;
   placeholder?: string;
+  ref?: React.Ref<HTMLTextAreaElement>;
 }
 
 const MAX_HEIGHT = 180;
 const LINE_HEIGHT = 24;
 
-export const MessageInput = memo(forwardRef<HTMLTextAreaElement, MessageInputProps>(
-  (
-    {
-      value,
-      onChange,
-      onKeyDown,
-      disabled,
-      placeholder = "Type your message..."
-    },
-    ref
-  ) => {
-    const internalRef = useRef<HTMLTextAreaElement>(null);
-    const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
-    const autoFocusEnabled = useAutoFocusEnabled();
+export const MessageInput = memo(function MessageInput({
+  value,
+  onChange,
+  onKeyDown,
+  disabled,
+  placeholder = "Type your message...",
+  ref
+}: MessageInputProps) {
+  const internalRef = useRef<HTMLTextAreaElement>(null);
+  const textareaRef =
+    (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+  const autoFocusEnabled = useAutoFocusEnabled();
 
-    const adjustHeight = useCallback(() => {
-      const textarea = textareaRef.current;
-      if (!textarea) { return; }
+  const adjustHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
 
-      // Reset height to auto to get the correct scrollHeight
-      textarea.style.height = "auto";
+    // Reset height to auto to get the correct scrollHeight
+    textarea.style.height = "auto";
 
-      const newHeight = Math.min(textarea.scrollHeight, MAX_HEIGHT);
-      textarea.style.height = `${newHeight}px`;
-      textarea.style.overflowY = textarea.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
-    }, [textareaRef]);
+    const newHeight = Math.min(textarea.scrollHeight, MAX_HEIGHT);
+    textarea.style.height = `${newHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
+  }, [textareaRef]);
 
-    useEffect(() => {
-      adjustHeight();
-    }, [value, adjustHeight]);
+  useEffect(() => {
+    adjustHeight();
+  }, [value, adjustHeight]);
 
-    // Skipped on touch, where the virtual keyboard would cover the thread.
-    useLayoutEffect(() => {
-      const textarea = textareaRef.current;
-      if (textarea && !disabled && autoFocusEnabled) {
-        textarea.focus();
-      }
-    }, [textareaRef, disabled, autoFocusEnabled]);
+  // Skipped on touch, where the virtual keyboard would cover the thread.
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea && !disabled && autoFocusEnabled) {
+      textarea.focus();
+    }
+  }, [textareaRef, disabled, autoFocusEnabled]);
 
-    const handleChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange(event);
-    }, [onChange]);
+    },
+    [onChange]
+  );
 
-    return (
-      <textarea
-        className="chat-input"
-        id="chat-prompt"
-        aria-label={placeholder}
-        ref={textareaRef}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={onKeyDown}
-        disabled={disabled}
-        placeholder={placeholder}
-        autoCorrect="off"
-        autoCapitalize="none"
-        spellCheck="false"
-        autoComplete="off"
-        rows={1}
-        style={{
-          maxHeight: `${MAX_HEIGHT}px`,
-          lineHeight: `${LINE_HEIGHT}px`
-        }}
-      />
-    );
-  }
-));
-
-MessageInput.displayName = "MessageInput";
+  return (
+    <textarea
+      className="chat-input"
+      id="chat-prompt"
+      aria-label={placeholder}
+      ref={textareaRef}
+      value={value}
+      onChange={handleChange}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+      placeholder={placeholder}
+      autoCorrect="off"
+      autoCapitalize="none"
+      spellCheck="false"
+      autoComplete="off"
+      rows={1}
+      style={{
+        maxHeight: `${MAX_HEIGHT}px`,
+        lineHeight: `${LINE_HEIGHT}px`
+      }}
+    />
+  );
+});

--- a/web/src/components/chat/composer/SendMessageButton.tsx
+++ b/web/src/components/chat/composer/SendMessageButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import type { Ref } from "react";
 import SendRoundedIcon from "@mui/icons-material/SendRounded";
 import { ToolbarIconButton, MOTION } from "../../ui_primitives";
 
@@ -6,12 +6,15 @@ interface SendMessageButtonProps {
   disabled?: boolean;
   onClick: () => void;
   hasContent?: boolean;
+  ref?: Ref<HTMLButtonElement>;
 }
 
-export const SendMessageButton = forwardRef<
-  HTMLButtonElement,
-  SendMessageButtonProps
->(({ disabled = false, onClick, hasContent = true }, ref) => {
+export function SendMessageButton({
+  disabled = false,
+  onClick,
+  hasContent = true,
+  ref
+}: SendMessageButtonProps) {
   const isDisabled = disabled || !hasContent;
   return (
     <ToolbarIconButton
@@ -41,6 +44,4 @@ export const SendMessageButton = forwardRef<
       })}
     />
   );
-});
-
-SendMessageButton.displayName = "SendMessageButton";
+}

--- a/web/src/components/chat/composer/StopGenerationButton.tsx
+++ b/web/src/components/chat/composer/StopGenerationButton.tsx
@@ -1,15 +1,16 @@
-import React, { forwardRef } from "react";
+import type { Ref } from "react";
 import StopIcon from "@mui/icons-material/Stop";
 import { ToolbarIconButton, MOTION } from "../../ui_primitives";
 
 interface StopGenerationButtonProps {
   onClick: () => void;
+  ref?: Ref<HTMLButtonElement>;
 }
 
-export const StopGenerationButton = forwardRef<
-  HTMLButtonElement,
-  StopGenerationButtonProps
->(({ onClick }, ref) => {
+export function StopGenerationButton({
+  onClick,
+  ref
+}: StopGenerationButtonProps) {
   return (
     <ToolbarIconButton
       ref={ref}
@@ -37,6 +38,4 @@ export const StopGenerationButton = forwardRef<
       })}
     />
   );
-});
-
-StopGenerationButton.displayName = "StopGenerationButton";
+}

--- a/web/src/components/common/ExternalLink.tsx
+++ b/web/src/components/common/ExternalLink.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import React, { memo, forwardRef } from "react";
+import React, { memo } from "react";
 import { Tooltip } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import NorthEastIcon from "@mui/icons-material/NorthEast";
@@ -11,56 +11,61 @@ interface ExternalLinkProps {
   className?: string;
   size?: "small" | "medium" | "large";
   tooltipText?: string;
+  ref?: React.Ref<HTMLAnchorElement>;
 }
 
-const ExternalLink = forwardRef<HTMLAnchorElement, ExternalLinkProps>(
-  ({ href, children, className, size = "small", tooltipText }, ref) => {
-    const theme = useTheme();
+function ExternalLink({
+  href,
+  children,
+  className,
+  size = "small",
+  tooltipText,
+  ref
+}: ExternalLinkProps) {
+  const theme = useTheme();
 
-    const linkStyles = css({
-      color: theme.vars.palette.grey[400],
-      textDecoration: "none",
-      display: "inline-flex",
-      alignItems: "center",
-      gap: theme.spacing(0.5),
-      "&:hover": {
-        textDecoration: "underline"
-      }
-    });
+  const linkStyles = css({
+    color: theme.vars.palette.grey[400],
+    textDecoration: "none",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: theme.spacing(0.5),
+    "&:hover": {
+      textDecoration: "underline"
+    }
+  });
 
-    const link = (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        css={linkStyles}
-        style={{
-          fontSize:
-            size === "small"
-              ? theme.fontSizeSmaller
-              : size === "medium"
+  const link = (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      css={linkStyles}
+      style={{
+        fontSize:
+          size === "small"
+            ? theme.fontSizeSmaller
+            : size === "medium"
               ? theme.fontSizeSmall
               : theme.fontSizeNormal
+      }}
+      className={className}
+      ref={ref}
+    >
+      <span>{children}</span>
+      <NorthEastIcon
+        fontSize={size}
+        sx={{
+          marginLeft: theme.spacing(0.5),
+          fontSize: theme.fontSizeSmall,
+          color: theme.vars.palette.c_link,
+          opacity: 0.8
         }}
-        className={className}
-        ref={ref}
-      >
-        <span>{children}</span>
-        <NorthEastIcon
-          fontSize={size}
-          sx={{
-            marginLeft: theme.spacing(0.5),
-            fontSize: theme.fontSizeSmall,
-            color: theme.vars.palette.c_link,
-            opacity: 0.8
-          }}
-        />
-      </a>
-    );
+      />
+    </a>
+  );
 
-    return tooltipText ? <Tooltip title={tooltipText}>{link}</Tooltip> : link;
-  }
-);
-ExternalLink.displayName = "ExternalLink";
+  return tooltipText ? <Tooltip title={tooltipText}>{link}</Tooltip> : link;
+}
 
 export default memo(ExternalLink);

--- a/web/src/components/editor_ui/EditorButton.tsx
+++ b/web/src/components/editor_ui/EditorButton.tsx
@@ -9,7 +9,7 @@
  * - `density`: Controls compact vs normal sizing
  */
 
-import { forwardRef, memo } from "react";
+import { memo, type Ref } from "react";
 import { Button, ButtonProps } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useEditorScope } from "./EditorUiContext";
@@ -33,6 +33,7 @@ export interface EditorButtonProps extends Omit<ButtonProps, "size"> {
   rel?: string;
   /** Saves the href instead of navigating to it; "" keeps the server's name. */
   download?: string;
+  ref?: Ref<HTMLButtonElement>;
 }
 
 /**
@@ -47,48 +48,51 @@ export interface EditorButtonProps extends Omit<ButtonProps, "size"> {
  *   Click me
  * </EditorButton>
  */
-export const EditorButton = forwardRef<HTMLButtonElement, EditorButtonProps>(
-  ({ density = "compact", size, href, target, rel, sx, className, ...props }, ref) => {
-    const theme = useTheme();
-    const scope = useEditorScope();
+export function EditorButton({
+  density = "compact",
+  size,
+  href,
+  target,
+  rel,
+  sx,
+  className,
+  ref,
+  ...props
+}: EditorButtonProps) {
+  const theme = useTheme();
+  const scope = useEditorScope();
 
-    const fontSize =
-      scope === "inspector" ? theme.fontSizeSmall : theme.fontSizeSmaller;
-    const densityHeight =
-      density === "compact" ? CONTROL.height.xs : CONTROL.height.sm;
-    const sizeHeights = {
-      small: CONTROL.height.sm,
-      medium: CONTROL.height.md,
-      large: CONTROL.height.lg
-    } as const;
-    const height = size ? sizeHeights[size] : densityHeight;
-    const paddingX =
-      density === "compact" ? CONTROL.paddingX.compact : CONTROL.paddingX.normal;
+  const fontSize =
+    scope === "inspector" ? theme.fontSizeSmall : theme.fontSizeSmaller;
+  const densityHeight =
+    density === "compact" ? CONTROL.height.xs : CONTROL.height.sm;
+  const sizeHeights = {
+    small: CONTROL.height.sm,
+    medium: CONTROL.height.md,
+    large: CONTROL.height.lg
+  } as const;
+  const height = size ? sizeHeights[size] : densityHeight;
+  const paddingX =
+    density === "compact" ? CONTROL.paddingX.compact : CONTROL.paddingX.normal;
 
-    return (
-      <Button
-        ref={ref}
-        size={size ?? "small"}
-        className={cn(editorClassNames.nodrag, className)}
-        {...(href ? { href, target, rel, component: "a" as const } : {})}
-        sx={{
-          fontSize,
-          height,
-          minWidth: "auto",
-          padding: `4px ${paddingX}px`,
-          borderRadius: BORDER_RADIUS.md,
-          textTransform: "none",
-          ...sx
-        }}
-        {...props}
-      />
-    );
-  }
-);
+  return (
+    <Button
+      ref={ref}
+      size={size ?? "small"}
+      className={cn(editorClassNames.nodrag, className)}
+      {...(href ? { href, target, rel, component: "a" as const } : {})}
+      sx={{
+        fontSize,
+        height,
+        minWidth: "auto",
+        padding: `4px ${paddingX}px`,
+        borderRadius: BORDER_RADIUS.md,
+        textTransform: "none",
+        ...sx
+      }}
+      {...props}
+    />
+  );
+}
 
-EditorButton.displayName = "EditorButton";
-
-const EditorButtonMemo = memo(EditorButton);
-EditorButtonMemo.displayName = "EditorButton";
-
-export default EditorButtonMemo;
+export default memo(EditorButton);

--- a/web/src/components/editor_ui/NodeSelect.tsx
+++ b/web/src/components/editor_ui/NodeSelect.tsx
@@ -1,187 +1,177 @@
 /** @jsxImportSource @emotion/react */
- /**
-  * NodeSelect, NodeMenuItem, and NodeSelectPrimitive
-  *
-  * Select primitives for editor/node UI that apply consistent styling
-  * via sx/slotProps and maintain nodrag behavior.
-  *
-  * Accepts semantic props for state-based styling:
-  * - `changed`: Shows visual indicator when value differs from default
-  * - `invalid`: Shows error state styling
-  * - `density`: Controls compact vs normal sizing
-  */
+/**
+ * NodeSelect, NodeMenuItem, and NodeSelectPrimitive
+ *
+ * Select primitives for editor/node UI that apply consistent styling
+ * via sx/slotProps and maintain nodrag behavior.
+ *
+ * Accepts semantic props for state-based styling:
+ * - `changed`: Shows visual indicator when value differs from default
+ * - `invalid`: Shows error state styling
+ * - `density`: Controls compact vs normal sizing
+ */
 
- import React, { forwardRef, useMemo, memo } from "react";
- import {
-   Select,
-   SelectProps,
-   MenuItem,
-   MenuItemProps,
-   FormControl
- } from "@mui/material";
- import { useTheme } from "@mui/material/styles";
- import { useEditorScope } from "./EditorUiContext";
- import { editorUiClasses } from "../../constants/editorUiClasses";
- import { editorClassNames, cn } from "./editorUtils";
+import React, { useMemo, memo, type Ref } from "react";
+import {
+  Select,
+  SelectProps,
+  MenuItem,
+  MenuItemProps,
+  FormControl
+} from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import { useEditorScope } from "./EditorUiContext";
+import { editorUiClasses } from "../../constants/editorUiClasses";
+import { editorClassNames, cn } from "./editorUtils";
 
- export interface NodeSelectProps
-   extends Omit<SelectProps, "size"> {
-   /**
-    * Additional class name for the root element.
-    */
-   className?: string;
-   /**
-    * Value differs from default — shows visual indicator (right border)
-    */
-   changed?: boolean;
-   /**
-    * Validation failed — shows error state
-    */
-   invalid?: boolean;
-   /**
-    * Density variant
-    */
-   density?: "compact" | "normal";
- }
+export interface NodeSelectProps extends Omit<SelectProps, "size"> {
+  /**
+   * Additional class name for the root element.
+   */
+  className?: string;
+  /**
+   * Value differs from default — shows visual indicator (right border)
+   */
+  changed?: boolean;
+  /**
+   * Validation failed — shows error state
+   */
+  invalid?: boolean;
+  /**
+   * Density variant
+   */
+  density?: "compact" | "normal";
+  ref?: Ref<HTMLDivElement>;
+}
 
- /**
-  * A styled Select for use in node properties and editor UI.
-  * Applies editor tokens for consistent styling and maintains nodrag behavior.
-  *
-  * @example
-  * <NodeSelect
-  *   value={value}
-  *   onChange={(e) => onChange(e.target.value)}
-  *   changed={hasChanged}
-  *   invalid={hasError}
-  * >
-  *   <NodeMenuItem value="option1">Option 1</NodeMenuItem>
-  *   <NodeMenuItem value="option2">Option 2</NodeMenuItem>
-  * </NodeSelect>
-  */
- export const NodeSelect = forwardRef<HTMLDivElement, NodeSelectProps>(
-   (
-     {
-       className,
-       sx,
-       MenuProps,
-       changed,
-       invalid,
-       density = "compact",
-       children,
-       ...props
-     },
-     ref
-   ) => {
-     const theme = useTheme();
-     const scope = useEditorScope();
-     const scopeClass =
-       scope === "inspector"
-         ? editorUiClasses.scopeInspector
-         : editorUiClasses.scopeNode;
+/**
+ * A styled Select for use in node properties and editor UI.
+ * Applies editor tokens for consistent styling and maintains nodrag behavior.
+ *
+ * @example
+ * <NodeSelect
+ *   value={value}
+ *   onChange={(e) => onChange(e.target.value)}
+ *   changed={hasChanged}
+ *   invalid={hasError}
+ * >
+ *   <NodeMenuItem value="option1">Option 1</NodeMenuItem>
+ *   <NodeMenuItem value="option2">Option 2</NodeMenuItem>
+ * </NodeSelect>
+ */
+export function NodeSelect({
+  className,
+  sx,
+  MenuProps,
+  changed,
+  invalid,
+  density = "compact",
+  children,
+  ref,
+  ...props
+}: NodeSelectProps) {
+  const theme = useTheme();
+  const scope = useEditorScope();
+  const scopeClass =
+    scope === "inspector"
+      ? editorUiClasses.scopeInspector
+      : editorUiClasses.scopeNode;
 
-     const fontSize =
-       scope === "inspector" ? theme.fontSizeSmall : theme.fontSizeSmaller;
-     const height = density === "compact" ? 24 : 28;
+  const fontSize =
+    scope === "inspector" ? theme.fontSizeSmall : theme.fontSizeSmaller;
+  const height = density === "compact" ? 24 : 28;
 
-     const selectSx = useMemo(() => ({
-       fontSize,
-       height,
-       ...(invalid && {
-         "& .MuiOutlinedInput-notchedOutline": {
-           borderColor: theme.vars.palette.error.main
-         }
-       }),
-       ...sx
-     }), [fontSize, height, changed, invalid, theme, sx]);
+  const selectSx = useMemo(
+    () => ({
+      fontSize,
+      height,
+      ...(invalid && {
+        "& .MuiOutlinedInput-notchedOutline": {
+          borderColor: theme.vars.palette.error.main
+        }
+      }),
+      ...sx
+    }),
+    [fontSize, height, invalid, theme, sx]
+  );
 
-     return (
-       <FormControl
-         fullWidth
-         size="small"
-         ref={ref}
-         className={cn(editorClassNames.nodrag, className)}
-       >
-         <Select
-           className={cn(
-             editorClassNames.nodrag,
-             editorUiClasses.control,
-             scopeClass
-           )}
-           variant="outlined"
-           size="small"
-           MenuProps={{
-             anchorOrigin: {
-               vertical: "bottom",
-               horizontal: "left"
-             },
-             transformOrigin: {
-               vertical: "top",
-               horizontal: "left"
-             },
-             ...MenuProps,
-             PaperProps: {
-               ...MenuProps?.PaperProps,
-               className: cn(
-                 editorUiClasses.menuPaper,
-                 (MenuProps?.PaperProps as { className?: string } | undefined)
-                   ?.className
-               )
-             },
-             classes: {
-               paper: editorUiClasses.menuPaper,
-               list: editorUiClasses.menuList
-             }
-           }}
-           sx={selectSx}
-           {...props}
-         >
-           {children}
-         </Select>
-       </FormControl>
-     );
-   }
- );
+  return (
+    <FormControl
+      fullWidth
+      size="small"
+      ref={ref}
+      className={cn(editorClassNames.nodrag, className)}
+    >
+      <Select
+        className={cn(
+          editorClassNames.nodrag,
+          editorUiClasses.control,
+          scopeClass
+        )}
+        variant="outlined"
+        size="small"
+        MenuProps={{
+          anchorOrigin: {
+            vertical: "bottom",
+            horizontal: "left"
+          },
+          transformOrigin: {
+            vertical: "top",
+            horizontal: "left"
+          },
+          ...MenuProps,
+          PaperProps: {
+            ...MenuProps?.PaperProps,
+            className: cn(
+              editorUiClasses.menuPaper,
+              (MenuProps?.PaperProps as { className?: string } | undefined)
+                ?.className
+            )
+          },
+          classes: {
+            paper: editorUiClasses.menuPaper,
+            list: editorUiClasses.menuList
+          }
+        }}
+        sx={selectSx}
+        {...props}
+      >
+        {children}
+      </Select>
+    </FormControl>
+  );
+}
 
-NodeSelect.displayName = "NodeSelect";
+export default memo(NodeSelect);
 
-const NodeSelectMemo = memo(NodeSelect);
-NodeSelectMemo.displayName = "NodeSelect";
+export interface NodeMenuItemProps extends MenuItemProps {
+  /**
+   * Additional class name for the root element.
+   */
+  className?: string;
+  ref?: Ref<HTMLLIElement>;
+}
 
-export default NodeSelectMemo;
+/**
+ * A styled MenuItem for use with NodeSelect.
+ * Applies editor tokens for consistent styling.
+ *
+ * @example
+ * <NodeSelect value={value} onChange={handleChange}>
+ *   <NodeMenuItem value="option1">Option 1</NodeMenuItem>
+ * </NodeSelect>
+ */
+function NodeMenuItemBase({ className, sx, ref, ...props }: NodeMenuItemProps) {
+  return (
+    <MenuItem
+      ref={ref}
+      className={cn(editorUiClasses.menuItem, className)}
+      sx={sx}
+      {...props}
+    />
+  );
+}
 
- export interface NodeMenuItemProps extends MenuItemProps {
-   /**
-    * Additional class name for the root element.
-    */
-   className?: string;
- }
+const NodeMenuItem = memo(NodeMenuItemBase);
 
- /**
-  * A styled MenuItem for use with NodeSelect.
-  * Applies editor tokens for consistent styling.
-  *
-  * @example
-  * <NodeSelect value={value} onChange={handleChange}>
-  *   <NodeMenuItem value="option1">Option 1</NodeMenuItem>
-  * </NodeSelect>
-  */
- const NodeMenuItem = forwardRef<HTMLLIElement, NodeMenuItemProps>(
-   ({ className, sx, ...props }, ref) => {
-     return (
-       <MenuItem
-         ref={ref}
-         className={cn(editorUiClasses.menuItem, className)}
-         sx={sx}
-         {...props}
-       />
-     );
-   }
- );
-
-NodeMenuItem.displayName = "NodeMenuItem";
-
-const NodeMenuItemMemo = memo(NodeMenuItem);
-NodeMenuItemMemo.displayName = "NodeMenuItem";
-
-export { NodeMenuItemMemo as NodeMenuItem };
+export { NodeMenuItem };

--- a/web/src/components/editor_ui/NodeSwitch.tsx
+++ b/web/src/components/editor_ui/NodeSwitch.tsx
@@ -9,7 +9,7 @@
  * - `changed`: Shows visual indicator when value differs from default
  */
 
-import { forwardRef, useMemo, memo } from "react";
+import { memo, type Ref } from "react";
 import { Switch, SwitchProps } from "@mui/material";
 import { useEditorScope } from "./EditorUiContext";
 import { editorUiClasses } from "../../constants/editorUiClasses";
@@ -24,6 +24,7 @@ export interface NodeSwitchProps extends Omit<SwitchProps, "size"> {
    * Value differs from default — shows visual indicator
    */
   changed?: boolean;
+  ref?: Ref<HTMLButtonElement>;
 }
 
 /**
@@ -41,38 +42,33 @@ export interface NodeSwitchProps extends Omit<SwitchProps, "size"> {
  *   name="enabled"
  * />
  */
-export const NodeSwitch = forwardRef<HTMLButtonElement, NodeSwitchProps>(
-  ({ className, sx, changed, ...props }, ref) => {
-    const scope = useEditorScope();
-    const scopeClass =
-      scope === "inspector"
-        ? editorUiClasses.scopeInspector
-        : editorUiClasses.scopeNode;
+export function NodeSwitch({
+  className,
+  sx,
+  changed,
+  ref,
+  ...props
+}: NodeSwitchProps) {
+  const scope = useEditorScope();
+  const scopeClass =
+    scope === "inspector"
+      ? editorUiClasses.scopeInspector
+      : editorUiClasses.scopeNode;
 
-    const switchSx = useMemo(() => ({
-      ...sx
-    }), [sx]);
+  return (
+    <Switch
+      ref={ref}
+      size="small"
+      className={cn(
+        editorClassNames.nodrag,
+        editorUiClasses.switchRoot,
+        scopeClass,
+        className
+      )}
+      sx={sx}
+      {...props}
+    />
+  );
+}
 
-    return (
-      <Switch
-        ref={ref}
-        size="small"
-        className={cn(
-          editorClassNames.nodrag,
-          editorUiClasses.switchRoot,
-          scopeClass,
-          className
-        )}
-        sx={switchSx}
-        {...props}
-      />
-    );
-  }
-);
-
-NodeSwitch.displayName = "NodeSwitch";
-
-const NodeSwitchMemo = memo(NodeSwitch);
-NodeSwitchMemo.displayName = "NodeSwitch";
-
-export default NodeSwitchMemo;
+export default memo(NodeSwitch);

--- a/web/src/components/editor_ui/NodeTextField.tsx
+++ b/web/src/components/editor_ui/NodeTextField.tsx
@@ -11,7 +11,7 @@
  * - `density`: Controls compact vs normal sizing
  */
 
-import { forwardRef, memo } from "react";
+import { memo, type Ref } from "react";
 import { TextField, TextFieldProps } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useEditorScope } from "./EditorUiContext";
@@ -24,8 +24,10 @@ interface SlotPropsWithClassName {
   [key: string]: unknown;
 }
 
-export interface NodeTextFieldProps
-  extends Omit<TextFieldProps, "variant" | "size"> {
+export interface NodeTextFieldProps extends Omit<
+  TextFieldProps,
+  "variant" | "size"
+> {
   /**
    * Additional class name for the root element.
    */
@@ -38,6 +40,7 @@ export interface NodeTextFieldProps
    * Validation failed — shows error state
    */
   invalid?: boolean;
+  ref?: Ref<HTMLDivElement>;
 }
 
 /**
@@ -55,90 +58,78 @@ export interface NodeTextFieldProps
  *   maxRows={2}
  * />
  */
-export const NodeTextField = forwardRef<HTMLDivElement, NodeTextFieldProps>(
-  (
-    {
-      className,
-      slotProps,
-      sx,
-      changed,
-      invalid,
-      // Extract legacy props that Autocomplete passes - these contain critical refs
-      InputProps,
-      inputProps,
-      ...props
-    },
-    ref
-  ) => {
-    const theme = useTheme();
-    const scope = useEditorScope();
-    const scopeClass =
-      scope === "inspector"
-        ? editorUiClasses.scopeInspector
-        : editorUiClasses.scopeNode;
+export function NodeTextField({
+  className,
+  slotProps,
+  sx,
+  changed,
+  invalid,
+  // Extract legacy props that Autocomplete passes - these contain critical refs
+  InputProps,
+  inputProps,
+  ref,
+  ...props
+}: NodeTextFieldProps) {
+  const theme = useTheme();
+  const scope = useEditorScope();
+  const scopeClass =
+    scope === "inspector"
+      ? editorUiClasses.scopeInspector
+      : editorUiClasses.scopeNode;
 
-    return (
-      <TextField
-        ref={ref}
-        variant="outlined"
-        size="small"
-        fullWidth
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        className={cn(
-          editorClassNames.nodrag,
-          editorUiClasses.control,
-          scopeClass,
-          className
-        )}
-        slotProps={
-          {
-            ...slotProps,
-            input: {
-              // Merge legacy InputProps (from Autocomplete) with slotProps.input
-              ...InputProps,
-              ...slotProps?.input,
-              className: cn(
-                editorClassNames.nodrag,
-                editorUiClasses.control,
-                scopeClass,
-                (InputProps as SlotPropsWithClassName | undefined)?.className,
-                (slotProps?.input as SlotPropsWithClassName | undefined)
-                  ?.className
-              )
-            },
-            htmlInput: {
-              // Merge legacy inputProps (from Autocomplete) with slotProps.htmlInput
-              ...inputProps,
-              ...slotProps?.htmlInput,
-              className: cn(
-                editorClassNames.nodrag,
-                (inputProps as SlotPropsWithClassName | undefined)?.className,
-                (slotProps?.htmlInput as SlotPropsWithClassName | undefined)
-                  ?.className
-              )
-            }
-          }
+  return (
+    <TextField
+      ref={ref}
+      variant="outlined"
+      size="small"
+      fullWidth
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
+      className={cn(
+        editorClassNames.nodrag,
+        editorUiClasses.control,
+        scopeClass,
+        className
+      )}
+      slotProps={{
+        ...slotProps,
+        input: {
+          // Merge legacy InputProps (from Autocomplete) with slotProps.input
+          ...InputProps,
+          ...slotProps?.input,
+          className: cn(
+            editorClassNames.nodrag,
+            editorUiClasses.control,
+            scopeClass,
+            (InputProps as SlotPropsWithClassName | undefined)?.className,
+            (slotProps?.input as SlotPropsWithClassName | undefined)?.className
+          )
+        },
+        htmlInput: {
+          // Merge legacy inputProps (from Autocomplete) with slotProps.htmlInput
+          ...inputProps,
+          ...slotProps?.htmlInput,
+          className: cn(
+            editorClassNames.nodrag,
+            (inputProps as SlotPropsWithClassName | undefined)?.className,
+            (slotProps?.htmlInput as SlotPropsWithClassName | undefined)
+              ?.className
+          )
         }
-        sx={{
-          ...(invalid && {
-            "& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline": {
-              borderColor: theme.vars.palette.error.main
-            }
-          }),
-          ...sx
-        }}
-        {...props}
-      />
-    );
-  }
-);
+      }}
+      sx={{
+        ...(invalid && {
+          "& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline": {
+            borderColor: theme.vars.palette.error.main
+          }
+        }),
+        ...sx
+      }}
+      {...props}
+    />
+  );
+}
 
-NodeTextField.displayName = "NodeTextField";
-
-const NodeTextFieldMemo = memo(NodeTextField);
-NodeTextFieldMemo.displayName = "NodeTextField";
-
-export default NodeTextFieldMemo;
+export default memo(NodeTextField);

--- a/web/src/components/node_menu/CategorySearchBar.tsx
+++ b/web/src/components/node_menu/CategorySearchBar.tsx
@@ -2,14 +2,8 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import {
-  forwardRef,
-  memo,
-  useCallback,
-  useImperativeHandle,
-  useRef
-} from "react";
-import type { KeyboardEvent } from "react";
+import { memo, useCallback, useImperativeHandle, useRef } from "react";
+import type { KeyboardEvent, Ref } from "react";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
@@ -57,62 +51,62 @@ interface CategorySearchBarProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  ref?: Ref<HTMLInputElement>;
 }
 
 /**
  * Slim search input shown at the top of a tile-grid category. Filters the
  * grid below by title/node_type/namespace substring.
  */
-const CategorySearchBar = memo(
-  forwardRef<HTMLInputElement, CategorySearchBarProps>(
-    ({ value, onChange, placeholder = "Filter..." }, ref) => {
-      const theme = useTheme();
-      const inputRef = useRef<HTMLInputElement>(null);
-      useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
+const CategorySearchBar = memo(function CategorySearchBar({
+  value,
+  onChange,
+  placeholder = "Filter...",
+  ref
+}: CategorySearchBarProps) {
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
 
-      const handleClear = useCallback(() => {
+  const handleClear = useCallback(() => {
+    onChange("");
+    // Keep the cursor in the field so users can keep typing after clearing.
+    inputRef.current?.focus();
+  }, [onChange]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape" && value) {
+        e.stopPropagation();
         onChange("");
-        // Keep the cursor in the field so users can keep typing after clearing.
-        inputRef.current?.focus();
-      }, [onChange]);
+      }
+    },
+    [value, onChange]
+  );
 
-      const handleKeyDown = useCallback(
-        (e: KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Escape" && value) {
-            e.stopPropagation();
-            onChange("");
-          }
-        },
-        [value, onChange]
-      );
-
-      return (
-        <div css={styles(theme)} className="qa-search">
-          <SearchIcon className="search-glyph" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            aria-label="Filter category"
-          />
-          {value && (
-            <ToolbarIconButton
-              tabIndex={-1}
-              tooltip="Clear filter"
-              ariaLabel="Clear filter"
-              onClick={handleClear}
-              icon={<ClearIcon />}
-            />
-          )}
-        </div>
-      );
-    }
-  )
-);
-
-CategorySearchBar.displayName = "CategorySearchBar";
+  return (
+    <div css={styles(theme)} className="qa-search">
+      <SearchIcon className="search-glyph" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        aria-label="Filter category"
+      />
+      {value && (
+        <ToolbarIconButton
+          tabIndex={-1}
+          tooltip="Clear filter"
+          ariaLabel="Clear filter"
+          onClick={handleClear}
+          icon={<ClearIcon />}
+        />
+      )}
+    </div>
+  );
+});
 
 export default CategorySearchBar;

--- a/web/src/components/node_menu/NodeItem.tsx
+++ b/web/src/components/node_menu/NodeItem.tsx
@@ -1,6 +1,16 @@
-import { memo, useCallback, forwardRef, useMemo } from "react";
+import { memo, useCallback, useMemo, type Ref } from "react";
 import { useTheme } from "@mui/material/styles";
-import { Tooltip, Text, ToolbarIconButton, FlexRow, Box, BORDER_RADIUS, FONT_WEIGHT, SPACING, getSpacingPx } from "../ui_primitives";
+import {
+  Tooltip,
+  Text,
+  ToolbarIconButton,
+  FlexRow,
+  Box,
+  BORDER_RADIUS,
+  FONT_WEIGHT,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import CheckIcon from "@mui/icons-material/Check";
@@ -11,7 +21,10 @@ import { IconForType } from "../../config/IconForType";
 import { HighlightText } from "../ui_primitives";
 import { useFavoriteNodesStore } from "../../stores/FavoriteNodesStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
-import { TOOLTIP_ENTER_DELAY, NOTIFICATION_TIMEOUT_SHORT } from "../../config/constants";
+import {
+  TOOLTIP_ENTER_DELAY,
+  NOTIFICATION_TIMEOUT_SHORT
+} from "../../config/constants";
 import { formatNodeDocumentation } from "../../stores/formatNodeDocumentation";
 import { findSnippetByNodeType } from "../../config/snippetMetadata";
 
@@ -28,378 +41,397 @@ interface NodeItemProps {
   onToggleSelection?: (nodeType: string) => void;
   showFavoriteButton?: boolean;
   showDescriptionTooltip?: boolean;
+  ref?: Ref<HTMLDivElement>;
 }
 
-const NodeItem = memo(
-  forwardRef<HTMLDivElement, NodeItemProps>(
-    (
-      {
-        node,
-        onDragStart,
-        onDragEnd,
-        onClick,
-        showCheckbox = false,
-        isSelected = false,
-        onToggleSelection,
-        showFavoriteButton = true,
-        showDescriptionTooltip = false
-      },
-      ref
-    ) => {
-      const theme = useTheme();
-      const outputType =
-        node.outputs.length > 0 ? node.outputs[0].type.type : "";
-      const hasRuntimeDeps =
-        node.required_runtimes && node.required_runtimes.length > 0;
-      const isSnippet = !!findSnippetByNodeType(node.node_type);
-      const { searchTerm, hoveredNode, setHoveredNode } = useNodeMenuStore(
-        useShallow((state) => ({
-          searchTerm: state.searchTerm,
-          hoveredNode: state.hoveredNode,
-          setHoveredNode: state.setHoveredNode
-        }))
-      );
-      const isHovered = hoveredNode?.node_type === node.node_type;
-      const isFavorite = useFavoriteNodesStore((state) =>
-        state.isFavorite(node.node_type)
-      );
-      const toggleFavorite = useFavoriteNodesStore(
-        (state) => state.toggleFavorite
-      );
-      const addNotification = useNotificationStore(
-        (state) => state.addNotification
-      );
+const NodeItem = memo(function NodeItem({
+  node,
+  onDragStart,
+  onDragEnd,
+  onClick,
+  showCheckbox = false,
+  isSelected = false,
+  onToggleSelection,
+  showFavoriteButton = true,
+  showDescriptionTooltip = false,
+  ref
+}: NodeItemProps) {
+  const theme = useTheme();
+  const outputType = node.outputs.length > 0 ? node.outputs[0].type.type : "";
+  const hasRuntimeDeps =
+    node.required_runtimes && node.required_runtimes.length > 0;
+  const isSnippet = !!findSnippetByNodeType(node.node_type);
+  const { searchTerm, hoveredNode, setHoveredNode } = useNodeMenuStore(
+    useShallow((state) => ({
+      searchTerm: state.searchTerm,
+      hoveredNode: state.hoveredNode,
+      setHoveredNode: state.setHoveredNode
+    }))
+  );
+  const isHovered = hoveredNode?.node_type === node.node_type;
+  const isFavorite = useFavoriteNodesStore((state) =>
+    state.isFavorite(node.node_type)
+  );
+  const toggleFavorite = useFavoriteNodesStore((state) => state.toggleFavorite);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
 
-      const parsedDescription = useMemo(() => {
-        if (!node.description) {
-          return null;
-        }
-        return formatNodeDocumentation(node.description);
-      }, [node.description]);
+  const parsedDescription = useMemo(() => {
+    if (!node.description) {
+      return null;
+    }
+    return formatNodeDocumentation(node.description);
+  }, [node.description]);
 
-      const tooltipContent = useMemo(() => {
-        if (!parsedDescription) {
-          return node.title;
-        }
-        return (
-          <Box sx={{ maxWidth: 300 }}>
-            <Text size="normal" weight={FONT_WEIGHT.medium} sx={{ mb: 0.5 }}>
-              {parsedDescription.description}
-            </Text>
-            {parsedDescription.tags.length > 0 && (
-              <FlexRow gap={0.5} wrap sx={{ mt: 1 }}>
-                {parsedDescription.tags.map((tag) => (
-                  <Box
-                    key={tag}
-                    component="span"
-                    sx={{
-                      fontSize: "var(--fontSizeSmaller)",
-                      fontWeight: FONT_WEIGHT.medium,
-                      textTransform: "uppercase",
-                      bgcolor: "grey.700",
-                      color: "grey.300",
-                      px: SPACING.xs,
-                      py: SPACING.micro,
-                      borderRadius: BORDER_RADIUS.sm
-                    }}
-                  >
-                    {tag}
-                  </Box>
-                ))}
-              </FlexRow>
-            )}
-            {parsedDescription.useCases.raw && (
-              <Box sx={{ mt: 1 }}>
-                <Text size="smaller" weight={FONT_WEIGHT.semibold} sx={{ color: "grey.400", textTransform: "uppercase", mb: 0.5 }}>
-                  Use cases
-                </Text>
-                <Box component="ul" sx={{ m: 0, pl: 2, fontSize: "var(--fontSizeSmall)", color: "grey.300" }}>
-                  {parsedDescription.useCases.raw.split("\n").map((useCase, index) => (
-                    <li key={`${useCase}-${index}`}>{useCase}</li>
-                  ))}
-                </Box>
-              </Box>
-            )}
-          </Box>
-        );
-      }, [parsedDescription, node.title]);
-
-      const onMouseEnter = useCallback(() => {
-        setHoveredNode(node);
-      }, [node, setHoveredNode]);
-
-      const handleClick = useCallback(
-        (e: React.MouseEvent) => {
-          if (showCheckbox && onToggleSelection) {
-            e.preventDefault();
-            onToggleSelection(node.node_type);
-          } else {
-            onClick(node);
-          }
-        },
-        [showCheckbox, onToggleSelection, node, onClick]
-      );
-
-      const handleFavoriteClick = useCallback(
-        (e: React.MouseEvent) => {
-          e.stopPropagation();
-          const wasAdded = !isFavorite;
-          toggleFavorite(node.node_type);
-          addNotification({
-            type: "info",
-            content: wasAdded
-              ? "Node added to favorites"
-              : "Node removed from favorites",
-            timeout: NOTIFICATION_TIMEOUT_SHORT
-          });
-        },
-        [node.node_type, isFavorite, toggleFavorite, addNotification]
-      );
-
-      const handleDragStart = useCallback(
-        (e: React.DragEvent<HTMLDivElement>) => {
-          if (!showCheckbox) {
-            onDragStart(node, e);
-          }
-        },
-        [showCheckbox, onDragStart, node]
-      );
-
-      const nodeButtonStyle = useMemo(
-        () => ({
-          cursor: "pointer" as const,
-          display: "flex",
-          alignItems: "center",
-          flex: 1,
-          gap: "0.5em",
-          position: "relative" as const,
-          minHeight: "34px",
-          paddingLeft: showCheckbox ? "24px" : undefined
-        }),
-        [showCheckbox]
-      );
-
-      const checkboxContainerStyle = useMemo(
-        () => ({
-          position: "absolute" as const,
-          left: "4px",
-          width: "20px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center"
-        }),
-        []
-      );
-
-      const iconContainerStyle = useMemo(
-        () => ({
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5em",
-          flex: 1,
-          minWidth: 0
-        }),
-        []
-      );
-
-      const iconForTypeContainerStyle = useMemo(
-        () => ({
-          borderRadius: `0 0 ${BORDER_RADIUS.xs} 0`,
-          marginLeft: "0",
-          marginTop: "0"
-        }),
-        []
-      );
-
-      const iconForTypeBgStyle = useMemo(
-        () => ({
-          backgroundColor: theme.vars.palette.grey[900],
-          margin: "0",
-          padding: getSpacingPx(SPACING.micro), // was 1px
-          borderRadius: `0 0 ${BORDER_RADIUS.xs} 0`,
-          boxShadow: `inset 1px 1px 2px ${theme.vars.palette.action.disabledBackground}`,
-          width: "20px",
-          height: "20px"
-        }),
-        [theme.vars.palette.grey, theme.vars.palette.action.disabledBackground]
-      );
-
-      const iconForTypeSvgProps = useMemo(
-        () => ({ width: "15px", height: "15px" }),
-        []
-      );
-
-      const favoriteButtonSx = useMemo(
-        () => ({
-          padding: getSpacingPx(SPACING.micro),
-          marginLeft: "auto",
-          opacity: isFavorite ? 1 : 0.5,
-          color: isFavorite ? "warning.main" : "text.secondary",
-          "&:hover": {
-            backgroundColor: "action.hover",
-            opacity: 1
-          }
-        }),
-        [isFavorite]
-      );
-
-      const iconWithText = (
-        <>
-          <IconForType
-            iconName={outputType}
-            containerStyle={iconForTypeContainerStyle}
-            bgStyle={iconForTypeBgStyle}
-            svgProps={iconForTypeSvgProps}
-          />
-          <Text
-            size="small"
-            sx={{
-              lineHeight: 1.3,
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis"
-            }}
-          >
-            <HighlightText
-              text={node.title}
-              query={searchTerm}
-              matchStyle="primary"
-            />
-          </Text>
-        </>
-      );
-
-      return (
-        <div
-          ref={ref}
-          className={`node ${isHovered ? "hovered" : ""} ${
-            showCheckbox && isSelected ? "selected" : ""
-          }`}
-          draggable={!showCheckbox}
-          onMouseEnter={onMouseEnter}
-          onDragStart={handleDragStart}
-          onDragEnd={onDragEnd}
-        >
-          <div
-            className="node-button"
-            role="button"
-            tabIndex={0}
-            onClick={handleClick}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                if (showCheckbox && onToggleSelection) {
-                  onToggleSelection(node.node_type);
-                } else {
-                  onClick(node);
-                }
-              }
-            }}
-            style={nodeButtonStyle}
-          >
-            {showCheckbox && (
-              <div style={checkboxContainerStyle}>
-                {isSelected && (
-                  <CheckIcon
-                    sx={{
-                      fontSize: "var(--fontSizeBig)",
-                      color: theme.vars.palette.primary.main,
-                      padding: getSpacingPx(SPACING.micro)
-                    }}
-                  />
-                )}
-              </div>
-            )}
-            {showDescriptionTooltip ? (
-              <Tooltip
-                title={tooltipContent}
-                placement="right"
-                delay={TOOLTIP_ENTER_DELAY}
-                slotProps={{
-                  popper: { sx: { zIndex: theme.zIndex.commandMenu } },
-                  tooltip: { sx: { bgcolor: "grey.800", color: "grey.100", maxWidth: 350, padding: getSpacingPx(SPACING.xl) } }
-                }}
-              >
-                <div style={iconContainerStyle}>
-                  {iconWithText}
-                </div>
-              </Tooltip>
-            ) : (
-              <div style={iconContainerStyle}>
-                {iconWithText}
-              </div>
-            )}
-            {hasRuntimeDeps && (
-              <Tooltip
-                title={`Requires: ${node.required_runtimes!.join(", ")}`}
-                placement="top"
-                delay={TOOLTIP_ENTER_DELAY}
-                slotProps={{
-                  popper: { sx: { zIndex: theme.zIndex.tooltip } },
-                  tooltip: { sx: { bgcolor: "grey.800", color: "grey.100", fontSize: "var(--fontSizeSmaller)" } }
-                }}
-              >
-                <Box
-                  component="span"
-                  sx={{
-                    fontSize: "var(--fontSizeSmaller)",
-                    fontWeight: FONT_WEIGHT.semibold,
-                    textTransform: "uppercase",
-                    bgcolor: `color-mix(in srgb, ${theme.vars.palette.warning.main} 20%, transparent)`,
-                    color: theme.vars.palette.warning.main,
-                    px: SPACING.micro,
-                    py: SPACING.micro,
-                    borderRadius: BORDER_RADIUS.sm,
-                    whiteSpace: "nowrap",
-                    flexShrink: 0
-                  }}
-                >
-                  {node.required_runtimes!.join(", ")}
-                </Box>
-              </Tooltip>
-            )}
-            {isSnippet && (
+  const tooltipContent = useMemo(() => {
+    if (!parsedDescription) {
+      return node.title;
+    }
+    return (
+      <Box sx={{ maxWidth: 300 }}>
+        <Text size="normal" weight={FONT_WEIGHT.medium} sx={{ mb: 0.5 }}>
+          {parsedDescription.description}
+        </Text>
+        {parsedDescription.tags.length > 0 && (
+          <FlexRow gap={0.5} wrap sx={{ mt: 1 }}>
+            {parsedDescription.tags.map((tag) => (
               <Box
+                key={tag}
                 component="span"
                 sx={{
                   fontSize: "var(--fontSizeSmaller)",
-                  fontWeight: FONT_WEIGHT.semibold,
-                  fontFamily: "monospace",
-                  letterSpacing: "0.03em",
-                  bgcolor: `color-mix(in srgb, ${theme.vars.palette.info.main} 18%, transparent)`,
-                  color: theme.vars.palette.info.main,
-                  px: SPACING.micro,
+                  fontWeight: FONT_WEIGHT.medium,
+                  textTransform: "uppercase",
+                  bgcolor: "grey.700",
+                  color: "grey.300",
+                  px: SPACING.xs,
                   py: SPACING.micro,
-                  borderRadius: BORDER_RADIUS.sm,
-                  whiteSpace: "nowrap",
-                  flexShrink: 0
+                  borderRadius: BORDER_RADIUS.sm
                 }}
               >
-                JS
+                {tag}
               </Box>
-            )}
-            {showFavoriteButton && (
-              <ToolbarIconButton
-                icon={isFavorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
-                tooltip={isFavorite ? "Remove from favorites" : "Add to favorites"}
-                tooltipPlacement="top"
-                size="small"
-                onClick={handleFavoriteClick}
-                sx={favoriteButtonSx}
-                aria-label={
-                  isFavorite
-                    ? `Remove ${node.title} from favorites`
-                    : `Add ${node.title} to favorites`
-                }
+            ))}
+          </FlexRow>
+        )}
+        {parsedDescription.useCases.raw && (
+          <Box sx={{ mt: 1 }}>
+            <Text
+              size="smaller"
+              weight={FONT_WEIGHT.semibold}
+              sx={{ color: "grey.400", textTransform: "uppercase", mb: 0.5 }}
+            >
+              Use cases
+            </Text>
+            <Box
+              component="ul"
+              sx={{
+                m: 0,
+                pl: 2,
+                fontSize: "var(--fontSizeSmall)",
+                color: "grey.300"
+              }}
+            >
+              {parsedDescription.useCases.raw
+                .split("\n")
+                .map((useCase, index) => (
+                  <li key={`${useCase}-${index}`}>{useCase}</li>
+                ))}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    );
+  }, [parsedDescription, node.title]);
+
+  const onMouseEnter = useCallback(() => {
+    setHoveredNode(node);
+  }, [node, setHoveredNode]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (showCheckbox && onToggleSelection) {
+        e.preventDefault();
+        onToggleSelection(node.node_type);
+      } else {
+        onClick(node);
+      }
+    },
+    [showCheckbox, onToggleSelection, node, onClick]
+  );
+
+  const handleFavoriteClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const wasAdded = !isFavorite;
+      toggleFavorite(node.node_type);
+      addNotification({
+        type: "info",
+        content: wasAdded
+          ? "Node added to favorites"
+          : "Node removed from favorites",
+        timeout: NOTIFICATION_TIMEOUT_SHORT
+      });
+    },
+    [node.node_type, isFavorite, toggleFavorite, addNotification]
+  );
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!showCheckbox) {
+        onDragStart(node, e);
+      }
+    },
+    [showCheckbox, onDragStart, node]
+  );
+
+  const nodeButtonStyle = useMemo(
+    () => ({
+      cursor: "pointer" as const,
+      display: "flex",
+      alignItems: "center",
+      flex: 1,
+      gap: "0.5em",
+      position: "relative" as const,
+      minHeight: "34px",
+      paddingLeft: showCheckbox ? "24px" : undefined
+    }),
+    [showCheckbox]
+  );
+
+  const checkboxContainerStyle = useMemo(
+    () => ({
+      position: "absolute" as const,
+      left: "4px",
+      width: "20px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center"
+    }),
+    []
+  );
+
+  const iconContainerStyle = useMemo(
+    () => ({
+      display: "flex",
+      alignItems: "center",
+      gap: "0.5em",
+      flex: 1,
+      minWidth: 0
+    }),
+    []
+  );
+
+  const iconForTypeContainerStyle = useMemo(
+    () => ({
+      borderRadius: `0 0 ${BORDER_RADIUS.xs} 0`,
+      marginLeft: "0",
+      marginTop: "0"
+    }),
+    []
+  );
+
+  const iconForTypeBgStyle = useMemo(
+    () => ({
+      backgroundColor: theme.vars.palette.grey[900],
+      margin: "0",
+      padding: getSpacingPx(SPACING.micro), // was 1px
+      borderRadius: `0 0 ${BORDER_RADIUS.xs} 0`,
+      boxShadow: `inset 1px 1px 2px ${theme.vars.palette.action.disabledBackground}`,
+      width: "20px",
+      height: "20px"
+    }),
+    [theme.vars.palette.grey, theme.vars.palette.action.disabledBackground]
+  );
+
+  const iconForTypeSvgProps = useMemo(
+    () => ({ width: "15px", height: "15px" }),
+    []
+  );
+
+  const favoriteButtonSx = useMemo(
+    () => ({
+      padding: getSpacingPx(SPACING.micro),
+      marginLeft: "auto",
+      opacity: isFavorite ? 1 : 0.5,
+      color: isFavorite ? "warning.main" : "text.secondary",
+      "&:hover": {
+        backgroundColor: "action.hover",
+        opacity: 1
+      }
+    }),
+    [isFavorite]
+  );
+
+  const iconWithText = (
+    <>
+      <IconForType
+        iconName={outputType}
+        containerStyle={iconForTypeContainerStyle}
+        bgStyle={iconForTypeBgStyle}
+        svgProps={iconForTypeSvgProps}
+      />
+      <Text
+        size="small"
+        sx={{
+          lineHeight: 1.3,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis"
+        }}
+      >
+        <HighlightText
+          text={node.title}
+          query={searchTerm}
+          matchStyle="primary"
+        />
+      </Text>
+    </>
+  );
+
+  return (
+    <div
+      ref={ref}
+      className={`node ${isHovered ? "hovered" : ""} ${
+        showCheckbox && isSelected ? "selected" : ""
+      }`}
+      draggable={!showCheckbox}
+      onMouseEnter={onMouseEnter}
+      onDragStart={handleDragStart}
+      onDragEnd={onDragEnd}
+    >
+      <div
+        className="node-button"
+        role="button"
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            if (showCheckbox && onToggleSelection) {
+              onToggleSelection(node.node_type);
+            } else {
+              onClick(node);
+            }
+          }
+        }}
+        style={nodeButtonStyle}
+      >
+        {showCheckbox && (
+          <div style={checkboxContainerStyle}>
+            {isSelected && (
+              <CheckIcon
+                sx={{
+                  fontSize: "var(--fontSizeBig)",
+                  color: theme.vars.palette.primary.main,
+                  padding: getSpacingPx(SPACING.micro)
+                }}
               />
             )}
           </div>
-        </div>
-      );
-    }
-  )
-);
-
-NodeItem.displayName = "NodeItem";
+        )}
+        {showDescriptionTooltip ? (
+          <Tooltip
+            title={tooltipContent}
+            placement="right"
+            delay={TOOLTIP_ENTER_DELAY}
+            slotProps={{
+              popper: { sx: { zIndex: theme.zIndex.commandMenu } },
+              tooltip: {
+                sx: {
+                  bgcolor: "grey.800",
+                  color: "grey.100",
+                  maxWidth: 350,
+                  padding: getSpacingPx(SPACING.xl)
+                }
+              }
+            }}
+          >
+            <div style={iconContainerStyle}>{iconWithText}</div>
+          </Tooltip>
+        ) : (
+          <div style={iconContainerStyle}>{iconWithText}</div>
+        )}
+        {hasRuntimeDeps && (
+          <Tooltip
+            title={`Requires: ${node.required_runtimes!.join(", ")}`}
+            placement="top"
+            delay={TOOLTIP_ENTER_DELAY}
+            slotProps={{
+              popper: { sx: { zIndex: theme.zIndex.tooltip } },
+              tooltip: {
+                sx: {
+                  bgcolor: "grey.800",
+                  color: "grey.100",
+                  fontSize: "var(--fontSizeSmaller)"
+                }
+              }
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                fontSize: "var(--fontSizeSmaller)",
+                fontWeight: FONT_WEIGHT.semibold,
+                textTransform: "uppercase",
+                bgcolor: `color-mix(in srgb, ${theme.vars.palette.warning.main} 20%, transparent)`,
+                color: theme.vars.palette.warning.main,
+                px: SPACING.micro,
+                py: SPACING.micro,
+                borderRadius: BORDER_RADIUS.sm,
+                whiteSpace: "nowrap",
+                flexShrink: 0
+              }}
+            >
+              {node.required_runtimes!.join(", ")}
+            </Box>
+          </Tooltip>
+        )}
+        {isSnippet && (
+          <Box
+            component="span"
+            sx={{
+              fontSize: "var(--fontSizeSmaller)",
+              fontWeight: FONT_WEIGHT.semibold,
+              fontFamily: "monospace",
+              letterSpacing: "0.03em",
+              bgcolor: `color-mix(in srgb, ${theme.vars.palette.info.main} 18%, transparent)`,
+              color: theme.vars.palette.info.main,
+              px: SPACING.micro,
+              py: SPACING.micro,
+              borderRadius: BORDER_RADIUS.sm,
+              whiteSpace: "nowrap",
+              flexShrink: 0
+            }}
+          >
+            JS
+          </Box>
+        )}
+        {showFavoriteButton && (
+          <ToolbarIconButton
+            icon={
+              isFavorite ? (
+                <StarIcon fontSize="small" />
+              ) : (
+                <StarBorderIcon fontSize="small" />
+              )
+            }
+            tooltip={isFavorite ? "Remove from favorites" : "Add to favorites"}
+            tooltipPlacement="top"
+            size="small"
+            onClick={handleFavoriteClick}
+            sx={favoriteButtonSx}
+            aria-label={
+              isFavorite
+                ? `Remove ${node.title} from favorites`
+                : `Add ${node.title} to favorites`
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+});
 
 export default NodeItem;

--- a/web/src/components/node_menu/SearchResultItem.tsx
+++ b/web/src/components/node_menu/SearchResultItem.tsx
@@ -1,9 +1,19 @@
 /** @jsxImportSource @emotion/react */
-import { memo, useCallback, forwardRef, useState, useMemo } from "react";
+import { memo, useCallback, useState, useMemo, type Ref } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Text, Box, Collapse, MOTION, BORDER_RADIUS, FONT_WEIGHT, Z_INDEX, SPACING, getSpacingPx } from "../ui_primitives";
+import {
+  Text,
+  Box,
+  Collapse,
+  MOTION,
+  BORDER_RADIUS,
+  FONT_WEIGHT,
+  Z_INDEX,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { NodeMetadata } from "../../stores/ApiTypes";
 import useNodeMenuStore from "../../stores/NodeMenuStore";
@@ -42,6 +52,7 @@ interface SearchResultItemProps {
    * space is narrow (~280 px). Default false.
    */
   compact?: boolean;
+  ref?: Ref<HTMLDivElement>;
 }
 
 const searchResultStyles = (theme: Theme, compact: boolean) =>
@@ -214,337 +225,316 @@ const searchResultStyles = (theme: Theme, compact: boolean) =>
     }
   });
 
-const SearchResultItem = memo(
-  forwardRef<HTMLDivElement, SearchResultItemProps>(
-    (
-      {
-        node,
-        onDragStart,
-        onDragEnd,
-        onClick,
-        isKeyboardSelected = false,
-        compact = false
-      },
-      ref
-    ) => {
-      const theme = useTheme();
-      const outputType =
-        node.outputs.length > 0 ? node.outputs[0].type.type : "";
-      const providerKind = getProviderKindForNamespace(node.namespace);
-      const searchTerm = useNodeMenuStore((state) => state.searchTerm);
-      const isFavorite = useFavoriteNodesStore((state) =>
-        state.isFavorite(node.node_type)
-      );
-      const toggleFavorite = useFavoriteNodesStore(
-        (state) => state.toggleFavorite
-      );
-      const addNotification = useNotificationStore(
-        (state) => state.addNotification
-      );
+const SearchResultItem = memo(function SearchResultItem({
+  node,
+  onDragStart,
+  onDragEnd,
+  onClick,
+  isKeyboardSelected = false,
+  compact = false,
+  ref
+}: SearchResultItemProps) {
+  const theme = useTheme();
+  const outputType = node.outputs.length > 0 ? node.outputs[0].type.type : "";
+  const providerKind = getProviderKindForNamespace(node.namespace);
+  const searchTerm = useNodeMenuStore((state) => state.searchTerm);
+  const isFavorite = useFavoriteNodesStore((state) =>
+    state.isFavorite(node.node_type)
+  );
+  const toggleFavorite = useFavoriteNodesStore((state) => state.toggleFavorite);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
 
-      const handleFavoriteToggle = useCallback(
-        (next: boolean) => {
-          toggleFavorite(node.node_type);
-          addNotification({
-            type: "info",
-            content: next
-              ? "Node added to favorites"
-              : "Node removed from favorites",
-            timeout: NOTIFICATION_TIMEOUT_SHORT
-          });
-        },
-        [toggleFavorite, addNotification, node.node_type]
-      );
+  const handleFavoriteToggle = useCallback(
+    (next: boolean) => {
+      toggleFavorite(node.node_type);
+      addNotification({
+        type: "info",
+        content: next
+          ? "Node added to favorites"
+          : "Node removed from favorites",
+        timeout: NOTIFICATION_TIMEOUT_SHORT
+      });
+    },
+    [toggleFavorite, addNotification, node.node_type]
+  );
 
-      const { description, tags } = useMemo(
-        () =>
-          formatNodeDocumentation(
-            node.description,
-            searchTerm,
-            node.searchInfo
-          ),
-        [node.description, searchTerm, node.searchInfo]
-      );
+  const { description, tags } = useMemo(
+    () =>
+      formatNodeDocumentation(node.description, searchTerm, node.searchInfo),
+    [node.description, searchTerm, node.searchInfo]
+  );
 
-      const matchingTags = useMemo(() => {
-        if (!searchTerm) {
-          return [];
-        }
-        const searchLower = searchTerm.toLowerCase();
-        return tags.filter((tag) => tag.toLowerCase().includes(searchLower));
-      }, [searchTerm, tags]);
+  const matchingTags = useMemo(() => {
+    if (!searchTerm) {
+      return [];
+    }
+    const searchLower = searchTerm.toLowerCase();
+    return tags.filter((tag) => tag.toLowerCase().includes(searchLower));
+  }, [searchTerm, tags]);
 
-      const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
-      const handleClick = useCallback(() => {
+  const handleClick = useCallback(() => {
+    onClick(node);
+  }, [onClick, node]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
         onClick(node);
-      }, [onClick, node]);
+      }
+    },
+    [onClick, node]
+  );
 
-      const handleKeyDown = useCallback(
-        (e: React.KeyboardEvent) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onClick(node);
-          }
-        },
-        [onClick, node]
-      );
+  const handleToggleExpand = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsExpanded((prev) => !prev);
+  }, []);
 
-      const handleToggleExpand = useCallback((e: React.MouseEvent) => {
-        e.stopPropagation();
-        setIsExpanded((prev) => !prev);
-      }, []);
+  const handleExpandKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsExpanded((prev) => !prev);
+    }
+  }, []);
 
-      const handleExpandKeyDown = useCallback(
-        (e: React.KeyboardEvent) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            e.stopPropagation();
-            setIsExpanded((prev) => !prev);
-          }
-        },
-        []
-      );
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      onDragStart(node, event);
+    },
+    [onDragStart, node]
+  );
 
-      const handleDragStart = useCallback(
-        (event: React.DragEvent<HTMLDivElement>) => {
-          onDragStart(node, event);
-        },
-        [onDragStart, node]
-      );
+  const compactBgStyle = useMemo(
+    () => ({
+      backgroundColor: theme.vars.palette.grey[900],
+      width: "18px",
+      height: "18px",
+      margin: 0,
+      padding: getSpacingPx(SPACING.micro),
+      borderRadius: BORDER_RADIUS.sm
+    }),
+    [theme.vars.palette.grey[900]]
+  );
 
-      const compactBgStyle = useMemo(
-        () => ({
-          backgroundColor: theme.vars.palette.grey[900],
-          width: "18px",
-          height: "18px",
-          margin: 0,
-          padding: getSpacingPx(SPACING.micro),
-          borderRadius: BORDER_RADIUS.sm
-        }),
-        [theme.vars.palette.grey[900]]
-      );
+  const expandedContainerStyle = useMemo(
+    () => ({
+      marginLeft: "0",
+      marginTop: "0"
+    }),
+    []
+  );
 
-      const expandedContainerStyle = useMemo(
-        () => ({
-          marginLeft: "0",
-          marginTop: "0"
-        }),
-        []
-      );
+  const expandedBgStyle = useMemo(
+    () => ({
+      backgroundColor: theme.vars.palette.action.hover,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      margin: "0",
+      padding: getSpacingPx(SPACING.xs),
+      borderRadius: BORDER_RADIUS.md,
+      width: "28px",
+      height: "28px"
+    }),
+    [theme.vars.palette.action.hover, theme.vars.palette.divider]
+  );
 
-      const expandedBgStyle = useMemo(
-        () => ({
-          backgroundColor: theme.vars.palette.action.hover,
-          border: `1px solid ${theme.vars.palette.divider}`,
-          margin: "0",
-          padding: getSpacingPx(SPACING.xs),
-          borderRadius: BORDER_RADIUS.md,
-          width: "28px",
-          height: "28px"
-        }),
-        [theme.vars.palette.action.hover, theme.vars.palette.divider]
-      );
+  const cssStyles = useMemo(
+    () => searchResultStyles(theme, compact),
+    [theme, compact]
+  );
 
-      const cssStyles = useMemo(
-        () => searchResultStyles(theme, compact),
-        [theme, compact]
-      );
+  const providerTagStyle = useMemo(
+    () => ({
+      color:
+        providerKind === "api"
+          ? theme.vars.palette.c_provider_api
+          : theme.vars.palette.c_provider_local
+    }),
+    [
+      providerKind,
+      theme.vars.palette.c_provider_api,
+      theme.vars.palette.c_provider_local
+    ]
+  );
 
-      const providerTagStyle = useMemo(
-        () => ({
-          color:
-            providerKind === "api"
-              ? theme.vars.palette.c_provider_api
-              : theme.vars.palette.c_provider_local
-        }),
-        [providerKind, theme.vars.palette.c_provider_api, theme.vars.palette.c_provider_local]
-      );
+  if (compact) {
+    return (
+      <div
+        ref={ref}
+        className={`search-result-item ${isKeyboardSelected ? "keyboard-selected" : ""}`}
+        css={cssStyles}
+        role="button"
+        tabIndex={0}
+        draggable
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onDragStart={handleDragStart}
+        onDragEnd={onDragEnd}
+      >
+        <IconForType
+          iconName={outputType}
+          bgStyle={compactBgStyle}
+          svgProps={COMPACT_SVG_PROPS}
+        />
+        <Text className="result-title" component="div" sx={COMPACT_TITLE_SX}>
+          <HighlightText
+            text={node.title}
+            query={searchTerm}
+            matchStyle="primary"
+          />
+        </Text>
+        <span className="provider-tag" style={providerTagStyle}>
+          {providerKind === "api" ? "API" : "Local"}
+        </span>
+        <FavoriteButton
+          isFavorite={isFavorite}
+          onToggle={handleFavoriteToggle}
+          buttonSize="small"
+        />
+      </div>
+    );
+  }
 
-      if (compact) {
-        return (
-          <div
-            ref={ref}
-            className={`search-result-item ${isKeyboardSelected ? "keyboard-selected" : ""}`}
-            css={cssStyles}
-            role="button"
-            tabIndex={0}
-            draggable
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
-            onDragStart={handleDragStart}
-            onDragEnd={onDragEnd}
-          >
+  return (
+    <div
+      ref={ref}
+      className={`search-result-item ${isExpanded ? "expanded" : ""} ${isKeyboardSelected ? "keyboard-selected" : ""}`}
+      css={cssStyles}
+      role="button"
+      tabIndex={0}
+      draggable
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onDragStart={handleDragStart}
+      onDragEnd={onDragEnd}
+    >
+      <div className="result-header">
+        <div className="result-main">
+          <div className="result-title-row">
             <IconForType
               iconName={outputType}
-              bgStyle={compactBgStyle}
-              svgProps={COMPACT_SVG_PROPS}
+              containerStyle={expandedContainerStyle}
+              bgStyle={expandedBgStyle}
+              svgProps={EXPANDED_SVG_PROPS}
             />
-            <Text
-              className="result-title"
-              component="div"
-              sx={COMPACT_TITLE_SX}
-            >
+            <Text className="result-title" component="div">
               <HighlightText
                 text={node.title}
                 query={searchTerm}
                 matchStyle="primary"
               />
             </Text>
-            <span
-              className="provider-tag"
-              style={providerTagStyle}
-            >
+            {matchingTags.length > 0 && (
+              <div className="matched-tags-inline">
+                {matchingTags.slice(0, 2).map((tag, idx) => (
+                  <span
+                    key={`${node.node_type}-tag-${tag}-${idx}`}
+                    className="result-tag matched"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            <span className="provider-tag" style={providerTagStyle}>
               {providerKind === "api" ? "API" : "Local"}
             </span>
-            <FavoriteButton
-              isFavorite={isFavorite}
-              onToggle={handleFavoriteToggle}
-              buttonSize="small"
-            />
           </div>
-        );
-      }
-
-      return (
-        <div
-          ref={ref}
-          className={`search-result-item ${isExpanded ? "expanded" : ""} ${isKeyboardSelected ? "keyboard-selected" : ""}`}
-          css={cssStyles}
-          role="button"
-          tabIndex={0}
-          draggable
-          onClick={handleClick}
-          onKeyDown={handleKeyDown}
-          onDragStart={handleDragStart}
-          onDragEnd={onDragEnd}
-        >
-          <div className="result-header">
-            <div className="result-main">
-              <div className="result-title-row">
-                <IconForType
-                  iconName={outputType}
-                  containerStyle={expandedContainerStyle}
-                  bgStyle={expandedBgStyle}
-                  svgProps={EXPANDED_SVG_PROPS}
-                />
-                <Text className="result-title" component="div">
-                  <HighlightText
-                    text={node.title}
-                    query={searchTerm}
-                    matchStyle="primary"
-                  />
-                </Text>
-                {matchingTags.length > 0 && (
-                  <div className="matched-tags-inline">
-                    {matchingTags.slice(0, 2).map((tag, idx) => (
-                      <span key={`${node.node_type}-tag-${tag}-${idx}`} className="result-tag matched">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <span
-                  className="provider-tag"
-                  style={providerTagStyle}
-                >
-                  {providerKind === "api" ? "API" : "Local"}
-                </span>
-              </div>
-            </div>
-            <div className="result-header-right">
-              <Text className="result-namespace" component="div">
-                <HighlightText
-                  text={node.namespace}
-                  query={searchTerm}
-                  matchStyle="primary"
-                />
-              </Text>
-              <FavoriteButton
-                isFavorite={isFavorite}
-                onToggle={handleFavoriteToggle}
-                buttonSize="small"
-              />
-              <div
-                className={`expand-indicator ${isExpanded ? "expanded" : ""}`}
-                role="button"
-                tabIndex={0}
-                onClick={handleToggleExpand}
-                onKeyDown={handleExpandKeyDown}
-                aria-expanded={isExpanded}
-                aria-label={isExpanded ? "Collapse details" : "Show details"}
-                title={isExpanded ? "Collapse details" : "Show details"}
-              >
-                <ExpandMoreIcon />
-              </div>
-            </div>
-          </div>
-
-          {description && (
-            <Text className="result-description" component="div">
-              <HighlightText
-                text={description}
-                query={searchTerm}
-                matchStyle="primary"
-              />
-            </Text>
-          )}
-
-          {/* Input/Output info - click to expand (absolutely positioned overlay) */}
-          <Collapse in={isExpanded} timeout={150} className="io-info-wrapper">
-            <Box className="io-info">
-              {node.properties.length > 0 && (
-                <Box className="io-row">
-                  <span className="io-label">Input:</span>
-                  <Box className="io-items">
-                    {node.properties.slice(0, 6).map((prop) => (
-                      <span
-                        key={prop.name}
-                        className="io-item"
-                        style={{
-                          borderColor: colorForType(prop.type.type)
-                        }}
-                      >
-                        {prop.name}
-                      </span>
-                    ))}
-                    {node.properties.length > 6 && (
-                      <span
-                        className="io-item"
-                        style={{ borderColor: "var(--palette-grey-500)" }}
-                      >
-                        +{node.properties.length - 6}
-                      </span>
-                    )}
-                  </Box>
-                </Box>
-              )}
-              {node.outputs.length > 0 && (
-                <Box className="io-row">
-                  <span className="io-label">Output:</span>
-                  <Box className="io-items">
-                    {node.outputs.map((output) => (
-                      <span
-                        key={output.name}
-                        className="io-item"
-                        style={{
-                          borderColor: colorForType(output.type.type)
-                        }}
-                      >
-                        {output.type.type}
-                      </span>
-                    ))}
-                  </Box>
-                </Box>
-              )}
-            </Box>
-          </Collapse>
         </div>
-      );
-    }
-  )
-);
+        <div className="result-header-right">
+          <Text className="result-namespace" component="div">
+            <HighlightText
+              text={node.namespace}
+              query={searchTerm}
+              matchStyle="primary"
+            />
+          </Text>
+          <FavoriteButton
+            isFavorite={isFavorite}
+            onToggle={handleFavoriteToggle}
+            buttonSize="small"
+          />
+          <div
+            className={`expand-indicator ${isExpanded ? "expanded" : ""}`}
+            role="button"
+            tabIndex={0}
+            onClick={handleToggleExpand}
+            onKeyDown={handleExpandKeyDown}
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? "Collapse details" : "Show details"}
+            title={isExpanded ? "Collapse details" : "Show details"}
+          >
+            <ExpandMoreIcon />
+          </div>
+        </div>
+      </div>
 
-SearchResultItem.displayName = "SearchResultItem";
+      {description && (
+        <Text className="result-description" component="div">
+          <HighlightText
+            text={description}
+            query={searchTerm}
+            matchStyle="primary"
+          />
+        </Text>
+      )}
+
+      {/* Input/Output info - click to expand (absolutely positioned overlay) */}
+      <Collapse in={isExpanded} timeout={150} className="io-info-wrapper">
+        <Box className="io-info">
+          {node.properties.length > 0 && (
+            <Box className="io-row">
+              <span className="io-label">Input:</span>
+              <Box className="io-items">
+                {node.properties.slice(0, 6).map((prop) => (
+                  <span
+                    key={prop.name}
+                    className="io-item"
+                    style={{
+                      borderColor: colorForType(prop.type.type)
+                    }}
+                  >
+                    {prop.name}
+                  </span>
+                ))}
+                {node.properties.length > 6 && (
+                  <span
+                    className="io-item"
+                    style={{ borderColor: "var(--palette-grey-500)" }}
+                  >
+                    +{node.properties.length - 6}
+                  </span>
+                )}
+              </Box>
+            </Box>
+          )}
+          {node.outputs.length > 0 && (
+            <Box className="io-row">
+              <span className="io-label">Output:</span>
+              <Box className="io-items">
+                {node.outputs.map((output) => (
+                  <span
+                    key={output.name}
+                    className="io-item"
+                    style={{
+                      borderColor: colorForType(output.type.type)
+                    }}
+                  >
+                    {output.type.type}
+                  </span>
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+    </div>
+  );
+});
 
 export default SearchResultItem;

--- a/web/src/components/portal/dashboardChrome.tsx
+++ b/web/src/components/portal/dashboardChrome.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import { forwardRef, memo, type ReactNode } from "react";
+import { memo, type ReactNode, type Ref } from "react";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 
 /** Shared horizontal rhythm for the dashboard: a centered column that the hero
@@ -138,70 +138,71 @@ interface DashboardSearchBoxProps {
   placeholder: string;
   kbd?: string;
   "aria-label": string;
+  ref?: Ref<HTMLInputElement>;
 }
 
-export const DashboardSearchBox = memo(
-  forwardRef<HTMLInputElement, DashboardSearchBoxProps>(
-    function DashboardSearchBox(
-      { value, onChange, placeholder, kbd, "aria-label": ariaLabel },
-      ref
-    ) {
-      const theme = useTheme();
-      const hasValue = value.length > 0;
-      return (
-        <label css={searchStyles(theme)}>
+export const DashboardSearchBox = memo(function DashboardSearchBox({
+  value,
+  onChange,
+  placeholder,
+  kbd,
+  "aria-label": ariaLabel,
+  ref
+}: DashboardSearchBoxProps) {
+  const theme = useTheme();
+  const hasValue = value.length > 0;
+  return (
+    <label css={searchStyles(theme)}>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <circle cx="7" cy="7" r="4.5" />
+        <path d="m10.5 10.5 3 3" />
+      </svg>
+      <input
+        ref={ref}
+        value={value}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape" && hasValue) {
+            e.stopPropagation();
+            onChange("");
+          }
+        }}
+      />
+      {hasValue ? (
+        <button
+          type="button"
+          className="search-clear"
+          aria-label="Clear search"
+          // Keep focus in the input so typing can continue immediately.
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onChange("")}
+        >
           <svg
-            width="14"
-            height="14"
+            width="11"
+            height="11"
             viewBox="0 0 16 16"
             fill="none"
             stroke="currentColor"
-            strokeWidth="1.5"
+            strokeWidth="1.6"
           >
-            <circle cx="7" cy="7" r="4.5" />
-            <path d="m10.5 10.5 3 3" />
+            <path d="m4 4 8 8M12 4l-8 8" />
           </svg>
-          <input
-            ref={ref}
-            value={value}
-            placeholder={placeholder}
-            aria-label={ariaLabel}
-            onChange={(e) => onChange(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape" && hasValue) {
-                e.stopPropagation();
-                onChange("");
-              }
-            }}
-          />
-          {hasValue ? (
-            <button
-              type="button"
-              className="search-clear"
-              aria-label="Clear search"
-              // Keep focus in the input so typing can continue immediately.
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => onChange("")}
-            >
-              <svg
-                width="11"
-                height="11"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.6"
-              >
-                <path d="m4 4 8 8M12 4l-8 8" />
-              </svg>
-            </button>
-          ) : (
-            kbd && <span className="kbd">{kbd}</span>
-          )}
-        </label>
-      );
-    }
-  )
-);
+        </button>
+      ) : (
+        kbd && <span className="kbd">{kbd}</span>
+      )}
+    </label>
+  );
+});
 
 /** Small "Browse all →" style link used in section headers. */
 const linkStyles = (theme: Theme) =>

--- a/web/src/components/properties/shared/ModelSelectButton.tsx
+++ b/web/src/components/properties/shared/ModelSelectButton.tsx
@@ -1,9 +1,20 @@
-import React, { forwardRef, memo } from "react";
+import React, { memo } from "react";
 import type { SxProps, Theme } from "@mui/material";
 import { TOOLTIP_ENTER_DELAY } from "../../../config/constants";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useEditorScope } from "../../editor_ui";
-import { FlexColumn, FlexRow, Text, Caption, Tooltip, EditorButton, MOTION, SPACING, getSpacingPx, BORDER_RADIUS } from "../../ui_primitives";
+import {
+  FlexColumn,
+  FlexRow,
+  Text,
+  Caption,
+  Tooltip,
+  EditorButton,
+  MOTION,
+  SPACING,
+  getSpacingPx,
+  BORDER_RADIUS
+} from "../../ui_primitives";
 
 interface ModelSelectButtonProps {
   label: React.ReactNode;
@@ -14,133 +25,130 @@ interface ModelSelectButtonProps {
   className?: string;
   tooltipTitle?: React.ReactNode;
   sx?: SxProps<Theme>;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const ModelSelectButton = memo(forwardRef<HTMLButtonElement, ModelSelectButtonProps>(
-  ({
-    label,
-    secondaryLabel,
-    subLabel,
-    onClick,
-    active,
-    className,
-    tooltipTitle,
-    sx,
-  },
-    ref
-  ) => {
-    const scope = useEditorScope();
+function ModelSelectButton({
+  label,
+  secondaryLabel,
+  subLabel,
+  onClick,
+  active,
+  className,
+  tooltipTitle,
+  sx,
+  ref
+}: ModelSelectButtonProps) {
+  const scope = useEditorScope();
 
-    return (
-      <Tooltip
-        title={
-          tooltipTitle || (
-            <FlexColumn gap={0.5} sx={{ textAlign: "center" }}>
-              <Text>{label}</Text>
-              {secondaryLabel && (
-                <Caption size="smaller">{secondaryLabel}</Caption>
-              )}
-              {subLabel && (
-                <Caption size="smaller" color="secondary">
-                  {subLabel}
-                </Caption>
-              )}
-            </FlexColumn>
-          )
-        }
-        delay={TOOLTIP_ENTER_DELAY * 2}
-        nextDelay={TOOLTIP_ENTER_DELAY * 2}
-        slotProps={{
-          tooltip: {
-            sx: {
-              maxWidth: "350px !important"
-            }
-          }
-        }}
-      >
-        <EditorButton
-          ref={ref}
-          className={`select-model-button ${className || ""} ${active ? "active" : ""
-            }`}
-          sx={{
-            border: "1px solid var(--palette-divider)",
-            backgroundColor: active
-              ? "var(--palette-action-selected)"
-              : "var(--palette-Paper-overlay)",
-            borderRadius: BORDER_RADIUS.sm,
-            color: "var(--palette-text-primary)",
-            textTransform: "none",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            lineHeight: 1.2,
-            minHeight: "28px",
-            height: "auto",
-            padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
-            width: "100%",
-            transition: MOTION.all,
-            "&:hover": {
-              backgroundColor: "var(--palette-action-hover)",
-              borderColor: "var(--palette-text-secondary)"
-            },
-            ...sx
-          }}
-          onClick={onClick}
-          size="small"
-        >
-          <FlexRow
-            className="model-select-button-label"
-            gap={1}
-            align="center"
-            sx={{
-              textAlign: "left",
-              flexGrow: 1,
-              overflow: "hidden",
-              marginRight: getSpacingPx(SPACING.xs)
-            }}
-          >
-            <Text
-              className="model-select-button-label-text"
-              size={scope === "inspector" ? "normal" : "small"}
-              weight={active ? 500 : 400}
-              truncate
-              sx={{
-                flexShrink: 1,
-                minWidth: 0
-              }}
-            >
-              {label}
-            </Text>
+  return (
+    <Tooltip
+      title={
+        tooltipTitle || (
+          <FlexColumn gap={0.5} sx={{ textAlign: "center" }}>
+            <Text>{label}</Text>
             {secondaryLabel && (
-              <Caption
-                className="model-select-button-label-text-secondary"
-                size={scope === "inspector" ? "small" : "smaller"}
-                sx={{
-                  opacity: 0.6,
-                  flexShrink: 0,
-                  whiteSpace: "nowrap"
-                }}
-              >
-                {secondaryLabel}
+              <Caption size="smaller">{secondaryLabel}</Caption>
+            )}
+            {subLabel && (
+              <Caption size="smaller" color="secondary">
+                {subLabel}
               </Caption>
             )}
-          </FlexRow>
-          <ExpandMoreIcon
+          </FlexColumn>
+        )
+      }
+      delay={TOOLTIP_ENTER_DELAY * 2}
+      nextDelay={TOOLTIP_ENTER_DELAY * 2}
+      slotProps={{
+        tooltip: {
+          sx: {
+            maxWidth: "350px !important"
+          }
+        }
+      }}
+    >
+      <EditorButton
+        ref={ref}
+        className={`select-model-button ${className || ""} ${
+          active ? "active" : ""
+        }`}
+        sx={{
+          border: "1px solid var(--palette-divider)",
+          backgroundColor: active
+            ? "var(--palette-action-selected)"
+            : "var(--palette-Paper-overlay)",
+          borderRadius: BORDER_RADIUS.sm,
+          color: "var(--palette-text-primary)",
+          textTransform: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          lineHeight: 1.2,
+          minHeight: "28px",
+          height: "auto",
+          padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
+          width: "100%",
+          transition: MOTION.all,
+          "&:hover": {
+            backgroundColor: "var(--palette-action-hover)",
+            borderColor: "var(--palette-text-secondary)"
+          },
+          ...sx
+        }}
+        onClick={onClick}
+        size="small"
+      >
+        <FlexRow
+          className="model-select-button-label"
+          gap={1}
+          align="center"
+          sx={{
+            textAlign: "left",
+            flexGrow: 1,
+            overflow: "hidden",
+            marginRight: getSpacingPx(SPACING.xs)
+          }}
+        >
+          <Text
+            className="model-select-button-label-text"
+            size={scope === "inspector" ? "normal" : "small"}
+            weight={active ? 500 : 400}
+            truncate
             sx={{
-              fontSize: 14,
-              color: "inherit",
-              opacity: 0.7,
-              flexShrink: 0,
-              ml: 0,
-              mr: `-${getSpacingPx(SPACING.xs)}`
+              flexShrink: 1,
+              minWidth: 0
             }}
-          />
-        </EditorButton>
-      </Tooltip>
-    );
-  }
-));
+          >
+            {label}
+          </Text>
+          {secondaryLabel && (
+            <Caption
+              className="model-select-button-label-text-secondary"
+              size={scope === "inspector" ? "small" : "smaller"}
+              sx={{
+                opacity: 0.6,
+                flexShrink: 0,
+                whiteSpace: "nowrap"
+              }}
+            >
+              {secondaryLabel}
+            </Caption>
+          )}
+        </FlexRow>
+        <ExpandMoreIcon
+          sx={{
+            fontSize: 14,
+            color: "inherit",
+            opacity: 0.7,
+            flexShrink: 0,
+            ml: 0,
+            mr: `-${getSpacingPx(SPACING.xs)}`
+          }}
+        />
+      </EditorButton>
+    </Tooltip>
+  );
+}
 
-ModelSelectButton.displayName = "ModelSelectButton";
-
-export default ModelSelectButton;
+export default memo(ModelSelectButton);

--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -11,13 +11,7 @@
  * - `SketchCanvasPresentation` — stacked canvas JSX, chrome, info bar
  */
 
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  forwardRef
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import type { Asset } from "../../stores/ApiTypes";
 import {
   deserializeDragData,
@@ -230,376 +224,375 @@ export interface SketchCanvasProps {
   // ── Layout / testing ───────────────────────────────────────────────
   /** Merged onto the root container (e.g. for layout hooks / E2E). */
   className?: string;
+  ref?: React.Ref<SketchCanvasRef>;
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-const SketchCanvas = forwardRef<SketchCanvasRef, SketchCanvasProps>(
-  function SketchCanvas(props, ref) {
-    const {
-      document: doc,
-      activeTool,
-      interactionTool,
-      zoom,
-      pan,
-      mirrorX,
-      mirrorY,
-      symmetryMode,
-      symmetryRays,
-      isolatedLayerId,
-      onZoomChange,
-      onPanChange,
-      onStrokeStart,
-      onStrokeEnd,
-      onLayerTransformChange,
-      onLayerContentBoundsChange,
-      onBrushSizeChange,
-      onContextMenu,
-      onTransformContextMenu,
-      onCropComplete,
-      onEyedropperPick,
-      selection,
-      selectionPreviewMode,
-      onSelectionChange,
-      onAutoPickLayer,
-      foregroundColor,
-      className: rootClassName,
-      onCanvasLeave,
-      onDropImage,
-      onDropAsset,
-      onCanvasResizeStart,
-      onCanvasResize
-    } = props;
+function SketchCanvas({ ref, ...props }: SketchCanvasProps) {
+  const {
+    document: doc,
+    activeTool,
+    interactionTool,
+    zoom,
+    pan,
+    mirrorX,
+    mirrorY,
+    symmetryMode,
+    symmetryRays,
+    isolatedLayerId,
+    onZoomChange,
+    onPanChange,
+    onStrokeStart,
+    onStrokeEnd,
+    onLayerTransformChange,
+    onLayerContentBoundsChange,
+    onBrushSizeChange,
+    onContextMenu,
+    onTransformContextMenu,
+    onCropComplete,
+    onEyedropperPick,
+    selection,
+    selectionPreviewMode,
+    onSelectionChange,
+    onAutoPickLayer,
+    foregroundColor,
+    className: rootClassName,
+    onCanvasLeave,
+    onDropImage,
+    onDropAsset,
+    onCanvasResizeStart,
+    onCanvasResize
+  } = props;
 
-    // Subscribe to live toolSettings directly so that brush/color changes trigger
-    // only a SketchCanvas re-render (not a compositing cascade). The bare `doc`
-    // prop is intentionally passed to useCompositing so that compositing effects
-    // do not fire on every slider tick.
-    const liveToolSettings = useSketchStore((s) => s.toolSettings);
-    const docWithTools = useMemo(
-      () => ({ ...doc, toolSettings: liveToolSettings }),
-      [doc, liveToolSettings]
-    );
+  // Subscribe to live toolSettings directly so that brush/color changes trigger
+  // only a SketchCanvas re-render (not a compositing cascade). The bare `doc`
+  // prop is intentionally passed to useCompositing so that compositing effects
+  // do not fire on every slider tick.
+  const liveToolSettings = useSketchStore((s) => s.toolSettings);
+  const docWithTools = useMemo(
+    () => ({ ...doc, toolSettings: liveToolSettings }),
+    [doc, liveToolSettings]
+  );
 
-    // ─── Transform preview bridge ──────────────────────────────────────
+  // ─── Transform preview bridge ──────────────────────────────────────
 
-    const coordinatorRef = useRef<DisplayFrameCoordinator | null>(null);
-    if (!coordinatorRef.current) {
-      coordinatorRef.current = new DisplayFrameCoordinator();
-    }
-
-    const {
-      transformPreviewByLayerIdRef,
-      requestPreviewRedrawRef,
-      invalidateLayerRef,
-      setLayerTransformPreview,
-      clearLayerTransformPreview
-    } = useTransformPreviewBridge({ coordinatorRef });
-
-    // ─── Canvas orchestration (refs, compositing, overlay, pointer) ────
-
-    const {
-      containerRef,
-      selectionGpuCanvasRef,
-      selectionCanvasRef,
-      cursorCanvasRef,
-      gizmoCanvasRef,
-      lastPointerClientRef,
-      compositing,
-      overlay,
-      pointerHandlers
-    } = useCanvasOrchestration({
-      doc,
-      docWithTools,
-      activeTool,
-      interactionTool,
-      zoom,
-      pan,
-      mirrorX,
-      mirrorY,
-      symmetryMode,
-      symmetryRays,
-      selection,
-      selectionPreviewMode,
-      isolatedLayerId,
-      foregroundColor,
-      transformPreviewByLayerIdRef,
-      requestPreviewRedrawRef,
-      invalidateLayerRef,
-      coordinatorRef,
-      setLayerTransformPreview,
-      clearLayerTransformPreview,
-      onZoomChange,
-      onPanChange,
-      onStrokeStart,
-      onStrokeEnd,
-      onLayerTransformChange,
-      onLayerContentBoundsChange,
-      onBrushSizeChange,
-      onContextMenu,
-      onTransformContextMenu,
-      onCropComplete,
-      onEyedropperPick,
-      onSelectionChange,
-      onAutoPickLayer,
-      onCanvasLeave
-    });
-
-    // ─── Drag-and-drop image import ─────────────────────────────────
-
-    const handleDragOver = useCallback((e: React.DragEvent) => {
-      if (
-        e.dataTransfer.types.includes("Files") ||
-        e.dataTransfer.types.includes(DRAG_DATA_MIME) ||
-        e.dataTransfer.types.includes("asset")
-      ) {
-        e.preventDefault();
-        e.dataTransfer.dropEffect = "copy";
-      }
-    }, []);
-
-    const handleDrop = useCallback(
-      (e: React.DragEvent) => {
-        e.preventDefault();
-        const dragData = deserializeDragData(e.dataTransfer);
-        const draggedAsset =
-          dragData?.type === "asset" ? (dragData.payload as Asset) : null;
-        if (
-          draggedAsset &&
-          draggedAsset.content_type.startsWith("image/") &&
-          onDropAsset
-        ) {
-          onDropAsset(draggedAsset);
-          return;
-        }
-        const file = Array.from(e.dataTransfer.files).find((f) =>
-          f.type.startsWith("image/")
-        );
-        if (file && onDropImage) {
-          onDropImage(file);
-        }
-      },
-      [onDropAsset, onDropImage]
-    );
-
-    // ─── Imperative handle ──────────────────────────────────────────────
-
-    useCanvasImperativeHandle({
-      ref,
-      doc,
-      runtime: compositing.runtime,
-      containerRef,
-      displayCanvasRef: compositing.displayCanvasRef,
-      overlayCanvasRef: compositing.overlayCanvasRef,
-      redraw: compositing.redraw,
-      drainPendingStrokeCommit: compositing.drainPendingStrokeCommit,
-      zoom,
-      lastPointerClientRef,
-      cancelActiveTool: pointerHandlers.cancelActiveTool,
-      commitPendingCrop: pointerHandlers.commitPendingCrop
-    });
-
-    // ─── Redraw cursor when tool settings change ──────────────────────
-    // When brush size/hardness/etc. change via sliders or keyboard shortcuts,
-    // the cursor ring must update immediately even without pointer movement.
-    useEffect(() => {
-      const client = lastPointerClientRef.current;
-      if (client) {
-        overlay.drawCursor(client.x, client.y);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [overlay.drawCursor]);
-
-    // ─── Document-space cursor tracking ─────────────────────────────────
-
-    // The document-space cursor lives in the store only (`cursorDocPos`), not
-    // in local state: pointer moves fire at 60–120+ Hz and a local setState
-    // here would re-render the whole canvas subtree per event. The store
-    // setter dedupes same-cell writes, and only the tiny readout components
-    // (status bar / info pill) subscribe to it.
-    const setStoreCursorDocPos = useSketchStore((s) => s.setCursorDocPos);
-    // The standalone editor (bound document) shows the full-width status bar,
-    // which subsumes the floating info pill — hide the pill there. The in-node
-    // modal (no documentId) keeps the pill.
-    const standaloneDocumentId = useSketchSessionStore((s) => s.documentId);
-
-    const updateCursorDocPosFromClient = useCallback(
-      (clientX: number, clientY: number) => {
-        const displayCanvas = compositing.displayCanvasRef.current;
-        if (displayCanvas) {
-          const rect = displayCanvas.getBoundingClientRect();
-          if (rect.width > 0 && rect.height > 0) {
-            const p = {
-              x: ((clientX - rect.left) / rect.width) * doc.canvas.width,
-              y: ((clientY - rect.top) / rect.height) * doc.canvas.height
-            };
-            setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
-            return;
-          }
-        }
-
-        const container = containerRef.current;
-        if (container) {
-          const rect = container.getBoundingClientRect();
-          const p = clientToDocumentCanvas(
-            clientX,
-            clientY,
-            rect,
-            zoom,
-            pan,
-            doc.canvas.width,
-            doc.canvas.height
-          );
-          setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
-        }
-      },
-      [
-        compositing.displayCanvasRef,
-        doc.canvas.width,
-        doc.canvas.height,
-        containerRef,
-        zoom,
-        pan,
-        setStoreCursorDocPos
-      ]
-    );
-
-    // `pointerHandlers` (from useCanvasOrchestration) is a fresh object each
-    // render, but the handlers inside it are useCallback-stable. Destructure
-    // the ones the wrappers below call so the wrappers depend on stable
-    // function identities, not the churning object — keeping SketchCanvas-
-    // Presentation's memoization intact.
-    const {
-      handlePointerDown: drawPointerDown,
-      handlePointerMove: drawPointerMove,
-      handlePointerUp: drawPointerUp,
-      cancelDrawing
-    } = pointerHandlers;
-
-    // Two-finger pan / pinch-zoom. Runs before the drawing handlers and, once a
-    // pinch begins, consumes the touch events so a gesture never paints. The
-    // hook returns a fresh object each render, so destructure the individually
-    // memoized handlers and depend on those (not the wrapper object) to keep
-    // the pointer callbacks stable for the memoized presentation layer.
-    const {
-      onPointerDown: onGesturePointerDown,
-      onPointerMove: onGesturePointerMove,
-      onPointerUp: onGesturePointerUp,
-      onPointerCancel: onGesturePointerCancel
-    } = useCanvasTouchGestures({
-      containerRef,
-      zoom,
-      pan,
-      onZoomChange,
-      onPanChange,
-      cancelDrawing
-    });
-
-    const handlePointerMoveWithCoords = useCallback(
-      (e: React.PointerEvent) => {
-        lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
-        if (onGesturePointerMove(e)) {
-          return;
-        }
-        drawPointerMove(e);
-        updateCursorDocPosFromClient(e.clientX, e.clientY);
-      },
-      [
-        lastPointerClientRef,
-        drawPointerMove,
-        onGesturePointerMove,
-        updateCursorDocPosFromClient
-      ]
-    );
-
-    const handlePointerDownWithClient = useCallback(
-      (e: React.PointerEvent) => {
-        lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
-        if (onGesturePointerDown(e)) {
-          return;
-        }
-        drawPointerDown(e);
-      },
-      [lastPointerClientRef, drawPointerDown, onGesturePointerDown]
-    );
-
-    const handlePointerUpWithGesture = useCallback(
-      (e: React.PointerEvent) => {
-        if (onGesturePointerUp(e)) {
-          return;
-        }
-        drawPointerUp(e);
-      },
-      [drawPointerUp, onGesturePointerUp]
-    );
-
-    // pointercancel (OS interrupts the touch, or pointer capture is lost) must
-    // tear down the gesture refs so a later touch isn't consumed by a stuck
-    // "always active" gesture. When it wasn't a gesture, the input sequence was
-    // aborted — discard the in-progress stroke via cancelDrawing() rather than
-    // committing it like a normal pointerup would.
-    const handlePointerCancelWithGesture = useCallback(
-      (e: React.PointerEvent) => {
-        if (onGesturePointerCancel(e)) {
-          return;
-        }
-        cancelDrawing();
-      },
-      [cancelDrawing, onGesturePointerCancel]
-    );
-
-    const handleMouseLeaveWithCoords = useCallback(() => {
-      pointerHandlers.handleMouseLeave();
-      setStoreCursorDocPos(null);
-    }, [pointerHandlers, setStoreCursorDocPos]);
-
-    // ─── Render ──────────────────────────────────────────────────────────
-
-    const transformTool = useMemo(() => {
-      const handler = getToolHandler("transform");
-      if (!(handler instanceof TransformTool)) {
-        throw new Error("Expected TransformTool singleton from tool registry");
-      }
-      return handler;
-    }, []);
-
-    return (
-      <SketchCanvasPresentation
-        containerRef={containerRef}
-        bootstrapDisplayRef={compositing.bootstrapDisplayRef}
-        displayCanvasRef={compositing.displayCanvasRef}
-        overlayCanvasRef={compositing.overlayCanvasRef}
-        selectionGpuCanvasRef={selectionGpuCanvasRef}
-        selectionCanvasRef={selectionCanvasRef}
-        cursorCanvasRef={cursorCanvasRef}
-        gizmoCanvasRef={gizmoCanvasRef}
-        transformTool={transformTool}
-        canvasWidth={doc.canvas.width}
-        canvasHeight={doc.canvas.height}
-        zoom={zoom}
-        pan={pan}
-        interactionTool={interactionTool}
-        bootstrapPhaseActive={compositing.bootstrapPhaseActive}
-        backend={compositing.backend}
-        showInfoBar={!standaloneDocumentId}
-        containerCursor={pointerHandlers.containerCursor}
-        onPointerDown={handlePointerDownWithClient}
-        onPointerMove={handlePointerMoveWithCoords}
-        onPointerUp={handlePointerUpWithGesture}
-        onPointerCancel={handlePointerCancelWithGesture}
-        onDoubleClick={pointerHandlers.handleDoubleClick}
-        onPointerLeave={pointerHandlers.handlePointerLeave}
-        onMouseLeave={handleMouseLeaveWithCoords}
-        onContextMenu={pointerHandlers.handleContextMenu}
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        onCanvasResizeStart={onCanvasResizeStart}
-        onCanvasResize={onCanvasResize}
-        className={rootClassName}
-        docOverlay={<GeneratingLayerOverlay />}
-      />
-    );
+  const coordinatorRef = useRef<DisplayFrameCoordinator | null>(null);
+  if (!coordinatorRef.current) {
+    coordinatorRef.current = new DisplayFrameCoordinator();
   }
-);
+
+  const {
+    transformPreviewByLayerIdRef,
+    requestPreviewRedrawRef,
+    invalidateLayerRef,
+    setLayerTransformPreview,
+    clearLayerTransformPreview
+  } = useTransformPreviewBridge({ coordinatorRef });
+
+  // ─── Canvas orchestration (refs, compositing, overlay, pointer) ────
+
+  const {
+    containerRef,
+    selectionGpuCanvasRef,
+    selectionCanvasRef,
+    cursorCanvasRef,
+    gizmoCanvasRef,
+    lastPointerClientRef,
+    compositing,
+    overlay,
+    pointerHandlers
+  } = useCanvasOrchestration({
+    doc,
+    docWithTools,
+    activeTool,
+    interactionTool,
+    zoom,
+    pan,
+    mirrorX,
+    mirrorY,
+    symmetryMode,
+    symmetryRays,
+    selection,
+    selectionPreviewMode,
+    isolatedLayerId,
+    foregroundColor,
+    transformPreviewByLayerIdRef,
+    requestPreviewRedrawRef,
+    invalidateLayerRef,
+    coordinatorRef,
+    setLayerTransformPreview,
+    clearLayerTransformPreview,
+    onZoomChange,
+    onPanChange,
+    onStrokeStart,
+    onStrokeEnd,
+    onLayerTransformChange,
+    onLayerContentBoundsChange,
+    onBrushSizeChange,
+    onContextMenu,
+    onTransformContextMenu,
+    onCropComplete,
+    onEyedropperPick,
+    onSelectionChange,
+    onAutoPickLayer,
+    onCanvasLeave
+  });
+
+  // ─── Drag-and-drop image import ─────────────────────────────────
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (
+      e.dataTransfer.types.includes("Files") ||
+      e.dataTransfer.types.includes(DRAG_DATA_MIME) ||
+      e.dataTransfer.types.includes("asset")
+    ) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const dragData = deserializeDragData(e.dataTransfer);
+      const draggedAsset =
+        dragData?.type === "asset" ? (dragData.payload as Asset) : null;
+      if (
+        draggedAsset &&
+        draggedAsset.content_type.startsWith("image/") &&
+        onDropAsset
+      ) {
+        onDropAsset(draggedAsset);
+        return;
+      }
+      const file = Array.from(e.dataTransfer.files).find((f) =>
+        f.type.startsWith("image/")
+      );
+      if (file && onDropImage) {
+        onDropImage(file);
+      }
+    },
+    [onDropAsset, onDropImage]
+  );
+
+  // ─── Imperative handle ──────────────────────────────────────────────
+
+  useCanvasImperativeHandle({
+    ref,
+    doc,
+    runtime: compositing.runtime,
+    containerRef,
+    displayCanvasRef: compositing.displayCanvasRef,
+    overlayCanvasRef: compositing.overlayCanvasRef,
+    redraw: compositing.redraw,
+    drainPendingStrokeCommit: compositing.drainPendingStrokeCommit,
+    zoom,
+    lastPointerClientRef,
+    cancelActiveTool: pointerHandlers.cancelActiveTool,
+    commitPendingCrop: pointerHandlers.commitPendingCrop
+  });
+
+  // ─── Redraw cursor when tool settings change ──────────────────────
+  // When brush size/hardness/etc. change via sliders or keyboard shortcuts,
+  // the cursor ring must update immediately even without pointer movement.
+  useEffect(() => {
+    const client = lastPointerClientRef.current;
+    if (client) {
+      overlay.drawCursor(client.x, client.y);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overlay.drawCursor]);
+
+  // ─── Document-space cursor tracking ─────────────────────────────────
+
+  // The document-space cursor lives in the store only (`cursorDocPos`), not
+  // in local state: pointer moves fire at 60–120+ Hz and a local setState
+  // here would re-render the whole canvas subtree per event. The store
+  // setter dedupes same-cell writes, and only the tiny readout components
+  // (status bar / info pill) subscribe to it.
+  const setStoreCursorDocPos = useSketchStore((s) => s.setCursorDocPos);
+  // The standalone editor (bound document) shows the full-width status bar,
+  // which subsumes the floating info pill — hide the pill there. The in-node
+  // modal (no documentId) keeps the pill.
+  const standaloneDocumentId = useSketchSessionStore((s) => s.documentId);
+
+  const updateCursorDocPosFromClient = useCallback(
+    (clientX: number, clientY: number) => {
+      const displayCanvas = compositing.displayCanvasRef.current;
+      if (displayCanvas) {
+        const rect = displayCanvas.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          const p = {
+            x: ((clientX - rect.left) / rect.width) * doc.canvas.width,
+            y: ((clientY - rect.top) / rect.height) * doc.canvas.height
+          };
+          setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
+          return;
+        }
+      }
+
+      const container = containerRef.current;
+      if (container) {
+        const rect = container.getBoundingClientRect();
+        const p = clientToDocumentCanvas(
+          clientX,
+          clientY,
+          rect,
+          zoom,
+          pan,
+          doc.canvas.width,
+          doc.canvas.height
+        );
+        setStoreCursorDocPos({ x: Math.floor(p.x), y: Math.floor(p.y) });
+      }
+    },
+    [
+      compositing.displayCanvasRef,
+      doc.canvas.width,
+      doc.canvas.height,
+      containerRef,
+      zoom,
+      pan,
+      setStoreCursorDocPos
+    ]
+  );
+
+  // `pointerHandlers` (from useCanvasOrchestration) is a fresh object each
+  // render, but the handlers inside it are useCallback-stable. Destructure
+  // the ones the wrappers below call so the wrappers depend on stable
+  // function identities, not the churning object — keeping SketchCanvas-
+  // Presentation's memoization intact.
+  const {
+    handlePointerDown: drawPointerDown,
+    handlePointerMove: drawPointerMove,
+    handlePointerUp: drawPointerUp,
+    cancelDrawing
+  } = pointerHandlers;
+
+  // Two-finger pan / pinch-zoom. Runs before the drawing handlers and, once a
+  // pinch begins, consumes the touch events so a gesture never paints. The
+  // hook returns a fresh object each render, so destructure the individually
+  // memoized handlers and depend on those (not the wrapper object) to keep
+  // the pointer callbacks stable for the memoized presentation layer.
+  const {
+    onPointerDown: onGesturePointerDown,
+    onPointerMove: onGesturePointerMove,
+    onPointerUp: onGesturePointerUp,
+    onPointerCancel: onGesturePointerCancel
+  } = useCanvasTouchGestures({
+    containerRef,
+    zoom,
+    pan,
+    onZoomChange,
+    onPanChange,
+    cancelDrawing
+  });
+
+  const handlePointerMoveWithCoords = useCallback(
+    (e: React.PointerEvent) => {
+      lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
+      if (onGesturePointerMove(e)) {
+        return;
+      }
+      drawPointerMove(e);
+      updateCursorDocPosFromClient(e.clientX, e.clientY);
+    },
+    [
+      lastPointerClientRef,
+      drawPointerMove,
+      onGesturePointerMove,
+      updateCursorDocPosFromClient
+    ]
+  );
+
+  const handlePointerDownWithClient = useCallback(
+    (e: React.PointerEvent) => {
+      lastPointerClientRef.current = { x: e.clientX, y: e.clientY };
+      if (onGesturePointerDown(e)) {
+        return;
+      }
+      drawPointerDown(e);
+    },
+    [lastPointerClientRef, drawPointerDown, onGesturePointerDown]
+  );
+
+  const handlePointerUpWithGesture = useCallback(
+    (e: React.PointerEvent) => {
+      if (onGesturePointerUp(e)) {
+        return;
+      }
+      drawPointerUp(e);
+    },
+    [drawPointerUp, onGesturePointerUp]
+  );
+
+  // pointercancel (OS interrupts the touch, or pointer capture is lost) must
+  // tear down the gesture refs so a later touch isn't consumed by a stuck
+  // "always active" gesture. When it wasn't a gesture, the input sequence was
+  // aborted — discard the in-progress stroke via cancelDrawing() rather than
+  // committing it like a normal pointerup would.
+  const handlePointerCancelWithGesture = useCallback(
+    (e: React.PointerEvent) => {
+      if (onGesturePointerCancel(e)) {
+        return;
+      }
+      cancelDrawing();
+    },
+    [cancelDrawing, onGesturePointerCancel]
+  );
+
+  const handleMouseLeaveWithCoords = useCallback(() => {
+    pointerHandlers.handleMouseLeave();
+    setStoreCursorDocPos(null);
+  }, [pointerHandlers, setStoreCursorDocPos]);
+
+  // ─── Render ──────────────────────────────────────────────────────────
+
+  const transformTool = useMemo(() => {
+    const handler = getToolHandler("transform");
+    if (!(handler instanceof TransformTool)) {
+      throw new Error("Expected TransformTool singleton from tool registry");
+    }
+    return handler;
+  }, []);
+
+  return (
+    <SketchCanvasPresentation
+      containerRef={containerRef}
+      bootstrapDisplayRef={compositing.bootstrapDisplayRef}
+      displayCanvasRef={compositing.displayCanvasRef}
+      overlayCanvasRef={compositing.overlayCanvasRef}
+      selectionGpuCanvasRef={selectionGpuCanvasRef}
+      selectionCanvasRef={selectionCanvasRef}
+      cursorCanvasRef={cursorCanvasRef}
+      gizmoCanvasRef={gizmoCanvasRef}
+      transformTool={transformTool}
+      canvasWidth={doc.canvas.width}
+      canvasHeight={doc.canvas.height}
+      zoom={zoom}
+      pan={pan}
+      interactionTool={interactionTool}
+      bootstrapPhaseActive={compositing.bootstrapPhaseActive}
+      backend={compositing.backend}
+      showInfoBar={!standaloneDocumentId}
+      containerCursor={pointerHandlers.containerCursor}
+      onPointerDown={handlePointerDownWithClient}
+      onPointerMove={handlePointerMoveWithCoords}
+      onPointerUp={handlePointerUpWithGesture}
+      onPointerCancel={handlePointerCancelWithGesture}
+      onDoubleClick={pointerHandlers.handleDoubleClick}
+      onPointerLeave={pointerHandlers.handlePointerLeave}
+      onMouseLeave={handleMouseLeaveWithCoords}
+      onContextMenu={pointerHandlers.handleContextMenu}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onCanvasResizeStart={onCanvasResizeStart}
+      onCanvasResize={onCanvasResize}
+      className={rootClassName}
+      docOverlay={<GeneratingLayerOverlay />}
+    />
+  );
+}
 
 export default SketchCanvas;

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -37,7 +37,7 @@
 
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import React, { memo, forwardRef, useEffect } from "react";
+import React, { memo, useEffect } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
@@ -197,553 +197,532 @@ export interface SketchEditorProps {
    * menu's close callback, and returns an array — MUI's Menu rejects a
    * Fragment child. */
   menuItems?: (close: () => void) => React.ReactNode[];
+  ref?: React.Ref<SketchEditorHandle>;
 }
 
-const SketchEditor = forwardRef<SketchEditorHandle, SketchEditorProps>(
-  function SketchEditor(
-    {
-      initialDocument,
-      initialEditorState,
-      documentId,
-      onDocumentChange,
-      onExportImage,
-      onExportMask,
-      suspendKeyboardShortcuts,
-      headerActions,
-      menuItems
-    },
-    ref
-  ) {
-    const theme = useTheme();
-    // Tab toggles a fully chrome-less canvas view: hide the left tools
-    // column AND the entire right panel column (color / layers / canvas).
-    // The right column is gated here at the wrapper instead of inside
-    // every child so the column's reserved width also collapses, letting
-    // the canvas grow into the freed space.
-    const panelsHidden = useSketchStore((s) => s.panelsHidden);
-    const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
-    const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
+function SketchEditor({
+  initialDocument,
+  initialEditorState,
+  documentId,
+  onDocumentChange,
+  onExportImage,
+  onExportMask,
+  suspendKeyboardShortcuts,
+  headerActions,
+  menuItems,
+  ref
+}: SketchEditorProps) {
+  const theme = useTheme();
+  // Tab toggles a fully chrome-less canvas view: hide the left tools
+  // column AND the entire right panel column (color / layers / canvas).
+  // The right column is gated here at the wrapper instead of inside
+  // every child so the column's reserved width also collapses, letting
+  // the canvas grow into the freed space.
+  const panelsHidden = useSketchStore((s) => s.panelsHidden);
+  const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
+  const assistantPanelOpen = useSketchStore((s) => s.assistantPanelOpen);
 
-    // On narrow/touch viewports the fixed side columns can't sit beside the
-    // canvas, so the right panel and assistant move into bottom sheets and the
-    // canvas keeps the full width. See useSketchIsMobile (600px, app breakpoint).
-    const isMobile = useSketchIsMobile();
-    const mobilePanelsOpen = useSketchStore((s) => s.mobilePanelsOpen);
-    const setMobilePanelsOpen = useSketchStore((s) => s.setMobilePanelsOpen);
-    const setAssistantPanelOpen = useSketchStore(
-      (s) => s.setAssistantPanelOpen
-    );
+  // On narrow/touch viewports the fixed side columns can't sit beside the
+  // canvas, so the right panel and assistant move into bottom sheets and the
+  // canvas keeps the full width. See useSketchIsMobile (600px, app breakpoint).
+  const isMobile = useSketchIsMobile();
+  const mobilePanelsOpen = useSketchStore((s) => s.mobilePanelsOpen);
+  const setMobilePanelsOpen = useSketchStore((s) => s.setMobilePanelsOpen);
+  const setAssistantPanelOpen = useSketchStore((s) => s.setAssistantPanelOpen);
 
-    // The mobile panels sheet is a mobile-only surface. Clear its flag when the
-    // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
-    // the next time the viewport shrinks back to mobile. Also keep the two
-    // mobile bottom sheets mutually exclusive: when the Assistant opens (its
-    // toggle lives in the tool bar menu), close the panels sheet so two stacked
-    // SwipeableDrawer modals never fight over focus/scroll.
-    useEffect(() => {
-      if (!mobilePanelsOpen) {
-        return;
-      }
-      if (!isMobile || assistantPanelOpen) {
-        setMobilePanelsOpen(false);
-      }
-    }, [isMobile, assistantPanelOpen, mobilePanelsOpen, setMobilePanelsOpen]);
+  // The mobile panels sheet is a mobile-only surface. Clear its flag when the
+  // viewport grows to desktop (rotate/resize) so it doesn't silently reopen
+  // the next time the viewport shrinks back to mobile. Also keep the two
+  // mobile bottom sheets mutually exclusive: when the Assistant opens (its
+  // toggle lives in the tool bar menu), close the panels sheet so two stacked
+  // SwipeableDrawer modals never fight over focus/scroll.
+  useEffect(() => {
+    if (!mobilePanelsOpen) {
+      return;
+    }
+    if (!isMobile || assistantPanelOpen) {
+      setMobilePanelsOpen(false);
+    }
+  }, [isMobile, assistantPanelOpen, mobilePanelsOpen, setMobilePanelsOpen]);
 
-    // Register the agent bridge under this document's id so the `ui_sketch_*`
-    // tools can address it whether or not this surface is focused. The session
-    // store is the authority: a never-saved document has no id yet, and gains
-    // one the moment it is persisted.
-    const sessionDocumentId = useSketchSessionStore((s) => s.documentId);
-    useSketchAgentBridge(sessionDocumentId);
+  // Register the agent bridge under this document's id so the `ui_sketch_*`
+  // tools can address it whether or not this surface is focused. The session
+  // store is the authority: a never-saved document has no id yet, and gains
+  // one the moment it is persisted.
+  const sessionDocumentId = useSketchSessionStore((s) => s.documentId);
+  useSketchAgentBridge(sessionDocumentId);
 
-    // ─── Session layer (all transient editor-session state) ─────────────
-    const session = useEditorSession({
-      initialDocument,
-      initialEditorState,
-      documentId,
-      onDocumentChange,
-      onExportImage,
-      onExportMask
+  // ─── Session layer (all transient editor-session state) ─────────────
+  const session = useEditorSession({
+    initialDocument,
+    initialEditorState,
+    documentId,
+    onDocumentChange,
+    onExportImage,
+    onExportMask
+  });
+
+  // ─── Command surface (shortcuts, context-menu actions, imperative handle)
+  const commands = useEditorCommands({
+    editorRef: ref as React.RefObject<SketchEditorHandle | null>,
+    canvasRef: session.canvasRef,
+    initialDocumentRef: session.initialDocumentRef,
+    document: session.document,
+    handleUndo: session.handleUndo,
+    handleRedo: session.handleRedo,
+    canvasActions: session.canvasActions,
+    layerActions: session.layerActions,
+    colorActions: session.colorActions,
+    segmentation: session.segmentation,
+    canvasStore: session.canvasStore,
+    colorStore: session.colorStore,
+    sessionStore: session.sessionStore,
+    suspendKeyboardShortcuts
+  });
+
+  // Register live canvas getters into the global ref store so consumers
+  // (Inpaint Here, Re-generate Stale, etc.) can read the composite without
+  // prop-drilling the canvas ref.
+  const setCanvasGetters = useSketchCanvasRefStore((s) => s.setGetters);
+  const clearCanvasGetters = useSketchCanvasRefStore((s) => s.clearGetters);
+  useEffect(() => {
+    const canvasRef = session.canvasRef;
+    setCanvasGetters({
+      flattenToDataUrl: () => canvasRef.current?.flattenToDataUrl() ?? "",
+      getMaskDataUrl: () => canvasRef.current?.getMaskDataUrl() ?? null,
+      setLayerData: (layerId, data) =>
+        canvasRef.current?.setLayerData(layerId, data),
+      getLayerData: (layerId) =>
+        canvasRef.current?.getLayerData(layerId) ?? null,
+      fillLayerWithColor: (layerId, color) =>
+        canvasRef.current?.fillLayerWithColor(layerId, color),
+      clearActiveLayer: () => session.canvasActions.handleClearLayer(),
+      fitViewToScreen: () => session.canvasActions.handleZoomFit()
     });
+    return () => {
+      clearCanvasGetters();
+    };
+  }, [
+    session.canvasRef,
+    session.canvasActions,
+    setCanvasGetters,
+    clearCanvasGetters
+  ]);
 
-    // ─── Command surface (shortcuts, context-menu actions, imperative handle)
-    const commands = useEditorCommands({
-      editorRef: ref as React.RefObject<SketchEditorHandle | null>,
-      canvasRef: session.canvasRef,
-      initialDocumentRef: session.initialDocumentRef,
-      document: session.document,
-      handleUndo: session.handleUndo,
-      handleRedo: session.handleRedo,
-      canvasActions: session.canvasActions,
-      layerActions: session.layerActions,
-      colorActions: session.colorActions,
-      segmentation: session.segmentation,
-      canvasStore: session.canvasStore,
-      colorStore: session.colorStore,
-      sessionStore: session.sessionStore,
-      suspendKeyboardShortcuts
-    });
+  // Reconcile bindings on document load: stale-mark layers whose source
+  // workflow changed, merge paramOverrides against current Input* nodes,
+  // and auto-resolve a missing selectedOutputNodeId.
+  useSketchWorkflowFreshnessCheck(sessionDocumentId);
 
-    // Register live canvas getters into the global ref store so consumers
-    // (Inpaint Here, Re-generate Stale, etc.) can read the composite without
-    // prop-drilling the canvas ref.
-    const setCanvasGetters = useSketchCanvasRefStore((s) => s.setGetters);
-    const clearCanvasGetters = useSketchCanvasRefStore((s) => s.clearGetters);
-    useEffect(() => {
-      const canvasRef = session.canvasRef;
-      setCanvasGetters({
-        flattenToDataUrl: () => canvasRef.current?.flattenToDataUrl() ?? "",
-        getMaskDataUrl: () => canvasRef.current?.getMaskDataUrl() ?? null,
-        setLayerData: (layerId, data) =>
-          canvasRef.current?.setLayerData(layerId, data),
-        getLayerData: (layerId) =>
-          canvasRef.current?.getLayerData(layerId) ?? null,
-        fillLayerWithColor: (layerId, color) =>
-          canvasRef.current?.fillLayerWithColor(layerId, color),
-        clearActiveLayer: () => session.canvasActions.handleClearLayer(),
-        fitViewToScreen: () => session.canvasActions.handleZoomFit()
-      });
-      return () => {
-        clearCanvasGetters();
-      };
-    }, [
-      session.canvasRef,
-      session.canvasActions,
-      setCanvasGetters,
-      clearCanvasGetters
-    ]);
+  // Color / Layers / Canvas sections. Shared between the docked desktop
+  // column and the mobile bottom sheet so the two stay in lockstep.
+  const rightPanelSections = (
+    <>
+      <CollapsibleSection
+        className="sketch-editor__color-section"
+        title={<ColorSectionHeader />}
+        defaultOpen={false}
+        compact
+        sx={{
+          fontSize: theme.fontSizeSmall,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`,
+          "& > [role='button']": {
+            padding: theme.spacing(1, 1),
+            backgroundColor: theme.vars.palette.background.paper
+          }
+        }}
+      >
+        <ConnectedColorPanel />
+      </CollapsibleSection>
 
-    // Reconcile bindings on document load: stale-mark layers whose source
-    // workflow changed, merge paramOverrides against current Input* nodes,
-    // and auto-resolve a missing selectedOutputNodeId.
-    useSketchWorkflowFreshnessCheck(sessionDocumentId);
+      <CollapsibleSection
+        className="sketch-editor__layers-section"
+        title={<SectionTitle>Layers</SectionTitle>}
+        defaultOpen
+        compact
+        sx={{
+          fontSize: theme.fontSizeSmall,
+          minHeight: 0,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`,
+          "& > [role='button']": {
+            padding: theme.spacing(1, 1),
+            backgroundColor: theme.vars.palette.background.paper
+          }
+        }}
+      >
+        <ConnectedLayersPanel
+          onClearLayer={session.canvasActions.handleClearLayer}
+          onFlipHorizontal={session.layerActions.handleFlipHorizontal}
+          onFlipVertical={session.layerActions.handleFlipVertical}
+          onRotate180={session.layerActions.handleRotate180}
+          onMergeDown={session.layerActions.handleMergeDown}
+          onFlattenVisible={session.layerActions.handleFlattenVisible}
+          onTrimLayerToBounds={session.canvasActions.handleTrimLayerToBounds}
+          onCropCanvasToActiveLayerVisiblePixels={
+            session.canvasActions.handleCropCanvasToActiveLayerVisiblePixels
+          }
+          onCropCanvasToActiveLayerExtents={
+            session.canvasActions.handleCropCanvasToActiveLayerExtents
+          }
+          onToggleVisibility={session.layerActions.handleToggleVisibility}
+          onAddLayer={(fillColor) =>
+            session.layerActions.handleAddLayer({
+              fillColor: fillColor ?? undefined
+            })
+          }
+          onRemoveLayer={session.layerActions.handleRemoveLayer}
+          onDuplicateLayer={session.layerActions.handleDuplicateLayer}
+          onReorderLayers={session.layerActions.handleReorderLayers}
+          onSetMaskLayer={session.layerActions.handleSetMaskLayer}
+          onToggleAlphaLock={session.layerActions.handleToggleAlphaLock}
+          onToggleExposedInput={session.layerActions.handleToggleExposedInput}
+          onToggleExposedOutput={session.layerActions.handleToggleExposedOutput}
+          onLayerOpacityChange={session.layerActions.handleSetLayerOpacity}
+          onLayerBlendModeChange={session.layerActions.handleSetLayerBlendMode}
+          onRenameLayer={session.layerActions.handleRenameLayer}
+          onAddGroup={session.layerActions.handleAddGroup}
+          onToggleGroupCollapsed={
+            session.layerActions.handleToggleGroupCollapsed
+          }
+          onMoveLayerToGroup={session.layerActions.handleMoveLayerToGroup}
+          onUngroupLayer={session.layerActions.handleUngroupLayer}
+          onGroupSelectedLayers={session.layerActions.handleGroupSelectedLayers}
+          onMergeSelectedLayers={session.layerActions.handleMergeSelectedLayers}
+          onDeleteSelectedLayers={
+            session.layerActions.handleDeleteSelectedLayers
+          }
+          onLoadLayerAsSelection={
+            session.canvasActions.handleLoadLayerAsSelection
+          }
+        />
+      </CollapsibleSection>
 
-    // Color / Layers / Canvas sections. Shared between the docked desktop
-    // column and the mobile bottom sheet so the two stay in lockstep.
-    const rightPanelSections = (
-      <>
-        <CollapsibleSection
-          className="sketch-editor__color-section"
-          title={<ColorSectionHeader />}
-          defaultOpen={false}
-          compact
+      <CollapsibleSection
+        className="sketch-editor__canvas-section"
+        title={<SectionTitle>Canvas</SectionTitle>}
+        defaultOpen={false}
+        compact
+        sx={{
+          fontSize: theme.fontSizeSmall,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`,
+          "& > [role='button']": {
+            padding: theme.spacing(1, 1),
+            backgroundColor: theme.vars.palette.background.paper
+          }
+        }}
+      >
+        <ConnectedCanvasSizePanel
+          onCanvasResize={session.canvasActions.handleCanvasResize}
+          canvasResizeHandlesEnabled={session.canvasResizeHandlesEnabled}
+          onCanvasResizeHandlesEnabledChange={
+            session.handleCanvasResizeHandlesEnabledChange
+          }
+        />
+      </CollapsibleSection>
+
+      <ConnectedGeneratedLayerSection />
+    </>
+  );
+
+  return (
+    <FlexColumn className="sketch-editor" css={styles(theme)} gap={0}>
+      <FlexRow
+        className="sketch-editor__body"
+        sx={{ flex: 1, minHeight: 0, width: "100%", overflow: "hidden" }}
+      >
+        {/* ConnectedToolbar subscribes to its own state — no prop drilling */}
+        <ConnectedToolbar />
+
+        <FlexColumn
+          className="sketch-editor__workspace"
           sx={{
-            fontSize: theme.fontSizeSmall,
-            borderBottom: `1px solid ${theme.vars.palette.divider}`,
-            "& > [role='button']": {
-              padding: theme.spacing(1, 1),
-              backgroundColor: theme.vars.palette.background.paper
-            }
-          }}
-        >
-          <ConnectedColorPanel />
-        </CollapsibleSection>
-
-        <CollapsibleSection
-          className="sketch-editor__layers-section"
-          title={<SectionTitle>Layers</SectionTitle>}
-          defaultOpen
-          compact
-          sx={{
-            fontSize: theme.fontSizeSmall,
+            flex: 1,
+            overflow: "hidden",
             minHeight: 0,
-            borderBottom: `1px solid ${theme.vars.palette.divider}`,
-            "& > [role='button']": {
-              padding: theme.spacing(1, 1),
-              backgroundColor: theme.vars.palette.background.paper
-            }
+            position: "relative"
           }}
         >
-          <ConnectedLayersPanel
-            onClearLayer={session.canvasActions.handleClearLayer}
-            onFlipHorizontal={session.layerActions.handleFlipHorizontal}
-            onFlipVertical={session.layerActions.handleFlipVertical}
-            onRotate180={session.layerActions.handleRotate180}
-            onMergeDown={session.layerActions.handleMergeDown}
-            onFlattenVisible={session.layerActions.handleFlattenVisible}
-            onTrimLayerToBounds={session.canvasActions.handleTrimLayerToBounds}
-            onCropCanvasToActiveLayerVisiblePixels={
-              session.canvasActions.handleCropCanvasToActiveLayerVisiblePixels
-            }
-            onCropCanvasToActiveLayerExtents={
-              session.canvasActions.handleCropCanvasToActiveLayerExtents
-            }
-            onToggleVisibility={session.layerActions.handleToggleVisibility}
-            onAddLayer={(fillColor) =>
-              session.layerActions.handleAddLayer({
-                fillColor: fillColor ?? undefined
-              })
-            }
-            onRemoveLayer={session.layerActions.handleRemoveLayer}
-            onDuplicateLayer={session.layerActions.handleDuplicateLayer}
-            onReorderLayers={session.layerActions.handleReorderLayers}
-            onSetMaskLayer={session.layerActions.handleSetMaskLayer}
-            onToggleAlphaLock={session.layerActions.handleToggleAlphaLock}
-            onToggleExposedInput={session.layerActions.handleToggleExposedInput}
-            onToggleExposedOutput={
-              session.layerActions.handleToggleExposedOutput
-            }
-            onLayerOpacityChange={session.layerActions.handleSetLayerOpacity}
-            onLayerBlendModeChange={
-              session.layerActions.handleSetLayerBlendMode
-            }
-            onRenameLayer={session.layerActions.handleRenameLayer}
-            onAddGroup={session.layerActions.handleAddGroup}
-            onToggleGroupCollapsed={
-              session.layerActions.handleToggleGroupCollapsed
-            }
-            onMoveLayerToGroup={session.layerActions.handleMoveLayerToGroup}
-            onUngroupLayer={session.layerActions.handleUngroupLayer}
-            onGroupSelectedLayers={
-              session.layerActions.handleGroupSelectedLayers
-            }
-            onMergeSelectedLayers={
-              session.layerActions.handleMergeSelectedLayers
-            }
-            onDeleteSelectedLayers={
-              session.layerActions.handleDeleteSelectedLayers
-            }
-            onLoadLayerAsSelection={
-              session.canvasActions.handleLoadLayerAsSelection
-            }
-          />
-        </CollapsibleSection>
-
-        <CollapsibleSection
-          className="sketch-editor__canvas-section"
-          title={<SectionTitle>Canvas</SectionTitle>}
-          defaultOpen={false}
-          compact
-          sx={{
-            fontSize: theme.fontSizeSmall,
-            borderBottom: `1px solid ${theme.vars.palette.divider}`,
-            "& > [role='button']": {
-              padding: theme.spacing(1, 1),
-              backgroundColor: theme.vars.palette.background.paper
-            }
-          }}
-        >
-          <ConnectedCanvasSizePanel
-            onCanvasResize={session.canvasActions.handleCanvasResize}
-            canvasResizeHandlesEnabled={session.canvasResizeHandlesEnabled}
-            onCanvasResizeHandlesEnabledChange={
-              session.handleCanvasResizeHandlesEnabledChange
-            }
-          />
-        </CollapsibleSection>
-
-        <ConnectedGeneratedLayerSection />
-      </>
-    );
-
-    return (
-      <FlexColumn className="sketch-editor" css={styles(theme)} gap={0}>
-        <FlexRow
-          className="sketch-editor__body"
-          sx={{ flex: 1, minHeight: 0, width: "100%", overflow: "hidden" }}
-        >
-          {/* ConnectedToolbar subscribes to its own state — no prop drilling */}
-          <ConnectedToolbar />
-
-          <FlexColumn
-            className="sketch-editor__workspace"
+          <Container
+            className="sketch-editor__canvas-region"
+            padding="none"
             sx={{
               flex: 1,
-              overflow: "hidden",
               minHeight: 0,
-              position: "relative"
+              position: "relative",
+              zIndex: Z_INDEX.raised,
+              overflow: "hidden"
             }}
           >
-            <Container
-              className="sketch-editor__canvas-region"
-              padding="none"
-              sx={{
-                flex: 1,
-                minHeight: 0,
-                position: "relative",
-                zIndex: Z_INDEX.raised,
-                overflow: "hidden"
-              }}
-            >
-              <SketchCanvasPane
-                canvasReady={session.canvasReady}
-                canvasRef={session.canvasRef}
-                document={session.document}
-                activeTool={session.activeTool}
-                interactionTool={session.interactionTool}
-                onZoomChange={session.canvasStore.setZoom}
-                onPanChange={session.canvasStore.setPan}
-                onStrokeStart={session.canvasActions.handleStrokeStart}
-                onStrokeEnd={session.canvasActions.handleStrokeEnd}
-                onCanvasLeave={
-                  session.canvasActions.flushLayerThumbnailsWhenIdle
-                }
-                onLayerTransformChange={
-                  session.canvasActions.handleCommitLayerTransform
-                }
-                onLayerContentBoundsChange={
-                  session.layerStore.setLayerContentBounds
-                }
-                onBrushSizeChange={session.colorActions.handleBrushSizeChange}
-                onContextMenu={session.canvasActions.handleContextMenu}
-                onTransformContextMenu={
-                  session.canvasActions.handleTransformContextMenu
-                }
-                onCropComplete={session.canvasActions.handleCropComplete}
-                onEyedropperPick={session.colorActions.handleEyedropperPick}
-                onAutoPickLayer={session.layerStore.setActiveLayer}
-                onDropImage={session.canvasActions.handleDropImage}
-                onDropAsset={session.canvasActions.handleDropAsset}
-                onCanvasResizeStart={
-                  session.canvasResizeHandlesEnabled
-                    ? session.canvasActions.handleCanvasResizeStart
-                    : undefined
-                }
-                onCanvasResize={
-                  session.canvasResizeHandlesEnabled
-                    ? session.canvasActions.handleCanvasResizeDrag
-                    : undefined
-                }
-                segmentation={session.segmentation}
-              />
-            </Container>
-            {/*
+            <SketchCanvasPane
+              canvasReady={session.canvasReady}
+              canvasRef={session.canvasRef}
+              document={session.document}
+              activeTool={session.activeTool}
+              interactionTool={session.interactionTool}
+              onZoomChange={session.canvasStore.setZoom}
+              onPanChange={session.canvasStore.setPan}
+              onStrokeStart={session.canvasActions.handleStrokeStart}
+              onStrokeEnd={session.canvasActions.handleStrokeEnd}
+              onCanvasLeave={session.canvasActions.flushLayerThumbnailsWhenIdle}
+              onLayerTransformChange={
+                session.canvasActions.handleCommitLayerTransform
+              }
+              onLayerContentBoundsChange={
+                session.layerStore.setLayerContentBounds
+              }
+              onBrushSizeChange={session.colorActions.handleBrushSizeChange}
+              onContextMenu={session.canvasActions.handleContextMenu}
+              onTransformContextMenu={
+                session.canvasActions.handleTransformContextMenu
+              }
+              onCropComplete={session.canvasActions.handleCropComplete}
+              onEyedropperPick={session.colorActions.handleEyedropperPick}
+              onAutoPickLayer={session.layerStore.setActiveLayer}
+              onDropImage={session.canvasActions.handleDropImage}
+              onDropAsset={session.canvasActions.handleDropAsset}
+              onCanvasResizeStart={
+                session.canvasResizeHandlesEnabled
+                  ? session.canvasActions.handleCanvasResizeStart
+                  : undefined
+              }
+              onCanvasResize={
+                session.canvasResizeHandlesEnabled
+                  ? session.canvasActions.handleCanvasResizeDrag
+                  : undefined
+              }
+              segmentation={session.segmentation}
+            />
+          </Container>
+          {/*
           Tool top bar sits above the canvas in z-order but does not consume flex
           height, so wrap/resize of tool settings no longer shrinks the canvas or
           shifts the image. Pass-through clicks use pointer-events below.
         */}
-            <Container
-              padding="none"
-              sx={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                right: 0,
-                zIndex: Z_INDEX.raised + 1,
-                pointerEvents: "none",
-                "& > *": { pointerEvents: "auto" }
-              }}
-            >
-              <ConnectedToolTopBar
-                adjBrightness={session.canvasActions.adjBrightness}
-                adjContrast={session.canvasActions.adjContrast}
-                adjSaturation={session.canvasActions.adjSaturation}
-                onAdjustBrightnessChange={
-                  session.canvasActions.setAdjBrightness
-                }
-                onAdjustContrastChange={session.canvasActions.setAdjContrast}
-                onAdjustSaturationChange={
-                  session.canvasActions.setAdjSaturation
-                }
-                onAdjustApply={session.canvasActions.handleApplyAdjustments}
-                onAdjustCancel={session.canvasActions.handleCancelAdjustments}
-                onTransformCommit={session.canvasActions.handleTransformCommit}
-                onTransformCancel={session.canvasActions.handleTransformCancel}
-                onTransformReset={session.canvasActions.handleTransformReset}
-                segmentation={session.segmentation}
-                onRunSegmentation={commands.handleRunSegmentation}
-                onClearSegmentPrompts={commands.handleClearSegmentPrompts}
-                onCropCanvasToSelection={
-                  session.canvasActions.handleCropCanvasToSelection
-                }
-                onCropCommit={session.canvasActions.handleCropCommit}
-                onCropCancelPreview={
-                  session.canvasActions.handleCropCancelPreview
-                }
-                headerActions={headerActions}
-                menuItems={menuItems}
-              />
-            </Container>
+          <Container
+            padding="none"
+            sx={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              zIndex: Z_INDEX.raised + 1,
+              pointerEvents: "none",
+              "& > *": { pointerEvents: "auto" }
+            }}
+          >
+            <ConnectedToolTopBar
+              adjBrightness={session.canvasActions.adjBrightness}
+              adjContrast={session.canvasActions.adjContrast}
+              adjSaturation={session.canvasActions.adjSaturation}
+              onAdjustBrightnessChange={session.canvasActions.setAdjBrightness}
+              onAdjustContrastChange={session.canvasActions.setAdjContrast}
+              onAdjustSaturationChange={session.canvasActions.setAdjSaturation}
+              onAdjustApply={session.canvasActions.handleApplyAdjustments}
+              onAdjustCancel={session.canvasActions.handleCancelAdjustments}
+              onTransformCommit={session.canvasActions.handleTransformCommit}
+              onTransformCancel={session.canvasActions.handleTransformCancel}
+              onTransformReset={session.canvasActions.handleTransformReset}
+              segmentation={session.segmentation}
+              onRunSegmentation={commands.handleRunSegmentation}
+              onClearSegmentPrompts={commands.handleClearSegmentPrompts}
+              onCropCanvasToSelection={
+                session.canvasActions.handleCropCanvasToSelection
+              }
+              onCropCommit={session.canvasActions.handleCropCommit}
+              onCropCancelPreview={
+                session.canvasActions.handleCropCancelPreview
+              }
+              headerActions={headerActions}
+              menuItems={menuItems}
+            />
+          </Container>
 
-            {/* Restoring the chrome is otherwise Tab-only, and a touch device
+          {/* Restoring the chrome is otherwise Tab-only, and a touch device
               has no Tab key — keep one always-visible affordance on the bare
               canvas. */}
-            {panelsHidden && (
-              <Tooltip title="Show panels">
-                <Fab
-                  className="sketch-editor__show-panels-fab"
-                  size="small"
-                  aria-label="Show panels"
-                  onClick={togglePanelsHidden}
-                  sx={{
-                    position: "absolute",
-                    top: (t) => t.spacing(1),
-                    right: (t) => t.spacing(1),
-                    zIndex: Z_INDEX.raised + 2
-                  }}
-                >
-                  <ViewSidebarOutlinedIcon fontSize="small" />
-                </Fab>
-              </Tooltip>
-            )}
-          </FlexColumn>
+          {panelsHidden && (
+            <Tooltip title="Show panels">
+              <Fab
+                className="sketch-editor__show-panels-fab"
+                size="small"
+                aria-label="Show panels"
+                onClick={togglePanelsHidden}
+                sx={{
+                  position: "absolute",
+                  top: (t) => t.spacing(1),
+                  right: (t) => t.spacing(1),
+                  zIndex: Z_INDEX.raised + 2
+                }}
+              >
+                <ViewSidebarOutlinedIcon fontSize="small" />
+              </Fab>
+            </Tooltip>
+          )}
+        </FlexColumn>
 
-          {/* Right column: color, layers, canvas size sections. The wrapper
+        {/* Right column: color, layers, canvas size sections. The wrapper
           itself is gated on `panelsHidden` so Tab collapses the column's
           reserved width (not just blanks its contents), giving the
           canvas the freed real estate. On mobile the column is dropped here
           and the same sections render in a bottom sheet below. */}
-          {!panelsHidden && !isMobile && (
-            <FlexColumn
-              className="sketch-editor__panel-right"
-              sx={{
-                width: SKETCH_SIZE.panelWidth,
-                minWidth: SKETCH_SIZE.panelWidth,
-                maxWidth: SKETCH_SIZE.panelWidth,
-                minHeight: 0,
-                flexShrink: 0,
-                backgroundColor: theme.vars.palette.background.paper,
-                borderLeft: `1px solid ${theme.vars.palette.divider}`,
-                overflow: "hidden"
+        {!panelsHidden && !isMobile && (
+          <FlexColumn
+            className="sketch-editor__panel-right"
+            sx={{
+              width: SKETCH_SIZE.panelWidth,
+              minWidth: SKETCH_SIZE.panelWidth,
+              maxWidth: SKETCH_SIZE.panelWidth,
+              minHeight: 0,
+              flexShrink: 0,
+              backgroundColor: theme.vars.palette.background.paper,
+              borderLeft: `1px solid ${theme.vars.palette.divider}`,
+              overflow: "hidden"
+            }}
+            gap={0}
+          >
+            {rightPanelSections}
+          </FlexColumn>
+        )}
+
+        {/* AI assistant chat column — a toggleable right-most panel that
+          drives the editor through the ui_sketch_* agent tools. Gated on the
+          same panelsHidden chrome toggle so Tab collapses it too. On mobile
+          it moves into a bottom sheet (below). */}
+        {!panelsHidden && !isMobile && assistantPanelOpen && (
+          <FlexColumn
+            className="sketch-editor__assistant-panel"
+            sx={{
+              width: SKETCH_SIZE.assistantPanelWidth,
+              minWidth: SKETCH_SIZE.assistantPanelWidth,
+              maxWidth: SKETCH_SIZE.assistantPanelWidth,
+              minHeight: 0,
+              flexShrink: 0,
+              backgroundColor: theme.vars.palette.background.paper,
+              borderLeft: `1px solid ${theme.vars.palette.divider}`,
+              overflow: "hidden"
+            }}
+            gap={0}
+          >
+            <SketchAgentPanel />
+          </FlexColumn>
+        )}
+      </FlexRow>
+
+      {/* ── Mobile chrome ─────────────────────────────────────────────
+          On narrow viewports the right panel and assistant can't dock beside
+          the canvas, so they become bottom sheets and a floating button opens
+          the panels sheet. Gated on the same panelsHidden chrome toggle. */}
+      {isMobile && !panelsHidden && (
+        <>
+          <Tooltip title="Layers & color">
+            <Fab
+              className="sketch-editor__mobile-panels-fab"
+              size="medium"
+              color="primary"
+              aria-label="Open layers and color panel"
+              onClick={() => {
+                // Last action wins — never stack the two mobile sheets.
+                setAssistantPanelOpen(false);
+                setMobilePanelsOpen(true);
               }}
+              sx={{
+                position: "absolute",
+                bottom: (t) => t.spacing(2),
+                right: (t) => t.spacing(2),
+                zIndex: Z_INDEX.raised + 2
+              }}
+            >
+              <LayersOutlinedIcon />
+            </Fab>
+          </Tooltip>
+
+          <MobileBottomSheet
+            open={mobilePanelsOpen}
+            onClose={() => setMobilePanelsOpen(false)}
+            title="Layers & color"
+            ariaLabel="Layers and color panel"
+          >
+            <FlexColumn
+              className="sketch-editor__panel-right sketch-editor__panel-right--mobile"
+              sx={{ minHeight: 0, overflow: "auto" }}
               gap={0}
             >
               {rightPanelSections}
             </FlexColumn>
-          )}
+          </MobileBottomSheet>
 
-          {/* AI assistant chat column — a toggleable right-most panel that
-          drives the editor through the ui_sketch_* agent tools. Gated on the
-          same panelsHidden chrome toggle so Tab collapses it too. On mobile
-          it moves into a bottom sheet (below). */}
-          {!panelsHidden && !isMobile && assistantPanelOpen && (
+          <MobileBottomSheet
+            open={assistantPanelOpen}
+            onClose={() => setAssistantPanelOpen(false)}
+            title="Assistant"
+            ariaLabel="AI assistant panel"
+            maxHeight="85vh"
+          >
             <FlexColumn
-              className="sketch-editor__assistant-panel"
-              sx={{
-                width: SKETCH_SIZE.assistantPanelWidth,
-                minWidth: SKETCH_SIZE.assistantPanelWidth,
-                maxWidth: SKETCH_SIZE.assistantPanelWidth,
-                minHeight: 0,
-                flexShrink: 0,
-                backgroundColor: theme.vars.palette.background.paper,
-                borderLeft: `1px solid ${theme.vars.palette.divider}`,
-                overflow: "hidden"
-              }}
+              className="sketch-editor__assistant-panel sketch-editor__assistant-panel--mobile"
+              sx={{ height: "70vh", minHeight: 0, overflow: "hidden" }}
               gap={0}
             >
               <SketchAgentPanel />
             </FlexColumn>
-          )}
-        </FlexRow>
+          </MobileBottomSheet>
+        </>
+      )}
 
-        {/* ── Mobile chrome ─────────────────────────────────────────────
-          On narrow viewports the right panel and assistant can't dock beside
-          the canvas, so they become bottom sheets and a floating button opens
-          the panels sheet. Gated on the same panelsHidden chrome toggle. */}
-        {isMobile && !panelsHidden && (
-          <>
-            <Tooltip title="Layers & color">
-              <Fab
-                className="sketch-editor__mobile-panels-fab"
-                size="medium"
-                color="primary"
-                aria-label="Open layers and color panel"
-                onClick={() => {
-                  // Last action wins — never stack the two mobile sheets.
-                  setAssistantPanelOpen(false);
-                  setMobilePanelsOpen(true);
-                }}
-                sx={{
-                  position: "absolute",
-                  bottom: (t) => t.spacing(2),
-                  right: (t) => t.spacing(2),
-                  zIndex: Z_INDEX.raised + 2
-                }}
-              >
-                <LayersOutlinedIcon />
-              </Fab>
-            </Tooltip>
+      {/* Full-width status bar — standalone editor only (gates internally). */}
+      <ConnectedStatusBar />
 
-            <MobileBottomSheet
-              open={mobilePanelsOpen}
-              onClose={() => setMobilePanelsOpen(false)}
-              title="Layers & color"
-              ariaLabel="Layers and color panel"
-            >
-              <FlexColumn
-                className="sketch-editor__panel-right sketch-editor__panel-right--mobile"
-                sx={{ minHeight: 0, overflow: "auto" }}
-                gap={0}
-              >
-                {rightPanelSections}
-              </FlexColumn>
-            </MobileBottomSheet>
+      <ConnectedContextMenu
+        open={session.canvasActions.contextMenu !== null}
+        position={session.canvasActions.contextMenu}
+        adjBrightness={session.canvasActions.adjBrightness}
+        adjContrast={session.canvasActions.adjContrast}
+        adjSaturation={session.canvasActions.adjSaturation}
+        onClose={session.canvasActions.handleContextMenuClose}
+        onAdjustBrightnessChange={session.canvasActions.setAdjBrightness}
+        onAdjustContrastChange={session.canvasActions.setAdjContrast}
+        onAdjustSaturationChange={session.canvasActions.setAdjSaturation}
+        onAdjustApply={session.canvasActions.handleApplyAdjustments}
+        onAdjustCancel={session.canvasActions.handleCancelAdjustments}
+        onTransformCommit={session.canvasActions.handleTransformCommit}
+        onTransformCancel={session.canvasActions.handleTransformCancel}
+        onTransformReset={session.canvasActions.handleTransformReset}
+        segmentation={session.segmentation}
+        onRunSegmentation={commands.handleRunSegmentation}
+        onClearSegmentPrompts={commands.handleClearSegmentPrompts}
+        onSwapColors={session.colorStore.swapColors}
+        onFillSelectionWithForeground={
+          commands.handleFillSelectionWithForeground
+        }
+        onStrokeSelectionWithForeground={
+          commands.handleStrokeSelectionWithForeground
+        }
+        onCropCanvasToSelection={
+          session.canvasActions.handleCropCanvasToSelection
+        }
+        onLayerViaCopy={commands.handleLayerViaCopy}
+        onLayerViaCut={commands.handleLayerViaCut}
+      />
 
-            <MobileBottomSheet
-              open={assistantPanelOpen}
-              onClose={() => setAssistantPanelOpen(false)}
-              title="Assistant"
-              ariaLabel="AI assistant panel"
-              maxHeight="85vh"
-            >
-              <FlexColumn
-                className="sketch-editor__assistant-panel sketch-editor__assistant-panel--mobile"
-                sx={{ height: "70vh", minHeight: 0, overflow: "hidden" }}
-                gap={0}
-              >
-                <SketchAgentPanel />
-              </FlexColumn>
-            </MobileBottomSheet>
-          </>
-        )}
-
-        {/* Full-width status bar — standalone editor only (gates internally). */}
-        <ConnectedStatusBar />
-
-        <ConnectedContextMenu
-          open={session.canvasActions.contextMenu !== null}
-          position={session.canvasActions.contextMenu}
-          adjBrightness={session.canvasActions.adjBrightness}
-          adjContrast={session.canvasActions.adjContrast}
-          adjSaturation={session.canvasActions.adjSaturation}
-          onClose={session.canvasActions.handleContextMenuClose}
-          onAdjustBrightnessChange={session.canvasActions.setAdjBrightness}
-          onAdjustContrastChange={session.canvasActions.setAdjContrast}
-          onAdjustSaturationChange={session.canvasActions.setAdjSaturation}
-          onAdjustApply={session.canvasActions.handleApplyAdjustments}
-          onAdjustCancel={session.canvasActions.handleCancelAdjustments}
-          onTransformCommit={session.canvasActions.handleTransformCommit}
-          onTransformCancel={session.canvasActions.handleTransformCancel}
-          onTransformReset={session.canvasActions.handleTransformReset}
-          segmentation={session.segmentation}
-          onRunSegmentation={commands.handleRunSegmentation}
-          onClearSegmentPrompts={commands.handleClearSegmentPrompts}
-          onSwapColors={session.colorStore.swapColors}
-          onFillSelectionWithForeground={
-            commands.handleFillSelectionWithForeground
-          }
-          onStrokeSelectionWithForeground={
-            commands.handleStrokeSelectionWithForeground
-          }
-          onCropCanvasToSelection={
-            session.canvasActions.handleCropCanvasToSelection
-          }
-          onLayerViaCopy={commands.handleLayerViaCopy}
-          onLayerViaCut={commands.handleLayerViaCut}
-        />
-
-        <TransformContextMenu
-          open={session.canvasActions.transformContextMenu !== null}
-          position={session.canvasActions.transformContextMenu}
-          onClose={session.canvasActions.handleTransformContextMenuClose}
-          onTransformCommit={session.canvasActions.handleTransformCommit}
-          onTransformCancel={session.canvasActions.handleTransformCancel}
-          onTransformReset={session.canvasActions.handleTransformReset}
-          onRotate90CW={() =>
-            session.canvasActions.handleTransformRotate(Math.PI / 2)
-          }
-          onRotate90CCW={() =>
-            session.canvasActions.handleTransformRotate(-Math.PI / 2)
-          }
-          onRotate180={() =>
-            session.canvasActions.handleTransformRotate(Math.PI)
-          }
-          onFlipHorizontal={session.canvasActions.handleTransformFlipH}
-          onFlipVertical={session.canvasActions.handleTransformFlipV}
-        />
-      </FlexColumn>
-    );
-  }
-);
+      <TransformContextMenu
+        open={session.canvasActions.transformContextMenu !== null}
+        position={session.canvasActions.transformContextMenu}
+        onClose={session.canvasActions.handleTransformContextMenuClose}
+        onTransformCommit={session.canvasActions.handleTransformCommit}
+        onTransformCancel={session.canvasActions.handleTransformCancel}
+        onTransformReset={session.canvasActions.handleTransformReset}
+        onRotate90CW={() =>
+          session.canvasActions.handleTransformRotate(Math.PI / 2)
+        }
+        onRotate90CCW={() =>
+          session.canvasActions.handleTransformRotate(-Math.PI / 2)
+        }
+        onRotate180={() => session.canvasActions.handleTransformRotate(Math.PI)}
+        onFlipHorizontal={session.canvasActions.handleTransformFlipH}
+        onFlipVertical={session.canvasActions.handleTransformFlipV}
+      />
+    </FlexColumn>
+  );
+}
 
 export default memo(SketchEditor);

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
@@ -19,7 +19,7 @@ import type { SketchRuntime } from "../rendering";
 import { useSketchStore } from "../state/useSketchStore";
 
 export interface UseCanvasImperativeHandleParams {
-  ref: Ref<SketchCanvasRef>;
+  ref: Ref<SketchCanvasRef> | undefined;
   doc: SketchDocument;
   /** The rendering runtime that owns layer storage and compositing. */
   runtime: SketchRuntime;

--- a/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.tsx
@@ -9,20 +9,34 @@
  */
 
 import React, {
-  forwardRef,
   memo,
   useCallback,
   useEffect,
   useId,
   useMemo,
   useRef,
-  useState
+  useState,
+  type Ref
 } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
-import { NodeSlider, Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx, reducedMotion, SelectField, Switch, type SelectOption } from "../../ui_primitives";
+import {
+  NodeSlider,
+  Tooltip,
+  MOTION,
+  BORDER_RADIUS,
+  FONT_SIZE_SANS,
+  FONT_SIZE_MONO,
+  FONT_WEIGHT,
+  SPACING,
+  getSpacingPx,
+  reducedMotion,
+  SelectField,
+  Switch,
+  type SelectOption
+} from "../../ui_primitives";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 
 // ── Header ─────────────────────────────────────────────────────────────────
@@ -368,205 +382,200 @@ export interface InspectorPillInputProps {
    * `value` parses as a plain number (not timecodes).
    */
   scrub?: InspectorPillScrub;
+  ref?: Ref<HTMLInputElement>;
 }
 
-export const InspectorPillInput = memo(
-  forwardRef<HTMLInputElement, InspectorPillInputProps>(
-    function InspectorPillInput(
-      {
-        value,
-        onCommit,
-        unit,
-        placeholder,
-        disabled = false,
-        ariaLabel,
-        id,
-        minWidth,
-        scrub
-      },
-      ref
-    ) {
-      const theme = useTheme();
-      const [draft, setDraft] = useState(value);
-      const [focused, setFocused] = useState(false);
+export const InspectorPillInput = memo(function InspectorPillInput({
+  value,
+  onCommit,
+  unit,
+  placeholder,
+  disabled = false,
+  ariaLabel,
+  id,
+  minWidth,
+  scrub,
+  ref
+}: InspectorPillInputProps) {
+  const theme = useTheme();
+  const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
 
-      const inputRef = useRef<HTMLInputElement | null>(null);
-      const setRefs = useCallback(
-        (node: HTMLInputElement | null) => {
-          inputRef.current = node;
-          if (typeof ref === "function") {
-            ref(node);
-          } else if (ref) {
-            ref.current = node;
-          }
-        },
-        [ref]
-      );
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const setRefs = useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref]
+  );
 
-      useEffect(() => {
-        if (!focused) {
-          setDraft(value);
-        }
-      }, [value, focused]);
-
-      const commit = useCallback(() => {
-        if (draft !== value) {
-          onCommit(draft);
-        }
-      }, [draft, value, onCommit]);
-
-      const handleKeyDown = useCallback(
-        (e: React.KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Enter") {
-            (e.target as HTMLInputElement).blur();
-          } else if (e.key === "Escape") {
-            setDraft(value);
-            (e.target as HTMLInputElement).blur();
-          }
-        },
-        [value]
-      );
-
-      // ── Scrub gesture ────────────────────────────────────────────────────
-      // Drag scrubs; a click without movement focuses the input for typing.
-      // pointerdown preventDefault stops the native focus so the drag doesn't
-      // enter edit mode; store writes are rAF-coalesced and wrapped in one
-      // undo batch, same as InspectorSliderRow.
-
-      const history = useTimelineHistoryBatch();
-      const onCommitRef = useRef(onCommit);
-      onCommitRef.current = onCommit;
-      const gestureRef = useRef<{
-        pointerId: number;
-        startX: number;
-        startValue: number;
-        moved: boolean;
-      } | null>(null);
-      const pendingRef = useRef<string | null>(null);
-      const rafIdRef = useRef<number | null>(null);
-
-      const scrubDecimals = useMemo(() => {
-        if (!scrub) return 0;
-        return (String(scrub.step).split(".")[1] ?? "").length;
-      }, [scrub]);
-
-      const flushScrub = useCallback(() => {
-        rafIdRef.current = null;
-        if (pendingRef.current === null) return;
-        const next = pendingRef.current;
-        pendingRef.current = null;
-        onCommitRef.current(next);
-        history.mark();
-      }, [history]);
-
-      const handlePointerDown = useCallback(
-        (e: React.PointerEvent<HTMLDivElement>) => {
-          if (!scrub || disabled || focused || e.button !== 0) return;
-          const start = parseFloat(value);
-          if (!Number.isFinite(start)) return;
-          e.preventDefault();
-          e.currentTarget.setPointerCapture(e.pointerId);
-          gestureRef.current = {
-            pointerId: e.pointerId,
-            startX: e.clientX,
-            startValue: start,
-            moved: false
-          };
-        },
-        [scrub, disabled, focused, value]
-      );
-
-      const handlePointerMove = useCallback(
-        (e: React.PointerEvent<HTMLDivElement>) => {
-          const gesture = gestureRef.current;
-          if (!gesture || !scrub) return;
-          const dx = e.clientX - gesture.startX;
-          if (!gesture.moved) {
-            if (Math.abs(dx) < 3) return;
-            gesture.moved = true;
-            history.begin();
-          }
-          const multiplier = e.shiftKey ? 10 : e.altKey ? 0.1 : 1;
-          let next = gesture.startValue + dx * scrub.step * multiplier;
-          if (scrub.min != null) next = Math.max(scrub.min, next);
-          if (scrub.max != null) next = Math.min(scrub.max, next);
-          const formatted = next.toFixed(scrubDecimals);
-          setDraft(formatted);
-          pendingRef.current = formatted;
-          if (rafIdRef.current === null) {
-            rafIdRef.current = requestAnimationFrame(flushScrub);
-          }
-        },
-        [scrub, scrubDecimals, history, flushScrub]
-      );
-
-      const handlePointerUp = useCallback(
-        (e: React.PointerEvent<HTMLDivElement>) => {
-          const gesture = gestureRef.current;
-          if (!gesture || gesture.pointerId !== e.pointerId) return;
-          gestureRef.current = null;
-          if (gesture.moved) {
-            if (rafIdRef.current !== null) {
-              cancelAnimationFrame(rafIdRef.current);
-              rafIdRef.current = null;
-            }
-            if (pendingRef.current !== null) {
-              const next = pendingRef.current;
-              pendingRef.current = null;
-              onCommitRef.current(next);
-              history.mark();
-            }
-            history.end();
-          } else {
-            inputRef.current?.focus();
-            inputRef.current?.select();
-          }
-        },
-        [history]
-      );
-
-      useEffect(() => {
-        return () => {
-          if (rafIdRef.current !== null) {
-            cancelAnimationFrame(rafIdRef.current);
-          }
-        };
-      }, []);
-
-      return (
-        <div
-          css={pillWrapStyles(theme, disabled, focused, !!scrub)}
-          style={minWidth ? { minWidth } : undefined}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-        >
-          <input
-            id={id}
-            ref={setRefs}
-            type="text"
-            // size=1 kills the input's ~20-char intrinsic width so the pill
-            // sizes from minWidth instead of overflowing narrow panels.
-            size={1}
-            css={pillInputStyles(theme, !!scrub, focused)}
-            value={draft}
-            placeholder={placeholder}
-            disabled={disabled}
-            aria-label={ariaLabel}
-            onChange={(e) => setDraft(e.target.value)}
-            onFocus={() => setFocused(true)}
-            onBlur={() => {
-              setFocused(false);
-              commit();
-            }}
-            onKeyDown={handleKeyDown}
-          />
-          {unit && <span css={pillUnitStyles(theme)}>{unit}</span>}
-        </div>
-      );
+  useEffect(() => {
+    if (!focused) {
+      setDraft(value);
     }
-  )
-);
+  }, [value, focused]);
+
+  const commit = useCallback(() => {
+    if (draft !== value) {
+      onCommit(draft);
+    }
+  }, [draft, value, onCommit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        (e.target as HTMLInputElement).blur();
+      } else if (e.key === "Escape") {
+        setDraft(value);
+        (e.target as HTMLInputElement).blur();
+      }
+    },
+    [value]
+  );
+
+  // ── Scrub gesture ────────────────────────────────────────────────────
+  // Drag scrubs; a click without movement focuses the input for typing.
+  // pointerdown preventDefault stops the native focus so the drag doesn't
+  // enter edit mode; store writes are rAF-coalesced and wrapped in one
+  // undo batch, same as InspectorSliderRow.
+
+  const history = useTimelineHistoryBatch();
+  const onCommitRef = useRef(onCommit);
+  onCommitRef.current = onCommit;
+  const gestureRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startValue: number;
+    moved: boolean;
+  } | null>(null);
+  const pendingRef = useRef<string | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+
+  const scrubDecimals = useMemo(() => {
+    if (!scrub) return 0;
+    return (String(scrub.step).split(".")[1] ?? "").length;
+  }, [scrub]);
+
+  const flushScrub = useCallback(() => {
+    rafIdRef.current = null;
+    if (pendingRef.current === null) return;
+    const next = pendingRef.current;
+    pendingRef.current = null;
+    onCommitRef.current(next);
+    history.mark();
+  }, [history]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!scrub || disabled || focused || e.button !== 0) return;
+      const start = parseFloat(value);
+      if (!Number.isFinite(start)) return;
+      e.preventDefault();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      gestureRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startValue: start,
+        moved: false
+      };
+    },
+    [scrub, disabled, focused, value]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture || !scrub) return;
+      const dx = e.clientX - gesture.startX;
+      if (!gesture.moved) {
+        if (Math.abs(dx) < 3) return;
+        gesture.moved = true;
+        history.begin();
+      }
+      const multiplier = e.shiftKey ? 10 : e.altKey ? 0.1 : 1;
+      let next = gesture.startValue + dx * scrub.step * multiplier;
+      if (scrub.min != null) next = Math.max(scrub.min, next);
+      if (scrub.max != null) next = Math.min(scrub.max, next);
+      const formatted = next.toFixed(scrubDecimals);
+      setDraft(formatted);
+      pendingRef.current = formatted;
+      if (rafIdRef.current === null) {
+        rafIdRef.current = requestAnimationFrame(flushScrub);
+      }
+    },
+    [scrub, scrubDecimals, history, flushScrub]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture || gesture.pointerId !== e.pointerId) return;
+      gestureRef.current = null;
+      if (gesture.moved) {
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        if (pendingRef.current !== null) {
+          const next = pendingRef.current;
+          pendingRef.current = null;
+          onCommitRef.current(next);
+          history.mark();
+        }
+        history.end();
+      } else {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    },
+    [history]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      css={pillWrapStyles(theme, disabled, focused, !!scrub)}
+      style={minWidth ? { minWidth } : undefined}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      <input
+        id={id}
+        ref={setRefs}
+        type="text"
+        // size=1 kills the input's ~20-char intrinsic width so the pill
+        // sizes from minWidth instead of overflowing narrow panels.
+        size={1}
+        css={pillInputStyles(theme, !!scrub, focused)}
+        value={draft}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => {
+          setFocused(false);
+          commit();
+        }}
+        onKeyDown={handleKeyDown}
+      />
+      {unit && <span css={pillUnitStyles(theme)}>{unit}</span>}
+    </div>
+  );
+});
 
 // ── Select ─────────────────────────────────────────────────────────────────
 
@@ -888,8 +897,7 @@ export const InspectorSliderRow: React.FC<InspectorSliderRowProps> = memo(
       ((Math.min(max, Math.max(min, v)) - min) / span) * 100;
     const valuePct = toPct(value);
     const originPct = toPct(origin ?? min);
-    const showTick =
-      origin !== undefined && origin > min && origin < max;
+    const showTick = origin !== undefined && origin > min && origin < max;
 
     const fillVars = {
       "--fill-lo": `${Math.min(originPct, valuePct)}%`,


### PR DESCRIPTION
React 19 passes `ref` as an ordinary prop to function components, so every `forwardRef` wrapper in `web/src` outside `ui_primitives/` was doing nothing but adding a layer — plus the `displayName` assignment each one forced. This removes all 16 of them; each component now declares `ref?: Ref<T>` in its props interface.

`ui_primitives/` is left alone: those 45 wrappers sit on the MUI boundary and are a separate call.

## Changes

16 components converted across `chat/composer`, `editor_ui`, `node_menu`, `sketch`, `portal`, `properties`, `timeline/Inspector`, and `common`.

Slop found while converting and fixed in place:

- `NodeSwitch` built its `sx` through a `useMemo` whose body only spread `sx` straight back — a memo around an identity transform.
- `NodeSelect`'s `selectSx` listed `changed` in its dependency array but never read it.
- `useCanvasImperativeHandle` took `Ref<T>`; a ref *prop* is optional where a forwarded ref never was, so it now takes `Ref<T> | undefined`.

Two prose fixes in docs per `docs/WRITING_STYLE.md`: "deep dive" in `docs/user-interface.md` and "Leverage" in `README_EXAMPLES.md`.

## Diff size

The raw diff reads as ~2,500 lines changed, but that is almost entirely re-indentation from unwrapping the closures. `git diff -w` shows the real change: **309 insertions, 305 deletions**. Reviewing with whitespace ignored is much faster.

## Verification

- `npm run typecheck` — 102 error lines, byte-identical to the pre-existing baseline on `main` (all from unbuilt `@nodetool-ai/*-nodes` declarations; verified by stashing and re-running). Zero errors in any touched file.
- `npm run lint` — passes; only pre-existing warnings.
- `npx jest` in `web/` — **1036 suites, 12,277 tests passed**, 0 failures.

## Note

`workspace/bolt.md` is a committed agent scratchpad sitting in the CLI's runtime workspace directory, and looks like a stray artifact. I left it in place rather than delete notes I can't confirm are disposable — worth a look separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTCxFEXs3ExVUXnNn4wxeA)_