### PR TITLE
Add Sketch and Timeline widgets to the mini-app builder

### DIFF
--- a/docs/mini-apps-guide.md
+++ b/docs/mini-apps-guide.md
@@ -255,6 +255,24 @@ Turn on image attachments in the composer when the model is multimodal — the
 message then carries content parts instead of plain text, which is what a
 Message Input node and every provider expect.
 
+## 11. An app that shows a sketch or a timeline
+
+**Shape:** a run that produces an editor document, previewed in the app.
+**Good for:** generated artwork you want to see composited, a cut assembled from
+a script, anything where the result is a document rather than a file.
+
+1. Build the workflow so it ends at an Output node fed by a node that emits a
+   sketch (`nodetool.sketch.CreateSketch`, `nodetool.constant.Sketch`) or a
+   timeline (`nodetool.timeline.AddClips`, `nodetool.script.ScriptToTimeline`).
+2. Place a **Sketch** or **Timeline** widget and bind it to that Output node.
+3. Set a max height so a tall canvas or a long sequence doesn't push the rest of
+   the app off screen.
+
+These nodes emit a reference — `{type: "sketch", id}` — not an image or a video
+file, so the media widgets show nothing when bound to them. If you also want the
+flat result, add a `RenderSketch` or `RenderTimeline` node and bind an **Image**
+or **Video** widget to its output; the two can sit side by side.
+
 ---
 
 ## Before you share it

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -28,10 +28,19 @@ its own settings.
 | Image | An image. Fit `contain` or `cover`, fixed height, placeholder. |
 | Audio | An audio file, with a player. |
 | Video | A video, with a player, max height, placeholder. |
+| Sketch | A sketch document, layers composited. Max height, optional canvas size. |
+| Timeline | A timeline sequence, with its tracks and clips. Max height, optional metadata. |
 | JSON | Structured data, formatted. |
 | Table | A list, as rows. Max height, placeholder. |
 | Output | A value whose type varies; picks a display based on what arrives. |
 | Progress | How far along the run is. |
+
+Sketch and Timeline take a document reference — `{type: "sketch", id}` or
+`{type: "timeline", id}` — which is what the nodes that produce them emit. They
+also accept the document inline, so a node that returns the payload rather than
+a saved id renders too. Binding one to Image or Video instead shows nothing: a
+reference is not a media URL. On mobile these summarize the document (canvas
+size and layer count; duration, tracks, and clips) rather than drawing it.
 
 ### Widgets the user changes
 

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -25,8 +25,13 @@ import {
 } from "react-native";
 import {
   composeUserMessage,
+  formatDuration,
   messagesFrom,
   messageText,
+  readSketchBinding,
+  readTimelineBinding,
+  sketchSummary,
+  timelineSummary,
   WIDGET_CATALOG,
   type AppEvent,
   type ConditionProps,
@@ -180,6 +185,81 @@ const MediaOutputWidget: React.FC<WidgetProps> = (widget) => {
         <OutputRenderer key={index} value={item} />
       ))}
     </View>
+  );
+};
+
+/**
+ * Sketch and timeline previews.
+ *
+ * Mobile has neither the layer compositor nor the preview renderer the web
+ * editors use, so these summarize the document instead of drawing it. A ref
+ * that carries only an id has nothing to summarize — mobile has no endpoint to
+ * resolve it — and says so rather than showing an empty frame.
+ */
+const DocumentCard: React.FC<{
+  title: string;
+  meta: string;
+  colors: ThemeColors;
+}> = ({ title, meta, colors }) => (
+  <View style={[styles.documentCard, { borderColor: colors.border }]}>
+    <Text style={[styles.label, { color: colors.text }]}>{title}</Text>
+    <Text style={[styles.hint, { color: colors.textTertiary }]}>{meta}</Text>
+  </View>
+);
+
+const SketchWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const { document, id } = readSketchBinding(value);
+  const summary = sketchSummary(document);
+  if (summary) {
+    return (
+      <DocumentCard
+        title="Sketch"
+        meta={`${summary.width} × ${summary.height} · ${summary.layerCount} layer${
+          summary.layerCount === 1 ? "" : "s"
+        }`}
+        colors={colors}
+      />
+    );
+  }
+  if (id) {
+    return <DocumentCard title="Sketch" meta="Open on desktop to view" colors={colors} />;
+  }
+  return (
+    <Placeholder
+      text={str(widget.props.placeholder) || "No sketch yet"}
+      colors={colors}
+    />
+  );
+};
+
+const TimelineWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const { document, id } = readTimelineBinding(value);
+  const summary = timelineSummary(document);
+  if (summary) {
+    return (
+      <DocumentCard
+        title={summary.name || "Timeline"}
+        meta={`${formatDuration(summary.durationMs)} · ${summary.trackCount} track${
+          summary.trackCount === 1 ? "" : "s"
+        } · ${summary.clipCount} clip${summary.clipCount === 1 ? "" : "s"}`}
+        colors={colors}
+      />
+    );
+  }
+  if (id) {
+    return (
+      <DocumentCard title="Timeline" meta="Open on desktop to view" colors={colors} />
+    );
+  }
+  return (
+    <Placeholder
+      text={str(widget.props.placeholder) || "No timeline yet"}
+      colors={colors}
+    />
   );
 };
 
@@ -1362,6 +1442,8 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Video: MediaOutputWidget,
   Json: MediaOutputWidget,
   Output: MediaOutputWidget,
+  Sketch: SketchWidget,
+  Timeline: TimelineWidget,
   Table: TableWidget,
   Progress: ProgressWidget,
   Alert: AlertWidget,
@@ -1517,6 +1599,12 @@ const styles = StyleSheet.create({
     gap: 4,
     padding: 12,
     borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  documentCard: {
+    gap: 4,
+    padding: 12,
+    borderRadius: 10,
     borderWidth: StyleSheet.hairlineWidth,
   },
   placeholder: {

--- a/packages/agents/src/evals/surfaces/app.ts
+++ b/packages/agents/src/evals/surfaces/app.ts
@@ -1156,5 +1156,111 @@ export const APP_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<AppBridgeFinalState>
           }
         ]
       }
+    },
+    {
+      // A sketch output is a ref, not media — bind it to Image and the app
+      // shows nothing. The model has to find the widget that resolves it.
+      id: "show-sketch-output",
+      description:
+        "Pick the widget that renders a sketch output and bind it, over the media widgets",
+      objective:
+        "Show the workflow's sketch output in the app using the widget that renders a sketch document.",
+      createBridge: () =>
+        createAppToolBridge({
+          workflowId: "wf-app",
+          workflow: {
+            inputs: [{ nodeId: "in-1", name: "prompt", label: "Prompt" }],
+            outputs: [{ nodeId: "out-1", name: "artwork", label: "Artwork" }],
+            variables: []
+          }
+        }),
+      systemPrompt: APP_SYSTEM_PROMPT,
+      userPrompt:
+        "Objective: App 'app-1' (application_id 'app-1') is empty. Its workflow emits a sketch document " +
+        "(a layered image document) on the 'artwork' output. Add the widget that previews a sketch and bind it " +
+        "to that output. Look the widget type and the binding token up with the tools rather than guessing — " +
+        "a sketch is a document reference, not an image URL, so the Image widget will not render it.",
+      expect: {
+        requiredTools: ["ui_app_add_component"],
+        noErrorResults: true,
+        minToolCalls: 2,
+        maxToolCalls: 12,
+        finalState: [
+          {
+            name: "hasSketchWidget",
+            detail: "no Sketch widget present",
+            test: (s) => countByType(s, "Sketch") >= 1
+          },
+          {
+            name: "sketchBoundToArtworkOutput",
+            detail: "the Sketch widget is not bound to op:main/out:out-1",
+            test: (s) =>
+              s.components.some(
+                (c) =>
+                  c.type === "Sketch" && c.props.binding === "op:main/out:out-1"
+              )
+          },
+          {
+            name: "noImageWidget",
+            detail:
+              "an Image widget was added, which cannot render a sketch reference",
+            test: (s) => countByType(s, "Image") === 0
+          }
+        ]
+      }
+    },
+    {
+      id: "show-timeline-output",
+      description:
+        "Pick the widget that renders a timeline output and nest it in a Panel",
+      objective:
+        "Show the workflow's timeline output inside the app's existing Panel.",
+      createBridge: () =>
+        createAppToolBridge({
+          workflowId: "wf-app",
+          workflow: {
+            inputs: [],
+            outputs: [{ nodeId: "out-1", name: "cut", label: "Cut" }],
+            variables: []
+          },
+          components: [
+            { type: "Container", id: "panel-1", props: { title: "Preview" } }
+          ]
+        }),
+      systemPrompt: APP_SYSTEM_PROMPT,
+      userPrompt:
+        "Objective: App 'app-1' (application_id 'app-1') has an empty Panel (a Container widget with id 'panel-1'). " +
+        "The workflow emits a timeline sequence on its 'cut' output. Add the widget that previews a timeline inside " +
+        "that Panel's content slot and bind it to the output. A timeline is a document reference, not a video file — " +
+        "look the widget type and the binding token up with the tools rather than guessing.",
+      expect: {
+        requiredTools: ["ui_app_add_component"],
+        noErrorResults: true,
+        minToolCalls: 2,
+        maxToolCalls: 12,
+        finalState: [
+          {
+            name: "timelineNestedInPanel",
+            detail: "no Timeline widget nested in 'panel-1' content slot",
+            test: (s) =>
+              s.components.some(
+                (c) =>
+                  c.type === "Timeline" &&
+                  c.parentId === "panel-1" &&
+                  c.slot === "content"
+              )
+          },
+          {
+            name: "timelineBoundToCutOutput",
+            detail: "the Timeline widget is not bound to op:main/out:out-1",
+            test: (s) =>
+              s.components.some(
+                (c) =>
+                  c.type === "Timeline" &&
+                  c.props.binding === "op:main/out:out-1"
+              )
+          }
+        ]
+      }
     }
   ];

--- a/packages/app-runtime/src/documents.ts
+++ b/packages/app-runtime/src/documents.ts
@@ -1,0 +1,160 @@
+/**
+ * Reading sketch and timeline refs out of a bound value.
+ *
+ * A node emits these documents as a ref — `{ type: "sketch", id }` — but the
+ * payload can also arrive inline, wrapped in a `document`/`sketch`/`sequence`
+ * envelope depending on which node produced it. These helpers unwrap both
+ * shapes and describe what they found, so a surface that cannot render the
+ * document itself still has something true to show.
+ */
+
+/** What a widget needs to know about a bound sketch/timeline value. */
+export interface DocumentBinding<TDoc> {
+  /** The inline document, when the value carried one. */
+  document: TDoc | null;
+  /** The persisted document's id, when the value carried one. */
+  id: string | null;
+}
+
+export interface SketchSummary {
+  width: number;
+  height: number;
+  layerCount: number;
+}
+
+export interface TimelineSummary {
+  name: string;
+  durationMs: number;
+  trackCount: number;
+  clipCount: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** A bound output holds one value or an accumulated list of streamed items. */
+const lastItem = (value: unknown): unknown =>
+  Array.isArray(value) ? value[value.length - 1] : value;
+
+const refId = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  return typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+};
+
+/**
+ * Walk the envelopes a document can arrive in. Depth is bounded because these
+ * values come off the wire, where a self-referential object is possible.
+ */
+const unwrap = (
+  value: unknown,
+  keys: ReadonlyArray<string>,
+  refType: string,
+  isDoc: (candidate: unknown) => boolean,
+  depth = 0
+): unknown => {
+  if (depth > 4 || isDoc(value) || !isRecord(value)) {
+    return value;
+  }
+  for (const key of keys) {
+    if (key in value) {
+      return unwrap(value[key], keys, refType, isDoc, depth + 1);
+    }
+  }
+  if (value.type === refType && "data" in value) {
+    return unwrap(value.data, keys, refType, isDoc, depth + 1);
+  }
+  return value;
+};
+
+export const isSketchDocumentLike = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const canvas = value.canvas;
+  return (
+    isRecord(canvas) &&
+    typeof canvas.width === "number" &&
+    typeof canvas.height === "number" &&
+    Array.isArray(value.layers)
+  );
+};
+
+export const isTimelineSequenceLike = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.durationMs === "number" &&
+  Array.isArray(value.tracks) &&
+  Array.isArray(value.clips);
+
+/** Read a bound value as a sketch: its inline document, its id, or neither. */
+export const readSketchBinding = (
+  value: unknown
+): DocumentBinding<Record<string, unknown>> => {
+  const bound = lastItem(value);
+  const candidate = unwrap(
+    bound,
+    ["document", "sketch"],
+    "sketch",
+    isSketchDocumentLike
+  );
+  return {
+    document: isSketchDocumentLike(candidate)
+      ? (candidate as Record<string, unknown>)
+      : null,
+    id: refId(bound)
+  };
+};
+
+/** Read a bound value as a timeline: its inline sequence, its id, or neither. */
+export const readTimelineBinding = (
+  value: unknown
+): DocumentBinding<Record<string, unknown>> => {
+  const bound = lastItem(value);
+  const candidate = unwrap(
+    bound,
+    ["sequence", "document", "timeline"],
+    "timeline",
+    isTimelineSequenceLike
+  );
+  return {
+    document: isTimelineSequenceLike(candidate)
+      ? (candidate as Record<string, unknown>)
+      : null,
+    id: refId(bound)
+  };
+};
+
+export const sketchSummary = (document: unknown): SketchSummary | null => {
+  if (!isSketchDocumentLike(document)) {
+    return null;
+  }
+  const doc = document as Record<string, unknown>;
+  const canvas = doc.canvas as Record<string, unknown>;
+  return {
+    width: canvas.width as number,
+    height: canvas.height as number,
+    layerCount: (doc.layers as unknown[]).length
+  };
+};
+
+export const timelineSummary = (document: unknown): TimelineSummary | null => {
+  if (!isTimelineSequenceLike(document)) {
+    return null;
+  }
+  const doc = document as Record<string, unknown>;
+  return {
+    name: typeof doc.name === "string" ? doc.name : "",
+    durationMs: doc.durationMs as number,
+    trackCount: (doc.tracks as unknown[]).length,
+    clipCount: (doc.clips as unknown[]).length
+  };
+};
+
+/** `m:ss` for a clip/sequence duration, the form the timeline editor uses. */
+export const formatDuration = (ms: number): string => {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+};

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -18,5 +18,6 @@ export * from "./conditions.js";
 export * from "./actions.js";
 export * from "./widgets.js";
 export * from "./chat.js";
+export * from "./documents.js";
 export * from "./doc-ops.js";
 export * from "./bundle.js";

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -96,6 +96,29 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
     fields: { binding: "custom", height: "number", placeholder: "text" }
   },
   Json: { label: "JSON", mode: "read", format: true, fields: { binding: "custom" } },
+  // Composites the layers of a bound sketch document — what a run that emits a
+  // SketchRef needs, since the raw ref renders as an opaque `{type, id}`.
+  Sketch: {
+    label: "Sketch",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      height: "number",
+      showDimensions: "radio",
+      placeholder: "text"
+    }
+  },
+  // Previews a bound timeline sequence: its tracks, clips, and current frame.
+  Timeline: {
+    label: "Timeline",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      height: "number",
+      showMetadata: "radio",
+      placeholder: "text"
+    }
+  },
   // Lays out an array value as rows — what a run that emits N results needs.
   Table: {
     label: "Table",

--- a/packages/app-runtime/tests/documents.test.ts
+++ b/packages/app-runtime/tests/documents.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatDuration,
+  readSketchBinding,
+  readTimelineBinding,
+  sketchSummary,
+  timelineSummary
+} from "../src/documents.js";
+
+const SKETCH = {
+  version: 1,
+  canvas: { width: 1024, height: 768, backgroundColor: "#fff" },
+  layers: [{ id: "l1" }, { id: "l2" }],
+  activeLayerId: "l1"
+};
+
+const TIMELINE = {
+  id: "seq-1",
+  name: "Trailer",
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  durationMs: 92_000,
+  tracks: [{ id: "t1" }, { id: "t2" }],
+  clips: [{ id: "c1" }, { id: "c2" }, { id: "c3" }],
+  markers: []
+};
+
+describe("readSketchBinding", () => {
+  it("unwraps the envelopes a sketch arrives in", () => {
+    for (const value of [
+      SKETCH,
+      { document: SKETCH },
+      { sketch: SKETCH },
+      { type: "sketch", data: SKETCH }
+    ]) {
+      expect(readSketchBinding(value).document).toEqual(SKETCH);
+    }
+  });
+
+  it("takes the last item of an accumulated streamed output", () => {
+    const older = { ...SKETCH, canvas: { ...SKETCH.canvas, width: 512 } };
+    expect(readSketchBinding([older, SKETCH]).document).toEqual(SKETCH);
+  });
+
+  it("reports the id of a ref that carries no inline document", () => {
+    expect(readSketchBinding({ type: "sketch", id: "img-1" })).toEqual({
+      document: null,
+      id: "img-1"
+    });
+  });
+
+  it("reports neither for a value that is not a sketch", () => {
+    expect(readSketchBinding("hello")).toEqual({ document: null, id: null });
+    expect(readSketchBinding({ id: "" })).toEqual({ document: null, id: null });
+  });
+
+  it("stops unwrapping a self-referential value instead of recursing forever", () => {
+    const loop: Record<string, unknown> = {};
+    loop.document = loop;
+    expect(() => readSketchBinding(loop)).not.toThrow();
+    expect(readSketchBinding(loop).document).toBeNull();
+  });
+});
+
+describe("readTimelineBinding", () => {
+  it("unwraps the envelopes a timeline arrives in", () => {
+    for (const value of [
+      TIMELINE,
+      { sequence: TIMELINE },
+      { document: TIMELINE },
+      { type: "timeline", data: TIMELINE }
+    ]) {
+      expect(readTimelineBinding(value).document).toEqual(TIMELINE);
+    }
+  });
+
+  it("reports the id of a ref that carries no inline sequence", () => {
+    expect(readTimelineBinding({ type: "timeline", id: "seq-9" })).toEqual({
+      document: null,
+      id: "seq-9"
+    });
+  });
+});
+
+describe("summaries", () => {
+  it("describes a sketch by canvas size and layer count", () => {
+    expect(sketchSummary(SKETCH)).toEqual({
+      width: 1024,
+      height: 768,
+      layerCount: 2
+    });
+  });
+
+  it("describes a timeline by name, duration, tracks and clips", () => {
+    expect(timelineSummary(TIMELINE)).toEqual({
+      name: "Trailer",
+      durationMs: 92_000,
+      trackCount: 2,
+      clipCount: 3
+    });
+  });
+
+  it("returns null for a value of the wrong shape", () => {
+    expect(sketchSummary(TIMELINE)).toBeNull();
+    expect(timelineSummary(SKETCH)).toBeNull();
+    expect(sketchSummary(null)).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  it("renders m:ss, padding the seconds and clamping negatives", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(9_000)).toBe("0:09");
+    expect(formatDuration(92_000)).toBe("1:32");
+    expect(formatDuration(-5)).toBe("0:00");
+  });
+});

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -50,6 +50,18 @@ describe("widget catalog", () => {
     expect(WIDGET_CATALOG.ModelSelect.trigger).toBe("change");
   });
 
+  it("declares the sketch and timeline widgets as single-binding displays", () => {
+    for (const type of ["Sketch", "Timeline"]) {
+      expect(widgetMode(type)).toBe("read");
+      expect(widgetBindingProps(type)).toEqual([]);
+      expect(WIDGET_CATALOG[type].trigger).toBeUndefined();
+      // Neither renders formattable text, so the editor must not offer the
+      // format template — it would silently replace the document preview.
+      expect(WIDGET_CATALOG[type].format).toBeUndefined();
+      expect(widgetFields(type)).not.toHaveProperty("format");
+    }
+  });
+
   it("reports no extra bindings for a widget that binds once", () => {
     expect(widgetBindingProps("Text")).toEqual([]);
     expect(widgetBindingProps("Bogus")).toEqual([]);

--- a/web/src/components/appbuilder/puck/DocumentWidgets.tsx
+++ b/web/src/components/appbuilder/puck/DocumentWidgets.tsx
@@ -1,0 +1,185 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Display widgets for the two editor documents a workflow can emit: a sketch
+ * (an image document with layers) and a timeline (a sequence of tracks and
+ * clips).
+ *
+ * A node emits these as a ref — `{ type: "sketch", id }` — so without a widget
+ * that resolves the ref they land in an app as an opaque JSON blob. Each widget
+ * takes the same two shapes the node editor's OutputRenderer accepts: an inline
+ * document payload, or an id it fetches. The renderers are the read-only ones
+ * the editors already ship; the timeline one is lazy because it pulls in the
+ * preview compositor.
+ */
+import React from "react";
+
+import {
+  Caption,
+  EmptyState,
+  LoadingSpinner,
+  Box,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { AppEvent } from "../types";
+import { trpc } from "../../../trpc/client";
+import {
+  getSketchId,
+  getTimelineId,
+  resolveSketchDocument,
+  resolveTimelineSequence
+} from "../../node/outputValueResolvers";
+import SketchRenderer from "../../sketch/SketchRenderer";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+const LazyTimelineRenderer = React.lazy(async () => ({
+  default: (await import("../../timeline/TimelineRenderer")).default
+}));
+
+interface DocumentWidgetProps {
+  id: string;
+  binding?: string;
+  events?: AppEvent[];
+  disabled?: boolean;
+  height?: number;
+  placeholder?: string;
+}
+
+/** A bound output may hold the ref alone or an accumulated list of them. */
+const firstItem = (value: unknown): unknown =>
+  Array.isArray(value) ? value[value.length - 1] : value;
+
+const useReadBinding = (props: DocumentWidgetProps) =>
+  useWidgetRuntime({
+    id: props.id,
+    bindingMode: "read",
+    binding: props.binding,
+    events: props.events
+  });
+
+/** Constrains a preview to the widget's height without cropping its aspect. */
+const frame = (height?: number): React.CSSProperties => ({
+  width: "100%",
+  maxHeight: height ? `${height}px` : undefined,
+  overflow: "hidden",
+  borderRadius: BORDER_RADIUS.md
+});
+
+export const SketchWidget: React.FC<
+  DocumentWidgetProps & { showDimensions?: boolean }
+> = (props) => {
+  const { value, designMode } = useReadBinding(props);
+  const bound = firstItem(value);
+
+  const inlineDocument = React.useMemo(
+    () => resolveSketchDocument(bound),
+    [bound]
+  );
+  const sketchId = React.useMemo(() => getSketchId(bound), [bound]);
+  const shouldLoad = Boolean(sketchId && !inlineDocument);
+  const query = trpc.sketch.get.useQuery(
+    { id: sketchId ?? "" },
+    { enabled: shouldLoad, staleTime: 30_000 }
+  );
+  const loadedDocument = React.useMemo(
+    () => resolveSketchDocument(query.data),
+    [query.data]
+  );
+  const document = inlineDocument ?? loadedDocument;
+
+  if (document) {
+    return (
+      <Box sx={frame(props.height)}>
+        <SketchRenderer
+          document={document}
+          ariaLabel="Sketch"
+          showDimensions={props.showDimensions ?? false}
+        />
+      </Box>
+    );
+  }
+  if (shouldLoad && query.isLoading) {
+    return <LoadingSpinner size="small" text="Loading sketch" />;
+  }
+  if (query.isError) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Could not load sketch"
+        description={query.error.message}
+      />
+    );
+  }
+  if (designMode) {
+    return (
+      <Caption color="secondary">
+        Bind this to a sketch output to preview it.
+      </Caption>
+    );
+  }
+  return (
+    <Caption color="secondary">{props.placeholder ?? "No sketch yet"}</Caption>
+  );
+};
+
+export const TimelineWidget: React.FC<
+  DocumentWidgetProps & { showMetadata?: boolean }
+> = (props) => {
+  const { value, designMode } = useReadBinding(props);
+  const bound = firstItem(value);
+
+  const inlineSequence = React.useMemo(
+    () => resolveTimelineSequence(bound),
+    [bound]
+  );
+  const timelineId = React.useMemo(() => getTimelineId(bound), [bound]);
+  const shouldLoad = Boolean(timelineId && !inlineSequence);
+  const query = trpc.timeline.get.useQuery(
+    { id: timelineId ?? "" },
+    { enabled: shouldLoad, staleTime: 30_000 }
+  );
+  const loadedSequence = React.useMemo(
+    () => resolveTimelineSequence(query.data),
+    [query.data]
+  );
+  const sequence = inlineSequence ?? loadedSequence;
+
+  if (sequence) {
+    return (
+      <Box sx={frame(props.height)}>
+        <React.Suspense
+          fallback={<LoadingSpinner size="small" text="Loading preview" />}
+        >
+          <LazyTimelineRenderer
+            sequence={sequence}
+            ariaLabel="Timeline"
+            showMetadata={props.showMetadata ?? true}
+          />
+        </React.Suspense>
+      </Box>
+    );
+  }
+  if (shouldLoad && query.isLoading) {
+    return <LoadingSpinner size="small" text="Loading timeline" />;
+  }
+  if (query.isError) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Could not load timeline"
+        description={query.error.message}
+      />
+    );
+  }
+  if (designMode) {
+    return (
+      <Caption color="secondary">
+        Bind this to a timeline output to preview it.
+      </Caption>
+    );
+  }
+  return (
+    <Caption color="secondary">
+      {props.placeholder ?? "No timeline yet"}
+    </Caption>
+  );
+};

--- a/web/src/components/appbuilder/puck/__tests__/documentWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/documentWidgets.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * The sketch and timeline widgets: resolving a bound value into a document,
+ * fetching one that arrives as a bare ref, and the states in between.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+
+interface QueryResult {
+  data: unknown;
+  isLoading: boolean;
+  isError: boolean;
+  error: { message: string } | null;
+}
+
+const IDLE: QueryResult = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null
+};
+
+/** What each fetch resolves to, per test. */
+const results: { sketch: QueryResult; timeline: QueryResult } = {
+  sketch: IDLE,
+  timeline: IDLE
+};
+const sketchEnabled = jest.fn();
+const timelineEnabled = jest.fn();
+
+// A disabled query never resolves, so the mock returns the idle result when the
+// widget didn't ask — that's what tells "resolved inline" apart from "fetched".
+jest.mock("../../../../trpc/client", () => ({
+  trpc: {
+    sketch: {
+      get: {
+        useQuery: (_input: { id: string }, options: { enabled: boolean }) => {
+          sketchEnabled(options.enabled);
+          return options.enabled ? results.sketch : IDLE;
+        }
+      }
+    },
+    timeline: {
+      get: {
+        useQuery: (_input: { id: string }, options: { enabled: boolean }) => {
+          timelineEnabled(options.enabled);
+          return options.enabled ? results.timeline : IDLE;
+        }
+      }
+    }
+  }
+}));
+
+// The real renderers composite layers onto a canvas / mount the preview
+// compositor — neither runs under jsdom, and neither is what these tests are
+// about. Stub them down to what they were handed.
+jest.mock("../../../sketch/SketchRenderer", () => ({
+  __esModule: true,
+  default: ({ document }: { document: { canvas: { width: number } } }) => (
+    <div data-testid="sketch-renderer">sketch {document.canvas.width}</div>
+  )
+}));
+jest.mock("../../../timeline/TimelineRenderer", () => ({
+  __esModule: true,
+  default: ({ sequence }: { sequence: { name: string } }) => (
+    <div data-testid="timeline-renderer">timeline {sequence.name}</div>
+  )
+}));
+
+import { SketchWidget, TimelineWidget } from "../DocumentWidgets";
+
+const OUTPUT_KEY = "main:out1";
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const { wrapper: Wrapper } = makeTestRuntime(initial);
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <Wrapper>{element}</Wrapper>
+    </ThemeProvider>
+  );
+};
+
+const withOutput = (value: unknown): Partial<AppInstanceState> => ({
+  outputs: {
+    [OUTPUT_KEY]: { value, invocationId: "j1", status: "done", revision: 1 }
+  }
+});
+
+const SKETCH_DOC = {
+  version: 1,
+  canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+  layers: [
+    {
+      id: "l1",
+      name: "Layer 1",
+      type: "raster",
+      visible: true,
+      locked: false,
+      data: null
+    }
+  ],
+  activeLayerId: "l1",
+  maskLayerId: null
+};
+
+const TIMELINE_SEQ = {
+  id: "seq-1",
+  projectId: "p1",
+  name: "Trailer",
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  durationMs: 12_000,
+  tracks: [],
+  clips: [],
+  markers: [],
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z"
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  results.sketch = IDLE;
+  results.timeline = IDLE;
+});
+
+describe("SketchWidget", () => {
+  it("renders an inline sketch document without fetching", () => {
+    renderWidget(
+      <SketchWidget id="s1" binding="result" />,
+      withOutput({ type: "sketch", data: SKETCH_DOC })
+    );
+    expect(screen.getByTestId("sketch-renderer")).toHaveTextContent("1024");
+    expect(sketchEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("fetches a ref that carries only an id", () => {
+    results.sketch = { ...IDLE, data: { document: { sketch: SKETCH_DOC } } };
+    renderWidget(
+      <SketchWidget id="s1" binding="result" />,
+      withOutput({ type: "sketch", id: "img-1" })
+    );
+    expect(sketchEnabled).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId("sketch-renderer")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when nothing is bound yet", () => {
+    renderWidget(<SketchWidget id="s1" binding="result" placeholder="Nothing" />);
+    expect(screen.getByText("Nothing")).toBeInTheDocument();
+    expect(sketchEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("surfaces a failed fetch instead of an empty frame", () => {
+    results.sketch = { ...IDLE, isError: true, error: { message: "gone" } };
+    renderWidget(
+      <SketchWidget id="s1" binding="result" />,
+      withOutput({ type: "sketch", id: "img-1" })
+    );
+    expect(screen.getByText("Could not load sketch")).toBeInTheDocument();
+    expect(screen.getByText("gone")).toBeInTheDocument();
+  });
+});
+
+describe("TimelineWidget", () => {
+  it("renders an inline timeline sequence without fetching", async () => {
+    renderWidget(
+      <TimelineWidget id="t1" binding="result" />,
+      withOutput({ type: "timeline", data: TIMELINE_SEQ })
+    );
+    expect(await screen.findByTestId("timeline-renderer")).toHaveTextContent(
+      "Trailer"
+    );
+    expect(timelineEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("fetches a ref that carries only an id", async () => {
+    results.timeline = { ...IDLE, data: TIMELINE_SEQ };
+    renderWidget(
+      <TimelineWidget id="t1" binding="result" />,
+      withOutput({ type: "timeline", id: "seq-1" })
+    );
+    expect(timelineEnabled).toHaveBeenCalledWith(true);
+    expect(await screen.findByTestId("timeline-renderer")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when nothing is bound yet", () => {
+    renderWidget(
+      <TimelineWidget id="t1" binding="result" placeholder="No cut" />
+    );
+    expect(screen.getByText("No cut")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -56,6 +56,7 @@ import {
   ModelSelectWidget
 } from "./WorkflowInputWidget";
 import { ChatThreadWidget, ChatComposerWidget } from "./ChatWidgets";
+import { SketchWidget, TimelineWidget } from "./DocumentWidgets";
 
 const ACTION_OPTIONS = [
   { label: "Run workflow", value: "run" },
@@ -274,6 +275,8 @@ export const appConfig: Config = {
         "Image",
         "Audio",
         "Video",
+        "Sketch",
+        "Timeline",
         "Json",
         "Table",
         "List",
@@ -378,6 +381,52 @@ export const appConfig: Config = {
       },
       defaultProps: { height: 320, placeholder: "No video yet" },
       render: withConditions((props) => <VideoWidget {...props} />)
+    },
+    Sketch: {
+      label: "Sketch",
+      fields: {
+        binding: bindingField("read"),
+        height: { type: "number", label: "Max height (px)" },
+        showDimensions: {
+          type: "radio",
+          label: "Show size",
+          options: [
+            { label: "Hide", value: false },
+            { label: "Show", value: true }
+          ]
+        },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        height: 360,
+        showDimensions: false,
+        placeholder: "No sketch yet"
+      },
+      render: withConditions((props) => <SketchWidget {...props} />)
+    },
+    Timeline: {
+      label: "Timeline",
+      fields: {
+        binding: bindingField("read"),
+        height: { type: "number", label: "Max height (px)" },
+        showMetadata: {
+          type: "radio",
+          label: "Show metadata",
+          options: [
+            { label: "Hide", value: false },
+            { label: "Show", value: true }
+          ]
+        },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        height: 360,
+        showMetadata: true,
+        placeholder: "No timeline yet"
+      },
+      render: withConditions((props) => <TimelineWidget {...props} />)
     },
     Json: {
       label: "JSON",


### PR DESCRIPTION
A workflow that ends at a sketch or a timeline emits a document reference — `{type: "sketch", id}` — not media. Bound to **Image** or **Video** that renders as nothing; bound to **Output** it renders as a JSON blob. Two new display widgets resolve the reference and preview the document.

## What changed

**The widgets** (`packages/app-runtime/src/widgets.ts`)

Two `read`-mode entries, `Sketch` and `Timeline`, each with `binding`, `height`, a show-metadata toggle, and `placeholder`. Neither sets `format` — the template would replace the preview rather than reformat it.

**Web** (`web/src/components/appbuilder/puck/DocumentWidgets.tsx`)

Each widget accepts either shape the nodes produce: an inline payload, or an id it fetches through `trpc.sketch.get` / `trpc.timeline.get`. It reuses the read-only renderers the editors already ship — `SketchRenderer` eagerly, `TimelineRenderer` lazily because it pulls in the preview compositor. Loading, fetch-error, unbound, and design-mode states are each distinct, so a blank frame never stands in for a failure.

**Mobile** (`mobile/src/components/app_runtime/widgets.tsx`)

Mobile has neither the layer compositor nor the preview renderer, so it summarizes rather than draws: canvas size and layer count for a sketch, duration and track/clip counts for a timeline. A ref carrying only an id has nothing to summarize — mobile has no endpoint to resolve it — and says so instead of showing an empty frame. Previously both types fell through to the unlabelled `UnknownWidget` hint.

**Shared shape-reading** (`packages/app-runtime/src/documents.ts`, new)

`readSketchBinding` / `readTimelineBinding` unwrap the envelopes a document can arrive in (`document`, `sketch`, `sequence`, `timeline`, `{type, data}`), take the last item of an accumulated streamed output, and report the inline document or the id. Web and mobile share this so the two surfaces cannot disagree about which values count as a document. Recursion is depth-bounded — these values come off the wire.

**Agents** (`packages/agents/src/evals/surfaces/app.ts`)

The `ui_app_*` tools derive their catalog from `WIDGET_CATALOG`, so agents building apps pick both widgets up with no tool change — `ui_app_list_component_types` reports them and their fields. Two `app-tools` eval cases cover the choice, since it is one a model can plausibly get wrong:

- `show-sketch-output` — bind a sketch output to `Sketch`, and *not* to `Image`.
- `show-timeline-output` — nest a `Timeline` in an existing Panel's `content` slot and bind it.

## Testing

- `npm run typecheck` — web, electron, and mobile all clean.
- `npm run lint` — no new errors or warnings.
- `npm run test` — 1039 web + 63 electron + 67 mobile suites pass.
- `packages/app-runtime` (187), `packages/agents` (1647), `packages/cli` (444) pass.
- New: `packages/app-runtime/tests/documents.test.ts` (envelope unwrapping, streamed-output tail, summaries, a self-referential value), a catalog assertion in `widgets.test.ts`, and `web/.../__tests__/documentWidgets.test.tsx` (inline vs. fetched vs. placeholder vs. failed fetch, asserting the query is only enabled when the widget actually needs it).
- The existing `configCatalog` parity test covers the catalog ↔ Puck-config match.

No change was needed in `packages/cli/src/app-debug/` — the harness is driven by `bindingMode` from the catalog, with no per-type branching.

## Docs

A row each in the reference widget table plus a note that these take a document reference, not a media URL; and a guide recipe (§11) covering which nodes emit them and how to pair one with `RenderSketch`/`RenderTimeline` when you want the flat result too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUc9H3gg45s1AsCADiWowL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUc9H3gg45s1AsCADiWowL)_