### PR TITLE
Composite sketches in the mobile viewer and the app widget

### DIFF
--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -172,6 +172,12 @@ ApplicationAppView   # renders the document's widget tree
   at phone width), there is no reactive-subgraph path (no browser worker, so
   every run is a full server run), and `ResourcePicker`/`ResourceGallery`
   collapse into one list of rows — a grid of tiles buys nothing at phone width.
+- **Sketch widget**: a bound sketch draws rather than being summarised.
+  `components/sketch/SketchRenderer` composites it — the same compositor the
+  sketch viewer screen uses — for a document bound inline and for a bare
+  `SketchRef`, which is read through the sketch document backend. The widget's
+  `height` caps the preview: the composite shrinks to fit instead of cropping.
+  Timelines still summarise, because mobile has no preview compositor.
 - **Resource widgets** (`resourceWidgets.tsx`) render a bound document as a card
   — name, kind icon, and a summary read off the body ("6 shots") — that opens
   the screen its kind already has. The route comes from `documents/kinds.ts`, so
@@ -278,6 +284,18 @@ animations by role, rebases clip-local caption words, and clears the fades and
 transition the halves must not inherit; hand-rolling that would get it wrong.
 Its id factory calls `crypto.randomUUID`, which Hermes lacks, so
 `src/polyfills/randomUuid.ts` supplies one from `uuid` in `index.ts`.
+
+**Sketches composite, they do not summarize.** `components/sketch/SketchRenderer`
+stacks the layers the way `web/.../canvas2d/composite.ts` does: bottom-first,
+groups as containers rather than pixels, a layer drawn only when it and every
+ancestor group is visible, alpha multiplied down the chain. Pixels come from the
+layer's generated asset, a stable `imageReference.uri`, or the raster serialized
+into the document, in that order; a layer with none of those renders a labelled
+placeholder in its own footprint. Blend modes and rotation are deliberately not
+reproduced — React Native has no compositing operator, and approximating them
+quietly would lie. `SketchViewerScreen` wraps the renderer with the layer list
+and its generation statuses; the app-runtime `Sketch` widget draws the same
+composite inside an app.
 
 Kinds with no dedicated screen fall back to `DocumentViewerScreen`, so every
 document can at least be opened.

--- a/mobile/src/components/app_runtime/__tests__/sketchWidget.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/sketchWidget.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * The app-runtime `Sketch` widget on mobile.
+ *
+ * A bound value arrives in one of two shapes — the document inline, or a
+ * `SketchRef` carrying only an id — and both must end up composited. The
+ * document backend is mocked so the ref path is exercised without a server.
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    assets: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+    },
+  },
+}));
+
+const mockRead = jest.fn();
+
+jest.mock("../../../documents/backends", () => ({
+  documentBackend: () => ({ read: (id: string) => mockRead(id) }),
+}));
+
+import ApplicationAppView from "../ApplicationAppView";
+
+const CANVAS = { width: 200, height: 100, backgroundColor: "#ffffff" };
+
+/** A bare editor document, the shape a node emits inline. */
+const inlineDocument = {
+  version: 1,
+  activeLayerId: "l-1",
+  canvas: CANVAS,
+  layers: [
+    {
+      id: "l-1",
+      name: "Base",
+      type: "raster",
+      visible: true,
+      opacity: 1,
+      data: "data:image/png;base64,AAAA",
+    },
+  ],
+};
+
+const appDoc = (props: Record<string, unknown>, value?: unknown) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Sketch app" } },
+    content: [{ type: "Sketch", props: { id: "sketch-1", ...props } }],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-sketch",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    {
+      id: "data",
+      name: "data",
+      scope: "instance",
+      persist: false,
+      default: value,
+    },
+  ],
+});
+
+const makeWorkflow = (id: string): Workflow =>
+  ({
+    id,
+    name: "Sketch app",
+    description: "",
+    graph: { nodes: [], edges: [] },
+  }) as unknown as Workflow;
+
+const renderApp = (doc: unknown) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ApplicationAppView
+        document={parseApplicationDocument(doc) as ApplicationDocument}
+        workflow={makeWorkflow(`wf-${Math.random()}`)}
+      />
+    </QueryClientProvider>
+  );
+};
+
+/** Nothing composites until the frame reports a width. */
+const layoutCanvas = async () => {
+  const frame = await screen.findByLabelText(/Sketch preview/);
+  fireEvent(frame, "layout", {
+    nativeEvent: { layout: { width: 400, height: 0, x: 0, y: 0 } },
+  });
+};
+
+describe("Sketch widget", () => {
+  beforeEach(() => {
+    mockRead.mockReset();
+  });
+
+  it("composites a document bound inline, without reading anything", async () => {
+    renderApp(appDoc({ binding: "var:data" }, inlineDocument));
+    await layoutCanvas();
+
+    expect(screen.getByLabelText("Layer Base")).toBeTruthy();
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  it("reads a ref by id and composites what comes back", async () => {
+    mockRead.mockResolvedValue({
+      name: "Doodle",
+      doc: { sketch: inlineDocument, layerBindings: [] },
+      token: 1,
+      updatedAt: "2026-07-01T00:00:00Z",
+    });
+
+    renderApp(
+      appDoc({ binding: "var:data" }, { type: "sketch", id: "sk-1" })
+    );
+    await layoutCanvas();
+
+    expect(mockRead).toHaveBeenCalledWith("sk-1");
+    expect(screen.getByLabelText("Layer Base")).toBeTruthy();
+  });
+
+  it("draws the dimensions badge when the widget asks for it", async () => {
+    renderApp(
+      appDoc({ binding: "var:data", showDimensions: true }, inlineDocument)
+    );
+    await layoutCanvas();
+
+    expect(screen.getByText("200 × 100")).toBeTruthy();
+  });
+
+  it("says so when a ref cannot be read", async () => {
+    mockRead.mockRejectedValue(new Error("not found"));
+
+    renderApp(
+      appDoc({ binding: "var:data" }, { type: "sketch", id: "sk-gone" })
+    );
+
+    expect(
+      await screen.findByText("Could not load this sketch")
+    ).toBeTruthy();
+  });
+
+  it("shows the placeholder while nothing is bound", async () => {
+    renderApp(appDoc({ binding: "var:data", placeholder: "Run to draw" }));
+
+    expect(await screen.findByText("Run to draw")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -37,9 +37,16 @@ import {
   type ConditionProps,
 } from "@nodetool-ai/app-runtime";
 
+import { useQuery } from "@tanstack/react-query";
+
 import { useTheme } from "../../hooks/useTheme";
 import type { ThemeColors } from "../../utils/theme";
 import { apiService } from "../../services/api";
+import { documentBackend } from "../../documents/backends";
+import {
+  SketchRenderer,
+  asSketchDocument,
+} from "../sketch/SketchRenderer";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
 import { OutputRenderer } from "../outputs/OutputRenderer";
 import {
@@ -191,10 +198,13 @@ const MediaOutputWidget: React.FC<WidgetProps> = (widget) => {
 /**
  * Sketch and timeline previews.
  *
- * Mobile has neither the layer compositor nor the preview renderer the web
- * editors use, so these summarize the document instead of drawing it. A ref
- * that carries only an id has nothing to summarize — mobile has no endpoint to
- * resolve it — and says so rather than showing an empty frame.
+ * The sketch widget draws: `components/sketch/SketchRenderer` composites the
+ * bound document the same way the viewer screen does. A ref carrying only an id
+ * is read through the sketch document backend, so an app whose run emits a
+ * `SketchRef` shows the picture rather than a card pointing at a desktop.
+ *
+ * Timelines still summarize — mobile has no preview compositor — and a timeline
+ * ref that resolves to nothing says so rather than showing an empty frame.
  */
 const DocumentCard: React.FC<{
   title: string;
@@ -207,24 +217,59 @@ const DocumentCard: React.FC<{
   </View>
 );
 
+/** How tall a sketch preview grows before it shrinks to fit. */
+const SKETCH_DEFAULT_HEIGHT = 320;
+
 const SketchWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const { document, id } = readSketchBinding(value);
-  const summary = sketchSummary(document);
-  if (summary) {
+
+  const inline = useMemo(() => asSketchDocument(document), [document]);
+  // Only fetch when the value carried a bare ref: an inline document is already
+  // everything the compositor needs.
+  const shouldLoad = Boolean(id) && inline === null;
+  const query = useQuery({
+    queryKey: ["app-runtime", "sketch", id],
+    queryFn: async () => {
+      const loaded = await documentBackend("sketch").read(id ?? "");
+      return loaded.doc;
+    },
+    enabled: shouldLoad,
+    staleTime: 30_000,
+    retry: false,
+  });
+  const loaded = useMemo(() => asSketchDocument(query.data), [query.data]);
+  const doc = inline ?? loaded;
+
+  if (doc) {
     return (
-      <DocumentCard
-        title="Sketch"
-        meta={`${summary.width} × ${summary.height} · ${summary.layerCount} layer${
-          summary.layerCount === 1 ? "" : "s"
-        }`}
-        colors={colors}
+      <SketchRenderer
+        doc={doc}
+        maxHeight={numOr(widget.props.height, SKETCH_DEFAULT_HEIGHT)}
+        showDimensions={widget.props.showDimensions === true}
       />
     );
   }
+  if (shouldLoad && query.isLoading) {
+    return <ActivityIndicator color={colors.primary} />;
+  }
   if (id) {
-    return <DocumentCard title="Sketch" meta="Open on desktop to view" colors={colors} />;
+    // A ref that resolves to nothing, or to a body the compositor cannot read.
+    const summary = sketchSummary(document);
+    return (
+      <DocumentCard
+        title="Sketch"
+        meta={
+          summary
+            ? `${summary.width} × ${summary.height} · ${summary.layerCount} layer${
+                summary.layerCount === 1 ? "" : "s"
+              }`
+            : "Could not load this sketch"
+        }
+        colors={colors}
+      />
+    );
   }
   return (
     <Placeholder

--- a/mobile/src/components/sketch/SketchRenderer.tsx
+++ b/mobile/src/components/sketch/SketchRenderer.tsx
@@ -1,0 +1,538 @@
+/**
+ * Read-only sketch renderer.
+ *
+ * A sketch is layer-based, so "showing" one means compositing: stack the layers
+ * bottom-to-top the way the web editor does. This component is the mobile
+ * counterpart of `web/src/components/sketch/SketchRenderer.tsx`, shared by the
+ * sketch viewer screen and the app-runtime `Sketch` widget.
+ *
+ * Compositing agrees with `web/src/components/sketch/rendering/canvas2d/composite.ts`:
+ * `layers` is stored bottom-first, groups are containers rather than pixels, a
+ * layer is drawn only when it and every ancestor group is visible, and its alpha
+ * is its own opacity times the opacity of every ancestor group. Mask layers are
+ * drawn, matching web's on-screen preview (its *export* path is the one that
+ * drops them).
+ *
+ * Pixels come from three places, in order: the layer's generated asset
+ * (`layerBindings[].currentAssetId`, resolved through `assets.get` like every
+ * other image in the app), a stable external `imageReference.uri`, or the raster
+ * serialized into the document itself. A layer with none of those — or whose
+ * generation failed — renders a labelled placeholder in its own footprint rather
+ * than a broken image or an invisible gap.
+ *
+ * What is deliberately not reproduced: blend modes and layer rotation. React
+ * Native has no compositing operator, and a preview that silently approximated
+ * them would be lying more quietly than one that does not.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  StyleSheet,
+  Text,
+  View,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useTheme } from '../../hooks/useTheme';
+import { apiService } from '../../services/api';
+import { trpc } from '../../trpc/client';
+import type { ThemeColors } from '../../utils/theme';
+
+// ── Document shape ─────────────────────────────────────────────────────────
+//
+// Mirrors `ImageDocumentData` from `@nodetool-ai/protocol/api-schemas/sketch`,
+// narrowed to the fields a renderer reads. The protocol types the layer array
+// as `unknown[]` (the full `Layer` lives in the web editor), so the fields this
+// file needs are declared here and every one of them is optional.
+
+/** Layer generation status carried by a binding. */
+export type SketchLayerStatus =
+  | 'draft'
+  | 'queued'
+  | 'generating'
+  | 'generated'
+  | 'stale'
+  | 'failed'
+  | 'locked'
+  | 'missing';
+
+export interface SketchRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SketchCanvas {
+  width: number;
+  height: number;
+  backgroundColor?: string;
+}
+
+export interface SketchLayer {
+  id: string;
+  name?: string;
+  type?: 'raster' | 'mask' | 'group';
+  visible?: boolean;
+  opacity?: number;
+  parentId?: string | null;
+  /** Serialized raster payload, or a legacy PNG data URL. */
+  data?: string | null;
+  /** Backing raster bounds in layer-local space. */
+  contentBounds?: SketchRect;
+  transform?: { kind?: string; x?: number; y?: number; scaleX?: number; scaleY?: number };
+  imageReference?: { uri?: string } | null;
+}
+
+export interface SketchLayerBinding {
+  layerId: string;
+  status: SketchLayerStatus;
+  currentAssetId?: string;
+  prompt?: string;
+  model?: string;
+  versions?: unknown[];
+}
+
+/** The persisted body of a sketch document. */
+export interface SketchDocumentData {
+  sketch: {
+    canvas: SketchCanvas;
+    layers: SketchLayer[];
+  };
+  layerBindings: SketchLayerBinding[];
+}
+
+// ── Reading a value as a sketch ────────────────────────────────────────────
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * A value read as a sketch document, or null.
+ *
+ * Two shapes arrive: the persisted `{ sketch, layerBindings }` envelope a
+ * document read returns, and the bare `{ canvas, layers }` editor state a node
+ * emits inline. The second carries no bindings, so its generated layers fall
+ * back to whatever raster the document itself holds.
+ */
+export function asSketchDocument(value: unknown): SketchDocumentData | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (isRecord(value.sketch)) {
+    const inner = asSketchDocument(value.sketch);
+    if (inner === null) {
+      return null;
+    }
+    return {
+      sketch: inner.sketch,
+      layerBindings: Array.isArray(value.layerBindings)
+        ? (value.layerBindings as SketchLayerBinding[])
+        : [],
+    };
+  }
+  const canvas = value.canvas;
+  if (
+    !isRecord(canvas) ||
+    typeof canvas.width !== 'number' ||
+    typeof canvas.height !== 'number' ||
+    !Array.isArray(value.layers)
+  ) {
+    return null;
+  }
+  return {
+    sketch: {
+      canvas: canvas as unknown as SketchCanvas,
+      layers: value.layers as SketchLayer[],
+    },
+    layerBindings: Array.isArray(value.layerBindings)
+      ? (value.layerBindings as SketchLayerBinding[])
+      : [],
+  };
+}
+
+// ── Layer data decoding ────────────────────────────────────────────────────
+
+const SERIALIZED_LAYER_DATA_PREFIX = 'ntlayer:';
+
+/**
+ * The image URL inside a layer's `data` field, or null.
+ *
+ * Ported from web's `deserializeLayerData`: a payload is either a base64 blob
+ * of JSON behind the `ntlayer:` prefix or, on older documents, a bare data URL.
+ */
+export function layerDataImageUri(data: string | null | undefined): string | null {
+  if (!data) {
+    return null;
+  }
+  if (!data.startsWith(SERIALIZED_LAYER_DATA_PREFIX)) {
+    return data;
+  }
+  try {
+    const decoded: unknown = JSON.parse(
+      atob(data.slice(SERIALIZED_LAYER_DATA_PREFIX.length))
+    );
+    if (decoded === null || typeof decoded !== 'object') {
+      return null;
+    }
+    const image = (decoded as { image?: unknown }).image;
+    return typeof image === 'string' ? image : null;
+  } catch {
+    // A payload we cannot decode is not a URL either; the layer falls through
+    // to its placeholder, which is the honest outcome.
+    return null;
+  }
+}
+
+// ── Compositing ────────────────────────────────────────────────────────────
+
+/** One layer, resolved into everything the composite and a layer list need. */
+export interface ResolvedLayer {
+  id: string;
+  name: string;
+  type: 'raster' | 'mask' | 'group';
+  /** True when this layer and every ancestor group is visible. */
+  composited: boolean;
+  /** Own opacity times every ancestor group's opacity. */
+  opacity: number;
+  /** Footprint in document pixels. */
+  rect: SketchRect;
+  /** A ready-to-render URI (data URL or absolute http URL), if one is known. */
+  directUri: string | null;
+  /** The generated asset to look up when there is no direct URI. */
+  assetId: string | null;
+  status: SketchLayerStatus | null;
+  prompt: string | null;
+  model: string | null;
+  versionCount: number;
+}
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+/** Statuses that mean "these pixels do not exist", whatever else is set. */
+export function statusHasNoPixels(status: SketchLayerStatus | null): boolean {
+  return status === 'failed' || status === 'missing';
+}
+
+function ancestorChain(layers: SketchLayer[], layer: SketchLayer): SketchLayer[] {
+  const byId = new Map(layers.map((entry) => [entry.id, entry]));
+  const chain: SketchLayer[] = [];
+  const seen = new Set<string>([layer.id]);
+  let parentId = layer.parentId;
+  while (parentId) {
+    if (seen.has(parentId)) {
+      throw new Error(`Sketch layer "${layer.id}" has a cyclic parent chain.`);
+    }
+    seen.add(parentId);
+    const parent = byId.get(parentId);
+    if (!parent) {
+      break;
+    }
+    chain.push(parent);
+    parentId = parent.parentId;
+  }
+  return chain;
+}
+
+export function resolveLayers(doc: SketchDocumentData): ResolvedLayer[] {
+  const layers = doc.sketch.layers;
+  const canvas = doc.sketch.canvas;
+  const bindings = new Map(
+    doc.layerBindings.map((binding) => [binding.layerId, binding])
+  );
+
+  return layers.map((layer) => {
+    const ancestors = ancestorChain(layers, layer);
+    const visible = layer.visible !== false;
+    const composited =
+      visible && ancestors.every((ancestor) => ancestor.visible !== false);
+    const ownOpacity = clamp01(layer.opacity ?? 1);
+    const groupOpacity = ancestors.reduce(
+      (product, ancestor) =>
+        ancestor.type === 'group' ? product * clamp01(ancestor.opacity ?? 1) : product,
+      1
+    );
+
+    const bounds = layer.contentBounds ?? {
+      x: 0,
+      y: 0,
+      width: canvas.width,
+      height: canvas.height,
+    };
+    // Only the translation and scale of an affine transform are honored;
+    // rotation and quad transforms are not reproducible as a plain <Image>.
+    const transform = layer.transform?.kind === 'affine' ? layer.transform : undefined;
+    const rect: SketchRect = {
+      x: bounds.x + (transform?.x ?? 0),
+      y: bounds.y + (transform?.y ?? 0),
+      width: bounds.width * (transform?.scaleX ?? 1),
+      height: bounds.height * (transform?.scaleY ?? 1),
+    };
+
+    const binding = bindings.get(layer.id) ?? null;
+    const status = binding?.status ?? null;
+    const inlineUri = layerDataImageUri(layer.data);
+    const referenceUri = apiService.resolveUrl(layer.imageReference?.uri);
+    const hasPixels = !statusHasNoPixels(status);
+
+    return {
+      id: layer.id,
+      name: layer.name ?? 'Untitled layer',
+      type: layer.type ?? 'raster',
+      composited,
+      opacity: ownOpacity * groupOpacity,
+      rect,
+      directUri: hasPixels ? (referenceUri ?? inlineUri) : null,
+      assetId: hasPixels ? (binding?.currentAssetId ?? null) : null,
+      status,
+      prompt: binding?.prompt ?? null,
+      model: binding?.model ?? null,
+      versionCount: binding?.versions?.length ?? 0,
+    };
+  });
+}
+
+// ── Status presentation ────────────────────────────────────────────────────
+
+export const STATUS_LABEL: Record<SketchLayerStatus, string> = {
+  draft: 'Draft',
+  queued: 'Queued',
+  generating: 'Generating',
+  generated: 'Generated',
+  stale: 'Stale',
+  failed: 'Failed',
+  locked: 'Locked',
+  missing: 'Missing',
+};
+
+export function statusColor(status: SketchLayerStatus, colors: ThemeColors): string {
+  switch (status) {
+    case 'failed':
+    case 'missing':
+      return colors.error;
+    case 'queued':
+    case 'generating':
+      return colors.warning;
+    case 'generated':
+      return colors.success;
+    case 'stale':
+      return colors.info;
+    default:
+      return colors.textTertiary;
+  }
+}
+
+// ── Renderer ───────────────────────────────────────────────────────────────
+
+export interface SketchRendererProps {
+  doc: SketchDocumentData;
+  /** Pre-resolved layers, when the caller already computed them. */
+  layers?: ResolvedLayer[];
+  /** Caps the drawn canvas; the composite shrinks to fit rather than cropping. */
+  maxHeight?: number;
+  /** Draws a `w × h` badge in the corner, the way the web renderer does. */
+  showDimensions?: boolean;
+  accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * The composited canvas.
+ *
+ * Nothing draws until the frame reports a width: document pixels only become
+ * layout once the scale between them and the screen is known.
+ */
+export const SketchRenderer: React.FC<SketchRendererProps> = ({
+  doc,
+  layers,
+  maxHeight,
+  showDimensions = false,
+  accessibilityLabel,
+  style,
+}) => {
+  const { colors } = useTheme();
+  const [frameWidth, setFrameWidth] = useState(0);
+  const onFrameLayout = useCallback((event: LayoutChangeEvent) => {
+    setFrameWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const resolved = useMemo(() => layers ?? resolveLayers(doc), [doc, layers]);
+  const composited = useMemo(
+    () => resolved.filter((layer) => layer.composited && layer.type !== 'group'),
+    [resolved]
+  );
+
+  const canvas = doc.sketch.canvas;
+  const widthScale = frameWidth > 0 && canvas.width > 0 ? frameWidth / canvas.width : 0;
+  const heightScale =
+    maxHeight !== undefined && canvas.height > 0 ? maxHeight / canvas.height : Infinity;
+  const scale = Math.min(widthScale, heightScale);
+
+  const label =
+    accessibilityLabel ??
+    `Sketch preview, ${composited.length} visible ${
+      composited.length === 1 ? 'layer' : 'layers'
+    }`;
+
+  return (
+    <View onLayout={onFrameLayout} style={[styles.frame, style]}>
+      <View
+        accessibilityLabel={label}
+        style={[
+          styles.canvas,
+          {
+            width: scale > 0 ? canvas.width * scale : '100%',
+            height: scale > 0 ? canvas.height * scale : undefined,
+            aspectRatio: scale > 0 ? undefined : 1,
+            backgroundColor: canvas.backgroundColor ?? colors.surfaceElevated,
+            borderColor: colors.border,
+          },
+        ]}
+      >
+        {scale > 0 &&
+          composited.map((layer) => (
+            <CompositedLayer key={layer.id} layer={layer} scale={scale} colors={colors} />
+          ))}
+        {showDimensions && (
+          <View
+            pointerEvents="none"
+            style={[
+              styles.dimensions,
+              { backgroundColor: colors.cardBg, borderColor: colors.border },
+            ]}
+          >
+            <Text style={[styles.dimensionsText, { color: colors.textSecondary }]}>
+              {`${canvas.width} × ${canvas.height}`}
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+// ── One composited layer ───────────────────────────────────────────────────
+
+interface CompositedLayerProps {
+  layer: ResolvedLayer;
+  /** Document pixels → screen points. */
+  scale: number;
+  colors: ThemeColors;
+}
+
+/**
+ * A single stacked layer image.
+ *
+ * The asset lookup lives here rather than in the parent so each layer resolves
+ * its own URL through the same `assets.get` + `resolveUrl` path the asset
+ * viewer uses, and so a layer that already carries a URI costs no request.
+ */
+function CompositedLayer({ layer, scale, colors }: CompositedLayerProps) {
+  const [failed, setFailed] = useState(false);
+  const needsAsset = layer.directUri === null && layer.assetId !== null;
+  const assetQuery = trpc.assets.get.useQuery(
+    { id: layer.assetId ?? '' },
+    { enabled: needsAsset }
+  );
+
+  const uri = layer.directUri ?? apiService.resolveUrl(assetQuery.data?.get_url ?? null);
+
+  const frame = {
+    left: layer.rect.x * scale,
+    top: layer.rect.y * scale,
+    width: layer.rect.width * scale,
+    height: layer.rect.height * scale,
+  };
+
+  const onError = useCallback(() => setFailed(true), []);
+
+  if (needsAsset && assetQuery.isLoading) {
+    return (
+      <View style={[styles.layerFrame, frame]} pointerEvents="none">
+        <ActivityIndicator size="small" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (uri === null || failed) {
+    const reason =
+      layer.status !== null && statusHasNoPixels(layer.status)
+        ? STATUS_LABEL[layer.status]
+        : 'No image';
+    return (
+      <View
+        pointerEvents="none"
+        accessibilityLabel={`Layer ${layer.name} has no image: ${reason}`}
+        style={[
+          styles.layerFrame,
+          styles.placeholder,
+          frame,
+          { borderColor: colors.error, backgroundColor: colors.surfaceElevated },
+        ]}
+      >
+        <Ionicons name="image-outline" size={20} color={colors.error} />
+        <Text style={[styles.placeholderText, { color: colors.error }]} numberOfLines={2}>
+          {`${layer.name} · ${reason}`}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <Image
+      source={{ uri }}
+      onError={onError}
+      resizeMode="contain"
+      accessibilityLabel={`Layer ${layer.name}`}
+      style={[styles.layerFrame, frame, { opacity: layer.opacity }]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  canvas: {
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  layerFrame: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholder: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderRadius: 8,
+    gap: 4,
+    padding: 6,
+  },
+  placeholderText: {
+    fontSize: 11,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  dimensions: {
+    position: 'absolute',
+    right: 6,
+    bottom: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  dimensionsText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+});
+
+export default SketchRenderer;

--- a/mobile/src/components/sketch/__tests__/SketchRenderer.test.tsx
+++ b/mobile/src/components/sketch/__tests__/SketchRenderer.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Tests for the sketch compositor shared by the viewer screen and the
+ * app-runtime `Sketch` widget.
+ *
+ * `assets.get` is mocked at the tRPC client so layer asset resolution runs
+ * without a server, and the frame gets a width through a synthetic `onLayout`,
+ * which is what turns the document's pixel geometry into layout.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import {
+  SketchRenderer,
+  asSketchDocument,
+  layerDataImageUri,
+  resolveLayers,
+  type SketchDocumentData,
+} from '../SketchRenderer';
+
+jest.mock('../../../services/api', () => ({
+  apiService: {
+    resolveUrl: (path?: string | null) =>
+      path ? (path.startsWith('http') ? path : `https://example.test${path}`) : null,
+  },
+}));
+
+interface AssetQueryResult {
+  data?: { get_url: string };
+  isLoading: boolean;
+}
+
+const mockAssetsById = new Map<string, AssetQueryResult>();
+
+jest.mock('../../../trpc/client', () => ({
+  trpc: {
+    assets: {
+      get: {
+        useQuery: (input: { id: string }, options?: { enabled?: boolean }) => {
+          if (options?.enabled === false) {
+            return { data: undefined, isLoading: false };
+          }
+          return mockAssetsById.get(input.id) ?? { data: undefined, isLoading: false };
+        },
+      },
+    },
+  },
+}));
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      surface: '#111',
+      surfaceElevated: '#222',
+      primary: '#6DB3F8',
+      text: '#fff',
+      textSecondary: '#aaa',
+      textTertiary: '#777',
+      border: '#222',
+      borderLight: '#333',
+      cardBg: '#111',
+      error: '#f00',
+      success: '#0f0',
+      warning: '#fc0',
+      info: '#08f',
+    },
+    shadows: { small: {}, medium: {}, large: {} },
+  }),
+}));
+
+const CANVAS = { width: 200, height: 100, backgroundColor: '#ffffff' };
+
+const makeDoc = (): SketchDocumentData =>
+  ({
+    sketch: {
+      canvas: CANVAS,
+      layers: [
+        {
+          id: 'l-base',
+          name: 'Background',
+          type: 'raster',
+          visible: true,
+          opacity: 1,
+          data: 'data:image/png;base64,AAAA',
+        },
+        {
+          id: 'l-gen',
+          name: 'Sky',
+          type: 'raster',
+          visible: true,
+          opacity: 0.5,
+          contentBounds: { x: 10, y: 20, width: 100, height: 50 },
+        },
+        {
+          id: 'l-hidden',
+          name: 'Notes',
+          type: 'raster',
+          visible: false,
+          opacity: 1,
+          data: 'data:image/png;base64,BBBB',
+        },
+      ],
+    },
+    layerBindings: [
+      { layerId: 'l-gen', status: 'generated', currentAssetId: 'a-sky', versions: [] },
+    ],
+  }) as SketchDocumentData;
+
+function renderComposite(props: Partial<React.ComponentProps<typeof SketchRenderer>> = {}) {
+  const result = render(<SketchRenderer doc={makeDoc()} {...props} />);
+  // Nothing composites until the frame reports a width.
+  fireEvent(screen.getByLabelText(/Sketch preview/), 'layout', {
+    nativeEvent: { layout: { width: 400, height: 0, x: 0, y: 0 } },
+  });
+  return result;
+}
+
+describe('SketchRenderer', () => {
+  beforeEach(() => {
+    mockAssetsById.clear();
+    mockAssetsById.set('a-sky', {
+      data: { get_url: '/api/assets/a-sky/file' },
+      isLoading: false,
+    });
+  });
+
+  it('composites only the visible layers', () => {
+    renderComposite();
+
+    expect(screen.getByLabelText('Sketch preview, 2 visible layers')).toBeTruthy();
+    expect(screen.getByLabelText('Layer Background')).toBeTruthy();
+    expect(screen.queryByLabelText('Layer Notes')).toBeNull();
+  });
+
+  it('scales document pixels to the measured frame', () => {
+    renderComposite();
+
+    const sky = screen.getByLabelText('Layer Sky');
+    expect(sky.props.source).toEqual({
+      uri: 'https://example.test/api/assets/a-sky/file',
+    });
+    // Canvas is 200px wide shown at 400pt, so document pixels double.
+    expect(sky.props.style).toEqual(
+      expect.arrayContaining([
+        { left: 20, top: 40, width: 200, height: 100 },
+        { opacity: 0.5 },
+      ])
+    );
+  });
+
+  it('shrinks to fit a height cap rather than cropping', () => {
+    renderComposite({ maxHeight: 50 });
+
+    // 50pt over a 100px-tall canvas halves the scale the width alone allowed.
+    expect(screen.getByLabelText('Layer Sky').props.style).toEqual(
+      expect.arrayContaining([{ left: 5, top: 10, width: 50, height: 25 }])
+    );
+  });
+
+  it('draws the dimensions badge only when asked', () => {
+    const { unmount } = renderComposite();
+    expect(screen.queryByText('200 × 100')).toBeNull();
+    unmount();
+
+    renderComposite({ showDimensions: true });
+    expect(screen.getByText('200 × 100')).toBeTruthy();
+  });
+
+  it('renders a placeholder instead of a broken image for a failed layer', () => {
+    const doc = makeDoc();
+    doc.layerBindings = [
+      { layerId: 'l-gen', status: 'failed', currentAssetId: 'a-sky', versions: [] },
+    ];
+    render(<SketchRenderer doc={doc} />);
+    fireEvent(screen.getByLabelText(/Sketch preview/), 'layout', {
+      nativeEvent: { layout: { width: 400, height: 0, x: 0, y: 0 } },
+    });
+
+    expect(screen.queryByLabelText('Layer Sky')).toBeNull();
+    expect(screen.getByLabelText('Layer Sky has no image: Failed')).toBeTruthy();
+  });
+});
+
+describe('resolveLayers', () => {
+  it('dims a layer by its ancestor group opacity and drops hidden groups', () => {
+    const layers = resolveLayers({
+      sketch: {
+        canvas: CANVAS,
+        layers: [
+          { id: 'g-1', name: 'Folder', type: 'group', visible: true, opacity: 0.5 },
+          {
+            id: 'l-1',
+            name: 'Inside',
+            type: 'raster',
+            visible: true,
+            opacity: 0.5,
+            parentId: 'g-1',
+          },
+          { id: 'g-2', name: 'Closed', type: 'group', visible: false, opacity: 1 },
+          {
+            id: 'l-2',
+            name: 'Buried',
+            type: 'raster',
+            visible: true,
+            opacity: 1,
+            parentId: 'g-2',
+          },
+        ],
+      },
+      layerBindings: [],
+    });
+
+    expect(layers.find((layer) => layer.id === 'l-1')).toMatchObject({
+      composited: true,
+      opacity: 0.25,
+    });
+    expect(layers.find((layer) => layer.id === 'l-2')?.composited).toBe(false);
+  });
+
+  it('refuses a cyclic parent chain rather than looping', () => {
+    expect(() =>
+      resolveLayers({
+        sketch: {
+          canvas: CANVAS,
+          layers: [
+            { id: 'a', type: 'group', parentId: 'b' },
+            { id: 'b', type: 'group', parentId: 'a' },
+          ],
+        },
+        layerBindings: [],
+      })
+    ).toThrow(/cyclic parent chain/);
+  });
+});
+
+describe('asSketchDocument', () => {
+  it('reads the persisted envelope with its bindings', () => {
+    const doc = asSketchDocument({
+      sketch: { canvas: CANVAS, layers: [{ id: 'l-1' }] },
+      layerBindings: [{ layerId: 'l-1', status: 'generated' }],
+    });
+
+    expect(doc?.sketch.canvas.width).toBe(200);
+    expect(doc?.layerBindings).toHaveLength(1);
+  });
+
+  it('reads a bare editor document, which carries no bindings', () => {
+    const doc = asSketchDocument({
+      version: 1,
+      canvas: CANVAS,
+      layers: [{ id: 'l-1' }],
+      activeLayerId: 'l-1',
+    });
+
+    expect(doc?.sketch.layers).toHaveLength(1);
+    expect(doc?.layerBindings).toEqual([]);
+  });
+
+  it('rejects anything without a canvas and layers', () => {
+    expect(asSketchDocument(null)).toBeNull();
+    expect(asSketchDocument({ canvas: { width: 4 }, layers: [] })).toBeNull();
+    expect(asSketchDocument({ type: 'sketch', id: 'sk-1' })).toBeNull();
+  });
+});
+
+describe('layerDataImageUri', () => {
+  it('passes a legacy bare data URL straight through', () => {
+    expect(layerDataImageUri('data:image/png;base64,AAAA')).toBe(
+      'data:image/png;base64,AAAA'
+    );
+  });
+
+  it('unwraps an ntlayer: payload', () => {
+    const payload = btoa(
+      JSON.stringify({
+        version: 1,
+        image: 'data:image/png;base64,CCCC',
+        bounds: { x: 0, y: 0, width: 4, height: 4 },
+      })
+    );
+    expect(layerDataImageUri(`ntlayer:${payload}`)).toBe('data:image/png;base64,CCCC');
+  });
+
+  it('returns null for an empty or undecodable payload', () => {
+    expect(layerDataImageUri(null)).toBeNull();
+    expect(layerDataImageUri('ntlayer:@@@not-base64@@@')).toBeNull();
+    expect(layerDataImageUri(`ntlayer:${btoa('{"version":1,"image":null}')}`)).toBeNull();
+  });
+});

--- a/mobile/src/screens/SketchViewerScreen.tsx
+++ b/mobile/src/screens/SketchViewerScreen.tsx
@@ -1,42 +1,24 @@
 /**
  * Read-only sketch viewer.
  *
- * A sketch is layer-based, so "showing" one means compositing: stack the
- * layers bottom-to-top the way the web editor does, then list them with the
- * generation status each one carries. There is no canvas here and no editing —
- * placing a brush stroke with a thumb is not the phone's job, and there are no
- * `ui_sketch_*` tools yet either, so `kinds.ts` classifies this as a `viewer`
- * with `agentEditable: false`.
+ * The canvas itself is `components/sketch/SketchRenderer` — the same compositor
+ * the app-runtime `Sketch` widget draws with. This screen adds what only a
+ * document screen needs: loading the document, and listing every layer with the
+ * generation status it carries.
  *
- * Compositing agrees with `web/src/components/sketch/rendering/canvas2d/composite.ts`:
- * `layers` is stored bottom-first, groups are containers rather than pixels,
- * a layer is drawn only when it and every ancestor group is visible, and its
- * alpha is its own opacity times the opacity of every ancestor group. Mask
- * layers are drawn, matching web's on-screen preview (its *export* path is the
- * one that drops them).
- *
- * Pixels come from three places, in order: the layer's generated asset
- * (`layerBindings[].currentAssetId`, resolved through `assets.get` like every
- * other image in the app), a stable external `imageReference.uri`, or the
- * raster serialized into the document itself. A layer with none of those — or
- * whose generation failed — renders a labelled placeholder in its own footprint
- * rather than a broken image or an invisible gap.
- *
- * What is deliberately not reproduced: blend modes and layer rotation. React
- * Native has no compositing operator, and a read-only preview that silently
- * approximated them would be lying more quietly than one that does not.
+ * There is no editing here: placing a brush stroke with a thumb is not the
+ * phone's job, and there are no `ui_sketch_*` tools yet either, so `kinds.ts`
+ * classifies this as a `viewer` with `agentEditable: false`.
  */
 
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import {
   ActivityIndicator,
-  Image,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
-  type LayoutChangeEvent,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -46,242 +28,15 @@ import { useShallow } from 'zustand/react/shallow';
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../hooks/useTheme';
 import { documentStore } from '../documents/documentStore';
-import { apiService } from '../services/api';
-import { trpc } from '../trpc/client';
-import type { ThemeColors } from '../utils/theme';
+import {
+  SketchRenderer,
+  resolveLayers,
+  STATUS_LABEL,
+  statusColor,
+  type SketchDocumentData,
+} from '../components/sketch/SketchRenderer';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SketchViewer'>;
-
-// ── Document shape ─────────────────────────────────────────────────────────
-//
-// Mirrors `ImageDocumentData` from `@nodetool-ai/protocol/api-schemas/sketch`,
-// narrowed to the fields a viewer reads. The protocol types the layer array as
-// `unknown[]` (the full `Layer` lives in the web editor), so the fields this
-// screen needs are declared here and every one of them is optional.
-
-/** Layer generation status carried by a binding. */
-export type SketchLayerStatus =
-  | 'draft'
-  | 'queued'
-  | 'generating'
-  | 'generated'
-  | 'stale'
-  | 'failed'
-  | 'locked'
-  | 'missing';
-
-interface SketchRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-interface SketchLayer {
-  id: string;
-  name?: string;
-  type?: 'raster' | 'mask' | 'group';
-  visible?: boolean;
-  opacity?: number;
-  parentId?: string | null;
-  /** Serialized raster payload, or a legacy PNG data URL. */
-  data?: string | null;
-  /** Backing raster bounds in layer-local space. */
-  contentBounds?: SketchRect;
-  transform?: { kind?: string; x?: number; y?: number; scaleX?: number; scaleY?: number };
-  imageReference?: { uri?: string } | null;
-}
-
-interface SketchLayerBinding {
-  layerId: string;
-  status: SketchLayerStatus;
-  currentAssetId?: string;
-  prompt?: string;
-  model?: string;
-  versions?: unknown[];
-}
-
-interface SketchDocumentData {
-  sketch: {
-    canvas: { width: number; height: number; backgroundColor?: string };
-    layers: SketchLayer[];
-  };
-  layerBindings: SketchLayerBinding[];
-}
-
-// ── Layer data decoding ────────────────────────────────────────────────────
-
-const SERIALIZED_LAYER_DATA_PREFIX = 'ntlayer:';
-
-/**
- * The image URL inside a layer's `data` field, or null.
- *
- * Ported from web's `deserializeLayerData`: a payload is either a base64 blob
- * of JSON behind the `ntlayer:` prefix or, on older documents, a bare data URL.
- */
-export function layerDataImageUri(data: string | null | undefined): string | null {
-  if (!data) {
-    return null;
-  }
-  if (!data.startsWith(SERIALIZED_LAYER_DATA_PREFIX)) {
-    return data;
-  }
-  try {
-    const decoded: unknown = JSON.parse(
-      atob(data.slice(SERIALIZED_LAYER_DATA_PREFIX.length))
-    );
-    if (decoded === null || typeof decoded !== 'object') {
-      return null;
-    }
-    const image = (decoded as { image?: unknown }).image;
-    return typeof image === 'string' ? image : null;
-  } catch {
-    // A payload we cannot decode is not a URL either; the layer falls through
-    // to its placeholder, which is the honest outcome.
-    return null;
-  }
-}
-
-// ── Compositing ────────────────────────────────────────────────────────────
-
-/** One layer, resolved into everything the composite and the list need. */
-interface ResolvedLayer {
-  id: string;
-  name: string;
-  type: 'raster' | 'mask' | 'group';
-  /** True when this layer and every ancestor group is visible. */
-  composited: boolean;
-  /** Own opacity times every ancestor group's opacity. */
-  opacity: number;
-  /** Footprint in document pixels. */
-  rect: SketchRect;
-  /** A ready-to-render URI (data URL or absolute http URL), if one is known. */
-  directUri: string | null;
-  /** The generated asset to look up when there is no direct URI. */
-  assetId: string | null;
-  status: SketchLayerStatus | null;
-  prompt: string | null;
-  model: string | null;
-  versionCount: number;
-}
-
-const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
-
-/** Statuses that mean "these pixels do not exist", whatever else is set. */
-function statusHasNoPixels(status: SketchLayerStatus | null): boolean {
-  return status === 'failed' || status === 'missing';
-}
-
-function ancestorChain(
-  layers: SketchLayer[],
-  layer: SketchLayer
-): SketchLayer[] {
-  const byId = new Map(layers.map((entry) => [entry.id, entry]));
-  const chain: SketchLayer[] = [];
-  const seen = new Set<string>([layer.id]);
-  let parentId = layer.parentId;
-  while (parentId) {
-    if (seen.has(parentId)) {
-      throw new Error(`Sketch layer "${layer.id}" has a cyclic parent chain.`);
-    }
-    seen.add(parentId);
-    const parent = byId.get(parentId);
-    if (!parent) {
-      break;
-    }
-    chain.push(parent);
-    parentId = parent.parentId;
-  }
-  return chain;
-}
-
-export function resolveLayers(doc: SketchDocumentData): ResolvedLayer[] {
-  const layers = doc.sketch.layers;
-  const canvas = doc.sketch.canvas;
-  const bindings = new Map(
-    doc.layerBindings.map((binding) => [binding.layerId, binding])
-  );
-
-  return layers.map((layer) => {
-    const ancestors = ancestorChain(layers, layer);
-    const visible = layer.visible !== false;
-    const composited =
-      visible && ancestors.every((ancestor) => ancestor.visible !== false);
-    const ownOpacity = clamp01(layer.opacity ?? 1);
-    const groupOpacity = ancestors.reduce(
-      (product, ancestor) =>
-        ancestor.type === 'group' ? product * clamp01(ancestor.opacity ?? 1) : product,
-      1
-    );
-
-    const bounds = layer.contentBounds ?? {
-      x: 0,
-      y: 0,
-      width: canvas.width,
-      height: canvas.height,
-    };
-    // Only the translation and scale of an affine transform are honored;
-    // rotation and quad transforms are not reproducible as a plain <Image>.
-    const transform = layer.transform?.kind === 'affine' ? layer.transform : undefined;
-    const rect: SketchRect = {
-      x: bounds.x + (transform?.x ?? 0),
-      y: bounds.y + (transform?.y ?? 0),
-      width: bounds.width * (transform?.scaleX ?? 1),
-      height: bounds.height * (transform?.scaleY ?? 1),
-    };
-
-    const binding = bindings.get(layer.id) ?? null;
-    const status = binding?.status ?? null;
-    const inlineUri = layerDataImageUri(layer.data);
-    const referenceUri = apiService.resolveUrl(layer.imageReference?.uri);
-    const hasPixels = !statusHasNoPixels(status);
-
-    return {
-      id: layer.id,
-      name: layer.name ?? 'Untitled layer',
-      type: layer.type ?? 'raster',
-      composited,
-      opacity: ownOpacity * groupOpacity,
-      rect,
-      directUri: hasPixels ? (referenceUri ?? inlineUri) : null,
-      assetId: hasPixels ? (binding?.currentAssetId ?? null) : null,
-      status,
-      prompt: binding?.prompt ?? null,
-      model: binding?.model ?? null,
-      versionCount: binding?.versions?.length ?? 0,
-    };
-  });
-}
-
-// ── Status presentation ────────────────────────────────────────────────────
-
-const STATUS_LABEL: Record<SketchLayerStatus, string> = {
-  draft: 'Draft',
-  queued: 'Queued',
-  generating: 'Generating',
-  generated: 'Generated',
-  stale: 'Stale',
-  failed: 'Failed',
-  locked: 'Locked',
-  missing: 'Missing',
-};
-
-function statusColor(status: SketchLayerStatus, colors: ThemeColors): string {
-  switch (status) {
-    case 'failed':
-    case 'missing':
-      return colors.error;
-    case 'queued':
-    case 'generating':
-      return colors.warning;
-    case 'generated':
-      return colors.success;
-    case 'stale':
-      return colors.info;
-    default:
-      return colors.textTertiary;
-  }
-}
 
 const LAYER_ICONS: Record<'raster' | 'mask' | 'group', keyof typeof Ionicons.glyphMap> = {
   raster: 'image-outline',
@@ -318,11 +73,6 @@ export default function SketchViewerScreen({ navigation, route }: Props) {
   useLayoutEffect(() => {
     navigation.setOptions({ title });
   }, [navigation, title]);
-
-  const [frameWidth, setFrameWidth] = useState(0);
-  const onFrameLayout = useCallback((event: LayoutChangeEvent) => {
-    setFrameWidth(event.nativeEvent.layout.width);
-  }, []);
 
   const layers = useMemo(() => (doc === null ? [] : resolveLayers(doc)), [doc]);
 
@@ -362,36 +112,13 @@ export default function SketchViewerScreen({ navigation, route }: Props) {
   }
 
   const canvas = doc.sketch.canvas;
-  const scale = frameWidth > 0 && canvas.width > 0 ? frameWidth / canvas.width : 0;
-  const composited = layers.filter(
-    (layer) => layer.composited && layer.type !== 'group'
-  );
 
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: colors.background }]}
       contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
     >
-      <View
-        onLayout={onFrameLayout}
-        accessibilityLabel={`Sketch preview, ${composited.length} visible ${
-          composited.length === 1 ? 'layer' : 'layers'
-        }`}
-        style={[
-          styles.canvas,
-          {
-            height: scale > 0 ? canvas.height * scale : undefined,
-            aspectRatio: scale > 0 ? undefined : 1,
-            backgroundColor: canvas.backgroundColor ?? colors.surfaceElevated,
-            borderColor: colors.border,
-          },
-        ]}
-      >
-        {scale > 0 &&
-          composited.map((layer) => (
-            <CompositedLayer key={layer.id} layer={layer} scale={scale} colors={colors} />
-          ))}
-      </View>
+      <SketchRenderer doc={doc} layers={layers} />
 
       <View style={styles.headerSection}>
         <Text style={[styles.name, { color: colors.text }]} numberOfLines={2}>
@@ -482,85 +209,6 @@ export default function SketchViewerScreen({ navigation, route }: Props) {
   );
 }
 
-// ── One composited layer ───────────────────────────────────────────────────
-
-interface CompositedLayerProps {
-  layer: ResolvedLayer;
-  /** Document pixels → screen points. */
-  scale: number;
-  colors: ThemeColors;
-}
-
-/**
- * A single stacked layer image.
- *
- * The asset lookup lives here rather than in the parent so each layer resolves
- * its own URL through the same `assets.get` + `resolveUrl` path the asset
- * viewer uses, and so a layer that already carries a URI costs no request.
- */
-function CompositedLayer({ layer, scale, colors }: CompositedLayerProps) {
-  const [failed, setFailed] = useState(false);
-  const needsAsset = layer.directUri === null && layer.assetId !== null;
-  const assetQuery = trpc.assets.get.useQuery(
-    { id: layer.assetId ?? '' },
-    { enabled: needsAsset }
-  );
-
-  const uri =
-    layer.directUri ?? apiService.resolveUrl(assetQuery.data?.get_url ?? null);
-
-  const frame = {
-    left: layer.rect.x * scale,
-    top: layer.rect.y * scale,
-    width: layer.rect.width * scale,
-    height: layer.rect.height * scale,
-  };
-
-  const onError = useCallback(() => setFailed(true), []);
-
-  if (needsAsset && assetQuery.isLoading) {
-    return (
-      <View style={[styles.layerFrame, frame]} pointerEvents="none">
-        <ActivityIndicator size="small" color={colors.primary} />
-      </View>
-    );
-  }
-
-  if (uri === null || failed) {
-    const reason =
-      layer.status !== null && statusHasNoPixels(layer.status)
-        ? STATUS_LABEL[layer.status]
-        : 'No image';
-    return (
-      <View
-        pointerEvents="none"
-        accessibilityLabel={`Layer ${layer.name} has no image: ${reason}`}
-        style={[
-          styles.layerFrame,
-          styles.placeholder,
-          frame,
-          { borderColor: colors.error, backgroundColor: colors.surfaceElevated },
-        ]}
-      >
-        <Ionicons name="image-outline" size={20} color={colors.error} />
-        <Text style={[styles.placeholderText, { color: colors.error }]} numberOfLines={2}>
-          {`${layer.name} · ${reason}`}
-        </Text>
-      </View>
-    );
-  }
-
-  return (
-    <Image
-      source={{ uri }}
-      onError={onError}
-      resizeMode="contain"
-      accessibilityLabel={`Layer ${layer.name}`}
-      style={[styles.layerFrame, frame, { opacity: layer.opacity }]}
-    />
-  );
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -591,28 +239,6 @@ const styles = StyleSheet.create({
   retryText: {
     fontSize: 15,
     fontWeight: '600',
-  },
-  canvas: {
-    width: '100%',
-    overflow: 'hidden',
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  layerFrame: {
-    position: 'absolute',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  placeholder: {
-    borderWidth: 1,
-    borderStyle: 'dashed',
-    borderRadius: 8,
-    gap: 4,
-    padding: 6,
-  },
-  placeholderText: {
-    fontSize: 11,
-    fontWeight: '600',
-    textAlign: 'center',
   },
   headerSection: {
     paddingHorizontal: 20,

--- a/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
@@ -3,14 +3,15 @@
  *
  * The document store is mocked so the screen's states can be driven directly,
  * and `assets.get` is mocked at the tRPC client so layer asset resolution is
- * exercised without a server. The canvas gets a width through a synthetic
- * `onLayout`, which is what turns the document's pixel geometry into layout.
+ * exercised without a server. Compositing itself is covered in
+ * `components/sketch/__tests__/SketchRenderer.test.tsx`; what is checked here is
+ * the screen around it — loading, retry, and the layer list.
  */
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
-import SketchViewerScreen, { layerDataImageUri } from '../SketchViewerScreen';
+import SketchViewerScreen from '../SketchViewerScreen';
 import type { DocumentStatus } from '../../documents/documentStore';
 
 // ── Module mocks ───────────────────────────────────────────────────────────
@@ -202,53 +203,12 @@ describe('SketchViewerScreen', () => {
     expect(load).toHaveBeenCalled();
   });
 
-  it('composites only the visible layers, hidden ones excluded', () => {
+  it('draws the composite for the loaded document', () => {
     renderScreen();
 
     expect(screen.getByLabelText('Sketch preview, 3 visible layers')).toBeTruthy();
     expect(screen.getByLabelText('Layer Background')).toBeTruthy();
-    expect(screen.getByLabelText('Layer Sky')).toBeTruthy();
     expect(screen.queryByLabelText('Layer Notes')).toBeNull();
-  });
-
-  it('renders an inline layer raster and an asset-backed one at document scale', () => {
-    renderScreen();
-
-    const base = screen.getByLabelText('Layer Background');
-    expect(base.props.source).toEqual({ uri: 'data:image/png;base64,AAAA' });
-
-    const sky = screen.getByLabelText('Layer Sky');
-    expect(sky.props.source).toEqual({
-      uri: 'https://example.test/api/assets/a-sky/file',
-    });
-    // Canvas is 200px wide shown at 400pt, so document pixels double.
-    expect(sky.props.style).toEqual(
-      expect.arrayContaining([
-        { left: 20, top: 40, width: 200, height: 100 },
-        { opacity: 0.5 },
-      ])
-    );
-  });
-
-  it('renders a placeholder instead of a broken image for a failed layer', () => {
-    renderScreen();
-
-    expect(screen.queryByLabelText('Layer Dragon')).toBeNull();
-    expect(
-      screen.getByLabelText('Layer Dragon has no image: Failed')
-    ).toBeTruthy();
-    expect(screen.getByText('Dragon · Failed')).toBeTruthy();
-  });
-
-  it('renders a placeholder when a layer has neither raster nor asset', () => {
-    const doc = makeDoc();
-    doc.layerBindings = [];
-    mockState = { ...mockState, doc };
-    renderScreen();
-
-    expect(
-      screen.getByLabelText('Layer Sky has no image: No image')
-    ).toBeTruthy();
   });
 
   it('lists every layer top-first with its generation status', () => {
@@ -262,76 +222,4 @@ describe('SketchViewerScreen', () => {
     expect(screen.getByText('raster · 50%')).toBeTruthy();
   });
 
-  it('dims a layer by its ancestor group opacity and drops hidden groups', () => {
-    mockState = {
-      ...mockState,
-      doc: {
-        sketch: {
-          canvas: CANVAS,
-          layers: [
-            { id: 'g-1', name: 'Folder', type: 'group', visible: true, opacity: 0.5 },
-            {
-              id: 'l-1',
-              name: 'Inside',
-              type: 'raster',
-              visible: true,
-              opacity: 0.5,
-              parentId: 'g-1',
-              data: 'data:image/png;base64,AAAA',
-            },
-            {
-              id: 'g-2',
-              name: 'Closed folder',
-              type: 'group',
-              visible: false,
-              opacity: 1,
-            },
-            {
-              id: 'l-2',
-              name: 'Buried',
-              type: 'raster',
-              visible: true,
-              opacity: 1,
-              parentId: 'g-2',
-              data: 'data:image/png;base64,BBBB',
-            },
-          ],
-        },
-        layerBindings: [],
-      },
-    };
-    renderScreen();
-
-    // Groups hold no pixels, so only one layer composites.
-    expect(screen.getByLabelText('Sketch preview, 1 visible layer')).toBeTruthy();
-    expect(screen.getByLabelText('Layer Inside').props.style).toEqual(
-      expect.arrayContaining([{ opacity: 0.25 }])
-    );
-    expect(screen.queryByLabelText('Layer Buried')).toBeNull();
-  });
-});
-
-describe('layerDataImageUri', () => {
-  it('passes a legacy bare data URL straight through', () => {
-    expect(layerDataImageUri('data:image/png;base64,AAAA')).toBe(
-      'data:image/png;base64,AAAA'
-    );
-  });
-
-  it('unwraps an ntlayer: payload', () => {
-    const payload = btoa(
-      JSON.stringify({
-        version: 1,
-        image: 'data:image/png;base64,CCCC',
-        bounds: { x: 0, y: 0, width: 4, height: 4 },
-      })
-    );
-    expect(layerDataImageUri(`ntlayer:${payload}`)).toBe('data:image/png;base64,CCCC');
-  });
-
-  it('returns null for an empty or undecodable payload', () => {
-    expect(layerDataImageUri(null)).toBeNull();
-    expect(layerDataImageUri('ntlayer:@@@not-base64@@@')).toBeNull();
-    expect(layerDataImageUri(`ntlayer:${btoa('{"version":1,"image":null}')}`)).toBeNull();
-  });
 });


### PR DESCRIPTION
Follow-up to #4569, which added the Sketch widget to the mini-app builder. On mobile that widget rendered a card saying "Open on desktop to view".

## What changed

- **New `mobile/src/components/sketch/SketchRenderer.tsx`** — the compositor extracted out of `SketchViewerScreen`, so a document screen and an app can draw the same picture. Layers stack the way `web/src/components/sketch/rendering/canvas2d/composite.ts` stacks them: bottom-first, groups as containers rather than pixels, a layer drawn only when it and every ancestor group is visible, alpha multiplied down the chain. Pixels come from the layer's generated asset, an `imageReference.uri`, or the raster serialized into the document, in that order; a layer with none of those renders a labelled placeholder in its own footprint. Blend modes and rotation stay unreproduced — React Native has no compositing operator.
- **New props the widget needs**: `maxHeight` (the composite shrinks to fit rather than cropping) and `showDimensions` (the `w × h` badge the web renderer draws).
- **`asSketchDocument`** reads both shapes a bound value arrives in: the persisted `{ sketch, layerBindings }` envelope and the bare `{ canvas, layers }` editor state a node emits inline.
- **`SketchWidget`** (`components/app_runtime/widgets.tsx`) now composites. An inline document draws with no request; a bare `SketchRef` is read through the sketch document backend mobile already has. A ref that cannot be read falls back to a card that says so.
- **`SketchViewerScreen`** keeps what only a document screen owns — loading, retry, the layer list with generation statuses — and renders the shared component for the canvas.
- Timelines still summarize: mobile has no preview compositor.

## Tests

- `components/sketch/__tests__/SketchRenderer.test.tsx` — visible-layer selection, document-pixel scaling, the height cap, the dimensions badge, failed-layer placeholders, group opacity/visibility, cyclic parent chains, `asSketchDocument`, `layerDataImageUri`.
- `components/app_runtime/__tests__/sketchWidget.test.tsx` — inline document composites without a read, a ref is read by id and composited, the badge, an unreadable ref, and the unbound placeholder.
- `SketchViewerScreen.test.tsx` trimmed to the screen's own behaviour now that compositing is covered once.

`npm --prefix mobile run typecheck`, `lint`, and `test` (936 tests, 69 suites) all pass.

## Docs

`mobile/ARCHITECTURE.md` — the compositing rules under Documents, and the widget's behaviour under Mini apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMws2sjaN9XZqTNVw8mbyV)_