### PR TITLE
Add chat and AI widgets to the mini-app builder

### DIFF
--- a/docs/mini-apps-guide.md
+++ b/docs/mini-apps-guide.md
@@ -233,6 +233,28 @@ graph: emit one flag from a node and condition on that.
 `nodetool app debug` can't simulate resource inputs — resources only exist in the
 browser. Test these in the app.
 
+## 10. A chat app
+
+**Shape:** a conversation the user adds to, one workflow run per turn.
+**Good for:** assistants, Q&A over a collection, anything where the previous
+turns matter.
+
+1. Build the workflow with a **Message List Input** (the whole conversation) or a
+   **String Input** (just the latest message), an LLM node, and an Output node.
+2. Declare a variable — call it `chat` — to hold the conversation.
+3. Place a **Chat Thread**: bind it to `var:chat`, and set **Live reply** to the
+   Output node so the answer appears as it streams.
+4. Place a **Chat Composer** below it: bind it to the workflow input, set
+   **Conversation variable** to `chat`, and pick what it sends — *Whole
+   conversation* for a Message List Input, *Message text* for a String Input.
+   Its **On click** event runs the operation.
+5. Add a **Model Select** bound to the LLM node's `model` property to let the
+   user choose the model.
+
+Turn on image attachments in the composer when the model is multimodal — the
+message then carries content parts instead of plain text, which is what a
+Message Input node and every provider expect.
+
 ---
 
 ## Before you share it

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -56,6 +56,24 @@ That's what makes on-release pacing possible — see
 | Resource Gallery | The same, from a grid of tiles. Tile size. | no |
 | Storyboard Scenes | Edits the bound storyboard directly. Fires no event. | no |
 
+### Chat and AI
+
+| Widget | Does |
+| --- | --- |
+| Chat Thread | Shows a conversation. `binding` is the conversation (an app variable, or an output that emits messages), `streamBinding` the reply arriving from the current run. Max height, placeholder. |
+| Chat Composer | Writes the next message and runs the operation. `binding` is the workflow input it sends to, `historyBinding` the conversation variable it appends to. Sends the message text, a message object, or the whole conversation. Optional image attachments. |
+| Model Select | Picks a model and writes its reference. Kind: language, image, video, speech, transcription, or embedding. |
+
+A conversation is a list of `{role, content}` objects. Anything else a binding
+holds — a streamed string, a media ref, a list of results — reads as one
+assistant turn, so a thread bound straight to an LLM output still renders.
+
+The thread does the bookkeeping a second turn needs: when a run settles, it
+folds the streamed reply into the conversation variable. An output slot is
+cleared at the start of every run, so a reply left there alone would disappear
+the moment the user sends again. This only happens when `binding` is a variable
+and `streamBinding` is an output.
+
 ### Buttons and layout
 
 | Widget | Does |

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -24,6 +24,9 @@ import {
   View,
 } from "react-native";
 import {
+  composeUserMessage,
+  messagesFrom,
+  messageText,
   WIDGET_CATALOG,
   type AppEvent,
   type ConditionProps,
@@ -34,7 +37,13 @@ import type { ThemeColors } from "../../utils/theme";
 import { apiService } from "../../services/api";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
 import { OutputRenderer } from "../outputs/OutputRenderer";
-import { useAppRuntimeContext, useCondition, useFormatted } from "./AppRuntimeContext";
+import {
+  useAppRuntimeContext,
+  useBindingRef,
+  useBindingValue,
+  useCondition,
+  useFormatted,
+} from "./AppRuntimeContext";
 import { useWidgetRuntime } from "./useWidgetRuntime";
 import { SliderControl } from "./SliderControl";
 import { RESOURCE_RENDERERS } from "./resourceWidgets";
@@ -1007,6 +1016,153 @@ const WorkflowInputWidget: React.FC<WidgetProps> = (widget) => {
 
 // ── Actions ─────────────────────────────────────────────────────────────────
 
+// ── Chat ────────────────────────────────────────────────────────────────────
+
+/**
+ * The conversation, plus the reply streaming in from the current run. Unlike
+ * the web thread this one only displays: folding a finished reply back into the
+ * conversation variable happens wherever the app was authored, and doing it
+ * again here would double every turn when both surfaces are open.
+ */
+const ChatThreadWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const streamValue = useBindingValue(
+    useBindingRef(str(widget.props.streamBinding) || undefined, "read")
+  );
+
+  const messages = useMemo(
+    () => [
+      ...messagesFrom(value),
+      ...messagesFrom(streamValue).map((m) => ({ ...m, role: "assistant" })),
+    ],
+    [streamValue, value]
+  );
+  const maxHeight = numOr(widget.props.maxHeight, 360);
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      {messages.length === 0 ? (
+        <Placeholder
+          text={str(widget.props.placeholder) || "No messages yet"}
+          colors={colors}
+        />
+      ) : (
+        <ScrollView style={{ maxHeight }} contentContainerStyle={styles.stack}>
+          {messages.map((message, index) => (
+            <View
+              key={index}
+              style={[
+                styles.bubble,
+                {
+                  backgroundColor:
+                    message.role === "user" ? colors.inputBg : colors.surface,
+                  borderColor: colors.border,
+                  alignSelf:
+                    message.role === "user" ? "flex-end" : "flex-start",
+                },
+              ]}
+            >
+              <Text style={[styles.hint, { color: colors.textTertiary }]}>
+                {message.role === "user" ? "You" : message.role}
+              </Text>
+              <MarkdownRenderer content={messageText(message.content)} />
+              {(Array.isArray(message.content) ? message.content : [])
+                .filter(
+                  (part): part is Record<string, unknown> =>
+                    typeof part === "object" && part !== null &&
+                    (part as Record<string, unknown>).type !== "text"
+                )
+                .map((part, at) => (
+                  <OutputRenderer
+                    key={at}
+                    value={part.image ?? part.video ?? part.audio ?? part}
+                  />
+                ))}
+            </View>
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  );
+};
+
+/** Writes the next message and runs the operation. No attachments on mobile. */
+const ChatComposerWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { write } = useAppRuntimeContext();
+  const { setValue, emit, running } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const historyRef = useBindingRef(
+    str(widget.props.historyBinding) || undefined,
+    "read"
+  );
+  const historyValue = useBindingValue(historyRef);
+  const [draft, setDraft] = useState("");
+
+  const format = str(widget.props.valueFormat) || "text";
+  const canSend = draft.trim().length > 0 && !running && !widget.disabled;
+
+  const send = useCallback(() => {
+    const text = draft.trim();
+    if (!text) {return;}
+    const message = composeUserMessage(text);
+    const history = [...messagesFrom(historyValue), message];
+    if (historyRef) {write(historyRef, history);}
+    setValue(
+      format === "history" ? history : format === "message" ? message : text
+    );
+    setDraft("");
+    emit("click");
+  }, [draft, emit, format, historyRef, historyValue, setValue, write]);
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <TextInput
+        style={[
+          styles.input,
+          styles.inputMultiline,
+          {
+            backgroundColor: colors.inputBg,
+            color: colors.text,
+            borderColor: colors.border,
+          },
+        ]}
+        editable={!widget.disabled}
+        value={draft}
+        multiline
+        placeholder={str(widget.props.placeholder) || "Write a message…"}
+        placeholderTextColor={colors.textTertiary}
+        onChangeText={setDraft}
+      />
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={!canSend}
+        onPress={send}
+        style={[
+          styles.button,
+          {
+            backgroundColor: colors.primary,
+            borderColor: colors.primary,
+            opacity: canSend ? 1 : 0.5,
+          },
+        ]}
+      >
+        {running ? (
+          <ActivityIndicator size="small" color={colors.textOnPrimary} />
+        ) : null}
+        <Text style={[styles.buttonText, { color: colors.textOnPrimary }]}>
+          {str(widget.props.sendLabel) || "Send"}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
 const ButtonWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { emit, running } = useWidgetRuntime({
@@ -1229,6 +1385,8 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   VideoInput: (props) => <MediaInputWidget {...props} kind="video" />,
   DocumentInput: (props) => <MediaInputWidget {...props} kind="document" />,
   ...RESOURCE_RENDERERS,
+  ChatThread: ChatThreadWidget,
+  ChatComposer: ChatComposerWidget,
   Button: ButtonWidget,
   Container: ContainerWidget,
   Columns: ColumnsWidget,
@@ -1353,6 +1511,13 @@ const styles = StyleSheet.create({
   },
   mediaPreview: {
     height: 180,
+  },
+  bubble: {
+    maxWidth: "88%",
+    gap: 4,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
   },
   placeholder: {
     padding: 24,

--- a/packages/app-runtime/src/chat.ts
+++ b/packages/app-runtime/src/chat.ts
@@ -1,0 +1,77 @@
+/**
+ * Conversation semantics for the chat widgets.
+ *
+ * A thread and a composer exist on three surfaces (web, mobile, the headless
+ * `app debug` harness), and all three have to agree on what a bound value means
+ * as a conversation — otherwise an app that reads correctly in the builder
+ * renders as one long assistant turn on a phone.
+ */
+
+/** One turn of a conversation. `content` is text, or a list of content parts. */
+export interface ChatMessage {
+  role: string;
+  content: unknown;
+}
+
+/** What a composer writes to its bound input when the user sends. */
+export type ComposerValueFormat = "text" | "message" | "history";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Read a bound value as a conversation. A list of `{role, content}` objects is
+ * the canonical form; anything else — a streamed string, a media ref, a list of
+ * results — reads as one assistant turn, so a thread bound straight to an LLM
+ * output still renders.
+ */
+export const messagesFrom = (value: unknown): ChatMessage[] => {
+  if (value == null || value === "") return [];
+  const items = Array.isArray(value) ? value : [value];
+  const messages: ChatMessage[] = [];
+  for (const item of items) {
+    if (item == null || item === "") continue;
+    if (isRecord(item) && typeof item.role === "string") {
+      messages.push({ role: item.role, content: item.content ?? "" });
+    } else {
+      messages.push({ role: "assistant", content: item });
+    }
+  }
+  return messages;
+};
+
+/**
+ * The message a composer sends: plain text when there is nothing attached, and
+ * the protocol's content-part list when there is — the shape a MessageInput
+ * node and every provider already accept.
+ */
+export const composeUserMessage = (
+  text: string,
+  imageUris: ReadonlyArray<string> = []
+): ChatMessage & { type: "message" } => {
+  if (imageUris.length === 0) {
+    return { type: "message", role: "user", content: text };
+  }
+  return {
+    type: "message",
+    role: "user",
+    content: [
+      ...(text ? [{ type: "text", text }] : []),
+      ...imageUris.map((uri) => ({
+        type: "image_url",
+        image: { type: "image", uri }
+      }))
+    ]
+  };
+};
+
+/** The plain text of a message's content, ignoring media parts. */
+export const messageText = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return content == null ? "" : String(content);
+  return content
+    .filter((part): part is Record<string, unknown> => isRecord(part))
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text as string)
+    .join("\n");
+};

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -17,5 +17,6 @@ export * from "./policy.js";
 export * from "./conditions.js";
 export * from "./actions.js";
 export * from "./widgets.js";
+export * from "./chat.js";
 export * from "./doc-ops.js";
 export * from "./bundle.js";

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -38,6 +38,12 @@ export interface WidgetDescriptor {
   /** Props holding child widgets, for tree traversal. */
   slots?: ReadonlyArray<string>;
   /**
+   * Binding-carrying props besides `binding`. A chat thread reads its history
+   * from one binding and the in-flight reply from another, so validation has to
+   * look past the single `binding` prop every other widget uses.
+   */
+  bindingProps?: ReadonlyArray<{ prop: string; mode: "read" | "write" }>;
+  /**
    * The widget's own editor fields, name → kind. The three logic props every
    * widget shares are not listed here — `widgetFields` adds them.
    */
@@ -352,6 +358,55 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
       allowRemove: "radio"
     }
   },
+  // Chat & AI
+  //
+  // A chat app is two widgets: the thread shows the conversation so far plus
+  // the reply currently streaming in, the composer writes the next message and
+  // runs the operation. Both address the same conversation value — the thread
+  // reads it, the composer appends to it — which is why the pair carries a
+  // second binding beyond `binding`.
+  ChatThread: {
+    label: "Chat Thread",
+    mode: "read",
+    bindingProps: [{ prop: "streamBinding", mode: "read" }],
+    fields: {
+      binding: "custom",
+      streamBinding: "custom",
+      label: "text",
+      maxHeight: "number",
+      placeholder: "text"
+    }
+  },
+  ChatComposer: {
+    label: "Chat Composer",
+    mode: "write",
+    trigger: "click",
+    bindingProps: [{ prop: "historyBinding", mode: "read" }],
+    fields: {
+      binding: "custom",
+      historyBinding: "custom",
+      valueFormat: "select",
+      label: "text",
+      placeholder: "text",
+      sendLabel: "text",
+      attachments: "radio",
+      events: "array"
+    }
+  },
+  // Writes a model reference — `{type, id, provider, name}` — so an app can
+  // offer the model choice its workflow's LLM node reads.
+  ModelSelect: {
+    label: "Model Select",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: {
+      binding: "custom",
+      modelKind: "select",
+      label: "text",
+      events: "array"
+    }
+  },
   // Actions
   Button: {
     label: "Button",
@@ -429,6 +484,15 @@ export const widgetFields = (
     ...(descriptor.format ? { format: "text" as const } : {})
   };
 };
+
+/**
+ * Binding-carrying props beyond `binding`, with the mode each resolves in.
+ * Empty for every widget that binds once.
+ */
+export const widgetBindingProps = (
+  type: string
+): ReadonlyArray<{ prop: string; mode: "read" | "write" }> =>
+  WIDGET_CATALOG[type]?.bindingProps ?? [];
 
 /** Slot field names of a widget — the props children nest into. */
 export const widgetSlots = (type: string): ReadonlyArray<string> =>

--- a/packages/app-runtime/tests/chat.test.ts
+++ b/packages/app-runtime/tests/chat.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { composeUserMessage, messagesFrom, messageText } from "../src/chat.js";
+
+describe("messagesFrom", () => {
+  it("reads a list of role/content objects as the conversation", () => {
+    expect(
+      messagesFrom([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" }
+      ])
+    ).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" }
+    ]);
+  });
+
+  it("reads a streamed string as one assistant turn", () => {
+    expect(messagesFrom("partial reply")).toEqual([
+      { role: "assistant", content: "partial reply" }
+    ]);
+  });
+
+  it("reads accumulated non-message items as assistant turns", () => {
+    expect(messagesFrom([{ type: "image", uri: "a.png" }])).toEqual([
+      { role: "assistant", content: { type: "image", uri: "a.png" } }
+    ]);
+  });
+
+  it("treats an empty value as no conversation", () => {
+    expect(messagesFrom(undefined)).toEqual([]);
+    expect(messagesFrom("")).toEqual([]);
+    expect(messagesFrom([null, ""])).toEqual([]);
+  });
+
+  it("defaults missing content to an empty string", () => {
+    expect(messagesFrom([{ role: "user" }])).toEqual([
+      { role: "user", content: "" }
+    ]);
+  });
+});
+
+describe("composeUserMessage", () => {
+  it("sends plain text when nothing is attached", () => {
+    expect(composeUserMessage("hi")).toEqual({
+      type: "message",
+      role: "user",
+      content: "hi"
+    });
+  });
+
+  it("sends content parts when images are attached", () => {
+    expect(composeUserMessage("look", ["data:image/png;base64,AAA"])).toEqual({
+      type: "message",
+      role: "user",
+      content: [
+        { type: "text", text: "look" },
+        {
+          type: "image_url",
+          image: { type: "image", uri: "data:image/png;base64,AAA" }
+        }
+      ]
+    });
+  });
+
+  it("omits the text part when the draft was only an attachment", () => {
+    const message = composeUserMessage("", ["data:image/png;base64,AAA"]);
+    expect(message.content).toHaveLength(1);
+  });
+});
+
+describe("messageText", () => {
+  it("joins the text parts of a content list", () => {
+    expect(
+      messageText([
+        { type: "text", text: "one" },
+        { type: "image_url", image: { type: "image", uri: "a.png" } },
+        { type: "text", text: "two" }
+      ])
+    ).toBe("one\ntwo");
+  });
+
+  it("passes a plain string through", () => {
+    expect(messageText("hello")).toBe("hello");
+  });
+});

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   WIDGET_CATALOG,
   isKnownWidget,
+  widgetBindingProps,
   widgetFields,
   widgetMode,
   widgetSlots
@@ -33,6 +34,25 @@ describe("widget catalog", () => {
     // the resource provider, so it has no event of its own.
     expect(WIDGET_CATALOG.ResourceGallery.trigger).toBe("change");
     expect(WIDGET_CATALOG.StoryboardSceneList.trigger).toBeUndefined();
+  });
+
+  it("declares the chat and AI widgets with the bindings they carry", () => {
+    expect(widgetMode("ChatThread")).toBe("read");
+    expect(widgetBindingProps("ChatThread")).toEqual([
+      { prop: "streamBinding", mode: "read" }
+    ]);
+    expect(widgetMode("ChatComposer")).toBe("write");
+    expect(WIDGET_CATALOG.ChatComposer.trigger).toBe("click");
+    expect(widgetBindingProps("ChatComposer")).toEqual([
+      { prop: "historyBinding", mode: "read" }
+    ]);
+    expect(widgetMode("ModelSelect")).toBe("write");
+    expect(WIDGET_CATALOG.ModelSelect.trigger).toBe("change");
+  });
+
+  it("reports no extra bindings for a widget that binds once", () => {
+    expect(widgetBindingProps("Text")).toEqual([]);
+    expect(widgetBindingProps("Bogus")).toEqual([]);
   });
 
   it("reports unknown widget types rather than guessing a mode", () => {

--- a/packages/cli/src/app-debug/app-spec.ts
+++ b/packages/cli/src/app-debug/app-spec.ts
@@ -14,6 +14,7 @@ import {
   parseBinding,
   resolveBinding,
   stateKey,
+  widgetBindingProps,
   widgetMode,
   WIDGET_CATALOG,
   type ApplicationDocument,
@@ -251,6 +252,11 @@ export function parseAppSpec(
         stateKey: ref ? stateKey(ref) : null,
         canonicalBinding: ref ? encodeBinding(ref) : null,
         resourceBindingId,
+        extraBindings: widgetBindingProps(item.type).flatMap(({ prop, mode }) => {
+          const value = str(item.props[prop]);
+          if (!value) return [];
+          return [{ prop, binding: value, ref: resolveBinding(value, scope, mode) }];
+        }),
         label: str(item.props.label) ?? str(item.props.text) ?? null,
         events: parseEvents(item.props.events),
         parentId,
@@ -435,6 +441,15 @@ export function validateApp(
         errors.push(
           `${where}: bound to "${w.binding}" but the app declares no operation "${explicit.operationId}".`
         );
+      }
+    }
+    for (const extra of w.extraBindings) {
+      if (!extra.ref) {
+        errors.push(
+          `${where}: ${extra.prop} is bound to "${extra.binding}" but the workflow has no output or variable with that name.`
+        );
+      } else if (extra.ref.kind === "output") {
+        displayedOutputs.add(`${extra.ref.operationId}:${extra.ref.nodeId}`);
       }
     }
     if (w.ref?.kind === "output") {

--- a/packages/cli/src/app-debug/harness.ts
+++ b/packages/cli/src/app-debug/harness.ts
@@ -216,9 +216,24 @@ function buildAppVerdict(
     const nodeIds = new Set(
       graph.nodes.map((n) => (typeof n.id === "string" ? n.id : "")).filter(Boolean)
     );
+    // Variables a widget writes rather than the graph — a chat composer's
+    // conversation. Nothing the run emits fills them, so an empty one after a
+    // headless run says nothing about the wiring.
+    const uiWrittenVariables = new Set(
+      (report.spec?.widgets ?? []).flatMap((w) =>
+        w.extraBindings
+          .filter((extra) => extra.ref?.kind === "variable")
+          .map((extra) =>
+            extra.ref?.kind === "variable" ? extra.ref.variableId : ""
+          )
+      )
+    );
     for (const w of report.widgets) {
       if (w.bindingMode !== "read" || !w.binding || w.hasValue) continue;
       const ref = parseBinding(w.binding);
+      if (ref?.kind === "variable" && uiWrittenVariables.has(ref.variableId)) {
+        continue;
+      }
       if (ref?.kind === "execution") {
         // Execution state is not a value the graph emits — an empty one only
         // means the operation never ran, or reported no activity.

--- a/packages/cli/src/app-debug/types.ts
+++ b/packages/cli/src/app-debug/types.ts
@@ -56,6 +56,12 @@ export interface AppWidgetSpec {
    * state, so this is their binding rather than {@link binding}.
    */
   resourceBindingId: string | null;
+  /**
+   * Bindings the widget carries besides {@link binding} — a chat thread's live
+   * reply, a composer's conversation variable. Same resolution rules; `ref` is
+   * null when the workflow no longer has what the binding names.
+   */
+  extraBindings: Array<{ prop: string; binding: string; ref: BindingRef | null }>;
   label: string | null;
   events: AppEventSpec[];
   parentId: string | null;

--- a/packages/cli/tests/app-debug-harness.test.ts
+++ b/packages/cli/tests/app-debug-harness.test.ts
@@ -135,6 +135,55 @@ describe("runAppDebug", () => {
     expect(report.verdict.issues.join("\n")).toMatch(/never received a value/);
   });
 
+  it("passes a chat app whose conversation only the UI writes", async () => {
+    // The composer's send and the thread's fold are browser-side, so the
+    // conversation variable is empty after a headless run. That says nothing
+    // about the wiring, and must not read as a missing value.
+    const runOnServer = stubRunner([
+      { type: "output_update", node_id: "out1", output_name: "output", value: "hi" },
+      { type: "job_update", status: "completed" }
+    ]);
+    const report = await runAppDebug(
+      workflowFile({
+        app_doc: {
+          version: 2,
+          variables: [
+            { id: "chat", name: "chat", scope: "instance", persist: false }
+          ],
+          data: {
+            root: { props: { title: "Chat" } },
+            content: [
+              {
+                type: "ChatThread",
+                props: {
+                  id: "ChatThread-1",
+                  binding: "var:chat",
+                  streamBinding: "result"
+                }
+              },
+              {
+                type: "ChatComposer",
+                props: {
+                  id: "ChatComposer-1",
+                  binding: "prompt",
+                  historyBinding: "var:chat",
+                  events: [{ trigger: "click", kind: "run", key: "", value: "" }]
+                }
+              }
+            ],
+            zones: {}
+          }
+        }
+      }),
+      { outDir: mkdtempSync(join(tmpdir(), "app-bundle-")) },
+      deps(runOnServer)
+    );
+
+    expect(report.interactions[0]).toMatchObject({ step: "click ChatComposer-1" });
+    expect(report.verdict.issues).toEqual([]);
+    expect(report.verdict.ok).toBe(true);
+  });
+
   it("warns rather than fails when the empty widget sits on an untaken branch", async () => {
     // One `If` fires one handle per run, so the other branch's widget is
     // legitimately empty. It still gets said out loud: a branch no input can

--- a/packages/cli/tests/app-debug-spec.test.ts
+++ b/packages/cli/tests/app-debug-spec.test.ts
@@ -184,6 +184,44 @@ describe("validateApp", () => {
     expect(errors.join("\n")).toMatch(/no SetVariable node/);
   });
 
+  it("resolves and validates a chat app's second binding", () => {
+    const ok = parseAppSpec(
+      appDoc([
+        widget("ChatThread", "ChatThread-1", {
+          binding: "dark",
+          streamBinding: "result"
+        }),
+        widget("ChatComposer", "ChatComposer-1", {
+          binding: "prompt",
+          historyBinding: "dark",
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    ).spec!;
+    expect(ok.widgets[0].extraBindings[0]).toMatchObject({
+      prop: "streamBinding",
+      binding: "result"
+    });
+    // The thread displays the output through streamBinding, so nothing warns
+    // that the workflow's output goes unshown.
+    expect(validateApp(ok, io)).toEqual({ errors: [], warnings: [] });
+
+    const broken = parseAppSpec(
+      appDoc([
+        widget("ChatThread", "ChatThread-1", {
+          binding: "dark",
+          streamBinding: "ghost"
+        }),
+        widget("Button", "Button-1", { events: [{ trigger: "click", kind: "run" }] })
+      ]),
+      io
+    ).spec!;
+    expect(validateApp(broken, io).errors.join("\n")).toMatch(
+      /streamBinding is bound to "ghost"/
+    );
+  });
+
   it("flags an app that can never run and warns on undisplayed outputs", () => {
     const { spec } = parseAppSpec(
       appDoc([widget("TextInput", "TextInput-1", { binding: "prompt" })]),

--- a/web/src/components/appbuilder/puck/ChatWidgets.tsx
+++ b/web/src/components/appbuilder/puck/ChatWidgets.tsx
@@ -1,0 +1,425 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Chat widgets for mini apps: a thread that renders a conversation and a
+ * composer that writes the next message and runs the workflow.
+ *
+ * The pair shares one value — the conversation, held in an app variable. The
+ * composer appends the user's message to it before the run; the thread reads
+ * it, shows the reply streaming in from the operation's output, and folds that
+ * reply into the conversation once the run settles. That fold is what makes a
+ * second turn keep the first one: an output slot is cleared at the start of
+ * every run, so a reply that stayed there alone would vanish on send.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  composeUserMessage,
+  messagesFrom,
+  stateKey,
+  type ChatMessage
+} from "@nodetool-ai/app-runtime";
+
+import {
+  Box,
+  Caption,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Label,
+  ScrollArea,
+  TextInput,
+  BORDER_RADIUS,
+  SPACING
+} from "../../ui_primitives";
+import { AppEvent } from "../types";
+import {
+  useAppRuntimeContext,
+  useBindingRef,
+  useBindingValue,
+  useRuntimeSelector
+} from "../runtime/AppRuntimeContext";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+import { MarkdownBlock, renderOutputItem, resolveImageSrc } from "./widgets";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const str = (value: unknown): string =>
+  typeof value === "string" ? value : value == null ? "" : String(value);
+
+const ROLE_LABELS: Record<string, string> = {
+  user: "You",
+  assistant: "Assistant",
+  system: "System",
+  tool: "Tool"
+};
+
+const MessageParts: React.FC<{ content: unknown }> = ({ content }) => {
+  if (typeof content === "string") return <MarkdownBlock text={content} />;
+  const parts = Array.isArray(content) ? content : [content];
+  return (
+    <FlexColumn gap={SPACING.sm} fullWidth>
+      {parts.map((part, index) => {
+        if (isRecord(part) && part.type === "text") {
+          return <MarkdownBlock key={index} text={str(part.text)} />;
+        }
+        // The message content types wrap their ref one level down
+        // (`image_url` → `image`, `audio` → `audio`); unwrap so the shared
+        // output renderer sees a media ref it knows.
+        if (isRecord(part)) {
+          const inner = part.image ?? part.video ?? part.audio ?? part.document;
+          if (inner !== undefined) return renderOutputItem(inner, index);
+        }
+        return renderOutputItem(part, index);
+      })}
+    </FlexColumn>
+  );
+};
+
+const Bubble: React.FC<{ message: ChatMessage }> = ({ message }) => {
+  const isUser = message.role === "user";
+  return (
+    <FlexRow
+      fullWidth
+      justify={isUser ? "flex-end" : "flex-start"}
+      sx={{ minWidth: 0 }}
+    >
+      <FlexColumn
+        gap={SPACING.micro}
+        sx={{
+          maxWidth: "85%",
+          minWidth: 0,
+          px: SPACING.md,
+          py: SPACING.sm,
+          borderRadius: BORDER_RADIUS.md,
+          backgroundColor: isUser ? "action.selected" : "action.hover"
+        }}
+      >
+        <Caption color="secondary">
+          {ROLE_LABELS[message.role] ?? message.role}
+        </Caption>
+        <MessageParts content={message.content} />
+      </FlexColumn>
+    </FlexRow>
+  );
+};
+
+export interface ChatThreadWidgetProps {
+  id: string;
+  /** The conversation: an app variable, or an output that emits messages. */
+  binding?: string;
+  /** The reply streaming in from the current run. */
+  streamBinding?: string;
+  label?: string;
+  maxHeight?: number;
+  placeholder?: string;
+}
+
+export const ChatThreadWidget: React.FC<ChatThreadWidgetProps> = ({
+  id,
+  binding,
+  streamBinding,
+  label,
+  maxHeight,
+  placeholder
+}) => {
+  const { write, designMode } = useAppRuntimeContext();
+  const historyRef = useBindingRef(binding, "read");
+  const historyValue = useBindingValue(historyRef);
+  const streamRef = useBindingRef(streamBinding, "read");
+  const streamValue = useBindingValue(streamRef);
+
+  // The invocation that produced the streamed reply, and whether it settled —
+  // the two facts the fold needs, and the only reason the thread looks at the
+  // output slot rather than just its value.
+  const streamKey = streamRef?.kind === "output" ? stateKey(streamRef) : null;
+  const streamInvocationId = useRuntimeSelector((s) =>
+    streamKey ? s.outputs[streamKey]?.invocationId : undefined
+  );
+  const streamSettled = useRuntimeSelector((s) =>
+    streamInvocationId
+      ? s.invocations[streamInvocationId]?.status === "completed"
+      : false
+  );
+
+  const messages = useMemo(() => messagesFrom(historyValue), [historyValue]);
+  const [foldedInvocation, setFoldedInvocation] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!streamInvocationId || !streamSettled) return;
+    if (foldedInvocation === streamInvocationId) return;
+    if (historyRef?.kind !== "variable") return;
+    if (streamValue == null || streamValue === "") return;
+    setFoldedInvocation(streamInvocationId);
+    write(historyRef, [
+      ...messages,
+      { type: "message", role: "assistant", content: streamValue }
+    ]);
+  }, [
+    foldedInvocation,
+    historyRef,
+    messages,
+    streamInvocationId,
+    streamSettled,
+    streamValue,
+    write
+  ]);
+
+  const live =
+    streamValue != null &&
+    streamValue !== "" &&
+    foldedInvocation !== streamInvocationId
+      ? messagesFrom(streamValue).map((m) => ({ ...m, role: "assistant" }))
+      : [];
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element) element.scrollTop = element.scrollHeight;
+  }, [messages, live.length, streamValue]);
+
+  const all = [...messages, ...live];
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {label ? <Label>{label}</Label> : null}
+      <ScrollArea
+        ref={scrollRef}
+        thin
+        maxHeight={maxHeight && maxHeight > 0 ? maxHeight : 360}
+        aria-label={label || "Conversation"}
+        sx={{
+          width: "100%",
+          minHeight: 96,
+          p: SPACING.md,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: BORDER_RADIUS.md
+        }}
+      >
+        {all.length === 0 ? (
+          <Caption color="secondary">
+            {placeholder ??
+              (designMode
+                ? "Messages appear here once the app runs."
+                : "No messages yet")}
+          </Caption>
+        ) : (
+          <FlexColumn gap={SPACING.md} fullWidth>
+            {all.map((message, index) => (
+              <Bubble key={`${id}-${index}`} message={message} />
+            ))}
+          </FlexColumn>
+        )}
+      </ScrollArea>
+    </FlexColumn>
+  );
+};
+
+export interface ChatComposerWidgetProps {
+  id: string;
+  /** The workflow input the composed message is written to. */
+  binding?: string;
+  /** The conversation variable the user's message is appended to. */
+  historyBinding?: string;
+  valueFormat?: string;
+  label?: string;
+  placeholder?: string;
+  sendLabel?: string;
+  attachments?: boolean;
+  events?: AppEvent[];
+  disabled?: boolean;
+}
+
+interface Attachment {
+  name: string;
+  dataUrl: string;
+}
+
+const readAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(str(reader.result));
+    reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+    reader.readAsDataURL(file);
+  });
+
+export const ChatComposerWidget: React.FC<ChatComposerWidgetProps> = ({
+  id,
+  binding,
+  historyBinding,
+  valueFormat,
+  label,
+  placeholder,
+  sendLabel,
+  attachments,
+  events,
+  disabled
+}) => {
+  const { write } = useAppRuntimeContext();
+  const { setValue, emit, designMode, runnerState } = useWidgetRuntime({
+    id,
+    bindingMode: "write",
+    binding,
+    events
+  });
+  const historyRef = useBindingRef(historyBinding, "read");
+  const historyValue = useBindingValue(historyRef);
+
+  const [draft, setDraft] = useState("");
+  const [files, setFiles] = useState<Attachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isRunning = runnerState === "running" && !designMode;
+  const canSend = (draft.trim().length > 0 || files.length > 0) && !isRunning;
+
+  const send = useCallback(() => {
+    const text = draft.trim();
+    if (text.length === 0 && files.length === 0) return;
+
+    const message = composeUserMessage(
+      text,
+      files.map((file) => file.dataUrl)
+    );
+    const history = [...messagesFrom(historyValue), message];
+    if (historyRef) write(historyRef, history);
+
+    setValue(
+      valueFormat === "history"
+        ? history
+        : valueFormat === "message"
+          ? message
+          : text
+    );
+    setDraft("");
+    setFiles([]);
+    emit("click");
+  }, [
+    draft,
+    emit,
+    files,
+    historyRef,
+    historyValue,
+    setValue,
+    valueFormat,
+    write
+  ]);
+
+  const attach = async (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    const read = await Promise.all(
+      Array.from(list).map(async (file) => ({
+        name: file.name,
+        dataUrl: await readAsDataUrl(file)
+      }))
+    );
+    setFiles((previous) => [...previous, ...read]);
+  };
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {label ? <Label>{label}</Label> : null}
+      {files.length > 0 ? (
+        <FlexRow gap={SPACING.sm} sx={{ flexWrap: "wrap" }}>
+          {files.map((file, index) => {
+            const src = resolveImageSrc(file.dataUrl);
+            return (
+              <FlexRow
+                key={`${file.name}-${index}`}
+                gap={SPACING.xs}
+                align="center"
+                sx={{
+                  px: SPACING.sm,
+                  py: SPACING.micro,
+                  borderRadius: BORDER_RADIUS.md,
+                  backgroundColor: "action.hover"
+                }}
+              >
+                {src ? (
+                  <Box
+                    component="img"
+                    src={src}
+                    alt=""
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      objectFit: "cover",
+                      borderRadius: BORDER_RADIUS.sm
+                    }}
+                  />
+                ) : null}
+                <Caption>{file.name}</Caption>
+                <EditorButton
+                  size="small"
+                  variant="text"
+                  aria-label={`Remove ${file.name}`}
+                  onClick={() =>
+                    setFiles((previous) =>
+                      previous.filter((_, at) => at !== index)
+                    )
+                  }
+                >
+                  ×
+                </EditorButton>
+              </FlexRow>
+            );
+          })}
+        </FlexRow>
+      ) : null}
+      <FlexRow gap={SPACING.sm} align="flex-end" fullWidth>
+        <TextInput
+          value={draft}
+          placeholder={placeholder ?? "Write a message…"}
+          multiline
+          minRows={2}
+          maxRows={8}
+          size="small"
+          fullWidth
+          disabled={disabled}
+          inputProps={{ "aria-label": label || "Message" }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setDraft(e.target.value)
+          }
+          onKeyDown={(e: React.KeyboardEvent) => {
+            // Enter sends, Shift+Enter breaks the line — what every chat box does.
+            if (e.key !== "Enter" || e.shiftKey) return;
+            e.preventDefault();
+            if (canSend) send();
+          }}
+        />
+        {attachments ? (
+          <>
+            <Box
+              component="input"
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              sx={{ display: "none" }}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                void attach(e.target.files);
+                e.target.value = "";
+              }}
+            />
+            <EditorButton
+              variant="outlined"
+              size="small"
+              disabled={disabled}
+              aria-label="Attach image"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Attach
+            </EditorButton>
+          </>
+        ) : null}
+        <EditorButton
+          variant="contained"
+          size="small"
+          disabled={disabled || !canSend}
+          onClick={send}
+        >
+          {isRunning ? "Sending…" : sendLabel || "Send"}
+        </EditorButton>
+      </FlexRow>
+    </FlexColumn>
+  );
+};

--- a/web/src/components/appbuilder/puck/WorkflowInputWidget.tsx
+++ b/web/src/components/appbuilder/puck/WorkflowInputWidget.tsx
@@ -250,6 +250,78 @@ export const WorkflowInputWidget: React.FC<WorkflowInputWidgetProps> = (
   );
 };
 
+/**
+ * The model kinds a ModelSelect widget can offer. Same six the workflow input
+ * form resolves, picked here by the app author instead of by a node's type —
+ * an app often wants to drive an LLM node's `model` property directly.
+ */
+export const MODEL_WIDGET_KINDS = [
+  "language_model",
+  "image_model",
+  "video_model",
+  "tts_model",
+  "asr_model",
+  "embedding_model"
+] as const;
+
+export type ModelWidgetKind = (typeof MODEL_WIDGET_KINDS)[number];
+
+const MODEL_KIND_NODE_TYPE: Record<ModelWidgetKind, string> = {
+  language_model: "nodetool.input.LanguageModelInput",
+  image_model: "nodetool.input.ImageModelInput",
+  video_model: "nodetool.input.VideoModelInput",
+  tts_model: "nodetool.input.TTSModelInput",
+  asr_model: "nodetool.input.ASRModelInput",
+  embedding_model: "nodetool.input.EmbeddingModelInput"
+};
+
+const isModelKind = (value: unknown): value is ModelWidgetKind =>
+  MODEL_WIDGET_KINDS.includes(value as ModelWidgetKind);
+
+export interface ModelSelectWidgetProps {
+  id: string;
+  binding?: string;
+  label?: string;
+  modelKind?: string;
+  events?: AppEvent[];
+}
+
+/**
+ * Picks a model and writes its reference — `{type, id, provider, name}` — to
+ * the bound input or node property.
+ */
+export const ModelSelectWidget: React.FC<ModelSelectWidgetProps> = (props) => {
+  const kind = isModelKind(props.modelKind) ? props.modelKind : "language_model";
+  const { value, setValue, emit } = useWidgetRuntime({
+    id: props.id,
+    bindingMode: "write",
+    binding: props.binding,
+    events: props.events
+  });
+
+  const input = useMemo<WorkflowInputIO>(
+    () => ({
+      nodeId: props.id,
+      nodeType: MODEL_KIND_NODE_TYPE[kind],
+      name: props.label || "Model",
+      label: props.label || "Model",
+      kind
+    }),
+    [kind, props.id, props.label]
+  );
+
+  return (
+    <InputControl
+      input={input}
+      value={value}
+      onValue={(next) => {
+        setValue(next);
+        emit("change");
+      }}
+    />
+  );
+};
+
 /** Kinds exposed as standalone palette widgets alongside the auto-resolving
  * WorkflowInput — so an app authored from scratch can offer media pickers. */
 export type FixedInputKind = "image" | "audio" | "video" | "document" | "color";

--- a/web/src/components/appbuilder/puck/__tests__/chatWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/chatWidgets.test.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { DEFAULT_OPERATION_ID } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime, OUTPUT_KEY } from "../../__tests__/testRuntime";
+import { ChatComposerWidget, ChatThreadWidget } from "../ChatWidgets";
+
+const HISTORY = "var:chat";
+const REPLY = `op:${DEFAULT_OPERATION_ID}/out:out1`;
+const PROMPT = `op:${DEFAULT_OPERATION_ID}/in:in1`;
+
+const SCOPED = {
+  scope: {
+    defaultOperationId: DEFAULT_OPERATION_ID,
+    operations: [
+      {
+        operationId: DEFAULT_OPERATION_ID,
+        inputs: [{ nodeId: "in1", name: "prompt" }],
+        outputs: [{ nodeId: "out1", name: "result" }],
+        nodeIds: ["in1", "out1"]
+      }
+    ],
+    variables: [
+      { id: "chat", name: "chat", scope: "instance" as const, persist: false }
+    ]
+  }
+};
+
+const renderWith = (
+  ui: React.ReactElement,
+  runtime: ReturnType<typeof makeTestRuntime>
+) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <runtime.wrapper>{ui}</runtime.wrapper>
+    </ThemeProvider>
+  );
+
+describe("ChatThreadWidget", () => {
+  it("renders a bound conversation as user and assistant turns", () => {
+    const runtime = makeTestRuntime(
+      {
+        variables: {
+          chat: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi there" }
+          ]
+        }
+      },
+      SCOPED
+    );
+    renderWith(<ChatThreadWidget id="t1" binding={HISTORY} />, runtime);
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hi there")).toBeInTheDocument();
+    expect(screen.getByText("You")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when the conversation is empty", () => {
+    const runtime = makeTestRuntime({}, SCOPED);
+    renderWith(
+      <ChatThreadWidget id="t1" binding={HISTORY} placeholder="Say something" />,
+      runtime
+    );
+    expect(screen.getByText("Say something")).toBeInTheDocument();
+  });
+
+  it("appends the streaming reply after the conversation", () => {
+    const runtime = makeTestRuntime(
+      {
+        variables: { chat: [{ role: "user", content: "hello" }] },
+        outputs: {
+          [OUTPUT_KEY]: {
+            value: "thinking out loud",
+            invocationId: "inv1",
+            status: "streaming",
+            revision: 1
+          }
+        },
+        invocations: {
+          inv1: {
+            id: "inv1",
+            operationId: DEFAULT_OPERATION_ID,
+            status: "running" as const,
+            startedAt: 1
+          }
+        }
+      },
+      SCOPED
+    );
+    renderWith(
+      <ChatThreadWidget id="t1" binding={HISTORY} streamBinding={REPLY} />,
+      runtime
+    );
+    expect(screen.getByText("thinking out loud")).toBeInTheDocument();
+  });
+
+  it("folds a completed reply into the conversation variable", async () => {
+    const runtime = makeTestRuntime(
+      {
+        variables: { chat: [{ role: "user", content: "hello" }] },
+        outputs: {
+          [OUTPUT_KEY]: {
+            value: "the answer",
+            invocationId: "inv1",
+            status: "done",
+            revision: 2
+          }
+        },
+        invocations: {
+          inv1: {
+            id: "inv1",
+            operationId: DEFAULT_OPERATION_ID,
+            status: "completed" as const,
+            startedAt: 1
+          }
+        }
+      },
+      SCOPED
+    );
+    renderWith(
+      <ChatThreadWidget id="t1" binding={HISTORY} streamBinding={REPLY} />,
+      runtime
+    );
+
+    await waitFor(() =>
+      expect(runtime.value.write).toHaveBeenCalledWith(
+        { kind: "variable", variableId: "chat" },
+        [
+          { role: "user", content: "hello" },
+          { type: "message", role: "assistant", content: "the answer" }
+        ]
+      )
+    );
+    // The reply now lives in the conversation, so the live bubble must not
+    // render it a second time.
+    expect(screen.getAllByText("the answer")).toHaveLength(1);
+  });
+});
+
+describe("ChatComposerWidget", () => {
+  const RUN_EVENT = [{ trigger: "click" as const, kind: "run" }];
+
+  it("sends the draft to the bound input and runs the workflow", async () => {
+    const user = userEvent.setup();
+    const runtime = makeTestRuntime({}, SCOPED);
+    renderWith(
+      <ChatComposerWidget
+        id="c1"
+        binding={PROMPT}
+        historyBinding={HISTORY}
+        events={RUN_EVENT}
+      />,
+      runtime
+    );
+
+    const box = screen.getByLabelText("Message");
+    await user.type(box, "write me a poem");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(runtime.store.getState().inputs[`${DEFAULT_OPERATION_ID}:in1`].value).toBe(
+      "write me a poem"
+    );
+    expect(runtime.value.write).toHaveBeenCalledWith(
+      { kind: "variable", variableId: "chat" },
+      [{ type: "message", role: "user", content: "write me a poem" }]
+    );
+    expect(runtime.value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run", operationId: DEFAULT_OPERATION_ID })
+    );
+    expect(box).toHaveValue("");
+  });
+
+  it("sends the whole conversation when the format asks for it", async () => {
+    const user = userEvent.setup();
+    const runtime = makeTestRuntime(
+      { variables: { chat: [{ role: "assistant", content: "how can I help?" }] } },
+      SCOPED
+    );
+    renderWith(
+      <ChatComposerWidget
+        id="c1"
+        binding={PROMPT}
+        historyBinding={HISTORY}
+        valueFormat="history"
+        events={RUN_EVENT}
+      />,
+      runtime
+    );
+
+    await user.type(screen.getByLabelText("Message"), "hi");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(runtime.store.getState().inputs[`${DEFAULT_OPERATION_ID}:in1`].value).toEqual([
+      { role: "assistant", content: "how can I help?" },
+      { type: "message", role: "user", content: "hi" }
+    ]);
+  });
+
+  it("will not send an empty draft", async () => {
+    const runtime = makeTestRuntime({}, SCOPED);
+    renderWith(
+      <ChatComposerWidget id="c1" binding={PROMPT} events={RUN_EVENT} />,
+      runtime
+    );
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(runtime.value.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/modelSelectWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/modelSelectWidget.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { DEFAULT_OPERATION_ID } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { ModelSelectWidget } from "../WorkflowInputWidget";
+
+// The real selects open a model dialog backed by the models API; the widget's
+// job is only to hand the chosen model to the runtime, so each select is stood
+// in for by a button that reports one.
+jest.mock("../../../properties/LanguageModelSelect", () => {
+  const react = jest.requireActual("react");
+  const model = {
+    type: "language_model",
+    id: "gpt-5.4-mini",
+    provider: "openai",
+    name: "gpt-5.4-mini"
+  };
+  return {
+    __esModule: true,
+    default: ({ value, onChange }: { value: string; onChange: (v: unknown) => void }) =>
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange(model) },
+        `language_model:${value || "none"}`
+      )
+  };
+});
+
+jest.mock("../../../properties/ImageModelSelect", () => {
+  const react = jest.requireActual("react");
+  const model = {
+    type: "image_model",
+    id: "flux-schnell",
+    provider: "fal_ai",
+    name: "flux-schnell"
+  };
+  return {
+    __esModule: true,
+    default: ({ value, onChange }: { value: string; onChange: (v: unknown) => void }) =>
+      react.createElement(
+        "button",
+        { type: "button", onClick: () => onChange(model) },
+        `image_model:${value || "none"}`
+      )
+  };
+});
+
+const MODEL_PROPERTY_BINDING = `op:${DEFAULT_OPERATION_ID}/prop:n5#model`;
+
+const renderWidget = (props: {
+  binding?: string;
+  modelKind?: string;
+  label?: string;
+}) => {
+  const runtime = makeTestRuntime();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <runtime.wrapper>
+        <ModelSelectWidget id="m1" {...props} />
+      </runtime.wrapper>
+    </ThemeProvider>
+  );
+  return runtime;
+};
+
+describe("ModelSelectWidget", () => {
+  it("writes the picked language model to the bound node property", async () => {
+    const user = userEvent.setup();
+    const runtime = renderWidget({ binding: MODEL_PROPERTY_BINDING });
+
+    await user.click(screen.getByRole("button", { name: "language_model:none" }));
+
+    expect(
+      runtime.store.getState().inputs[`${DEFAULT_OPERATION_ID}:n5#model`].value
+    ).toEqual({
+      type: "language_model",
+      id: "gpt-5.4-mini",
+      provider: "openai",
+      name: "gpt-5.4-mini"
+    });
+  });
+
+  it("renders the select for the chosen model kind", () => {
+    renderWidget({ binding: MODEL_PROPERTY_BINDING, modelKind: "image_model" });
+    expect(
+      screen.getByRole("button", { name: "image_model:none" })
+    ).toBeInTheDocument();
+  });
+
+  it("holds its value locally when nothing is bound", async () => {
+    const user = userEvent.setup();
+    const runtime = renderWidget({});
+
+    await user.click(screen.getByRole("button", { name: "language_model:none" }));
+
+    expect(runtime.store.getState().view["m1:value"]).toEqual(
+      expect.objectContaining({ id: "gpt-5.4-mini" })
+    );
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -52,8 +52,10 @@ import {
   WorkflowInputWidget,
   FixedKindInputWidget,
   FixedInputKind,
-  FixedInputWidgetProps
+  FixedInputWidgetProps,
+  ModelSelectWidget
 } from "./WorkflowInputWidget";
+import { ChatThreadWidget, ChatComposerWidget } from "./ChatWidgets";
 
 const ACTION_OPTIONS = [
   { label: "Run workflow", value: "run" },
@@ -257,6 +259,10 @@ export const appConfig: Config = {
         "DocumentInput",
         "ColorInput"
       ]
+    },
+    ai: {
+      title: "Chat & AI",
+      components: ["ChatThread", "ChatComposer", "ModelSelect"]
     },
     actions: { title: "Actions", components: ["Button"] },
     display: {
@@ -697,6 +703,93 @@ export const appConfig: Config = {
         allowRemove: true
       },
       render: withConditions((props) => <StoryboardSceneListWidget {...props} />)
+    },
+    // ── Chat & AI ──
+    ChatThread: {
+      label: "Chat Thread",
+      fields: {
+        binding: bindingField("read", "Conversation"),
+        streamBinding: bindingField("read", "Live reply"),
+        label: { type: "text", label: "Label" },
+        maxHeight: { type: "number", label: "Max height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        binding: "",
+        streamBinding: "",
+        label: "",
+        maxHeight: 360,
+        placeholder: "No messages yet"
+      },
+      render: withConditions((props) => <ChatThreadWidget {...props} />)
+    },
+    ChatComposer: {
+      label: "Chat Composer",
+      fields: {
+        binding: bindingField("write", "Sends to"),
+        historyBinding: variableField("Conversation variable"),
+        valueFormat: {
+          type: "select",
+          label: "Sends",
+          options: [
+            { label: "Message text", value: "text" },
+            { label: "Message object", value: "message" },
+            { label: "Whole conversation", value: "history" }
+          ]
+        },
+        label: { type: "text", label: "Label" },
+        placeholder: { type: "text", label: "Placeholder" },
+        sendLabel: { type: "text", label: "Send button" },
+        attachments: {
+          type: "radio",
+          label: "Image attachments",
+          options: [
+            { label: "Off", value: false },
+            { label: "On", value: true }
+          ]
+        },
+        events: eventsField("click"),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        binding: "",
+        historyBinding: "",
+        valueFormat: "text",
+        label: "",
+        placeholder: "Write a message…",
+        sendLabel: "Send",
+        attachments: false,
+        events: [{ trigger: "click", kind: "run", key: "", value: "" }]
+      },
+      render: withConditions((props) => <ChatComposerWidget {...props} />)
+    },
+    ModelSelect: {
+      label: "Model Select",
+      fields: {
+        binding: bindingField("write"),
+        modelKind: {
+          type: "select",
+          label: "Model kind",
+          options: [
+            { label: "Language", value: "language_model" },
+            { label: "Image", value: "image_model" },
+            { label: "Video", value: "video_model" },
+            { label: "Speech (TTS)", value: "tts_model" },
+            { label: "Transcription (ASR)", value: "asr_model" },
+            { label: "Embedding", value: "embedding_model" }
+          ]
+        },
+        label: { type: "text", label: "Label" },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        binding: "",
+        modelKind: "language_model",
+        label: "Model"
+      },
+      render: withConditions((props) => <ModelSelectWidget {...props} />)
     },
     ImageInput: fixedInputEntry("Image Input", "image"),
     AudioInput: fixedInputEntry("Audio Input", "audio"),

--- a/web/src/components/appbuilder/puck/widgets.tsx
+++ b/web/src/components/appbuilder/puck/widgets.tsx
@@ -60,7 +60,7 @@ const str = (v: unknown): string =>
 const numOr = (v: unknown, fallback: number): number =>
   typeof v === "number" && Number.isFinite(v) ? v : fallback;
 
-const resolveImageSrc = (value: unknown): string | null => {
+export const resolveImageSrc = (value: unknown): string | null => {
   if (typeof value === "string") return value.length > 0 ? value : null;
   if (value && typeof value === "object") {
     const obj = value as Record<string, unknown>;
@@ -71,7 +71,7 @@ const resolveImageSrc = (value: unknown): string | null => {
 };
 
 /** Resolve a playable media source from a string, MediaRef, or data payload. */
-const resolveMediaSrc = (value: unknown, mime: string): string | null => {
+export const resolveMediaSrc = (value: unknown, mime: string): string | null => {
   const src = resolveImageSrc(value);
   if (!src) return null;
   // Raw base64 payloads (no scheme) become a data URI so <audio>/<video> play them.
@@ -172,7 +172,7 @@ const VideoItem: React.FC<{ src: string; height: number }> = ({
   />
 );
 
-const MarkdownBlock: React.FC<{ text: string }> = ({ text }) => (
+export const MarkdownBlock: React.FC<{ text: string }> = ({ text }) => (
   <Box className="appbuilder-markdown" sx={{ width: "100%" }}>
     <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
   </Box>
@@ -341,7 +341,7 @@ const mediaRefKind = (value: unknown): "image" | "audio" | "video" | null => {
 };
 
 /** Render one untyped output item by its runtime shape. */
-const renderOutputItem = (item: unknown, key: number): React.ReactNode => {
+export const renderOutputItem = (item: unknown, key: number): React.ReactNode => {
   switch (mediaRefKind(item)) {
     case "image": {
       const src = resolveImageSrc(item);


### PR DESCRIPTION
A mini app could show a workflow's output but never hold a conversation: composing the next message, keeping the previous turns, and choosing the model all had to happen in the graph.

## What's new

Three widgets, in a new **Chat & AI** palette category:

| Widget | Does |
| --- | --- |
| **Chat Thread** | Renders a conversation (`binding`) plus the reply streaming in from the current run (`streamBinding`). When the run settles it folds that reply into the conversation variable — an output slot is cleared at the start of every run, so a reply left there alone would vanish on the next send. |
| **Chat Composer** | Writes the next message and runs the operation. Sends the message text, a message object, or the whole conversation (`valueFormat`), appends the user's turn to the conversation variable (`historyBinding`), and can attach images as content parts. Enter sends, Shift+Enter breaks the line. |
| **Model Select** | Picks a language / image / video / speech / transcription / embedding model and writes its reference (`{type, id, provider, name}`) to the bound input or node property. Reuses the editor's existing model selects. |

A chat app is then: a variable for the conversation, a Chat Thread bound to it with the Output node as the live reply, a Chat Composer bound to the workflow input, and optionally a Model Select on the LLM node's `model`.

## Shared semantics, not three copies

- Conversation reading (`messagesFrom`), message composition (`composeUserMessage`), and plain-text extraction live in `@nodetool-ai/app-runtime`, used by the web widgets, the native renderers, and the harness. A value that isn't a list of `{role, content}` objects — a streamed string, a media ref, an accumulated list — reads as one assistant turn, so a thread bound straight to an LLM output still renders.
- The widget catalog gains `bindingProps`: the binding-carrying props a widget has beyond `binding`. `nodetool app debug` resolves and validates those the same way, and an output shown through `streamBinding` counts as displayed.
- The harness stops reporting an empty conversation variable as a missing value. Only the UI writes it, so a headless run legitimately leaves it empty; before this, every chat app failed `app debug` with "never received a value — check the output node emits".

Mobile renders the thread and composer natively (no attachments); Model Select needs the model dialog and stays web-only, which the mobile renderer already reports rather than dropping.

## Verification

- `npm run typecheck` (web, electron, mobile), `npm run lint`, `npm run test` — all green.
- New tests: web widget tests for the thread's rendering/fold and the composer's send paths, a Model Select test, `app-runtime` chat-semantics and catalog tests, CLI spec + harness tests for the second binding and the chat verdict.
- End to end: a hand-built chat app run through `nodetool app debug` validates statically and runs clean.

Docs: a Chat and AI section in the mini-apps reference and a chat-app recipe in the guide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du4ZC2vKzBbiLC67LcB1cJ)_