### PR TITLE
Render ModelSelect on mobile and join streamed chunks into one turn

### DIFF
--- a/mobile/src/components/app_runtime/ModelSelectWidget.tsx
+++ b/mobile/src/components/app_runtime/ModelSelectWidget.tsx
@@ -1,0 +1,146 @@
+/**
+ * Native renderer for the catalog's `ModelSelect`.
+ *
+ * The web widget offers the graph editor's model menus; a phone has no menu of
+ * that shape, so the same choice renders as a chip row over the models the
+ * device can reach. The written value is identical either way — the
+ * `{type, id, provider, name}` ref a workflow's model input reads — so an app
+ * authored in the builder runs the same model here.
+ *
+ * The tRPC model queries live in this file rather than in `widgets.tsx` so the
+ * shared widget module keeps rendering without them.
+ */
+import React from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import type { AppEvent } from "@nodetool-ai/app-runtime";
+
+import { useTheme } from "../../hooks/useTheme";
+import { useModelsForType } from "../../hooks/useModelsByProvider";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+interface ModelSelectProps {
+  id: string;
+  binding?: string;
+  events?: AppEvent[];
+  disabled?: boolean;
+  props: Record<string, unknown>;
+}
+
+const str = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+/** The six model kinds a workflow input can ask for. */
+const MODEL_KINDS = [
+  "language_model",
+  "image_model",
+  "video_model",
+  "tts_model",
+  "asr_model",
+  "embedding_model",
+] as const;
+
+type ModelKind = (typeof MODEL_KINDS)[number];
+
+const modelKindOf = (value: unknown): ModelKind =>
+  MODEL_KINDS.includes(value as ModelKind)
+    ? (value as ModelKind)
+    : "language_model";
+
+export const ModelSelectWidget: React.FC<ModelSelectProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const kind = modelKindOf(widget.props.modelKind);
+  const { models, isLoading, error } = useModelsForType(kind);
+  const selectedId = str((value as Record<string, unknown> | null)?.id);
+
+  const label = str(widget.props.label);
+  const status = error
+    ? error
+    : !isLoading && models.length === 0
+      ? "No models available"
+      : null;
+
+  return (
+    <View style={styles.field}>
+      {label ? (
+        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+      ) : null}
+      {isLoading ? <ActivityIndicator color={colors.primary} /> : null}
+      {status ? (
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          {status}
+        </Text>
+      ) : null}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={styles.chipRow}>
+          {models.map((model) => {
+            const selected = model.id === selectedId;
+            return (
+              <TouchableOpacity
+                key={`${model.provider}:${model.id}`}
+                disabled={widget.disabled}
+                onPress={() => {
+                  setValue({
+                    type: kind,
+                    id: model.id,
+                    provider: model.provider,
+                    name: model.name || "",
+                  });
+                  emit("change");
+                }}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: selected ? colors.primary : colors.inputBg,
+                    borderColor: selected ? colors.primary : colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={{
+                    color: selected ? colors.textOnPrimary : colors.text,
+                  }}
+                >
+                  {model.name || model.id}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  field: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  hint: {
+    fontSize: 12,
+  },
+  chipRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+});

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -47,6 +47,7 @@ import {
 import { useWidgetRuntime } from "./useWidgetRuntime";
 import { SliderControl } from "./SliderControl";
 import { RESOURCE_RENDERERS } from "./resourceWidgets";
+import { ModelSelectWidget } from "./ModelSelectWidget";
 import { pickMediaValue, type MediaKind } from "./mediaPicker";
 import { clampNumber } from "./inputKinds";
 
@@ -1387,6 +1388,7 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   ...RESOURCE_RENDERERS,
   ChatThread: ChatThreadWidget,
   ChatComposer: ChatComposerWidget,
+  ModelSelect: ModelSelectWidget,
   Button: ButtonWidget,
   Container: ContainerWidget,
   Columns: ColumnsWidget,

--- a/packages/app-runtime/src/chat.ts
+++ b/packages/app-runtime/src/chat.ts
@@ -29,13 +29,25 @@ export const messagesFrom = (value: unknown): ChatMessage[] => {
   if (value == null || value === "") return [];
   const items = Array.isArray(value) ? value : [value];
   const messages: ChatMessage[] = [];
+  // A streaming output accumulates one item per chunk. Those chunks are one
+  // reply, so consecutive text joins into the turn in progress rather than
+  // giving the thread a bubble per token.
+  let streaming = false;
   for (const item of items) {
     if (item == null || item === "") continue;
     if (isRecord(item) && typeof item.role === "string") {
       messages.push({ role: item.role, content: item.content ?? "" });
-    } else {
-      messages.push({ role: "assistant", content: item });
+      streaming = false;
+      continue;
     }
+    const chunk = typeof item === "string" ? item : null;
+    const last = messages[messages.length - 1];
+    if (chunk !== null && streaming && last) {
+      last.content = `${last.content as string}${chunk}`;
+      continue;
+    }
+    messages.push({ role: "assistant", content: item });
+    streaming = chunk !== null;
   }
   return messages;
 };

--- a/packages/app-runtime/tests/chat.test.ts
+++ b/packages/app-runtime/tests/chat.test.ts
@@ -26,6 +26,39 @@ describe("messagesFrom", () => {
     ]);
   });
 
+  it("joins the chunks of one streamed reply into a single turn", () => {
+    // A streaming output accumulates one item per chunk; a bubble per token is
+    // not what the reply looked like when it was produced.
+    expect(messagesFrom(["hel", "lo", " there"])).toEqual([
+      { role: "assistant", content: "hello there" }
+    ]);
+  });
+
+  it("starts a new turn when a message interrupts the chunks", () => {
+    expect(
+      messagesFrom([
+        "thinking",
+        { role: "user", content: "wait" },
+        "resum",
+        "ed"
+      ])
+    ).toEqual([
+      { role: "assistant", content: "thinking" },
+      { role: "user", content: "wait" },
+      { role: "assistant", content: "resumed" }
+    ]);
+  });
+
+  it("keeps non-text items as their own turns", () => {
+    // Two images are two results, not one concatenated reply.
+    expect(
+      messagesFrom([{ type: "image", uri: "a.png" }, { type: "image", uri: "b.png" }])
+    ).toEqual([
+      { role: "assistant", content: { type: "image", uri: "a.png" } },
+      { role: "assistant", content: { type: "image", uri: "b.png" } }
+    ]);
+  });
+
   it("treats an empty value as no conversation", () => {
     expect(messagesFrom(undefined)).toEqual([]);
     expect(messagesFrom("")).toEqual([]);


### PR DESCRIPTION
Follow-up to #4567, which landed the chat and AI widgets while this PR was open. The duplicate implementation that was here has been dropped in favour of #4567; what remains is the two gaps that survived it.

## Mobile ModelSelect

`ModelSelect` had a web renderer but no native one, so a phone showed *"Model Select is not available on mobile"* where the builder shows a model menu. It now renders the models the device can reach as a chip row, over the same `useModelsForType` queries the model selection screen uses, and writes the same `{type, id, provider, name}` ref the web menus write — so an app authored in the builder runs the same model on either surface.

The tRPC queries live in `ModelSelectWidget.tsx` rather than in `widgets.tsx`, so the shared widget module keeps rendering without them.

## Streamed chunks are one reply

`messagesFrom` mapped every accumulated item to its own assistant turn, so a thread bound to an output that streamed its reply chunk by chunk drew a bubble per chunk. Consecutive text now joins into the turn in progress. A message carrying a `role` still starts a new turn, and non-text items stay their own turns — two images are two results, not one concatenated reply. `ChatThread`'s separate `streamBinding` path is unaffected; this is about a thread bound straight at an accumulated output.

## Testing

- `packages/app-runtime` vitest: 178 passed, including three new `messagesFrom` cases (chunk joining, a message interrupting the chunks, non-text items kept apart).
- `web` appbuilder jest: 303 passed; mobile: 925 passed.
- `typecheck:web` and `typecheck:mobile` clean; `npm run lint` reports nothing new for the touched files.