### PR TITLE
feat(cli): asset output modes and asset persistence for `workflows run`

### DIFF
--- a/packages/base-nodes/nodetool/examples/nodetool-base/AI Spokesperson.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/AI Spokesperson.json
@@ -1,0 +1,258 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-21T16:03:52.969Z",
+  "updated_at": "2026-06-21T16:55:51.256Z",
+  "name": "AI Spokesperson",
+  "tool_name": null,
+  "description": "Give a presenter clip a new script. Text-to-speech voices the script, then a lip-sync model redrives the mouth in the source footage so the delivery matches. Useful for localising a take, fixing a fluffed line, or spinning one recording into many variants. Both the speech and lip-sync steps are paid per run.",
+  "tags": [
+    "video",
+    "audio",
+    "marketing",
+    "example"
+  ],
+  "thumbnail": "AI Spokesperson.jpg",
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "comment-1",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "headline": "AI Spokesperson",
+          "comment": [
+            "Re-voice an existing presenter clip without a reshoot.\n\n",
+            "1. Drop in footage of a person talking to camera.\n",
+            "2. Write the new script.\n",
+            "3. TTS voices it, then lip-sync redrives the mouth to match.\n\n",
+            "Keep the script close to the original length — lip-sync follows the audio, and a much longer script will run past the footage."
+          ]
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 560,
+          "selectable": true,
+          "height": 170
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-clip",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "presenter_clip",
+          "value": null,
+          "description": "Footage of a person speaking to camera"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 240
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Presenter clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-script",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "script",
+          "value": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
+          "description": "The new words the presenter should say"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  New script"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "speech",
+        "type": "nodetool.audio.TextToSpeech",
+        "data": {
+          "model": {
+            "type": "tts_model",
+            "provider": "replicate",
+            "id": "inworld/realtime-tts-1.5-max",
+            "name": "Inworld Realtime TTS 1.5 Max",
+            "path": null,
+            "voices": []
+          },
+          "speed": 1.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 380,
+            "y": 380
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Voice the script"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "sync",
+        "type": "nodetool.video.LipSync",
+        "data": {
+          "model": {
+            "type": "video_model",
+            "provider": "replicate",
+            "id": "sync/lipsync-2-pro",
+            "name": "Lipsync 2 Pro",
+            "path": null,
+            "supported_tasks": []
+          }
+        },
+        "ui_properties": {
+          "position": {
+            "x": 760,
+            "y": 300
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Lip-sync to the new audio"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "output-clip",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "revoiced_clip"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1120,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "5  Re-voiced clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in-script",
+        "sourceHandle": "output",
+        "target": "speech",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "in-clip",
+        "sourceHandle": "output",
+        "target": "sync",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e3",
+        "source": "speech",
+        "sourceHandle": "audio",
+        "target": "sync",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e4",
+        "source": "sync",
+        "sourceHandle": "output",
+        "target": "output-clip",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "presenter_clip": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      },
+      "script": {
+        "type": "string",
+        "default": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
+        "label": ""
+      }
+    },
+    "required": [
+      "presenter_clip",
+      "script"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "revoiced_clip": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      }
+    },
+    "required": [
+      "revoiced_clip"
+    ]
+  },
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": "e31acfae86ee104dbf9df243c9ba6084"
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/B-Roll Reel from a Brief.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/B-Roll Reel from a Brief.json
@@ -1,0 +1,344 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-21T16:03:52.969Z",
+  "updated_at": "2026-06-21T16:55:51.256Z",
+  "name": "B-Roll Reel from a Brief",
+  "tool_name": null,
+  "description": "One line of direction becomes a two-shot b-roll reel. Prompt nodes expand the brief into a wide establishing shot and a matching detail shot, text-to-video renders both, and a crossfade cuts them together. Two paid video generations per run.",
+  "tags": [
+    "video",
+    "content",
+    "example"
+  ],
+  "thumbnail": "B-Roll Reel from a Brief.jpg",
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "comment-1",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "headline": "B-Roll Reel from a Brief",
+          "comment": [
+            "Turn one line of direction into a cut b-roll reel.\n\n",
+            "The two shots share a subject and a look, so they cut together: a wide establishing shot, then a detail shot.\n\n",
+            "Both prompts inherit the same look note — that shared line is what stops the two clips from feeling unrelated."
+          ]
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 560,
+          "selectable": true,
+          "height": 170
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-subject",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "subject",
+          "value": "A coastal roastery at first light, steam rising off the drum",
+          "description": "What the b-roll is of"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 240
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Subject"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-look",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "look",
+          "value": "handheld documentary, warm morning light, 35mm, shallow depth of field",
+          "description": "Shared look across both shots"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Look"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief-wide",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Wide establishing shot.\n\nSubject: {{ subject }}\nLook: {{ look }}\n\nHold the full scene in frame with a slow push-in. Natural motion only. No text, no logos, no on-screen graphics."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 380,
+            "y": 280
+          },
+          "zIndex": 0,
+          "width": 320,
+          "selectable": true,
+          "title": "Shot 1 brief"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief-detail",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Close detail shot of the same scene.\n\nSubject: {{ subject }}\nLook: {{ look }}\n\nTight on texture and material — hands, surfaces, steam. Shallow focus, small camera drift. Same time of day and colour as the wide shot so the two cut together. No text, no logos."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 380,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 320,
+          "selectable": true,
+          "title": "Shot 2 brief"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shot-wide",
+        "type": "nodetool.video.TextToVideo",
+        "data": {
+          "model": {
+            "type": "video_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/ltx-2.3/text-to-video/fast",
+            "name": "LTX-2.3 Text to Video Fast",
+            "path": null,
+            "supported_tasks": []
+          },
+          "negative_prompt": "text, watermark, logo, subtitles",
+          "aspect_ratio": "16:9",
+          "resolution": "1080p",
+          "duration": 6,
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 760,
+            "y": 260
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Render wide"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shot-detail",
+        "type": "nodetool.video.TextToVideo",
+        "data": {
+          "model": {
+            "type": "video_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/ltx-2.3/text-to-video/fast",
+            "name": "LTX-2.3 Text to Video Fast",
+            "path": null,
+            "supported_tasks": []
+          },
+          "negative_prompt": "text, watermark, logo, subtitles",
+          "aspect_ratio": "16:9",
+          "resolution": "1080p",
+          "duration": 6,
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 760,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Render detail"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "cut",
+        "type": "nodetool.video.Transition",
+        "data": {
+          "transition_type": "fade",
+          "duration": 0.6
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1120,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Crossfade"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "output-reel",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "reel"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1460,
+            "y": 420
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "6  B-roll reel"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in-subject",
+        "sourceHandle": "output",
+        "target": "brief-wide",
+        "targetHandle": "subject"
+      },
+      {
+        "id": "e2",
+        "source": "in-look",
+        "sourceHandle": "output",
+        "target": "brief-wide",
+        "targetHandle": "look"
+      },
+      {
+        "id": "e3",
+        "source": "in-subject",
+        "sourceHandle": "output",
+        "target": "brief-detail",
+        "targetHandle": "subject"
+      },
+      {
+        "id": "e4",
+        "source": "in-look",
+        "sourceHandle": "output",
+        "target": "brief-detail",
+        "targetHandle": "look"
+      },
+      {
+        "id": "e5",
+        "source": "brief-wide",
+        "sourceHandle": "output",
+        "target": "shot-wide",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e6",
+        "source": "brief-detail",
+        "sourceHandle": "output",
+        "target": "shot-detail",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e7",
+        "source": "shot-wide",
+        "sourceHandle": "output",
+        "target": "cut",
+        "targetHandle": "video_a"
+      },
+      {
+        "id": "e8",
+        "source": "shot-detail",
+        "sourceHandle": "output",
+        "target": "cut",
+        "targetHandle": "video_b"
+      },
+      {
+        "id": "e9",
+        "source": "cut",
+        "sourceHandle": "output",
+        "target": "output-reel",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "subject": {
+        "type": "string",
+        "default": "A coastal roastery at first light, steam rising off the drum",
+        "label": ""
+      },
+      "look": {
+        "type": "string",
+        "default": "handheld documentary, warm morning light, 35mm, shallow depth of field",
+        "label": ""
+      }
+    },
+    "required": [
+      "subject",
+      "look"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "reel": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      }
+    },
+    "required": [
+      "reel"
+    ]
+  },
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": "e31acfae86ee104dbf9df243c9ba6084"
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Product Spot from Text.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Product Spot from Text.json
@@ -1,0 +1,339 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-21T16:03:52.969Z",
+  "updated_at": "2026-06-21T16:55:51.256Z",
+  "name": "Product Spot from Text",
+  "tool_name": null,
+  "description": "Turn a product description into a short commercial spot — no photo needed. A prompt assembles a studio hero-shot brief, FLUX.2 [klein] renders the still, then LTX-2.3 animates that exact frame following only the camera notes. Cost note: the animation step is billed per second of output, so this costs more per run than an image-only template.",
+  "tags": [
+    "image",
+    "video",
+    "example"
+  ],
+  "thumbnail": "Product Spot from Text.jpg",
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "comment-1",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "headline": "Product Spot from Text",
+          "comment": [
+            "Describe the product and how it should be staged; get a short commercial spot back.\n\n",
+            "Unlike Product Video Generator, this needs no product photo — the hero frame is generated.\n\n",
+            "The motion brief deliberately forbids restyling the product: the model may move the camera, nothing else."
+          ]
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 560,
+          "height": 180,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-product",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "product",
+          "value": "Matte-black wireless over-ear headphones with a brushed-copper accent ring",
+          "description": "What the product is, including materials and finish"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 240
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Product"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-staging",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "staging",
+          "value": "Polished dark concrete pedestal, volumetric rim light, fine dust drifting through a soft teal backlight",
+          "description": "Set, lighting, and atmosphere around the product"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Staging"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-motion",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "camera_motion",
+          "value": "Slow dolly push-in with a gentle rotation, shallow depth of field holding focus on the product",
+          "description": "How the camera should move during the clip"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Camera motion"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "prompt-still",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Cinematic product photograph for a premium commercial.\n\nProduct: {{ product }}\nStaging: {{ staging }}\n\nSingle hero subject, centered, filling the frame. Macro detail on materials and edges. Moody premium studio lighting with deep shadows and controlled highlights. Physically plausible reflections. No text, no logos, no watermark, no packaging, no people, no hands."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 340,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 320,
+          "selectable": true,
+          "title": "Hero-shot brief"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "still",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/flux-2/klein/9b",
+            "name": "FLUX.2 [klein] 9B",
+            "path": null,
+            "supported_tasks": []
+          },
+          "negative_prompt": "text, logo, watermark, packaging, people, hands, clutter",
+          "width": 1280,
+          "height": 720,
+          "guidance_scale": 7.5,
+          "num_inference_steps": 6,
+          "seed": -1,
+          "safety_check": true
+        },
+        "ui_properties": {
+          "position": {
+            "x": 720,
+            "y": 280
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Hero still"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "prompt-motion",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Animate the reference still into a short product commercial.\n\nCamera: {{ camera_motion }}\n\nPreserve the product, its proportions, framing, and materials exactly as in the reference frame. Add camera movement and subtle atmospheric motion only. Do not deform, relabel, or restyle the product. Keep the motion smooth and physically plausible for the full duration."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 720,
+            "y": 600
+          },
+          "zIndex": 0,
+          "width": 320,
+          "selectable": true,
+          "title": "Motion brief"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "spot",
+        "type": "nodetool.video.ImageToVideo",
+        "data": {
+          "model": {
+            "type": "video_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/ltx-2.3/image-to-video/fast",
+            "name": "LTX-2.3 Image to Video Fast",
+            "path": null,
+            "supported_tasks": []
+          },
+          "negative_prompt": "",
+          "aspect_ratio": "16:9",
+          "resolution": "1080p",
+          "duration": 6,
+          "timeout_seconds": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1100,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Animate"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "output-spot",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "spot"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1460,
+            "y": 420
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "6  Commercial spot"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in-product",
+        "sourceHandle": "output",
+        "target": "prompt-still",
+        "targetHandle": "product"
+      },
+      {
+        "id": "e2",
+        "source": "in-staging",
+        "sourceHandle": "output",
+        "target": "prompt-still",
+        "targetHandle": "staging"
+      },
+      {
+        "id": "e3",
+        "source": "prompt-still",
+        "sourceHandle": "output",
+        "target": "still",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e4",
+        "source": "in-motion",
+        "sourceHandle": "output",
+        "target": "prompt-motion",
+        "targetHandle": "camera_motion"
+      },
+      {
+        "id": "e5",
+        "source": "still",
+        "sourceHandle": "output",
+        "target": "spot",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e6",
+        "source": "prompt-motion",
+        "sourceHandle": "output",
+        "target": "spot",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e7",
+        "source": "spot",
+        "sourceHandle": "output",
+        "target": "output-spot",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "product": {
+        "type": "string",
+        "default": "Matte-black wireless over-ear headphones with a brushed-copper accent ring",
+        "label": ""
+      },
+      "staging": {
+        "type": "string",
+        "default": "Polished dark concrete pedestal, volumetric rim light, fine dust drifting through a soft teal backlight",
+        "label": ""
+      },
+      "camera_motion": {
+        "type": "string",
+        "default": "Slow dolly push-in with a gentle rotation, shallow depth of field holding focus on the product",
+        "label": ""
+      }
+    },
+    "required": [
+      "product",
+      "staging",
+      "camera_motion"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "spot": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      }
+    },
+    "required": [
+      "spot"
+    ]
+  },
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": "e31acfae86ee104dbf9df243c9ba6084"
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Video Restyle Studio.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Video Restyle Studio.json
@@ -1,0 +1,283 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-06-21T16:03:52.969Z",
+  "updated_at": "2026-06-21T16:55:51.256Z",
+  "name": "Video Restyle Studio",
+  "tool_name": null,
+  "description": "Repaint an existing clip in a new visual style while its motion stays put. A prompt node turns a short style note into a full restyle brief, then a video-to-video model applies it. Strength is the dial: low keeps the original read, high commits to the new look.",
+  "tags": [
+    "video",
+    "design",
+    "example"
+  ],
+  "thumbnail": "Video Restyle Studio.jpg",
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "comment-1",
+        "type": "nodetool.workflows.base_node.Comment",
+        "data": {
+          "headline": "Video Restyle Studio",
+          "comment": [
+            "Restyle a clip without re-shooting or re-animating it.\n\n",
+            "Motion, timing and framing come from the source video. Only the look changes.\n\n",
+            "Strength is the dial to turn: 0.3-0.5 keeps faces and text legible, 0.7+ commits to the style and will drift."
+          ]
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "zIndex": 0,
+          "width": 560,
+          "selectable": true,
+          "height": 170
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-video",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "source_video",
+          "value": null,
+          "description": "The clip to restyle"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 240
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Source clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-style",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "style",
+          "value": "1980s anime cel animation, hand-inked outlines, flat gouache colour, visible film grain",
+          "description": "The look to apply"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 400
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Target style"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "in-keep",
+        "type": "nodetool.input.StringInput",
+        "data": {
+          "name": "preserve",
+          "value": "faces, text, and the position of every subject in frame",
+          "description": "What must survive the restyle"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Preserve"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "brief",
+        "type": "nodetool.text.Prompt",
+        "data": {
+          "prompt": "Restyle this footage.\n\nTarget style: {{ style }}\n\nPreserve exactly: {{ preserve }}\n\nApply the style uniformly across every frame so the look does not flicker or drift shot to shot. Do not change camera movement, subject motion, timing, or composition."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 380,
+            "y": 420
+          },
+          "zIndex": 0,
+          "width": 320,
+          "selectable": true,
+          "title": "Restyle brief"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "restyle",
+        "type": "nodetool.video.VideoToVideo",
+        "data": {
+          "model": {
+            "type": "video_model",
+            "provider": "replicate",
+            "id": "decart/lucy-edit-2",
+            "name": "Lucy Edit 2",
+            "path": null,
+            "supported_tasks": []
+          },
+          "negative_prompt": "flicker, warping, melting faces, unreadable text, frame-to-frame drift",
+          "strength": 0.45
+        },
+        "ui_properties": {
+          "position": {
+            "x": 780,
+            "y": 320
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Restyle"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "output-video",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "restyled"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1140,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 240,
+          "selectable": true,
+          "title": "5  Restyled clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in-style",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "style"
+      },
+      {
+        "id": "e2",
+        "source": "in-keep",
+        "sourceHandle": "output",
+        "target": "brief",
+        "targetHandle": "preserve"
+      },
+      {
+        "id": "e3",
+        "source": "in-video",
+        "sourceHandle": "output",
+        "target": "restyle",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e4",
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "restyle",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e5",
+        "source": "restyle",
+        "sourceHandle": "output",
+        "target": "output-video",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "source_video": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      },
+      "style": {
+        "type": "string",
+        "default": "1980s anime cel animation, hand-inked outlines, flat gouache colour, visible film grain",
+        "label": ""
+      },
+      "preserve": {
+        "type": "string",
+        "default": "faces, text, and the position of every subject in frame",
+        "label": ""
+      }
+    },
+    "required": [
+      "source_video",
+      "style",
+      "preserve"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "restyled": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "const": "video"
+          }
+        },
+        "required": [
+          "uri",
+          "type"
+        ],
+        "label": ""
+      }
+    },
+    "required": [
+      "restyled"
+    ]
+  },
+  "settings": {},
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": "workflow",
+  "workspace_id": null,
+  "required_providers": null,
+  "required_models": null,
+  "html_app": null,
+  "etag": "e31acfae86ee104dbf9df243c9ba6084"
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -34,7 +34,11 @@ import { readCachedHfModels, searchCachedHfModels } from "@nodetool-ai/huggingfa
 import { initMasterKey } from "@nodetool-ai/security";
 import { getDefaultDbPath, getDefaultAssetsPath } from "@nodetool-ai/config";
 import { WorkflowRunner } from "@nodetool-ai/kernel";
-import { hydrateGraphNodeFlags, NodeRegistry } from "@nodetool-ai/node-sdk";
+import {
+  hydrateGraphNodeFlags,
+  isEditorOnlyType,
+  NodeRegistry
+} from "@nodetool-ai/node-sdk";
 import type { GraphData } from "@nodetool-ai/protocol";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
@@ -582,6 +586,16 @@ workflows
         if (!graph?.nodes || !graph?.edges) {
           throw new Error("Invalid workflow: missing nodes or edges");
         }
+
+        // Drop editor-only nodes (Comment, Group, Reroute). They are
+        // annotations the editor draws and carry no executable class, so
+        // resolveExecutor below would reject them as "Unknown node type" and
+        // fail the whole run — which is what happened to every shipped example
+        // containing a Comment. The headless job runner and `nodetool debug`
+        // already filter them at their own entry points.
+        graph.nodes = graph.nodes.filter(
+          (n: Record<string, unknown>) => !isEditorOnlyType(String(n.type ?? ""))
+        );
 
         // Normalize graph: convert node.data → node.properties (kernel format)
         graph.nodes = graph.nodes.map((n: Record<string, unknown>) => {

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -55,6 +55,8 @@ import {
   connectPythonBridgeForGraph,
   resolvePythonNodeExecutor
 } from "@nodetool-ai/runtime";
+import type { AssetOutputMode } from "@nodetool-ai/runtime";
+import { mkdirSync } from "node:fs";
 import { registerPackageCommands } from "./commands/package.js";
 import { registerDeployCommands } from "./commands/deploy.js";
 import { registerHfCommands } from "./commands/models-hf.js";
@@ -541,8 +543,25 @@ workflows
   .description("Run a workflow by ID, JSON file, or TypeScript DSL file")
   .option("--params <json>", "JSON params string")
   .option("--json", "Output as JSON")
+  .option(
+    "--asset-output-mode <mode>",
+    "How media outputs are materialized: native | raw | data_uri | workspace | storage_url | temp_url",
+    "native"
+  )
+  .option(
+    "--workspace <dir>",
+    "Workspace directory for workspace-mode asset output (default: ./nodetool-output)"
+  )
   .action(
-    async (idOrFile: string, opts: { params?: string; json?: boolean }) => {
+    async (
+      idOrFile: string,
+      opts: {
+        params?: string;
+        json?: boolean;
+        assetOutputMode?: string;
+        workspace?: string;
+      }
+    ) => {
       try {
         await setupDb();
         let graph: { nodes: any[]; edges: any[] };
@@ -628,16 +647,96 @@ workflows
         const workspaceDir = workflowId
           ? await resolveWorkflowWorkspace(workflowId, "1")
           : null;
+        const ASSET_OUTPUT_MODES = [
+          "native",
+          "raw",
+          "data_uri",
+          "workspace",
+          "storage_url",
+          "temp_url"
+        ] as const;
+        const assetOutputMode = (opts.assetOutputMode ??
+          "native") as AssetOutputMode;
+        if (
+          !(ASSET_OUTPUT_MODES as readonly string[]).includes(assetOutputMode)
+        ) {
+          throw new Error(
+            `Unknown --asset-output-mode "${assetOutputMode}". ` +
+              `Expected one of: ${ASSET_OUTPUT_MODES.join(", ")}`
+          );
+        }
+
+        // `workspace` mode writes each output into <workspace>/assets, so it
+        // needs a directory even when the run has no saved workflow (a JSON or
+        // DSL file target). Fall back to ./nodetool-output so a bare
+        // `workflows run file.json --asset-output-mode workspace` produces
+        // files in the current directory rather than failing.
+        const effectiveWorkspaceDir =
+          opts.workspace ??
+          workspaceDir ??
+          (assetOutputMode === "workspace"
+            ? resolve(process.cwd(), "nodetool-output")
+            : null);
+        if (effectiveWorkspaceDir) {
+          mkdirSync(effectiveWorkspaceDir, { recursive: true });
+        }
+
+        const assetStorage = new FileStorageAdapter(getDefaultAssetsPath());
         const context = new ProcessingContext({
           jobId,
           workflowId,
           userId: "1",
           secretResolver: getSecret,
-          storage: new FileStorageAdapter(getDefaultAssetsPath()),
-          workspaceDir,
-          workspaceStorage: workspaceDir
-            ? new FileStorageAdapter(workspaceDir)
+          storage: assetStorage,
+          assetOutputMode,
+          workspaceDir: effectiveWorkspaceDir,
+          workspaceStorage: effectiveWorkspaceDir
+            ? new FileStorageAdapter(effectiveWorkspaceDir)
             : null
+        });
+
+        // Persist assets to the local DB + asset store. Without this, any node
+        // that saves an asset fails with "ProcessingContext model interface
+        // 'createAsset' is not configured" — the server wires this in
+        // createRuntimeContext(), the CLI previously wired nothing.
+        const MIME_TO_EXT: Record<string, string> = {
+          "image/png": "png",
+          "image/jpeg": "jpg",
+          "image/webp": "webp",
+          "image/gif": "gif",
+          "audio/mpeg": "mp3",
+          "audio/wav": "wav",
+          "audio/ogg": "ogg",
+          "video/mp4": "mp4",
+          "video/webm": "webm",
+          "application/pdf": "pdf",
+          "text/plain": "txt",
+          "text/html": "html",
+          "model/gltf-binary": "glb"
+        };
+        context.setModelInterfaces({
+          createAsset: async (args) => {
+            const asset = new Asset({
+              user_id: args.userId,
+              workflow_id: args.workflowId ?? null,
+              node_id: args.nodeId ?? null,
+              job_id: args.jobId ?? null,
+              name: args.name,
+              content_type: args.contentType,
+              parent_id: args.parentId ?? null
+            });
+            if (args.content) {
+              const ext = MIME_TO_EXT[args.contentType] ?? "bin";
+              await assetStorage.store(
+                `${asset.user_id}/${asset.id}.${ext}`,
+                args.content,
+                args.contentType
+              );
+              asset.size = args.content.length;
+            }
+            await asset.save();
+            return asset;
+          }
         });
 
         // Connect a Python worker bridge when the graph has non-TS (Python)

--- a/packages/fal-nodes/src/fal-manifest.json
+++ b/packages/fal-nodes/src/fal-manifest.json
@@ -133975,13 +133975,37 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt describing the desired motion and action for the video.",
         "fieldType": "input",
-        "required": false
+        "required": true
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
       },
       {
         "name": "generate_audio",
@@ -133993,6 +134017,22 @@
         "required": false
       },
       {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
         "name": "end_image",
         "tsType": "image",
         "propType": "image",
@@ -134001,6 +134041,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "end_image_url"
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -134020,25 +134069,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "image",
-        "tsType": "image",
-        "propType": "image",
-        "default": null,
-        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
-        "fieldType": "input",
-        "required": true,
-        "apiParamName": "image_url"
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt describing the desired motion and action for the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -134064,49 +134094,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p",
-          "1080p",
-          "4k"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -134115,9 +134106,54 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ],
+          [
+            "VALUE_4K",
+            "4k"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -134209,42 +134245,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ],
-          [
-            "VALUE_1080P",
-            "1080p"
-          ],
-          [
-            "VALUE_4K",
-            "4k"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality."
-      },
-      {
-        "name": "BitrateMode",
-        "values": [
-          [
-            "STANDARD",
-            "standard"
-          ],
-          [
-            "HIGH",
-            "high"
-          ]
-        ],
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
       }
     ],
     "moduleName": "image_to_video"
@@ -134270,22 +134270,52 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt used to generate the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
         "fieldType": "input",
         "required": false
       },
       {
-        "name": "audio_urls",
-        "tsType": "audio[]",
-        "propType": "list[audio]",
-        "default": [],
-        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
         "fieldType": "input",
-        "required": false
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p",
+          "4k"
+        ]
       },
       {
         "name": "generate_audio",
@@ -134297,11 +134327,11 @@
         "required": false
       },
       {
-        "name": "video_urls",
-        "tsType": "video[]",
-        "propType": "list[video]",
-        "default": [],
-        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
         "fieldType": "input",
         "required": false
       },
@@ -134314,6 +134344,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "image_urls"
+      },
+      {
+        "name": "audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -134333,15 +134372,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -134367,49 +134397,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p",
-          "1080p",
-          "4k"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -134418,9 +134409,54 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ],
+          [
+            "VALUE_4K",
+            "4k"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -134512,42 +134548,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ],
-          [
-            "VALUE_1080P",
-            "1080p"
-          ],
-          [
-            "VALUE_4K",
-            "4k"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality."
-      },
-      {
-        "name": "BitrateMode",
-        "values": [
-          [
-            "STANDARD",
-            "standard"
-          ],
-          [
-            "HIGH",
-            "high"
-          ]
-        ],
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
       }
     ],
     "moduleName": "image_to_video"
@@ -134573,13 +134573,37 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt describing the desired motion and action for the video.",
         "fieldType": "input",
-        "required": false
+        "required": true
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
       },
       {
         "name": "generate_audio",
@@ -134591,6 +134615,20 @@
         "required": false
       },
       {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
         "name": "end_image",
         "tsType": "image",
         "propType": "image",
@@ -134599,6 +134637,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "end_image_url"
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -134618,25 +134665,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "image",
-        "tsType": "image",
-        "propType": "image",
-        "default": null,
-        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
-        "fieldType": "input",
-        "required": true,
-        "apiParamName": "image_url"
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt describing the desired motion and action for the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -134662,47 +134690,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -134711,9 +134702,46 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -134805,34 +134833,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance."
-      },
-      {
-        "name": "BitrateMode",
-        "values": [
-          [
-            "STANDARD",
-            "standard"
-          ],
-          [
-            "HIGH",
-            "high"
-          ]
-        ],
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
       }
     ],
     "moduleName": "image_to_video"
@@ -134859,22 +134859,50 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt used to generate the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
         "fieldType": "input",
         "required": false
       },
       {
-        "name": "audio_urls",
-        "tsType": "audio[]",
-        "propType": "list[audio]",
-        "default": [],
-        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
         "fieldType": "input",
-        "required": false
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
       },
       {
         "name": "generate_audio",
@@ -134886,11 +134914,11 @@
         "required": false
       },
       {
-        "name": "video_urls",
-        "tsType": "video[]",
-        "propType": "list[video]",
-        "default": [],
-        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
         "fieldType": "input",
         "required": false
       },
@@ -134903,6 +134931,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "image_urls"
+      },
+      {
+        "name": "audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -134922,15 +134959,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -134956,47 +134984,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -135005,9 +134996,46 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -135099,34 +135127,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance."
-      },
-      {
-        "name": "BitrateMode",
-        "values": [
-          [
-            "STANDARD",
-            "standard"
-          ],
-          [
-            "HIGH",
-            "high"
-          ]
-        ],
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
       }
     ],
     "moduleName": "image_to_video"
@@ -137711,13 +137711,23 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt describing the desired motion and action for the video.",
         "fieldType": "input",
-        "required": false
+        "required": true
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
       },
       {
         "name": "generate_audio",
@@ -137729,6 +137739,20 @@
         "required": false
       },
       {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
         "name": "end_image",
         "tsType": "image",
         "propType": "image",
@@ -137737,6 +137761,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "end_image_url"
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -137756,25 +137789,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "image",
-        "tsType": "image",
-        "propType": "image",
-        "default": null,
-        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
-        "fieldType": "input",
-        "required": true,
-        "apiParamName": "image_url"
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt describing the desired motion and action for the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -137800,33 +137814,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -137835,9 +137826,32 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -137929,20 +137943,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance."
       }
     ],
     "moduleName": "image_to_video"
@@ -137969,22 +137969,36 @@
     ],
     "inputFields": [
       {
-        "name": "end_user_id",
+        "name": "prompt",
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The unique user ID of the end user.",
+        "description": "The text prompt used to generate the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
         "fieldType": "input",
         "required": false
       },
       {
-        "name": "audio_urls",
-        "tsType": "audio[]",
-        "propType": "list[audio]",
-        "default": [],
-        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
         "fieldType": "input",
-        "required": false
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
       },
       {
         "name": "generate_audio",
@@ -137996,11 +138010,11 @@
         "required": false
       },
       {
-        "name": "video_urls",
-        "tsType": "video[]",
-        "propType": "list[video]",
-        "default": [],
-        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.",
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
         "fieldType": "input",
         "required": false
       },
@@ -138013,6 +138027,15 @@
         "fieldType": "input",
         "required": false,
         "apiParamName": "image_urls"
+      },
+      {
+        "name": "audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file.If audio is provided, at least one reference image or video is required.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "aspect_ratio",
@@ -138032,15 +138055,6 @@
           "3:4",
           "9:16"
         ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video.",
-        "fieldType": "input",
-        "required": true
       },
       {
         "name": "duration",
@@ -138066,33 +138080,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -138101,9 +138092,32 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -138195,20 +138209,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance."
       }
     ],
     "moduleName": "image_to_video"
@@ -241637,6 +241637,36 @@
     ],
     "inputFields": [
       {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
         "name": "end_user_id",
         "tsType": "string",
         "propType": "str",
@@ -241674,6 +241704,15 @@
         ]
       },
       {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the video",
+        "fieldType": "input",
+        "required": true
+      },
+      {
         "name": "duration",
         "tsType": "enum",
         "propType": "enum",
@@ -241697,58 +241736,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video",
-        "fieldType": "input",
-        "required": true
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p",
-          "1080p",
-          "4k"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -241757,101 +241748,18 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
-      {
-        "name": "AspectRatio",
-        "values": [
-          [
-            "AUTO",
-            "auto"
-          ],
-          [
-            "RATIO_21_9",
-            "21:9"
-          ],
-          [
-            "RATIO_16_9",
-            "16:9"
-          ],
-          [
-            "RATIO_4_3",
-            "4:3"
-          ],
-          [
-            "RATIO_1_1",
-            "1:1"
-          ],
-          [
-            "RATIO_3_4",
-            "3:4"
-          ],
-          [
-            "RATIO_9_16",
-            "9:16"
-          ]
-        ],
-        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide."
-      },
-      {
-        "name": "Duration",
-        "values": [
-          [
-            "AUTO",
-            "auto"
-          ],
-          [
-            "VALUE_4",
-            "4"
-          ],
-          [
-            "VALUE_5",
-            "5"
-          ],
-          [
-            "VALUE_6",
-            "6"
-          ],
-          [
-            "VALUE_7",
-            "7"
-          ],
-          [
-            "VALUE_8",
-            "8"
-          ],
-          [
-            "VALUE_9",
-            "9"
-          ],
-          [
-            "VALUE_10",
-            "10"
-          ],
-          [
-            "VALUE_11",
-            "11"
-          ],
-          [
-            "VALUE_12",
-            "12"
-          ],
-          [
-            "VALUE_13",
-            "13"
-          ],
-          [
-            "VALUE_14",
-            "14"
-          ],
-          [
-            "VALUE_15",
-            "15"
-          ]
-        ],
-        "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
       {
         "name": "Resolution",
         "values": [
@@ -241887,152 +241795,7 @@
           ]
         ],
         "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
-      }
-    ],
-    "moduleName": "text_to_video"
-  },
-  {
-    "endpointId": "bytedance/seedance-2.0/fast/text-to-video",
-    "className": "BytedanceSeedance20FastTextToVideo",
-    "docstring": "Fast text-to-video with ByteDance Seedance 2.0.",
-    "tags": [
-      "generation",
-      "text-to-video",
-      "txt2vid",
-      "seedance",
-      "bytedance",
-      "fast"
-    ],
-    "useCases": [
-      "Automated content generation",
-      "Creative workflows",
-      "Batch processing",
-      "Professional applications",
-      "Rapid prototyping"
-    ],
-    "inputFields": [
-      {
-        "name": "end_user_id",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The unique user ID of the end user.",
-        "fieldType": "input",
-        "required": false
       },
-      {
-        "name": "generate_audio",
-        "tsType": "boolean",
-        "propType": "bool",
-        "default": true,
-        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
-        "fieldType": "input",
-        "required": false
-      },
-      {
-        "name": "aspect_ratio",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "auto",
-        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "AspectRatio",
-        "enumValues": [
-          "auto",
-          "21:9",
-          "16:9",
-          "4:3",
-          "1:1",
-          "3:4",
-          "9:16"
-        ]
-      },
-      {
-        "name": "duration",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "auto",
-        "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Duration",
-        "enumValues": [
-          "auto",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15"
-        ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video",
-        "fieldType": "input",
-        "required": true
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
-      },
-      {
-        "name": "bitrate_mode",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "standard",
-        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "BitrateMode",
-        "enumValues": [
-          "standard",
-          "high"
-        ]
-      }
-    ],
-    "outputType": "video",
-    "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
-      {
-        "name": "video",
-        "tsType": "video",
-        "propType": "video",
-        "default": null,
-        "description": "The generated video file.",
-        "fieldType": "output",
-        "required": true
-      }
-    ],
-    "enums": [
       {
         "name": "AspectRatio",
         "values": [
@@ -242124,7 +241887,152 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "bytedance/seedance-2.0/fast/text-to-video",
+    "className": "BytedanceSeedance20FastTextToVideo",
+    "docstring": "Fast text-to-video with ByteDance Seedance 2.0.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "seedance",
+      "bytedance",
+      "fast"
+    ],
+    "useCases": [
+      "Automated content generation",
+      "Creative workflows",
+      "Batch processing",
+      "Professional applications",
+      "Rapid prototyping"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
       },
+      {
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the video",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "auto",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
       {
         "name": "Resolution",
         "values": [
@@ -242152,6 +242060,98 @@
           ]
         ],
         "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_11",
+            "11"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_13",
+            "13"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
       }
     ],
     "moduleName": "text_to_video"
@@ -250179,6 +250179,29 @@
     ],
     "inputFields": [
       {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
         "name": "end_user_id",
         "tsType": "string",
         "propType": "str",
@@ -250207,6 +250230,15 @@
         ]
       },
       {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the video",
+        "fieldType": "input",
+        "required": true
+      },
+      {
         "name": "duration",
         "tsType": "enum",
         "propType": "enum",
@@ -250230,51 +250262,10 @@
           "14",
           "15"
         ]
-      },
-      {
-        "name": "prompt",
-        "tsType": "string",
-        "propType": "str",
-        "default": "",
-        "description": "The text prompt used to generate the video",
-        "fieldType": "input",
-        "required": true
-      },
-      {
-        "name": "resolution",
-        "tsType": "enum",
-        "propType": "enum",
-        "default": "720p",
-        "description": "Video resolution - 480p for faster generation, 720p for balance.",
-        "fieldType": "input",
-        "required": false,
-        "enumRef": "Resolution",
-        "enumValues": [
-          "480p",
-          "720p"
-        ]
-      },
-      {
-        "name": "generate_audio",
-        "tsType": "boolean",
-        "propType": "bool",
-        "default": true,
-        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
-        "fieldType": "input",
-        "required": false
       }
     ],
     "outputType": "video",
     "outputFields": [
-      {
-        "name": "seed",
-        "tsType": "number",
-        "propType": "int",
-        "default": -1,
-        "description": "The seed used for generation.",
-        "fieldType": "output",
-        "required": true
-      },
       {
         "name": "video",
         "tsType": "video",
@@ -250283,9 +250274,32 @@
         "description": "The generated video file.",
         "fieldType": "output",
         "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
       }
     ],
     "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance."
+      },
       {
         "name": "AspectRatio",
         "values": [
@@ -250377,20 +250391,6 @@
           ]
         ],
         "description": "Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt."
-      },
-      {
-        "name": "Resolution",
-        "values": [
-          [
-            "VALUE_480P",
-            "480p"
-          ],
-          [
-            "VALUE_720P",
-            "720p"
-          ]
-        ],
-        "description": "Video resolution - 480p for faster generation, 720p for balance."
       }
     ],
     "moduleName": "text_to_video"

--- a/packages/fal-nodes/src/generated/fal-node-type-pricing.json
+++ b/packages/fal-nodes/src/generated/fal-node-type-pricing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "writtenAt": "2026-05-17T22:25:00.943Z",
+  "writtenAt": "2026-07-28T10:34:08.198Z",
   "byNodeType": {
     "fal.3d_to_3d.Sam33DAlign": {
       "endpoint_id": "fal-ai/sam-3/3d-align",
@@ -23,6 +23,30 @@
     "fal.3d_to_3d.HunyuanPart": {
       "endpoint_id": "fal-ai/hunyuan-part",
       "unit_price": 0.04,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.3d_to_3d.Hunyuan3dV31Part": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/part",
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.3d_to_3d.Hunyuan3dV31SmartTopology": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/smart-topology",
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.3d_to_3d.MeshyRigging": {
+      "endpoint_id": "fal-ai/meshy/rigging",
+      "unit_price": 0.8,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.3d_to_3d.MeshyRiggingMultiAnimation": {
+      "endpoint_id": "fal-ai/meshy/rigging/multi-animation",
+      "unit_price": 0.08,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -122,6 +146,156 @@
       "billing_unit": "minutes",
       "currency": "USD"
     },
+    "fal.audio_to_audio.PersonaplexRealtime": {
+      "endpoint_id": "fal-ai/personaplex/realtime",
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/audio-inpainting",
+      "unit_price": 0.0442,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/audio-outpainting",
+      "unit_price": 0.0446,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/audio-to-audio",
+      "unit_price": 0.0417,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumBaseAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/base/audio-inpainting",
+      "unit_price": 0.0537,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumBaseAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/base/audio-outpainting",
+      "unit_price": 0.0554,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3MediumBaseAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/base/audio-to-audio",
+      "unit_price": 0.0523,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/audio-inpainting",
+      "unit_price": 0.026,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/audio-outpainting",
+      "unit_price": 0.0265,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/audio-to-audio",
+      "unit_price": 0.0248,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicBaseAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/base/audio-inpainting",
+      "unit_price": 0.0333,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicBaseAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/base/audio-outpainting",
+      "unit_price": 0.0339,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallMusicBaseAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/base/audio-to-audio",
+      "unit_price": 0.032,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/audio-inpainting",
+      "unit_price": 0.0259,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/audio-outpainting",
+      "unit_price": 0.0271,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/audio-to-audio",
+      "unit_price": 0.024,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxBaseAudioInpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/base/audio-inpainting",
+      "unit_price": 0.0331,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxBaseAudioOutpainting": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/base/audio-outpainting",
+      "unit_price": 0.0337,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.StableAudio3SmallSfxBaseAudioToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/base/audio-to-audio",
+      "unit_price": 0.0315,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.Tada1bTextToSpeech": {
+      "endpoint_id": "fal-ai/tada/1b/text-to-speech",
+      "unit_price": 0.05,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.Tada3bTextToSpeech": {
+      "endpoint_id": "fal-ai/tada/3b/text-to-speech",
+      "unit_price": 0.08,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.WorkflowUtilitiesAudioCompressor": {
+      "endpoint_id": "fal-ai/workflow-utilities/audio-compressor",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.WorkflowUtilitiesImpulseResponse": {
+      "endpoint_id": "fal-ai/workflow-utilities/impulse-response",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.Sfx16ExtendAudio": {
+      "endpoint_id": "mirelo-ai/sfx1.6/extend-audio",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.audio_to_audio.Sfx16InpaintAudio": {
+      "endpoint_id": "mirelo-ai/sfx1.6/inpaint-audio",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "fal.audio_to_text.NemotronAsr": {
       "endpoint_id": "fal-ai/nemotron/asr",
       "unit_price": 0.0008,
@@ -218,6 +392,54 @@
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
+    "fal.audio_to_video.Flashtalk": {
+      "endpoint_id": "fal-ai/flashtalk",
+      "unit_price": 0.02,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx2322bAudioToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/audio-to-video",
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx2322bAudioToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/audio-to-video/lora",
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx2322bDistilledAudioToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/audio-to-video",
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx2322bDistilledAudioToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/audio-to-video/lora",
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx23QualityAudioToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/audio-to-video",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx23QualityAudioToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/audio-to-video/lora",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.audio_to_video.Ltx23AudioToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3/audio-to-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal.image_to_image.FluxSchnellRedux": {
       "endpoint_id": "fal-ai/flux/schnell/redux",
       "unit_price": 0.025,
@@ -304,7 +526,7 @@
     },
     "fal.image_to_image.BiRefNet": {
       "endpoint_id": "fal-ai/birefnet",
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -370,7 +592,7 @@
     },
     "fal.image_to_image.Flux2Klein4BBaseEdit": {
       "endpoint_id": "fal-ai/flux-2/klein/4b/base/edit",
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -382,7 +604,7 @@
     },
     "fal.image_to_image.Flux2Klein9BBaseEdit": {
       "endpoint_id": "fal-ai/flux-2/klein/9b/base/edit",
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -612,6 +834,60 @@
       "endpoint_id": "fal-ai/kling-image/o3/image-to-image",
       "unit_price": 0.028,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryShirtDesign": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/shirt-design",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryRemoveLighting": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/remove-lighting",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryRemoveElement": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/remove-element",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryLightingRestoration": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/lighting-restoration",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryIntegrateProduct": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/integrate-product",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryGroupPhoto": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/group-photo",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryFaceToFullPortrait": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/face-to-full-portrait",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryAddBackground": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/add-background",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImageEdit2509LoraGalleryNextScene": {
+      "endpoint_id": "fal-ai/qwen-image-edit-2509-lora-gallery/next-scene",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
       "currency": "USD"
     },
     "fal.image_to_image.QwenImageEditPlusLoraGalleryLightingRestoration": {
@@ -1618,7 +1894,7 @@
     },
     "fal.image_to_image.Sam2AutoSegment": {
       "endpoint_id": "fal-ai/sam2/auto-segment",
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -1804,7 +2080,7 @@
     },
     "fal.image_to_image.BirefnetV2": {
       "endpoint_id": "fal-ai/birefnet/v2",
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -1882,7 +2158,7 @@
     },
     "fal.image_to_image.Sam2Image": {
       "endpoint_id": "fal-ai/sam2/image",
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -2156,10 +2432,334 @@
       "billing_unit": "units",
       "currency": "USD"
     },
-    "fal.image_to_image.BytedanceSeedreamV5LiteEdit": {
-      "endpoint_id": "fal-ai/bytedance/seedream/v5/lite/edit",
+    "fal.image_to_image.EmbedProduct": {
+      "endpoint_id": "bria/embed-product",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.ExtractObject": {
+      "endpoint_id": "bria/extract-object",
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.GenfillV2": {
+      "endpoint_id": "bria/genfill/v2",
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.ProductDimensions": {
+      "endpoint_id": "bria/product-dimensions",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.UpscaleCreative": {
+      "endpoint_id": "bria/upscale/creative",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.SeedreamV5LiteEdit": {
+      "endpoint_id": "bytedance/seedream/v5/lite/edit",
       "unit_price": 0.035,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.SeedreamV5ProEdit": {
+      "endpoint_id": "bytedance/seedream/v5/pro/edit",
+      "unit_price": 0.0675,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.BerniniREditImage": {
+      "endpoint_id": "fal-ai/bernini-r/edit-image",
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.BooguImageEdit": {
+      "endpoint_id": "fal-ai/boogu-image/edit",
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.ControlLight": {
+      "endpoint_id": "fal-ai/control-light",
+      "unit_price": 0.03,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.FireredImageEdit": {
+      "endpoint_id": "fal-ai/firered-image-edit",
+      "unit_price": 0.0325,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.FireredImageEditV11": {
+      "endpoint_id": "fal-ai/firered-image-edit-v1.1",
+      "unit_price": 0.0325,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Flux2ProOutpaint": {
+      "endpoint_id": "fal-ai/flux-2-pro/outpaint",
+      "unit_price": 0.03,
+      "billing_unit": "processed megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Flux2Klein4bEditLora": {
+      "endpoint_id": "fal-ai/flux-2/klein/4b/edit/lora",
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Flux2Klein9bEditLora": {
+      "endpoint_id": "fal-ai/flux-2/klein/9b/edit/lora",
+      "unit_price": 0.02,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Flux2KleinRealtime": {
+      "endpoint_id": "fal-ai/flux-2/klein/realtime",
+      "unit_price": 0.00194,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.FluxProV1Erase": {
+      "endpoint_id": "fal-ai/flux-pro/v1/erase",
+      "unit_price": 0.004,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.FluxProV1Vto": {
+      "endpoint_id": "fal-ai/flux-pro/v1/vto",
+      "unit_price": 0.005,
+      "billing_unit": "processed megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Gemini31FlashImagePreviewEdit": {
+      "endpoint_id": "fal-ai/gemini-3.1-flash-image-preview/edit",
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.HidreamO1ImageDevEdit": {
+      "endpoint_id": "fal-ai/hidream-o1-image/dev/edit",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.HidreamO1ImageEdit": {
+      "endpoint_id": "fal-ai/hidream-o1-image/edit",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.HyWuEdit": {
+      "endpoint_id": "fal-ai/hy-wu-edit",
+      "unit_price": 0.1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramRemoveBackground": {
+      "endpoint_id": "fal-ai/ideogram/remove-background",
+      "unit_price": 0.01,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramV3LayerizeText": {
+      "endpoint_id": "fal-ai/ideogram/v3/layerize-text",
+      "unit_price": 0.09,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.JoyaiImageEdit": {
+      "endpoint_id": "fal-ai/joyai-image-edit",
+      "unit_price": 0.1,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.KlingImageV3ImageToImage": {
+      "endpoint_id": "fal-ai/kling-image/v3/image-to-image",
+      "unit_price": 0.028,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Patina": {
+      "endpoint_id": "fal-ai/patina",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.PatinaMaterialExtract": {
+      "endpoint_id": "fal-ai/patina/material/extract",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.PhotaEdit": {
+      "endpoint_id": "fal-ai/phota/edit",
+      "unit_price": 0.09,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.PhotaEnhance": {
+      "endpoint_id": "fal-ai/phota/enhance",
+      "unit_price": 0.13,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImage2Edit": {
+      "endpoint_id": "fal-ai/qwen-image-2/edit",
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.QwenImage2ProEdit": {
+      "endpoint_id": "fal-ai/qwen-image-2/pro/edit",
+      "unit_price": 0.075,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Sam31Image": {
+      "endpoint_id": "fal-ai/sam-3-1/image",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Sam31ImageRle": {
+      "endpoint_id": "fal-ai/sam-3-1/image-rle",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.SeedvrUpscaleImageSeamless": {
+      "endpoint_id": "fal-ai/seedvr/upscale/image/seamless",
+      "unit_price": 0.0025,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.SmartResize": {
+      "endpoint_id": "fal-ai/smart-resize",
+      "unit_price": 0.15,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.TelestyleV2": {
+      "endpoint_id": "fal-ai/telestyle-v2",
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_image.VecglypherImageToSvg": {
+      "endpoint_id": "fal-ai/vecglypher/image-to-svg",
+      "unit_price": 0.005,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.WanV27Edit": {
+      "endpoint_id": "fal-ai/wan/v2.7/edit",
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.WanV27ProEdit": {
+      "endpoint_id": "fal-ai/wan/v2.7/pro/edit",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.WorkflowUtilitiesExtractNthFrame": {
+      "endpoint_id": "fal-ai/workflow-utilities/extract-nth-frame",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.NanoBananaLiteEdit": {
+      "endpoint_id": "google/nano-banana-lite/edit",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramV4ImageToImage": {
+      "endpoint_id": "ideogram/v4/image-to-image",
+      "unit_price": 0.01,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramV4ImageToImageLora": {
+      "endpoint_id": "ideogram/v4/image-to-image/lora",
+      "unit_price": 0.015,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramV4Tiling": {
+      "endpoint_id": "ideogram/v4/tiling",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.IdeogramV4TilingLora": {
+      "endpoint_id": "ideogram/v4/tiling/lora",
+      "unit_price": 0.045,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Imagineart20EditPreviewImageToImage": {
+      "endpoint_id": "imagineart/imagineart-2.0-edit-preview/image-to-image",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.LumaAgentUni1V1Edit": {
+      "endpoint_id": "luma/agent/uni-1/v1/edit",
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.LumaAgentUni1V1MaxEdit": {
+      "endpoint_id": "luma/agent/uni-1/v1/max/edit",
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.MaiImage25Edit": {
+      "endpoint_id": "microsoft/mai-image-2.5/edit",
+      "unit_price": 1,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "fal.image_to_image.BackgroundRemoval": {
+      "endpoint_id": "pixelcut/background-removal",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Reve21Edit": {
+      "endpoint_id": "reve/2.1/edit",
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.Reve21Remix": {
+      "endpoint_id": "reve/2.1/remix",
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.GrokImagineImageEdit": {
+      "endpoint_id": "xai/grok-imagine-image/edit",
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.image_to_image.GrokImagineImageQualityEdit": {
+      "endpoint_id": "xai/grok-imagine-image/quality/edit",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal.image_to_3d.Trellis2": {
@@ -2207,12 +2807,6 @@
     "fal.image_to_3d.MeshyV5MultiImageTo3D": {
       "endpoint_id": "fal-ai/meshy/v5/multi-image-to-3d",
       "unit_price": 0.4,
-      "billing_unit": "generations",
-      "currency": "USD"
-    },
-    "fal.image_to_3d.MeshyV6PreviewImageTo3D": {
-      "endpoint_id": "fal-ai/meshy/v6-preview/image-to-3d",
-      "unit_price": 0.8,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -2297,7 +2891,7 @@
     "fal.image_to_3d.Trellis": {
       "endpoint_id": "fal-ai/trellis",
       "unit_price": 0.02,
-      "billing_unit": "",
+      "billing_unit": "generations",
       "currency": "USD"
     },
     "fal.image_to_3d.Triposr": {
@@ -2309,6 +2903,84 @@
     "fal.image_to_3d.MeshyV6MultiImageTo3d": {
       "endpoint_id": "fal-ai/meshy/v6/multi-image-to-3d",
       "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Hunyuan3dV31ProImageTo3d": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/pro/image-to-3d",
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Hunyuan3dV31RapidImageTo3d": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/rapid/image-to-3d",
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Hyper3dRodinV25": {
+      "endpoint_id": "fal-ai/hyper3d/rodin/v2.5",
+      "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Hyper3dRodinV25Fast": {
+      "endpoint_id": "fal-ai/hyper3d/rodin/v2.5/fast",
+      "unit_price": 0.1,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.MeshyV6ImageTo3d": {
+      "endpoint_id": "fal-ai/meshy/v6/image-to-3d",
+      "unit_price": 0.8,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Pixal3d": {
+      "endpoint_id": "fal-ai/pixal3d",
+      "unit_price": 0.06,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Reconviagen05": {
+      "endpoint_id": "fal-ai/reconviagen-0.5",
+      "unit_price": 0.05,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Trellis2Lora": {
+      "endpoint_id": "fal-ai/trellis-2-lora",
+      "unit_price": 0.05,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Trellis2Retexture": {
+      "endpoint_id": "fal-ai/trellis-2/retexture",
+      "unit_price": 0.04,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.H31ImageTo3d": {
+      "endpoint_id": "tripo3d/h3.1/image-to-3d",
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.H31MultiviewTo3d": {
+      "endpoint_id": "tripo3d/h3.1/multiview-to-3d",
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.P1ImageTo3d": {
+      "endpoint_id": "tripo3d/p1/image-to-3d",
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "fal.image_to_3d.Triposplat": {
+      "endpoint_id": "tripo3d/triposplat",
+      "unit_price": 0.05,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -2873,7 +3545,7 @@
     "fal.image_to_video.LtxVideo13bDistilledImageToVideo": {
       "endpoint_id": "fal-ai/ltx-video-13b-distilled/image-to-video",
       "unit_price": 0.04,
-      "billing_unit": "videos",
+      "billing_unit": "units",
       "currency": "USD"
     },
     "fal.image_to_video.LtxVideo13bDevImageToVideo": {
@@ -2950,8 +3622,8 @@
     },
     "fal.image_to_video.WanFlf2v": {
       "endpoint_id": "fal-ai/wan-flf2v",
-      "unit_price": 0.4,
-      "billing_unit": "videos",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal.image_to_video.Framepack": {
@@ -3236,6 +3908,234 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "fal.image_to_video.HappyHorseV11ImageToVideo": {
+      "endpoint_id": "alibaba/happy-horse/v1.1/image-to-video",
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.HappyHorseV11ReferenceToVideo": {
+      "endpoint_id": "alibaba/happy-horse/v1.1/reference-to-video",
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Seedance20MiniImageToVideo": {
+      "endpoint_id": "bytedance/seedance-2.0/mini/image-to-video",
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Seedance20MiniReferenceToVideo": {
+      "endpoint_id": "bytedance/seedance-2.0/mini/reference-to-video",
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.image_to_video.BerniniRReferenceToVideo": {
+      "endpoint_id": "fal-ai/bernini-r/reference-to-video",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.CosmosPredict25ImageToVideo": {
+      "endpoint_id": "fal-ai/cosmos-predict-2.5/image-to-video",
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.image_to_video.DavinciMagihuman": {
+      "endpoint_id": "fal-ai/davinci-magihuman",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.FfmpegApiImagesToVideo": {
+      "endpoint_id": "fal-ai/ffmpeg-api/images-to-video",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Flashhead": {
+      "endpoint_id": "fal-ai/flashhead",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.HeygenAvatar4ImageToVideo": {
+      "endpoint_id": "fal-ai/heygen/avatar4/image-to-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.KlingVideoV3TurboProImageToVideo": {
+      "endpoint_id": "fal-ai/kling-video/v3/turbo/pro/image-to-video",
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.KlingVideoV3TurboStandardImageToVideo": {
+      "endpoint_id": "fal-ai/kling-video/v3/turbo/standard/image-to-video",
+      "unit_price": 0.112,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx2322bDistilledImageToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/image-to-video",
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx2322bDistilledImageToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/image-to-video/lora",
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx2322bImageToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/image-to-video",
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx2322bImageToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/image-to-video/lora",
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx23QualityImageToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/image-to-video",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx23QualityImageToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/image-to-video/lora",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx23QualityIngredient": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/ingredient",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx23ImageToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3/image-to-video",
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Ltx23ImageToVideoFast": {
+      "endpoint_id": "fal-ai/ltx-2.3/image-to-video/fast",
+      "unit_price": 0.06,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.PixverseC1ImageToVideo": {
+      "endpoint_id": "fal-ai/pixverse/c1/image-to-video",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.PixverseV6Transition": {
+      "endpoint_id": "fal-ai/pixverse/v6/transition",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.SyncLipsyncV3ImageToVideo": {
+      "endpoint_id": "fal-ai/sync-lipsync/v3/image-to-video",
+      "unit_price": 8,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Veo31LiteFirstLastFrameToVideo": {
+      "endpoint_id": "fal-ai/veo3.1/lite/first-last-frame-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Veo31LiteImageToVideo": {
+      "endpoint_id": "fal-ai/veo3.1/lite/image-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.ViduQ3ImageToVideo": {
+      "endpoint_id": "fal-ai/vidu/q3/image-to-video",
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.image_to_video.ViduQ3ImageToVideoTurbo": {
+      "endpoint_id": "fal-ai/vidu/q3/image-to-video/turbo",
+      "unit_price": 0.035,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.image_to_video.ViduQ3ReferenceToVideoMix": {
+      "endpoint_id": "fal-ai/vidu/q3/reference-to-video/mix",
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.image_to_video.WanV27ImageToVideo": {
+      "endpoint_id": "fal-ai/wan/v2.7/image-to-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.WanV27ReferenceToVideo": {
+      "endpoint_id": "fal-ai/wan/v2.7/reference-to-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.GeminiOmniFlashImageToVideo": {
+      "endpoint_id": "google/gemini-omni-flash/image-to-video",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_video.GeminiOmniFlashReferenceToVideo": {
+      "endpoint_id": "google/gemini-omni-flash/reference-to-video",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.image_to_video.LumaAgentRayV32ImageToVideo": {
+      "endpoint_id": "luma/agent/ray/v3.2/image-to-video",
+      "unit_price": 0.5,
+      "billing_unit": "5 seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.Cosmos3SuperImageToVideo": {
+      "endpoint_id": "nvidia/cosmos-3-super/image-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.GrokImagineVideoImageToVideo": {
+      "endpoint_id": "xai/grok-imagine-video/image-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.GrokImagineVideoReferenceToVideo": {
+      "endpoint_id": "xai/grok-imagine-video/reference-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.image_to_video.GrokImagineVideoV15ImageToVideo": {
+      "endpoint_id": "xai/grok-imagine-video/v1.5/image-to-video",
+      "unit_price": 0.01,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal.json_processing.FfmpegApiLoudnorm": {
       "endpoint_id": "fal-ai/ffmpeg-api/loudnorm",
       "unit_price": 0.00017,
@@ -3252,6 +4152,24 @@
       "endpoint_id": "fal-ai/ffmpeg-api/metadata",
       "unit_price": 0.00017,
       "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.json_processing.Omnilottie": {
+      "endpoint_id": "fal-ai/omnilottie",
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.json_processing.OmnilottieImageToLottie": {
+      "endpoint_id": "fal-ai/omnilottie/image-to-lottie",
+      "unit_price": 0.1,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.json_processing.OmnilottieVideoToLottie": {
+      "endpoint_id": "fal-ai/omnilottie/video-to-lottie",
+      "unit_price": 0.05,
+      "billing_unit": "videos",
       "currency": "USD"
     },
     "fal.llm.OpenRouter": {
@@ -3290,6 +4208,12 @@
       "billing_unit": "1000 tokens",
       "currency": "USD"
     },
+    "fal.llm.BytedanceSeedV2Mini": {
+      "endpoint_id": "fal-ai/bytedance/seed/v2/mini",
+      "unit_price": 0.0001,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
     "fal.speech_to_speech.ResembleAiChatterboxhdSpeechToSpeech": {
       "endpoint_id": "resemble-ai/chatterboxhd/speech-to-speech",
       "unit_price": 0.00125,
@@ -3316,7 +4240,7 @@
     },
     "fal.speech_to_text.SmartTurn": {
       "endpoint_id": "fal-ai/smart-turn",
-      "unit_price": 0.00125,
+      "unit_price": 0.00111,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3350,6 +4274,12 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "fal.speech_to_text.NemotronAsrMultilingualAsr": {
+      "endpoint_id": "nvidia/nemotron-asr-multilingual/asr",
+      "unit_price": 0.00111,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "fal.text_to_3d.HunyuanMotionFast": {
       "endpoint_id": "fal-ai/hunyuan-motion/fast",
       "unit_price": 0.06,
@@ -3368,10 +4298,46 @@
       "billing_unit": "units",
       "currency": "USD"
     },
-    "fal.text_to_3d.MeshyV6PreviewTextTo3d": {
-      "endpoint_id": "fal-ai/meshy/v6-preview/text-to-3d",
+    "fal.text_to_3d.Hunyuan3dV31ProTextTo3d": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/pro/text-to-3d",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.Hunyuan3dV31RapidTextTo3d": {
+      "endpoint_id": "fal-ai/hunyuan-3d/v3.1/rapid/text-to-3d",
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.Hyper3dRodinV25TextTo3d": {
+      "endpoint_id": "fal-ai/hyper3d/rodin/v2.5/text-to-3d",
+      "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.Hyper3dRodinV25TextTo3dFast": {
+      "endpoint_id": "fal-ai/hyper3d/rodin/v2.5/text-to-3d/fast",
+      "unit_price": 0.1,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.MeshyV6TextTo3d": {
+      "endpoint_id": "fal-ai/meshy/v6/text-to-3d",
       "unit_price": 0.8,
       "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.H31TextTo3d": {
+      "endpoint_id": "tripo3d/h3.1/text-to-3d",
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "fal.text_to_3d.P1TextTo3d": {
+      "endpoint_id": "tripo3d/p1/text-to-3d",
+      "unit_price": 0.01,
+      "billing_unit": "credits",
       "currency": "USD"
     },
     "fal.text_to_audio.ACEStepPromptToAudio": {
@@ -3442,7 +4408,7 @@
     },
     "fal.text_to_audio.StableAudio": {
       "endpoint_id": "fal-ai/stable-audio",
-      "unit_price": 0.000575,
+      "unit_price": 0.00125,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3582,6 +4548,96 @@
       "endpoint_id": "fal-ai/minimax-music/v2.6",
       "unit_price": 0.15,
       "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.SeedAudio10": {
+      "endpoint_id": "bytedance/seed-audio-1.0",
+      "unit_price": 0.1875,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.GeminiTts": {
+      "endpoint_id": "fal-ai/gemini-tts",
+      "unit_price": 1,
+      "billing_unit": "1m tokens",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.Ltx23QualityTextToAudio": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/text-to-audio",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.Ltx23QualityTextToAudioLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/text-to-audio/lora",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.Lyria3": {
+      "endpoint_id": "fal-ai/lyria3",
+      "unit_price": 0.04,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.Lyria3Pro": {
+      "endpoint_id": "fal-ai/lyria3/pro",
+      "unit_price": 0.08,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3MediumBaseTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/base/text-to-audio",
+      "unit_price": 0.0479,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3MediumTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/medium/text-to-audio",
+      "unit_price": 0.0376,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3SmallMusicBaseTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/base/text-to-audio",
+      "unit_price": 0.0281,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3SmallMusicTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/music/text-to-audio",
+      "unit_price": 0.0217,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3SmallSfxBaseTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/base/text-to-audio",
+      "unit_price": 0.0283,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.StableAudio3SmallSfxTextToAudio": {
+      "endpoint_id": "fal-ai/stable-audio-3/small/sfx/text-to-audio",
+      "unit_price": 0.0206,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.Sfx16TextToAudio": {
+      "endpoint_id": "mirelo-ai/sfx1.6/text-to-audio",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.SoniloV11TextToMusic": {
+      "endpoint_id": "sonilo/v1.1/text-to-music",
+      "unit_price": 0.0025,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_audio.SoniloV11TextToSoundEffects": {
+      "endpoint_id": "sonilo/v1.1/text-to-sound-effects",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal.text_to_image.FluxDev": {
@@ -3730,7 +4786,7 @@
     },
     "fal.text_to_image.Flux2Klein4BBase": {
       "endpoint_id": "fal-ai/flux-2/klein/4b/base",
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3748,7 +4804,7 @@
     },
     "fal.text_to_image.Flux2Klein9BBase": {
       "endpoint_id": "fal-ai/flux-2/klein/9b/base",
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -4378,7 +5434,7 @@
     },
     "fal.text_to_image.IllusionDiffusion": {
       "endpoint_id": "fal-ai/illusion-diffusion",
-      "unit_price": 0.000575,
+      "unit_price": 0.00125,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -4476,6 +5532,306 @@
       "endpoint_id": "fal-ai/ideogram/custom-models/generate",
       "unit_price": 0.03,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.FiboBbqPreviewGenerate": {
+      "endpoint_id": "bria/fibo-bbq-preview/generate",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.SeedreamV5LiteTextToImage": {
+      "endpoint_id": "bytedance/seedream/v5/lite/text-to-image",
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.SeedreamV5ProTextToImage": {
+      "endpoint_id": "bytedance/seedream/v5/pro/text-to-image",
+      "unit_price": 0.0675,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Bitdance": {
+      "endpoint_id": "fal-ai/bitdance",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.BooguImage": {
+      "endpoint_id": "fal-ai/boogu-image",
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Flux2Klein4bLora": {
+      "endpoint_id": "fal-ai/flux-2/klein/4b/lora",
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Flux2Klein9bLora": {
+      "endpoint_id": "fal-ai/flux-2/klein/9b/lora",
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Gemini31FlashImagePreview": {
+      "endpoint_id": "fal-ai/gemini-3.1-flash-image-preview",
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.HidreamO1Image": {
+      "endpoint_id": "fal-ai/hidream-o1-image",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.HidreamO1ImageDev": {
+      "endpoint_id": "fal-ai/hidream-o1-image/dev",
+      "unit_price": 0.005,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.IdeogramV3GenerateTransparent": {
+      "endpoint_id": "fal-ai/ideogram/v3/generate-transparent",
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.KlingImageV3TextToImage": {
+      "endpoint_id": "fal-ai/kling-image/v3/text-to-image",
+      "unit_price": 0.028,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Krea2Turbo": {
+      "endpoint_id": "fal-ai/krea-2/turbo",
+      "unit_price": 0.008,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Krea2TurboLora": {
+      "endpoint_id": "fal-ai/krea-2/turbo/lora",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Krea2TurboStyle": {
+      "endpoint_id": "fal-ai/krea-2/turbo/style",
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.PatinaMaterial": {
+      "endpoint_id": "fal-ai/patina/material",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Phota": {
+      "endpoint_id": "fal-ai/phota",
+      "unit_price": 0.09,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.QwenImage2ProTextToImage": {
+      "endpoint_id": "fal-ai/qwen-image-2/pro/text-to-image",
+      "unit_price": 0.075,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.QwenImage2TextToImage": {
+      "endpoint_id": "fal-ai/qwen-image-2/text-to-image",
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41ProTextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4.1/pro/text-to-image",
+      "unit_price": 0.21,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41ProTextToVector": {
+      "endpoint_id": "fal-ai/recraft/v4.1/pro/text-to-vector",
+      "unit_price": 0.3,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41TextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4.1/text-to-image",
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41TextToVector": {
+      "endpoint_id": "fal-ai/recraft/v4.1/text-to-vector",
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41UtilityProTextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4.1/utility/pro/text-to-image",
+      "unit_price": 0.21,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV41UtilityTextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4.1/utility/text-to-image",
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV4ProTextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4/pro/text-to-image",
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV4ProTextToVector": {
+      "endpoint_id": "fal-ai/recraft/v4/pro/text-to-vector",
+      "unit_price": 0.3,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV4TextToImage": {
+      "endpoint_id": "fal-ai/recraft/v4/text-to-image",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.RecraftV4TextToVector": {
+      "endpoint_id": "fal-ai/recraft/v4/text-to-vector",
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.SensenovaU1Infographic": {
+      "endpoint_id": "fal-ai/sensenova-u1-infographic",
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Vecglypher": {
+      "endpoint_id": "fal-ai/vecglypher",
+      "unit_price": 0.005,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.WanV27ProTextToImage": {
+      "endpoint_id": "fal-ai/wan/v2.7/pro/text-to-image",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.WanV27TextToImage": {
+      "endpoint_id": "fal-ai/wan/v2.7/text-to-image",
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.ZImageTurboTiling": {
+      "endpoint_id": "fal-ai/z-image/turbo/tiling",
+      "unit_price": 0.02,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.ZImageTurboTilingLora": {
+      "endpoint_id": "fal-ai/z-image/turbo/tiling/lora",
+      "unit_price": 0.025,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_image.NanoBananaLite": {
+      "endpoint_id": "google/nano-banana-lite",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.IdeogramV4": {
+      "endpoint_id": "ideogram/v4",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.IdeogramV4Fast": {
+      "endpoint_id": "ideogram/v4/fast",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.IdeogramV4Instant": {
+      "endpoint_id": "ideogram/v4/instant",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.IdeogramV4Lora": {
+      "endpoint_id": "ideogram/v4/lora",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.KreaV2LargeTextToImage": {
+      "endpoint_id": "krea/v2/large/text-to-image",
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.KreaV2MediumTextToImage": {
+      "endpoint_id": "krea/v2/medium/text-to-image",
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.KreaV2MediumTurboTextToImage": {
+      "endpoint_id": "krea/v2/medium/turbo/text-to-image",
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_image.LumaAgentUni1V1Max": {
+      "endpoint_id": "luma/agent/uni-1/v1/max",
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.LumaAgentUni1V1TextToImage": {
+      "endpoint_id": "luma/agent/uni-1/v1/text-to-image",
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.MaiImage25": {
+      "endpoint_id": "microsoft/mai-image-2.5",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Cosmos3SuperTextToImage": {
+      "endpoint_id": "nvidia/cosmos-3-super/text-to-image",
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.Reve21TextToImage": {
+      "endpoint_id": "reve/2.1/text-to-image",
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.GrokImagineImage": {
+      "endpoint_id": "xai/grok-imagine-image",
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal.text_to_image.GrokImagineImageQualityTextToImage": {
+      "endpoint_id": "xai/grok-imagine-image/quality/text-to-image",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal.text_to_json.BriaFiboEditEditStructured_instruction": {
@@ -4644,6 +6000,48 @@
       "endpoint_id": "fal-ai/gemini-3.1-flash-tts",
       "unit_price": 0.15,
       "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.AsyncTtsProV10": {
+      "endpoint_id": "async/tts-pro/v1.0",
+      "unit_price": 0.00003,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.BytedanceSeedSpeechTtsV2": {
+      "endpoint_id": "fal-ai/bytedance/seed-speech/tts/v2",
+      "unit_price": 0.03,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.InworldTts": {
+      "endpoint_id": "fal-ai/inworld-tts",
+      "unit_price": 0.01,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.MinimaxSpeech28Hd": {
+      "endpoint_id": "fal-ai/minimax/speech-2.8-hd",
+      "unit_price": 0.1,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.MinimaxSpeech28Turbo": {
+      "endpoint_id": "fal-ai/minimax/speech-2.8-turbo",
+      "unit_price": 0.06,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.Zonos2": {
+      "endpoint_id": "fal-ai/zonos2",
+      "unit_price": 0.01,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal.text_to_speech.XaiTtsV1": {
+      "endpoint_id": "xai/tts/v1",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal.text_to_video.HunyuanVideo": {
@@ -5282,6 +6680,174 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "fal.text_to_video.HappyHorseV11TextToVideo": {
+      "endpoint_id": "alibaba/happy-horse/v1.1/text-to-video",
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Seedance20MiniTextToVideo": {
+      "endpoint_id": "bytedance/seedance-2.0/mini/text-to-video",
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.text_to_video.BerniniRTextToVideo": {
+      "endpoint_id": "fal-ai/bernini-r/text-to-video",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.CosmosPredict25DistilledTextToVideo": {
+      "endpoint_id": "fal-ai/cosmos-predict-2.5/distilled/text-to-video",
+      "unit_price": 0.08,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.text_to_video.CosmosPredict25TextToVideo": {
+      "endpoint_id": "fal-ai/cosmos-predict-2.5/text-to-video",
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.text_to_video.HeygenAvatar3DigitalTwin": {
+      "endpoint_id": "fal-ai/heygen/avatar3/digital-twin",
+      "unit_price": 0.034,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.HeygenAvatar4DigitalTwin": {
+      "endpoint_id": "fal-ai/heygen/avatar4/digital-twin",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.HeygenAvatar5DigitalTwin": {
+      "endpoint_id": "fal-ai/heygen/avatar5/digital-twin",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.HeygenV2VideoAgent": {
+      "endpoint_id": "fal-ai/heygen/v2/video-agent",
+      "unit_price": 0.034,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.KlingVideoV3TurboProTextToVideo": {
+      "endpoint_id": "fal-ai/kling-video/v3/turbo/pro/text-to-video",
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.KlingVideoV3TurboStandardTextToVideo": {
+      "endpoint_id": "fal-ai/kling-video/v3/turbo/standard/text-to-video",
+      "unit_price": 0.112,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx2322bDistilledTextToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/text-to-video",
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx2322bDistilledTextToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/text-to-video/lora",
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx2322bTextToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/text-to-video",
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx2322bTextToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/text-to-video/lora",
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx23QualityTextToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/text-to-video",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx23QualityTextToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/text-to-video/lora",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx23TextToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3/text-to-video",
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Ltx23TextToVideoFast": {
+      "endpoint_id": "fal-ai/ltx-2.3/text-to-video/fast",
+      "unit_price": 0.06,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.PixverseC1TextToVideo": {
+      "endpoint_id": "fal-ai/pixverse/c1/text-to-video",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.PixverseV6TextToVideo": {
+      "endpoint_id": "fal-ai/pixverse/v6/text-to-video",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.Veo31Lite": {
+      "endpoint_id": "fal-ai/veo3.1/lite",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.ViduQ3TextToVideo": {
+      "endpoint_id": "fal-ai/vidu/q3/text-to-video",
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.text_to_video.ViduQ3TextToVideoTurbo": {
+      "endpoint_id": "fal-ai/vidu/q3/text-to-video/turbo",
+      "unit_price": 0.035,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.text_to_video.WanV27TextToVideo": {
+      "endpoint_id": "fal-ai/wan/v2.7/text-to-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.GeminiOmniFlash": {
+      "endpoint_id": "google/gemini-omni-flash",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.text_to_video.LumaAgentRayV32TextToVideo": {
+      "endpoint_id": "luma/agent/ray/v3.2/text-to-video",
+      "unit_price": 0.5,
+      "billing_unit": "5 seconds",
+      "currency": "USD"
+    },
+    "fal.text_to_video.GrokImagineVideoTextToVideo": {
+      "endpoint_id": "xai/grok-imagine-video/text-to-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal.training.ZImageBaseTrainer": {
       "endpoint_id": "fal-ai/z-image-base-trainer",
       "unit_price": 0.00085,
@@ -5296,13 +6862,13 @@
     },
     "fal.training.Flux2Klein9BBaseTrainerEdit": {
       "endpoint_id": "fal-ai/flux-2-klein-9b-base-trainer/edit",
-      "unit_price": 0.008,
+      "unit_price": 0.002,
       "billing_unit": "units",
       "currency": "USD"
     },
     "fal.training.Flux2Klein9BBaseTrainer": {
       "endpoint_id": "fal-ai/flux-2-klein-9b-base-trainer",
-      "unit_price": 0.0086,
+      "unit_price": 0.0043,
       "billing_unit": "units",
       "currency": "USD"
     },
@@ -5326,13 +6892,13 @@
     },
     "fal.training.Flux2TrainerV2Edit": {
       "endpoint_id": "fal-ai/flux-2-trainer-v2/edit",
-      "unit_price": 0.0226,
+      "unit_price": 0.0056,
       "billing_unit": "units",
       "currency": "USD"
     },
     "fal.training.Flux2TrainerV2": {
       "endpoint_id": "fal-ai/flux-2-trainer-v2",
-      "unit_price": 0.0255,
+      "unit_price": 0.0064,
       "billing_unit": "units",
       "currency": "USD"
     },
@@ -5368,13 +6934,13 @@
     },
     "fal.training.Flux2TrainerEdit": {
       "endpoint_id": "fal-ai/flux-2-trainer/edit",
-      "unit_price": 0.009,
+      "unit_price": 0.0056,
       "billing_unit": "train units",
       "currency": "USD"
     },
     "fal.training.Flux2Trainer": {
       "endpoint_id": "fal-ai/flux-2-trainer",
-      "unit_price": 0.008,
+      "unit_price": 0.0064,
       "billing_unit": "train units",
       "currency": "USD"
     },
@@ -5516,6 +7082,18 @@
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
+    "fal.video_to_audio.SoniloV11VideoToMusic": {
+      "endpoint_id": "sonilo/v1.1/video-to-music",
+      "unit_price": 0.009,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_audio.SoniloV11VideoToSoundEffects": {
+      "endpoint_id": "sonilo/v1.1/video-to-sound-effects",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "fal.video_to_text.RouterVideoEnterprise": {
       "endpoint_id": "openrouter/router/video/enterprise",
       "unit_price": 0.01,
@@ -5566,7 +7144,7 @@
     },
     "fal.video_to_video.BiRefNetV2Video": {
       "endpoint_id": "fal-ai/birefnet/v2/video",
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -6268,7 +7846,7 @@
     },
     "fal.video_to_video.Sam2Video": {
       "endpoint_id": "fal-ai/sam2/video",
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -6318,6 +7896,390 @@
       "endpoint_id": "fal-ai/void-video-inpainting",
       "unit_price": 0.05,
       "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.video_to_video.VideoBackgroundRemovalRealtime": {
+      "endpoint_id": "bria/video/background-removal/realtime",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.VideoBackgroundRemovalV3": {
+      "endpoint_id": "bria/video/background-removal/v3",
+      "unit_price": 0.00003,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Lucy25Realtime": {
+      "endpoint_id": "decart/lucy-2-5/realtime",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Lucy2VtonRealtime": {
+      "endpoint_id": "decart/lucy2-vton/realtime",
+      "unit_price": 0.02,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.BerniniREditVideo": {
+      "endpoint_id": "fal-ai/bernini-r/edit-video",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.BerniniRReferenceEditVideo": {
+      "endpoint_id": "fal-ai/bernini-r/reference-edit-video",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.BytedanceDreamactorV2": {
+      "endpoint_id": "fal-ai/bytedance/dreamactor/v2",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.CosmosPredict25VideoToVideo": {
+      "endpoint_id": "fal-ai/cosmos-predict-2.5/video-to-video",
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal.video_to_video.DepthAnythingVideo": {
+      "endpoint_id": "fal-ai/depth-anything-video",
+      "unit_price": 0.04,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.HeygenV2TranslatePrecision": {
+      "endpoint_id": "fal-ai/heygen/v2/translate/precision",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.HeygenV2TranslateSpeed": {
+      "endpoint_id": "fal-ai/heygen/v2/translate/speed",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.KlingVideoV3ProMotionControl": {
+      "endpoint_id": "fal-ai/kling-video/v3/pro/motion-control",
+      "unit_price": 0.168,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.KlingVideoV3StandardMotionControl": {
+      "endpoint_id": "fal-ai/kling-video/v3/standard/motion-control",
+      "unit_price": 0.126,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bDistilledVideoToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/video-to-video",
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bDistilledVideoToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/distilled/video-to-video/lora",
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bExtendVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/extend-video",
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bExtendVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/extend-video/lora",
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bVideoToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/video-to-video",
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx2322bVideoToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-22b/video-to-video/lora",
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityCleanPlate": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/clean-plate",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityColorization": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/colorization",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityCrossEyed": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/cross-eyed",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityDayToNight": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/day-to-night",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityDeblur": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/deblur",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityDecompression": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/decompression",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityExtendVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/extend-video",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityExtendVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/extend-video/lora",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityHdr": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/hdr",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityHdrLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/hdr/lora",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityInpaint": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/inpaint",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityInpaintLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/inpaint/lora",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityInstantShave": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/instant-shave",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityOutpaint": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/outpaint",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityOutpaintLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/outpaint/lora",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityReferenceVideoToVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/reference-video-to-video",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityReferenceVideoToVideoLora": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/reference-video-to-video/lora",
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityRenderToReal": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/render-to-real",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23QualityWaterSimulation": {
+      "endpoint_id": "fal-ai/ltx-2.3-quality/water-simulation",
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23ExtendVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3/extend-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23Reframe": {
+      "endpoint_id": "fal-ai/ltx-2.3/reframe",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Ltx23RetakeVideo": {
+      "endpoint_id": "fal-ai/ltx-2.3/retake-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.PixverseV6Extend": {
+      "endpoint_id": "fal-ai/pixverse/v6/extend",
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Sam31Video": {
+      "endpoint_id": "fal-ai/sam-3-1/video",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Sam31VideoRle": {
+      "endpoint_id": "fal-ai/sam-3-1/video-rle",
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Scail2": {
+      "endpoint_id": "fal-ai/scail-2",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.SyncLipsyncV3": {
+      "endpoint_id": "fal-ai/sync-lipsync/v3",
+      "unit_price": 8,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WanMotion": {
+      "endpoint_id": "fal-ai/wan-motion",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WanV27EditVideo": {
+      "endpoint_id": "fal-ai/wan/v2.7/edit-video",
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WorkflowUtilitiesBlendVideo": {
+      "endpoint_id": "fal-ai/workflow-utilities/blend-video",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WorkflowUtilitiesReverseVideo": {
+      "endpoint_id": "fal-ai/workflow-utilities/reverse-video",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WorkflowUtilitiesScaleVideo": {
+      "endpoint_id": "fal-ai/workflow-utilities/scale-video",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WorkflowUtilitiesTrimVideo": {
+      "endpoint_id": "fal-ai/workflow-utilities/trim-video",
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.GeminiOmniFlashEdit": {
+      "endpoint_id": "google/gemini-omni-flash/edit",
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal.video_to_video.LumaAgentRayV32Reframe": {
+      "endpoint_id": "luma/agent/ray/v3.2/reframe",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.LumaAgentRayV32VideoToVideo": {
+      "endpoint_id": "luma/agent/ray/v3.2/video-to-video",
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Sfx16VideoToVideo": {
+      "endpoint_id": "mirelo-ai/sfx1.6/video-to-video",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.VideoBackgroundRemoval": {
+      "endpoint_id": "pixelcut/video-background-removal",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.SoniloV11VideoToVideoMusic": {
+      "endpoint_id": "sonilo/v1.1/video-to-video-music",
+      "unit_price": 0.009,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.SoniloV11VideoToVideoSoundEffects": {
+      "endpoint_id": "sonilo/v1.1/video-to-video-sound-effects",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.VeedLipsyncV2": {
+      "endpoint_id": "veed/lipsync/v2",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.Subtitles": {
+      "endpoint_id": "veed/subtitles",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.WanV26ReferenceToVideoFlash": {
+      "endpoint_id": "wan/v2.6/reference-to-video/flash",
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.GrokImagineVideoEditVideo": {
+      "endpoint_id": "xai/grok-imagine-video/edit-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal.video_to_video.GrokImagineVideoExtendVideo": {
+      "endpoint_id": "xai/grok-imagine-video/extend-video",
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
       "currency": "USD"
     },
     "fal.vision.ArbiterImageText": {
@@ -6522,6 +8484,30 @@
       "endpoint_id": "nvidia/nemotron-3-nano-omni/vision",
       "unit_price": 0.006,
       "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.vision.Marlin": {
+      "endpoint_id": "fal-ai/marlin",
+      "unit_price": 0.015,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.vision.MarlinFind": {
+      "endpoint_id": "fal-ai/marlin/find",
+      "unit_price": 0.015,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.vision.NemotronDiffusionVlm": {
+      "endpoint_id": "fal-ai/nemotron-diffusion-vlm",
+      "unit_price": 0.005,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal.vision.SceneFinder": {
+      "endpoint_id": "fal-ai/scene-finder",
+      "unit_price": 0.0042,
+      "billing_unit": "input seconds",
       "currency": "USD"
     }
   }

--- a/packages/fal-nodes/src/generated/fal-unit-pricing.json
+++ b/packages/fal-nodes/src/generated/fal-unit-pricing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "writtenAt": "2026-05-17T22:25:00.943Z",
+  "writtenAt": "2026-07-28T10:34:08.198Z",
   "prices": {
     "fal-ai/sam-3/3d-align": {
       "unit_price": 0.02,
@@ -19,6 +19,26 @@
     },
     "fal-ai/hunyuan-part": {
       "unit_price": 0.04,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/hunyuan-3d/v3.1/part": {
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/hunyuan-3d/v3.1/smart-topology": {
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/meshy/rigging": {
+      "unit_price": 0.8,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/meshy/rigging/multi-animation": {
+      "unit_price": 0.08,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -102,6 +122,131 @@
       "billing_unit": "minutes",
       "currency": "USD"
     },
+    "fal-ai/personaplex/realtime": {
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/audio-inpainting": {
+      "unit_price": 0.0442,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/audio-outpainting": {
+      "unit_price": 0.0446,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/audio-to-audio": {
+      "unit_price": 0.0417,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/base/audio-inpainting": {
+      "unit_price": 0.0537,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/base/audio-outpainting": {
+      "unit_price": 0.0554,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/base/audio-to-audio": {
+      "unit_price": 0.0523,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/audio-inpainting": {
+      "unit_price": 0.026,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/audio-outpainting": {
+      "unit_price": 0.0265,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/audio-to-audio": {
+      "unit_price": 0.0248,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/base/audio-inpainting": {
+      "unit_price": 0.0333,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/base/audio-outpainting": {
+      "unit_price": 0.0339,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/base/audio-to-audio": {
+      "unit_price": 0.032,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/audio-inpainting": {
+      "unit_price": 0.0259,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/audio-outpainting": {
+      "unit_price": 0.0271,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/audio-to-audio": {
+      "unit_price": 0.024,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/base/audio-inpainting": {
+      "unit_price": 0.0331,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/base/audio-outpainting": {
+      "unit_price": 0.0337,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/base/audio-to-audio": {
+      "unit_price": 0.0315,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/tada/1b/text-to-speech": {
+      "unit_price": 0.05,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/tada/3b/text-to-speech": {
+      "unit_price": 0.08,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/audio-compressor": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/impulse-response": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "mirelo-ai/sfx1.6/extend-audio": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "mirelo-ai/sfx1.6/inpaint-audio": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "fal-ai/nemotron/asr": {
       "unit_price": 0.0008,
       "billing_unit": "input seconds",
@@ -182,6 +327,46 @@
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
+    "fal-ai/flashtalk": {
+      "unit_price": 0.02,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/audio-to-video": {
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/audio-to-video/lora": {
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/audio-to-video": {
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/audio-to-video/lora": {
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/audio-to-video": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/audio-to-video/lora": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/audio-to-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal-ai/flux/schnell/redux": {
       "unit_price": 0.025,
       "billing_unit": "megapixels",
@@ -253,7 +438,7 @@
       "currency": "USD"
     },
     "fal-ai/birefnet": {
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -308,7 +493,7 @@
       "currency": "USD"
     },
     "fal-ai/flux-2/klein/4b/base/edit": {
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -318,7 +503,7 @@
       "currency": "USD"
     },
     "fal-ai/flux-2/klein/9b/base/edit": {
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -510,6 +695,51 @@
     "fal-ai/kling-image/o3/image-to-image": {
       "unit_price": 0.028,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/shirt-design": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/remove-lighting": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/remove-element": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/lighting-restoration": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/integrate-product": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/group-photo": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/face-to-full-portrait": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/add-background": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-edit-2509-lora-gallery/next-scene": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
       "currency": "USD"
     },
     "fal-ai/qwen-image-edit-plus-lora-gallery/lighting-restoration": {
@@ -1348,7 +1578,7 @@
       "currency": "USD"
     },
     "fal-ai/sam2/auto-segment": {
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -1503,7 +1733,7 @@
       "currency": "USD"
     },
     "fal-ai/birefnet/v2": {
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -1568,7 +1798,7 @@
       "currency": "USD"
     },
     "fal-ai/sam2/image": {
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -1797,9 +2027,279 @@
       "billing_unit": "units",
       "currency": "USD"
     },
-    "fal-ai/bytedance/seedream/v5/lite/edit": {
+    "bria/embed-product": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bria/extract-object": {
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bria/genfill/v2": {
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "bria/product-dimensions": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bria/upscale/creative": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bytedance/seedream/v5/lite/edit": {
       "unit_price": 0.035,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bytedance/seedream/v5/pro/edit": {
+      "unit_price": 0.0675,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/bernini-r/edit-image": {
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/boogu-image/edit": {
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/control-light": {
+      "unit_price": 0.03,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/firered-image-edit": {
+      "unit_price": 0.0325,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/firered-image-edit-v1.1": {
+      "unit_price": 0.0325,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2-pro/outpaint": {
+      "unit_price": 0.03,
+      "billing_unit": "processed megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2/klein/4b/edit/lora": {
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2/klein/9b/edit/lora": {
+      "unit_price": 0.02,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2/klein/realtime": {
+      "unit_price": 0.00194,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/flux-pro/v1/erase": {
+      "unit_price": 0.004,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/flux-pro/v1/vto": {
+      "unit_price": 0.005,
+      "billing_unit": "processed megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/gemini-3.1-flash-image-preview/edit": {
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/hidream-o1-image/dev/edit": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/hidream-o1-image/edit": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/hy-wu-edit": {
+      "unit_price": 0.1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/ideogram/remove-background": {
+      "unit_price": 0.01,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/ideogram/v3/layerize-text": {
+      "unit_price": 0.09,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/joyai-image-edit": {
+      "unit_price": 0.1,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/kling-image/v3/image-to-image": {
+      "unit_price": 0.028,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/patina": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/patina/material/extract": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/phota/edit": {
+      "unit_price": 0.09,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/phota/enhance": {
+      "unit_price": 0.13,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-2/edit": {
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-2/pro/edit": {
+      "unit_price": 0.075,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/sam-3-1/image": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/sam-3-1/image-rle": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/seedvr/upscale/image/seamless": {
+      "unit_price": 0.0025,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/smart-resize": {
+      "unit_price": 0.15,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/telestyle-v2": {
+      "unit_price": 0.035,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/vecglypher/image-to-svg": {
+      "unit_price": 0.005,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/edit": {
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/pro/edit": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/extract-nth-frame": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "google/nano-banana-lite/edit": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "ideogram/v4/image-to-image": {
+      "unit_price": 0.01,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "ideogram/v4/image-to-image/lora": {
+      "unit_price": 0.015,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "ideogram/v4/tiling": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "ideogram/v4/tiling/lora": {
+      "unit_price": 0.045,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "imagineart/imagineart-2.0-edit-preview/image-to-image": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "luma/agent/uni-1/v1/edit": {
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "luma/agent/uni-1/v1/max/edit": {
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "microsoft/mai-image-2.5/edit": {
+      "unit_price": 1,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "pixelcut/background-removal": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "reve/2.1/edit": {
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "reve/2.1/remix": {
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-image/edit": {
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-image/quality/edit": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal-ai/trellis-2": {
@@ -1839,11 +2339,6 @@
     },
     "fal-ai/meshy/v5/multi-image-to-3d": {
       "unit_price": 0.4,
-      "billing_unit": "generations",
-      "currency": "USD"
-    },
-    "fal-ai/meshy/v6-preview/image-to-3d": {
-      "unit_price": 0.8,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -1914,7 +2409,7 @@
     },
     "fal-ai/trellis": {
       "unit_price": 0.02,
-      "billing_unit": "",
+      "billing_unit": "generations",
       "currency": "USD"
     },
     "fal-ai/triposr": {
@@ -1924,6 +2419,71 @@
     },
     "fal-ai/meshy/v6/multi-image-to-3d": {
       "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/hunyuan-3d/v3.1/pro/image-to-3d": {
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/hunyuan-3d/v3.1/rapid/image-to-3d": {
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/hyper3d/rodin/v2.5": {
+      "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/hyper3d/rodin/v2.5/fast": {
+      "unit_price": 0.1,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/meshy/v6/image-to-3d": {
+      "unit_price": 0.8,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/pixal3d": {
+      "unit_price": 0.06,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/reconviagen-0.5": {
+      "unit_price": 0.05,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/trellis-2-lora": {
+      "unit_price": 0.05,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/trellis-2/retexture": {
+      "unit_price": 0.04,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "tripo3d/h3.1/image-to-3d": {
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "tripo3d/h3.1/multiview-to-3d": {
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "tripo3d/p1/image-to-3d": {
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "tripo3d/triposplat": {
+      "unit_price": 0.05,
       "billing_unit": "generations",
       "currency": "USD"
     },
@@ -2394,7 +2954,7 @@
     },
     "fal-ai/ltx-video-13b-distilled/image-to-video": {
       "unit_price": 0.04,
-      "billing_unit": "videos",
+      "billing_unit": "units",
       "currency": "USD"
     },
     "fal-ai/ltx-video-13b-dev/image-to-video": {
@@ -2458,8 +3018,8 @@
       "currency": "USD"
     },
     "fal-ai/wan-flf2v": {
-      "unit_price": 0.4,
-      "billing_unit": "videos",
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal-ai/framepack": {
@@ -2697,6 +3257,196 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "alibaba/happy-horse/v1.1/image-to-video": {
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "alibaba/happy-horse/v1.1/reference-to-video": {
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "bytedance/seedance-2.0/mini/image-to-video": {
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "bytedance/seedance-2.0/mini/reference-to-video": {
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/bernini-r/reference-to-video": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/cosmos-predict-2.5/image-to-video": {
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/davinci-magihuman": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ffmpeg-api/images-to-video": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/flashhead": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/avatar4/image-to-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/turbo/pro/image-to-video": {
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/turbo/standard/image-to-video": {
+      "unit_price": 0.112,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/image-to-video": {
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/image-to-video/lora": {
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/image-to-video": {
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/image-to-video/lora": {
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/image-to-video": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/image-to-video/lora": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/ingredient": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/image-to-video": {
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/image-to-video/fast": {
+      "unit_price": 0.06,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/pixverse/c1/image-to-video": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/pixverse/v6/transition": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/sync-lipsync/v3/image-to-video": {
+      "unit_price": 8,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal-ai/veo3.1/lite/first-last-frame-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/veo3.1/lite/image-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/vidu/q3/image-to-video": {
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/vidu/q3/image-to-video/turbo": {
+      "unit_price": 0.035,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/vidu/q3/reference-to-video/mix": {
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/image-to-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/reference-to-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "google/gemini-omni-flash/image-to-video": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "google/gemini-omni-flash/reference-to-video": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "luma/agent/ray/v3.2/image-to-video": {
+      "unit_price": 0.5,
+      "billing_unit": "5 seconds",
+      "currency": "USD"
+    },
+    "nvidia/cosmos-3-super/image-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/image-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/reference-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/v1.5/image-to-video": {
+      "unit_price": 0.01,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal-ai/ffmpeg-api/loudnorm": {
       "unit_price": 0.00017,
       "billing_unit": "compute seconds",
@@ -2710,6 +3460,21 @@
     "fal-ai/ffmpeg-api/metadata": {
       "unit_price": 0.00017,
       "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/omnilottie": {
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/omnilottie/image-to-lottie": {
+      "unit_price": 0.1,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/omnilottie/video-to-lottie": {
+      "unit_price": 0.05,
+      "billing_unit": "videos",
       "currency": "USD"
     },
     "openrouter/router": {
@@ -2742,6 +3507,11 @@
       "billing_unit": "1000 tokens",
       "currency": "USD"
     },
+    "fal-ai/bytedance/seed/v2/mini": {
+      "unit_price": 0.0001,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
     "resemble-ai/chatterboxhd/speech-to-speech": {
       "unit_price": 0.00125,
       "billing_unit": "compute seconds",
@@ -2763,7 +3533,7 @@
       "currency": "USD"
     },
     "fal-ai/smart-turn": {
-      "unit_price": 0.00125,
+      "unit_price": 0.00111,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -2792,6 +3562,11 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "nvidia/nemotron-asr-multilingual/asr": {
+      "unit_price": 0.00111,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "fal-ai/hunyuan-motion/fast": {
       "unit_price": 0.06,
       "billing_unit": "generations",
@@ -2807,9 +3582,39 @@
       "billing_unit": "units",
       "currency": "USD"
     },
-    "fal-ai/meshy/v6-preview/text-to-3d": {
+    "fal-ai/hunyuan-3d/v3.1/pro/text-to-3d": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/hunyuan-3d/v3.1/rapid/text-to-3d": {
+      "unit_price": 0.015,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/hyper3d/rodin/v2.5/text-to-3d": {
+      "unit_price": 0.4,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/hyper3d/rodin/v2.5/text-to-3d/fast": {
+      "unit_price": 0.1,
+      "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "fal-ai/meshy/v6/text-to-3d": {
       "unit_price": 0.8,
       "billing_unit": "generations",
+      "currency": "USD"
+    },
+    "tripo3d/h3.1/text-to-3d": {
+      "unit_price": 0.01,
+      "billing_unit": "credits",
+      "currency": "USD"
+    },
+    "tripo3d/p1/text-to-3d": {
+      "unit_price": 0.01,
+      "billing_unit": "credits",
       "currency": "USD"
     },
     "fal-ai/ace-step/prompt-to-audio": {
@@ -2868,7 +3673,7 @@
       "currency": "USD"
     },
     "fal-ai/stable-audio": {
-      "unit_price": 0.000575,
+      "unit_price": 0.00125,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -2985,6 +3790,81 @@
     "fal-ai/minimax-music/v2.6": {
       "unit_price": 0.15,
       "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "bytedance/seed-audio-1.0": {
+      "unit_price": 0.1875,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal-ai/gemini-tts": {
+      "unit_price": 1,
+      "billing_unit": "1m tokens",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/text-to-audio": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/text-to-audio/lora": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/lyria3": {
+      "unit_price": 0.04,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/lyria3/pro": {
+      "unit_price": 0.08,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/base/text-to-audio": {
+      "unit_price": 0.0479,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/medium/text-to-audio": {
+      "unit_price": 0.0376,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/base/text-to-audio": {
+      "unit_price": 0.0281,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/music/text-to-audio": {
+      "unit_price": 0.0217,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/base/text-to-audio": {
+      "unit_price": 0.0283,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "fal-ai/stable-audio-3/small/sfx/text-to-audio": {
+      "unit_price": 0.0206,
+      "billing_unit": "audios",
+      "currency": "USD"
+    },
+    "mirelo-ai/sfx1.6/text-to-audio": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "sonilo/v1.1/text-to-music": {
+      "unit_price": 0.0025,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "sonilo/v1.1/text-to-sound-effects": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal-ai/flux/dev": {
@@ -3108,7 +3988,7 @@
       "currency": "USD"
     },
     "fal-ai/flux-2/klein/4b/base": {
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3123,7 +4003,7 @@
       "currency": "USD"
     },
     "fal-ai/flux-2/klein/9b/base": {
-      "unit_price": 0.00125,
+      "unit_price": 0.00167,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3648,7 +4528,7 @@
       "currency": "USD"
     },
     "fal-ai/illusion-diffusion": {
-      "unit_price": 0.000575,
+      "unit_price": 0.00125,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -3730,6 +4610,256 @@
     "fal-ai/ideogram/custom-models/generate": {
       "unit_price": 0.03,
       "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bria/fibo-bbq-preview/generate": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bytedance/seedream/v5/lite/text-to-image": {
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "bytedance/seedream/v5/pro/text-to-image": {
+      "unit_price": 0.0675,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/bitdance": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/boogu-image": {
+      "unit_price": 0.04,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2/klein/4b/lora": {
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/flux-2/klein/9b/lora": {
+      "unit_price": 0.00167,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/gemini-3.1-flash-image-preview": {
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/hidream-o1-image": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/hidream-o1-image/dev": {
+      "unit_price": 0.005,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ideogram/v3/generate-transparent": {
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/kling-image/v3/text-to-image": {
+      "unit_price": 0.028,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/krea-2/turbo": {
+      "unit_price": 0.008,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/krea-2/turbo/lora": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/krea-2/turbo/style": {
+      "unit_price": 0.01,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/patina/material": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/phota": {
+      "unit_price": 0.09,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-2/pro/text-to-image": {
+      "unit_price": 0.075,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/qwen-image-2/text-to-image": {
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/pro/text-to-image": {
+      "unit_price": 0.21,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/pro/text-to-vector": {
+      "unit_price": 0.3,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/text-to-image": {
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/text-to-vector": {
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/utility/pro/text-to-image": {
+      "unit_price": 0.21,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4.1/utility/text-to-image": {
+      "unit_price": 0.035,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4/pro/text-to-image": {
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4/pro/text-to-vector": {
+      "unit_price": 0.3,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4/text-to-image": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/recraft/v4/text-to-vector": {
+      "unit_price": 0.08,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/sensenova-u1-infographic": {
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/vecglypher": {
+      "unit_price": 0.005,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/pro/text-to-image": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/text-to-image": {
+      "unit_price": 0.03,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "fal-ai/z-image/turbo/tiling": {
+      "unit_price": 0.02,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/z-image/turbo/tiling/lora": {
+      "unit_price": 0.025,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "google/nano-banana-lite": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "ideogram/v4": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "ideogram/v4/fast": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "ideogram/v4/instant": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "ideogram/v4/lora": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "krea/v2/large/text-to-image": {
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "krea/v2/medium/text-to-image": {
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "krea/v2/medium/turbo/text-to-image": {
+      "unit_price": 0.001,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "luma/agent/uni-1/v1/max": {
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "luma/agent/uni-1/v1/text-to-image": {
+      "unit_price": 0.003,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "microsoft/mai-image-2.5": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "nvidia/cosmos-3-super/text-to-image": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "reve/2.1/text-to-image": {
+      "unit_price": 0.25,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-image": {
+      "unit_price": 0.02,
+      "billing_unit": "images",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-image/quality/text-to-image": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "bria/fibo-edit/edit/structured_instruction": {
@@ -3870,6 +5000,41 @@
     "fal-ai/gemini-3.1-flash-tts": {
       "unit_price": 0.15,
       "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "async/tts-pro/v1.0": {
+      "unit_price": 0.00003,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/bytedance/seed-speech/tts/v2": {
+      "unit_price": 0.03,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/inworld-tts": {
+      "unit_price": 0.01,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/minimax/speech-2.8-hd": {
+      "unit_price": 0.1,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/minimax/speech-2.8-turbo": {
+      "unit_price": 0.06,
+      "billing_unit": "1000 characters",
+      "currency": "USD"
+    },
+    "fal-ai/zonos2": {
+      "unit_price": 0.01,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "xai/tts/v1": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
       "currency": "USD"
     },
     "fal-ai/hunyuan-video": {
@@ -4397,6 +5562,146 @@
       "billing_unit": "seconds",
       "currency": "USD"
     },
+    "alibaba/happy-horse/v1.1/text-to-video": {
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "bytedance/seedance-2.0/mini/text-to-video": {
+      "unit_price": 0.007,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/bernini-r/text-to-video": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/cosmos-predict-2.5/distilled/text-to-video": {
+      "unit_price": 0.08,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/cosmos-predict-2.5/text-to-video": {
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/avatar3/digital-twin": {
+      "unit_price": 0.034,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/avatar4/digital-twin": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/avatar5/digital-twin": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/v2/video-agent": {
+      "unit_price": 0.034,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/turbo/pro/text-to-video": {
+      "unit_price": 0.14,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/turbo/standard/text-to-video": {
+      "unit_price": 0.112,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/text-to-video": {
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/text-to-video/lora": {
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/text-to-video": {
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/text-to-video/lora": {
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/text-to-video": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/text-to-video/lora": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/text-to-video": {
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/text-to-video/fast": {
+      "unit_price": 0.06,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/pixverse/c1/text-to-video": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/pixverse/v6/text-to-video": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/veo3.1/lite": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/vidu/q3/text-to-video": {
+      "unit_price": 0.07,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/vidu/q3/text-to-video/turbo": {
+      "unit_price": 0.035,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/text-to-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "google/gemini-omni-flash": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "luma/agent/ray/v3.2/text-to-video": {
+      "unit_price": 0.5,
+      "billing_unit": "5 seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/text-to-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
     "fal-ai/z-image-base-trainer": {
       "unit_price": 0.00085,
       "billing_unit": "steps",
@@ -4408,12 +5713,12 @@
       "currency": "USD"
     },
     "fal-ai/flux-2-klein-9b-base-trainer/edit": {
-      "unit_price": 0.008,
+      "unit_price": 0.002,
       "billing_unit": "units",
       "currency": "USD"
     },
     "fal-ai/flux-2-klein-9b-base-trainer": {
-      "unit_price": 0.0086,
+      "unit_price": 0.0043,
       "billing_unit": "units",
       "currency": "USD"
     },
@@ -4433,12 +5738,12 @@
       "currency": "USD"
     },
     "fal-ai/flux-2-trainer-v2/edit": {
-      "unit_price": 0.0226,
+      "unit_price": 0.0056,
       "billing_unit": "units",
       "currency": "USD"
     },
     "fal-ai/flux-2-trainer-v2": {
-      "unit_price": 0.0255,
+      "unit_price": 0.0064,
       "billing_unit": "units",
       "currency": "USD"
     },
@@ -4468,12 +5773,12 @@
       "currency": "USD"
     },
     "fal-ai/flux-2-trainer/edit": {
-      "unit_price": 0.009,
+      "unit_price": 0.0056,
       "billing_unit": "train units",
       "currency": "USD"
     },
     "fal-ai/flux-2-trainer": {
-      "unit_price": 0.008,
+      "unit_price": 0.0064,
       "billing_unit": "train units",
       "currency": "USD"
     },
@@ -4592,6 +5897,16 @@
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
+    "sonilo/v1.1/video-to-music": {
+      "unit_price": 0.009,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "sonilo/v1.1/video-to-sound-effects": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
     "openrouter/router/video/enterprise": {
       "unit_price": 0.01,
       "billing_unit": "units",
@@ -4633,7 +5948,7 @@
       "currency": "USD"
     },
     "fal-ai/birefnet/v2/video": {
-      "unit_price": 0.00111,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -5218,7 +6533,7 @@
       "currency": "USD"
     },
     "fal-ai/sam2/video": {
-      "unit_price": 0.00125,
+      "unit_price": 0.0008,
       "billing_unit": "compute seconds",
       "currency": "USD"
     },
@@ -5260,6 +6575,326 @@
     "fal-ai/void-video-inpainting": {
       "unit_price": 0.05,
       "billing_unit": "units",
+      "currency": "USD"
+    },
+    "bria/video/background-removal/realtime": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "bria/video/background-removal/v3": {
+      "unit_price": 0.00003,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "decart/lucy-2-5/realtime": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "decart/lucy2-vton/realtime": {
+      "unit_price": 0.02,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/bernini-r/edit-video": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/bernini-r/reference-edit-video": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/bytedance/dreamactor/v2": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/cosmos-predict-2.5/video-to-video": {
+      "unit_price": 0.2,
+      "billing_unit": "videos",
+      "currency": "USD"
+    },
+    "fal-ai/depth-anything-video": {
+      "unit_price": 0.04,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/v2/translate/precision": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/heygen/v2/translate/speed": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/pro/motion-control": {
+      "unit_price": 0.168,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/kling-video/v3/standard/motion-control": {
+      "unit_price": 0.126,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/video-to-video": {
+      "unit_price": 0.001205,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/distilled/video-to-video/lora": {
+      "unit_price": 0.001405,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/extend-video": {
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/extend-video/lora": {
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/video-to-video": {
+      "unit_price": 0.001605,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-22b/video-to-video/lora": {
+      "unit_price": 0.001805,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/clean-plate": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/colorization": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/cross-eyed": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/day-to-night": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/deblur": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/decompression": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/extend-video": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/extend-video/lora": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/hdr": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/hdr/lora": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/inpaint": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/inpaint/lora": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/instant-shave": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/outpaint": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/outpaint/lora": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/reference-video-to-video": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/reference-video-to-video/lora": {
+      "unit_price": 0.0027075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/render-to-real": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3-quality/water-simulation": {
+      "unit_price": 0.0024075,
+      "billing_unit": "megapixels",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/extend-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/reframe": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/ltx-2.3/retake-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/pixverse/v6/extend": {
+      "unit_price": 0.005,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/sam-3-1/video": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/sam-3-1/video-rle": {
+      "unit_price": 0.01,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "fal-ai/scail-2": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/sync-lipsync/v3": {
+      "unit_price": 8,
+      "billing_unit": "minutes",
+      "currency": "USD"
+    },
+    "fal-ai/wan-motion": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/wan/v2.7/edit-video": {
+      "unit_price": 0.1,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/blend-video": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/reverse-video": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/scale-video": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "fal-ai/workflow-utilities/trim-video": {
+      "unit_price": 0.001,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "google/gemini-omni-flash/edit": {
+      "unit_price": 1,
+      "billing_unit": "units",
+      "currency": "USD"
+    },
+    "luma/agent/ray/v3.2/reframe": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "luma/agent/ray/v3.2/video-to-video": {
+      "unit_price": 0.00017,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "mirelo-ai/sfx1.6/video-to-video": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "pixelcut/video-background-removal": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "sonilo/v1.1/video-to-video-music": {
+      "unit_price": 0.009,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "sonilo/v1.1/video-to-video-sound-effects": {
+      "unit_price": 0.00125,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "veed/lipsync/v2": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "veed/subtitles": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "wan/v2.6/reference-to-video/flash": {
+      "unit_price": 0.00007,
+      "billing_unit": "compute seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/edit-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
+      "currency": "USD"
+    },
+    "xai/grok-imagine-video/extend-video": {
+      "unit_price": 0.05,
+      "billing_unit": "seconds",
       "currency": "USD"
     },
     "fal-ai/arbiter/image/text": {
@@ -5430,6 +7065,26 @@
     "nvidia/nemotron-3-nano-omni/vision": {
       "unit_price": 0.006,
       "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/marlin": {
+      "unit_price": 0.015,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/marlin/find": {
+      "unit_price": 0.015,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/nemotron-diffusion-vlm": {
+      "unit_price": 0.005,
+      "billing_unit": "1000 tokens",
+      "currency": "USD"
+    },
+    "fal-ai/scene-finder": {
+      "unit_price": 0.0042,
+      "billing_unit": "input seconds",
       "currency": "USD"
     }
   }

--- a/packages/replicate-codegen/src/configs/audio-generate.ts
+++ b/packages/replicate-codegen/src/configs/audio-generate.ts
@@ -68,6 +68,20 @@ export const audioGenerateConfig: ModuleConfig = {
     "minimax/music-2.5": {
       className: "Music_2_5",
       returnType: "audio"
+    },
+    "mirelo/video-to-sfx-v1": {
+      className: "Video_To_Sfx_V1",
+      returnType: "audio",
+      fieldOverrides: { video_path: { propType: "video" } }
+    },
+    "mirelo/video-to-sfx-v1.5": {
+      className: "Video_To_Sfx_V1_5",
+      returnType: "audio",
+      fieldOverrides: { video_path: { propType: "video" } }
+    },
+    "playht/play-dialog": {
+      className: "Play_Dialog",
+      returnType: "audio"
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/audio-generate.ts
+++ b/packages/replicate-codegen/src/configs/audio-generate.ts
@@ -54,6 +54,20 @@ export const audioGenerateConfig: ModuleConfig = {
       className: "Music_Cover",
       returnType: "audio",
       fieldOverrides: { audio: { propType: "audio" } }
+    },
+    "google/lyria-3": {
+      className: "Lyria_3",
+      returnType: "audio",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "google/lyria-3-pro": {
+      className: "Lyria_3_Pro",
+      returnType: "audio",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "minimax/music-2.5": {
+      className: "Music_2_5",
+      returnType: "audio"
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/audio-speech.ts
+++ b/packages/replicate-codegen/src/configs/audio-speech.ts
@@ -112,6 +112,14 @@ export const audioSpeechConfig: ModuleConfig = {
     "google/gemini-3.1-flash-tts": {
       className: "Gemini_3_1_Flash_TTS",
       returnType: "audio"
+    },
+    "inworld/realtime-tts-1.5-max": {
+      className: "Realtime_Tts_1_5_Max",
+      returnType: "audio"
+    },
+    "inworld/realtime-tts-1.5-mini": {
+      className: "Realtime_Tts_1_5_Mini",
+      returnType: "audio"
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-3d.ts
+++ b/packages/replicate-codegen/src/configs/image-3d.ts
@@ -24,6 +24,24 @@ export const image3dConfig: ModuleConfig = {
       className: "SeedVR2",
       returnType: "str",
       fieldOverrides: { image: { propType: "image" } }
+    },
+    "tencent/hunyuan-3d-3.1": {
+      className: "Hunyuan_3d_3_1",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "uthana/create-character-v1": {
+      className: "Create_Character_V1",
+      returnType: "str",
+      fieldOverrides: { character_file: { propType: "image" } }
+    },
+    "uthana/text-to-motion-diffusion-v2": {
+      className: "Text_To_Motion_Diffusion_V2",
+      returnType: "str"
+    },
+    "uthana/text-to-motion-vqvae-v1": {
+      className: "Text_To_Motion_Vqvae_V1",
+      returnType: "str"
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-3d.ts
+++ b/packages/replicate-codegen/src/configs/image-3d.ts
@@ -42,6 +42,21 @@ export const image3dConfig: ModuleConfig = {
     "uthana/text-to-motion-vqvae-v1": {
       className: "Text_To_Motion_Vqvae_V1",
       returnType: "str"
+    },
+    "fishwowater/trellis2": {
+      className: "Trellis2",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "hyper3d/rodin": {
+      className: "Rodin",
+      returnType: "str",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "valllllex/cartoonia_3d": {
+      className: "Cartoonia_3d",
+      returnType: "str",
+      fieldOverrides: { input_image: { propType: "image" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-generate.ts
+++ b/packages/replicate-codegen/src/configs/image-generate.ts
@@ -594,6 +594,157 @@ export const imageGenerateConfig: ModuleConfig = {
     "xai/grok-imagine-image-quality": {
       className: "Grok_Imagine_Image_Quality",
       returnType: "image"
+    },
+    "black-forest-labs/flux-2-klein-4b-base": {
+      className: "Flux_2_Klein_4b_Base",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "black-forest-labs/flux-2-klein-4b-base-lora": {
+      className: "Flux_2_Klein_4b_Base_Lora",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "black-forest-labs/flux-2-klein-9b": {
+      className: "Flux_2_Klein_9b",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "black-forest-labs/flux-2-klein-9b-base": {
+      className: "Flux_2_Klein_9b_Base",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "black-forest-labs/flux-2-klein-9b-base-lora": {
+      className: "Flux_2_Klein_9b_Base_Lora",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "bytedance/seedream-5-pro": {
+      className: "Seedream_5_Pro",
+      returnType: "image",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "google/nano-banana-2-lite": {
+      className: "Nano_Banana_2_Lite",
+      returnType: "image",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "ideogram-ai/ideogram-v4-balanced": {
+      className: "Ideogram_V4_Balanced",
+      returnType: "image"
+    },
+    "ideogram-ai/ideogram-v4-quality": {
+      className: "Ideogram_V4_Quality",
+      returnType: "image"
+    },
+    "ideogram-ai/layerize": {
+      className: "Layerize",
+      returnType: "image",
+      fieldOverrides: { flat_graphic_image: { propType: "image" } }
+    },
+    "krea/krea-2-large": {
+      className: "Krea_2_Large",
+      returnType: "image",
+      fieldOverrides: { style_reference_images: { propType: "list[image]" } }
+    },
+    "krea/krea-2-medium": {
+      className: "Krea_2_Medium",
+      returnType: "image",
+      fieldOverrides: { style_reference_images: { propType: "list[image]" } }
+    },
+    "prunaai/p-image-edit-lora": {
+      className: "P_Image_Edit_Lora",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "prunaai/p-image-lora": {
+      className: "P_Image_Lora",
+      returnType: "image"
+    },
+    "prunaai/p-image-try-on": {
+      className: "P_Image_Try_On",
+      returnType: "image",
+      fieldOverrides: {
+        person_image: { propType: "image" },
+        garment_images: { propType: "list[image]" },
+        reference_pose: { propType: "image" }
+      }
+    },
+    "qwen/qwen-image-2": {
+      className: "Qwen_Image_2",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen/qwen-image-2-pro": {
+      className: "Qwen_Image_2_Pro",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "recraft-ai/recraft-v4.1": {
+      className: "Recraft_V4_1",
+      returnType: "image"
+    },
+    "recraft-ai/recraft-v4.1-pro": {
+      className: "Recraft_V4_1_Pro",
+      returnType: "image"
+    },
+    "recraft-ai/recraft-v4.1-pro-svg": {
+      className: "Recraft_V4_1_Pro_Svg",
+      returnType: "image"
+    },
+    "recraft-ai/recraft-v4.1-svg": {
+      className: "Recraft_V4_1_Svg",
+      returnType: "image"
+    },
+    "recraft-ai/recraft-v4.1-utility": {
+      className: "Recraft_V4_1_Utility",
+      returnType: "image"
+    },
+    "recraft-ai/recraft-v4.1-utility-pro": {
+      className: "Recraft_V4_1_Utility_Pro",
+      returnType: "image"
+    },
+    "reve/reve-2.1": {
+      className: "Reve_2_1",
+      returnType: "image",
+      fieldOverrides: { reference_images: { propType: "list[image]" } }
+    },
+    "sourceful/riverflow-2.0-fast": {
+      className: "Riverflow_2_0_Fast",
+      returnType: "image",
+      fieldOverrides: {
+        init_images: { propType: "list[image]" },
+        super_resolution_refs: { propType: "list[image]" }
+      }
+    },
+    "sourceful/riverflow-2.0-pro": {
+      className: "Riverflow_2_0_Pro",
+      returnType: "image",
+      fieldOverrides: {
+        init_images: { propType: "list[image]" },
+        super_resolution_refs: { propType: "list[image]" }
+      }
+    },
+    "sourceful/riverflow-v2.5-fast": {
+      className: "Riverflow_V2_5_Fast",
+      returnType: "image",
+      fieldOverrides: { init_images: { propType: "list[image]" } }
+    },
+    "sourceful/riverflow-v2.5-pro": {
+      className: "Riverflow_V2_5_Pro",
+      returnType: "image",
+      fieldOverrides: { init_images: { propType: "list[image]" } }
+    },
+    "wan-video/wan-2.7-image": {
+      className: "Wan_2_7_Image",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "wan-video/wan-2.7-image-pro": {
+      className: "Wan_2_7_Image_Pro",
+      returnType: "image",
+      fieldOverrides: { images: { propType: "list[image]" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-generate.ts
+++ b/packages/replicate-codegen/src/configs/image-generate.ts
@@ -745,6 +745,524 @@ export const imageGenerateConfig: ModuleConfig = {
       className: "Wan_2_7_Image_Pro",
       returnType: "image",
       fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "aaronaftab/mirage-ghibli": {
+      className: "Mirage_Ghibli",
+      returnType: "image",
+      fieldOverrides: {
+        mask: { propType: "image" },
+        image: { propType: "image" }
+      }
+    },
+    "anon987654321/ra2": {
+      className: "Ra2",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "arthuryeti/dwiss-qwen-2": {
+      className: "Dwiss_Qwen_2",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "black-forest-labs/flux-1.1-pro-ultra-finetuned": {
+      className: "Flux_1_1_Pro_Ultra_Finetuned",
+      returnType: "image",
+      fieldOverrides: { image_prompt: { propType: "image" } }
+    },
+    "black-forest-labs/flux-2-dev": {
+      className: "Flux_2_Dev",
+      returnType: "image",
+      fieldOverrides: { input_images: { propType: "list[image]" } }
+    },
+    "black-forest-labs/flux-kontext-dev": {
+      className: "Flux_Kontext_Dev",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "black-forest-labs/flux-kontext-dev-lora": {
+      className: "Flux_Kontext_Dev_Lora",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "black-forest-labs/flux-krea-dev": {
+      className: "Flux_Krea_Dev",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "black-forest-labs/flux-pro-finetuned": {
+      className: "Flux_Pro_Finetuned",
+      returnType: "image",
+      fieldOverrides: { image_prompt: { propType: "image" } }
+    },
+    "bria/product-cutout": {
+      className: "Product_Cutout",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "bria/product-packshot": {
+      className: "Product_Packshot",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "bria/product-shadow": {
+      className: "Product_Shadow",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "bytedance/bagel": {
+      className: "Bagel",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "bytedance/dolphin": {
+      className: "Dolphin",
+      returnType: "image",
+      fieldOverrides: { file: { propType: "image" } }
+    },
+    "bytedance/dreamina-3.1": {
+      className: "Dreamina_3_1",
+      returnType: "image"
+    },
+    "ccchot-osk103/buacat": {
+      className: "Buacat",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "ccchot-osk103/happycat": {
+      className: "Happycat",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "ccchot-osk103/moneycat": {
+      className: "Moneycat",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "ccchot-osk103/pai_qwen_21102568": {
+      className: "Pai_Qwen_21102568",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "codingdudecom/flux-kontext-stencil-lora": {
+      className: "Flux_Kontext_Stencil_Lora",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "damdam775/portraits_dialogues": {
+      className: "Portraits_Dialogues",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/cartoonify": {
+      className: "Cartoonify",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/depth-of-field": {
+      className: "Depth_Of_Field",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/face-to-many-kontext": {
+      className: "Face_To_Many_Kontext",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/filters": {
+      className: "Filters",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/iconic-locations": {
+      className: "Iconic_Locations",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/impossible-scenarios": {
+      className: "Impossible_Scenarios",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/multi-image-kontext-max": {
+      className: "Multi_Image_Kontext_Max",
+      returnType: "image",
+      fieldOverrides: {
+        input_image_1: { propType: "image" },
+        input_image_2: { propType: "image" }
+      }
+    },
+    "flux-kontext-apps/multi-image-kontext-pro": {
+      className: "Multi_Image_Kontext_Pro",
+      returnType: "image",
+      fieldOverrides: {
+        input_image_1: { propType: "image" },
+        input_image_2: { propType: "image" }
+      }
+    },
+    "flux-kontext-apps/multi-image-list": {
+      className: "Multi_Image_List",
+      returnType: "image",
+      fieldOverrides: { input_images: { propType: "list[image]" } }
+    },
+    "flux-kontext-apps/portrait-series": {
+      className: "Portrait_Series",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "flux-kontext-apps/text-removal": {
+      className: "Text_Removal",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/kontext-0_1-webp": {
+      className: "Kontext_0_1_Webp",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/kontext-fix-jpeg-compression": {
+      className: "Kontext_Fix_Jpeg_Compression",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/kontext-long-exposure-for-water": {
+      className: "Kontext_Long_Exposure_For_Water",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/kontext-make-person-real": {
+      className: "Kontext_Make_Person_Real",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/kontext-old-and-damaged": {
+      className: "Kontext_Old_And_Damaged",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "fofr/qwen-2004": {
+      className: "Qwen_2004",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-bad-70s-food": {
+      className: "Qwen_Bad_70s_Food",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-black-sclera": {
+      className: "Qwen_Black_Sclera",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-dark-art": {
+      className: "Qwen_Dark_Art",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-fantasy-art": {
+      className: "Qwen_Fantasy_Art",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-midjourney-v3": {
+      className: "Qwen_Midjourney_V3",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-my-subconscious": {
+      className: "Qwen_My_Subconscious",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-n74": {
+      className: "Qwen_N74",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-tron-ares": {
+      className: "Qwen_Tron_Ares",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "fofr/qwen-william-blake": {
+      className: "Qwen_William_Blake",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "gaby94500/mamav": {
+      className: "Mamav",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "google/gemini-2.5-flash-image": {
+      className: "Gemini_2_5_Flash_Image",
+      returnType: "image",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "ibm-granite/granite-4.0-h-small": {
+      className: "Granite_4_0_H_Small",
+      returnType: "image"
+    },
+    "intelligent-utilities/html-to-image": {
+      className: "Html_To_Image",
+      returnType: "image"
+    },
+    "leonardoai/lucid-origin": {
+      className: "Lucid_Origin",
+      returnType: "image"
+    },
+    "leonardoai/phoenix-1.0": {
+      className: "Phoenix_1_0",
+      returnType: "image"
+    },
+    "lucataco/flux-content-filter": {
+      className: "Flux_Content_Filter",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "lucataco/gpt-oss-safeguard-20b": {
+      className: "Gpt_Oss_Safeguard_20b",
+      returnType: "image"
+    },
+    "lucataco/kontext-meta-cars": {
+      className: "Kontext_Meta_Cars",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "lucataco/kontext-realearth": {
+      className: "Kontext_Realearth",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "lucataco/merge-img": {
+      className: "Merge_Img",
+      returnType: "image",
+      fieldOverrides: {
+        background: { propType: "image" },
+        foreground: { propType: "image" }
+      }
+    },
+    "lucataco/qwen-davinci": {
+      className: "Qwen_Davinci",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "lucataco/vid2webp": {
+      className: "Vid2webp",
+      returnType: "image",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "luma/reframe-image": {
+      className: "Reframe_Image",
+      returnType: "image",
+      fieldOverrides: {
+        image: { propType: "image" },
+        image_url: { propType: "image" }
+      }
+    },
+    "maikocode/ascii-style": {
+      className: "Ascii_Style",
+      returnType: "image",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "meta/llama-guard-4-12b": {
+      className: "Llama_Guard_4_12b",
+      returnType: "image",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "moonshotai/kimi-k2-thinking": {
+      className: "Kimi_K2_Thinking",
+      returnType: "image"
+    },
+    "nvidia/sana-sprint-1.6b": {
+      className: "Sana_Sprint_1_6b",
+      returnType: "image"
+    },
+    "openai/clip": {
+      className: "Clip",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "openai/dall-e-2": {
+      className: "Dall_E_2",
+      returnType: "image"
+    },
+    "openai/gpt-image-1": {
+      className: "Gpt_Image_1",
+      returnType: "image",
+      fieldOverrides: { input_images: { propType: "list[image]" } }
+    },
+    "openai/gpt-image-1-mini": {
+      className: "Gpt_Image_1_Mini",
+      returnType: "image",
+      fieldOverrides: { input_images: { propType: "list[image]" } }
+    },
+    "perceptron-ai-inc/isaac-0.1": {
+      className: "Isaac_0_1",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "prunaai/flux-fast": {
+      className: "Flux_Fast",
+      returnType: "image"
+    },
+    "prunaai/hidream-l1-dev": {
+      className: "Hidream_L1_Dev",
+      returnType: "image"
+    },
+    "prunaai/hidream-l1-fast": {
+      className: "Hidream_L1_Fast",
+      returnType: "image"
+    },
+    "prunaai/hidream-l1-full": {
+      className: "Hidream_L1_Full",
+      returnType: "image"
+    },
+    "prunaai/p-image": {
+      className: "P_Image",
+      returnType: "image"
+    },
+    "prunaai/p-image-trainer": {
+      className: "P_Image_Trainer",
+      returnType: "image",
+      fieldOverrides: { image_data: { propType: "image" } }
+    },
+    "prunaai/sdxl-lightning": {
+      className: "Sdxl_Lightning",
+      returnType: "image"
+    },
+    "prunaai/wan-2.2-image": {
+      className: "Wan_2_2_Image",
+      returnType: "image"
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-fusion": {
+      className: "Qwen_Image_Edit_Plus_Lora_Fusion",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-next-scene": {
+      className: "Qwen_Image_Edit_Plus_Lora_Next_Scene",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-photo-to-anime": {
+      className: "Qwen_Image_Edit_Plus_Lora_Photo_To_Anime",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-relight": {
+      className: "Qwen_Image_Edit_Plus_Lora_Relight",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-skin": {
+      className: "Qwen_Image_Edit_Plus_Lora_Skin",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen/qwen-edit-multiangle": {
+      className: "Qwen_Edit_Multiangle",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen/qwen-image-2512": {
+      className: "Qwen_Image_2512",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "qwen/qwen-image-edit-2511": {
+      className: "Qwen_Image_Edit_2511",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "list[image]" } }
+    },
+    "qwen/qwen-image-edit-plus-lora": {
+      className: "Qwen_Image_Edit_Plus_Lora",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "list[image]" } }
+    },
+    "qwen/qwen-image-lora-trainer-legacy": {
+      className: "Qwen_Image_Lora_Trainer_Legacy",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "recraft-ai/recraft-remove-background": {
+      className: "Recraft_Remove_Background",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "recraft-ai/recraft-vectorize": {
+      className: "Recraft_Vectorize",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "retro-diffusion/rd-fast": {
+      className: "Rd_Fast",
+      returnType: "image",
+      fieldOverrides: {
+        input_image: { propType: "image" },
+        input_palette: { propType: "image" }
+      }
+    },
+    "retro-diffusion/rd-plus": {
+      className: "Rd_Plus",
+      returnType: "image",
+      fieldOverrides: {
+        input_image: { propType: "image" },
+        input_palette: { propType: "image" }
+      }
+    },
+    "retro-diffusion/rd-tile": {
+      className: "Rd_Tile",
+      returnType: "image",
+      fieldOverrides: {
+        input_image: { propType: "image" },
+        extra_input_image: { propType: "image" }
+      }
+    },
+    "reve/create": {
+      className: "Create",
+      returnType: "image"
+    },
+    "reve/edit": {
+      className: "Edit",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "reve/edit-fast": {
+      className: "Edit_Fast",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "reve/remix": {
+      className: "Remix",
+      returnType: "image",
+      fieldOverrides: { reference_images: { propType: "list[image]" } }
+    },
+    "shridharathi/blueprint-qwen": {
+      className: "Blueprint_Qwen",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
+    },
+    "tencent/hunyuan-image-2.1": {
+      className: "Hunyuan_Image_2_1",
+      returnType: "image"
+    },
+    "wavespeedai/qwen-image": {
+      className: "Wavespeedai_Qwen_Image",
+      returnType: "image"
+    },
+    "wuzoobia/bruna-portrait": {
+      className: "Bruna_Portrait",
+      returnType: "image",
+      fieldOverrides: {
+        mask: { propType: "image" },
+        image: { propType: "image" }
+      }
+    },
+    "yosun/camcorgi-qwern": {
+      className: "Camcorgi_Qwern",
+      returnType: "image",
+      fieldOverrides: { replicate_weights: { propType: "image" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-upscale.ts
+++ b/packages/replicate-codegen/src/configs/image-upscale.ts
@@ -155,6 +155,19 @@ export const imageUpscaleConfig: ModuleConfig = {
       className: "Clarity_Pro_Upscaler",
       returnType: "image",
       fieldOverrides: { image: { propType: "image" } }
+    },
+    "prunaai/p-image-upscale": {
+      className: "P_Image_Upscale",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "sourceful/riverflow-2.0-refsr": {
+      className: "Riverflow_2_0_Refsr",
+      returnType: "image",
+      fieldOverrides: {
+        image: { propType: "image" },
+        super_resolution_references: { propType: "list[image]" }
+      }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/image-upscale.ts
+++ b/packages/replicate-codegen/src/configs/image-upscale.ts
@@ -168,6 +168,11 @@ export const imageUpscaleConfig: ModuleConfig = {
         image: { propType: "image" },
         super_resolution_references: { propType: "list[image]" }
       }
+    },
+    "qwen-edit-apps/qwen-image-edit-plus-lora-upscale": {
+      className: "Qwen_Image_Edit_Plus_Lora_Upscale",
+      returnType: "image",
+      fieldOverrides: { image: { propType: "image" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/text-generate.ts
+++ b/packages/replicate-codegen/src/configs/text-generate.ts
@@ -208,6 +208,78 @@ export const textGenerateConfig: ModuleConfig = {
       className: "Qwen3_7_Plus",
       returnType: "str",
       fieldOverrides: { image: { propType: "list[image]" } }
+    },
+    "anthropic/claude-3.5-haiku": {
+      className: "Claude_3_5_Haiku",
+      returnType: "str"
+    },
+    "ibm-granite/granite-3.2-8b-instruct": {
+      className: "Granite_3_2_8b_Instruct",
+      returnType: "str"
+    },
+    "ibm-granite/granite-3.3-8b-instruct": {
+      className: "Granite_3_3_8b_Instruct",
+      returnType: "str"
+    },
+    "ibm-granite/granite-speech-3.3-8b": {
+      className: "Granite_Speech_3_3_8b",
+      returnType: "str",
+      fieldOverrides: { audio: { propType: "list[audio]" } }
+    },
+    "ibm-granite/granite-vision-3.3-2b": {
+      className: "Granite_Vision_3_3_2b",
+      returnType: "str",
+      fieldOverrides: {
+        image: { propType: "image" },
+        images: { propType: "list[image]" }
+      }
+    },
+    "lucataco/qwen2.5-omni-7b": {
+      className: "Qwen2_5_Omni_7b",
+      returnType: "str",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" },
+        video: { propType: "video" }
+      }
+    },
+    "meta/llama-4-maverick-instruct": {
+      className: "Llama_4_Maverick_Instruct",
+      returnType: "str"
+    },
+    "meta/llama-4-scout-instruct": {
+      className: "Llama_4_Scout_Instruct",
+      returnType: "str"
+    },
+    "openai/gpt-5.1": {
+      className: "Gpt_5_1",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "openai/gpt-5-pro": {
+      className: "Gpt_5_Pro",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "openai/gpt-oss-120b": {
+      className: "Gpt_Oss_120b",
+      returnType: "str"
+    },
+    "openai/gpt-oss-20b": {
+      className: "Gpt_Oss_20b",
+      returnType: "str"
+    },
+    "openai/o1-mini": {
+      className: "O1_Mini",
+      returnType: "str"
+    },
+    "rafaelgalle/whisper-diarization-advanced": {
+      className: "Whisper_Diarization_Advanced",
+      returnType: "str",
+      fieldOverrides: {
+        file_url: { propType: "audio" },
+        file_path: { propType: "audio" }
+      }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/text-generate.ts
+++ b/packages/replicate-codegen/src/configs/text-generate.ts
@@ -154,6 +154,60 @@ export const textGenerateConfig: ModuleConfig = {
       className: "Granite_Speech_4_1_2B",
       returnType: "str",
       fieldOverrides: { audio: { propType: "audio" } }
+    },
+    "anthropic/claude-fable-5": {
+      className: "Claude_Fable_5",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "anthropic/claude-sonnet-4.6": {
+      className: "Claude_Sonnet_4_6",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "anthropic/claude-sonnet-5": {
+      className: "Claude_Sonnet_5",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "google/gemini-3.5-flash": {
+      className: "Gemini_3_5_Flash",
+      returnType: "str",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        images: { propType: "list[image]" },
+        videos: { propType: "list[video]" }
+      }
+    },
+    "ibm-granite/granite-vision-4.1-4b": {
+      className: "Granite_Vision_4_1_4b",
+      returnType: "str",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "openai/gpt-5.4": {
+      className: "Gpt_5_4",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "openai/gpt-5.6-luna": {
+      className: "Gpt_5_6_Luna",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "openai/gpt-5.6-sol": {
+      className: "Gpt_5_6_Sol",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "openai/gpt-5.6-terra": {
+      className: "Gpt_5_6_Terra",
+      returnType: "str",
+      fieldOverrides: { image_input: { propType: "list[image]" } }
+    },
+    "qwen/qwen3-7-plus": {
+      className: "Qwen3_7_Plus",
+      returnType: "str",
+      fieldOverrides: { image: { propType: "list[image]" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/video-enhance.ts
+++ b/packages/replicate-codegen/src/configs/video-enhance.ts
@@ -8,6 +8,21 @@ export const videoEnhanceConfig: ModuleConfig = {
       fieldOverrides: {
         video: { propType: "video" }
       }
+    },
+    "bria/video-increase-resolution": {
+      className: "Video_Increase_Resolution",
+      returnType: "video",
+      fieldOverrides: { video_url: { propType: "video" } }
+    },
+    "bria/video-remove-background": {
+      className: "Video_Remove_Background",
+      returnType: "video",
+      fieldOverrides: { video_url: { propType: "video" } }
+    },
+    "bytedance/video-upscaler": {
+      className: "Video_Upscaler",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/video-generate.ts
+++ b/packages/replicate-codegen/src/configs/video-generate.ts
@@ -258,6 +258,213 @@ export const videoGenerateConfig: ModuleConfig = {
     "xai/grok-imagine-video": {
       className: "Grok_Imagine_Video",
       returnType: "video"
+    },
+    "alibaba/happyhorse-1.1": {
+      className: "Happyhorse_1_1",
+      returnType: "video",
+      fieldOverrides: { images: { propType: "list[image]" } }
+    },
+    "bytedance/seedance-2.0-fast": {
+      className: "Seedance_2_0_Fast",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" },
+        reference_audios: { propType: "list[audio]" },
+        reference_images: { propType: "list[image]" },
+        reference_videos: { propType: "list[video]" }
+      }
+    },
+    "bytedance/seedance-2.0-mini": {
+      className: "Seedance_2_0_Mini",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" },
+        reference_audios: { propType: "list[audio]" },
+        reference_images: { propType: "list[image]" },
+        reference_videos: { propType: "list[video]" }
+      }
+    },
+    "decart/lucy-edit-2": {
+      className: "Lucy_Edit_2",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        reference_image: { propType: "image" }
+      }
+    },
+    "heygen/avatar-iv": {
+      className: "Avatar_Iv",
+      returnType: "video"
+    },
+    "heygen/avatar-v": {
+      className: "Avatar_V",
+      returnType: "video"
+    },
+    "heygen/video-agent": {
+      className: "Video_Agent",
+      returnType: "video"
+    },
+    "kwaivgi/kling-o1": {
+      className: "Kling_O1",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" },
+        reference_video: { propType: "video" },
+        reference_images: { propType: "list[image]" }
+      }
+    },
+    "kwaivgi/kling-v3-motion-control": {
+      className: "Kling_V3_Motion_Control",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        video: { propType: "video" }
+      }
+    },
+    "lightricks/audio-to-video": {
+      className: "Audio_To_Video",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" }
+      }
+    },
+    "lightricks/ltx-2.3-fast": {
+      className: "Ltx_2_3_Fast",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" }
+      }
+    },
+    "lightricks/ltx-2.3-pro": {
+      className: "Ltx_2_3_Pro",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" },
+        video: { propType: "video" },
+        last_frame_image: { propType: "image" }
+      }
+    },
+    "lightricks/ltx-2-distilled": {
+      className: "Ltx_2_Distilled",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "luma/ray-3.2": {
+      className: "Ray_3_2",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" }
+      }
+    },
+    "prunaai/p-video": {
+      className: "P_Video",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" }
+      }
+    },
+    "prunaai/p-video-animate": {
+      className: "P_Video_Animate",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        video: { propType: "video" }
+      }
+    },
+    "prunaai/p-video-replace": {
+      className: "P_Video_Replace",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        images: { propType: "list[image]" }
+      }
+    },
+    "runwayml/aleph-2": {
+      className: "Aleph_2",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        keyframe_images: { propType: "list[image]" }
+      }
+    },
+    "vidu/q3-pro": {
+      className: "Q3_Pro",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" }
+      }
+    },
+    "vidu/q3-turbo": {
+      className: "Q3_Turbo",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" }
+      }
+    },
+    "wan-video/wan2.6-i2v-flash": {
+      className: "Wan2_6_I2v_Flash",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" }
+      }
+    },
+    "wan-video/wan-2.7-i2v": {
+      className: "Wan_2_7_I2v",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        first_clip: { propType: "video" },
+        last_frame: { propType: "image" },
+        first_frame: { propType: "image" }
+      }
+    },
+    "wan-video/wan-2.7-r2v": {
+      className: "Wan_2_7_R2v",
+      returnType: "video",
+      fieldOverrides: {
+        reference_images: { propType: "list[image]" },
+        reference_videos: { propType: "list[video]" }
+      }
+    },
+    "wan-video/wan-2.7-t2v": {
+      className: "Wan_2_7_T2v",
+      returnType: "video",
+      fieldOverrides: { audio: { propType: "audio" } }
+    },
+    "wan-video/wan-2.7-videoedit": {
+      className: "Wan_2_7_Videoedit",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        reference_image: { propType: "image" }
+      }
+    },
+    "xai/grok-imagine-r2v": {
+      className: "Grok_Imagine_R2v",
+      returnType: "video",
+      fieldOverrides: { reference_images: { propType: "list[image]" } }
+    },
+    "xai/grok-imagine-video-1.5": {
+      className: "Grok_Imagine_Video_1_5",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "xai/grok-imagine-video-extension": {
+      className: "Grok_Imagine_Video_Extension",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
     }
   }
 };

--- a/packages/replicate-codegen/src/configs/video-generate.ts
+++ b/packages/replicate-codegen/src/configs/video-generate.ts
@@ -465,6 +465,309 @@ export const videoGenerateConfig: ModuleConfig = {
       className: "Grok_Imagine_Video_Extension",
       returnType: "video",
       fieldOverrides: { video: { propType: "video" } }
+    },
+    "andreasjansson/wan-1.3b-inpaint": {
+      className: "Wan_1_3b_Inpaint",
+      returnType: "video",
+      fieldOverrides: {
+        mask_video: { propType: "video" },
+        input_video: { propType: "video" }
+      }
+    },
+    "bria/video-erase-object": {
+      className: "Video_Erase_Object",
+      returnType: "video",
+      fieldOverrides: {
+        mask_url: { propType: "image" },
+        video_url: { propType: "video" }
+      }
+    },
+    "bytedance/omni-human-1.5": {
+      className: "Omni_Human_1_5",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" }
+      }
+    },
+    "bytedance/seedance-1.5-pro": {
+      className: "Seedance_1_5_Pro",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" }
+      }
+    },
+    "character-ai/ovi-i2v": {
+      className: "Ovi_I2v",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        audio_negative_prompt: { propType: "audio" },
+        video_negative_prompt: { propType: "video" }
+      }
+    },
+    "easel/ai-avatars": {
+      className: "Ai_Avatars",
+      returnType: "video",
+      fieldOverrides: {
+        face_image: { propType: "image" },
+        face_image_b: { propType: "image" }
+      }
+    },
+    "flux-kontext-apps/restyle-video-frame": {
+      className: "Restyle_Video_Frame",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "fofr/kontext-ps1": {
+      className: "Kontext_Ps1",
+      returnType: "video",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "google/veo-3.1-fast": {
+      className: "Veo_3_1_Fast",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame: { propType: "image" }
+      }
+    },
+    "heygen/video-translate": {
+      className: "Video_Translate",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "kwaivgi/kling-v1.5-pro": {
+      className: "Kling_V1_5_Pro",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" }
+      }
+    },
+    "kwaivgi/kling-v1.5-standard": {
+      className: "Kling_V1_5_Standard",
+      returnType: "video",
+      fieldOverrides: { start_image: { propType: "image" } }
+    },
+    "kwaivgi/kling-v1.6-pro": {
+      className: "Kling_V1_6_Pro",
+      returnType: "video",
+      fieldOverrides: {
+        end_image: { propType: "image" },
+        start_image: { propType: "image" },
+        reference_images: { propType: "list[image]" }
+      }
+    },
+    "kwaivgi/kling-v1.6-standard": {
+      className: "Kling_V1_6_Standard",
+      returnType: "video",
+      fieldOverrides: {
+        start_image: { propType: "image" },
+        reference_images: { propType: "list[image]" }
+      }
+    },
+    "kwaivgi/kling-v2.0": {
+      className: "Kling_V2_0",
+      returnType: "video",
+      fieldOverrides: { start_image: { propType: "image" } }
+    },
+    "kwaivgi/kling-v2.1-master": {
+      className: "Kling_V2_1_Master",
+      returnType: "video",
+      fieldOverrides: { start_image: { propType: "image" } }
+    },
+    "kwaivgi/kling-v2.6-motion-control": {
+      className: "Kling_V2_6_Motion_Control",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        video: { propType: "video" }
+      }
+    },
+    "leonardoai/motion-2.0": {
+      className: "Motion_2_0",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "lightricks/ltx-2-fast": {
+      className: "Ltx_2_Fast",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "lightricks/ltx-2-pro": {
+      className: "Ltx_2_Pro",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "lightricks/ltx-2-retake": {
+      className: "Ltx_2_Retake",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "lightricks/ltx-video-0.9.7": {
+      className: "Ltx_Video_0_9_7",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "lightricks/ltx-video-0.9.7-distilled": {
+      className: "Ltx_Video_0_9_7_Distilled",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        video: { propType: "video" }
+      }
+    },
+    "lucataco/frame-extractor": {
+      className: "Frame_Extractor",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "lucataco/split-screen-video": {
+      className: "Split_Screen_Video",
+      returnType: "video",
+      fieldOverrides: {
+        video_1: { propType: "video" },
+        video_2: { propType: "video" }
+      }
+    },
+    "lucataco/trim-video": {
+      className: "Trim_Video",
+      returnType: "video",
+      fieldOverrides: { video: { propType: "video" } }
+    },
+    "lucataco/video-audio-merge": {
+      className: "Video_Audio_Merge",
+      returnType: "video",
+      fieldOverrides: {
+        audio_file: { propType: "audio" },
+        video_file: { propType: "video" }
+      }
+    },
+    "lucataco/video-merge": {
+      className: "Video_Merge",
+      returnType: "video",
+      fieldOverrides: { video_files: { propType: "list[video]" } }
+    },
+    "lucataco/wan-2.1-1.3b-vid2vid": {
+      className: "Wan_2_1_1_3b_Vid2vid",
+      returnType: "video",
+      fieldOverrides: { input_video: { propType: "video" } }
+    },
+    "minimax/hailuo-02-fast": {
+      className: "Hailuo_02_Fast",
+      returnType: "video",
+      fieldOverrides: {
+        last_frame_image: { propType: "image" },
+        first_frame_image: { propType: "image" }
+      }
+    },
+    "nicolascoutureau/video-utils": {
+      className: "Video_Utils",
+      returnType: "video",
+      fieldOverrides: { input_file: { propType: "video" } }
+    },
+    "pixverse/pixverse-v3.5": {
+      className: "Pixverse_V3_5",
+      returnType: "video",
+      fieldOverrides: {
+        image: { propType: "image" },
+        last_frame_image: { propType: "image" }
+      }
+    },
+    "prunaai/vace-1.3b": {
+      className: "Vace_1_3b",
+      returnType: "video",
+      fieldOverrides: {
+        src_mask: { propType: "image" },
+        src_video: { propType: "video" },
+        src_ref_images: { propType: "list[image]" }
+      }
+    },
+    "prunaai/vace-14b": {
+      className: "Vace_14b",
+      returnType: "video",
+      fieldOverrides: {
+        src_mask: { propType: "image" },
+        src_video: { propType: "video" },
+        src_ref_images: { propType: "list[image]" }
+      }
+    },
+    "retro-diffusion/rd-animation": {
+      className: "Rd_Animation",
+      returnType: "video",
+      fieldOverrides: { input_image: { propType: "image" } }
+    },
+    "shridharathi/ghibli-vid": {
+      className: "Ghibli_Vid",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "sync/react-1": {
+      className: "React_1",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        video: { propType: "video" }
+      }
+    },
+    "wan-video/wan2.1-with-lora": {
+      className: "Wan2_1_With_Lora",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "wan-video/wan-2.2-5b-fast": {
+      className: "Wan_2_2_5b_Fast",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "wan-video/wan-2.2-animate-animation": {
+      className: "Wan_2_2_Animate_Animation",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        character_image: { propType: "image" }
+      }
+    },
+    "wan-video/wan-2.2-animate-replace": {
+      className: "Wan_2_2_Animate_Replace",
+      returnType: "video",
+      fieldOverrides: {
+        video: { propType: "video" },
+        character_image: { propType: "image" }
+      }
+    },
+    "wan-video/wan-2.2-i2v-a14b": {
+      className: "Wan_2_2_I2v_A14b",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "wan-video/wan-2.6-i2v": {
+      className: "Wan_2_6_I2v",
+      returnType: "video",
+      fieldOverrides: {
+        audio: { propType: "audio" },
+        image: { propType: "image" }
+      }
+    },
+    "wan-video/wan-2.6-t2v": {
+      className: "Wan_2_6_T2v",
+      returnType: "video",
+      fieldOverrides: { audio: { propType: "audio" } }
+    },
+    "wavespeedai/wan-2.1-i2v-720p": {
+      className: "Wan_2_1_I2v_720p",
+      returnType: "video",
+      fieldOverrides: { image: { propType: "image" } }
+    },
+    "wavespeedai/wan-2.1-t2v-480p": {
+      className: "Wan_2_1_T2v_480p",
+      returnType: "video"
+    },
+    "wavespeedai/wan-2.1-t2v-720p": {
+      className: "Wan_2_1_T2v_720p",
+      returnType: "video"
     }
   }
 };

--- a/packages/replicate-nodes/src/replicate-manifest.json
+++ b/packages/replicate-nodes/src/replicate-manifest.json
@@ -31267,6 +31267,19885 @@
     ]
   },
   {
+    "endpointId": "aaronaftab/mirage-ghibli",
+    "className": "Mirage_Ghibli",
+    "moduleName": "image-generate",
+    "docstring": "Ghiblify any image, 10x cheaper/faster than GPT 4o",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. If custom is selected, uses height and width below & will run in bf16 mode",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "custom"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_lora",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the extra LoRA should be applied. Sane results between 0 and 1 for base inference. For go_fast we apply a 1.5x multiplier to this value; we've generally seen good performance when scaling the base value by that amount. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Run faster predictions with model optimized for speed (currently fp8 quantized); disable to run in original bf16",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Guidance scale for the diffusion process. Lower values can give more realistic images. Good values to try are 2, 2.5, 3 and 3.5",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of generated image. Only works if `aspect_ratio` is set to custom. Will be rounded to nearest multiple of 16. Incompatible with fast generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image to image or inpainting mode. If provided, aspect_ratio, width, and height inputs are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied. Sane results between 0 and 1 for base inference. For go_fast we apply a 1.5x multiplier to this value; we've generally seen good performance when scaling the base value by that amount. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "mask",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image mask for image inpainting mode. If provided, aspect_ratio, width, and height inputs are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "dev",
+        "description": "Which model to run inference with. The dev model performs best with around 28 inference steps but the schnell model only needs 4 steps.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "dev",
+          "schnell"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 28,
+        "description": "Number of denoising steps. More steps can give more detailed images, but take longer.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "num_outputs",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of outputs to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for generated image. If you include the `trigger_word` used in the training process you are more likely to activate the trained object, style, or concept in the resulting image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Prompt strength when using img2img. 1.0 corresponds to full destruction of information in image",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of generated image. Only works if `aspect_ratio` is set to custom. Will be rounded to nearest multiple of 16. Incompatible with fast generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. If custom is selected, uses height and width below & will run in bf16 mode"
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "DEV",
+            "dev"
+          ],
+          [
+            "SCHNELL",
+            "schnell"
+          ]
+        ],
+        "description": "Which model to run inference with. The dev model performs best with around 28 inference steps but the schnell model only needs 4 steps."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "anon987654321/ra2",
+    "className": "Ra2",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "arthuryeti/dwiss-qwen-2",
+    "className": "Dwiss_Qwen_2",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-1.1-pro-ultra-finetuned",
+    "className": "Flux_1_1_Pro_Ultra_Finetuned",
+    "moduleName": "image-generate",
+    "docstring": "Inference model for FLUX 1.1 [pro] Ultra using custom `finetune_id`. Supports 4MP images and raw mode for realism",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16",
+          "9:21"
+        ]
+      },
+      {
+        "name": "finetune_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Finetune ID for making images using a previously trained fine-tune. Only IDs from trainings made using Replicate's Flux Pro fine-tuning model are supported.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "finetune_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Controls finetune influence",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "image_prompt",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use with Flux Redux. This is used together with the text prompt to guide the generation towards the composition of the image_prompt. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_prompt_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "Blend between the prompt and the image prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "raw",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate less processed, more natural-looking images",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 1 is most strict and 6 is most permissive",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-dev",
+    "className": "Flux_2_Dev",
+    "moduleName": "image-generate",
+    "docstring": "Quality image generation and editing with support for reference images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the first input image's aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "custom",
+          "1:1",
+          "16:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "9:16",
+          "3:4",
+          "4:3"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of the generated image in text-to-image mode. Only used when aspect_ratio=custom. Must be a multiple of 32 (if it's not, it will be rounded to nearest multiple of 32).",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "input_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of the image to generate.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of the generated image in text-to-image mode. Only used when aspect_ratio=custom. Must be a multiple of 32 (if it's not, it will be rounded to nearest multiple of 32).",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the first input image's aspect ratio."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-kontext-dev",
+    "className": "Flux_Kontext_Dev",
+    "moduleName": "image-generate",
+    "docstring": "Open-weight version of FLUX.1 Kontext",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Make the model go fast, output quality may be slightly degraded for more difficult prompts",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 28,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for generated image",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-kontext-dev-lora",
+    "className": "Flux_Kontext_Dev_Lora",
+    "moduleName": "image-generate",
+    "docstring": "FLUX.1 Kontext[dev] image editing model for running lora finetunes",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Make the model go fast, output quality may be slightly degraded for more difficult prompts",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference for image-to-image generation. Leave blank for text-to-image generation. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-krea-dev",
+    "className": "Flux_Krea_Dev",
+    "moduleName": "image-generate",
+    "docstring": "An opinionated text-to-image model from Black Forest Labs in collaboration with Krea that excels in photorealism. Creates images that avoid the oversaturated \"AI look\".",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4.5,
+        "description": "Guidance for generated image. Lower values can give more realistic images. Good values to try are 2, 2.5, 3 and 3.5",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image to image mode. The aspect ratio of your output will match this image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 28,
+        "description": "Number of denoising steps. Recommended range is 28-50, and lower number of steps produce lower quality outputs, faster.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "num_outputs",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of outputs to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for generated image",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Prompt strength when using img2img. 1.0 corresponds to full destruction of information in image",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-pro-finetuned",
+    "className": "Flux_Pro_Finetuned",
+    "moduleName": "image-generate",
+    "docstring": "Inference model for FLUX.1 [pro] using custom `finetune_id`",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "custom",
+          "1:1",
+          "16:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "9:16",
+          "3:4",
+          "4:3"
+        ]
+      },
+      {
+        "name": "finetune_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Finetune ID for making images using a previously trained fine-tune. Only IDs from trainings made using Replicate's Flux Pro fine-tuning model are supported.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "finetune_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Controls finetune influence",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Controls the balance between adherence to the text prompt and image quality/diversity. Higher values make the output more closely match the prompt but may reduce overall image quality. Lower values allow for more creative freedom but might produce results less relevant to the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 5
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of the generated image in text-to-image mode. Only used when aspect_ratio=custom. Must be a multiple of 32 (if it's not, it will be rounded to nearest multiple of 32). Note: Ignored in img2img and inpainting modes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "image_prompt",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use with Flux Redux. This is used together with the text prompt to guide the generation towards the composition of the image_prompt. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_upsampling",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically modify the prompt for more creative generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 1 is most strict and 6 is most permissive",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 40,
+        "description": "Number of diffusion steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of the generated image in text-to-image mode. Only used when aspect_ratio=custom. Must be a multiple of 32 (if it's not, it will be rounded to nearest multiple of 32). Note: Ignored in img2img and inpainting modes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "CUSTOM",
+            "custom"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "bria/product-cutout",
+    "className": "Product_Cutout",
+    "moduleName": "image-generate",
+    "docstring": "Precise AI-powered product cutout with 256-level transparency for eCommerce",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "content_moderation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable content moderation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "force_rmbg",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Force background removal even if image has alpha channel",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Product image to create a precise cutout from",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "preserve_alpha",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve alpha channel in output",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "bria/product-packshot",
+    "className": "Product_Packshot",
+    "moduleName": "image-generate",
+    "docstring": "Transform any product photo into professional 2000x2000px packshots with optimal positioning",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "#FFFFFF",
+        "description": "The background hex color code (e.g., #FFFFFF) or 'transparent'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "content_moderation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable content moderation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "force_rmbg",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Force background removal even if image has alpha channel",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Product image to transform into a professional pack shot",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "bria/product-shadow",
+    "className": "Product_Shadow",
+    "moduleName": "image-generate",
+    "docstring": "Add consistent, customizable shadows to product cutouts for enhanced visual appeal",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "#FFFFFF",
+        "description": "The background hex color code (e.g., #FFFFFF) or 'transparent'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "content_moderation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable content moderation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "force_rmbg",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Force background removal even if image has alpha channel",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Product image to add shadow effects to",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "preserve_alpha",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve alpha channel in output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_blur",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Controls the blur level of the shadow's edges",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "#000000",
+        "description": "Shadow color hex code",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 70,
+        "description": "Controls the height of the elliptical shadow in pixels (for floating shadows)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_intensity",
+        "tsType": "number",
+        "propType": "int",
+        "default": 60,
+        "description": "Adjusts the intensity of the shadow (0-100)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_offset_x",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Horizontal shadow offset in pixels",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_offset_y",
+        "tsType": "number",
+        "propType": "int",
+        "default": 15,
+        "description": "Vertical shadow offset in pixels",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shadow_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "regular",
+        "description": "Type of shadow to apply: regular or float",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ShadowType",
+        "enumValues": [
+          "regular",
+          "float"
+        ]
+      },
+      {
+        "name": "shadow_width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Controls the width of the elliptical shadow in pixels (for floating shadows)",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ShadowType",
+        "values": [
+          [
+            "REGULAR",
+            "regular"
+          ],
+          [
+            "FLOAT",
+            "float"
+          ]
+        ],
+        "description": "Type of shadow to apply: regular or float"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/bagel",
+    "className": "Bagel",
+    "moduleName": "image-generate",
+    "docstring": "🥯ByteDance Seed's Bagel Unified multimodal AI that generates images, edits images, and understands images in one 7B parameter model🥯",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "cfg_img_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.5,
+        "description": "Image guidance scale for preserving input image details",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "cfg_renorm_min",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Minimum CFG renorm value",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "cfg_renorm_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "global",
+        "description": "CFG renormalization method",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CfgRenormType",
+        "enumValues": [
+          "global",
+          "local",
+          "text_channel"
+        ]
+      },
+      {
+        "name": "cfg_text_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Text guidance scale for how closely to follow the prompt",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable chain-of-thought reasoning for better results",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for editing or understanding tasks",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 90,
+        "description": "Image compression quality for lossy formats",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation, editing, or understanding",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible results",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "task",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "text-to-image",
+        "description": "Task to perform",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Task",
+        "enumValues": [
+          "text-to-image",
+          "image-editing",
+          "image-understanding"
+        ]
+      },
+      {
+        "name": "timestep_shift",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Distribution of denoising steps between composition and details",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "CfgRenormType",
+        "values": [
+          [
+            "GLOBAL",
+            "global"
+          ],
+          [
+            "LOCAL",
+            "local"
+          ],
+          [
+            "TEXT_CHANNEL",
+            "text_channel"
+          ]
+        ],
+        "description": "CFG renormalization method"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      },
+      {
+        "name": "Task",
+        "values": [
+          [
+            "TEXT_TO_IMAGE",
+            "text-to-image"
+          ],
+          [
+            "IMAGE_EDITING",
+            "image-editing"
+          ],
+          [
+            "IMAGE_UNDERSTANDING",
+            "image-understanding"
+          ]
+        ],
+        "description": "Task to perform"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/dolphin",
+    "className": "Dolphin",
+    "moduleName": "image-generate",
+    "docstring": "Document Image Parsing via Heterogeneous Anchor Prompting",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "file",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "PDF or image file to parse",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "markdown_content",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "markdown_content",
+          "json_content"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "MARKDOWN_CONTENT",
+            "markdown_content"
+          ],
+          [
+            "JSON_CONTENT",
+            "json_content"
+          ]
+        ],
+        "description": "Output format"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/dreamina-3.1",
+    "className": "Dreamina_3_1",
+    "moduleName": "image-generate",
+    "docstring": "4MP text-to-image generation with enhanced cinematic-quality image generation with precise style control, improved text rendering, and commercial design optimization.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Image aspect ratio. Set to 'custom' to specify width and height.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "21:9",
+          "9:21",
+          "custom"
+        ]
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1328,
+        "description": "Image height (only used when aspect_ratio is 'custom')",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 3024
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "Image resolution quality",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "use_pre_llm",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable text expansion for better results with short prompts",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1328,
+        "description": "Image width (only used when aspect_ratio is 'custom')",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 3024
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Image aspect ratio. Set to 'custom' to specify width and height."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ]
+        ],
+        "description": "Image resolution quality"
+      }
+    ]
+  },
+  {
+    "endpointId": "ccchot-osk103/buacat",
+    "className": "Buacat",
+    "moduleName": "image-generate",
+    "docstring": "the grey tabby cat",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "ccchot-osk103/happycat",
+    "className": "Happycat",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "ccchot-osk103/moneycat",
+    "className": "Moneycat",
+    "moduleName": "image-generate",
+    "docstring": "a cute and young orange British Shorthair cat",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "ccchot-osk103/pai_qwen_21102568",
+    "className": "Pai_Qwen_21102568",
+    "moduleName": "image-generate",
+    "docstring": "a young lady name Pai",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "codingdudecom/flux-kontext-stencil-lora",
+    "className": "Flux_Kontext_Stencil_Lora",
+    "moduleName": "image-generate",
+    "docstring": "Stencil maker - create a black and white stencil image from any photo",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "damdam775/portraits_dialogues",
+    "className": "Portraits_Dialogues",
+    "moduleName": "image-generate",
+    "docstring": "Create RPG like expressive character portraits for in game dialogs.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/cartoonify",
+    "className": "Cartoonify",
+    "moduleName": "image-generate",
+    "docstring": "Turn your image into a cartoon with FLUX.1 Kontext [pro]",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to convert to cartoon art style. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/depth-of-field",
+    "className": "Depth_Of_Field",
+    "moduleName": "image-generate",
+    "docstring": "Bring your subjects into focus with FLUX.1 Kontext [pro]",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "blur_effect",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "ultra shallow depth of field",
+        "description": "The professional blur effect to add to the background",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BlurEffect",
+        "enumValues": [
+          "Random",
+          "extreme background blur",
+          "maximum bokeh effect",
+          "ultra shallow depth of field",
+          "professional portrait blur",
+          "cinematic depth of field",
+          "studio photography blur",
+          "dramatic background blur",
+          "creamy smooth bokeh",
+          "intense background separation",
+          "golden hour lighting with background blur",
+          "dramatic rim lighting with blur",
+          "professional studio lighting with bokeh",
+          "moody lighting with background blur",
+          "high-key lighting with blur",
+          "low-key dramatic lighting with blur",
+          "85mm lens background separation",
+          "telephoto compression blur",
+          "portrait lens blur",
+          "fashion photography blur",
+          "headshot photography blur",
+          "dreamy ethereal background blur",
+          "film photography vintage blur",
+          "commercial photography blur",
+          "editorial style background blur",
+          "luxury portrait blur"
+        ]
+      },
+      {
+        "name": "gender",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "The gender of the person",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Gender",
+        "enumValues": [
+          "none",
+          "male",
+          "female"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to add professional background blur effects. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "BlurEffect",
+        "values": [
+          [
+            "RANDOM",
+            "Random"
+          ],
+          [
+            "EXTREME_BACKGROUND_BLUR",
+            "extreme background blur"
+          ],
+          [
+            "MAXIMUM_BOKEH_EFFECT",
+            "maximum bokeh effect"
+          ],
+          [
+            "ULTRA_SHALLOW_DEPTH_OF_FIELD",
+            "ultra shallow depth of field"
+          ],
+          [
+            "PROFESSIONAL_PORTRAIT_BLUR",
+            "professional portrait blur"
+          ],
+          [
+            "CINEMATIC_DEPTH_OF_FIELD",
+            "cinematic depth of field"
+          ],
+          [
+            "STUDIO_PHOTOGRAPHY_BLUR",
+            "studio photography blur"
+          ],
+          [
+            "DRAMATIC_BACKGROUND_BLUR",
+            "dramatic background blur"
+          ],
+          [
+            "CREAMY_SMOOTH_BOKEH",
+            "creamy smooth bokeh"
+          ],
+          [
+            "INTENSE_BACKGROUND_SEPARATION",
+            "intense background separation"
+          ],
+          [
+            "GOLDEN_HOUR_LIGHTING_WITH_BACKGROUND_BLUR",
+            "golden hour lighting with background blur"
+          ],
+          [
+            "DRAMATIC_RIM_LIGHTING_WITH_BLUR",
+            "dramatic rim lighting with blur"
+          ],
+          [
+            "PROFESSIONAL_STUDIO_LIGHTING_WITH_BOKEH",
+            "professional studio lighting with bokeh"
+          ],
+          [
+            "MOODY_LIGHTING_WITH_BACKGROUND_BLUR",
+            "moody lighting with background blur"
+          ],
+          [
+            "HIGH_KEY_LIGHTING_WITH_BLUR",
+            "high-key lighting with blur"
+          ],
+          [
+            "LOW_KEY_DRAMATIC_LIGHTING_WITH_BLUR",
+            "low-key dramatic lighting with blur"
+          ],
+          [
+            "_85MM_LENS_BACKGROUND_SEPARATION",
+            "85mm lens background separation"
+          ],
+          [
+            "TELEPHOTO_COMPRESSION_BLUR",
+            "telephoto compression blur"
+          ],
+          [
+            "PORTRAIT_LENS_BLUR",
+            "portrait lens blur"
+          ],
+          [
+            "FASHION_PHOTOGRAPHY_BLUR",
+            "fashion photography blur"
+          ],
+          [
+            "HEADSHOT_PHOTOGRAPHY_BLUR",
+            "headshot photography blur"
+          ],
+          [
+            "DREAMY_ETHEREAL_BACKGROUND_BLUR",
+            "dreamy ethereal background blur"
+          ],
+          [
+            "FILM_PHOTOGRAPHY_VINTAGE_BLUR",
+            "film photography vintage blur"
+          ],
+          [
+            "COMMERCIAL_PHOTOGRAPHY_BLUR",
+            "commercial photography blur"
+          ],
+          [
+            "EDITORIAL_STYLE_BACKGROUND_BLUR",
+            "editorial style background blur"
+          ],
+          [
+            "LUXURY_PORTRAIT_BLUR",
+            "luxury portrait blur"
+          ]
+        ],
+        "description": "The professional blur effect to add to the background"
+      },
+      {
+        "name": "Gender",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "MALE",
+            "male"
+          ],
+          [
+            "FEMALE",
+            "female"
+          ]
+        ],
+        "description": "The gender of the person"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/face-to-many-kontext",
+    "className": "Face_To_Many_Kontext",
+    "moduleName": "image-generate",
+    "docstring": "Become a character, in style",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image of the person to transform. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "The number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "persona",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "The persona to apply to the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Persona",
+        "enumValues": [
+          "Angel",
+          "Astronaut",
+          "Demon",
+          "Mage",
+          "Ninja",
+          "Na'vi",
+          "None",
+          "Random",
+          "Robot",
+          "Samurai",
+          "Vampire",
+          "Werewolf",
+          "Zombie"
+        ]
+      },
+      {
+        "name": "preserve_background",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to preserve the background",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "preserve_outfit",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to preserve the outfit",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Random",
+        "description": "The artistic style to apply to the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "Anime",
+          "Cartoon",
+          "Clay",
+          "Gothic",
+          "Graphic Novel",
+          "Lego",
+          "Memoji",
+          "Minecraft",
+          "Minimalist",
+          "Pixel Art",
+          "Random",
+          "Simpsons",
+          "Sketch",
+          "South Park",
+          "Toy",
+          "Watercolor"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      },
+      {
+        "name": "Persona",
+        "values": [
+          [
+            "ANGEL",
+            "Angel"
+          ],
+          [
+            "ASTRONAUT",
+            "Astronaut"
+          ],
+          [
+            "DEMON",
+            "Demon"
+          ],
+          [
+            "MAGE",
+            "Mage"
+          ],
+          [
+            "NINJA",
+            "Ninja"
+          ],
+          [
+            "NAVI",
+            "Na'vi"
+          ],
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "RANDOM",
+            "Random"
+          ],
+          [
+            "ROBOT",
+            "Robot"
+          ],
+          [
+            "SAMURAI",
+            "Samurai"
+          ],
+          [
+            "VAMPIRE",
+            "Vampire"
+          ],
+          [
+            "WEREWOLF",
+            "Werewolf"
+          ],
+          [
+            "ZOMBIE",
+            "Zombie"
+          ]
+        ],
+        "description": "The persona to apply to the image"
+      },
+      {
+        "name": "Style",
+        "values": [
+          [
+            "ANIME",
+            "Anime"
+          ],
+          [
+            "CARTOON",
+            "Cartoon"
+          ],
+          [
+            "CLAY",
+            "Clay"
+          ],
+          [
+            "GOTHIC",
+            "Gothic"
+          ],
+          [
+            "GRAPHIC_NOVEL",
+            "Graphic Novel"
+          ],
+          [
+            "LEGO",
+            "Lego"
+          ],
+          [
+            "MEMOJI",
+            "Memoji"
+          ],
+          [
+            "MINECRAFT",
+            "Minecraft"
+          ],
+          [
+            "MINIMALIST",
+            "Minimalist"
+          ],
+          [
+            "PIXEL_ART",
+            "Pixel Art"
+          ],
+          [
+            "RANDOM",
+            "Random"
+          ],
+          [
+            "SIMPSONS",
+            "Simpsons"
+          ],
+          [
+            "SKETCH",
+            "Sketch"
+          ],
+          [
+            "SOUTH_PARK",
+            "South Park"
+          ],
+          [
+            "TOY",
+            "Toy"
+          ],
+          [
+            "WATERCOLOR",
+            "Watercolor"
+          ]
+        ],
+        "description": "The artistic style to apply to the image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/filters",
+    "className": "Filters",
+    "moduleName": "image-generate",
+    "docstring": "Add simple filters to your images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "image_filter",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Vivid",
+        "description": "The filter to apply to the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageFilter",
+        "enumValues": [
+          "Vivid",
+          "Black and White",
+          "Sepia",
+          "Grayscale",
+          "Warm",
+          "Cool"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to apply filter to. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "ImageFilter",
+        "values": [
+          [
+            "VIVID",
+            "Vivid"
+          ],
+          [
+            "BLACK_AND_WHITE",
+            "Black and White"
+          ],
+          [
+            "SEPIA",
+            "Sepia"
+          ],
+          [
+            "GRAYSCALE",
+            "Grayscale"
+          ],
+          [
+            "WARM",
+            "Warm"
+          ],
+          [
+            "COOL",
+            "Cool"
+          ]
+        ],
+        "description": "The filter to apply to the image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/iconic-locations",
+    "className": "Iconic_Locations",
+    "moduleName": "image-generate",
+    "docstring": "Put yourself in an iconic location around the world from a single image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "gender",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "The gender of the person",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Gender",
+        "enumValues": [
+          "none",
+          "male",
+          "female"
+        ]
+      },
+      {
+        "name": "iconic_location",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Eiffel Tower",
+        "description": "The iconic location to place the person in",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "IconicLocation",
+        "enumValues": [
+          "Random",
+          "Eiffel Tower",
+          "Times Square",
+          "Trevi Fountain",
+          "Colosseum",
+          "Statue of Liberty",
+          "Big Ben",
+          "Taj Mahal",
+          "Great Wall of China",
+          "Sydney Opera House",
+          "Machu Picchu",
+          "Golden Gate Bridge",
+          "Arc de Triomphe",
+          "Louvre Museum",
+          "Notre Dame Cathedral",
+          "Palace of Versailles",
+          "Hollywood Sign",
+          "Grand Canyon",
+          "Mount Rushmore",
+          "Brooklyn Bridge",
+          "Yosemite",
+          "Antelope Canyon",
+          "Monument Valley",
+          "Leaning Tower of Pisa",
+          "Vatican City",
+          "Venice",
+          "Florence",
+          "Tower Bridge",
+          "Buckingham Palace",
+          "Edinburgh Castle",
+          "Stonehenge",
+          "Scottish Highlands",
+          "Giant's Causeway",
+          "Cliffs of Moher",
+          "Loch Ness",
+          "Sagrada Familia",
+          "Barcelona",
+          "Santorini",
+          "Acropolis",
+          "Neuschwanstein Castle",
+          "Lisbon",
+          "Reykjavik",
+          "Blue Lagoon",
+          "Northern Lights",
+          "Pyramids of Giza",
+          "Forbidden City",
+          "Mount Fuji",
+          "Tokyo Tower",
+          "Shibuya Crossing",
+          "Fushimi Inari Shrine",
+          "Bondi Beach",
+          "Christ the Redeemer",
+          "Copacabana Beach",
+          "Amazon Rainforest",
+          "Petra",
+          "Angkor Wat",
+          "Chichen Itza",
+          "Burj Khalifa",
+          "Easter Island",
+          "Victoria Falls",
+          "Kilimanjaro",
+          "Maldives",
+          "Bora Bora",
+          "Bali",
+          "Everest Base Camp",
+          "Red Square",
+          "St. Basil's Cathedral"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image of the person to transport to an iconic location. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Gender",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "MALE",
+            "male"
+          ],
+          [
+            "FEMALE",
+            "female"
+          ]
+        ],
+        "description": "The gender of the person"
+      },
+      {
+        "name": "IconicLocation",
+        "values": [
+          [
+            "RANDOM",
+            "Random"
+          ],
+          [
+            "EIFFEL_TOWER",
+            "Eiffel Tower"
+          ],
+          [
+            "TIMES_SQUARE",
+            "Times Square"
+          ],
+          [
+            "TREVI_FOUNTAIN",
+            "Trevi Fountain"
+          ],
+          [
+            "COLOSSEUM",
+            "Colosseum"
+          ],
+          [
+            "STATUE_OF_LIBERTY",
+            "Statue of Liberty"
+          ],
+          [
+            "BIG_BEN",
+            "Big Ben"
+          ],
+          [
+            "TAJ_MAHAL",
+            "Taj Mahal"
+          ],
+          [
+            "GREAT_WALL_OF_CHINA",
+            "Great Wall of China"
+          ],
+          [
+            "SYDNEY_OPERA_HOUSE",
+            "Sydney Opera House"
+          ],
+          [
+            "MACHU_PICCHU",
+            "Machu Picchu"
+          ],
+          [
+            "GOLDEN_GATE_BRIDGE",
+            "Golden Gate Bridge"
+          ],
+          [
+            "ARC_DE_TRIOMPHE",
+            "Arc de Triomphe"
+          ],
+          [
+            "LOUVRE_MUSEUM",
+            "Louvre Museum"
+          ],
+          [
+            "NOTRE_DAME_CATHEDRAL",
+            "Notre Dame Cathedral"
+          ],
+          [
+            "PALACE_OF_VERSAILLES",
+            "Palace of Versailles"
+          ],
+          [
+            "HOLLYWOOD_SIGN",
+            "Hollywood Sign"
+          ],
+          [
+            "GRAND_CANYON",
+            "Grand Canyon"
+          ],
+          [
+            "MOUNT_RUSHMORE",
+            "Mount Rushmore"
+          ],
+          [
+            "BROOKLYN_BRIDGE",
+            "Brooklyn Bridge"
+          ],
+          [
+            "YOSEMITE",
+            "Yosemite"
+          ],
+          [
+            "ANTELOPE_CANYON",
+            "Antelope Canyon"
+          ],
+          [
+            "MONUMENT_VALLEY",
+            "Monument Valley"
+          ],
+          [
+            "LEANING_TOWER_OF_PISA",
+            "Leaning Tower of Pisa"
+          ],
+          [
+            "VATICAN_CITY",
+            "Vatican City"
+          ],
+          [
+            "VENICE",
+            "Venice"
+          ],
+          [
+            "FLORENCE",
+            "Florence"
+          ],
+          [
+            "TOWER_BRIDGE",
+            "Tower Bridge"
+          ],
+          [
+            "BUCKINGHAM_PALACE",
+            "Buckingham Palace"
+          ],
+          [
+            "EDINBURGH_CASTLE",
+            "Edinburgh Castle"
+          ],
+          [
+            "STONEHENGE",
+            "Stonehenge"
+          ],
+          [
+            "SCOTTISH_HIGHLANDS",
+            "Scottish Highlands"
+          ],
+          [
+            "GIANTS_CAUSEWAY",
+            "Giant's Causeway"
+          ],
+          [
+            "CLIFFS_OF_MOHER",
+            "Cliffs of Moher"
+          ],
+          [
+            "LOCH_NESS",
+            "Loch Ness"
+          ],
+          [
+            "SAGRADA_FAMILIA",
+            "Sagrada Familia"
+          ],
+          [
+            "BARCELONA",
+            "Barcelona"
+          ],
+          [
+            "SANTORINI",
+            "Santorini"
+          ],
+          [
+            "ACROPOLIS",
+            "Acropolis"
+          ],
+          [
+            "NEUSCHWANSTEIN_CASTLE",
+            "Neuschwanstein Castle"
+          ],
+          [
+            "LISBON",
+            "Lisbon"
+          ],
+          [
+            "REYKJAVIK",
+            "Reykjavik"
+          ],
+          [
+            "BLUE_LAGOON",
+            "Blue Lagoon"
+          ],
+          [
+            "NORTHERN_LIGHTS",
+            "Northern Lights"
+          ],
+          [
+            "PYRAMIDS_OF_GIZA",
+            "Pyramids of Giza"
+          ],
+          [
+            "FORBIDDEN_CITY",
+            "Forbidden City"
+          ],
+          [
+            "MOUNT_FUJI",
+            "Mount Fuji"
+          ],
+          [
+            "TOKYO_TOWER",
+            "Tokyo Tower"
+          ],
+          [
+            "SHIBUYA_CROSSING",
+            "Shibuya Crossing"
+          ],
+          [
+            "FUSHIMI_INARI_SHRINE",
+            "Fushimi Inari Shrine"
+          ],
+          [
+            "BONDI_BEACH",
+            "Bondi Beach"
+          ],
+          [
+            "CHRIST_THE_REDEEMER",
+            "Christ the Redeemer"
+          ],
+          [
+            "COPACABANA_BEACH",
+            "Copacabana Beach"
+          ],
+          [
+            "AMAZON_RAINFOREST",
+            "Amazon Rainforest"
+          ],
+          [
+            "PETRA",
+            "Petra"
+          ],
+          [
+            "ANGKOR_WAT",
+            "Angkor Wat"
+          ],
+          [
+            "CHICHEN_ITZA",
+            "Chichen Itza"
+          ],
+          [
+            "BURJ_KHALIFA",
+            "Burj Khalifa"
+          ],
+          [
+            "EASTER_ISLAND",
+            "Easter Island"
+          ],
+          [
+            "VICTORIA_FALLS",
+            "Victoria Falls"
+          ],
+          [
+            "KILIMANJARO",
+            "Kilimanjaro"
+          ],
+          [
+            "MALDIVES",
+            "Maldives"
+          ],
+          [
+            "BORA_BORA",
+            "Bora Bora"
+          ],
+          [
+            "BALI",
+            "Bali"
+          ],
+          [
+            "EVEREST_BASE_CAMP",
+            "Everest Base Camp"
+          ],
+          [
+            "RED_SQUARE",
+            "Red Square"
+          ],
+          [
+            "ST_BASILS_CATHEDRAL",
+            "St. Basil's Cathedral"
+          ]
+        ],
+        "description": "The iconic location to place the person in"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/impossible-scenarios",
+    "className": "Impossible_Scenarios",
+    "moduleName": "image-generate",
+    "docstring": "Experience impossible adventures and extreme scenarios from a single image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "gender",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "The gender of the person",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Gender",
+        "enumValues": [
+          "none",
+          "male",
+          "female"
+        ]
+      },
+      {
+        "name": "impossible_scenario",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Floating in space as an astronaut",
+        "description": "The impossible scenario to place the person in",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImpossibleScenario",
+        "enumValues": [
+          "Random",
+          "Floating in space as an astronaut",
+          "Walking on the moon surface",
+          "Spacewalk outside the International Space Station",
+          "Standing on Mars in a spacesuit",
+          "Swimming with great white sharks",
+          "Deep sea diving with giant whales",
+          "Underwater with full scuba gear surrounded by jellyfish",
+          "Skydiving from 30,000 feet",
+          "Wingsuit flying through mountains",
+          "Bungee jumping from a helicopter",
+          "Free climbing El Capitan without ropes",
+          "Base jumping off a skyscraper",
+          "Riding on the back of a great white shark",
+          "Standing face-to-face with a roaring lion",
+          "Swimming with killer whales in Arctic waters",
+          "Gorilla encounter in dense jungle",
+          "Running with a pack of cheetahs",
+          "Standing in the eye of a hurricane",
+          "Surfing a massive tsunami wave",
+          "Volcano exploration in heat-proof suit",
+          "Lightning strike survivor in a storm",
+          "Avalanche escape on skis",
+          "Motorcycle jumping over helicopters",
+          "Hanging from a helicopter ladder",
+          "High-speed car chase as driver",
+          "Zipline across the Grand Canyon",
+          "Parachuting into a volcano",
+          "Flying through clouds without equipment",
+          "Superhero landing with impact crater",
+          "Dragon encounter in medieval armor",
+          "Levitating with magical energy",
+          "Standing on top of Mount Everest"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image of the person to place in an impossible scenario. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Gender",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "MALE",
+            "male"
+          ],
+          [
+            "FEMALE",
+            "female"
+          ]
+        ],
+        "description": "The gender of the person"
+      },
+      {
+        "name": "ImpossibleScenario",
+        "values": [
+          [
+            "RANDOM",
+            "Random"
+          ],
+          [
+            "FLOATING_IN_SPACE_AS_AN_ASTRONAUT",
+            "Floating in space as an astronaut"
+          ],
+          [
+            "WALKING_ON_THE_MOON_SURFACE",
+            "Walking on the moon surface"
+          ],
+          [
+            "SPACEWALK_OUTSIDE_THE_INTERNATIONAL_SPACE_STATION",
+            "Spacewalk outside the International Space Station"
+          ],
+          [
+            "STANDING_ON_MARS_IN_A_SPACESUIT",
+            "Standing on Mars in a spacesuit"
+          ],
+          [
+            "SWIMMING_WITH_GREAT_WHITE_SHARKS",
+            "Swimming with great white sharks"
+          ],
+          [
+            "DEEP_SEA_DIVING_WITH_GIANT_WHALES",
+            "Deep sea diving with giant whales"
+          ],
+          [
+            "UNDERWATER_WITH_FULL_SCUBA_GEAR_SURROUNDED_BY_JELLYFISH",
+            "Underwater with full scuba gear surrounded by jellyfish"
+          ],
+          [
+            "SKYDIVING_FROM_30_000_FEET",
+            "Skydiving from 30,000 feet"
+          ],
+          [
+            "WINGSUIT_FLYING_THROUGH_MOUNTAINS",
+            "Wingsuit flying through mountains"
+          ],
+          [
+            "BUNGEE_JUMPING_FROM_A_HELICOPTER",
+            "Bungee jumping from a helicopter"
+          ],
+          [
+            "FREE_CLIMBING_EL_CAPITAN_WITHOUT_ROPES",
+            "Free climbing El Capitan without ropes"
+          ],
+          [
+            "BASE_JUMPING_OFF_A_SKYSCRAPER",
+            "Base jumping off a skyscraper"
+          ],
+          [
+            "RIDING_ON_THE_BACK_OF_A_GREAT_WHITE_SHARK",
+            "Riding on the back of a great white shark"
+          ],
+          [
+            "STANDING_FACE_TO_FACE_WITH_A_ROARING_LION",
+            "Standing face-to-face with a roaring lion"
+          ],
+          [
+            "SWIMMING_WITH_KILLER_WHALES_IN_ARCTIC_WATERS",
+            "Swimming with killer whales in Arctic waters"
+          ],
+          [
+            "GORILLA_ENCOUNTER_IN_DENSE_JUNGLE",
+            "Gorilla encounter in dense jungle"
+          ],
+          [
+            "RUNNING_WITH_A_PACK_OF_CHEETAHS",
+            "Running with a pack of cheetahs"
+          ],
+          [
+            "STANDING_IN_THE_EYE_OF_A_HURRICANE",
+            "Standing in the eye of a hurricane"
+          ],
+          [
+            "SURFING_A_MASSIVE_TSUNAMI_WAVE",
+            "Surfing a massive tsunami wave"
+          ],
+          [
+            "VOLCANO_EXPLORATION_IN_HEAT_PROOF_SUIT",
+            "Volcano exploration in heat-proof suit"
+          ],
+          [
+            "LIGHTNING_STRIKE_SURVIVOR_IN_A_STORM",
+            "Lightning strike survivor in a storm"
+          ],
+          [
+            "AVALANCHE_ESCAPE_ON_SKIS",
+            "Avalanche escape on skis"
+          ],
+          [
+            "MOTORCYCLE_JUMPING_OVER_HELICOPTERS",
+            "Motorcycle jumping over helicopters"
+          ],
+          [
+            "HANGING_FROM_A_HELICOPTER_LADDER",
+            "Hanging from a helicopter ladder"
+          ],
+          [
+            "HIGH_SPEED_CAR_CHASE_AS_DRIVER",
+            "High-speed car chase as driver"
+          ],
+          [
+            "ZIPLINE_ACROSS_THE_GRAND_CANYON",
+            "Zipline across the Grand Canyon"
+          ],
+          [
+            "PARACHUTING_INTO_A_VOLCANO",
+            "Parachuting into a volcano"
+          ],
+          [
+            "FLYING_THROUGH_CLOUDS_WITHOUT_EQUIPMENT",
+            "Flying through clouds without equipment"
+          ],
+          [
+            "SUPERHERO_LANDING_WITH_IMPACT_CRATER",
+            "Superhero landing with impact crater"
+          ],
+          [
+            "DRAGON_ENCOUNTER_IN_MEDIEVAL_ARMOR",
+            "Dragon encounter in medieval armor"
+          ],
+          [
+            "LEVITATING_WITH_MAGICAL_ENERGY",
+            "Levitating with magical energy"
+          ],
+          [
+            "STANDING_ON_TOP_OF_MOUNT_EVEREST",
+            "Standing on top of Mount Everest"
+          ]
+        ],
+        "description": "The impossible scenario to place the person in"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/multi-image-kontext-max",
+    "className": "Multi_Image_Kontext_Max",
+    "moduleName": "image-generate",
+    "docstring": "An experimental FLUX Kontext model that can combine two input images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_image_1",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First input image. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "input_image_2",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Second input image. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how to combine or transform the two input images",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/multi-image-kontext-pro",
+    "className": "Multi_Image_Kontext_Pro",
+    "moduleName": "image-generate",
+    "docstring": "An experimental model with FLUX Kontext Pro that can combine two input images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_image_1",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First input image. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "input_image_2",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Second input image. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how to combine or transform the two input images",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/multi-image-list",
+    "className": "Multi_Image_List",
+    "moduleName": "image-generate",
+    "docstring": "FLUX Kontext max with list input for multiple images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how to combine or transform the input images",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/portrait-series",
+    "className": "Portrait_Series",
+    "moduleName": "image-generate",
+    "docstring": "Create a series of portrait photos from a single image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "background",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "white",
+        "description": "The background of the photo",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Background",
+        "enumValues": [
+          "white",
+          "black",
+          "gray",
+          "green screen",
+          "neutral",
+          "original"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image of the person to create a series of photos for. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4,
+        "description": "The number of poses to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 13
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "randomize_images",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to randomize the poses",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Background",
+        "values": [
+          [
+            "WHITE",
+            "white"
+          ],
+          [
+            "BLACK",
+            "black"
+          ],
+          [
+            "GRAY",
+            "gray"
+          ],
+          [
+            "GREEN_SCREEN",
+            "green screen"
+          ],
+          [
+            "NEUTRAL",
+            "neutral"
+          ],
+          [
+            "ORIGINAL",
+            "original"
+          ]
+        ],
+        "description": "The background of the photo"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/text-removal",
+    "className": "Text_Removal",
+    "moduleName": "image-generate",
+    "docstring": "Remove all text from an image with FLUX.1 Kontext",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "21:9",
+          "9:21",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to remove text from. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-0_1-webp",
+    "className": "Kontext_0_1_Webp",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-fix-jpeg-compression",
+    "className": "Kontext_Fix_Jpeg_Compression",
+    "moduleName": "image-generate",
+    "docstring": "Use this flux-kontext fine-tune to fix JPEG compression artifacts",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-long-exposure-for-water",
+    "className": "Kontext_Long_Exposure_For_Water",
+    "moduleName": "image-generate",
+    "docstring": "Edit photos of water to be a long exposure using this kontext fine-tune",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-make-person-real",
+    "className": "Kontext_Make_Person_Real",
+    "moduleName": "image-generate",
+    "docstring": "A FLUX Kontext fine-tune to fix plastic AI skin textures",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-old-and-damaged",
+    "className": "Kontext_Old_And_Damaged",
+    "moduleName": "image-generate",
+    "docstring": "Use this kontext fine-tune to turn any photo into an old and damaged photo",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-2004",
+    "className": "Qwen_2004",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on bad photos from 2004",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-bad-70s-food",
+    "className": "Qwen_Bad_70s_Food",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on photos of bad 70s food",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-black-sclera",
+    "className": "Qwen_Black_Sclera",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-dark-art",
+    "className": "Qwen_Dark_Art",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on classical dark artwork",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-fantasy-art",
+    "className": "Qwen_Fantasy_Art",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on fantasy art",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-midjourney-v3",
+    "className": "Qwen_Midjourney_V3",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on Midjourney v3 images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-my-subconscious",
+    "className": "Qwen_My_Subconscious",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on trippy and vibrant FLUX Pro outputs",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-n74",
+    "className": "Qwen_N74",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-tron-ares",
+    "className": "Qwen_Tron_Ares",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on TRON: ARES trailer",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/qwen-william-blake",
+    "className": "Qwen_William_Blake",
+    "moduleName": "image-generate",
+    "docstring": "Qwen fine-tuned on the art of William Blake",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "gaby94500/mamav",
+    "className": "Mamav",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "google/gemini-2.5-flash-image",
+    "className": "Gemini_2_5_Flash_Image",
+    "moduleName": "image-generate",
+    "docstring": "Google's latest image generation model in Gemini 2.5",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "2:3",
+          "3:2",
+          "3:4",
+          "4:3",
+          "4:5",
+          "5:4",
+          "9:16",
+          "16:9",
+          "21:9"
+        ]
+      },
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images to transform or use as reference (supports multiple images)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A text description of the image you want to generate",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output image"
+      }
+    ]
+  },
+  {
+    "endpointId": "ibm-granite/granite-4.0-h-small",
+    "className": "Granite_4_0_H_Small",
+    "moduleName": "image-generate",
+    "docstring": "Granite-4.0-H-Small is a 32B parameter long-context instruct model finetuned from Granite-4.0-H-Small-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "add_generation_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Add generation prompt. Passed to the chat template. Defaults to True.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not specified, the chat template provided by the model will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template_kwargs",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": null,
+        "description": "Additional arguments to be passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "documents",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Documents for request. Passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "max_tokens is deprecated in favor of the max_completion_tokens field.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Chat completion API messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API user prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "repetition_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Repetition penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "response_format",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": null,
+        "description": "An object specifying the format that the model must output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave unspecified to randomize the seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "A list of sequences to stop generation at. For example, [\"<end>\",\"<stop>\"] will stop generation at the first instance of \"<end>\" or \"<stop>\".",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stream",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Request streaming response. Defaults to False.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API system prompt. The chat template provides a good default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tool_choice",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Tool choice for request. If the choice is a specific function, this should be specified as a JSON string.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tools",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Tools for request. Passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "intelligent-utilities/html-to-image",
+    "className": "Html_To_Image",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "file_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FileType",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 867,
+        "description": "Viewport height",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4320
+      },
+      {
+        "name": "html",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "HTML to render",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1680,
+        "description": "Viewport width",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 7680
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "FileType",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      }
+    ]
+  },
+  {
+    "endpointId": "leonardoai/lucid-origin",
+    "className": "Lucid_Origin",
+    "moduleName": "image-generate",
+    "docstring": "Artistic and high-quality visuals with improved prompt adherence, diversity, and definition",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "2:1",
+          "1:2",
+          "3:1",
+          "1:3"
+        ]
+      },
+      {
+        "name": "contrast",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Contrast level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Contrast",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "generation_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Generation mode",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "GenerationMode",
+        "enumValues": [
+          "standard",
+          "ultra"
+        ]
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_enhance",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enhance the prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Style to use for the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "bokeh",
+          "cinematic",
+          "cinematic_close_up",
+          "creative",
+          "dynamic",
+          "fashion",
+          "film",
+          "food",
+          "hdr",
+          "long_exposure",
+          "macro",
+          "minimalist",
+          "monochrome",
+          "moody",
+          "neutral",
+          "none",
+          "portrait",
+          "retro",
+          "stock_photo",
+          "unprocessed",
+          "vibrant"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_3_1",
+            "3:1"
+          ],
+          [
+            "RATIO_1_3",
+            "1:3"
+          ]
+        ],
+        "description": "Aspect ratio of the output image"
+      },
+      {
+        "name": "Contrast",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Contrast level"
+      },
+      {
+        "name": "GenerationMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "ULTRA",
+            "ultra"
+          ]
+        ],
+        "description": "Generation mode"
+      },
+      {
+        "name": "Style",
+        "values": [
+          [
+            "BOKEH",
+            "bokeh"
+          ],
+          [
+            "CINEMATIC",
+            "cinematic"
+          ],
+          [
+            "CINEMATIC_CLOSE_UP",
+            "cinematic_close_up"
+          ],
+          [
+            "CREATIVE",
+            "creative"
+          ],
+          [
+            "DYNAMIC",
+            "dynamic"
+          ],
+          [
+            "FASHION",
+            "fashion"
+          ],
+          [
+            "FILM",
+            "film"
+          ],
+          [
+            "FOOD",
+            "food"
+          ],
+          [
+            "HDR",
+            "hdr"
+          ],
+          [
+            "LONG_EXPOSURE",
+            "long_exposure"
+          ],
+          [
+            "MACRO",
+            "macro"
+          ],
+          [
+            "MINIMALIST",
+            "minimalist"
+          ],
+          [
+            "MONOCHROME",
+            "monochrome"
+          ],
+          [
+            "MOODY",
+            "moody"
+          ],
+          [
+            "NEUTRAL",
+            "neutral"
+          ],
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "PORTRAIT",
+            "portrait"
+          ],
+          [
+            "RETRO",
+            "retro"
+          ],
+          [
+            "STOCK_PHOTO",
+            "stock_photo"
+          ],
+          [
+            "UNPROCESSED",
+            "unprocessed"
+          ],
+          [
+            "VIBRANT",
+            "vibrant"
+          ]
+        ],
+        "description": "Style to use for the output image"
+      }
+    ]
+  },
+  {
+    "endpointId": "leonardoai/phoenix-1.0",
+    "className": "Phoenix_1_0",
+    "moduleName": "image-generate",
+    "docstring": "Leonardo AI’s first foundational model produces images up to 5 megapixels (fast, quality and ultra modes)",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "3:2",
+        "description": "Aspect ratio of the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "2:1",
+          "1:2",
+          "3:1",
+          "1:3"
+        ]
+      },
+      {
+        "name": "contrast",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Contrast level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Contrast",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "generation_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "quality",
+        "description": "Generation mode",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "GenerationMode",
+        "enumValues": [
+          "fast",
+          "quality",
+          "ultra"
+        ]
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_enhance",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enhance the prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Style to use for the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "3d_render",
+          "bokeh",
+          "cinematic",
+          "cinematic_concept",
+          "creative",
+          "dynamic",
+          "fashion",
+          "graphic_design_pop_art",
+          "graphic_design_vector",
+          "hdr",
+          "illustration",
+          "macro",
+          "minimalist",
+          "moody",
+          "none",
+          "portrait",
+          "pro_bw_photography",
+          "pro_color_photography",
+          "pro_film_photography",
+          "portrait_fashion",
+          "ray_traced",
+          "sketch_bw",
+          "sketch_color",
+          "stock_photo",
+          "vibrant"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_3_1",
+            "3:1"
+          ],
+          [
+            "RATIO_1_3",
+            "1:3"
+          ]
+        ],
+        "description": "Aspect ratio of the output image"
+      },
+      {
+        "name": "Contrast",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Contrast level"
+      },
+      {
+        "name": "GenerationMode",
+        "values": [
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ],
+          [
+            "ULTRA",
+            "ultra"
+          ]
+        ],
+        "description": "Generation mode"
+      },
+      {
+        "name": "Style",
+        "values": [
+          [
+            "_3D_RENDER",
+            "3d_render"
+          ],
+          [
+            "BOKEH",
+            "bokeh"
+          ],
+          [
+            "CINEMATIC",
+            "cinematic"
+          ],
+          [
+            "CINEMATIC_CONCEPT",
+            "cinematic_concept"
+          ],
+          [
+            "CREATIVE",
+            "creative"
+          ],
+          [
+            "DYNAMIC",
+            "dynamic"
+          ],
+          [
+            "FASHION",
+            "fashion"
+          ],
+          [
+            "GRAPHIC_DESIGN_POP_ART",
+            "graphic_design_pop_art"
+          ],
+          [
+            "GRAPHIC_DESIGN_VECTOR",
+            "graphic_design_vector"
+          ],
+          [
+            "HDR",
+            "hdr"
+          ],
+          [
+            "ILLUSTRATION",
+            "illustration"
+          ],
+          [
+            "MACRO",
+            "macro"
+          ],
+          [
+            "MINIMALIST",
+            "minimalist"
+          ],
+          [
+            "MOODY",
+            "moody"
+          ],
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "PORTRAIT",
+            "portrait"
+          ],
+          [
+            "PRO_BW_PHOTOGRAPHY",
+            "pro_bw_photography"
+          ],
+          [
+            "PRO_COLOR_PHOTOGRAPHY",
+            "pro_color_photography"
+          ],
+          [
+            "PRO_FILM_PHOTOGRAPHY",
+            "pro_film_photography"
+          ],
+          [
+            "PORTRAIT_FASHION",
+            "portrait_fashion"
+          ],
+          [
+            "RAY_TRACED",
+            "ray_traced"
+          ],
+          [
+            "SKETCH_BW",
+            "sketch_bw"
+          ],
+          [
+            "SKETCH_COLOR",
+            "sketch_color"
+          ],
+          [
+            "STOCK_PHOTO",
+            "stock_photo"
+          ],
+          [
+            "VIBRANT",
+            "vibrant"
+          ]
+        ],
+        "description": "Style to use for the output image"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/flux-content-filter",
+    "className": "Flux_Content_Filter",
+    "moduleName": "image-generate",
+    "docstring": "Flux Content Filter - Check for public figures and copyright concerns",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to analyze for content filtering",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "nsfw_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.85,
+        "description": "NSFW detection threshold (0.0 to 1.0)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to analyze for copyright concerns or public figures",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lucataco/gpt-oss-safeguard-20b",
+    "className": "Gpt_Oss_Safeguard_20b",
+    "moduleName": "image-generate",
+    "docstring": "classify text content based on safety policies that you provide and perform a suite of foundational safety tasks",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "max_new_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 512,
+        "description": "Maximum number of tokens to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8192
+      },
+      {
+        "name": "policy",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Safety policy or rules to evaluate the prompt against. This defines the criteria for classification.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Your bank details are needed to complete this transaction.",
+        "description": "Input prompt or question to evaluate",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Reasoning effort level: 'low' for faster responses on straightforward cases, 'medium' for balanced reasoning (default), or 'high' for deeper analysis of complex edge cases",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "repetition_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Repetition penalty to reduce repetitive text (1.0 = no penalty)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.8,
+        "max": 2
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Sampling temperature (0 for greedy decoding)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Nucleus sampling top-p",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Reasoning effort level: 'low' for faster responses on straightforward cases, 'medium' for balanced reasoning (default), or 'high' for deeper analysis of complex edge cases"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/kontext-meta-cars",
+    "className": "Kontext_Meta_Cars",
+    "moduleName": "image-generate",
+    "docstring": "Change your car into a CDMX Meta Car",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/kontext-realearth",
+    "className": "Kontext_Realearth",
+    "moduleName": "image-generate",
+    "docstring": "This Kontext LoRA turns basic satellite images into quality drone shots",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/merge-img",
+    "className": "Merge_Img",
+    "moduleName": "image-generate",
+    "docstring": "Simple tool to merge a foreground and background image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "background",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "JPG image to be used as background",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "foreground",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "PNG image with transparency to be used as foreground",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "position_x",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "X coordinate for foreground image position (optional, defaults to center)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "position_y",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Y coordinate for foreground image position (optional, defaults to center)",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lucataco/qwen-davinci",
+    "className": "Qwen_Davinci",
+    "moduleName": "image-generate",
+    "docstring": "Qwen-image fine-tuned on Drawings by Leonardo da Vinci",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/vid2webp",
+    "className": "Vid2webp",
+    "moduleName": "image-generate",
+    "docstring": "Convert your video into webp format (with looping)",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Frames per second for the output",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 60
+      },
+      {
+        "name": "loop",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable infinite looping",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "luma/reframe-image",
+    "className": "Reframe_Image",
+    "moduleName": "image-generate",
+    "docstring": "Change the aspect ratio of any photo using AI (not cropping)",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "9:21",
+          "21:9"
+        ]
+      },
+      {
+        "name": "grid_position_x",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The x position of the input in the grid, in pixels. Controls horizontal positioning of the source within the target output dimensions.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "grid_position_y",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The y position of the input in the grid, in pixels. Controls vertical positioning of the source within the target output dimensions.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The image to reframe",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_url",
+        "tsType": "string",
+        "propType": "image",
+        "default": "",
+        "description": "URL of the image to reframe",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "photon-flash-1",
+        "description": "The model to use for the reframe generation",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "photon-flash-1",
+          "photon-1"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A prompt to guide the reframing generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "x_end",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The x end of the crop bounds, in pixels. Defines the right boundary where your source will be placed in the output frame. The distance between x_start and x_end determines the resized width of your content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "x_start",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The x start of the crop bounds, in pixels. Defines the left boundary where your source will be placed in the output frame. The distance between x_start and x_end determines the resized width of your content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "y_end",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The y end of the crop bounds, in pixels. Defines the bottom boundary where your source will be placed in the output frame. The distance between y_start and y_end determines the resized height of your content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "y_start",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The y start of the crop bounds, in pixels. Defines the top boundary where your source will be placed in the output frame. The distance between y_start and y_end determines the resized height of your content.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio of the output"
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "PHOTON_FLASH_1",
+            "photon-flash-1"
+          ],
+          [
+            "PHOTON_1",
+            "photon-1"
+          ]
+        ],
+        "description": "The model to use for the reframe generation"
+      }
+    ]
+  },
+  {
+    "endpointId": "maikocode/ascii-style",
+    "className": "Ascii_Style",
+    "moduleName": "image-generate",
+    "docstring": "Turn image into ASCII style. If you like this LoRA visit my app: YourAIPhotographer.com",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "meta/llama-guard-4-12b",
+    "className": "Llama_Guard_4_12b",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty parameter - positive values penalize the repetition of tokens.",
+        "fieldType": "input",
+        "required": false,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "name": "image_input",
+        "tsType": "string[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 512,
+        "description": "Maximum number of completion tokens to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 1024
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty parameter - positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+        "fieldType": "input",
+        "required": false,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Sampling temperature between 0 and 2",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Nucleus sampling parameter - the model considers the results of the tokens with top_p probability mass. (0.1 means only the tokens comprising the top 10% probability mass are considered.)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "moonshotai/kimi-k2-thinking",
+    "className": "Kimi_K2_Thinking",
+    "moduleName": "image-generate",
+    "docstring": "Kimi K2 Thinking is the latest, most capable version of an open-source thinking model.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2048,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Top-p (nucleus) sampling",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "nvidia/sana-sprint-1.6b",
+    "className": "Sana_Sprint_1_6b",
+    "moduleName": "image-generate",
+    "docstring": "SANA-Sprint: One-Step Diffusion with Continuous-Time Consistency Distillation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4.5,
+        "description": "CFG guidance scale",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1024,
+        "description": "Height of output image",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 4096
+      },
+      {
+        "name": "inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Number of sampling steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "intermediate_timesteps",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.3,
+        "description": "Intermediate timestep value (only used when inference_steps=2, recommended values: 1.0-1.4)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 1.5
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "a tiny astronaut hatching from an egg on the moon",
+        "description": "Input prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Seed value. Set to a value less than 0 to randomize the seed",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1024,
+        "description": "Width of output image",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 4096
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/clip",
+    "className": "Clip",
+    "moduleName": "image-generate",
+    "docstring": "Official CLIP models, generate CLIP (clip-vit-large-patch14) text & image embeddings",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to encode",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Input text to encode",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/dall-e-2",
+    "className": "Dall_E_2",
+    "moduleName": "image-generate",
+    "docstring": "The original classic DALLᐧE 2",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "number_of_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate (1-10)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A text description of the desired image",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/gpt-image-1",
+    "className": "Gpt_Image_1",
+    "moduleName": "image-generate",
+    "docstring": "A multimodal image generation model that creates high-quality images. You need to bring your own verified OpenAI key to use this model. Your OpenAI account will be charged for usage.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "background",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Set whether the background is transparent or opaque or choose automatically",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Background",
+        "enumValues": [
+          "auto",
+          "transparent",
+          "opaque"
+        ]
+      },
+      {
+        "name": "input_fidelity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "low",
+        "description": "Control how much effort the model will exert to match the style and features, especially facial features, of input images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "InputFidelity",
+        "enumValues": [
+          "low",
+          "high"
+        ]
+      },
+      {
+        "name": "input_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "A list of images to use as input for the generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "moderation",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Content moderation level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Moderation",
+        "enumValues": [
+          "auto",
+          "low"
+        ]
+      },
+      {
+        "name": "number_of_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate (1-10)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "openai_api_key",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Your OpenAI API key",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_compression",
+        "tsType": "number",
+        "propType": "int",
+        "default": 90,
+        "description": "Compression level (0-100%)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A text description of the desired image",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The quality of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "low",
+          "medium",
+          "high",
+          "auto"
+        ]
+      },
+      {
+        "name": "user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "An optional unique identifier representing your end-user. This helps OpenAI monitor and detect abuse.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "The aspect ratio of the generated image"
+      },
+      {
+        "name": "Background",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "TRANSPARENT",
+            "transparent"
+          ],
+          [
+            "OPAQUE",
+            "opaque"
+          ]
+        ],
+        "description": "Set whether the background is transparent or opaque or choose automatically"
+      },
+      {
+        "name": "InputFidelity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Control how much effort the model will exert to match the style and features, especially facial features, of input images"
+      },
+      {
+        "name": "Moderation",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "LOW",
+            "low"
+          ]
+        ],
+        "description": "Content moderation level"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The quality of the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-image-1-mini",
+    "className": "Gpt_Image_1_Mini",
+    "moduleName": "image-generate",
+    "docstring": "A cost-efficient version of GPT Image 1",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "background",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Set whether the background is transparent or opaque or choose automatically",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Background",
+        "enumValues": [
+          "auto",
+          "transparent",
+          "opaque"
+        ]
+      },
+      {
+        "name": "input_fidelity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "low",
+        "description": "Control how much effort the model will exert to match the style and features, especially facial features, of input images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "InputFidelity",
+        "enumValues": [
+          "low",
+          "high"
+        ]
+      },
+      {
+        "name": "input_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "A list of images to use as input for the generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "moderation",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Content moderation level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Moderation",
+        "enumValues": [
+          "auto",
+          "low"
+        ]
+      },
+      {
+        "name": "number_of_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate (1-10)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "openai_api_key",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Your OpenAI API key",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "output_compression",
+        "tsType": "number",
+        "propType": "int",
+        "default": 90,
+        "description": "Compression level (0-100%)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A text description of the desired image",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The quality of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "low",
+          "medium",
+          "high",
+          "auto"
+        ]
+      },
+      {
+        "name": "user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "An optional unique identifier representing your end-user. This helps OpenAI monitor and detect abuse.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "The aspect ratio of the generated image"
+      },
+      {
+        "name": "Background",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "TRANSPARENT",
+            "transparent"
+          ],
+          [
+            "OPAQUE",
+            "opaque"
+          ]
+        ],
+        "description": "Set whether the background is transparent or opaque or choose automatically"
+      },
+      {
+        "name": "InputFidelity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Control how much effort the model will exert to match the style and features, especially facial features, of input images"
+      },
+      {
+        "name": "Moderation",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "LOW",
+            "low"
+          ]
+        ],
+        "description": "Content moderation level"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The quality of the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "perceptron-ai-inc/isaac-0.1",
+    "className": "Isaac_0_1",
+    "moduleName": "image-generate",
+    "docstring": "an open-source, 2B-parameter model built for real-world applications",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for analysis",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "max_new_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 256,
+        "description": "Maximum number of tokens to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 512
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Determine whether it is safe to cross the street. Look for signage and moving traffic.",
+        "description": "Prompt for the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "response",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "box",
+        "description": "Response type: box for bounding boxes, point for coordinates, polygon for shapes, text for description only",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Response",
+        "enumValues": [
+          "text",
+          "box",
+          "point",
+          "polygon"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Response",
+        "values": [
+          [
+            "TEXT",
+            "text"
+          ],
+          [
+            "BOX",
+            "box"
+          ],
+          [
+            "POINT",
+            "point"
+          ],
+          [
+            "POLYGON",
+            "polygon"
+          ]
+        ],
+        "description": "Response type: box for bounding boxes, point for coordinates, polygon for shapes, text for description only"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/flux-fast",
+    "className": "Flux_Fast",
+    "moduleName": "image-generate",
+    "docstring": "This is the fastest Flux endpoint in the world.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21"
+        ]
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3.5,
+        "description": "Guidance scale",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_size",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1024,
+        "description": "Base image size (longest side)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 28,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Output quality (for jpg and webp)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Seed",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Extra Juiced 🔥 (more speed)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (default)",
+          "Extra Juiced 🔥 (more speed)",
+          "Blink of an eye 👁️"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "Aspect ratio of the output image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_DEFAULT",
+            "Juiced 🔥 (default)"
+          ],
+          [
+            "EXTRA_JUICED_MORE_SPEED",
+            "Extra Juiced 🔥 (more speed)"
+          ],
+          [
+            "BLINK_OF_AN_EYE",
+            "Blink of an eye 👁️"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/hidream-l1-dev",
+    "className": "Hidream_L1_Dev",
+    "moduleName": "image-generate",
+    "docstring": "This is an optimised version of the hidream-l1-dev model using the pruna ai optimisation toolkit!",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "model_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "dev",
+        "description": "Model type",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelType",
+        "enumValues": [
+          "dev"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 100,
+        "description": "Output quality (for jpg and webp)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024 × 1024 (Square)",
+        "description": "Output resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1024 × 1024 (Square)",
+          "768 × 1360 (Portrait)",
+          "1360 × 768 (Landscape)",
+          "880 × 1168 (Portrait)",
+          "1168 × 880 (Landscape)",
+          "1248 × 832 (Landscape)",
+          "832 × 1248 (Portrait)"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed (-1 for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Lightly Juiced 🍊 (more consistent)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Unsqueezed 🍋 (highest quality)",
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (more speed)",
+          "Extra Juiced 🚀 (even more speed)"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ModelType",
+        "values": [
+          [
+            "DEV",
+            "dev"
+          ]
+        ],
+        "description": "Model type"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1024_1024_SQUARE",
+            "1024 × 1024 (Square)"
+          ],
+          [
+            "_768_1360_PORTRAIT",
+            "768 × 1360 (Portrait)"
+          ],
+          [
+            "_1360_768_LANDSCAPE",
+            "1360 × 768 (Landscape)"
+          ],
+          [
+            "_880_1168_PORTRAIT",
+            "880 × 1168 (Portrait)"
+          ],
+          [
+            "_1168_880_LANDSCAPE",
+            "1168 × 880 (Landscape)"
+          ],
+          [
+            "_1248_832_LANDSCAPE",
+            "1248 × 832 (Landscape)"
+          ],
+          [
+            "_832_1248_PORTRAIT",
+            "832 × 1248 (Portrait)"
+          ]
+        ],
+        "description": "Output resolution"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "UNSQUEEZED_HIGHEST_QUALITY",
+            "Unsqueezed 🍋 (highest quality)"
+          ],
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_MORE_SPEED",
+            "Juiced 🔥 (more speed)"
+          ],
+          [
+            "EXTRA_JUICED_EVEN_MORE_SPEED",
+            "Extra Juiced 🚀 (even more speed)"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/hidream-l1-fast",
+    "className": "Hidream_L1_Fast",
+    "moduleName": "image-generate",
+    "docstring": "This is an optimised version of the hidream-l1 model using the pruna ai optimisation toolkit!",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "model_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "fast",
+        "description": "Model type",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelType",
+        "enumValues": [
+          "fast"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt for generated image. Leave blank to use the default negative prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 100,
+        "description": "Output quality (for jpg and webp)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024 × 1024 (Square)",
+        "description": "Output resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1024 × 1024 (Square)",
+          "768 × 1360 (Portrait)",
+          "1360 × 768 (Landscape)",
+          "880 × 1168 (Portrait)",
+          "1168 × 880 (Landscape)",
+          "1248 × 832 (Landscape)",
+          "832 × 1248 (Portrait)"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed (-1 for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Extra Juiced 🚀 (even more speed)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Unsqueezed 🍋 (highest quality)",
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (more speed)",
+          "Extra Juiced 🚀 (even more speed)"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ModelType",
+        "values": [
+          [
+            "FAST",
+            "fast"
+          ]
+        ],
+        "description": "Model type"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1024_1024_SQUARE",
+            "1024 × 1024 (Square)"
+          ],
+          [
+            "_768_1360_PORTRAIT",
+            "768 × 1360 (Portrait)"
+          ],
+          [
+            "_1360_768_LANDSCAPE",
+            "1360 × 768 (Landscape)"
+          ],
+          [
+            "_880_1168_PORTRAIT",
+            "880 × 1168 (Portrait)"
+          ],
+          [
+            "_1168_880_LANDSCAPE",
+            "1168 × 880 (Landscape)"
+          ],
+          [
+            "_1248_832_LANDSCAPE",
+            "1248 × 832 (Landscape)"
+          ],
+          [
+            "_832_1248_PORTRAIT",
+            "832 × 1248 (Portrait)"
+          ]
+        ],
+        "description": "Output resolution"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "UNSQUEEZED_HIGHEST_QUALITY",
+            "Unsqueezed 🍋 (highest quality)"
+          ],
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_MORE_SPEED",
+            "Juiced 🔥 (more speed)"
+          ],
+          [
+            "EXTRA_JUICED_EVEN_MORE_SPEED",
+            "Extra Juiced 🚀 (even more speed)"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/hidream-l1-full",
+    "className": "Hidream_L1_Full",
+    "moduleName": "image-generate",
+    "docstring": "This is an optimised version of the hidream-full model using the pruna ai optimisation toolkit!",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "model_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "full",
+        "description": "Model type",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelType",
+        "enumValues": [
+          "full"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 100,
+        "description": "Output quality (for jpg and webp)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024 × 1024 (Square)",
+        "description": "Output resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1024 × 1024 (Square)",
+          "768 × 1360 (Portrait)",
+          "1360 × 768 (Landscape)",
+          "880 × 1168 (Portrait)",
+          "1168 × 880 (Landscape)",
+          "1248 × 832 (Landscape)",
+          "832 × 1248 (Portrait)"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed (-1 for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Lightly Juiced 🍊 (more consistent)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Unsqueezed 🍋 (highest quality)",
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (more speed)",
+          "Extra Juiced 🚀 (even more speed)"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ModelType",
+        "values": [
+          [
+            "FULL",
+            "full"
+          ]
+        ],
+        "description": "Model type"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1024_1024_SQUARE",
+            "1024 × 1024 (Square)"
+          ],
+          [
+            "_768_1360_PORTRAIT",
+            "768 × 1360 (Portrait)"
+          ],
+          [
+            "_1360_768_LANDSCAPE",
+            "1360 × 768 (Landscape)"
+          ],
+          [
+            "_880_1168_PORTRAIT",
+            "880 × 1168 (Portrait)"
+          ],
+          [
+            "_1168_880_LANDSCAPE",
+            "1168 × 880 (Landscape)"
+          ],
+          [
+            "_1248_832_LANDSCAPE",
+            "1248 × 832 (Landscape)"
+          ],
+          [
+            "_832_1248_PORTRAIT",
+            "832 × 1248 (Portrait)"
+          ]
+        ],
+        "description": "Output resolution"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "UNSQUEEZED_HIGHEST_QUALITY",
+            "Unsqueezed 🍋 (highest quality)"
+          ],
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_MORE_SPEED",
+            "Juiced 🔥 (more speed)"
+          ],
+          [
+            "EXTRA_JUICED_EVEN_MORE_SPEED",
+            "Extra Juiced 🚀 (even more speed)"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-image",
+    "className": "P_Image",
+    "moduleName": "image-generate",
+    "docstring": "A sub 1 second text-to-image model built for production use cases.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "custom"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "hf_api_token",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "HuggingFace API token. If you're using a HuggingFace LoRAs that needs authentication, you'll need to provide an API token.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Determines how strongly the main LoRA should be applied. 0.5 usually works well for most LoRAs.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>]. HuggingFace LoRAs may require an API token to access, which you can provide in the `hf_api_token` input.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_upsampling",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Upsample the prompt with an LLM.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-image-trainer",
+    "className": "P_Image_Trainer",
+    "moduleName": "image-generate",
+    "docstring": "Fast LoRA trainer for p-image, a super fast text-to-image model developed by Pruna AI. Use LoRAs here: https://replicate.com/prunaai/p-image-lora. Find or contribute LoRAs here: https://huggingface.co/collections/PrunaAI/p-image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "default_caption",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Default caption to use when caption files are missing. If not provided and captions are missing, training will fail.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_data",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Zip archive with images of a consistent style. Use at least 10 images. The zip can also contain a text file for each image (e.g., photo.txt for photo.jpg) to specify edit instructions for the image pair. You can also pass a URL pointing to the zip file instead of uploading a file directly.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0001,
+        "description": "Learning rate applied to trainable parameters",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.00001,
+        "max": 0.01
+      },
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1000,
+        "description": "Total number of training steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 5000
+      },
+      {
+        "name": "training_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "Type of training to perform",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TrainingType",
+        "enumValues": [
+          "content",
+          "style",
+          "balanced"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "TrainingType",
+        "values": [
+          [
+            "CONTENT",
+            "content"
+          ],
+          [
+            "STYLE",
+            "style"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ]
+        ],
+        "description": "Type of training to perform"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/sdxl-lightning",
+    "className": "Sdxl_Lightning",
+    "moduleName": "image-generate",
+    "docstring": "This is the fastest sdxl-lightning endpoint in the world on A100, contact us for more at pruna.ai",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Guidance scale",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1024,
+        "description": "Image height",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1024,
+        "description": "Image width",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Output format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Output quality (for jpg and webp)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 42,
+        "description": "Seed",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Output format"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/wan-2.2-image",
+    "className": "Wan_2_2_Image",
+    "moduleName": "image-generate",
+    "docstring": "This model generates beautiful cinematic 2 megapixel images in 3-4 seconds and is derived from the Wan 2.2 model through optimisation techniques from the pruna package",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "21:9"
+        ]
+      },
+      {
+        "name": "juiced",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Faster inference with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale_transformer",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the transformer LoRA should be applied.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale_transformer_2",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the transformer_2 LoRA should be applied.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_weights_transformer",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights for transformer. Supports arbitrary .safetensors URLs from the Internet (for example, 'https://huggingface.co/TheRaf7/instagirl-v2/resolve/main/Instagirlv2.0_hinoise.safetensors')",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_weights_transformer_2",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights for transformer_2. Supports arbitrary .safetensors URLs from the Internet. Can be different from transformer LoRA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 2,
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "2"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpg",
+          "webp"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-fusion",
+    "className": "Qwen_Image_Edit_Plus_Lora_Fusion",
+    "moduleName": "image-generate",
+    "docstring": "Fusion – Product/object blending that fixes perspective and lighting so the subject melts into a new background via the Fusion LoRA.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "溶图,纠正产品透视角度和光影并使产品融入背景, 描述新的环境与灯光让主体自然融入. Blend the product into a modern showroom with warm diffused lighting.",
+        "description": "Prompt hint: paste the Chinese trigger `溶图,纠正产品透视角度和光影并使产品融入背景` (it means “blend the product into the background with corrected perspective and lighting”), then describe in English the scene and lighting you want.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-next-scene",
+    "className": "Qwen_Image_Edit_Plus_Lora_Next_Scene",
+    "moduleName": "image-generate",
+    "docstring": "Next Scene – “Next beat” cinematic edits that keep subject identity while steering to the next camera move via the Next Scene LoRA",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Next Scene: The camera glides forward as warm cinematic light reveals the wider setting.",
+        "description": "Prompt hint: start with `Next Scene:` then describe the new camera move, framing, and lighting so the shot feels like the next beat in a cinematic sequence.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-photo-to-anime",
+    "className": "Qwen_Image_Edit_Plus_Lora_Photo_To_Anime",
+    "moduleName": "image-generate",
+    "docstring": "Photo to Anime – Stylized conversion that turns photos into crisp cel-shaded anime frames using the Photo-to-Anime LoRA.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "transform into anime, clean line art, vibrant cel-shaded colors",
+        "description": "Prompt hint: `transform into anime` and optionally add style cues (cel shading, energetic lighting, manga line work).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-relight",
+    "className": "Qwen_Image_Edit_Plus_Lora_Relight",
+    "moduleName": "image-generate",
+    "docstring": "Relight – Soft, curtain-filtered relighting that repaints the scene with golden-hour or moody tones using the Relight LoRA.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "重新照明,使用窗帘透光(柔和漫射)的光线对图片进行重新照明, 带来温暖的日落氛围. Relight with soft window glow and golden-hour warmth.",
+        "description": "Prompt hint: paste `重新照明,使用窗帘透光(柔和漫射)的光线对图片进行重新照明` (meaning “relight the scene with soft curtain-filtered light”), then continue in English with the mood or color temperature you want.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-skin",
+    "className": "Qwen_Image_Edit_Plus_Lora_Skin",
+    "moduleName": "image-generate",
+    "docstring": "Skin – Natural beauty retouch that enhances pores and tonal variation (no plastic skin) via the Skin LoRA.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "make the subject's skin details more prominent and natural, keep pores and tonal variation",
+        "description": "Prompt hint: `make the subject's skin details more prominent and natural` and specify the retouch mood (e.g. retain pores, flattering studio light).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-edit-multiangle",
+    "className": "Qwen_Edit_Multiangle",
+    "moduleName": "image-generate",
+    "docstring": "Camera-aware edits for Qwen/Qwen-Image-Edit-2509 with Lightning + multi-angle LoRA",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If num_inference_steps is omitted, true runs the 4-step fast preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.25,
+        "description": "Strength applied to the selected LoRA.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "dx8152/Qwen-Edit-2509-Multiple-angles",
+        "description": "LoRA weights to apply. Pass a Hugging Face repo slug like 'dx8152/Qwen-Edit-2509-Multiple-angles' or a direct .safetensors/zip/tar URL (for example, 'https://huggingface.co/flymy-ai/qwen-image-lora/resolve/main/pytorch_lora_weights.safetensors', 'https://example.com/lora_weights.tar.gz', or 'https://example.com/lora_weights.zip').",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "move_forward",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Move the camera forward (zoom in). Higher values push toward a close-up framing.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (4 or 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional text instruction appended after the camera directive.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rotate_degrees",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Camera rotation in degrees. Positive rotates left, negative rotates right.",
+        "fieldType": "input",
+        "required": false,
+        "min": -90,
+        "max": 90
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "use_wide_angle",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Switch to a wide-angle lens instruction.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "vertical_tilt",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Vertical camera tilt. -1 = bird's-eye, 0 = level, 1 = worm's-eye.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-2512",
+    "className": "Qwen_Image_2512",
+    "moduleName": "image-generate",
+    "docstring": "Qwen Image 2512 is an improved version of Qwen Image with more realistic human generation, finer textures, and stronger text rendering",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "custom"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Use the model with additional optimizations for faster generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance for generated image. Use higher values for stronger prompt adherence.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 2048
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image2image generation. The aspect ratio of your output will match this image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": " ",
+        "description": "Negative prompt for image generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 40,
+        "description": "Number of denoising steps. Use less steps for faster generation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 20,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Strength for image2image generation. 1.0 corresponds to full destruction of information in image.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-edit-2511",
+    "className": "Qwen_Image_Edit_2511",
+    "moduleName": "image-generate",
+    "docstring": "An enhanced version over Qwen-Image-Edit-2509, featuring multiple improvements including notably better consistency",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Images to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength applied to the selected LoRA.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Pass a Hugging Face repo slug (for example 'owner/model') or a direct .safetensors URL. Leave blank to run without a LoRA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-edit-plus-lora",
+    "className": "Qwen_Image_Edit_Plus_Lora",
+    "moduleName": "image-generate",
+    "docstring": "Qwen Image Edit 2509 LoRA explorer, uses HuggingFace URLs to load any safetensor",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Images to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength applied to the selected LoRA.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Pass a Hugging Face repo slug (for example 'owner/model') or a direct .safetensors/zip/tar URL such as 'https://huggingface.co/flymy-ai/qwen-image-lora/resolve/main/pytorch_lora_weights.safetensors'. Leave blank to run without a LoRA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-lora-trainer-legacy",
+    "className": "Qwen_Image_Lora_Trainer_Legacy",
+    "moduleName": "image-generate",
+    "docstring": "Fine-tunable Qwen Image model with exceptional composition abilities - train custom LoRAs for any style or subject",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-remove-background",
+    "className": "Recraft_Remove_Background",
+    "moduleName": "image-generate",
+    "docstring": "Automated background removal for images. Tuned for AI-generated content, product photos, portraits, and design workflows",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to remove background from. Supported formats: PNG, JPG, WEBP. Max 5MB, max 16MP, max dimension 4096px, min dimension 256px.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "recraft-ai/recraft-vectorize",
+    "className": "Recraft_Vectorize",
+    "moduleName": "image-generate",
+    "docstring": "Convert raster images to high-quality SVG format with precision and clean vector paths, perfect for logos, icons, and scalable graphics.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Raster image to convert to SVG format. Supported formats: PNG, JPG, WEBP. Max 5MB, max 16MP, max dimension 4096px, min dimension 256px.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "retro-diffusion/rd-fast",
+    "className": "Rd_Fast",
+    "moduleName": "image-generate",
+    "docstring": "Fast pixel art image generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "bypass_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable automatic prompt expansion",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 256,
+        "description": "Image height",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-image generation or reference. Will be converted to RGB without transparency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "input_palette",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference palette image to guide color choices",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "remove_bg",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Remove background to create transparent images",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Prompt strength in image-to-image generation. Higher values give closer adherence to the prompt, and lower values use more information from the input image. Only used when input_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "default",
+        "description": "Style to apply to the generated image\n\ndefault: Simple clean pixel art, with Anime illustration influences\nsimple: Simple shading with minimalist shapes and designs\ndetailed: Pixel art with lots of shading and details\nretro: A classic arcade game aesthetic inspired by early PC games\ngame_asset: Distinct assets set on a simple background\nportrait: Character portrait focused images with high detail\ntexture: Flat game textures like stones, bricks, or wood\nui: User interface boxes and buttons\nitem_sheet: Sheets of objects placed on a simple background\ncharacter_turnaround: Character sprites viewed from different angles\n1_bit: Two color black and white only images\nlow_res: General low resolution pixel art images\nmc_item: Minecraft-styled items with automatic transparency\nmc_texture: Minecraft-styled flat textures, like grass, stones, or wood\nno_style: Pixel art with no style influence applied",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "default",
+          "simple",
+          "detailed",
+          "retro",
+          "game_asset",
+          "portrait",
+          "texture",
+          "ui",
+          "item_sheet",
+          "character_turnaround",
+          "1_bit",
+          "low_res",
+          "mc_item",
+          "mc_texture",
+          "no_style"
+        ]
+      },
+      {
+        "name": "tile_x",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable seamless tiling on X axis",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tile_y",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable seamless tiling on Y axis",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 256,
+        "description": "Image width",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Style",
+        "values": [
+          [
+            "DEFAULT",
+            "default"
+          ],
+          [
+            "SIMPLE",
+            "simple"
+          ],
+          [
+            "DETAILED",
+            "detailed"
+          ],
+          [
+            "RETRO",
+            "retro"
+          ],
+          [
+            "GAME_ASSET",
+            "game_asset"
+          ],
+          [
+            "PORTRAIT",
+            "portrait"
+          ],
+          [
+            "TEXTURE",
+            "texture"
+          ],
+          [
+            "UI",
+            "ui"
+          ],
+          [
+            "ITEM_SHEET",
+            "item_sheet"
+          ],
+          [
+            "CHARACTER_TURNAROUND",
+            "character_turnaround"
+          ],
+          [
+            "_1_BIT",
+            "1_bit"
+          ],
+          [
+            "LOW_RES",
+            "low_res"
+          ],
+          [
+            "MC_ITEM",
+            "mc_item"
+          ],
+          [
+            "MC_TEXTURE",
+            "mc_texture"
+          ],
+          [
+            "NO_STYLE",
+            "no_style"
+          ]
+        ],
+        "description": "Style to apply to the generated image\n\ndefault: Simple clean pixel art, with Anime illustration influences\nsimple: Simple shading with minimalist shapes and designs\ndetailed: Pixel art with lots of shading and details\nretro: A classic arcade game aesthetic inspired by early PC games\ngame_asset: Distinct assets set on a simple background\nportrait: Character portrait focused images with high detail\ntexture: Flat game textures like stones, bricks, or wood\nui: User interface boxes and buttons\nitem_sheet: Sheets of objects placed on a simple background\ncharacter_turnaround: Character sprites viewed from different angles\n1_bit: Two color black and white only images\nlow_res: General low resolution pixel art images\nmc_item: Minecraft-styled items with automatic transparency\nmc_texture: Minecraft-styled flat textures, like grass, stones, or wood\nno_style: Pixel art with no style influence applied"
+      }
+    ]
+  },
+  {
+    "endpointId": "retro-diffusion/rd-plus",
+    "className": "Rd_Plus",
+    "moduleName": "image-generate",
+    "docstring": "High quality and authentic pixel art image generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "bypass_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable automatic prompt expansion",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 256,
+        "description": "Image height",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-image generation or reference. Will be converted to RGB without transparency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "input_palette",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference palette image to guide color choices",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "remove_bg",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Remove background to create transparent images",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Prompt strength in image-to-image generation. Higher values give closer adherence to the prompt, and lower values use more information from the input image. Only used when input_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "default",
+        "description": "Style to apply to the generated image\n\ndefault: Clean pixel art style with bold colors and outlines\nretro: Classic pixel art style inspired by PC98 games\nwatercolor: Pixel art mixed with a watercolor painting aesthetic\ntextured: Semi-realistic pixel art style with lots of shading and texture\ncartoon: Simple shapes and shading, with bold outlines\nui_element: User interface boxes and buttons\nitem_sheet: Sheets of objects placed on a simple background\ncharacter_turnaround: Character sprites viewed from different angles\nenvironment: One-point perspective scenes with outlines and strong shapes\nisometric: 45 degree isometric perspective, with consistent outlines\nisometric_asset: 45 degree isometric objects or assets, on a neutral background\ntopdown_map: Video game map style pixel art with a 3/4 top down perspective\ntopdown_asset: 3/4 top down perspective game assets on a simple background\nclassic: Strongly outlined medium-resolution pixel art with a focus on simple shading and clear design\ntopdown_item: Small 3/4 top down perspective assets with no background\nlow_res: High quality, low resolution pixel art assets and backgrounds\nmc_item: High quality Minecraft-styled items and game assets\nmc_texture: Detailed Minecraft-style flat block textures, with enhanced prompt following\nskill_icon: Video game style skill icons for representing abilities",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "default",
+          "retro",
+          "watercolor",
+          "textured",
+          "cartoon",
+          "ui_element",
+          "item_sheet",
+          "character_turnaround",
+          "environment",
+          "isometric",
+          "isometric_asset",
+          "topdown_map",
+          "topdown_asset",
+          "classic",
+          "topdown_item",
+          "low_res",
+          "mc_item",
+          "mc_texture",
+          "skill_icon"
+        ]
+      },
+      {
+        "name": "tile_x",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable seamless tiling on X axis",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tile_y",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable seamless tiling on Y axis",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 256,
+        "description": "Image width",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Style",
+        "values": [
+          [
+            "DEFAULT",
+            "default"
+          ],
+          [
+            "RETRO",
+            "retro"
+          ],
+          [
+            "WATERCOLOR",
+            "watercolor"
+          ],
+          [
+            "TEXTURED",
+            "textured"
+          ],
+          [
+            "CARTOON",
+            "cartoon"
+          ],
+          [
+            "UI_ELEMENT",
+            "ui_element"
+          ],
+          [
+            "ITEM_SHEET",
+            "item_sheet"
+          ],
+          [
+            "CHARACTER_TURNAROUND",
+            "character_turnaround"
+          ],
+          [
+            "ENVIRONMENT",
+            "environment"
+          ],
+          [
+            "ISOMETRIC",
+            "isometric"
+          ],
+          [
+            "ISOMETRIC_ASSET",
+            "isometric_asset"
+          ],
+          [
+            "TOPDOWN_MAP",
+            "topdown_map"
+          ],
+          [
+            "TOPDOWN_ASSET",
+            "topdown_asset"
+          ],
+          [
+            "CLASSIC",
+            "classic"
+          ],
+          [
+            "TOPDOWN_ITEM",
+            "topdown_item"
+          ],
+          [
+            "LOW_RES",
+            "low_res"
+          ],
+          [
+            "MC_ITEM",
+            "mc_item"
+          ],
+          [
+            "MC_TEXTURE",
+            "mc_texture"
+          ],
+          [
+            "SKILL_ICON",
+            "skill_icon"
+          ]
+        ],
+        "description": "Style to apply to the generated image\n\ndefault: Clean pixel art style with bold colors and outlines\nretro: Classic pixel art style inspired by PC98 games\nwatercolor: Pixel art mixed with a watercolor painting aesthetic\ntextured: Semi-realistic pixel art style with lots of shading and texture\ncartoon: Simple shapes and shading, with bold outlines\nui_element: User interface boxes and buttons\nitem_sheet: Sheets of objects placed on a simple background\ncharacter_turnaround: Character sprites viewed from different angles\nenvironment: One-point perspective scenes with outlines and strong shapes\nisometric: 45 degree isometric perspective, with consistent outlines\nisometric_asset: 45 degree isometric objects or assets, on a neutral background\ntopdown_map: Video game map style pixel art with a 3/4 top down perspective\ntopdown_asset: 3/4 top down perspective game assets on a simple background\nclassic: Strongly outlined medium-resolution pixel art with a focus on simple shading and clear design\ntopdown_item: Small 3/4 top down perspective assets with no background\nlow_res: High quality, low resolution pixel art assets and backgrounds\nmc_item: High quality Minecraft-styled items and game assets\nmc_texture: Detailed Minecraft-style flat block textures, with enhanced prompt following\nskill_icon: Video game style skill icons for representing abilities"
+      }
+    ]
+  },
+  {
+    "endpointId": "retro-diffusion/rd-tile",
+    "className": "Rd_Tile",
+    "moduleName": "image-generate",
+    "docstring": "All the tools you need for generating pixel art tilesets",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "bypass_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable automatic prompt expansion",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Extra input image for advanced tileset generation (tileset_advanced only)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Extra prompt for advanced tileset generation (tileset_advanced only)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 32,
+        "description": "Tile height (for tilesets, this is the size of each individual tile, not the output image)",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-image generation or reference. Will be converted to RGB without transparency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "tileset",
+        "description": "Style to apply to the generated image\n\ntileset: Create full tilesets from a simple prompt describing the textures or environment, using a simple set of \"wang\" style combinations\ntileset_advanced: Full tilesets from two prompts and/or textures, using a simple set of \"wang\" style combinations\nsingle_tile: Detailed single tile texture for creating full tilesets or surfaces\ntile_variation: Texture variations of the provided tile image\ntile_object: Small assets for placing on sections of tiles\nscene_object: Large assets for placing on tileset maps",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "tileset",
+          "tileset_advanced",
+          "single_tile",
+          "tile_variation",
+          "tile_object",
+          "scene_object"
+        ]
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 32,
+        "description": "Tile width (for tilesets, this is the size of each individual tile, not the output image)",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 384
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Style",
+        "values": [
+          [
+            "TILESET",
+            "tileset"
+          ],
+          [
+            "TILESET_ADVANCED",
+            "tileset_advanced"
+          ],
+          [
+            "SINGLE_TILE",
+            "single_tile"
+          ],
+          [
+            "TILE_VARIATION",
+            "tile_variation"
+          ],
+          [
+            "TILE_OBJECT",
+            "tile_object"
+          ],
+          [
+            "SCENE_OBJECT",
+            "scene_object"
+          ]
+        ],
+        "description": "Style to apply to the generated image\n\ntileset: Create full tilesets from a simple prompt describing the textures or environment, using a simple set of \"wang\" style combinations\ntileset_advanced: Full tilesets from two prompts and/or textures, using a simple set of \"wang\" style combinations\nsingle_tile: Detailed single tile texture for creating full tilesets or surfaces\ntile_variation: Texture variations of the provided tile image\ntile_object: Small assets for placing on sections of tiles\nscene_object: Large assets for placing on tileset maps"
+      }
+    ]
+  },
+  {
+    "endpointId": "reve/create",
+    "className": "Create",
+    "moduleName": "image-generate",
+    "docstring": "Image generation model from Reve",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "3:2",
+        "description": "The desired aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "1:1"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "A serene mountain landscape at sunset with snow-capped peaks",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "version",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "latest",
+        "description": "The specific model version to use when generating the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Version",
+        "enumValues": [
+          "latest",
+          "reve-create@20250915"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "The desired aspect ratio of the generated image"
+      },
+      {
+        "name": "Version",
+        "values": [
+          [
+            "LATEST",
+            "latest"
+          ],
+          [
+            "REVE_CREATE_20250915",
+            "reve-create@20250915"
+          ]
+        ],
+        "description": "The specific model version to use when generating the image"
+      }
+    ]
+  },
+  {
+    "endpointId": "reve/edit",
+    "className": "Edit",
+    "moduleName": "image-generate",
+    "docstring": "Image editing model from Reve",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file to edit (Path)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Remove all of the people in the background from this image.",
+        "description": "Text instruction describing how to edit the image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "version",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "latest",
+        "description": "The specific model version to use when generating the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Version",
+        "enumValues": [
+          "latest",
+          "latest-fast",
+          "reve-edit@20250915",
+          "reve-edit-fast@20251030"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Version",
+        "values": [
+          [
+            "LATEST",
+            "latest"
+          ],
+          [
+            "LATEST_FAST",
+            "latest-fast"
+          ],
+          [
+            "REVE_EDIT_20250915",
+            "reve-edit@20250915"
+          ],
+          [
+            "REVE_EDIT_FAST_20251030",
+            "reve-edit-fast@20251030"
+          ]
+        ],
+        "description": "The specific model version to use when generating the image"
+      }
+    ]
+  },
+  {
+    "endpointId": "reve/edit-fast",
+    "className": "Edit_Fast",
+    "moduleName": "image-generate",
+    "docstring": "Reve's fast image edit model at only $0.01 per edit",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file to edit (Path)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Remove all of the people in the background from this image.",
+        "description": "Text instruction describing how to edit the image",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "reve/remix",
+    "className": "Remix",
+    "moduleName": "image-generate",
+    "docstring": "Image generation model from Reve which handles multiple input reference images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "3:2",
+        "description": "The desired aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "1:1"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "A serene mountain landscape at sunset with snow-capped peaks",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of 1-4 image files to remix from (Paths)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "version",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "latest",
+        "description": "The specific model version to use when generating the image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Version",
+        "enumValues": [
+          "latest",
+          "reve-remix@20250915"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "The desired aspect ratio of the generated image"
+      },
+      {
+        "name": "Version",
+        "values": [
+          [
+            "LATEST",
+            "latest"
+          ],
+          [
+            "REVE_REMIX_20250915",
+            "reve-remix@20250915"
+          ]
+        ],
+        "description": "The specific model version to use when generating the image"
+      }
+    ]
+  },
+  {
+    "endpointId": "shridharathi/blueprint-qwen",
+    "className": "Blueprint_Qwen",
+    "moduleName": "image-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "tencent/hunyuan-image-2.1",
+    "className": "Hunyuan_Image_2_1",
+    "moduleName": "image-generate",
+    "docstring": "Generate high-quality 2K resolution images from text prompts",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "wavespeedai/qwen-image",
+    "className": "Wavespeedai_Qwen_Image",
+    "moduleName": "image-generate",
+    "docstring": "A 20B MMDiT model for next-gen text-to-image generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the output image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio of the output image."
+      }
+    ]
+  },
+  {
+    "endpointId": "wuzoobia/bruna-portrait",
+    "className": "Bruna_Portrait",
+    "moduleName": "image-generate",
+    "docstring": "Create stunning corporate portraits and executive headshots with photorealistic quality",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. If custom is selected, uses height and width below & will run in bf16 mode",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "custom"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_lora",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "extra_lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the extra LoRA should be applied. Sane results between 0 and 1 for base inference. For go_fast we apply a 1.5x multiplier to this value; we've generally seen good performance when scaling the base value by that amount. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Run faster predictions with model optimized for speed (currently fp8 quantized); disable to run in original bf16",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Guidance scale for the diffusion process. Lower values can give more realistic images. Good values to try are 2, 2.5, 3 and 3.5",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of generated image. Only works if `aspect_ratio` is set to custom. Will be rounded to nearest multiple of 16. Incompatible with fast generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image to image or inpainting mode. If provided, aspect_ratio, width, and height inputs are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied. Sane results between 0 and 1 for base inference. For go_fast we apply a 1.5x multiplier to this value; we've generally seen good performance when scaling the base value by that amount. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "mask",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image mask for image inpainting mode. If provided, aspect_ratio, width, and height inputs are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "dev",
+        "description": "Which model to run inference with. The dev model performs best with around 28 inference steps but the schnell model only needs 4 steps.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "dev",
+          "schnell"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 28,
+        "description": "Number of denoising steps. More steps can give more detailed images, but take longer.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "num_outputs",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of outputs to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for generated image. If you include the `trigger_word` used in the training process you are more likely to activate the trained object, style, or concept in the resulting image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Prompt strength when using img2img. 1.0 corresponds to full destruction of information in image",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of generated image. Only works if `aspect_ratio` is set to custom. Will be rounded to nearest multiple of 16. Incompatible with fast generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. If custom is selected, uses height and width below & will run in bf16 mode"
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "DEV",
+            "dev"
+          ],
+          [
+            "SCHNELL",
+            "schnell"
+          ]
+        ],
+        "description": "Which model to run inference with. The dev model performs best with around 28 inference steps but the schnell model only needs 4 steps."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
+    "endpointId": "yosun/camcorgi-qwern",
+    "className": "Camcorgi_Qwern",
+    "moduleName": "image-generate",
+    "docstring": "a qwen lora that knows that CAM corgi looks like... https://replicate.delivery/xezq/Qeh4prhrfEjLOEoB2kgdzS98yArm2SoruIPG8mkV3TLoHYNVA/qwen_lora_1755827163_trained.zip",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically enhance the prompt for better image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use LCM-LoRA to accelerate image generation (trades quality for 8x speed)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Guidance scale for image generation. Defaults to 1 if go_fast, else 3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom height in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "optimize_for_quality",
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "optimize_for_quality",
+          "optimize_for_speed"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Scale for LoRA weights (0 = base model, 1 = full LoRA)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps. More steps = higher quality. Defaults to 4 if go_fast, else 28.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving images (0-100, higher is better, 100 = lossless)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The main prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Path to LoRA weights file. Leave blank to use base model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom width in pixels. Provide both width and height for custom dimensions (overrides aspect_ratio/image_size).",
+        "fieldType": "input",
+        "required": false,
+        "min": 512,
+        "max": 2048
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Ignored if width and height are both provided."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "OPTIMIZE_FOR_QUALITY",
+            "optimize_for_quality"
+          ],
+          [
+            "OPTIMIZE_FOR_SPEED",
+            "optimize_for_speed"
+          ]
+        ],
+        "description": "Image size preset (quality = larger, speed = faster). Ignored if width and height are both provided."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      }
+    ]
+  },
+  {
     "endpointId": "lucataco/sdxl-clip-interrogator",
     "className": "SDXLClipInterrogator",
     "moduleName": "image-analyze",
@@ -38439,6 +58318,199 @@
     "enums": []
   },
   {
+    "endpointId": "qwen-edit-apps/qwen-image-edit-plus-lora-upscale",
+    "className": "Qwen_Image_Edit_Plus_Lora_Upscale",
+    "moduleName": "image-upscale",
+    "docstring": "Upscale – Detail-loving upscale/restore pass that sharpens textures and color fidelity with the Upscale LoRA.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If num_inference_steps is omitted, true runs the 8-step Lightning preset and false runs the 40-step detailed preset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image file uploaded to Cog (jpeg, png, gif, or webp).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Strength applied to the selected LoRA. Leave blank for the proxy default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "LoRA weights to apply. Leave blank to use the proxy's default adapter.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Explicit denoising step count (1-40). Leave blank to use the go_fast presets (fast = 8 steps, slow = 40 steps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Format of the output images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Enhance image quality, sharpen fine textures, restore natural colors and contrast",
+        "description": "Prompt hint: `Enhance image quality, sharpen fine textures, restore natural colors` and add a quick scene description so the LoRA knows what details to recover.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "true_guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "True classifier-free guidance scale passed to the pipeline.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images."
+      }
+    ]
+  },
+  {
     "endpointId": "lucataco/codeformer",
     "className": "CodeFormer",
     "moduleName": "image-enhance",
@@ -42528,6 +62600,761 @@
           ]
         ],
         "description": "Output file type"
+      }
+    ]
+  },
+  {
+    "endpointId": "fishwowater/trellis2",
+    "className": "Trellis2",
+    "moduleName": "image-3d",
+    "docstring": "TRELLIS.2: Native and Compact Structured Latents for 3D Generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "decimation_target",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1000000,
+        "description": "Target number of faces for decimation (only used if generate_model=True)",
+        "fieldType": "input",
+        "required": false,
+        "min": 100000,
+        "max": 2000000
+      },
+      {
+        "name": "generate_model",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate 3D model file (GLB)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "generate_video",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate rendered video preview",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to generate 3D asset from",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "pipeline_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024_cascade",
+        "description": "Pipeline type for quality/speed tradeoff",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PipelineType",
+        "enumValues": [
+          "512",
+          "1024",
+          "1024_cascade",
+          "1536_cascade"
+        ]
+      },
+      {
+        "name": "preprocess_image",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preprocess image (remove background and crop)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "randomize_seed",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Randomize seed",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "return_no_background",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the preprocessed image without background",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 42,
+        "description": "Random seed for generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shape_slat_guidance_rescale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Shape SLat guidance rescale",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "shape_slat_guidance_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 7.5,
+        "description": "Shape SLat guidance strength",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 15
+      },
+      {
+        "name": "shape_slat_rescale_t",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Shape SLat rescale T",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "shape_slat_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 12,
+        "description": "Shape SLat sampling steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "sparse_structure_guidance_rescale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.7,
+        "description": "Sparse structure guidance rescale",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sparse_structure_guidance_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 7.5,
+        "description": "Sparse structure guidance strength",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 15
+      },
+      {
+        "name": "sparse_structure_rescale_t",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Sparse structure rescale T",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "sparse_structure_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 12,
+        "description": "Sparse structure sampling steps (more steps = better quality, slower)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "tex_slat_guidance_rescale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Texture SLat guidance rescale",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "tex_slat_guidance_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Texture SLat guidance strength",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 15
+      },
+      {
+        "name": "tex_slat_rescale_t",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Texture SLat rescale T",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "tex_slat_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 12,
+        "description": "Texture SLat sampling steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "texture_size",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4096,
+        "description": "Texture size for GLB export (only used if generate_model=True)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1024,
+        "max": 8192
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "PipelineType",
+        "values": [
+          [
+            "VALUE_512",
+            "512"
+          ],
+          [
+            "VALUE_1024",
+            "1024"
+          ],
+          [
+            "_1024_CASCADE",
+            "1024_cascade"
+          ],
+          [
+            "_1536_CASCADE",
+            "1536_cascade"
+          ]
+        ],
+        "description": "Pipeline type for quality/speed tradeoff"
+      }
+    ]
+  },
+  {
+    "endpointId": "hyper3d/rodin",
+    "className": "Rodin",
+    "moduleName": "image-3d",
+    "docstring": "Generate complex 3D models from images with Rodin Gen-2",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "addons",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Additional features",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "bbox_condition",
+        "tsType": "number[]",
+        "propType": "list[int]",
+        "default": [],
+        "description": "Bounding box condition [Width, Height, Length]",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "geometry_file_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "Output geometry format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "GeometryFileFormat",
+        "enumValues": [
+          "glb",
+          "usdz",
+          "fbx",
+          "obj",
+          "stl"
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images for 3D generation (up to 5 images)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "material",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "PBR",
+        "description": "Material type",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Material",
+        "enumValues": [
+          "PBR",
+          "Shaded",
+          "All"
+        ]
+      },
+      {
+        "name": "mesh_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Quad",
+        "description": "Mesh face type",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "MeshMode",
+        "enumValues": [
+          "Quad",
+          "Raw"
+        ]
+      },
+      {
+        "name": "preview_render",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate preview render",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for 3D model generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Generation quality",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "high",
+          "medium",
+          "low",
+          "extra-low"
+        ]
+      },
+      {
+        "name": "quality_override",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Custom poly count for generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tapose",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate T/A pose for human-like models",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tier",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Gen-2",
+        "description": "Generation tier",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "use_original_alpha",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use original transparency channel",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "GeometryFileFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ]
+        ],
+        "description": "Output geometry format"
+      },
+      {
+        "name": "Material",
+        "values": [
+          [
+            "PBR",
+            "PBR"
+          ],
+          [
+            "SHADED",
+            "Shaded"
+          ],
+          [
+            "ALL",
+            "All"
+          ]
+        ],
+        "description": "Material type"
+      },
+      {
+        "name": "MeshMode",
+        "values": [
+          [
+            "QUAD",
+            "Quad"
+          ],
+          [
+            "RAW",
+            "Raw"
+          ]
+        ],
+        "description": "Mesh face type"
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "EXTRA_LOW",
+            "extra-low"
+          ]
+        ],
+        "description": "Generation quality"
+      }
+    ]
+  },
+  {
+    "endpointId": "valllllex/cartoonia_3d",
+    "className": "Cartoonia_3d",
+    "moduleName": "image-3d",
+    "docstring": "Restyling the classic cartoon and comic book characters into a soft painterly 3D style. FLUX Kontext Lora",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
       }
     ]
   },
@@ -55062,6 +75889,7857 @@
     "enums": []
   },
   {
+    "endpointId": "andreasjansson/wan-1.3b-inpaint",
+    "className": "Wan_1_3b_Inpaint",
+    "moduleName": "video-generate",
+    "docstring": "Inpainting and video2video experiments with Wan 2.1",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "expand_mask",
+        "tsType": "number",
+        "propType": "int",
+        "default": 10,
+        "description": "Expand the mask by a number of pixels",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "Output video FPS",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 30
+      },
+      {
+        "name": "guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Guidance scale for prompt adherence",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15
+      },
+      {
+        "name": "inpaint_fixup_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Number of steps for final inpaint fixup. Ignored when in video-to-video mode (when mask_video is empty)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Original video to be inpainted",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "keep_aspect_ratio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Keep the aspect ratio of the input video. This will degrade the quality of the inpainting.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mask_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Mask video (white areas will be inpainted). Leave blank for video-to-video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for inpainting the masked area",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sampling_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of sampling steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 20,
+        "max": 100
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "Strength of inpainting effect, 1.0 is full regeneration",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "bria/video-erase-object",
+    "className": "Video_Erase_Object",
+    "moduleName": "video-generate",
+    "docstring": "A high-fidelity capability for erasing unwanted objects, people, or visual elements from videos while maintaining aesthetic quality and temporal consistency",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "auto_trim",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos longer than 5 seconds are trimmed to the first 5 seconds. If false, videos over 5 seconds will be rejected.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mask_url",
+        "tsType": "string",
+        "propType": "image",
+        "default": "",
+        "description": "URL of the mask video file defining the area to erase",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_container_and_codec",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp4_h264",
+        "description": "Output format and codec",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputContainerAndCodec",
+        "enumValues": [
+          "mp4_h264",
+          "mp4_h265",
+          "webm_vp9",
+          "mov_h265",
+          "mov_proresks",
+          "mkv_h264",
+          "mkv_h265",
+          "mkv_vp9",
+          "gif"
+        ]
+      },
+      {
+        "name": "preserve_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to maintain original audio in output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_url",
+        "tsType": "string",
+        "propType": "video",
+        "default": "",
+        "description": "URL of the video file",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputContainerAndCodec",
+        "values": [
+          [
+            "MP4_H264",
+            "mp4_h264"
+          ],
+          [
+            "MP4_H265",
+            "mp4_h265"
+          ],
+          [
+            "WEBM_VP9",
+            "webm_vp9"
+          ],
+          [
+            "MOV_H265",
+            "mov_h265"
+          ],
+          [
+            "MOV_PRORESKS",
+            "mov_proresks"
+          ],
+          [
+            "MKV_H264",
+            "mkv_h264"
+          ],
+          [
+            "MKV_H265",
+            "mkv_h265"
+          ],
+          [
+            "MKV_VP9",
+            "mkv_vp9"
+          ],
+          [
+            "GIF",
+            "gif"
+          ]
+        ],
+        "description": "Output format and codec"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/omni-human-1.5",
+    "className": "Omni_Human_1_5",
+    "moduleName": "video-generate",
+    "docstring": "A film-grade digital human model that generates realistic video from a single image, audio clip, and optional text prompt.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio file (MP3, WAV, etc.). Duration must be less than 35 seconds. If the audio exceeds 35 seconds, an error will be generated and the generation will fail.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable fast mode to speed up generation by sacrificing some effects.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image containing a human subject, face or character.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional prompt for precise control of the scene, movements, camera movements, etc. Supports Chinese, English, Japanese, Korean, Spanish, and Indonesian.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "bytedance/seedance-1.5-pro",
+    "className": "Seedance_1_5_Pro",
+    "moduleName": "video-generate",
+    "docstring": "A joint audio-video model that accurately follows complex instructions.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Video aspect ratio. Ignored if an image is used.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16",
+          "21:9",
+          "9:21"
+        ]
+      },
+      {
+        "name": "camera_fixed",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to fix camera position",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Video duration in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 12
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 24,
+        "description": "Frame rate (frames per second)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio synchronized with the video. When enabled, the model outputs a video with audio that matches the visuals.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for last frame generation. This only works if an image start frame is given too.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "Video aspect ratio. Ignored if an image is used."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ]
+        ],
+        "description": "Frame rate (frames per second)"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "character-ai/ovi-i2v",
+    "className": "Ovi_I2v",
+    "moduleName": "video-generate",
+    "docstring": "Ovi: generate videos with audio from image and text inputs",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio_negative_prompt",
+        "tsType": "string",
+        "propType": "audio",
+        "default": "robotic, muffled, echo, distorted",
+        "description": "Negative prompt for audio generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to generate video from.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for generated video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_negative_prompt",
+        "tsType": "string",
+        "propType": "video",
+        "default": "jitter, bad hands, blur, distortion",
+        "description": "Negative prompt for video generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "easel/ai-avatars",
+    "className": "Ai_Avatars",
+    "moduleName": "video-generate",
+    "docstring": "Use one or two face images to create AI avatars",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "face_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Face image to generate avatar from. A front facing selfie works best.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_image_b",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional second face image for multi-person avatars",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "standing in a modern office space",
+        "description": "A prompt describing the scene to put the user(s) in",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "user_b_gender",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "female",
+        "description": "Gender of the second user (if using user_b)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "UserBGender",
+        "enumValues": [
+          "male",
+          "female",
+          "non_binary"
+        ]
+      },
+      {
+        "name": "user_gender",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "female",
+        "description": "Gender of the first user",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "UserGender",
+        "enumValues": [
+          "male",
+          "female",
+          "non_binary"
+        ]
+      },
+      {
+        "name": "workflow_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "HyperRealistic-likeness",
+        "description": "The output style to use",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "WorkflowType",
+        "enumValues": [
+          "HyperRealistic-likeness",
+          "HyperRealistic",
+          "Realistic",
+          "Stylistic"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "UserBGender",
+        "values": [
+          [
+            "MALE",
+            "male"
+          ],
+          [
+            "FEMALE",
+            "female"
+          ],
+          [
+            "NON_BINARY",
+            "non_binary"
+          ]
+        ],
+        "description": "Gender of the second user (if using user_b)"
+      },
+      {
+        "name": "UserGender",
+        "values": [
+          [
+            "MALE",
+            "male"
+          ],
+          [
+            "FEMALE",
+            "female"
+          ],
+          [
+            "NON_BINARY",
+            "non_binary"
+          ]
+        ],
+        "description": "Gender of the first user"
+      },
+      {
+        "name": "WorkflowType",
+        "values": [
+          [
+            "HYPERREALISTIC_LIKENESS",
+            "HyperRealistic-likeness"
+          ],
+          [
+            "HYPERREALISTIC",
+            "HyperRealistic"
+          ],
+          [
+            "REALISTIC",
+            "Realistic"
+          ],
+          [
+            "STYLISTIC",
+            "Stylistic"
+          ]
+        ],
+        "description": "The output style to use"
+      }
+    ]
+  },
+  {
+    "endpointId": "flux-kontext-apps/restyle-video-frame",
+    "className": "Restyle_Video_Frame",
+    "moduleName": "video-generate",
+    "docstring": "Use flux-kontext-pro to change the first or last frame of a video. Useful to use as inputs for restyling an entire video in a certain way",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "frame",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "first",
+        "description": "First or last frame to restyle",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Frame",
+        "enumValues": [
+          "first",
+          "last"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output format for the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how to restyle the video frame",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Safety tolerance, 0 is most strict and 2 is most permissive. 2 is currently the maximum allowed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Video to extract the first frame from and restyle",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Frame",
+        "values": [
+          [
+            "FIRST",
+            "first"
+          ],
+          [
+            "LAST",
+            "last"
+          ]
+        ],
+        "description": "First or last frame to restyle"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format for the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "fofr/kontext-ps1",
+    "className": "Kontext_Ps1",
+    "moduleName": "video-generate",
+    "docstring": "FLUX Kontext fine-tune that let's you restyle any image as a PS1 or PS2 video game",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "21:9",
+          "3:2",
+          "2:3",
+          "4:5",
+          "5:4",
+          "3:4",
+          "4:3",
+          "9:16",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable NSFW safety checker",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2.5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as reference. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the lora",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Approximate number of megapixels for generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Megapixels",
+        "enumValues": [
+          "1",
+          "0.25"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 4,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what you want to generate, or the instruction on how to edit the given image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Path to the lora weights",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image. Use 'match_input_image' to match the aspect ratio of the input image."
+      },
+      {
+        "name": "Megapixels",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "_0_25",
+            "0.25"
+          ]
+        ],
+        "description": "Approximate number of megapixels for generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format"
+      }
+    ]
+  },
+  {
+    "endpointId": "google/veo-3.1-fast",
+    "className": "Veo_3_1_Fast",
+    "moduleName": "video-generate",
+    "docstring": "New and improved version of Veo 3 Fast, with higher-fidelity video, context-aware audio and last frame support",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Video aspect ratio",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 8,
+        "description": "Video duration in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "4",
+          "6",
+          "8"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio with the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to start generating from. Ideal images are 16:9 or 9:16 and 1280x720 or 720x1280, depending on the aspect ratio you choose.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Ending image for interpolation. When provided with an input image, creates a transition between the two images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Description of what to exclude from the generated video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Resolution of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Omit for random generations",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Video aspect ratio"
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ]
+        ],
+        "description": "Video duration in seconds"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Resolution of the generated video"
+      }
+    ]
+  },
+  {
+    "endpointId": "heygen/video-translate",
+    "className": "Video_Translate",
+    "moduleName": "video-generate",
+    "docstring": "Translate videos into over 150 languages",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "precision",
+        "description": "Translation mode. 'speed' is optimized for fast turnaround. 'precision' is optimized for higher quality output.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "speed",
+          "precision"
+        ]
+      },
+      {
+        "name": "output_language",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "English",
+        "description": "The target language in which the video will be translated",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputLanguage",
+        "enumValues": [
+          "English",
+          "Spanish",
+          "French",
+          "Hindi",
+          "Italian",
+          "German",
+          "Polish",
+          "Portuguese",
+          "Chinese",
+          "Japanese",
+          "Dutch",
+          "Turkish",
+          "Korean",
+          "Danish",
+          "Arabic",
+          "Romanian",
+          "Mandarin",
+          "Filipino",
+          "Swedish",
+          "Indonesian",
+          "Ukrainian",
+          "Greek",
+          "Czech",
+          "Bulgarian",
+          "Malay",
+          "Slovak",
+          "Croatian",
+          "Tamil",
+          "Finnish",
+          "Russian",
+          "Afrikaans (South Africa)",
+          "Albanian (Albania)",
+          "Amharic (Ethiopia)",
+          "Arabic (Algeria)",
+          "Arabic (Bahrain)",
+          "Arabic (Egypt)",
+          "Arabic (Iraq)",
+          "Arabic (Jordan)",
+          "Arabic (Kuwait)",
+          "Arabic (Lebanon)",
+          "Arabic (Libya)",
+          "Arabic (Morocco)",
+          "Arabic (Oman)",
+          "Arabic (Qatar)",
+          "Arabic (Saudi Arabia)",
+          "Arabic (Syria)",
+          "Arabic (Tunisia)",
+          "Arabic (United Arab Emirates)",
+          "Arabic (Yemen)",
+          "Armenian (Armenia)",
+          "Azerbaijani (Latin, Azerbaijan)",
+          "Bangla (Bangladesh)",
+          "Basque",
+          "Bengali (India)",
+          "Bosnian (Bosnia and Herzegovina)",
+          "Bulgarian (Bulgaria)",
+          "Burmese (Myanmar)",
+          "Catalan",
+          "Chinese (Cantonese, Traditional)",
+          "Chinese (Jilu Mandarin, Simplified)",
+          "Chinese (Mandarin, Simplified)",
+          "Chinese (Northeastern Mandarin, Simplified)",
+          "Chinese (Southwestern Mandarin, Simplified)",
+          "Chinese (Taiwanese Mandarin, Traditional)",
+          "Chinese (Wu, Simplified)",
+          "Chinese (Zhongyuan Mandarin Henan, Simplified)",
+          "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)",
+          "Croatian (Croatia)",
+          "Czech (Czechia)",
+          "Danish (Denmark)",
+          "Dutch (Belgium)",
+          "Dutch (Netherlands)",
+          "English (Australia)",
+          "English (Canada)",
+          "English (Hong Kong SAR)",
+          "English (India)",
+          "English (Ireland)",
+          "English (Kenya)",
+          "English (New Zealand)",
+          "English (Nigeria)",
+          "English (Philippines)",
+          "English (Singapore)",
+          "English (South Africa)",
+          "English (Tanzania)",
+          "English (UK)",
+          "English (United States)",
+          "Estonian (Estonia)",
+          "Filipino (Philippines)",
+          "Finnish (Finland)",
+          "French (Belgium)",
+          "French (Canada)",
+          "French (France)",
+          "French (Switzerland)",
+          "Galician",
+          "Georgian (Georgia)",
+          "German (Austria)",
+          "German (Germany)",
+          "German (Switzerland)",
+          "Greek (Greece)",
+          "Gujarati (India)",
+          "Hebrew (Israel)",
+          "Hindi (India)",
+          "Hungarian (Hungary)",
+          "Icelandic (Iceland)",
+          "Indonesian (Indonesia)",
+          "Irish (Ireland)",
+          "Italian (Italy)",
+          "Japanese (Japan)",
+          "Javanese (Latin, Indonesia)",
+          "Kannada (India)",
+          "Kazakh (Kazakhstan)",
+          "Khmer (Cambodia)",
+          "Korean (Korea)",
+          "Lao (Laos)",
+          "Latvian (Latvia)",
+          "Lithuanian (Lithuania)",
+          "Macedonian (North Macedonia)",
+          "Malay (Malaysia)",
+          "Malayalam (India)",
+          "Maltese (Malta)",
+          "Marathi (India)",
+          "Mongolian (Mongolia)",
+          "Nepali (Nepal)",
+          "Norwegian Bokmål (Norway)",
+          "Pashto (Afghanistan)",
+          "Persian (Iran)",
+          "Polish (Poland)",
+          "Portuguese (Brazil)",
+          "Portuguese (Portugal)",
+          "Romanian (Romania)",
+          "Russian (Russia)",
+          "Serbian (Latin, Serbia)",
+          "Sinhala (Sri Lanka)",
+          "Slovak (Slovakia)",
+          "Slovenian (Slovenia)",
+          "Somali (Somalia)",
+          "Spanish (Argentina)",
+          "Spanish (Bolivia)",
+          "Spanish (Chile)",
+          "Spanish (Colombia)",
+          "Spanish (Costa Rica)",
+          "Spanish (Cuba)",
+          "Spanish (Dominican Republic)",
+          "Spanish (Ecuador)",
+          "Spanish (El Salvador)",
+          "Spanish (Equatorial Guinea)",
+          "Spanish (Guatemala)",
+          "Spanish (Honduras)",
+          "Spanish (Mexico)",
+          "Spanish (Nicaragua)",
+          "Spanish (Panama)",
+          "Spanish (Paraguay)",
+          "Spanish (Peru)",
+          "Spanish (Puerto Rico)",
+          "Spanish (Spain)",
+          "Spanish (United States)",
+          "Spanish (Uruguay)",
+          "Spanish (Venezuela)",
+          "Sundanese (Indonesia)",
+          "Swahili (Kenya)",
+          "Swahili (Tanzania)",
+          "Swedish (Sweden)",
+          "Tamil (India)",
+          "Tamil (Malaysia)",
+          "Tamil (Singapore)",
+          "Tamil (Sri Lanka)",
+          "Telugu (India)",
+          "Thai (Thailand)",
+          "Turkish (Türkiye)",
+          "Ukrainian (Ukraine)",
+          "Urdu (India)",
+          "Urdu (Pakistan)",
+          "Uzbek (Latin, Uzbekistan)",
+          "Vietnamese (Vietnam)",
+          "Welsh (United Kingdom)",
+          "Zulu (South Africa)",
+          "English - Your Accent",
+          "English - American Accent"
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file (.mp4)",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "SPEED",
+            "speed"
+          ],
+          [
+            "PRECISION",
+            "precision"
+          ]
+        ],
+        "description": "Translation mode. 'speed' is optimized for fast turnaround. 'precision' is optimized for higher quality output."
+      },
+      {
+        "name": "OutputLanguage",
+        "values": [
+          [
+            "ENGLISH",
+            "English"
+          ],
+          [
+            "SPANISH",
+            "Spanish"
+          ],
+          [
+            "FRENCH",
+            "French"
+          ],
+          [
+            "HINDI",
+            "Hindi"
+          ],
+          [
+            "ITALIAN",
+            "Italian"
+          ],
+          [
+            "GERMAN",
+            "German"
+          ],
+          [
+            "POLISH",
+            "Polish"
+          ],
+          [
+            "PORTUGUESE",
+            "Portuguese"
+          ],
+          [
+            "CHINESE",
+            "Chinese"
+          ],
+          [
+            "JAPANESE",
+            "Japanese"
+          ],
+          [
+            "DUTCH",
+            "Dutch"
+          ],
+          [
+            "TURKISH",
+            "Turkish"
+          ],
+          [
+            "KOREAN",
+            "Korean"
+          ],
+          [
+            "DANISH",
+            "Danish"
+          ],
+          [
+            "ARABIC",
+            "Arabic"
+          ],
+          [
+            "ROMANIAN",
+            "Romanian"
+          ],
+          [
+            "MANDARIN",
+            "Mandarin"
+          ],
+          [
+            "FILIPINO",
+            "Filipino"
+          ],
+          [
+            "SWEDISH",
+            "Swedish"
+          ],
+          [
+            "INDONESIAN",
+            "Indonesian"
+          ],
+          [
+            "UKRAINIAN",
+            "Ukrainian"
+          ],
+          [
+            "GREEK",
+            "Greek"
+          ],
+          [
+            "CZECH",
+            "Czech"
+          ],
+          [
+            "BULGARIAN",
+            "Bulgarian"
+          ],
+          [
+            "MALAY",
+            "Malay"
+          ],
+          [
+            "SLOVAK",
+            "Slovak"
+          ],
+          [
+            "CROATIAN",
+            "Croatian"
+          ],
+          [
+            "TAMIL",
+            "Tamil"
+          ],
+          [
+            "FINNISH",
+            "Finnish"
+          ],
+          [
+            "RUSSIAN",
+            "Russian"
+          ],
+          [
+            "AFRIKAANS_SOUTH_AFRICA",
+            "Afrikaans (South Africa)"
+          ],
+          [
+            "ALBANIAN_ALBANIA",
+            "Albanian (Albania)"
+          ],
+          [
+            "AMHARIC_ETHIOPIA",
+            "Amharic (Ethiopia)"
+          ],
+          [
+            "ARABIC_ALGERIA",
+            "Arabic (Algeria)"
+          ],
+          [
+            "ARABIC_BAHRAIN",
+            "Arabic (Bahrain)"
+          ],
+          [
+            "ARABIC_EGYPT",
+            "Arabic (Egypt)"
+          ],
+          [
+            "ARABIC_IRAQ",
+            "Arabic (Iraq)"
+          ],
+          [
+            "ARABIC_JORDAN",
+            "Arabic (Jordan)"
+          ],
+          [
+            "ARABIC_KUWAIT",
+            "Arabic (Kuwait)"
+          ],
+          [
+            "ARABIC_LEBANON",
+            "Arabic (Lebanon)"
+          ],
+          [
+            "ARABIC_LIBYA",
+            "Arabic (Libya)"
+          ],
+          [
+            "ARABIC_MOROCCO",
+            "Arabic (Morocco)"
+          ],
+          [
+            "ARABIC_OMAN",
+            "Arabic (Oman)"
+          ],
+          [
+            "ARABIC_QATAR",
+            "Arabic (Qatar)"
+          ],
+          [
+            "ARABIC_SAUDI_ARABIA",
+            "Arabic (Saudi Arabia)"
+          ],
+          [
+            "ARABIC_SYRIA",
+            "Arabic (Syria)"
+          ],
+          [
+            "ARABIC_TUNISIA",
+            "Arabic (Tunisia)"
+          ],
+          [
+            "ARABIC_UNITED_ARAB_EMIRATES",
+            "Arabic (United Arab Emirates)"
+          ],
+          [
+            "ARABIC_YEMEN",
+            "Arabic (Yemen)"
+          ],
+          [
+            "ARMENIAN_ARMENIA",
+            "Armenian (Armenia)"
+          ],
+          [
+            "AZERBAIJANI_LATIN_AZERBAIJAN",
+            "Azerbaijani (Latin, Azerbaijan)"
+          ],
+          [
+            "BANGLA_BANGLADESH",
+            "Bangla (Bangladesh)"
+          ],
+          [
+            "BASQUE",
+            "Basque"
+          ],
+          [
+            "BENGALI_INDIA",
+            "Bengali (India)"
+          ],
+          [
+            "BOSNIAN_BOSNIA_AND_HERZEGOVINA",
+            "Bosnian (Bosnia and Herzegovina)"
+          ],
+          [
+            "BULGARIAN_BULGARIA",
+            "Bulgarian (Bulgaria)"
+          ],
+          [
+            "BURMESE_MYANMAR",
+            "Burmese (Myanmar)"
+          ],
+          [
+            "CATALAN",
+            "Catalan"
+          ],
+          [
+            "CHINESE_CANTONESE_TRADITIONAL",
+            "Chinese (Cantonese, Traditional)"
+          ],
+          [
+            "CHINESE_JILU_MANDARIN_SIMPLIFIED",
+            "Chinese (Jilu Mandarin, Simplified)"
+          ],
+          [
+            "CHINESE_MANDARIN_SIMPLIFIED",
+            "Chinese (Mandarin, Simplified)"
+          ],
+          [
+            "CHINESE_NORTHEASTERN_MANDARIN_SIMPLIFIED",
+            "Chinese (Northeastern Mandarin, Simplified)"
+          ],
+          [
+            "CHINESE_SOUTHWESTERN_MANDARIN_SIMPLIFIED",
+            "Chinese (Southwestern Mandarin, Simplified)"
+          ],
+          [
+            "CHINESE_TAIWANESE_MANDARIN_TRADITIONAL",
+            "Chinese (Taiwanese Mandarin, Traditional)"
+          ],
+          [
+            "CHINESE_WU_SIMPLIFIED",
+            "Chinese (Wu, Simplified)"
+          ],
+          [
+            "CHINESE_ZHONGYUAN_MANDARIN_HENAN_SIMPLIFIED",
+            "Chinese (Zhongyuan Mandarin Henan, Simplified)"
+          ],
+          [
+            "CHINESE_ZHONGYUAN_MANDARIN_SHAANXI_SIMPLIFIED",
+            "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)"
+          ],
+          [
+            "CROATIAN_CROATIA",
+            "Croatian (Croatia)"
+          ],
+          [
+            "CZECH_CZECHIA",
+            "Czech (Czechia)"
+          ],
+          [
+            "DANISH_DENMARK",
+            "Danish (Denmark)"
+          ],
+          [
+            "DUTCH_BELGIUM",
+            "Dutch (Belgium)"
+          ],
+          [
+            "DUTCH_NETHERLANDS",
+            "Dutch (Netherlands)"
+          ],
+          [
+            "ENGLISH_AUSTRALIA",
+            "English (Australia)"
+          ],
+          [
+            "ENGLISH_CANADA",
+            "English (Canada)"
+          ],
+          [
+            "ENGLISH_HONG_KONG_SAR",
+            "English (Hong Kong SAR)"
+          ],
+          [
+            "ENGLISH_INDIA",
+            "English (India)"
+          ],
+          [
+            "ENGLISH_IRELAND",
+            "English (Ireland)"
+          ],
+          [
+            "ENGLISH_KENYA",
+            "English (Kenya)"
+          ],
+          [
+            "ENGLISH_NEW_ZEALAND",
+            "English (New Zealand)"
+          ],
+          [
+            "ENGLISH_NIGERIA",
+            "English (Nigeria)"
+          ],
+          [
+            "ENGLISH_PHILIPPINES",
+            "English (Philippines)"
+          ],
+          [
+            "ENGLISH_SINGAPORE",
+            "English (Singapore)"
+          ],
+          [
+            "ENGLISH_SOUTH_AFRICA",
+            "English (South Africa)"
+          ],
+          [
+            "ENGLISH_TANZANIA",
+            "English (Tanzania)"
+          ],
+          [
+            "ENGLISH_UK",
+            "English (UK)"
+          ],
+          [
+            "ENGLISH_UNITED_STATES",
+            "English (United States)"
+          ],
+          [
+            "ESTONIAN_ESTONIA",
+            "Estonian (Estonia)"
+          ],
+          [
+            "FILIPINO_PHILIPPINES",
+            "Filipino (Philippines)"
+          ],
+          [
+            "FINNISH_FINLAND",
+            "Finnish (Finland)"
+          ],
+          [
+            "FRENCH_BELGIUM",
+            "French (Belgium)"
+          ],
+          [
+            "FRENCH_CANADA",
+            "French (Canada)"
+          ],
+          [
+            "FRENCH_FRANCE",
+            "French (France)"
+          ],
+          [
+            "FRENCH_SWITZERLAND",
+            "French (Switzerland)"
+          ],
+          [
+            "GALICIAN",
+            "Galician"
+          ],
+          [
+            "GEORGIAN_GEORGIA",
+            "Georgian (Georgia)"
+          ],
+          [
+            "GERMAN_AUSTRIA",
+            "German (Austria)"
+          ],
+          [
+            "GERMAN_GERMANY",
+            "German (Germany)"
+          ],
+          [
+            "GERMAN_SWITZERLAND",
+            "German (Switzerland)"
+          ],
+          [
+            "GREEK_GREECE",
+            "Greek (Greece)"
+          ],
+          [
+            "GUJARATI_INDIA",
+            "Gujarati (India)"
+          ],
+          [
+            "HEBREW_ISRAEL",
+            "Hebrew (Israel)"
+          ],
+          [
+            "HINDI_INDIA",
+            "Hindi (India)"
+          ],
+          [
+            "HUNGARIAN_HUNGARY",
+            "Hungarian (Hungary)"
+          ],
+          [
+            "ICELANDIC_ICELAND",
+            "Icelandic (Iceland)"
+          ],
+          [
+            "INDONESIAN_INDONESIA",
+            "Indonesian (Indonesia)"
+          ],
+          [
+            "IRISH_IRELAND",
+            "Irish (Ireland)"
+          ],
+          [
+            "ITALIAN_ITALY",
+            "Italian (Italy)"
+          ],
+          [
+            "JAPANESE_JAPAN",
+            "Japanese (Japan)"
+          ],
+          [
+            "JAVANESE_LATIN_INDONESIA",
+            "Javanese (Latin, Indonesia)"
+          ],
+          [
+            "KANNADA_INDIA",
+            "Kannada (India)"
+          ],
+          [
+            "KAZAKH_KAZAKHSTAN",
+            "Kazakh (Kazakhstan)"
+          ],
+          [
+            "KHMER_CAMBODIA",
+            "Khmer (Cambodia)"
+          ],
+          [
+            "KOREAN_KOREA",
+            "Korean (Korea)"
+          ],
+          [
+            "LAO_LAOS",
+            "Lao (Laos)"
+          ],
+          [
+            "LATVIAN_LATVIA",
+            "Latvian (Latvia)"
+          ],
+          [
+            "LITHUANIAN_LITHUANIA",
+            "Lithuanian (Lithuania)"
+          ],
+          [
+            "MACEDONIAN_NORTH_MACEDONIA",
+            "Macedonian (North Macedonia)"
+          ],
+          [
+            "MALAY_MALAYSIA",
+            "Malay (Malaysia)"
+          ],
+          [
+            "MALAYALAM_INDIA",
+            "Malayalam (India)"
+          ],
+          [
+            "MALTESE_MALTA",
+            "Maltese (Malta)"
+          ],
+          [
+            "MARATHI_INDIA",
+            "Marathi (India)"
+          ],
+          [
+            "MONGOLIAN_MONGOLIA",
+            "Mongolian (Mongolia)"
+          ],
+          [
+            "NEPALI_NEPAL",
+            "Nepali (Nepal)"
+          ],
+          [
+            "NORWEGIAN_BOKM_L_NORWAY",
+            "Norwegian Bokmål (Norway)"
+          ],
+          [
+            "PASHTO_AFGHANISTAN",
+            "Pashto (Afghanistan)"
+          ],
+          [
+            "PERSIAN_IRAN",
+            "Persian (Iran)"
+          ],
+          [
+            "POLISH_POLAND",
+            "Polish (Poland)"
+          ],
+          [
+            "PORTUGUESE_BRAZIL",
+            "Portuguese (Brazil)"
+          ],
+          [
+            "PORTUGUESE_PORTUGAL",
+            "Portuguese (Portugal)"
+          ],
+          [
+            "ROMANIAN_ROMANIA",
+            "Romanian (Romania)"
+          ],
+          [
+            "RUSSIAN_RUSSIA",
+            "Russian (Russia)"
+          ],
+          [
+            "SERBIAN_LATIN_SERBIA",
+            "Serbian (Latin, Serbia)"
+          ],
+          [
+            "SINHALA_SRI_LANKA",
+            "Sinhala (Sri Lanka)"
+          ],
+          [
+            "SLOVAK_SLOVAKIA",
+            "Slovak (Slovakia)"
+          ],
+          [
+            "SLOVENIAN_SLOVENIA",
+            "Slovenian (Slovenia)"
+          ],
+          [
+            "SOMALI_SOMALIA",
+            "Somali (Somalia)"
+          ],
+          [
+            "SPANISH_ARGENTINA",
+            "Spanish (Argentina)"
+          ],
+          [
+            "SPANISH_BOLIVIA",
+            "Spanish (Bolivia)"
+          ],
+          [
+            "SPANISH_CHILE",
+            "Spanish (Chile)"
+          ],
+          [
+            "SPANISH_COLOMBIA",
+            "Spanish (Colombia)"
+          ],
+          [
+            "SPANISH_COSTA_RICA",
+            "Spanish (Costa Rica)"
+          ],
+          [
+            "SPANISH_CUBA",
+            "Spanish (Cuba)"
+          ],
+          [
+            "SPANISH_DOMINICAN_REPUBLIC",
+            "Spanish (Dominican Republic)"
+          ],
+          [
+            "SPANISH_ECUADOR",
+            "Spanish (Ecuador)"
+          ],
+          [
+            "SPANISH_EL_SALVADOR",
+            "Spanish (El Salvador)"
+          ],
+          [
+            "SPANISH_EQUATORIAL_GUINEA",
+            "Spanish (Equatorial Guinea)"
+          ],
+          [
+            "SPANISH_GUATEMALA",
+            "Spanish (Guatemala)"
+          ],
+          [
+            "SPANISH_HONDURAS",
+            "Spanish (Honduras)"
+          ],
+          [
+            "SPANISH_MEXICO",
+            "Spanish (Mexico)"
+          ],
+          [
+            "SPANISH_NICARAGUA",
+            "Spanish (Nicaragua)"
+          ],
+          [
+            "SPANISH_PANAMA",
+            "Spanish (Panama)"
+          ],
+          [
+            "SPANISH_PARAGUAY",
+            "Spanish (Paraguay)"
+          ],
+          [
+            "SPANISH_PERU",
+            "Spanish (Peru)"
+          ],
+          [
+            "SPANISH_PUERTO_RICO",
+            "Spanish (Puerto Rico)"
+          ],
+          [
+            "SPANISH_SPAIN",
+            "Spanish (Spain)"
+          ],
+          [
+            "SPANISH_UNITED_STATES",
+            "Spanish (United States)"
+          ],
+          [
+            "SPANISH_URUGUAY",
+            "Spanish (Uruguay)"
+          ],
+          [
+            "SPANISH_VENEZUELA",
+            "Spanish (Venezuela)"
+          ],
+          [
+            "SUNDANESE_INDONESIA",
+            "Sundanese (Indonesia)"
+          ],
+          [
+            "SWAHILI_KENYA",
+            "Swahili (Kenya)"
+          ],
+          [
+            "SWAHILI_TANZANIA",
+            "Swahili (Tanzania)"
+          ],
+          [
+            "SWEDISH_SWEDEN",
+            "Swedish (Sweden)"
+          ],
+          [
+            "TAMIL_INDIA",
+            "Tamil (India)"
+          ],
+          [
+            "TAMIL_MALAYSIA",
+            "Tamil (Malaysia)"
+          ],
+          [
+            "TAMIL_SINGAPORE",
+            "Tamil (Singapore)"
+          ],
+          [
+            "TAMIL_SRI_LANKA",
+            "Tamil (Sri Lanka)"
+          ],
+          [
+            "TELUGU_INDIA",
+            "Telugu (India)"
+          ],
+          [
+            "THAI_THAILAND",
+            "Thai (Thailand)"
+          ],
+          [
+            "TURKISH_T_RKIYE",
+            "Turkish (Türkiye)"
+          ],
+          [
+            "UKRAINIAN_UKRAINE",
+            "Ukrainian (Ukraine)"
+          ],
+          [
+            "URDU_INDIA",
+            "Urdu (India)"
+          ],
+          [
+            "URDU_PAKISTAN",
+            "Urdu (Pakistan)"
+          ],
+          [
+            "UZBEK_LATIN_UZBEKISTAN",
+            "Uzbek (Latin, Uzbekistan)"
+          ],
+          [
+            "VIETNAMESE_VIETNAM",
+            "Vietnamese (Vietnam)"
+          ],
+          [
+            "WELSH_UNITED_KINGDOM",
+            "Welsh (United Kingdom)"
+          ],
+          [
+            "ZULU_SOUTH_AFRICA",
+            "Zulu (South Africa)"
+          ],
+          [
+            "ENGLISH_YOUR_ACCENT",
+            "English - Your Accent"
+          ],
+          [
+            "ENGLISH_AMERICAN_ACCENT",
+            "English - American Accent"
+          ]
+        ],
+        "description": "The target language in which the video will be translated"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v1.5-pro",
+    "className": "Kling_V1_5_Pro",
+    "moduleName": "video-generate",
+    "docstring": "Generate 5s and 10s videos in 1080p resolution at 30fps",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame of the video. A start or end image is required.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video. A start or end image is required.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v1.5-standard",
+    "className": "Kling_V1_5_Standard",
+    "moduleName": "video-generate",
+    "docstring": "Generate 5s and 10s videos in 720p resolution at 30fps",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v1.6-pro",
+    "className": "Kling_V1_6_Pro",
+    "moduleName": "video-generate",
+    "docstring": "Generate 5s and 10s videos in 1080p resolution",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame of the video. A start or end image is required.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images to use in video generation (up to 4 images). Also known as scene elements.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video. A start or end image is required.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v1.6-standard",
+    "className": "Kling_V1_6_Standard",
+    "moduleName": "video-generate",
+    "docstring": "Generate 5s and 10s videos in 720p resolution at 30fps",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images to use in video generation (up to 4 images). Also known as scene elements.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v2.0",
+    "className": "Kling_V2_0",
+    "moduleName": "video-generate",
+    "docstring": "Generate 5s and 10s videos in 720p resolution",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video (optional)",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v2.1-master",
+    "className": "Kling_V2_1_Master",
+    "moduleName": "video-generate",
+    "docstring": "A premium version of Kling v2.1 with superb dynamics and prompt adherence. Generate 1080p 5s and 10s videos from text or an image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored if start_image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the video",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored if start_image is provided."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v2.6-motion-control",
+    "className": "Kling_V2_6_Motion_Control",
+    "moduleName": "video-generate",
+    "docstring": "Enables precise control of character actions and expressions from a reference image.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "character_orientation",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "image",
+        "description": "Generate the orientation of the characters in the video. 'image': same orientation as the person in the picture (max 10s video). 'video': consistent with the orientation of the characters in the video (max 30s video).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CharacterOrientation",
+        "enumValues": [
+          "image",
+          "video"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference image. The characters, backgrounds, and other elements in the generated video are based on the reference image. Supports .jpg/.jpeg/.png, max 10MB, dimensions 340px-3850px, aspect ratio 1:2.5 to 2.5:1.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "keep_original_sound",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to keep the original sound of the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "std",
+        "description": "Video generation mode. 'std': Standard mode (cost-effective). 'pro': Professional mode (higher quality).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "std",
+          "pro"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. You can add elements to the screen and achieve motion effects through prompt words.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Reference video. The character actions in the generated video are consistent with the reference video. Supports .mp4/.mov, max 100MB, 3-30 seconds duration depending on character_orientation.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "CharacterOrientation",
+        "values": [
+          [
+            "IMAGE",
+            "image"
+          ],
+          [
+            "VIDEO",
+            "video"
+          ]
+        ],
+        "description": "Generate the orientation of the characters in the video. 'image': same orientation as the person in the picture (max 10s video). 'video': consistent with the orientation of the characters in the video (max 30s video)."
+      },
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "STD",
+            "std"
+          ],
+          [
+            "PRO",
+            "pro"
+          ]
+        ],
+        "description": "Video generation mode. 'std': Standard mode (cost-effective). 'pro': Professional mode (higher quality)."
+      }
+    ]
+  },
+  {
+    "endpointId": "leonardoai/motion-2.0",
+    "className": "Motion_2_0",
+    "moduleName": "video-generate",
+    "docstring": "Create 5s 480p videos from a text prompt",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video. Ignored if image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "9:16",
+          "16:9",
+          "2:3",
+          "4:5"
+        ]
+      },
+      {
+        "name": "color_theme_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Style for the color theme of the video. Ignored if image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ColorThemeStyle",
+        "enumValues": [
+          "None",
+          "autumn",
+          "complimentary",
+          "cool",
+          "dark",
+          "earthy",
+          "electric",
+          "iridescent",
+          "pastel",
+          "split",
+          "terracotta_teal",
+          "ultraviolet",
+          "vibrant",
+          "warm"
+        ]
+      },
+      {
+        "name": "frame_interpolation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Smoothly blend frames for fluid video transitions",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use for the first frame of the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lighting_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Style for the lighting of the video. Ignored if image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "LightingStyle",
+        "enumValues": [
+          "None",
+          "backlight",
+          "candle_lit",
+          "chiaroscuro",
+          "film_haze",
+          "foggy",
+          "golden_hour",
+          "hardlight",
+          "lens_flare",
+          "light_art",
+          "low_key",
+          "luminous",
+          "mystical",
+          "rainy",
+          "soft_light",
+          "volumetric"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The negative prompt used for the video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_enhance",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enhance the prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "shot_type_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Style for the shot type of the video. Ignored if image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ShotTypeStyle",
+        "enumValues": [
+          "None",
+          "bokeh",
+          "cinematic",
+          "close_up",
+          "overhead",
+          "spiritual",
+          "spooky"
+        ]
+      },
+      {
+        "name": "vibe_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Style for the overall vibe of the video. Ignored if image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "VibeStyle",
+        "enumValues": [
+          "None",
+          "clay",
+          "color_sketch",
+          "logo",
+          "papercraft",
+          "pro_photo",
+          "sci_fi",
+          "sketch",
+          "stock_footage",
+          "streetshot"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ]
+        ],
+        "description": "Aspect ratio of the output video. Ignored if image is provided."
+      },
+      {
+        "name": "ColorThemeStyle",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "AUTUMN",
+            "autumn"
+          ],
+          [
+            "COMPLIMENTARY",
+            "complimentary"
+          ],
+          [
+            "COOL",
+            "cool"
+          ],
+          [
+            "DARK",
+            "dark"
+          ],
+          [
+            "EARTHY",
+            "earthy"
+          ],
+          [
+            "ELECTRIC",
+            "electric"
+          ],
+          [
+            "IRIDESCENT",
+            "iridescent"
+          ],
+          [
+            "PASTEL",
+            "pastel"
+          ],
+          [
+            "SPLIT",
+            "split"
+          ],
+          [
+            "TERRACOTTA_TEAL",
+            "terracotta_teal"
+          ],
+          [
+            "ULTRAVIOLET",
+            "ultraviolet"
+          ],
+          [
+            "VIBRANT",
+            "vibrant"
+          ],
+          [
+            "WARM",
+            "warm"
+          ]
+        ],
+        "description": "Style for the color theme of the video. Ignored if image is provided."
+      },
+      {
+        "name": "LightingStyle",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "BACKLIGHT",
+            "backlight"
+          ],
+          [
+            "CANDLE_LIT",
+            "candle_lit"
+          ],
+          [
+            "CHIAROSCURO",
+            "chiaroscuro"
+          ],
+          [
+            "FILM_HAZE",
+            "film_haze"
+          ],
+          [
+            "FOGGY",
+            "foggy"
+          ],
+          [
+            "GOLDEN_HOUR",
+            "golden_hour"
+          ],
+          [
+            "HARDLIGHT",
+            "hardlight"
+          ],
+          [
+            "LENS_FLARE",
+            "lens_flare"
+          ],
+          [
+            "LIGHT_ART",
+            "light_art"
+          ],
+          [
+            "LOW_KEY",
+            "low_key"
+          ],
+          [
+            "LUMINOUS",
+            "luminous"
+          ],
+          [
+            "MYSTICAL",
+            "mystical"
+          ],
+          [
+            "RAINY",
+            "rainy"
+          ],
+          [
+            "SOFT_LIGHT",
+            "soft_light"
+          ],
+          [
+            "VOLUMETRIC",
+            "volumetric"
+          ]
+        ],
+        "description": "Style for the lighting of the video. Ignored if image is provided."
+      },
+      {
+        "name": "ShotTypeStyle",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "BOKEH",
+            "bokeh"
+          ],
+          [
+            "CINEMATIC",
+            "cinematic"
+          ],
+          [
+            "CLOSE_UP",
+            "close_up"
+          ],
+          [
+            "OVERHEAD",
+            "overhead"
+          ],
+          [
+            "SPIRITUAL",
+            "spiritual"
+          ],
+          [
+            "SPOOKY",
+            "spooky"
+          ]
+        ],
+        "description": "Style for the shot type of the video. Ignored if image is provided."
+      },
+      {
+        "name": "VibeStyle",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "CLAY",
+            "clay"
+          ],
+          [
+            "COLOR_SKETCH",
+            "color_sketch"
+          ],
+          [
+            "LOGO",
+            "logo"
+          ],
+          [
+            "PAPERCRAFT",
+            "papercraft"
+          ],
+          [
+            "PRO_PHOTO",
+            "pro_photo"
+          ],
+          [
+            "SCI_FI",
+            "sci_fi"
+          ],
+          [
+            "SKETCH",
+            "sketch"
+          ],
+          [
+            "STOCK_FOOTAGE",
+            "stock_footage"
+          ],
+          [
+            "STREETSHOT",
+            "streetshot"
+          ]
+        ],
+        "description": "Style for the overall vibe of the video. Ignored if image is provided."
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-2-fast",
+    "className": "Ltx_2_Fast",
+    "moduleName": "video-generate",
+    "docstring": "Ideal for rapid ideation and mobile workflows. Perfect for creators who need instant feedback, real-time previews, or high-throughput content.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 6,
+        "description": "Duration of the video in seconds. Durations longer than 10 seconds are only available with 1080p resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "6",
+          "8",
+          "10",
+          "12",
+          "14",
+          "16",
+          "18",
+          "20"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio for the video. Used for text_to_video and image_to_video tasks.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for image-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video to generate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Resolution quality of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1080p",
+          "2k",
+          "4k"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_16",
+            "16"
+          ],
+          [
+            "VALUE_18",
+            "18"
+          ],
+          [
+            "VALUE_20",
+            "20"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Durations longer than 10 seconds are only available with 1080p resolution."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_2K",
+            "2k"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Resolution quality of the generated video"
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-2-pro",
+    "className": "Ltx_2_Pro",
+    "moduleName": "video-generate",
+    "docstring": "Delivers high visual fidelity with fast turnaround. Great for daily content creation, marketing teams, and iterative creative workflows.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 6,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "6",
+          "8",
+          "10"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio for the video. Used for text_to_video and image_to_video tasks.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for image-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video to generate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Resolution quality of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1080p",
+          "2k",
+          "4k"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_2K",
+            "2k"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Resolution quality of the generated video"
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-2-retake",
+    "className": "Ltx_2_Retake",
+    "moduleName": "video-generate",
+    "docstring": "Take any shot and edit specific sections. Rephrase, change the action, camera angles and more",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 6,
+        "description": "Duration of the edited section in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 16
+      },
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "replace_video",
+        "description": "Mode of operation",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "replace_audio",
+          "replace_video",
+          "replace_audio_and_video"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the edit",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "start_time",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Start time of the edit in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to edit",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "REPLACE_AUDIO",
+            "replace_audio"
+          ],
+          [
+            "REPLACE_VIDEO",
+            "replace_video"
+          ],
+          [
+            "REPLACE_AUDIO_AND_VIDEO",
+            "replace_audio_and_video"
+          ]
+        ],
+        "description": "Mode of operation"
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-video-0.9.7",
+    "className": "Ltx_Video_0_9_7",
+    "moduleName": "video-generate",
+    "docstring": "DiT-based 13b video generation model, creating 30fps video",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Frames per second for the output video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Guidance scale. Recommended range: 3.0-3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 480,
+        "description": "Height of the output video. Actual height will be a multiple of 32.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-video generation. If not provided, text-to-video generation will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "worst quality, inconsistent motion, blurry, jittery, distorted",
+        "description": "Negative prompt for video generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 161,
+        "description": "Number of frames to generate. Actual frame count will be 8N+1 (e.g., 9, 17, 25, 161).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Number of denoising steps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible results. Leave blank for a random seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 704,
+        "description": "Width of the output video. Actual width will be a multiple of 32.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lightricks/ltx-video-0.9.7-distilled",
+    "className": "Ltx_Video_0_9_7_Distilled",
+    "moduleName": "video-generate",
+    "docstring": "Faster slight quality reduction compared to LTX-Video 13b",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "conditioning_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 21,
+        "description": "Number of frames to use for video-to-video conditioning (only used when video input is provided).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "denoise_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.4,
+        "description": "Denoising strength for final refinement step.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "downscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.667,
+        "description": "Factor to downscale initial generation (recommended: 2/3 for better quality).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "name": "final_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 10,
+        "description": "Number of inference steps for final denoising.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Frames per second for the output video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable fast mode with skip layer strategies (20-40% faster but slightly lower quality).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 3,
+        "description": "Guidance scale. Recommended range: 3.0-3.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-video generation. If provided, will generate video from this image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "worst quality, inconsistent motion, blurry, jittery, distorted",
+        "description": "Negative prompt for video generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 121,
+        "description": "Number of frames to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 257
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Number of denoising steps for initial generation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 50
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 720,
+        "description": "Resolution for the output video (height in pixels).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480",
+          "720"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible results. Leave blank for a random seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video for video-to-video generation. If provided, will generate video from this video. Takes precedence over image if both are provided.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the output video."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480",
+            "480"
+          ],
+          [
+            "VALUE_720",
+            "720"
+          ]
+        ],
+        "description": "Resolution for the output video (height in pixels)."
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/frame-extractor",
+    "className": "Frame_Extractor",
+    "moduleName": "video-generate",
+    "docstring": "Extract the first or last frame from any video file as a high-quality image",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "return_first_frame",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Toggle to return the first frame instead of the last frame",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lucataco/split-screen-video",
+    "className": "Split_Screen_Video",
+    "moduleName": "video-generate",
+    "docstring": "Combines two videos into a single split-screen layout",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio_source",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "video 1",
+        "description": "Which video's audio to use",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioSource",
+        "enumValues": [
+          "video 1",
+          "video 2"
+        ]
+      },
+      {
+        "name": "duration_source",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "video 1",
+        "description": "Which video's duration to use",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "DurationSource",
+        "enumValues": [
+          "video 1",
+          "video 2"
+        ]
+      },
+      {
+        "name": "layout",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "left and right",
+        "description": "Layout for combining videos",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Layout",
+        "enumValues": [
+          "left and right",
+          "top and bottom"
+        ]
+      },
+      {
+        "name": "loop_videos",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Loop shorter video to match duration",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "quality_preset",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "fast",
+        "description": "Speed vs quality tradeoff",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "QualityPreset",
+        "enumValues": [
+          "fastest",
+          "fast",
+          "balanced"
+        ]
+      },
+      {
+        "name": "video_1",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "First video file",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "video_2",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Second video file",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AudioSource",
+        "values": [
+          [
+            "VIDEO_1",
+            "video 1"
+          ],
+          [
+            "VIDEO_2",
+            "video 2"
+          ]
+        ],
+        "description": "Which video's audio to use"
+      },
+      {
+        "name": "DurationSource",
+        "values": [
+          [
+            "VIDEO_1",
+            "video 1"
+          ],
+          [
+            "VIDEO_2",
+            "video 2"
+          ]
+        ],
+        "description": "Which video's duration to use"
+      },
+      {
+        "name": "Layout",
+        "values": [
+          [
+            "LEFT_AND_RIGHT",
+            "left and right"
+          ],
+          [
+            "TOP_AND_BOTTOM",
+            "top and bottom"
+          ]
+        ],
+        "description": "Layout for combining videos"
+      },
+      {
+        "name": "QualityPreset",
+        "values": [
+          [
+            "FASTEST",
+            "fastest"
+          ],
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ]
+        ],
+        "description": "Speed vs quality tradeoff"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/trim-video",
+    "className": "Trim_Video",
+    "moduleName": "video-generate",
+    "docstring": "Simple tool to quickly trim a video or audio file",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Duration to trim from start time (format: HH:MM:SS or MM:SS or seconds). Ignored if end_time is specified.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "end_time",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "End time for trimming (format: HH:MM:SS or MM:SS or seconds). If not specified, uses duration instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp4",
+        "description": "Output video format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "mp4",
+          "mov",
+          "avi",
+          "mkv",
+          "webm"
+        ]
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Video quality preset",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "ultrafast",
+          "superfast",
+          "veryfast",
+          "faster",
+          "fast",
+          "medium",
+          "slow",
+          "slower",
+          "veryslow"
+        ]
+      },
+      {
+        "name": "remove_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Remove audio track from output video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_time",
+        "tsType": "string",
+        "propType": "str",
+        "default": "00:00:00",
+        "description": "Start time for trimming (format: HH:MM:SS or MM:SS or seconds)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file to trim",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "MP4",
+            "mp4"
+          ],
+          [
+            "MOV",
+            "mov"
+          ],
+          [
+            "AVI",
+            "avi"
+          ],
+          [
+            "MKV",
+            "mkv"
+          ],
+          [
+            "WEBM",
+            "webm"
+          ]
+        ],
+        "description": "Output video format"
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "ULTRAFAST",
+            "ultrafast"
+          ],
+          [
+            "SUPERFAST",
+            "superfast"
+          ],
+          [
+            "VERYFAST",
+            "veryfast"
+          ],
+          [
+            "FASTER",
+            "faster"
+          ],
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "SLOW",
+            "slow"
+          ],
+          [
+            "SLOWER",
+            "slower"
+          ],
+          [
+            "VERYSLOW",
+            "veryslow"
+          ]
+        ],
+        "description": "Video quality preset"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/video-audio-merge",
+    "className": "Video_Audio_Merge",
+    "moduleName": "video-generate",
+    "docstring": "merge a video and an audio file",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio_codec",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "aac",
+        "description": "Audio codec for output",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioCodec",
+        "enumValues": [
+          "aac",
+          "mp3",
+          "copy"
+        ]
+      },
+      {
+        "name": "audio_file",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio file (MP3, WAV, AAC, etc.)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio_volume",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Audio volume multiplier (1.0 = original volume)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "duration_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "video",
+        "description": "How to handle duration when video and audio lengths differ",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "DurationMode",
+        "enumValues": [
+          "video",
+          "audio"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp4",
+        "description": "Output video format",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "mp4",
+          "mov",
+          "avi",
+          "mkv"
+        ]
+      },
+      {
+        "name": "replace_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Replace original audio completely (True) or mix with original audio (False)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_codec",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "h264",
+        "description": "Video codec for output",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "VideoCodec",
+        "enumValues": [
+          "h264",
+          "h265",
+          "vp9",
+          "copy"
+        ]
+      },
+      {
+        "name": "video_file",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file (MP4, MOV, AVI, etc.)",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AudioCodec",
+        "values": [
+          [
+            "AAC",
+            "aac"
+          ],
+          [
+            "MP3",
+            "mp3"
+          ],
+          [
+            "COPY",
+            "copy"
+          ]
+        ],
+        "description": "Audio codec for output"
+      },
+      {
+        "name": "DurationMode",
+        "values": [
+          [
+            "VIDEO",
+            "video"
+          ],
+          [
+            "AUDIO",
+            "audio"
+          ]
+        ],
+        "description": "How to handle duration when video and audio lengths differ"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "MP4",
+            "mp4"
+          ],
+          [
+            "MOV",
+            "mov"
+          ],
+          [
+            "AVI",
+            "avi"
+          ],
+          [
+            "MKV",
+            "mkv"
+          ]
+        ],
+        "description": "Output video format"
+      },
+      {
+        "name": "VideoCodec",
+        "values": [
+          [
+            "H264",
+            "h264"
+          ],
+          [
+            "H265",
+            "h265"
+          ],
+          [
+            "VP9",
+            "vp9"
+          ],
+          [
+            "COPY",
+            "copy"
+          ]
+        ],
+        "description": "Video codec for output"
+      }
+    ]
+  },
+  {
+    "endpointId": "lucataco/video-merge",
+    "className": "Video_Merge",
+    "moduleName": "video-generate",
+    "docstring": "Simple tool to merge together separate video snippets",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Output video frame rate. If not specified, uses first video's fps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Output video height. If not specified, uses first video's height",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "keep_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to keep audio in the output video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_files",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "List of video files to concatenate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Output video width. If not specified, uses first video's width",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lucataco/wan-2.1-1.3b-vid2vid",
+    "className": "Wan_2_1_1_3b_Vid2vid",
+    "moduleName": "video-generate",
+    "docstring": "Wan 2.1 1.3b Video to Video. Wan is a powerful visual generation model developed by Tongyi Lab of Alibaba Group",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "832x480",
+        "description": "Aspect ratio for the output video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "832x480",
+          "480x832"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 6,
+        "description": "Classifier free guidance scale (higher values strengthen prompt adherence)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 20
+      },
+      {
+        "name": "denoising_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.7,
+        "description": "Strength of denoising when using video-to-video mode. Higher values change more content.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "Number of frames per second in the output video",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 24
+      },
+      {
+        "name": "input_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video for video-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "low quality, blurry, distorted, disfigured, text, watermark",
+        "description": "Negative prompt to specify what to avoid in the generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 81,
+        "description": "Number of frames to generate in the output video",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 40,
+        "description": "Number of sampling steps (higher = better quality but slower)",
+        "fieldType": "input",
+        "required": false,
+        "min": 10,
+        "max": 50
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing what you want to generate or modify",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible results (leave blank for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tiled",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to use tiled sampling for better quality on larger videos",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "_832X480",
+            "832x480"
+          ],
+          [
+            "_480X832",
+            "480x832"
+          ]
+        ],
+        "description": "Aspect ratio for the output video"
+      }
+    ]
+  },
+  {
+    "endpointId": "minimax/hailuo-02-fast",
+    "className": "Hailuo_02_Fast",
+    "moduleName": "video-generate",
+    "docstring": "A low cost and fast version of Hailuo 02. Generate 6s and 10s videos in 512p",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 6,
+        "description": "Duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "6",
+          "10"
+        ]
+      },
+      {
+        "name": "first_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for video generation. The output video will have the same aspect ratio as this image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate videos faster with slightly lower quality",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame image for video generation. The final frame of the output video will match this image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_optimizer",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Use prompt optimizer",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "512P",
+        "description": "The resolution to render (should be 512P).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "512P"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_512P",
+            "512P"
+          ]
+        ],
+        "description": "The resolution to render (should be 512P)."
+      }
+    ]
+  },
+  {
+    "endpointId": "nicolascoutureau/video-utils",
+    "className": "Video_Utils",
+    "moduleName": "video-generate",
+    "docstring": "",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "frames per second, if relevant. Use 0 to keep original fps (or use default). Converting to GIF defaults to 12fps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "input_file",
+        "tsType": "image",
+        "propType": "video",
+        "default": null,
+        "description": "File – zip, image or video to process",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "task",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Task to perform",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "Task",
+        "enumValues": [
+          "convert_input_to_mp4",
+          "convert_input_to_gif",
+          "extract_video_audio_as_mp3",
+          "zipped_frames_to_mp4",
+          "zipped_frames_to_gif",
+          "extract_frames_from_input",
+          "reverse_video",
+          "bounce_video",
+          "create_image_preview",
+          "create_preview_video",
+          "get_video_metadata",
+          "reencode_audio_for_fast_seeking",
+          "encode_for_insta",
+          "reencode_for_web"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Task",
+        "values": [
+          [
+            "CONVERT_INPUT_TO_MP4",
+            "convert_input_to_mp4"
+          ],
+          [
+            "CONVERT_INPUT_TO_GIF",
+            "convert_input_to_gif"
+          ],
+          [
+            "EXTRACT_VIDEO_AUDIO_AS_MP3",
+            "extract_video_audio_as_mp3"
+          ],
+          [
+            "ZIPPED_FRAMES_TO_MP4",
+            "zipped_frames_to_mp4"
+          ],
+          [
+            "ZIPPED_FRAMES_TO_GIF",
+            "zipped_frames_to_gif"
+          ],
+          [
+            "EXTRACT_FRAMES_FROM_INPUT",
+            "extract_frames_from_input"
+          ],
+          [
+            "REVERSE_VIDEO",
+            "reverse_video"
+          ],
+          [
+            "BOUNCE_VIDEO",
+            "bounce_video"
+          ],
+          [
+            "CREATE_IMAGE_PREVIEW",
+            "create_image_preview"
+          ],
+          [
+            "CREATE_PREVIEW_VIDEO",
+            "create_preview_video"
+          ],
+          [
+            "GET_VIDEO_METADATA",
+            "get_video_metadata"
+          ],
+          [
+            "REENCODE_AUDIO_FOR_FAST_SEEKING",
+            "reencode_audio_for_fast_seeking"
+          ],
+          [
+            "ENCODE_FOR_INSTA",
+            "encode_for_insta"
+          ],
+          [
+            "REENCODE_FOR_WEB",
+            "reencode_for_web"
+          ]
+        ],
+        "description": "Task to perform"
+      }
+    ]
+  },
+  {
+    "endpointId": "pixverse/pixverse-v3.5",
+    "className": "Pixverse_V3_5",
+    "moduleName": "video-generate",
+    "docstring": "Create videos in as little as 10 seconds. 5s or 8s videos at 360p, 540p, 720p or 1080p.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the video in seconds. 8 second videos cost twice as much as 5 second videos. (1080p does not support 8 second duration)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "8"
+        ]
+      },
+      {
+        "name": "effect",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Special effect to apply to the video. Does not work with last_frame_image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Effect",
+        "enumValues": [
+          "None",
+          "Let's YMCA!",
+          "Subject 3 Fever",
+          "Ghibli Live!",
+          "Suit Swagger",
+          "Muscle Surge",
+          "360° Microwave",
+          "Warmth of Jesus",
+          "Emergency Beat",
+          "Anything, Robot",
+          "Kungfu Club",
+          "Mint in Box",
+          "Retro Anime Pop",
+          "Vogue Walk",
+          "Mega Dive",
+          "Evil Trigger"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use for the first frame of the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Use to generate a video that transitions from the first image to the last image. Must be used with image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "motion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "normal",
+        "description": "Motion mode for the video. Smooth videos generate more frames, so they cost twice as much. (smooth is only available when using a 5 second duration, 1080p does not support smooth motion)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "MotionMode",
+        "enumValues": [
+          "normal",
+          "smooth"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "540p",
+        "description": "Resolution of the video. 360p and 540p cost the same, but 720p and 1080p cost more. See the README for details.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "360p",
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sound_effect_content",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Sound effect prompt. If not given, a random sound effect will be generated.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sound_effect_switch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable background music or sound effects",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Style of the video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "None",
+          "anime",
+          "3d_animation",
+          "clay",
+          "cyberpunk",
+          "comic"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video"
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ]
+        ],
+        "description": "Duration of the video in seconds. 8 second videos cost twice as much as 5 second videos. (1080p does not support 8 second duration)"
+      },
+      {
+        "name": "Effect",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "LETS_YMCA",
+            "Let's YMCA!"
+          ],
+          [
+            "SUBJECT_3_FEVER",
+            "Subject 3 Fever"
+          ],
+          [
+            "GHIBLI_LIVE",
+            "Ghibli Live!"
+          ],
+          [
+            "SUIT_SWAGGER",
+            "Suit Swagger"
+          ],
+          [
+            "MUSCLE_SURGE",
+            "Muscle Surge"
+          ],
+          [
+            "_360_MICROWAVE",
+            "360° Microwave"
+          ],
+          [
+            "WARMTH_OF_JESUS",
+            "Warmth of Jesus"
+          ],
+          [
+            "EMERGENCY_BEAT",
+            "Emergency Beat"
+          ],
+          [
+            "ANYTHING_ROBOT",
+            "Anything, Robot"
+          ],
+          [
+            "KUNGFU_CLUB",
+            "Kungfu Club"
+          ],
+          [
+            "MINT_IN_BOX",
+            "Mint in Box"
+          ],
+          [
+            "RETRO_ANIME_POP",
+            "Retro Anime Pop"
+          ],
+          [
+            "VOGUE_WALK",
+            "Vogue Walk"
+          ],
+          [
+            "MEGA_DIVE",
+            "Mega Dive"
+          ],
+          [
+            "EVIL_TRIGGER",
+            "Evil Trigger"
+          ]
+        ],
+        "description": "Special effect to apply to the video. Does not work with last_frame_image."
+      },
+      {
+        "name": "MotionMode",
+        "values": [
+          [
+            "NORMAL",
+            "normal"
+          ],
+          [
+            "SMOOTH",
+            "smooth"
+          ]
+        ],
+        "description": "Motion mode for the video. Smooth videos generate more frames, so they cost twice as much. (smooth is only available when using a 5 second duration, 1080p does not support smooth motion)"
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "_360P",
+            "360p"
+          ],
+          [
+            "_540P",
+            "540p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Resolution of the video. 360p and 540p cost the same, but 720p and 1080p cost more. See the README for details."
+      },
+      {
+        "name": "Style",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "ANIME",
+            "anime"
+          ],
+          [
+            "_3D_ANIMATION",
+            "3d_animation"
+          ],
+          [
+            "CLAY",
+            "clay"
+          ],
+          [
+            "CYBERPUNK",
+            "cyberpunk"
+          ],
+          [
+            "COMIC",
+            "comic"
+          ]
+        ],
+        "description": "Style of the video"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/vace-1.3b",
+    "className": "Vace_1_3b",
+    "moduleName": "video-generate",
+    "docstring": "This is VACE-1.3B model optimised with pruna ai. Wan2.1 VACE is an all-in-one model for video creation and editing.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "frame_num",
+        "tsType": "number",
+        "propType": "int",
+        "default": 81,
+        "description": "Number of frames to generate.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Sample guide scale",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "Sample shift",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sample_solver",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "unipc",
+        "description": "Sample solver",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SampleSolver",
+        "enumValues": [
+          "unipc",
+          "dpm++"
+        ]
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Sample steps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed (-1 for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "480*832",
+        "description": "Output resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "480*832",
+          "832*480"
+        ]
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Lightly Juiced 🍊 (more consistent)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (more speed)",
+          "Extra Juiced 🚀 (even more speed)"
+        ]
+      },
+      {
+        "name": "src_mask",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input mask video to edit.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "src_ref_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input reference images to edit.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "src_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to edit.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "SampleSolver",
+        "values": [
+          [
+            "UNIPC",
+            "unipc"
+          ],
+          [
+            "DPM_PLUS_PLUS",
+            "dpm++"
+          ]
+        ],
+        "description": "Sample solver"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_480_832",
+            "480*832"
+          ],
+          [
+            "_832_480",
+            "832*480"
+          ]
+        ],
+        "description": "Output resolution"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_MORE_SPEED",
+            "Juiced 🔥 (more speed)"
+          ],
+          [
+            "EXTRA_JUICED_EVEN_MORE_SPEED",
+            "Extra Juiced 🚀 (even more speed)"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/vace-14b",
+    "className": "Vace_14b",
+    "moduleName": "video-generate",
+    "docstring": "This is a faster VACE-14B model, optimised with pruna, contact us for more at pruna.ai",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "frame_num",
+        "tsType": "number",
+        "propType": "int",
+        "default": 81,
+        "description": "Number of frames to generate.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Sample guide scale",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "Sample shift",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sample_solver",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "unipc",
+        "description": "Sample solver",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SampleSolver",
+        "enumValues": [
+          "unipc",
+          "dpm++"
+        ]
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "Sample steps",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed (-1 for random)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "832*480",
+        "description": "Output resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "720*1280",
+          "1280*720",
+          "480*832",
+          "832*480"
+        ]
+      },
+      {
+        "name": "speed_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Lightly Juiced 🍊 (more consistent)",
+        "description": "Speed optimization level",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SpeedMode",
+        "enumValues": [
+          "Lightly Juiced 🍊 (more consistent)",
+          "Juiced 🔥 (more speed)",
+          "Extra Juiced 🚀 (even more speed)"
+        ]
+      },
+      {
+        "name": "src_mask",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input mask video or image to edit.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "src_ref_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input reference images to edit.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "src_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to edit.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "SampleSolver",
+        "values": [
+          [
+            "UNIPC",
+            "unipc"
+          ],
+          [
+            "DPM_PLUS_PLUS",
+            "dpm++"
+          ]
+        ],
+        "description": "Sample solver"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_720_1280",
+            "720*1280"
+          ],
+          [
+            "_1280_720",
+            "1280*720"
+          ],
+          [
+            "_480_832",
+            "480*832"
+          ],
+          [
+            "_832_480",
+            "832*480"
+          ]
+        ],
+        "description": "Output resolution"
+      },
+      {
+        "name": "SpeedMode",
+        "values": [
+          [
+            "LIGHTLY_JUICED_MORE_CONSISTENT",
+            "Lightly Juiced 🍊 (more consistent)"
+          ],
+          [
+            "JUICED_MORE_SPEED",
+            "Juiced 🔥 (more speed)"
+          ],
+          [
+            "EXTRA_JUICED_EVEN_MORE_SPEED",
+            "Extra Juiced 🚀 (even more speed)"
+          ]
+        ],
+        "description": "Speed optimization level"
+      }
+    ]
+  },
+  {
+    "endpointId": "retro-diffusion/rd-animation",
+    "className": "Rd_Animation",
+    "moduleName": "video-generate",
+    "docstring": "Style consistent animated pixel art sprite generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "bypass_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable automatic prompt expansion",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 48,
+        "description": "Animation height. four_angle_walking and walking_and_idle only support 48. small_sprites only supports 32. vfx supports 24-96.",
+        "fieldType": "input",
+        "required": false,
+        "min": 24,
+        "max": 96
+      },
+      {
+        "name": "input_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-image generation or reference. Will be converted to RGB without transparency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "return_spritesheet",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return animation as a spritesheet PNG instead of animated GIF",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "four_angle_walking",
+        "description": "Style to apply to the generated image\n\nfour_angle_walking: Consistent 4 direction, 4 frame long walking animations of humanoid characters\nwalking_and_idle: Consistent 4 direction walking and idle animations of humanoid characters\nsmall_sprites: 4 direction 32x32 sprites with walking, arm raising/attacking, looking around, surprised, and laying down animations\nvfx: Eye-catching animations for fire, explosions, lightning, or other simple effects",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Style",
+        "enumValues": [
+          "four_angle_walking",
+          "walking_and_idle",
+          "small_sprites",
+          "vfx"
+        ]
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 48,
+        "description": "Animation width. four_angle_walking and walking_and_idle only support 48. small_sprites only supports 32. vfx supports 24-96.",
+        "fieldType": "input",
+        "required": false,
+        "min": 24,
+        "max": 96
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Style",
+        "values": [
+          [
+            "FOUR_ANGLE_WALKING",
+            "four_angle_walking"
+          ],
+          [
+            "WALKING_AND_IDLE",
+            "walking_and_idle"
+          ],
+          [
+            "SMALL_SPRITES",
+            "small_sprites"
+          ],
+          [
+            "VFX",
+            "vfx"
+          ]
+        ],
+        "description": "Style to apply to the generated image\n\nfour_angle_walking: Consistent 4 direction, 4 frame long walking animations of humanoid characters\nwalking_and_idle: Consistent 4 direction walking and idle animations of humanoid characters\nsmall_sprites: 4 direction 32x32 sprites with walking, arm raising/attacking, looking around, surprised, and laying down animations\nvfx: Eye-catching animations for fire, explosions, lightning, or other simple effects"
+      }
+    ]
+  },
+  {
+    "endpointId": "shridharathi/ghibli-vid",
+    "className": "Ghibli_Vid",
+    "moduleName": "video-generate",
+    "docstring": "Make a video of anything in Studio Ghibli style",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the video. 16:9, 9:16, 1:1, etc.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Balanced",
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FastMode",
+        "enumValues": [
+          "Off",
+          "Balanced",
+          "Fast"
+        ]
+      },
+      {
+        "name": "frames",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 81,
+        "description": "The number of frames to generate (1 to 5 seconds)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Frames",
+        "enumValues": [
+          "17",
+          "33",
+          "49",
+          "65",
+          "81"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as a starting frame for image to video generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_strength_clip",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the LORA applied to the CLIP model. 0.0 is no LORA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_strength_model",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the LORA applied to the model. 0.0 is no LORA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "replicate_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Replicate LoRA weights to use. Leave blank to use the default weights.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "480p",
+        "description": "The resolution of the video. 720p is not supported for 1.3b.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Higher guide scale makes prompt adherence better, but can reduce variation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "float",
+        "default": 8,
+        "description": "Sample shift factor",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of generation steps. Fewer steps means faster generation, at the expensive of output quality. 30 steps is sufficient for most prompts",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "The aspect ratio of the video. 16:9, 9:16, 1:1, etc."
+      },
+      {
+        "name": "FastMode",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "BALANCED",
+            "Balanced"
+          ],
+          [
+            "FAST",
+            "Fast"
+          ]
+        ],
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups."
+      },
+      {
+        "name": "Frames",
+        "values": [
+          [
+            "VALUE_17",
+            "17"
+          ],
+          [
+            "VALUE_33",
+            "33"
+          ],
+          [
+            "VALUE_49",
+            "49"
+          ],
+          [
+            "VALUE_65",
+            "65"
+          ],
+          [
+            "VALUE_81",
+            "81"
+          ]
+        ],
+        "description": "The number of frames to generate (1 to 5 seconds)"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "The resolution of the video. 720p is not supported for 1.3b."
+      }
+    ]
+  },
+  {
+    "endpointId": "sync/react-1",
+    "className": "React_1",
+    "moduleName": "video-generate",
+    "docstring": "Realistic lipsync with refined human emotion capabilities",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio file (.wav)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "emotion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "neutral",
+        "description": "Emotion prompt for the generation (single word emotions only)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Emotion",
+        "enumValues": [
+          "happy",
+          "sad",
+          "angry",
+          "disgusted",
+          "surprised",
+          "neutral"
+        ]
+      },
+      {
+        "name": "model_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "face",
+        "description": "Edit region for the model (lips/face/head). When head is selected, model generates natural talking head movements along with emotions + lipsync",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelMode",
+        "enumValues": [
+          "lips",
+          "face",
+          "head"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "loop",
+        "description": "Lipsync mode when audio and video durations are out of sync",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SyncMode",
+        "enumValues": [
+          "loop",
+          "bounce",
+          "cut_off",
+          "silence",
+          "remap"
+        ]
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "How expressive lipsync can be (0-1)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file (.mp4)",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Emotion",
+        "values": [
+          [
+            "HAPPY",
+            "happy"
+          ],
+          [
+            "SAD",
+            "sad"
+          ],
+          [
+            "ANGRY",
+            "angry"
+          ],
+          [
+            "DISGUSTED",
+            "disgusted"
+          ],
+          [
+            "SURPRISED",
+            "surprised"
+          ],
+          [
+            "NEUTRAL",
+            "neutral"
+          ]
+        ],
+        "description": "Emotion prompt for the generation (single word emotions only)"
+      },
+      {
+        "name": "ModelMode",
+        "values": [
+          [
+            "LIPS",
+            "lips"
+          ],
+          [
+            "FACE",
+            "face"
+          ],
+          [
+            "HEAD",
+            "head"
+          ]
+        ],
+        "description": "Edit region for the model (lips/face/head). When head is selected, model generates natural talking head movements along with emotions + lipsync"
+      },
+      {
+        "name": "SyncMode",
+        "values": [
+          [
+            "LOOP",
+            "loop"
+          ],
+          [
+            "BOUNCE",
+            "bounce"
+          ],
+          [
+            "CUT_OFF",
+            "cut_off"
+          ],
+          [
+            "SILENCE",
+            "silence"
+          ],
+          [
+            "REMAP",
+            "remap"
+          ]
+        ],
+        "description": "Lipsync mode when audio and video durations are out of sync"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan2.1-with-lora",
+    "className": "Wan2_1_With_Lora",
+    "moduleName": "video-generate",
+    "docstring": "Run Wan2.1 14b or 1.3b with a lora",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the video. 16:9, 9:16, 1:1, etc.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Balanced",
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FastMode",
+        "enumValues": [
+          "Off",
+          "Balanced",
+          "Fast"
+        ]
+      },
+      {
+        "name": "frames",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 81,
+        "description": "The number of frames to generate (1 to 5 seconds)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Frames",
+        "enumValues": [
+          "17",
+          "33",
+          "49",
+          "65",
+          "81"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image to use as a starting frame for image to video generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_strength_clip",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the LORA applied to the CLIP model. 0.0 is no LORA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_strength_model",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of the LORA applied to the model. 0.0 is no LORA.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional: The URL of a LORA to use",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "14b",
+        "description": "The model to use. 1.3b is faster, but 14b is better quality. A LORA either works with 1.3b or 14b, depending on the version it was trained on.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "1.3b",
+          "14b"
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Things you do not want to see in your video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "480p",
+        "description": "The resolution of the video. 720p is not supported for 1.3b.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Higher guide scale makes prompt adherence better, but can reduce variation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "float",
+        "default": 8,
+        "description": "Sample shift factor",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of generation steps. Fewer steps means faster generation, at the expensive of output quality. 30 steps is sufficient for most prompts",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Set a seed for reproducibility. Random by default.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "The aspect ratio of the video. 16:9, 9:16, 1:1, etc."
+      },
+      {
+        "name": "FastMode",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "BALANCED",
+            "Balanced"
+          ],
+          [
+            "FAST",
+            "Fast"
+          ]
+        ],
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups."
+      },
+      {
+        "name": "Frames",
+        "values": [
+          [
+            "VALUE_17",
+            "17"
+          ],
+          [
+            "VALUE_33",
+            "33"
+          ],
+          [
+            "VALUE_49",
+            "49"
+          ],
+          [
+            "VALUE_65",
+            "65"
+          ],
+          [
+            "VALUE_81",
+            "81"
+          ]
+        ],
+        "description": "The number of frames to generate (1 to 5 seconds)"
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "_1_3B",
+            "1.3b"
+          ],
+          [
+            "_14B",
+            "14b"
+          ]
+        ],
+        "description": "The model to use. 1.3b is faster, but 14b is better quality. A LORA either works with 1.3b or 14b, depending on the version it was trained on."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "The resolution of the video. 720p is not supported for 1.3b."
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.2-5b-fast",
+    "className": "Wan_2_2_5b_Fast",
+    "moduleName": "video-generate",
+    "docstring": "The fastest Wan 2.2 text-to-image and image-to-video model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of video. 16:9 corresponds to 832x480px, and 9:16 is 480x832px",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Frames per second. Note that the pricing of this model is based on the video duration at 16 fps",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 30
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Go fast",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to generate video from.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt for generated image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 81,
+        "description": "Number of video frames. 81 frames give the best results",
+        "fieldType": "input",
+        "required": false,
+        "min": 81,
+        "max": 121
+      },
+      {
+        "name": "optimize_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Translate prompt to Chinese before generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Resolution of video. 16:9 corresponds to 832x480px, and 9:16 is 480x832px",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Sample shift factor",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of video. 16:9 corresponds to 832x480px, and 9:16 is 480x832px"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "Resolution of video. 16:9 corresponds to 832x480px, and 9:16 is 480x832px"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.2-animate-animation",
+    "className": "Wan_2_2_Animate_Animation",
+    "moduleName": "video-generate",
+    "docstring": "Use Wan 2.2 Animate to copy the motion of a video to another scene",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "character_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Character image to animate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Frames per second for output video",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 60
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Go fast",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "merge_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Merge audio from input video into output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "refert_num",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 1,
+        "description": "Number of reference frames to use (must be 1 or 5)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "RefertNum",
+        "enumValues": [
+          "1",
+          "5"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720",
+        "description": "Resolution for processing",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720",
+          "480"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to use as motion reference",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "RefertNum",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ]
+        ],
+        "description": "Number of reference frames to use (must be 1 or 5)"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720",
+            "720"
+          ],
+          [
+            "VALUE_480",
+            "480"
+          ]
+        ],
+        "description": "Resolution for processing"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.2-animate-replace",
+    "className": "Wan_2_2_Animate_Replace",
+    "moduleName": "video-generate",
+    "docstring": "Use Wan 2.2 Animate to replace a character in a video scene",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "character_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "New character image to replace the original character.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Frames per second for output video. Deprecated, will always be set to 30.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 60
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Apply additional optimizations for faster generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "merge_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Merge audio from input video into output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "refert_num",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 1,
+        "description": "Number of reference frames to use (must be 1 or 5. Deprecated, will always be set to 1.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "RefertNum",
+        "enumValues": [
+          "1",
+          "5"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720",
+        "description": "Resolution for processing.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720",
+          "480"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video containing the character to be replaced.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "RefertNum",
+        "values": [
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ]
+        ],
+        "description": "Number of reference frames to use (must be 1 or 5. Deprecated, will always be set to 1."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720",
+            "720"
+          ],
+          [
+            "VALUE_480",
+            "480"
+          ]
+        ],
+        "description": "Resolution for processing."
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.2-i2v-a14b",
+    "className": "Wan_2_2_I2v_A14b",
+    "moduleName": "video-generate",
+    "docstring": "Image-to-video at 720p and 480p with Wan 2.2 A14B",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "frames_per_second",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "Frames per second. Note that the pricing of this model is based on the video duration at 16 fps",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 24
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Go fast",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to generate video from.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 81,
+        "description": "Number of video frames. 81 frames give the best results",
+        "fieldType": "input",
+        "required": false,
+        "min": 81,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "480p",
+        "description": "Resolution of video. 832x480px corresponds to 16:9 aspect ratio, and 480x832px is 9:16",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Sample shift factor",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 40,
+        "description": "Number of generation steps. Fewer steps means faster generation, at the expensive of output quality. 30 steps is sufficient for most prompts",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "Resolution of video. 832x480px corresponds to 16:9 aspect ratio, and 480x832px is 9:16"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.6-i2v",
+    "className": "Wan_2_6_I2v",
+    "moduleName": "video-generate",
+    "docstring": "Alibaba Wan 2.6 image to video generation model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file (wav/mp3, 3-30s, ≤15MB) for voice/music synchronization",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10",
+          "15"
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the prompt optimizer will be enabled",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "multi_shots",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable intelligent multi-shot segmentation (only active when enable_prompt_expansion is enabled). True enables multi-shot segmentation, false generates single-shot content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ]
+        ],
+        "description": "Duration of the generated video in seconds"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.6-t2v",
+    "className": "Wan_2_6_T2v",
+    "moduleName": "video-generate",
+    "docstring": "Alibaba Wan 2.6 text to video generation model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file (wav/mp3, 3-30s, ≤15MB) for voice/music synchronization",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10",
+          "15"
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the prompt optimizer will be enabled",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "multi_shots",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable intelligent multi-shot segmentation (only active when enable_prompt_expansion is enabled). True enables multi-shot segmentation, false generates single-shot content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1280*720",
+        "description": "Video resolution and aspect ratio",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1280*720",
+          "720*1280",
+          "1920*1080",
+          "1080*1920"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ]
+        ],
+        "description": "Duration of the generated video in seconds"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1280_720",
+            "1280*720"
+          ],
+          [
+            "_720_1280",
+            "720*1280"
+          ],
+          [
+            "_1920_1080",
+            "1920*1080"
+          ],
+          [
+            "_1080_1920",
+            "1080*1920"
+          ]
+        ],
+        "description": "Video resolution and aspect ratio"
+      }
+    ]
+  },
+  {
+    "endpointId": "wavespeedai/wan-2.1-i2v-720p",
+    "className": "Wan_2_1_I2v_720p",
+    "moduleName": "video-generate",
+    "docstring": "Accelerated inference for Wan 2.1 14B image to video with high resolution, a comprehensive and open suite of video foundation models that pushes the boundaries of video generation.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated videos",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Balanced",
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FastMode",
+        "enumValues": [
+          "Off",
+          "Balanced",
+          "Fast"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image for use as the initial frame of the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied. Sane results between 0 and 1 for base inference. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3,
+        "description": "Flow shift parameter for video generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the output video."
+      },
+      {
+        "name": "FastMode",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "BALANCED",
+            "Balanced"
+          ],
+          [
+            "FAST",
+            "Fast"
+          ]
+        ],
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups."
+      }
+    ]
+  },
+  {
+    "endpointId": "wavespeedai/wan-2.1-t2v-480p",
+    "className": "Wan_2_1_T2v_480p",
+    "moduleName": "video-generate",
+    "docstring": "Accelerated inference for Wan 2.1 14B text to video, a comprehensive and open suite of video foundation models that pushes the boundaries of video generation.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated videos",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Balanced",
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FastMode",
+        "enumValues": [
+          "Off",
+          "Balanced",
+          "Fast"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied. Sane results between 0 and 1 for base inference. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3,
+        "description": "Flow shift parameter for video generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the output video."
+      },
+      {
+        "name": "FastMode",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "BALANCED",
+            "Balanced"
+          ],
+          [
+            "FAST",
+            "Fast"
+          ]
+        ],
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups."
+      }
+    ]
+  },
+  {
+    "endpointId": "wavespeedai/wan-2.1-t2v-720p",
+    "className": "Wan_2_1_T2v_720p",
+    "moduleName": "video-generate",
+    "docstring": "Accelerated inference for Wan 2.1 14B text to video with high resolution, a comprehensive and open suite of video foundation models that pushes the boundaries of video generation.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated videos",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "fast_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Balanced",
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FastMode",
+        "enumValues": [
+          "Off",
+          "Balanced",
+          "Fast"
+        ]
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied. Sane results between 0 and 1 for base inference. You may still need to experiment to find the best value for your particular lora.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "sample_guide_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Guidance scale for generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "sample_shift",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3,
+        "description": "Flow shift parameter for video generation",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "sample_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of inference steps",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 40
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the output video."
+      },
+      {
+        "name": "FastMode",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "BALANCED",
+            "Balanced"
+          ],
+          [
+            "FAST",
+            "Fast"
+          ]
+        ],
+        "description": "Speed up generation with different levels of acceleration. Faster modes may degrade quality somewhat. The speedup is dependent on the content, so different videos may see different speedups."
+      }
+    ]
+  },
+  {
     "endpointId": "topazlabs/video-upscale",
     "className": "Topaz_Video_Upscale",
     "moduleName": "video-enhance",
@@ -60732,6 +89410,834 @@
           ]
         ],
         "description": "Sample rate for the generated music"
+      }
+    ]
+  },
+  {
+    "endpointId": "mirelo/video-to-sfx-v1",
+    "className": "Video_To_Sfx_V1",
+    "moduleName": "audio-generate",
+    "docstring": "Generate synced sounds for any video, and return it with its new sound track",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "creativity_coef",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4.5,
+        "description": "Creativity coefficient to control the creativity of the generated sound. Higher values are more creative.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 10,
+        "description": "Duration of the generated sound effects in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "num_samples",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Number of sound effects to generate. Each sample will be a different variation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducibility. Leave blank (None) or use -1 for random seed, or any integer for deterministic results.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_offset",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Starting point in the video (in seconds) from which to generate audio. 0 means start from the beginning.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 300
+      },
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Number of processing steps for the generation model. Higher values may improve quality but take longer.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 30
+      },
+      {
+        "name": "text_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide sound effect generation. Optional text to guide the sound generation process.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_path",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Video file to process for sound effects. Video will be trimmed to 10 sec if longer",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "mirelo/video-to-sfx-v1.5",
+    "className": "Video_To_Sfx_V1_5",
+    "moduleName": "audio-generate",
+    "docstring": "Generate synced sounds for any video and return it with its new soundtrack - now enhanced in version 1.5 for improved sound synchronization and realism",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "creativity_coef",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4.5,
+        "description": "Creativity coefficient to control the creativity of the generated sound. Higher values are more creative.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 10,
+        "description": "Duration of the generated sound effects in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "num_samples",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Number of sound effects to generate. Each sample will be a different variation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducibility. Leave blank (None) or use -1 for random seed, or any integer for deterministic results.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_offset",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Starting point in the video (in seconds) from which to generate audio. 0 means start from the beginning.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 300
+      },
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Number of processing steps for the generation model. Higher values may improve quality but take longer.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 30
+      },
+      {
+        "name": "text_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide sound effect generation. Optional text to guide the sound generation process.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_path",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Video file to process for sound effects. Video will be trimmed to 10 sec if longer",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "playht/play-dialog",
+    "className": "Play_Dialog",
+    "moduleName": "audio-generate",
+    "docstring": "End-to-end AI speech model designed for natural-sounding conversational speech synthesis, with support for context-aware prosody, intonation, and emotional expression.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "emotion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "The emotion to use for the generated audio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Emotion",
+        "enumValues": [
+          "None",
+          "female_happy",
+          "female_sad",
+          "female_angry",
+          "female_fearful",
+          "female_disgust",
+          "female_surprised",
+          "male_happy",
+          "male_sad",
+          "male_angry",
+          "male_fearful",
+          "male_disgust",
+          "male_surprised"
+        ]
+      },
+      {
+        "name": "language",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "english",
+        "description": "The language of the text to be spoken.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Language",
+        "enumValues": [
+          "afrikaans",
+          "albanian",
+          "amharic",
+          "arabic",
+          "bengali",
+          "bulgarian",
+          "catalan",
+          "croatian",
+          "czech",
+          "danish",
+          "dutch",
+          "english",
+          "french",
+          "galician",
+          "german",
+          "greek",
+          "hebrew",
+          "hindi",
+          "hungarian",
+          "indonesian",
+          "italian",
+          "japanese",
+          "korean",
+          "malay",
+          "mandarin",
+          "polish",
+          "portuguese",
+          "russian",
+          "serbian",
+          "spanish",
+          "swedish",
+          "tagalog",
+          "thai",
+          "turkish",
+          "ukrainian",
+          "urdu",
+          "xhosa"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A prompt to guide the style of the output generated by the first voice.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt2",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A prompt to guide the style of the output generated by the second voice.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.02,
+        "description": "The temperature parameter controls variance. Lower temperatures result in more predictable results, higher temperatures allow each run to vary more, so the voice may sound less like the baseline voice. Between 1.02 and 1.05 give good results.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.1,
+        "max": 1.5
+      },
+      {
+        "name": "text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text for speech generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "turnPrefix",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Voice 1:",
+        "description": "The prefix to indicate the start of a turn in a multi-turn dialogue for the first voice.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "turnPrefix2",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Voice 2:",
+        "description": "The prefix to indicate the start of a turn in a multi-turn dialogue for the second voice.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "voice",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Angelo (Young male US conversational voice)",
+        "description": "Voice to use for generation",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Voice",
+        "enumValues": [
+          "Angelo (Young male US conversational voice)",
+          "Arsenio (Middle-aged male US African American conversational voice)",
+          "Cillian (Middle-aged male Irish conversational voice)",
+          "Timo (Middle-aged male US conversational voice)",
+          "Dexter (Middle-aged male US conversational voice)",
+          "Miles (Young male US African American conversational voice)",
+          "Briggs (Elderly male US Southern (Oklahoma) conversational voice)",
+          "Deedee (Middle-aged female US African American conversational voice)",
+          "Nia (Young female US conversational voice)",
+          "Inara (Middle-aged female US African American conversational voice)",
+          "Constanza (Young female US Latin American conversational voice)",
+          "Gideon (Elderly male British narrative voice)",
+          "Casper (Middle-aged male US narrative voice)",
+          "Mitch (Middle-aged male Australian narrative voice)",
+          "Ava (Middle-aged female Australian narrative voice)",
+          "Carmen (Middle-aged female Spanish conversational voice, calm and warm)",
+          "Andrei (Middle-aged male Russian conversational voice, calm and warm)",
+          "Ilias (Middle-aged male German narrative voice, deep and calm)",
+          "Gaelle (Middle-aged female French conversational voice, professional)",
+          "Alessandro (Older male Italian conversational voice, warm and gravelly)",
+          "Yumiko (Young female Japanese narrative voice, warm and light)"
+        ]
+      },
+      {
+        "name": "voice_2",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Optional second voice to use for generation",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Voice2",
+        "enumValues": [
+          "None",
+          "Angelo (Young male US conversational voice)",
+          "Arsenio (Middle-aged male US African American conversational voice)",
+          "Cillian (Middle-aged male Irish conversational voice)",
+          "Timo (Middle-aged male US conversational voice)",
+          "Dexter (Middle-aged male US conversational voice)",
+          "Miles (Young male US African American conversational voice)",
+          "Briggs (Elderly male US Southern (Oklahoma) conversational voice)",
+          "Deedee (Middle-aged female US African American conversational voice)",
+          "Nia (Young female US conversational voice)",
+          "Inara (Middle-aged female US African American conversational voice)",
+          "Constanza (Young female US Latin American conversational voice)",
+          "Gideon (Elderly male British narrative voice)",
+          "Casper (Middle-aged male US narrative voice)",
+          "Mitch (Middle-aged male Australian narrative voice)",
+          "Ava (Middle-aged female Australian narrative voice)",
+          "Carmen (Middle-aged female Spanish conversational voice, calm and warm)",
+          "Andrei (Middle-aged male Russian conversational voice, calm and warm)",
+          "Ilias (Middle-aged male German narrative voice, deep and calm)",
+          "Gaelle (Middle-aged female French conversational voice, professional)",
+          "Alessandro (Older male Italian conversational voice, warm and gravelly)",
+          "Yumiko (Young female Japanese narrative voice, warm and light)"
+        ]
+      },
+      {
+        "name": "voice_conditioning_seconds",
+        "tsType": "number",
+        "propType": "int",
+        "default": 20,
+        "description": "The number of seconds of conditioning to use from the selected voice. Lower values generate audio less similar to the cloned voice, but lead to more model stability and expressiveness. Higher values create output more similar to the cloned voice, but can lead to model instability and reduced expressiveness.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "voice_conditioning_seconds_2",
+        "tsType": "number",
+        "propType": "int",
+        "default": 20,
+        "description": "The number of seconds of conditioning to use from the second selected voice.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Emotion",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "FEMALE_HAPPY",
+            "female_happy"
+          ],
+          [
+            "FEMALE_SAD",
+            "female_sad"
+          ],
+          [
+            "FEMALE_ANGRY",
+            "female_angry"
+          ],
+          [
+            "FEMALE_FEARFUL",
+            "female_fearful"
+          ],
+          [
+            "FEMALE_DISGUST",
+            "female_disgust"
+          ],
+          [
+            "FEMALE_SURPRISED",
+            "female_surprised"
+          ],
+          [
+            "MALE_HAPPY",
+            "male_happy"
+          ],
+          [
+            "MALE_SAD",
+            "male_sad"
+          ],
+          [
+            "MALE_ANGRY",
+            "male_angry"
+          ],
+          [
+            "MALE_FEARFUL",
+            "male_fearful"
+          ],
+          [
+            "MALE_DISGUST",
+            "male_disgust"
+          ],
+          [
+            "MALE_SURPRISED",
+            "male_surprised"
+          ]
+        ],
+        "description": "The emotion to use for the generated audio."
+      },
+      {
+        "name": "Language",
+        "values": [
+          [
+            "AFRIKAANS",
+            "afrikaans"
+          ],
+          [
+            "ALBANIAN",
+            "albanian"
+          ],
+          [
+            "AMHARIC",
+            "amharic"
+          ],
+          [
+            "ARABIC",
+            "arabic"
+          ],
+          [
+            "BENGALI",
+            "bengali"
+          ],
+          [
+            "BULGARIAN",
+            "bulgarian"
+          ],
+          [
+            "CATALAN",
+            "catalan"
+          ],
+          [
+            "CROATIAN",
+            "croatian"
+          ],
+          [
+            "CZECH",
+            "czech"
+          ],
+          [
+            "DANISH",
+            "danish"
+          ],
+          [
+            "DUTCH",
+            "dutch"
+          ],
+          [
+            "ENGLISH",
+            "english"
+          ],
+          [
+            "FRENCH",
+            "french"
+          ],
+          [
+            "GALICIAN",
+            "galician"
+          ],
+          [
+            "GERMAN",
+            "german"
+          ],
+          [
+            "GREEK",
+            "greek"
+          ],
+          [
+            "HEBREW",
+            "hebrew"
+          ],
+          [
+            "HINDI",
+            "hindi"
+          ],
+          [
+            "HUNGARIAN",
+            "hungarian"
+          ],
+          [
+            "INDONESIAN",
+            "indonesian"
+          ],
+          [
+            "ITALIAN",
+            "italian"
+          ],
+          [
+            "JAPANESE",
+            "japanese"
+          ],
+          [
+            "KOREAN",
+            "korean"
+          ],
+          [
+            "MALAY",
+            "malay"
+          ],
+          [
+            "MANDARIN",
+            "mandarin"
+          ],
+          [
+            "POLISH",
+            "polish"
+          ],
+          [
+            "PORTUGUESE",
+            "portuguese"
+          ],
+          [
+            "RUSSIAN",
+            "russian"
+          ],
+          [
+            "SERBIAN",
+            "serbian"
+          ],
+          [
+            "SPANISH",
+            "spanish"
+          ],
+          [
+            "SWEDISH",
+            "swedish"
+          ],
+          [
+            "TAGALOG",
+            "tagalog"
+          ],
+          [
+            "THAI",
+            "thai"
+          ],
+          [
+            "TURKISH",
+            "turkish"
+          ],
+          [
+            "UKRAINIAN",
+            "ukrainian"
+          ],
+          [
+            "URDU",
+            "urdu"
+          ],
+          [
+            "XHOSA",
+            "xhosa"
+          ]
+        ],
+        "description": "The language of the text to be spoken."
+      },
+      {
+        "name": "Voice",
+        "values": [
+          [
+            "ANGELO_YOUNG_MALE_US_CONVERSATIONAL_VOICE",
+            "Angelo (Young male US conversational voice)"
+          ],
+          [
+            "ARSENIO_MIDDLE_AGED_MALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Arsenio (Middle-aged male US African American conversational voice)"
+          ],
+          [
+            "CILLIAN_MIDDLE_AGED_MALE_IRISH_CONVERSATIONAL_VOICE",
+            "Cillian (Middle-aged male Irish conversational voice)"
+          ],
+          [
+            "TIMO_MIDDLE_AGED_MALE_US_CONVERSATIONAL_VOICE",
+            "Timo (Middle-aged male US conversational voice)"
+          ],
+          [
+            "DEXTER_MIDDLE_AGED_MALE_US_CONVERSATIONAL_VOICE",
+            "Dexter (Middle-aged male US conversational voice)"
+          ],
+          [
+            "MILES_YOUNG_MALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Miles (Young male US African American conversational voice)"
+          ],
+          [
+            "BRIGGS_ELDERLY_MALE_US_SOUTHERN_OKLAHOMA_CONVERSATIONAL_VOICE",
+            "Briggs (Elderly male US Southern (Oklahoma) conversational voice)"
+          ],
+          [
+            "DEEDEE_MIDDLE_AGED_FEMALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Deedee (Middle-aged female US African American conversational voice)"
+          ],
+          [
+            "NIA_YOUNG_FEMALE_US_CONVERSATIONAL_VOICE",
+            "Nia (Young female US conversational voice)"
+          ],
+          [
+            "INARA_MIDDLE_AGED_FEMALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Inara (Middle-aged female US African American conversational voice)"
+          ],
+          [
+            "CONSTANZA_YOUNG_FEMALE_US_LATIN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Constanza (Young female US Latin American conversational voice)"
+          ],
+          [
+            "GIDEON_ELDERLY_MALE_BRITISH_NARRATIVE_VOICE",
+            "Gideon (Elderly male British narrative voice)"
+          ],
+          [
+            "CASPER_MIDDLE_AGED_MALE_US_NARRATIVE_VOICE",
+            "Casper (Middle-aged male US narrative voice)"
+          ],
+          [
+            "MITCH_MIDDLE_AGED_MALE_AUSTRALIAN_NARRATIVE_VOICE",
+            "Mitch (Middle-aged male Australian narrative voice)"
+          ],
+          [
+            "AVA_MIDDLE_AGED_FEMALE_AUSTRALIAN_NARRATIVE_VOICE",
+            "Ava (Middle-aged female Australian narrative voice)"
+          ],
+          [
+            "CARMEN_MIDDLE_AGED_FEMALE_SPANISH_CONVERSATIONAL_VOICE_CALM_AND_WARM",
+            "Carmen (Middle-aged female Spanish conversational voice, calm and warm)"
+          ],
+          [
+            "ANDREI_MIDDLE_AGED_MALE_RUSSIAN_CONVERSATIONAL_VOICE_CALM_AND_WARM",
+            "Andrei (Middle-aged male Russian conversational voice, calm and warm)"
+          ],
+          [
+            "ILIAS_MIDDLE_AGED_MALE_GERMAN_NARRATIVE_VOICE_DEEP_AND_CALM",
+            "Ilias (Middle-aged male German narrative voice, deep and calm)"
+          ],
+          [
+            "GAELLE_MIDDLE_AGED_FEMALE_FRENCH_CONVERSATIONAL_VOICE_PROFESSIONAL",
+            "Gaelle (Middle-aged female French conversational voice, professional)"
+          ],
+          [
+            "ALESSANDRO_OLDER_MALE_ITALIAN_CONVERSATIONAL_VOICE_WARM_AND_GRAVELLY",
+            "Alessandro (Older male Italian conversational voice, warm and gravelly)"
+          ],
+          [
+            "YUMIKO_YOUNG_FEMALE_JAPANESE_NARRATIVE_VOICE_WARM_AND_LIGHT",
+            "Yumiko (Young female Japanese narrative voice, warm and light)"
+          ]
+        ],
+        "description": "Voice to use for generation"
+      },
+      {
+        "name": "Voice2",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "ANGELO_YOUNG_MALE_US_CONVERSATIONAL_VOICE",
+            "Angelo (Young male US conversational voice)"
+          ],
+          [
+            "ARSENIO_MIDDLE_AGED_MALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Arsenio (Middle-aged male US African American conversational voice)"
+          ],
+          [
+            "CILLIAN_MIDDLE_AGED_MALE_IRISH_CONVERSATIONAL_VOICE",
+            "Cillian (Middle-aged male Irish conversational voice)"
+          ],
+          [
+            "TIMO_MIDDLE_AGED_MALE_US_CONVERSATIONAL_VOICE",
+            "Timo (Middle-aged male US conversational voice)"
+          ],
+          [
+            "DEXTER_MIDDLE_AGED_MALE_US_CONVERSATIONAL_VOICE",
+            "Dexter (Middle-aged male US conversational voice)"
+          ],
+          [
+            "MILES_YOUNG_MALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Miles (Young male US African American conversational voice)"
+          ],
+          [
+            "BRIGGS_ELDERLY_MALE_US_SOUTHERN_OKLAHOMA_CONVERSATIONAL_VOICE",
+            "Briggs (Elderly male US Southern (Oklahoma) conversational voice)"
+          ],
+          [
+            "DEEDEE_MIDDLE_AGED_FEMALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Deedee (Middle-aged female US African American conversational voice)"
+          ],
+          [
+            "NIA_YOUNG_FEMALE_US_CONVERSATIONAL_VOICE",
+            "Nia (Young female US conversational voice)"
+          ],
+          [
+            "INARA_MIDDLE_AGED_FEMALE_US_AFRICAN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Inara (Middle-aged female US African American conversational voice)"
+          ],
+          [
+            "CONSTANZA_YOUNG_FEMALE_US_LATIN_AMERICAN_CONVERSATIONAL_VOICE",
+            "Constanza (Young female US Latin American conversational voice)"
+          ],
+          [
+            "GIDEON_ELDERLY_MALE_BRITISH_NARRATIVE_VOICE",
+            "Gideon (Elderly male British narrative voice)"
+          ],
+          [
+            "CASPER_MIDDLE_AGED_MALE_US_NARRATIVE_VOICE",
+            "Casper (Middle-aged male US narrative voice)"
+          ],
+          [
+            "MITCH_MIDDLE_AGED_MALE_AUSTRALIAN_NARRATIVE_VOICE",
+            "Mitch (Middle-aged male Australian narrative voice)"
+          ],
+          [
+            "AVA_MIDDLE_AGED_FEMALE_AUSTRALIAN_NARRATIVE_VOICE",
+            "Ava (Middle-aged female Australian narrative voice)"
+          ],
+          [
+            "CARMEN_MIDDLE_AGED_FEMALE_SPANISH_CONVERSATIONAL_VOICE_CALM_AND_WARM",
+            "Carmen (Middle-aged female Spanish conversational voice, calm and warm)"
+          ],
+          [
+            "ANDREI_MIDDLE_AGED_MALE_RUSSIAN_CONVERSATIONAL_VOICE_CALM_AND_WARM",
+            "Andrei (Middle-aged male Russian conversational voice, calm and warm)"
+          ],
+          [
+            "ILIAS_MIDDLE_AGED_MALE_GERMAN_NARRATIVE_VOICE_DEEP_AND_CALM",
+            "Ilias (Middle-aged male German narrative voice, deep and calm)"
+          ],
+          [
+            "GAELLE_MIDDLE_AGED_FEMALE_FRENCH_CONVERSATIONAL_VOICE_PROFESSIONAL",
+            "Gaelle (Middle-aged female French conversational voice, professional)"
+          ],
+          [
+            "ALESSANDRO_OLDER_MALE_ITALIAN_CONVERSATIONAL_VOICE_WARM_AND_GRAVELLY",
+            "Alessandro (Older male Italian conversational voice, warm and gravelly)"
+          ],
+          [
+            "YUMIKO_YOUNG_FEMALE_JAPANESE_NARRATIVE_VOICE_WARM_AND_LIGHT",
+            "Yumiko (Young female Japanese narrative voice, warm and light)"
+          ]
+        ],
+        "description": "Optional second voice to use for generation"
       }
     ]
   },
@@ -78500,6 +108006,1489 @@
         "required": false,
         "min": 0,
         "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "anthropic/claude-3.5-haiku",
+    "className": "Claude_3_5_Haiku",
+    "moduleName": "text-generate",
+    "docstring": "Anthropic's fastest, most cost-effective model, with a 200K token context window (claude-3-5-haiku-20241022)",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8192,
+        "description": "Maximum number of output tokens",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8192
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Input prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "ibm-granite/granite-3.2-8b-instruct",
+    "className": "Granite_3_2_8b_Instruct",
+    "moduleName": "text-generate",
+    "docstring": "Granite-3.2-8B-Instruct is a 8-billion parameter 128K context length language model fine-tuned for reasoning and instruction-following capabilities.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 512,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop_sequences",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A comma-separated list of sequences to stop generation at. For example, '<end>,<stop>' will stop generation at the first instance of 'end' or '<stop>'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "You are a helpful assistant.",
+        "description": "System prompt to send to the model. This is prepended to the prompt and helps guide system behavior. Ignored for non-chat models.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "ibm-granite/granite-3.3-8b-instruct",
+    "className": "Granite_3_3_8b_Instruct",
+    "moduleName": "text-generate",
+    "docstring": "Granite-3.3-8B-Instruct is a 8-billion parameter 128K context length language model fine-tuned for improved reasoning and instruction-following capabilities.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "add_generation_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Add generation prompt. Passed to the chat template. Defaults to True.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not specified, the chat template provided by the model will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template_kwargs",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": null,
+        "description": "Additional arguments to be passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "documents",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Documents for request. Passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "max_tokens is deprecated in favor of the max_completion_tokens field.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Chat completion API messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API user prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "response_format",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": null,
+        "description": "An object specifying the format that the model must output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave unspecified to randomize the seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "A list of sequences to stop generation at. For example, [\"<end>\",\"<stop>\"] will stop generation at the first instance of \"<end>\" or \"<stop>\".",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stream",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Request streaming response. Defaults to False.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API system prompt. The chat template provides a good default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tool_choice",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Tool choice for request. If the choice is a specific function, this should be specified as a JSON string.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "tools",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Tools for request. Passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "ibm-granite/granite-speech-3.3-8b",
+    "className": "Granite_Speech_3_3_8b",
+    "moduleName": "text-generate",
+    "docstring": "Granite-speech-3.3-8b is a compact and efficient speech-language model, specifically designed for automatic speech recognition (ASR) and automatic speech translation (AST).",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Audio inputs for the model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not provided, the default prompt template will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 512,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "User prompt to send to the model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank to randomize the seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop_sequences",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A comma-separated list of sequences to stop generation at. For example, '<end>,<stop>' will stop generation at the first instance of 'end' or '<stop>'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to send to the model.The chat template provides a good default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "ibm-granite/granite-vision-3.3-2b",
+    "className": "Granite_Vision_3_3_2b",
+    "moduleName": "text-generate",
+    "docstring": "Granite-vision-3.3-2b is a compact and efficient vision-language model, specifically designed for visual document understanding, enabling automated content extraction from tables, charts, infographics, plots, diagrams, and more.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "chat_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not provided, the default prompt template will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Deprecated single image input.Use images input instead.Ignored if images used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Image inputs for the model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 512,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "User prompt to send to the model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank to randomize the seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop_sequences",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A comma-separated list of sequences to stop generation at. For example, '<end>,<stop>' will stop generation at the first instance of 'end' or '<stop>'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to send to the model.The chat template provides a good default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lucataco/qwen2.5-omni-7b",
+    "className": "Qwen2_5_Omni_7b",
+    "moduleName": "text-generate",
+    "docstring": "Qwen2.5-Omni is an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Optional audio input",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional image input",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.",
+        "description": "System prompt for the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "use_audio_in_video",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to use audio in video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Optional video input",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "voice_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Chelsie",
+        "description": "Voice type for audio output",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "VoiceType",
+        "enumValues": [
+          "Chelsie",
+          "Ethan"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "VoiceType",
+        "values": [
+          [
+            "CHELSIE",
+            "Chelsie"
+          ],
+          [
+            "ETHAN",
+            "Ethan"
+          ]
+        ],
+        "description": "Voice type for audio output"
+      }
+    ]
+  },
+  {
+    "endpointId": "meta/llama-4-maverick-instruct",
+    "className": "Llama_4_Maverick_Instruct",
+    "moduleName": "text-generate",
+    "docstring": "A 17 billion parameter model with 128 experts",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4096,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 131072
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not provided, the default prompt template will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop_sequences",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A comma-separated list of sequences to stop generation at. For example, '<end>,<stop>' will stop generation at the first instance of 'end' or '<stop>'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "You are a helpful assistant.",
+        "description": "System prompt to send to the model. This is prepended to the prompt and helps guide system behavior. Ignored for non-chat models.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "meta/llama-4-scout-instruct",
+    "className": "Llama_4_Scout_Instruct",
+    "moduleName": "text-generate",
+    "docstring": "A 17 billion parameter model with 16 experts",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4096,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 131072
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not provided, the default prompt template will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop_sequences",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A comma-separated list of sequences to stop generation at. For example, '<end>,<stop>' will stop generation at the first instance of 'end' or '<stop>'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "You are a helpful assistant.",
+        "description": "System prompt to send to the model. This is prepended to the prompt and helps guide system behavior. Ignored for non-chat models.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.6,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 50,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/gpt-5.1",
+    "className": "Gpt_5_1",
+    "moduleName": "text-generate",
+    "docstring": "The best model for coding and agentic tasks with configurable reasoning effort.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Constrains effort on reasoning for GPT-5.1. Supported values are none, low, medium, and high.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "none",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains effort on reasoning for GPT-5.1. Supported values are none, low, medium, and high."
+      },
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-5-pro",
+    "className": "Gpt_5_Pro",
+    "moduleName": "text-generate",
+    "docstring": "The smartest, fastest, most useful model yet, with built-in thinking that puts expert-level intelligence in everyone’s hands",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-oss-120b",
+    "className": "Gpt_Oss_120b",
+    "moduleName": "text-generate",
+    "docstring": "120b open-weight language model from OpenAI",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2048,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Top-p (nucleus) sampling",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/gpt-oss-20b",
+    "className": "Gpt_Oss_20b",
+    "moduleName": "text-generate",
+    "docstring": "20b open-weight language model from OpenAI",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2048,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Top-p (nucleus) sampling",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/o1-mini",
+    "className": "O1_Mini",
+    "moduleName": "text-generate",
+    "docstring": "A small model alternative to o1",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4096,
+        "description": "Maximum number of completion tokens to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 65536
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "rafaelgalle/whisper-diarization-advanced",
+    "className": "Whisper_Diarization_Advanced",
+    "moduleName": "text-generate",
+    "docstring": "Ultra-fast, customizable speech-to-text and speaker diarization for noisy, multi-speaker audio. Includes advanced noise reduction, stereo channel support, and flexible audio preprocessing—ideal for call centers, meetings, and podcasts.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "file_path",
+        "tsType": "image",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file path",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "file_string",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Base64 encoded audio",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "file_url",
+        "tsType": "string",
+        "propType": "audio",
+        "default": "",
+        "description": "Direct URL to audio",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "highpass_freq",
+        "tsType": "number",
+        "propType": "int",
+        "default": 45,
+        "description": "Highpass filter frequency (Hz)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "language",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Language code (e.g., 'en', 'pt')",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lowpass_freq",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8000,
+        "description": "Lowpass filter frequency (Hz)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_speakers",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Number of speakers (leave empty to auto-detect)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "preprocess",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Preprocessing level: 0=None, 1=Sanitize, 2=+Filter, 3=+ReduceNoise, 4=+Normalize",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Custom prompt with names/acronyms separated by punctuation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prop_decrease",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.3,
+        "description": "Noise reduction proportion",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "stationary",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Use stationary noise reduction",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "target_dBFS",
+        "tsType": "number",
+        "propType": "float",
+        "default": -18,
+        "description": "Target loudness in dBFS",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "translate",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Translate to English",
+        "fieldType": "input",
+        "required": false
       }
     ],
     "outputFields": [],

--- a/packages/replicate-nodes/src/replicate-manifest.json
+++ b/packages/replicate-nodes/src/replicate-manifest.json
@@ -24792,14 +24792,29 @@
         "tsType": "enum",
         "propType": "enum",
         "default": "1:1",
-        "description": "The aspect ratio of the generated image",
+        "description": "The size of the generated image. Use 'auto' to let the model pick. Sizes above 2560x1440 are experimental and may give more variable results.",
         "fieldType": "input",
         "required": false,
         "enumRef": "AspectRatio",
         "enumValues": [
           "1:1",
           "3:2",
-          "2:3"
+          "2:3",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "auto",
+          "1024x1024",
+          "1536x1024",
+          "1024x1536",
+          "1536x1152",
+          "1152x1536",
+          "2048x2048",
+          "2048x1152",
+          "1152x2048",
+          "3840x2160",
+          "2160x3840"
         ]
       },
       {
@@ -24937,9 +24952,69 @@
           [
             "RATIO_2_3",
             "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "_1024X1024",
+            "1024x1024"
+          ],
+          [
+            "_1536X1024",
+            "1536x1024"
+          ],
+          [
+            "_1024X1536",
+            "1024x1536"
+          ],
+          [
+            "_1536X1152",
+            "1536x1152"
+          ],
+          [
+            "_1152X1536",
+            "1152x1536"
+          ],
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_2048X1152",
+            "2048x1152"
+          ],
+          [
+            "_1152X2048",
+            "1152x2048"
+          ],
+          [
+            "_3840X2160",
+            "3840x2160"
+          ],
+          [
+            "_2160X3840",
+            "2160x3840"
           ]
         ],
-        "description": "The aspect ratio of the generated image"
+        "description": "The size of the generated image. Use 'auto' to let the model pick. Sizes above 2560x1440 are experimental and may give more variable results."
       },
       {
         "name": "Background",
@@ -25493,6 +25568,5701 @@
           ]
         ],
         "description": "Resolution of the generated image."
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-klein-4b-base",
+    "className": "Flux_2_Klein_4b_Base",
+    "moduleName": "image-generate",
+    "docstring": "Un-distilled version of FLUX.2 [klein]. Optimized for fine-tuning, customization, and post-training workflows",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "5:4",
+          "4:5",
+          "21:9",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Classifier-free guidance scale. Higher values produce images more closely related to the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Resolution of the output image in megapixels",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputMegapixels",
+        "enumValues": [
+          "0.25",
+          "0.5",
+          "1",
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "OutputMegapixels",
+        "values": [
+          [
+            "_0_25",
+            "0.25"
+          ],
+          [
+            "_0_5",
+            "0.5"
+          ],
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Resolution of the output image in megapixels"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-klein-4b-base-lora",
+    "className": "Flux_2_Klein_4b_Base_Lora",
+    "moduleName": "image-generate",
+    "docstring": "A version of FLUX.2 [klein] 4B-base that supports fast fine-tuned lora inference",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "5:4",
+          "4:5",
+          "21:9",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scales",
+        "tsType": "number[]",
+        "propType": "list[float]",
+        "default": [],
+        "description": "Scales for each LoRA as a list of floats. Must match the number of lora_weights. Defaults to 1.0 for each if not provided.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "LoRA weights as a list of URLs. Supports ComfyUI and native Flux Klein format LoRAs. ComfyUI LoRAs are automatically converted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Resolution of the output image in megapixels",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputMegapixels",
+        "enumValues": [
+          "0.25",
+          "0.5",
+          "1",
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "OutputMegapixels",
+        "values": [
+          [
+            "_0_25",
+            "0.25"
+          ],
+          [
+            "_0_5",
+            "0.5"
+          ],
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Resolution of the output image in megapixels"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-klein-9b",
+    "className": "Flux_2_Klein_9b",
+    "moduleName": "image-generate",
+    "docstring": "4 step distilled version of FLUX.2 [klein]. A foundation model for maximum flexibility and control",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "5:4",
+          "4:5",
+          "21:9",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Resolution of the output image in megapixels",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputMegapixels",
+        "enumValues": [
+          "0.25",
+          "0.5",
+          "1",
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "OutputMegapixels",
+        "values": [
+          [
+            "_0_25",
+            "0.25"
+          ],
+          [
+            "_0_5",
+            "0.5"
+          ],
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Resolution of the output image in megapixels"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-klein-9b-base",
+    "className": "Flux_2_Klein_9b_Base",
+    "moduleName": "image-generate",
+    "docstring": "Un-distilled version of FLUX.2 [klein]. A foundation model for maximum flexibility and control",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "5:4",
+          "4:5",
+          "21:9",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "go_fast",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Run faster predictions with additional optimizations.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "guidance",
+        "tsType": "number",
+        "propType": "float",
+        "default": 4,
+        "description": "Classifier-free guidance scale. Higher values produce images more closely related to the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Resolution of the output image in megapixels",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputMegapixels",
+        "enumValues": [
+          "0.25",
+          "0.5",
+          "1",
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "OutputMegapixels",
+        "values": [
+          [
+            "_0_25",
+            "0.25"
+          ],
+          [
+            "_0_5",
+            "0.5"
+          ],
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Resolution of the output image in megapixels"
+      }
+    ]
+  },
+  {
+    "endpointId": "black-forest-labs/flux-2-klein-9b-base-lora",
+    "className": "Flux_2_Klein_9b_Base_Lora",
+    "moduleName": "image-generate",
+    "docstring": "A version of FLUX.2 [klein] 9B-base that supports fast fine-tuned lora inference",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "5:4",
+          "4:5",
+          "21:9",
+          "9:21",
+          "match_input_image"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of input images for image-to-image generation. Maximum 5 images. Must be jpeg, png, gif, or webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scales",
+        "tsType": "number[]",
+        "propType": "list[float]",
+        "default": [],
+        "description": "Scales for each LoRA as a list of floats. Must match the number of lora_weights. Defaults to 1.0 for each if not provided.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "LoRA weights as a list of URLs. Supports ComfyUI and native Flux Klein format LoRAs. ComfyUI LoRAs are automatically converted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_megapixels",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1",
+        "description": "Resolution of the output image in megapixels",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputMegapixels",
+        "enumValues": [
+          "0.25",
+          "0.5",
+          "1",
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. Use 'match_input_image' to match the aspect ratio of the first input image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "OutputMegapixels",
+        "values": [
+          [
+            "_0_25",
+            "0.25"
+          ],
+          [
+            "_0_5",
+            "0.5"
+          ],
+          [
+            "VALUE_1",
+            "1"
+          ],
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Resolution of the output image in megapixels"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/seedream-5-pro",
+    "className": "Seedream_5_Pro",
+    "moduleName": "image-generate",
+    "docstring": "ByteDance's flagship text-to-image and image editing model, generating sharp 1K and 2K images from text or up to 10 reference images",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Image aspect ratio. Use 'match_input_image' to automatically match the input image's aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "3:2",
+          "2:3",
+          "21:9"
+        ]
+      },
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input image(s) for image-to-image generation. List of 1-10 reference images for single or multi-reference generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "Output image format.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation. Maximum 4000 characters. BytePlus recommends keeping prompts under 600 English words for best results.",
+        "fieldType": "input",
+        "required": true,
+        "max": 4000
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "Image resolution: 1K (~2 megapixels) or 2K (~4 megapixels).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1K",
+          "2K"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Image aspect ratio. Use 'match_input_image' to automatically match the input image's aspect ratio."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPEG",
+            "jpeg"
+          ]
+        ],
+        "description": "Output image format."
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ]
+        ],
+        "description": "Image resolution: 1K (~2 megapixels) or 2K (~4 megapixels)."
+      }
+    ]
+  },
+  {
+    "endpointId": "google/nano-banana-2-lite",
+    "className": "Nano_Banana_2_Lite",
+    "moduleName": "image-generate",
+    "docstring": "Google's fastest image generation model — the lightweight, low-cost version of Nano Banana 2, for rapid creation and editing",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "1:4",
+          "1:8",
+          "2:3",
+          "3:2",
+          "3:4",
+          "4:1",
+          "4:3",
+          "4:5",
+          "5:4",
+          "8:1",
+          "9:16",
+          "16:9",
+          "21:9"
+        ]
+      },
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images to transform or use as reference (supports up to 14 images)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A text description of the image you want to generate",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_1_4",
+            "1:4"
+          ],
+          [
+            "RATIO_1_8",
+            "1:8"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_1",
+            "4:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_8_1",
+            "8:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output image"
+      }
+    ]
+  },
+  {
+    "endpointId": "ideogram-ai/ideogram-v4-balanced",
+    "className": "Ideogram_V4_Balanced",
+    "moduleName": "image-generate",
+    "docstring": "Balance speed, quality and cost. Ideogram v4 creates images with stunning realism, creative designs, and consistent styles",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "enable_copyright_detection",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Opt into Ideogram 4.0 post-generation copyright detection.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "json_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Structured Ideogram 4.0 prompt as a JSON object. Use either prompt or json_prompt, not both.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Natural-language prompt. Enables Ideogram 4.0 Magic Prompt automatically.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Output resolution. Omit to let Ideogram 4.0 choose the aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "None",
+          "2048x2048",
+          "1440x2880",
+          "2880x1440",
+          "1664x2496",
+          "2496x1664",
+          "1792x2240",
+          "2240x1792",
+          "1440x2560",
+          "2560x1440",
+          "1600x2560",
+          "2560x1600",
+          "1728x2304",
+          "2304x1728",
+          "1296x3168",
+          "3168x1296",
+          "1152x2944",
+          "2944x1152",
+          "1248x3328",
+          "3328x1248",
+          "1280x3072",
+          "3072x1280"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_1440X2880",
+            "1440x2880"
+          ],
+          [
+            "_2880X1440",
+            "2880x1440"
+          ],
+          [
+            "_1664X2496",
+            "1664x2496"
+          ],
+          [
+            "_2496X1664",
+            "2496x1664"
+          ],
+          [
+            "_1792X2240",
+            "1792x2240"
+          ],
+          [
+            "_2240X1792",
+            "2240x1792"
+          ],
+          [
+            "_1440X2560",
+            "1440x2560"
+          ],
+          [
+            "_2560X1440",
+            "2560x1440"
+          ],
+          [
+            "_1600X2560",
+            "1600x2560"
+          ],
+          [
+            "_2560X1600",
+            "2560x1600"
+          ],
+          [
+            "_1728X2304",
+            "1728x2304"
+          ],
+          [
+            "_2304X1728",
+            "2304x1728"
+          ],
+          [
+            "_1296X3168",
+            "1296x3168"
+          ],
+          [
+            "_3168X1296",
+            "3168x1296"
+          ],
+          [
+            "_1152X2944",
+            "1152x2944"
+          ],
+          [
+            "_2944X1152",
+            "2944x1152"
+          ],
+          [
+            "_1248X3328",
+            "1248x3328"
+          ],
+          [
+            "_3328X1248",
+            "3328x1248"
+          ],
+          [
+            "_1280X3072",
+            "1280x3072"
+          ],
+          [
+            "_3072X1280",
+            "3072x1280"
+          ]
+        ],
+        "description": "Output resolution. Omit to let Ideogram 4.0 choose the aspect ratio."
+      }
+    ]
+  },
+  {
+    "endpointId": "ideogram-ai/ideogram-v4-quality",
+    "className": "Ideogram_V4_Quality",
+    "moduleName": "image-generate",
+    "docstring": "The highest quality Ideogram v4 model. v4 creates images with stunning realism, creative designs, and consistent styles",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "enable_copyright_detection",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Opt into Ideogram 4.0 post-generation copyright detection.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "json_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Structured Ideogram 4.0 prompt as a JSON object. Use either prompt or json_prompt, not both.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Natural-language prompt. Enables Ideogram 4.0 Magic Prompt automatically.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "None",
+        "description": "Output resolution. Omit to let Ideogram 4.0 choose the aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "None",
+          "2048x2048",
+          "1440x2880",
+          "2880x1440",
+          "1664x2496",
+          "2496x1664",
+          "1792x2240",
+          "2240x1792",
+          "1440x2560",
+          "2560x1440",
+          "1600x2560",
+          "2560x1600",
+          "1728x2304",
+          "2304x1728",
+          "1296x3168",
+          "3168x1296",
+          "1152x2944",
+          "2944x1152",
+          "1248x3328",
+          "3328x1248",
+          "1280x3072",
+          "3072x1280"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_1440X2880",
+            "1440x2880"
+          ],
+          [
+            "_2880X1440",
+            "2880x1440"
+          ],
+          [
+            "_1664X2496",
+            "1664x2496"
+          ],
+          [
+            "_2496X1664",
+            "2496x1664"
+          ],
+          [
+            "_1792X2240",
+            "1792x2240"
+          ],
+          [
+            "_2240X1792",
+            "2240x1792"
+          ],
+          [
+            "_1440X2560",
+            "1440x2560"
+          ],
+          [
+            "_2560X1440",
+            "2560x1440"
+          ],
+          [
+            "_1600X2560",
+            "1600x2560"
+          ],
+          [
+            "_2560X1600",
+            "2560x1600"
+          ],
+          [
+            "_1728X2304",
+            "1728x2304"
+          ],
+          [
+            "_2304X1728",
+            "2304x1728"
+          ],
+          [
+            "_1296X3168",
+            "1296x3168"
+          ],
+          [
+            "_3168X1296",
+            "3168x1296"
+          ],
+          [
+            "_1152X2944",
+            "1152x2944"
+          ],
+          [
+            "_2944X1152",
+            "2944x1152"
+          ],
+          [
+            "_1248X3328",
+            "1248x3328"
+          ],
+          [
+            "_3328X1248",
+            "3328x1248"
+          ],
+          [
+            "_1280X3072",
+            "1280x3072"
+          ],
+          [
+            "_3072X1280",
+            "3072x1280"
+          ]
+        ],
+        "description": "Output resolution. Omit to let Ideogram 4.0 choose the aspect ratio."
+      }
+    ]
+  },
+  {
+    "endpointId": "ideogram-ai/layerize",
+    "className": "Layerize",
+    "moduleName": "image-generate",
+    "docstring": "Take a flat graphic, remove text, and get structured text layers back for editing and recomposing",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "flat_graphic_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The flat graphic image to layerize. Supports JPEG, PNG, and WebP formats (max 10MB).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "font_name_body",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Font name for body text. Mutually exclusive with font file uploads.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_name_h1",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Font name for heading 1 (h1) text. Mutually exclusive with font file uploads.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_name_h2",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Font name for heading 2 (h2) text. Mutually exclusive with font file uploads.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_name_small",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Font name for small text. Mutually exclusive with font file uploads.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide the layerization.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "krea/krea-2-large",
+    "className": "Krea_2_Large",
+    "moduleName": "image-generate",
+    "docstring": "Krea's flagship foundation image model. Larger and more flexible than Krea 2 Medium, with particular strength in photorealism and expressive artistic styles.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "4:3",
+          "3:2",
+          "16:9",
+          "2.35:1",
+          "4:5",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "creativity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "How far the model expands on your prompt. 'raw' renders only what you describe; 'low' fills in obvious gaps; 'medium' adds reasonable interpretation; 'high' takes meaningful creative liberty.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Creativity",
+        "enumValues": [
+          "raw",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "moodboard_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional Krea moodboard UUID. Moodboards must first be created in the Krea webapp (https://www.krea.ai/moodboards). Get the UUID from the moodboard share URL: `?share=<uuid>`.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "moodboard_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.35,
+        "description": "How strongly the moodboard shapes the output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Up to 10 reference images whose style should be transferred to the output. Their style is extracted and applied with the strength controlled by `style_reference_strength`.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_reference_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "How strongly to apply the style of the reference images. 0 means no influence, 1 means the style dominates. Applied to all style reference images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "_2_35_1",
+            "2.35:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image."
+      },
+      {
+        "name": "Creativity",
+        "values": [
+          [
+            "RAW",
+            "raw"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "How far the model expands on your prompt. 'raw' renders only what you describe; 'low' fills in obvious gaps; 'medium' adds reasonable interpretation; 'high' takes meaningful creative liberty."
+      }
+    ]
+  },
+  {
+    "endpointId": "krea/krea-2-medium",
+    "className": "Krea_2_Medium",
+    "moduleName": "image-generate",
+    "docstring": "Foundation image model from Krea, tuned for expressive illustration, anime, and painterly styles. Fast and consistent across artistic directions.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "4:3",
+          "3:2",
+          "16:9",
+          "2.35:1",
+          "4:5",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "creativity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "How far the model expands on your prompt. 'raw' renders only what you describe; 'low' fills in obvious gaps; 'medium' adds reasonable interpretation; 'high' takes meaningful creative liberty.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Creativity",
+        "enumValues": [
+          "raw",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "moodboard_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional Krea moodboard UUID. Moodboards must first be created in the Krea webapp (https://www.krea.ai/moodboards). Get the UUID from the moodboard share URL: `?share=<uuid>`.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "moodboard_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.35,
+        "description": "How strongly the moodboard shapes the output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the image.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Up to 10 reference images whose style should be transferred to the output. Their style is extracted and applied with the strength controlled by `style_reference_strength`.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_reference_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "How strongly to apply the style of the reference images. 0 means no influence, 1 means the style dominates. Applied to all style reference images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "_2_35_1",
+            "2.35:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image."
+      },
+      {
+        "name": "Creativity",
+        "values": [
+          [
+            "RAW",
+            "raw"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "How far the model expands on your prompt. 'raw' renders only what you describe; 'low' fills in obvious gaps; 'medium' adds reasonable interpretation; 'high' takes meaningful creative liberty."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-image-edit-lora",
+    "className": "P_Image_Edit_Lora",
+    "moduleName": "image-generate",
+    "docstring": "Use trained LoRAs from the https://replicate.com/prunaai/p-image-edit-trainer. Find or contribute LoRAs here: https://huggingface.co/collections/PrunaAI/p-image-edit-loras.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "match_input_image",
+        "description": "Aspect ratio for the generated image. `match_input_image` will match the aspect ratio of the first image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "match_input_image",
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "hf_api_token",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "HuggingFace API token. If you're using a HuggingFace LoRAs that needs authentication, you'll need to provide an API token.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Images to use as a reference. For editing task, provide the main image as the first image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Determines how strongly the main LoRA should be applied.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>]. HuggingFace LoRAs may require an API token to access, which you can provide in the `hf_api_token` input.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation. Make sure to describe your edit task clearly. You can refer to the images as 'image 1' and 'image 2' and so on.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "turbo",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If turned on, the model will run faster with additional optimizations. For complicated tasks, it is recommended to turn this off.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "MATCH_INPUT_IMAGE",
+            "match_input_image"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image. `match_input_image` will match the aspect ratio of the first image."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-image-lora",
+    "className": "P_Image_Lora",
+    "moduleName": "image-generate",
+    "docstring": "Use trained LoRAs from the https://replicate.com/prunaai/p-image-trainer. Find or contribute LoRAs here https://huggingface.co/collections/PrunaAI/p-image-loras",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio for the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "custom"
+        ]
+      },
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      },
+      {
+        "name": "hf_api_token",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "HuggingFace API token. If you're using a HuggingFace LoRAs that needs authentication, you'll need to provide an API token.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "lora_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Determines how strongly the main LoRA should be applied. 0.5 usually works well for most LoRAs.",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 3
+      },
+      {
+        "name": "lora_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Load LoRA weights. Supports HuggingFace URLs in the format huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>]. HuggingFace LoRAs may require an API token to access, which you can provide in the `hf_api_token` input.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_upsampling",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Upsample the prompt with an LLM.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16.",
+        "fieldType": "input",
+        "required": false,
+        "min": 256,
+        "max": 1440
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "CUSTOM",
+            "custom"
+          ]
+        ],
+        "description": "Aspect ratio for the generated image."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-image-try-on",
+    "className": "P_Image_Try_On",
+    "moduleName": "image-generate",
+    "docstring": "Virtual try-on. Put one or more garments onto a person photo while keeping their face, pose, and body.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "garment_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Garment reference images. Up to 6 recommended, up to 11 supported.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "no_op",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Health check mode - returns status without inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the saved output image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 95,
+        "description": "Quality for jpg/webp outputs from 0 to 100.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "person_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Person image to edit.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "preserve_input_size",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Return the output at the original input resolution. ",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "EXPERIMENTAL. For non-flatlay garment images, indicates which garment of an image to use, e.g. 'the green t-shirt from image 1 and the trousers from image 2'.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_pose",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "EXPERIMENTAL: Optional reference pose image. When provided, the person is reposed to match this reference before virtual try-on. Might fail for some seeds.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for a random seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "turbo",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If turned on, the model will run faster with additional optimizations. Not recommended for more than 4 garments.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the saved output image."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-2",
+    "className": "Qwen_Image_2",
+    "moduleName": "image-generate",
+    "docstring": "A next-generation image generation and editing model from Alibaba's Qwen team. Supports text-to-image and image editing with strong text rendering, especially for Chinese.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Automatically expand and optimize the prompt for better results",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional reference image for image editing, style transfer, or image-to-image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "match_input_image",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When true and an image is provided, use the input image's aspect ratio and resolution instead of the aspect_ratio parameter",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to specify elements to avoid in the generated image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation or editing",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen-image-2-pro",
+    "className": "Qwen_Image_2_Pro",
+    "moduleName": "image-generate",
+    "docstring": "The pro version of Qwen Image 2 from Alibaba's Qwen team. Enhanced text rendering, realism, and semantic adherence for high-quality image generation and editing.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "2:1",
+          "1:2"
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Automatically expand and optimize the prompt for better results",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional reference image for image editing, style transfer, or image-to-image generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "match_input_image",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When true and an image is provided, use the input image's aspect ratio and resolution instead of the aspect_ratio parameter",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to specify elements to avoid in the generated image",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation or editing",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1",
+    "className": "Recraft_V4_1",
+    "moduleName": "image-generate",
+    "docstring": "Recraft's latest image generation model, built around design taste. Strong prompt accuracy, art-directed composition, and integrated text rendering. Fast and cost-efficient at standard resolution.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "14:10",
+          "10:14",
+          "4:5",
+          "5:4",
+          "6:10"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024x1024",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1024x1024",
+          "1536x768",
+          "768x1536",
+          "1280x832",
+          "832x1280",
+          "1216x896",
+          "896x1216",
+          "1152x896",
+          "896x1152",
+          "832x1344",
+          "1280x896",
+          "896x1280",
+          "1344x768",
+          "768x1344"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1024X1024",
+            "1024x1024"
+          ],
+          [
+            "_1536X768",
+            "1536x768"
+          ],
+          [
+            "_768X1536",
+            "768x1536"
+          ],
+          [
+            "_1280X832",
+            "1280x832"
+          ],
+          [
+            "_832X1280",
+            "832x1280"
+          ],
+          [
+            "_1216X896",
+            "1216x896"
+          ],
+          [
+            "_896X1216",
+            "896x1216"
+          ],
+          [
+            "_1152X896",
+            "1152x896"
+          ],
+          [
+            "_896X1152",
+            "896x1152"
+          ],
+          [
+            "_832X1344",
+            "832x1344"
+          ],
+          [
+            "_1280X896",
+            "1280x896"
+          ],
+          [
+            "_896X1280",
+            "896x1280"
+          ],
+          [
+            "_1344X768",
+            "1344x768"
+          ],
+          [
+            "_768X1344",
+            "768x1344"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1-pro",
+    "className": "Recraft_V4_1_Pro",
+    "moduleName": "image-generate",
+    "docstring": "Recraft's latest image generation model at ~2048px resolution. Same design taste and prompt accuracy as V4.1, with higher resolution for print-ready and large-scale work.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "4:5",
+          "5:4",
+          "6:10",
+          "14:10",
+          "10:14"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2048x2048",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "2048x2048",
+          "3072x1536",
+          "1536x3072",
+          "2560x1664",
+          "1664x2560",
+          "2432x1792",
+          "1792x2432",
+          "2304x1792",
+          "1792x2304",
+          "1664x2688",
+          "2560x1792",
+          "1792x2560",
+          "2688x1536",
+          "1536x2688"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_3072X1536",
+            "3072x1536"
+          ],
+          [
+            "_1536X3072",
+            "1536x3072"
+          ],
+          [
+            "_2560X1664",
+            "2560x1664"
+          ],
+          [
+            "_1664X2560",
+            "1664x2560"
+          ],
+          [
+            "_2432X1792",
+            "2432x1792"
+          ],
+          [
+            "_1792X2432",
+            "1792x2432"
+          ],
+          [
+            "_2304X1792",
+            "2304x1792"
+          ],
+          [
+            "_1792X2304",
+            "1792x2304"
+          ],
+          [
+            "_1664X2688",
+            "1664x2688"
+          ],
+          [
+            "_2560X1792",
+            "2560x1792"
+          ],
+          [
+            "_1792X2560",
+            "1792x2560"
+          ],
+          [
+            "_2688X1536",
+            "2688x1536"
+          ],
+          [
+            "_1536X2688",
+            "1536x2688"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1-pro-svg",
+    "className": "Recraft_V4_1_Pro_Svg",
+    "moduleName": "image-generate",
+    "docstring": "Generate detailed SVG vector graphics from text prompts. Recraft V4.1 Pro's design taste with more geometric detail and finer paths — clean layers, editable output, and scalable to any size.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "4:5",
+          "5:4",
+          "6:10",
+          "14:10",
+          "10:14"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2048x2048",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "2048x2048",
+          "3072x1536",
+          "1536x3072",
+          "2560x1664",
+          "1664x2560",
+          "2432x1792",
+          "1792x2432",
+          "2304x1792",
+          "1792x2304",
+          "1664x2688",
+          "2560x1792",
+          "1792x2560",
+          "2688x1536",
+          "1536x2688"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_3072X1536",
+            "3072x1536"
+          ],
+          [
+            "_1536X3072",
+            "1536x3072"
+          ],
+          [
+            "_2560X1664",
+            "2560x1664"
+          ],
+          [
+            "_1664X2560",
+            "1664x2560"
+          ],
+          [
+            "_2432X1792",
+            "2432x1792"
+          ],
+          [
+            "_1792X2432",
+            "1792x2432"
+          ],
+          [
+            "_2304X1792",
+            "2304x1792"
+          ],
+          [
+            "_1792X2304",
+            "1792x2304"
+          ],
+          [
+            "_1664X2688",
+            "1664x2688"
+          ],
+          [
+            "_2560X1792",
+            "2560x1792"
+          ],
+          [
+            "_1792X2560",
+            "1792x2560"
+          ],
+          [
+            "_2688X1536",
+            "2688x1536"
+          ],
+          [
+            "_1536X2688",
+            "1536x2688"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1-svg",
+    "className": "Recraft_V4_1_Svg",
+    "moduleName": "image-generate",
+    "docstring": "Generate production-ready SVG vector images from text prompts. Recraft V4.1's design taste applied to vector output — clean geometry, structured layers, and editable paths.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "14:10",
+          "10:14",
+          "4:5",
+          "5:4",
+          "6:10"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024x1024",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1024x1024",
+          "1536x768",
+          "768x1536",
+          "1280x832",
+          "832x1280",
+          "1216x896",
+          "896x1216",
+          "1152x896",
+          "896x1152",
+          "832x1344",
+          "1280x896",
+          "896x1280",
+          "1344x768",
+          "768x1344"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1024X1024",
+            "1024x1024"
+          ],
+          [
+            "_1536X768",
+            "1536x768"
+          ],
+          [
+            "_768X1536",
+            "768x1536"
+          ],
+          [
+            "_1280X832",
+            "1280x832"
+          ],
+          [
+            "_832X1280",
+            "832x1280"
+          ],
+          [
+            "_1216X896",
+            "1216x896"
+          ],
+          [
+            "_896X1216",
+            "896x1216"
+          ],
+          [
+            "_1152X896",
+            "1152x896"
+          ],
+          [
+            "_896X1152",
+            "896x1152"
+          ],
+          [
+            "_832X1344",
+            "832x1344"
+          ],
+          [
+            "_1280X896",
+            "1280x896"
+          ],
+          [
+            "_896X1280",
+            "896x1280"
+          ],
+          [
+            "_1344X768",
+            "1344x768"
+          ],
+          [
+            "_768X1344",
+            "768x1344"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1-utility",
+    "className": "Recraft_V4_1_Utility",
+    "moduleName": "image-generate",
+    "docstring": "A faster, lighter Recraft image generation model optimized for high-volume and production pipelines. Same design taste as V4.1, built for speed and throughput.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "14:10",
+          "10:14",
+          "4:5",
+          "5:4",
+          "6:10"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1024x1024",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1024x1024",
+          "1536x768",
+          "768x1536",
+          "1280x832",
+          "832x1280",
+          "1216x896",
+          "896x1216",
+          "1152x896",
+          "896x1152",
+          "832x1344",
+          "1280x896",
+          "896x1280",
+          "1344x768",
+          "768x1344"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1024X1024",
+            "1024x1024"
+          ],
+          [
+            "_1536X768",
+            "1536x768"
+          ],
+          [
+            "_768X1536",
+            "768x1536"
+          ],
+          [
+            "_1280X832",
+            "1280x832"
+          ],
+          [
+            "_832X1280",
+            "832x1280"
+          ],
+          [
+            "_1216X896",
+            "1216x896"
+          ],
+          [
+            "_896X1216",
+            "896x1216"
+          ],
+          [
+            "_1152X896",
+            "1152x896"
+          ],
+          [
+            "_896X1152",
+            "896x1152"
+          ],
+          [
+            "_832X1344",
+            "832x1344"
+          ],
+          [
+            "_1280X896",
+            "1280x896"
+          ],
+          [
+            "_896X1280",
+            "896x1280"
+          ],
+          [
+            "_1344X768",
+            "1344x768"
+          ],
+          [
+            "_768X1344",
+            "768x1344"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "recraft-ai/recraft-v4.1-utility-pro",
+    "className": "Recraft_V4_1_Utility_Pro",
+    "moduleName": "image-generate",
+    "docstring": "A faster, lighter Recraft image generation model at ~2048px resolution, optimized for high-volume production. Design taste and prompt accuracy at high resolution with better throughput.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Not set",
+        "description": "Aspect ratio of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "Not set",
+          "1:1",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "16:9",
+          "9:16",
+          "1:2",
+          "2:1",
+          "4:5",
+          "5:4",
+          "6:10",
+          "14:10",
+          "10:14"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation (up to 10,000 characters)",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2048x2048",
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "2048x2048",
+          "3072x1536",
+          "1536x3072",
+          "2560x1664",
+          "1664x2560",
+          "2432x1792",
+          "1792x2432",
+          "2304x1792",
+          "1792x2304",
+          "1664x2688",
+          "2560x1792",
+          "1792x2560",
+          "2688x1536",
+          "1536x2688"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "NOT_SET",
+            "Not set"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_6_10",
+            "6:10"
+          ],
+          [
+            "RATIO_14_10",
+            "14:10"
+          ],
+          [
+            "RATIO_10_14",
+            "10:14"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image"
+      },
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_2048X2048",
+            "2048x2048"
+          ],
+          [
+            "_3072X1536",
+            "3072x1536"
+          ],
+          [
+            "_1536X3072",
+            "1536x3072"
+          ],
+          [
+            "_2560X1664",
+            "2560x1664"
+          ],
+          [
+            "_1664X2560",
+            "1664x2560"
+          ],
+          [
+            "_2432X1792",
+            "2432x1792"
+          ],
+          [
+            "_1792X2432",
+            "1792x2432"
+          ],
+          [
+            "_2304X1792",
+            "2304x1792"
+          ],
+          [
+            "_1792X2304",
+            "1792x2304"
+          ],
+          [
+            "_1664X2688",
+            "1664x2688"
+          ],
+          [
+            "_2560X1792",
+            "2560x1792"
+          ],
+          [
+            "_1792X2560",
+            "1792x2560"
+          ],
+          [
+            "_2688X1536",
+            "2688x1536"
+          ],
+          [
+            "_1536X2688",
+            "1536x2688"
+          ]
+        ],
+        "description": "Width and height of the generated image. Size is ignored if an aspect ratio is set."
+      }
+    ]
+  },
+  {
+    "endpointId": "reve/reve-2.1",
+    "className": "Reve_2_1",
+    "moduleName": "image-generate",
+    "docstring": "Generate and edit images from text and reference images with Reve 2.1",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The desired aspect ratio of the generated image. Use 'auto' to let the model choose an appropriate aspect ratio for the request.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "4:1",
+          "3:1",
+          "21:9",
+          "2:1",
+          "17:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16",
+          "1:2",
+          "1:3",
+          "1:4"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "A serene mountain landscape at sunset with snow-capped peaks",
+        "description": "Text prompt describing the image to generate. When reference images are provided, describes how to edit or combine them. Refer to a specific reference image by frame using <frame>N</frame>, where N is its 0-based position in reference_images (e.g. 'put the hat from <frame>0</frame> on the person in <frame>1</frame>').",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional ordered list of up to 8 reference images to edit or remix. Leave empty for text-to-image generation. Address individual images from the prompt with <frame>N</frame> (0-based).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_4_1",
+            "4:1"
+          ],
+          [
+            "RATIO_3_1",
+            "3:1"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_17_9",
+            "17:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ],
+          [
+            "RATIO_1_3",
+            "1:3"
+          ],
+          [
+            "RATIO_1_4",
+            "1:4"
+          ]
+        ],
+        "description": "The desired aspect ratio of the generated image. Use 'auto' to let the model choose an appropriate aspect ratio for the request."
+      }
+    ]
+  },
+  {
+    "endpointId": "sourceful/riverflow-2.0-fast",
+    "className": "Riverflow_2_0_Fast",
+    "moduleName": "image-generate",
+    "docstring": "Agentic image model optimized for high-quality, fast generations supporting font control",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio for output. auto uses model choice.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Let model enhance the instruction.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_texts",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Text strings matching font_urls (≤300 chars each).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_urls",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Optional font URLs (ttf/otf/woff/woff2). Up to 2.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "init_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional init images (i2i). URLs or uploads. Pro: up to 10, Fast: up to 4.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generation instruction (text-to-image or edit). Minimum 2 characters.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2
+      },
+      {
+        "name": "max_iterations",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of internal reasoning iterations (1-3).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format. API returns webp; png will be converted in Python.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "png"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1K",
+        "description": "Target resolution: 1K or 2K.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Sourceful safety checker (t2i).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "super_resolution_refs",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional reference images for detail fix (up to 4). Used in i2i and refsr.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "transparency",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable transparent background when supported.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio for output. auto uses model choice."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format. API returns webp; png will be converted in Python."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ]
+        ],
+        "description": "Target resolution: 1K or 2K."
+      }
+    ]
+  },
+  {
+    "endpointId": "sourceful/riverflow-2.0-pro",
+    "className": "Riverflow_2_0_Pro",
+    "moduleName": "image-generate",
+    "docstring": "Agentic image model optimized for robust, high-precision generations supporting font control",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio for output. auto uses model choice.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Let model enhance the instruction.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_texts",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Text strings matching font_urls (≤300 chars each).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_urls",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Optional font URLs (ttf/otf/woff/woff2). Up to 2.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "init_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional init images (i2i). URLs or uploads. Pro: up to 10, Fast: up to 4.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generation instruction (text-to-image or edit). Minimum 2 characters.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2
+      },
+      {
+        "name": "max_iterations",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3,
+        "description": "Number of internal reasoning iterations (1-3).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Output image format. API returns webp; png will be converted in Python.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "png"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1K",
+        "description": "Target resolution: 1K, 2K, or 4K.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1K",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Sourceful safety checker (t2i).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "super_resolution_refs",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional reference images for detail fix (up to 4). Used in i2i and refsr.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "transparency",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable transparent background when supported.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio for output. auto uses model choice."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output image format. API returns webp; png will be converted in Python."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ],
+          [
+            "_4K",
+            "4K"
+          ]
+        ],
+        "description": "Target resolution: 1K, 2K, or 4K."
+      }
+    ]
+  },
+  {
+    "endpointId": "sourceful/riverflow-v2.5-fast",
+    "className": "Riverflow_V2_5_Fast",
+    "moduleName": "image-generate",
+    "docstring": "Speed-optimized variant of Riverflow 2.5 for production and latency-sensitive workflows",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio for output. auto uses model choice.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "background",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "original",
+        "description": "Final background handling.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Background",
+        "enumValues": [
+          "original",
+          "transparent",
+          "solid"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "#ffffff",
+        "description": "6-digit hex color used when background is solid.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Let model enhance the instruction.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_texts",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Text strings matching font_urls for RF2.5 font control.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_urls",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Optional HTTPS font URLs for RF2.5 font control. Up to 2.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "idempotency_key",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional stable key for safe retries against the RF2.5 API.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "init_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional init images for image-to-image edits. Pro: up to 10, Fast: up to 4.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generation or edit instruction. Minimum 2 characters.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Final output image format.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "png",
+          "jpg"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1K",
+        "description": "Target resolution: 1K, 2K, or 4K.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1K",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Sourceful safety checker.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "scoring_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional judging instructions for RF2.5 candidate scoring.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "scoring_rubric",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional RF2.5 scoring rubric, encoded as a JSON array string. Provide 1-8 dimensions, each with key, label, description, weight, optional passingScore, and optional scoreGuidance.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "thinking_level",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "RF2.5 thinking budget for fast.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ThinkingLevel",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio for output. auto uses model choice."
+      },
+      {
+        "name": "Background",
+        "values": [
+          [
+            "ORIGINAL",
+            "original"
+          ],
+          [
+            "TRANSPARENT",
+            "transparent"
+          ],
+          [
+            "SOLID",
+            "solid"
+          ]
+        ],
+        "description": "Final background handling."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ]
+        ],
+        "description": "Final output image format."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ],
+          [
+            "_4K",
+            "4K"
+          ]
+        ],
+        "description": "Target resolution: 1K, 2K, or 4K."
+      },
+      {
+        "name": "ThinkingLevel",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "RF2.5 thinking budget for fast."
+      }
+    ]
+  },
+  {
+    "endpointId": "sourceful/riverflow-v2.5-pro",
+    "className": "Riverflow_V2_5_Pro",
+    "moduleName": "image-generate",
+    "docstring": "Top-quality agentic image model with multi-step reasoning, candidate scoring, and adjustable thinking effort",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio for output. auto uses model choice.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16"
+        ]
+      },
+      {
+        "name": "background",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "original",
+        "description": "Final background handling.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Background",
+        "enumValues": [
+          "original",
+          "transparent",
+          "solid"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "#ffffff",
+        "description": "6-digit hex color used when background is solid.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Let model enhance the instruction.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_texts",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Text strings matching font_urls for RF2.5 font control.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "font_urls",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Optional HTTPS font URLs for RF2.5 font control. Up to 2.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "idempotency_key",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional stable key for safe retries against the RF2.5 API.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "init_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional init images for image-to-image edits. Pro: up to 10, Fast: up to 4.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generation or edit instruction. Minimum 2 characters.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "Final output image format.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "png",
+          "jpg"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1K",
+        "description": "Target resolution: 1K, 2K, or 4K.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1K",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Sourceful safety checker.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "scoring_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional judging instructions for RF2.5 candidate scoring.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "scoring_rubric",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional RF2.5 scoring rubric, encoded as a JSON array string. Provide 1-8 dimensions, each with key, label, description, weight, optional passingScore, and optional scoreGuidance.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "thinking_level",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "RF2.5 thinking budget for pro.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ThinkingLevel",
+        "enumValues": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio for output. auto uses model choice."
+      },
+      {
+        "name": "Background",
+        "values": [
+          [
+            "ORIGINAL",
+            "original"
+          ],
+          [
+            "TRANSPARENT",
+            "transparent"
+          ],
+          [
+            "SOLID",
+            "solid"
+          ]
+        ],
+        "description": "Final background handling."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ]
+        ],
+        "description": "Final output image format."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ],
+          [
+            "_4K",
+            "4K"
+          ]
+        ],
+        "description": "Target resolution: 1K, 2K, or 4K."
+      },
+      {
+        "name": "ThinkingLevel",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ]
+        ],
+        "description": "RF2.5 thinking budget for pro."
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-image",
+    "className": "Wan_2_7_Image",
+    "moduleName": "image-generate",
+    "docstring": "Generate and edit images with Alibaba's Wan 2.7",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image_set_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate a coherent set of related images from a single prompt (e.g. a character across seasons). When enabled, num_outputs can be up to 12.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images for editing, style transfer, or multi-reference generation (up to 9 images, jpg/png/bmp/webp). When provided, the model operates in image editing mode.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_outputs",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate (1-4 for standard mode, 1-12 for image set mode)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation or editing",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "Output image resolution. '1K' and '2K' auto-size based on input images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1K",
+          "2K",
+          "1024*1024",
+          "2048*2048",
+          "1280*720",
+          "720*1280",
+          "2048*1152",
+          "1152*2048",
+          "1024*768",
+          "768*1024",
+          "2048*1536",
+          "1536*2048"
+        ]
+      },
+      {
+        "name": "thinking_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable enhanced reasoning for improved image quality. Only applies to text-to-image (no input images, no image set mode). Increases generation time.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ],
+          [
+            "_1024_1024",
+            "1024*1024"
+          ],
+          [
+            "_2048_2048",
+            "2048*2048"
+          ],
+          [
+            "_1280_720",
+            "1280*720"
+          ],
+          [
+            "_720_1280",
+            "720*1280"
+          ],
+          [
+            "_2048_1152",
+            "2048*1152"
+          ],
+          [
+            "_1152_2048",
+            "1152*2048"
+          ],
+          [
+            "_1024_768",
+            "1024*768"
+          ],
+          [
+            "_768_1024",
+            "768*1024"
+          ],
+          [
+            "_2048_1536",
+            "2048*1536"
+          ],
+          [
+            "_1536_2048",
+            "1536*2048"
+          ]
+        ],
+        "description": "Output image resolution. '1K' and '2K' auto-size based on input images."
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-image-pro",
+    "className": "Wan_2_7_Image_Pro",
+    "moduleName": "image-generate",
+    "docstring": "Generate and edit high-quality images with Alibaba's Wan 2.7 Pro with 4K output, thinking mode, text-to-image, multi-image editing, and image set generation",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image_set_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate a coherent set of related images from a single prompt (e.g. a character across seasons). When enabled, num_outputs can be up to 12.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images for editing, style transfer, or multi-reference generation (up to 9 images, jpg/png/bmp/webp). When provided, the model operates in image editing mode.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "num_outputs",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate (1-4 for standard mode, 1-12 for image set mode)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for image generation or editing",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "Output image resolution. '1K', '2K', and '4K' auto-size based on input images. 4K is only available for text-to-image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Size",
+        "enumValues": [
+          "1K",
+          "2K",
+          "4K",
+          "1024*1024",
+          "2048*2048",
+          "4096*4096",
+          "1280*720",
+          "720*1280",
+          "2048*1152",
+          "1152*2048",
+          "4096*2304",
+          "2304*4096",
+          "1024*768",
+          "768*1024",
+          "2048*1536",
+          "1536*2048",
+          "4096*3072",
+          "3072*4096"
+        ]
+      },
+      {
+        "name": "thinking_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable enhanced reasoning for improved image quality. Only applies to text-to-image (no input images, no image set mode). Increases generation time.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Size",
+        "values": [
+          [
+            "_1K",
+            "1K"
+          ],
+          [
+            "_2K",
+            "2K"
+          ],
+          [
+            "_4K",
+            "4K"
+          ],
+          [
+            "_1024_1024",
+            "1024*1024"
+          ],
+          [
+            "_2048_2048",
+            "2048*2048"
+          ],
+          [
+            "_4096_4096",
+            "4096*4096"
+          ],
+          [
+            "_1280_720",
+            "1280*720"
+          ],
+          [
+            "_720_1280",
+            "720*1280"
+          ],
+          [
+            "_2048_1152",
+            "2048*1152"
+          ],
+          [
+            "_1152_2048",
+            "1152*2048"
+          ],
+          [
+            "_4096_2304",
+            "4096*2304"
+          ],
+          [
+            "_2304_4096",
+            "2304*4096"
+          ],
+          [
+            "_1024_768",
+            "1024*768"
+          ],
+          [
+            "_768_1024",
+            "768*1024"
+          ],
+          [
+            "_2048_1536",
+            "2048*1536"
+          ],
+          [
+            "_1536_2048",
+            "1536*2048"
+          ],
+          [
+            "_4096_3072",
+            "4096*3072"
+          ],
+          [
+            "_3072_4096",
+            "3072*4096"
+          ]
+        ],
+        "description": "Output image resolution. '1K', '2K', and '4K' auto-size based on input images. 4K is only available for text-to-image."
       }
     ]
   },
@@ -32485,6 +38255,190 @@
     ]
   },
   {
+    "endpointId": "prunaai/p-image-upscale",
+    "className": "P_Image_Upscale",
+    "moduleName": "image-upscale",
+    "docstring": "Fastest image upscaler in the world (<1s) supporting outputs up to 128 MP. contact us for dedicated endpoints.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enhance_details",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enhance fine textures and small details. May increase contrast and introduce minor deviations from the original image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enhance_realism",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Improve realism. May deviate more from the original image. Recommended for AI-generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Scaling factor applied to each side of the image (used when upscale_mode is 'factor'). Output capped at 128 MP.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to upscale.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "no_op",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Deprecated and ignored. Predictions always run normally.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpg",
+        "description": "Format of the output images",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "webp",
+          "jpg",
+          "png"
+        ]
+      },
+      {
+        "name": "output_quality",
+        "tsType": "number",
+        "propType": "int",
+        "default": 80,
+        "description": "Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "target",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4,
+        "description": "Target resolution in megapixels (used when upscale_mode is 'target').",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 128
+      },
+      {
+        "name": "upscale_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "target",
+        "description": "Upscale mode. 'target' scales to a fixed megapixel resolution. 'factor' multiplies each side by the given factor.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "UpscaleMode",
+        "enumValues": [
+          "target",
+          "factor"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "WEBP",
+            "webp"
+          ],
+          [
+            "JPG",
+            "jpg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Format of the output images"
+      },
+      {
+        "name": "UpscaleMode",
+        "values": [
+          [
+            "TARGET",
+            "target"
+          ],
+          [
+            "FACTOR",
+            "factor"
+          ]
+        ],
+        "description": "Upscale mode. 'target' scales to a fixed megapixel resolution. 'factor' multiplies each side by the given factor."
+      }
+    ]
+  },
+  {
+    "endpointId": "sourceful/riverflow-2.0-refsr",
+    "className": "Riverflow_2_0_Refsr",
+    "moduleName": "image-upscale",
+    "docstring": "Render product images with 100% accuracy and environmental blending",
+    "tags": [],
+    "useCases": [],
+    "outputType": "image",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The base image to apply super resolution to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "super_resolution_references",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images for super resolution guidance (1-4 images required).",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
     "endpointId": "lucataco/codeformer",
     "className": "CodeFormer",
     "moduleName": "image-enhance",
@@ -36122,6 +42076,458 @@
           ]
         ],
         "description": "Image output format (only used for image inputs)."
+      }
+    ]
+  },
+  {
+    "endpointId": "tencent/hunyuan-3d-3.1",
+    "className": "Hunyuan_3d_3_1",
+    "moduleName": "image-3d",
+    "docstring": "3D models with texture fidelity and geometry precision",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable PBR (Physically Based Rendering) material generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_count",
+        "tsType": "number",
+        "propType": "int",
+        "default": 500000,
+        "description": "Number of faces (polygons) in the generated 3D model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 40000,
+        "max": 1500000
+      },
+      {
+        "name": "generate_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Normal",
+        "description": "Type of 3D generation. 'Normal' generates textured model, 'Geometry' generates white model without textures (EnablePBR has no effect).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "GenerateType",
+        "enumValues": [
+          "Normal",
+          "Geometry"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to convert to 3D. Either prompt OR image must be provided, but not both. Recommendations: simple background, no text, single object, object occupies >50% of frame. Supported formats: jpg, png, jpeg, webp. Resolution: 128-5000px per side, max 6MB.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of the 3D model to generate. Either prompt OR image must be provided, but not both. Supports up to 1024 characters.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "GenerateType",
+        "values": [
+          [
+            "NORMAL",
+            "Normal"
+          ],
+          [
+            "GEOMETRY",
+            "Geometry"
+          ]
+        ],
+        "description": "Type of 3D generation. 'Normal' generates textured model, 'Geometry' generates white model without textures (EnablePBR has no effect)."
+      }
+    ]
+  },
+  {
+    "endpointId": "uthana/create-character-v1",
+    "className": "Create_Character_V1",
+    "moduleName": "image-3d",
+    "docstring": "Rig any 3D bipedal character mesh",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "auto_rig",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If input character has no bones, automatically generate them",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "character_file",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "fbx/glb character file",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "front_facing",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, the auto-rigged character will be front-facing",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "uthana/text-to-motion-diffusion-v2",
+    "className": "Text_To_Motion_Diffusion_V2",
+    "moduleName": "image-3d",
+    "docstring": "Generate 3D character animation data from a text prompt",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "cfg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Cfg Scale (higher values will attempt to follow the prompt more)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "character",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output character",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "Character",
+        "enumValues": [
+          "Tar",
+          "Ava",
+          "Manny",
+          "Quinn",
+          "Y Bot"
+        ]
+      },
+      {
+        "name": "foot_ik",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Feet Inverse Kinematics",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output frame rate",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24",
+          "30",
+          "60"
+        ]
+      },
+      {
+        "name": "internal_ik",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Use internal IK to improve result",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "motion_length",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Desired motion length (seconds)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.2,
+        "max": 9
+      },
+      {
+        "name": "no_mesh",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Should the output contain animation only",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_ext",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output file type",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "OutputExt",
+        "enumValues": [
+          "FBX",
+          "GLB"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Describe the desired motion",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "seed (0 indicates a random seed)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1000000000
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Character",
+        "values": [
+          [
+            "TAR",
+            "Tar"
+          ],
+          [
+            "AVA",
+            "Ava"
+          ],
+          [
+            "MANNY",
+            "Manny"
+          ],
+          [
+            "QUINN",
+            "Quinn"
+          ],
+          [
+            "Y_BOT",
+            "Y Bot"
+          ]
+        ],
+        "description": "Output character"
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ],
+          [
+            "VALUE_60",
+            "60"
+          ]
+        ],
+        "description": "Output frame rate"
+      },
+      {
+        "name": "OutputExt",
+        "values": [
+          [
+            "FBX",
+            "FBX"
+          ],
+          [
+            "GLB",
+            "GLB"
+          ]
+        ],
+        "description": "Output file type"
+      }
+    ]
+  },
+  {
+    "endpointId": "uthana/text-to-motion-vqvae-v1",
+    "className": "Text_To_Motion_Vqvae_V1",
+    "moduleName": "image-3d",
+    "docstring": "Generate 3D character animation data from a text prompt",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "character",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output character",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "Character",
+        "enumValues": [
+          "Tar",
+          "Ava",
+          "Manny",
+          "Quinn",
+          "Y Bot"
+        ]
+      },
+      {
+        "name": "foot_ik",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable Feet Inverse Kinematics",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output frame rate",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24",
+          "30",
+          "60"
+        ]
+      },
+      {
+        "name": "no_mesh",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Should the output contain animation only",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_ext",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Output file type",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "OutputExt",
+        "enumValues": [
+          "fbx",
+          "glb"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Describe the desired motion",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Character",
+        "values": [
+          [
+            "TAR",
+            "Tar"
+          ],
+          [
+            "AVA",
+            "Ava"
+          ],
+          [
+            "MANNY",
+            "Manny"
+          ],
+          [
+            "QUINN",
+            "Quinn"
+          ],
+          [
+            "Y_BOT",
+            "Y Bot"
+          ]
+        ],
+        "description": "Output character"
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ],
+          [
+            "VALUE_60",
+            "60"
+          ]
+        ],
+        "description": "Output frame rate"
+      },
+      {
+        "name": "OutputExt",
+        "values": [
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "GLB",
+            "glb"
+          ]
+        ],
+        "description": "Output file type"
       }
     ]
   },
@@ -43613,9 +50019,10 @@
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "Text prompt for video generation",
+        "description": "Text prompt for video generation. Maximum 4000 characters. BytePlus recommends keeping prompts under 600 English words for best results.",
         "fieldType": "input",
-        "required": true
+        "required": true,
+        "max": 4000
       },
       {
         "name": "reference_audios",
@@ -43649,14 +50056,15 @@
         "tsType": "enum",
         "propType": "enum",
         "default": "720p",
-        "description": "Video resolution.",
+        "description": "Video resolution. 4K outputs 10-bit H.265/HEVC at high bitrate.",
         "fieldType": "input",
         "required": false,
         "enumRef": "Resolution",
         "enumValues": [
           "480p",
           "720p",
-          "1080p"
+          "1080p",
+          "4k"
         ]
       },
       {
@@ -43723,9 +50131,13 @@
           [
             "_1080P",
             "1080p"
+          ],
+          [
+            "_4K",
+            "4k"
           ]
         ],
-        "description": "Video resolution."
+        "description": "Video resolution. 4K outputs 10-bit H.265/HEVC at high bitrate."
       }
     ]
   },
@@ -44390,6 +50802,4266 @@
     ]
   },
   {
+    "endpointId": "alibaba/happyhorse-1.1",
+    "className": "Happyhorse_1_1",
+    "moduleName": "video-generate",
+    "docstring": "Alibaba's Happy Horse 1.1 generates videos from text, animates a single image, or builds a video from multiple reference images. Supports 720p and 1080p, 3-15 second durations, and five aspect ratios.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video. Only applies to text-to-video and reference-to-video. When a single image is provided (image-to-video), the image's aspect ratio is used.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15"
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images. Provide no images for text-to-video, one image to animate it as the first frame (image-to-video), or multiple images (up to 9) for reference-to-video. Accepts jpg/png/bmp/webp, <=10MB each, aspect ratio between 1:2.5 and 2.5:1, each side >=300px.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Optional when a single image is provided (image-to-video). Required for text-to-video and reference-to-video. When providing multiple reference images, refer to them in the prompt as [Image 1], [Image 2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video. Only applies to text-to-video and reference-to-video. When a single image is provided (image-to-video), the image's aspect ratio is used."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_3",
+            "3"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_11",
+            "11"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_13",
+            "13"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ]
+        ],
+        "description": "Duration of the generated video in seconds"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/seedance-2.0-fast",
+    "className": "Seedance_2_0_Fast",
+    "moduleName": "video-generate",
+    "docstring": "A faster variant of Seedance 2.0 for quicker video generation with multimodal inputs and native audio.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Video aspect ratio. Set to 'adaptive' to let the model choose the best ratio based on inputs.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16",
+          "21:9",
+          "9:21",
+          "adaptive"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Video duration in seconds. Set to -1 for intelligent duration (model picks the best length).",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 15
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate synchronized audio with the video, including dialogue (use double quotes in prompt), sound effects, and background music.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-video generation (first frame). Cannot be combined with reference images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for last frame generation. Only works if a first frame image is also provided. Cannot be combined with reference images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_audios",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio files (up to 3, total duration max 15s) for audio-driven generation and lip-sync. Requires at least one reference image or video. Reference them in your prompt as [Audio1], [Audio2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images (up to 9) for character consistency, style guidance, and scene composition. Cannot be used together with first/last frame images. You can reference them in your prompt as [Image1], [Image2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_videos",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos (up to 3, total duration max 15s) for motion transfer, style reference, and editing. Reference them in your prompt as [Video1], [Video2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ]
+        ],
+        "description": "Video aspect ratio. Set to 'adaptive' to let the model choose the best ratio based on inputs."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution."
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/seedance-2.0-mini",
+    "className": "Seedance_2_0_Mini",
+    "moduleName": "video-generate",
+    "docstring": "A lower-cost variant of Seedance 2.0 for high-volume video generation with multimodal inputs and native audio.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Video aspect ratio. Set to 'adaptive' to let the model choose the best ratio based on inputs.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16",
+          "21:9",
+          "9:21",
+          "adaptive"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Video duration in seconds. Set to -1 for intelligent duration (model picks the best length).",
+        "fieldType": "input",
+        "required": false,
+        "min": -1,
+        "max": 15
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate synchronized audio with the video, including dialogue (use double quotes in prompt), sound effects, and background music.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for image-to-video generation (first frame). Cannot be combined with reference images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for last frame generation. Only works if a first frame image is also provided. Cannot be combined with reference images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Maximum 4000 characters. BytePlus recommends keeping prompts under 600 English words for best results.",
+        "fieldType": "input",
+        "required": true,
+        "max": 4000
+      },
+      {
+        "name": "reference_audios",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio files (up to 3, total duration max 15s) for audio-driven generation and lip-sync. Requires at least one reference image or video. Reference them in your prompt as [Audio1], [Audio2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images (up to 9) for character consistency, style guidance, and scene composition. Cannot be used together with first/last frame images. You can reference them in your prompt as [Image1], [Image2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_videos",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos (up to 3, total duration max 15s) for motion transfer, style reference, and editing. Reference them in your prompt as [Video1], [Video2], etc.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ],
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ]
+        ],
+        "description": "Video aspect ratio. Set to 'adaptive' to let the model choose the best ratio based on inputs."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "Video resolution."
+      }
+    ]
+  },
+  {
+    "endpointId": "decart/lucy-edit-2",
+    "className": "Lucy_Edit_2",
+    "moduleName": "video-generate",
+    "docstring": "Edit and transform videos with text prompts and reference images. Style transfers, object replacement, character transformation, and more.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enhance the prompt before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of the changes to apply. Send an empty string to use only a reference image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "An image to guide the edit. Use this to show the model what you want to add or change (e.g. a specific pair of sunglasses, a logo, or a style reference). Can be used alone, with a prompt, or omitted entirely.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4294967295
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video file to edit. MP4 format (H.264 or VP8), 16:9 or 9:16 aspect ratio, max 200MB.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "heygen/avatar-iv",
+    "className": "Avatar_Iv",
+    "moduleName": "video-generate",
+    "docstring": "Create realistic talking avatar videos from text with HeyGen's Avatar IV engine",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "avatar_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Unique identifier of the avatar. Get available avatar IDs from the HeyGen List All Avatars API.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "avatar_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "normal",
+        "description": "Visual style of the avatar.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AvatarStyle",
+        "enumValues": [
+          "normal",
+          "closeUp",
+          "circle"
+        ]
+      },
+      {
+        "name": "caption",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to enable captions in the video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "height",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1080,
+        "description": "Height of the output video in pixels.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 2160
+      },
+      {
+        "name": "input_text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text that the avatar will speak. Must be less than 5000 characters.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "title",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Title of the video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "voice_emotion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Adds emotion to voice, if supported by the selected voice. Set to 'none' for no emotion.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "VoiceEmotion",
+        "enumValues": [
+          "none",
+          "Excited",
+          "Friendly",
+          "Serious",
+          "Soothing",
+          "Broadcaster"
+        ]
+      },
+      {
+        "name": "voice_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Unique identifier of the voice. Get available voice IDs from the HeyGen List All Voices API.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "voice_speed",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Voice speed. Value ranges from 0.5 to 1.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 1.5
+      },
+      {
+        "name": "width",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1920,
+        "description": "Width of the output video in pixels.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 3840
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AvatarStyle",
+        "values": [
+          [
+            "NORMAL",
+            "normal"
+          ],
+          [
+            "CLOSEUP",
+            "closeUp"
+          ],
+          [
+            "CIRCLE",
+            "circle"
+          ]
+        ],
+        "description": "Visual style of the avatar."
+      },
+      {
+        "name": "VoiceEmotion",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "EXCITED",
+            "Excited"
+          ],
+          [
+            "FRIENDLY",
+            "Friendly"
+          ],
+          [
+            "SERIOUS",
+            "Serious"
+          ],
+          [
+            "SOOTHING",
+            "Soothing"
+          ],
+          [
+            "BROADCASTER",
+            "Broadcaster"
+          ]
+        ],
+        "description": "Adds emotion to voice, if supported by the selected voice. Set to 'none' for no emotion."
+      }
+    ]
+  },
+  {
+    "endpointId": "heygen/avatar-v",
+    "className": "Avatar_V",
+    "moduleName": "video-generate",
+    "docstring": "Create realistic talking avatar videos from text with HeyGen's Avatar V engine — the newest, highest-quality avatar engine with cross-reference-driven animation.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Output video aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "avatar_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Avatar ID. Must be an avatar that supports Avatar V — check `supported_api_engines` on the look via the HeyGen API.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "caption",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to burn captions into the rendered video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "input_text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text that the avatar will speak. Must be less than 5000 characters.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "title",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Title of the video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "voice_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Voice ID. Get available voice IDs from the HeyGen List All Voices API.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "voice_speed",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Voice speed multiplier. Value ranges from 0.5 to 1.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 1.5
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output video aspect ratio."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Output video resolution."
+      }
+    ]
+  },
+  {
+    "endpointId": "heygen/video-agent",
+    "className": "Video_Agent",
+    "moduleName": "video-generate",
+    "docstring": "Turn a text prompt into a complete, polished video with AI-generated script, avatar presenter, voiceover, visuals, and editing.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "avatar_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Avatar ID to use. If not provided, the Video Agent selects an appropriate avatar.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration_sec",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Approximate target duration of the video in seconds. Minimum is 5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5
+      },
+      {
+        "name": "orientation",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Video orientation. Must be \"landscape\" or \"portrait\". Leave empty to let the Video Agent decide.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video you want to create. The Video Agent handles avatar selection, scripting, scenes, and editing.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Visual style template ID from HeyGen's curated styles. Controls scene composition, pacing, and aesthetics.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "voice_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Voice ID for narration. If not provided, the Video Agent selects a voice automatically.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "kwaivgi/kling-o1",
+    "className": "Kling_O1",
+    "moduleName": "video-generate",
+    "docstring": "Modify an existing video through natural-language commands, changing subjects, environments, and visual style while preserving the original motion and timing.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video. Required for text-to-video. Ignored when using first frame image or video editing.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Video duration in seconds. For text/image-to-video: 5 or 10. With video reference (feature type): 3-10. Ignored for video editing (base type).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame image for the video. Requires start_image to be set. Supports .jpg/.jpeg/.png, max 10MB.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "keep_original_sound",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to keep the original sound from the reference video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "pro",
+        "description": "Video generation mode. 'std' is cost-effective, 'pro' has higher quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "std",
+          "pro"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Can include references like <<<image_1>>>, <<<video_1>>> to reference inputs.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images for elements, scenes, or styles (up to 7 without video, 4 with video). Supports .jpg/.jpeg/.png.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Reference video for style, camera movement, or as base for editing. Supports .mp4/.mov, 3-10s duration, max 200MB.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for the video. Supports .jpg/.jpeg/.png, max 10MB.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_reference_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "feature",
+        "description": "How to use the reference video: 'feature' for style/camera reference, 'base' for video editing.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "VideoReferenceType",
+        "enumValues": [
+          "feature",
+          "base"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video. Required for text-to-video. Ignored when using first frame image or video editing."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_3",
+            "3"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Video duration in seconds. For text/image-to-video: 5 or 10. With video reference (feature type): 3-10. Ignored for video editing (base type)."
+      },
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "STD",
+            "std"
+          ],
+          [
+            "PRO",
+            "pro"
+          ]
+        ],
+        "description": "Video generation mode. 'std' is cost-effective, 'pro' has higher quality."
+      },
+      {
+        "name": "VideoReferenceType",
+        "values": [
+          [
+            "FEATURE",
+            "feature"
+          ],
+          [
+            "BASE",
+            "base"
+          ]
+        ],
+        "description": "How to use the reference video: 'feature' for style/camera reference, 'base' for video editing."
+      }
+    ]
+  },
+  {
+    "endpointId": "kwaivgi/kling-v3-motion-control",
+    "className": "Kling_V3_Motion_Control",
+    "moduleName": "video-generate",
+    "docstring": "Kling 3.0 motion control: transfer motion from a reference video to any character image with improved consistency and quality.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "character_orientation",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "image",
+        "description": "Orientation of the character in the generated video. 'image': same orientation as the person in the picture (max 10s video). 'video': consistent with the orientation of the characters in the video (max 30s video). When binding elements, only 'video' orientation is supported.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CharacterOrientation",
+        "enumValues": [
+          "image",
+          "video"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference image. The characters, backgrounds, and other elements in the generated video are based on the reference image. Supports .jpg/.jpeg/.png, max 10MB, dimensions 340px-3850px, aspect ratio 1:2.5 to 2.5:1.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "keep_original_sound",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to keep the original sound of the reference video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "pro",
+        "description": "Video generation mode. 'std': Standard mode (720p, cost-effective). 'pro': Professional mode (1080p, higher quality).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "std",
+          "pro"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. You can add elements to the screen and achieve motion effects through prompt words.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Reference video. The character actions in the generated video are consistent with the reference video. Supports .mp4/.mov, max 100MB, 3-30 seconds duration depending on character_orientation.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "CharacterOrientation",
+        "values": [
+          [
+            "IMAGE",
+            "image"
+          ],
+          [
+            "VIDEO",
+            "video"
+          ]
+        ],
+        "description": "Orientation of the character in the generated video. 'image': same orientation as the person in the picture (max 10s video). 'video': consistent with the orientation of the characters in the video (max 30s video). When binding elements, only 'video' orientation is supported."
+      },
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "STD",
+            "std"
+          ],
+          [
+            "PRO",
+            "pro"
+          ]
+        ],
+        "description": "Video generation mode. 'std': Standard mode (720p, cost-effective). 'pro': Professional mode (1080p, higher quality)."
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/audio-to-video",
+    "className": "Audio_To_Video",
+    "moduleName": "video-generate",
+    "docstring": "Use audio input with an image or prompt to generate videos",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file to be used as the soundtrack for the video. Supported formats: wav, mp3, flac, ogg, m4a.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Guidance scale (CFG) for video generation. Higher values make the output more closely follow the prompt but may reduce quality.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to be used as the first frame of the video. Required if prompt is not provided.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how the video should be generated. Required if image is not provided. If image is provided, this describes how the image should be animated.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "lightricks/ltx-2.3-fast",
+    "className": "Ltx_2_3_Fast",
+    "moduleName": "video-generate",
+    "docstring": "Lightning-fast video generation with portrait support, camera controls, and synchronized audio. Up to 20 seconds at 1080p, 4K at 50 FPS.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Camera motion effect to apply to the generated video. Use 'none' for no camera motion.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "none",
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 6,
+        "description": "Duration of the video in seconds. Durations longer than 10 seconds are only available with 1080p resolution at 24 or 25 FPS.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "6",
+          "8",
+          "10",
+          "12",
+          "14",
+          "16",
+          "18",
+          "20"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "Frame rate in frames per second",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24",
+          "25",
+          "48",
+          "50"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio for the video. Used for text_to_video and image_to_video tasks.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for image-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame image for image-to-video generation. When provided, the video interpolates between the first frame and this last frame.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video to generate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Resolution quality of the generated video. Only 1080p is supported for audio_to_video, retake, and extend tasks.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1080p",
+          "2k",
+          "4k"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video"
+      },
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Camera motion effect to apply to the generated video. Use 'none' for no camera motion."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_16",
+            "16"
+          ],
+          [
+            "VALUE_18",
+            "18"
+          ],
+          [
+            "VALUE_20",
+            "20"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Durations longer than 10 seconds are only available with 1080p resolution at 24 or 25 FPS."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_25",
+            "25"
+          ],
+          [
+            "VALUE_48",
+            "48"
+          ],
+          [
+            "VALUE_50",
+            "50"
+          ]
+        ],
+        "description": "Frame rate in frames per second"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_2K",
+            "2k"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Resolution quality of the generated video. Only 1080p is supported for audio_to_video, retake, and extend tasks."
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-2.3-pro",
+    "className": "Ltx_2_3_Pro",
+    "moduleName": "video-generate",
+    "docstring": "High-fidelity video generation with portrait support, audio-to-video, retake, and extend. Text, image, and audio-driven creation up to 4K at 50 FPS.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio file for audio_to_video task",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Camera motion effect to apply to the generated video. Use 'none' for no camera motion.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "none",
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 6,
+        "description": "Duration of the video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "6",
+          "8",
+          "10"
+        ]
+      },
+      {
+        "name": "extend_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "end",
+        "description": "Where to extend the video. Used for extend task.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExtendMode",
+        "enumValues": [
+          "start",
+          "end"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "Frame rate in frames per second",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24",
+          "25",
+          "48",
+          "50"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate audio for the video. Used for text_to_video and image_to_video tasks.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image for image-to-video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame image for image-to-video generation. When provided, the video interpolates between the first frame and this last frame.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video to generate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Resolution quality of the generated video. Only 1080p is supported for audio_to_video, retake, and extend tasks.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1080p",
+          "2k",
+          "4k"
+        ]
+      },
+      {
+        "name": "retake_duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Duration in seconds of the section to edit. Must be at least 2 seconds. Used for retake task.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2
+      },
+      {
+        "name": "retake_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "replace_audio_and_video",
+        "description": "What to replace in the retake section. Used for retake task.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "RetakeMode",
+        "enumValues": [
+          "replace_audio",
+          "replace_video",
+          "replace_audio_and_video"
+        ]
+      },
+      {
+        "name": "retake_start_time",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Start time in seconds of the section to edit. Used for retake task.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "task",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "text_to_video",
+        "description": "The generation task to perform",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Task",
+        "enumValues": [
+          "text_to_video",
+          "image_to_video",
+          "audio_to_video",
+          "retake",
+          "extend"
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video for retake or extend tasks",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video"
+      },
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Camera motion effect to apply to the generated video. Use 'none' for no camera motion."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Duration of the video in seconds"
+      },
+      {
+        "name": "ExtendMode",
+        "values": [
+          [
+            "START",
+            "start"
+          ],
+          [
+            "END",
+            "end"
+          ]
+        ],
+        "description": "Where to extend the video. Used for extend task."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_25",
+            "25"
+          ],
+          [
+            "VALUE_48",
+            "48"
+          ],
+          [
+            "VALUE_50",
+            "50"
+          ]
+        ],
+        "description": "Frame rate in frames per second"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_2K",
+            "2k"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Resolution quality of the generated video. Only 1080p is supported for audio_to_video, retake, and extend tasks."
+      },
+      {
+        "name": "RetakeMode",
+        "values": [
+          [
+            "REPLACE_AUDIO",
+            "replace_audio"
+          ],
+          [
+            "REPLACE_VIDEO",
+            "replace_video"
+          ],
+          [
+            "REPLACE_AUDIO_AND_VIDEO",
+            "replace_audio_and_video"
+          ]
+        ],
+        "description": "What to replace in the retake section. Used for retake task."
+      },
+      {
+        "name": "Task",
+        "values": [
+          [
+            "TEXT_TO_VIDEO",
+            "text_to_video"
+          ],
+          [
+            "IMAGE_TO_VIDEO",
+            "image_to_video"
+          ],
+          [
+            "AUDIO_TO_VIDEO",
+            "audio_to_video"
+          ],
+          [
+            "RETAKE",
+            "retake"
+          ],
+          [
+            "EXTEND",
+            "extend"
+          ]
+        ],
+        "description": "The generation task to perform"
+      }
+    ]
+  },
+  {
+    "endpointId": "lightricks/ltx-2-distilled",
+    "className": "Ltx_2_Distilled",
+    "moduleName": "video-generate",
+    "docstring": "LTX-2: The first open source audio-video model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video. Ignored if an image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "1:1",
+          "21:9"
+        ]
+      },
+      {
+        "name": "enhance_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Use the model's prompt enhancement to expand and improve your prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional input image for image-to-video generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Strength of image conditioning for i2v (0.0-1.0). Higher values follow the image more closely.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "num_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 121,
+        "description": "Number of frames to generate. Must follow formula: 8*k + 1 (e.g., 81, 97, 113, 121).",
+        "fieldType": "input",
+        "required": false,
+        "min": 25,
+        "max": 241
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducibility.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video. Ignored if an image is provided."
+      }
+    ]
+  },
+  {
+    "endpointId": "luma/ray-3.2",
+    "className": "Ray_3_2",
+    "moduleName": "video-generate",
+    "docstring": "Luma's reasoning video model. Generates cinematic 5s or 10s video from text or images, with native HDR and EXR export for professional production pipelines.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video. Ignored when start_image or end_image is set — the model derives the ratio from the anchor frame(s).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "9:16",
+          "3:4",
+          "1:1",
+          "4:3",
+          "16:9",
+          "21:9"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Video duration in seconds. 10s is not supported with hdr, start_image, end_image, or loop.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional last frame of the video. Only valid with 5s duration; not supported with loop.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "exr_export",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Export an EXR file alongside the MP4 for professional colour-grading workflows. Requires hdr=true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "hdr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate HDR-encoded MP4. Requires 720p or 1080p, 5s duration, and no loop.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "loop",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate a seamlessly looping video. Not supported with 10s duration, hdr, or end_image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video. Be specific about subject, motion, camera movement, lighting, and pacing.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Output resolution. 540p is not available when hdr is true.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional first frame of the video. Only valid with 5s duration.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video. Ignored when start_image or end_image is set — the model derives the ratio from the anchor frame(s)."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ]
+        ],
+        "description": "Video duration in seconds. 10s is not supported with hdr, start_image, end_image, or loop."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_540P",
+            "540p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output resolution. 540p is not available when hdr is true."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-video",
+    "className": "P_Video",
+    "moduleName": "video-generate",
+    "docstring": "Fast video generation with built-in draft mode for rapid creative iteration. Text-to-video, image-to-video, and audio-to-video in a single endpoint.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the video. Ignored when an input image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3",
+          "1:1"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio to condition video generation. Supports flac, mp3, wav.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "disable_safety_filter",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Disable safety filter for prompts (and input image). When disabled, prompts are not checked for unsafe content before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "draft",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Draft mode. Generates a lower-quality preview of the video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the video in seconds (1-20). Ignored when audio is provided.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 24,
+        "description": "Frames per second of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          "24",
+          "48"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to generate video from (image-to-video). Supports jpg, jpeg, png, webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference image for the last frame of the video. Supports jpg, jpeg, png, webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "no_op",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Health check mode - returns status without inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt_upsampling",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Use prompt upsampling to enhance the prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "save_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Save the video with audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the video. Ignored when an input image is provided."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_48",
+            "48"
+          ]
+        ],
+        "description": "Frames per second of the video."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Resolution of the video."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-video-animate",
+    "className": "P_Video_Animate",
+    "moduleName": "video-generate",
+    "docstring": "p-video-animate animates a reference image with the motion and audio of a source video. Optimized for speed and cost — 5.24s per 1s of video.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated videos.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "ignore_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Ignore source audio during generation. If save_audio is true, the source audio is still saved with the final video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference image of the subject to animate.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "instruction_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Further instruction on how the reference subject should be animated using the motion of the input video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "no_op",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Target ~megapixel budget: 720p ≈ 1 MP, 1080p ≈ 2 MP (aspect ratio preserved).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "save_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Save the video with audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "target_fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "original",
+        "description": "Target FPS for the working video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TargetFps",
+        "enumValues": [
+          "original",
+          "24",
+          "48"
+        ]
+      },
+      {
+        "name": "turbo",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Turbo mode: faster generation for slightly lower quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Source RGB video (.mp4): motion + audio source.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Target ~megapixel budget: 720p ≈ 1 MP, 1080p ≈ 2 MP (aspect ratio preserved)."
+      },
+      {
+        "name": "TargetFps",
+        "values": [
+          [
+            "ORIGINAL",
+            "original"
+          ],
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_48",
+            "48"
+          ]
+        ],
+        "description": "Target FPS for the working video."
+      }
+    ]
+  },
+  {
+    "endpointId": "prunaai/p-video-replace",
+    "className": "P_Video_Replace",
+    "moduleName": "video-generate",
+    "docstring": "p-video-replace swaps the person in a video with one from a reference image, keeping motion, timing, camera, and scene exactly as they were. 3.58s per 1s of video generated.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "disable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Disable safety checker for generated videos.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "ignore_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Ignore source audio during generation. If save_audio is true, the source audio is still saved with the final video.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Identity reference image(s) (1-3) to place into the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "instruction_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Further instruction on how to place the people from the reference images into the scene.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "no_op",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Target ~megapixel budget: 720p ≈ 1 MP, 1080p ≈ 2 MP (aspect ratio preserved).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "save_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Save the video with audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave blank for random.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "target_fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "original",
+        "description": "Target FPS for the working video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TargetFps",
+        "enumValues": [
+          "original",
+          "24",
+          "48"
+        ]
+      },
+      {
+        "name": "turbo",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Turbo mode: faster generation for slightly lower quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Source RGB video (.mp4): motion + audio source.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Target ~megapixel budget: 720p ≈ 1 MP, 1080p ≈ 2 MP (aspect ratio preserved)."
+      },
+      {
+        "name": "TargetFps",
+        "values": [
+          [
+            "ORIGINAL",
+            "original"
+          ],
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_48",
+            "48"
+          ]
+        ],
+        "description": "Target FPS for the working video."
+      }
+    ]
+  },
+  {
+    "endpointId": "runwayml/aleph-2",
+    "className": "Aleph_2",
+    "moduleName": "video-generate",
+    "docstring": "Edit one frame to update an entire video. Aleph 2.0 is Runway's in-context video editor: longer clips (up to 30s), multi-shot edits, and image-level precision via keyframe references.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "keyframe_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Up to 5 optional keyframe images used as more precise control over edits. The position of each keyframe is given by keyframe_positions.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "keyframe_positions",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Position of each keyframe in keyframe_images. One entry per image. Each value must be 'first', 'last', or a timestamp in seconds (e.g. '1.67').",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the edit to be applied to the input video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to edit. Videos must be between 2 and 30 seconds and less than 16MB.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "vidu/q3-pro",
+    "className": "Q3_Pro",
+    "moduleName": "video-generate",
+    "docstring": "High-fidelity video generation with text-to-video, image-to-video, and start-end-to-video modes. Up to 16 seconds at 1080p with synchronized audio.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video. Only used in text-to-video mode (ignored when images are provided).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "3:4",
+          "4:3",
+          "1:1"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio synchronized with the video (dialogue and sound effects).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 16
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "End frame image for the video. Must be used together with start_image for start-end-to-video mode. The aspect ratios of start and end images must be similar (ratio between 0.8 and 1.25). Supported formats: png, jpeg, jpg, webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Maximum 5000 characters.",
+        "fieldType": "input",
+        "required": true,
+        "max": 5000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Resolution of the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Start frame image for the video. When provided without an end_image, the model runs in image-to-video mode. Supported formats: png, jpeg, jpg, webp.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the output video. Only used in text-to-video mode (ignored when images are provided)."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_540P",
+            "540p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Resolution of the output video."
+      }
+    ]
+  },
+  {
+    "endpointId": "vidu/q3-turbo",
+    "className": "Q3_Turbo",
+    "moduleName": "video-generate",
+    "docstring": "Fast video generation with text-to-video, image-to-video, and start-end-to-video modes. Up to 16 seconds at 1080p with synchronized audio.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the output video. Only used in text-to-video mode (ignored when images are provided).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "3:4",
+          "4:3",
+          "1:1"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio synchronized with the video (dialogue and sound effects).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 16
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "End frame image for the video. Must be used together with start_image for start-end-to-video mode. The aspect ratios of start and end images must be similar (ratio between 0.8 and 1.25). Supported formats: png, jpeg, jpg, webp.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Maximum 5000 characters.",
+        "fieldType": "input",
+        "required": true,
+        "max": 5000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Resolution of the output video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Set for reproducible generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Start frame image for the video. When provided without an end_image, the model runs in image-to-video mode. Supported formats: png, jpeg, jpg, webp.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ]
+        ],
+        "description": "Aspect ratio of the output video. Only used in text-to-video mode (ignored when images are provided)."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_540P",
+            "540p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Resolution of the output video."
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan2.6-i2v-flash",
+    "className": "Wan2_6_I2v_Flash",
+    "moduleName": "video-generate",
+    "docstring": "Image-to-video generation with optional audio, multi-shot narrative support, and faster inference",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file (wav/mp3, 3-30s, ≤15MB) for voice/music synchronization",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio_enabled",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate video with audio. When enabled, the model will auto-generate audio or use provided audio file. Disable for silent video output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "5",
+          "10",
+          "15"
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the prompt optimizer will be enabled",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "multi_shots",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable intelligent multi-shot segmentation (only active when enable_prompt_expansion is enabled). True enables multi-shot segmentation, false generates single-shot content.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt to avoid certain elements",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ]
+        ],
+        "description": "Duration of the generated video in seconds"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-i2v",
+    "className": "Wan_2_7_I2v",
+    "moduleName": "video-generate",
+    "docstring": "Generate videos from images, with support for first-and-last-frame control, clip continuation, and audio synchronization using Alibaba's Wan 2.7 model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file (wav/mp3, 3-30s, ≤15MB) for voice/music synchronization. If not provided, the model auto-generates matching audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 15
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Automatically expand and optimize the prompt for better results. Improves quality for short prompts but increases latency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "first_clip",
+        "tsType": "image",
+        "propType": "video",
+        "default": null,
+        "description": "Video clip to continue from (mp4/mov, 2-10s, ≤100MB). Cannot be combined with first_frame.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "first_frame",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame image to animate into video (jpg/png/bmp/webp, ≤20MB)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame image for first-and-last-frame video generation (jpg/png/bmp/webp, ≤20MB). Requires first_frame.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt — describes content that should not appear in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-r2v",
+    "className": "Wan_2_7_R2v",
+    "moduleName": "video-generate",
+    "docstring": "Generate videos from reference images or clips while preserving subject identity using Alibaba's Wan 2.7 reference-to-video model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 10
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt — describes content that should not appear in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images of the character/object to feature in the video (jpg/png/bmp/webp)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_videos",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos of the character/object to feature in the video (mp4/mov)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "shot_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "single",
+        "description": "Shot structure of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ShotType",
+        "enumValues": [
+          "single",
+          "multi"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution"
+      },
+      {
+        "name": "ShotType",
+        "values": [
+          [
+            "SINGLE",
+            "single"
+          ],
+          [
+            "MULTI",
+            "multi"
+          ]
+        ],
+        "description": "Shot structure of the generated video"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-t2v",
+    "className": "Wan_2_7_T2v",
+    "moduleName": "video-generate",
+    "docstring": "Generate videos with audio from text prompts using Alibaba's Wan 2.7 model. 1080p, up to 15 seconds, with audio synchronization.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Audio file (wav/mp3, 3-30s, ≤15MB) for voice/music synchronization. If not provided, the model auto-generates matching audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the generated video in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 15
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Automatically expand and optimize the prompt for better results. Improves quality for short prompts but increases latency.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Negative prompt — describes content that should not appear in the video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "wan-video/wan-2.7-videoedit",
+    "className": "Wan_2_7_Videoedit",
+    "moduleName": "video-generate",
+    "docstring": "Edit videos with natural language instructions using Alibaba's Wan 2.7 VideoEdit model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio of the output video. 'auto' uses the input video's aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "audio_setting",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Audio behavior for edited video. 'auto': model decides whether to regenerate audio. 'origin': keep the original audio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioSetting",
+        "enumValues": [
+          "auto",
+          "origin"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Duration of the output video in seconds. If not set, matches input video duration. Use this to truncate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Editing instructions or style transfer description",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Reference image for reference-based editing (jpg/png/bmp/webp)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for reproducible generation. Range: 0-2147483647",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Input video to edit (mp4/mov, 2-10s)",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ]
+        ],
+        "description": "Aspect ratio of the output video. 'auto' uses the input video's aspect ratio."
+      },
+      {
+        "name": "AudioSetting",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ORIGIN",
+            "origin"
+          ]
+        ],
+        "description": "Audio behavior for edited video. 'auto': model decides whether to regenerate audio. 'origin': keep the original audio."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "xai/grok-imagine-r2v",
+    "className": "Grok_Imagine_R2v",
+    "moduleName": "video-generate",
+    "docstring": "Generate videos guided by reference images using xAI's Grok Imagine Video model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "9:16",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8,
+        "description": "Duration of the video in seconds (1-10).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the video to generate",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images to guide the video generation (1-7 images). These are used as style and content references, not as starting frames.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "480p",
+        "description": "Resolution of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio of the generated video."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ]
+        ],
+        "description": "Resolution of the generated video."
+      }
+    ]
+  },
+  {
+    "endpointId": "xai/grok-imagine-video-1.5",
+    "className": "Grok_Imagine_Video_1_5",
+    "moduleName": "video-generate",
+    "docstring": "Image-to-video with synchronized audio using xAI's Grok Imagine Video 1.5 preview model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio of the output video. Defaults to the input image's native aspect ratio when 'auto' is selected.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "4:3",
+          "1:1",
+          "9:16",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "Duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Input image to animate (image-to-video). Supports jpg, jpeg, png, webp. The output aspect ratio defaults to the image's native aspect ratio.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the motion or scene for the generated video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "480p"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ]
+        ],
+        "description": "Aspect ratio of the output video. Defaults to the input image's native aspect ratio when 'auto' is selected."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_480P",
+            "480p"
+          ]
+        ],
+        "description": "Resolution of the video."
+      }
+    ]
+  },
+  {
+    "endpointId": "xai/grok-imagine-video-extension",
+    "className": "Grok_Imagine_Video_Extension",
+    "moduleName": "video-generate",
+    "docstring": "Extend videos with xAI's Grok Imagine Video model. Provide a source video and describe what happens next.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 6,
+        "description": "Length of the extension in seconds",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of what should happen next in the video",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Source video to extend. Must be MP4 format (H.264, H.265, or AV1 codec), 2-15 seconds long. The extension is generated from the last frame of the input video.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
     "endpointId": "topazlabs/video-upscale",
     "className": "Topaz_Video_Upscale",
     "moduleName": "video-enhance",
@@ -44453,6 +55125,502 @@
           ]
         ],
         "description": "Target resolution"
+      }
+    ]
+  },
+  {
+    "endpointId": "bria/video-increase-resolution",
+    "className": "Video_Increase_Resolution",
+    "moduleName": "video-enhance",
+    "docstring": "Upscale videos up to 8K output resolution. Trained on fully licensed and commercially safe data.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "desired_increase",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 2,
+        "description": "Scale factor for upscaling. Maximum output resolution is 8K (7680x4320)",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "DesiredIncrease",
+        "enumValues": [
+          "2",
+          "4"
+        ]
+      },
+      {
+        "name": "output_container_and_codec",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp4_h264",
+        "description": "Output format and codec",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputContainerAndCodec",
+        "enumValues": [
+          "mp4_h264",
+          "mp4_h265",
+          "webm_vp9",
+          "mov_h265",
+          "mov_proresks",
+          "mkv_h264",
+          "mkv_h265",
+          "mkv_vp9",
+          "gif"
+        ]
+      },
+      {
+        "name": "preserve_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to maintain original audio in output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_url",
+        "tsType": "string",
+        "propType": "video",
+        "default": "",
+        "description": "URL of the video file",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "DesiredIncrease",
+        "values": [
+          [
+            "VALUE_2",
+            "2"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ]
+        ],
+        "description": "Scale factor for upscaling. Maximum output resolution is 8K (7680x4320)"
+      },
+      {
+        "name": "OutputContainerAndCodec",
+        "values": [
+          [
+            "MP4_H264",
+            "mp4_h264"
+          ],
+          [
+            "MP4_H265",
+            "mp4_h265"
+          ],
+          [
+            "WEBM_VP9",
+            "webm_vp9"
+          ],
+          [
+            "MOV_H265",
+            "mov_h265"
+          ],
+          [
+            "MOV_PRORESKS",
+            "mov_proresks"
+          ],
+          [
+            "MKV_H264",
+            "mkv_h264"
+          ],
+          [
+            "MKV_H265",
+            "mkv_h265"
+          ],
+          [
+            "MKV_VP9",
+            "mkv_vp9"
+          ],
+          [
+            "GIF",
+            "gif"
+          ]
+        ],
+        "description": "Output format and codec"
+      }
+    ]
+  },
+  {
+    "endpointId": "bria/video-remove-background",
+    "className": "Video_Remove_Background",
+    "moduleName": "video-enhance",
+    "docstring": "Automatically remove backgrounds from videos -perfect for creating clean, professional content without a green screen.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "background_color",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Transparent",
+        "description": "Background color to apply. Use 'Transparent' for transparent background.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BackgroundColor",
+        "enumValues": [
+          "Transparent",
+          "Black",
+          "White",
+          "Gray",
+          "Red",
+          "Green",
+          "Blue",
+          "Yellow",
+          "Cyan",
+          "Magenta",
+          "Brown",
+          "Orange",
+          "Purple",
+          "Pink"
+        ]
+      },
+      {
+        "name": "output_container_and_codec",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webm_vp9",
+        "description": "Output format and codec. For transparency support use webm_vp9, mov_proresks, or gif.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputContainerAndCodec",
+        "enumValues": [
+          "mp4_h264",
+          "mp4_h265",
+          "webm_vp9",
+          "mov_h265",
+          "mov_proresks",
+          "mkv_h264",
+          "mkv_h265",
+          "mkv_vp9",
+          "gif"
+        ]
+      },
+      {
+        "name": "preserve_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to maintain original audio in output",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "video_url",
+        "tsType": "string",
+        "propType": "video",
+        "default": "",
+        "description": "URL of the video file",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "BackgroundColor",
+        "values": [
+          [
+            "TRANSPARENT",
+            "Transparent"
+          ],
+          [
+            "BLACK",
+            "Black"
+          ],
+          [
+            "WHITE",
+            "White"
+          ],
+          [
+            "GRAY",
+            "Gray"
+          ],
+          [
+            "RED",
+            "Red"
+          ],
+          [
+            "GREEN",
+            "Green"
+          ],
+          [
+            "BLUE",
+            "Blue"
+          ],
+          [
+            "YELLOW",
+            "Yellow"
+          ],
+          [
+            "CYAN",
+            "Cyan"
+          ],
+          [
+            "MAGENTA",
+            "Magenta"
+          ],
+          [
+            "BROWN",
+            "Brown"
+          ],
+          [
+            "ORANGE",
+            "Orange"
+          ],
+          [
+            "PURPLE",
+            "Purple"
+          ],
+          [
+            "PINK",
+            "Pink"
+          ]
+        ],
+        "description": "Background color to apply. Use 'Transparent' for transparent background."
+      },
+      {
+        "name": "OutputContainerAndCodec",
+        "values": [
+          [
+            "MP4_H264",
+            "mp4_h264"
+          ],
+          [
+            "MP4_H265",
+            "mp4_h265"
+          ],
+          [
+            "WEBM_VP9",
+            "webm_vp9"
+          ],
+          [
+            "MOV_H265",
+            "mov_h265"
+          ],
+          [
+            "MOV_PRORESKS",
+            "mov_proresks"
+          ],
+          [
+            "MKV_H264",
+            "mkv_h264"
+          ],
+          [
+            "MKV_H265",
+            "mkv_h265"
+          ],
+          [
+            "MKV_VP9",
+            "mkv_vp9"
+          ],
+          [
+            "GIF",
+            "gif"
+          ]
+        ],
+        "description": "Output format and codec. For transparency support use webm_vp9, mov_proresks, or gif."
+      }
+    ]
+  },
+  {
+    "endpointId": "bytedance/video-upscaler",
+    "className": "Video_Upscaler",
+    "moduleName": "video-enhance",
+    "docstring": "Upscale and enhance video up to 4K at 60fps, with scene-aware presets for AI-generated content, short dramas, UGC, and film restoration.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "video",
+    "inputFields": [
+      {
+        "name": "processing_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Processing tier. 'standard' is self-serve and works for any BytePlus VOD account. 'pro' uses a higher-quality enhancement model — better skin textures and fine detail for real-people footage — but requires your BytePlus account to be whitelisted first (file a support ticket).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ProcessingType",
+        "enumValues": [
+          "standard",
+          "pro"
+        ]
+      },
+      {
+        "name": "scene",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "aigc",
+        "description": "Scene-based enhancement preset. 'aigc' is recommended for Seedance / other model outputs. 'short_series' is tuned for short-form drama, 'ugc' for user-generated content, 'old_film' for film restoration, 'common' for everything else.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Scene",
+        "enumValues": [
+          "aigc",
+          "short_series",
+          "ugc",
+          "old_film",
+          "common"
+        ]
+      },
+      {
+        "name": "target_fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 60,
+        "description": "Target output frame rate. Frame interpolation is applied if higher than the source. Valid range: 1–120.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TargetFps",
+        "enumValues": [
+          "24",
+          "30",
+          "60",
+          "120"
+        ]
+      },
+      {
+        "name": "target_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "4k",
+        "description": "Target output resolution. BytePlus VOD uses lowercase suffixes (`2k`/`4k` not `2K`/`4K`). 4k is the native maximum.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TargetResolution",
+        "enumValues": [
+          "240p",
+          "360p",
+          "480p",
+          "540p",
+          "720p",
+          "1080p",
+          "2k",
+          "4k"
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Video to upscale and enhance. Typically a Seedance 2.0 output (1080p/24fps), but any AIGC video works.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ProcessingType",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "PRO",
+            "pro"
+          ]
+        ],
+        "description": "Processing tier. 'standard' is self-serve and works for any BytePlus VOD account. 'pro' uses a higher-quality enhancement model — better skin textures and fine detail for real-people footage — but requires your BytePlus account to be whitelisted first (file a support ticket)."
+      },
+      {
+        "name": "Scene",
+        "values": [
+          [
+            "AIGC",
+            "aigc"
+          ],
+          [
+            "SHORT_SERIES",
+            "short_series"
+          ],
+          [
+            "UGC",
+            "ugc"
+          ],
+          [
+            "OLD_FILM",
+            "old_film"
+          ],
+          [
+            "COMMON",
+            "common"
+          ]
+        ],
+        "description": "Scene-based enhancement preset. 'aigc' is recommended for Seedance / other model outputs. 'short_series' is tuned for short-form drama, 'ugc' for user-generated content, 'old_film' for film restoration, 'common' for everything else."
+      },
+      {
+        "name": "TargetFps",
+        "values": [
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ],
+          [
+            "VALUE_60",
+            "60"
+          ],
+          [
+            "VALUE_120",
+            "120"
+          ]
+        ],
+        "description": "Target output frame rate. Frame interpolation is applied if higher than the source. Valid range: 1–120."
+      },
+      {
+        "name": "TargetResolution",
+        "values": [
+          [
+            "_240P",
+            "240p"
+          ],
+          [
+            "_360P",
+            "360p"
+          ],
+          [
+            "_480P",
+            "480p"
+          ],
+          [
+            "_540P",
+            "540p"
+          ],
+          [
+            "_720P",
+            "720p"
+          ],
+          [
+            "_1080P",
+            "1080p"
+          ],
+          [
+            "_2K",
+            "2k"
+          ],
+          [
+            "_4K",
+            "4k"
+          ]
+        ],
+        "description": "Target output resolution. BytePlus VOD uses lowercase suffixes (`2k`/`4k` not `2K`/`4K`). 4k is the native maximum."
       }
     ]
   },
@@ -45482,7 +56650,7 @@
         "tsType": "audio",
         "propType": "audio",
         "default": null,
-        "description": "Optional uploaded audio to condition video generation. If both audio and script are provided, uploaded audio is used.",
+        "description": "Optional uploaded audio to drive avatar speech. If provided, this is used instead of voice_script and voice settings.",
         "fieldType": "input",
         "required": false
       },
@@ -45491,7 +56659,7 @@
         "tsType": "boolean",
         "propType": "bool",
         "default": false,
-        "description": "When true, skip the OpenRouter multimodal prompt upsampler and pass the raw user prompt to the video model.",
+        "description": "When true, skip automatic enhancement of the visual video prompt and use video_prompt directly.",
         "fieldType": "input",
         "required": false
       },
@@ -45512,6 +56680,15 @@
         "description": "Input image (first frame). Supports jpg, jpeg, png, webp.",
         "fieldType": "input",
         "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Disabled if empty.Mention what you do NOT want in the video, e.g. \"subtitles, text, blurry, low quality, frames, watermark, titles, scene change\". We recommend using multiple keywords at once.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "no_op",
@@ -45546,11 +56723,22 @@
         "required": false
       },
       {
+        "name": "strength_negative_prompt",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Strength of the Negative Prompt. Optimal value can differ for different video lengths (Experimental Feature)",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      },
+      {
         "name": "video_prompt",
         "tsType": "string",
         "propType": "str",
         "default": "The person is talking.",
-        "description": "Optional prompt for the video.",
+        "description": "Optional visual prompt describing how the person should appear or behave while speaking.",
         "fieldType": "input",
         "required": false
       },
@@ -45559,7 +56747,7 @@
         "tsType": "enum",
         "propType": "enum",
         "default": "Zephyr (Female)",
-        "description": "Voice for generated speech.",
+        "description": "Voice to use when generating speech from voice_script.",
         "fieldType": "input",
         "required": false,
         "enumRef": "Voice",
@@ -45601,7 +56789,7 @@
         "tsType": "enum",
         "propType": "enum",
         "default": "English (US)",
-        "description": "Output language.",
+        "description": "Language/accent target for generated speech.",
         "fieldType": "input",
         "required": false,
         "enumRef": "VoiceLanguage",
@@ -45623,7 +56811,7 @@
         "tsType": "string",
         "propType": "str",
         "default": "Say the following.",
-        "description": "Optional speaking style, tone, pacing, emotion.",
+        "description": "Optional style instructions for how to speak voice_script, such as tone, pacing, accent, or emotion. These instructions are not spoken.",
         "fieldType": "input",
         "required": false
       },
@@ -45632,7 +56820,7 @@
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "Script for the person to say when no audio is uploaded.",
+        "description": "Exact words the avatar should say. Required when no audio file is uploaded.",
         "fieldType": "input",
         "required": false
       }
@@ -45777,7 +56965,7 @@
             "Rasalgethi (Male)"
           ]
         ],
-        "description": "Voice for generated speech."
+        "description": "Voice to use when generating speech from voice_script."
       },
       {
         "name": "VoiceLanguage",
@@ -45823,7 +57011,7 @@
             "Hindi"
           ]
         ],
-        "description": "Output language."
+        "description": "Language/accent target for generated speech."
       }
     ]
   },
@@ -49242,6 +60430,227 @@
         "description": "A description of the target style for the cover. For example: 'R&B version, smooth vocal, groovy bass' or 'Hard rock, electric guitar riffs, powerful drums'. Up to 2000 characters.",
         "fieldType": "input",
         "required": true
+      },
+      {
+        "name": "sample_rate",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 44100,
+        "description": "Sample rate for the generated music",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SampleRate",
+        "enumValues": [
+          "16000",
+          "24000",
+          "32000",
+          "44100"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AudioFormat",
+        "values": [
+          [
+            "MP3",
+            "mp3"
+          ],
+          [
+            "WAV",
+            "wav"
+          ],
+          [
+            "PCM",
+            "pcm"
+          ]
+        ],
+        "description": "Audio format for the output"
+      },
+      {
+        "name": "Bitrate",
+        "values": [
+          [
+            "VALUE_32000",
+            "32000"
+          ],
+          [
+            "VALUE_64000",
+            "64000"
+          ],
+          [
+            "VALUE_128000",
+            "128000"
+          ],
+          [
+            "VALUE_256000",
+            "256000"
+          ]
+        ],
+        "description": "Bitrate for the generated music"
+      },
+      {
+        "name": "SampleRate",
+        "values": [
+          [
+            "VALUE_16000",
+            "16000"
+          ],
+          [
+            "VALUE_24000",
+            "24000"
+          ],
+          [
+            "VALUE_32000",
+            "32000"
+          ],
+          [
+            "VALUE_44100",
+            "44100"
+          ]
+        ],
+        "description": "Sample rate for the generated music"
+      }
+    ]
+  },
+  {
+    "endpointId": "google/lyria-3",
+    "className": "Lyria_3",
+    "moduleName": "audio-generate",
+    "docstring": "Generate 30-second music clips from text prompts or images with Lyria 3, Google's music generation model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images to inspire the music composition (up to 10 images)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the music to generate. Be specific \"\n            \"about genre, instruments, mood, tempo, and style for best results.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for generation. Set to a specific value for more \"\n            \"reproducible results, though exact determinism is not guaranteed.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "google/lyria-3-pro",
+    "className": "Lyria_3_Pro",
+    "moduleName": "audio-generate",
+    "docstring": "Generate full-length songs up to 3 minutes from text prompts or images with Lyria 3 Pro, Google's most capable music generation model",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images to inspire the music composition (up to 10 images)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the song to generate. Include details \"\n            \"like genre, instruments, mood, tempo, lyrics, and song structure \"\n            \"(e.g. [Verse], [Chorus], [Bridge]) for best results. You can also \"\n            \"use timestamps like [0:00 - 0:30] to control timing.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed for generation. Set to a specific value for more \"\n            \"reproducible results, though exact determinism is not guaranteed.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "minimax/music-2.5",
+    "className": "Music_2_5",
+    "moduleName": "audio-generate",
+    "docstring": "Generate full-length songs with vocals, lyrics, and rich instrumentation from a text prompt",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "audio_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp3",
+        "description": "Audio format for the output",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioFormat",
+        "enumValues": [
+          "mp3",
+          "wav",
+          "pcm"
+        ]
+      },
+      {
+        "name": "bitrate",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 256000,
+        "description": "Bitrate for the generated music",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Bitrate",
+        "enumValues": [
+          "32000",
+          "64000",
+          "128000",
+          "256000"
+        ]
+      },
+      {
+        "name": "lyrics",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Lyrics for the song. Use \\n to separate lines. You can add structure tags like [Intro], [Verse], [Pre Chorus], [Chorus], [Interlude], [Bridge], [Outro], [Post Chorus], [Transition], [Break], [Hook], [Build Up], [Inst], [Solo] to control the arrangement. 1-3500 characters.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A description of the music style, mood, and scenario. For example: 'Pop, melancholic, perfect for a rainy night'. 0-2000 characters.",
+        "fieldType": "input",
+        "required": false
       },
       {
         "name": "sample_rate",
@@ -60945,7 +72354,7 @@
         "tsType": "string",
         "propType": "str",
         "default": "Say the following.",
-        "description": "Style instructions to control how the text is spoken. Use natural language to describe the desired tone, pace, accent, and emotion. For example: \"Say this in a calm, professional tone\" or \"Speak with excitement and energy\". Maximum 4,000 bytes.",
+        "description": "Style instructions to control how the text is spoken. \"\n            \"Use natural language to describe the desired tone, pace, accent, \"\n            'and emotion. For example: \"Say this in a calm, professional tone\" '\n            'or \"Speak with excitement and energy\". Maximum 4,000 bytes.",
         "fieldType": "input",
         "required": false
       },
@@ -60954,7 +72363,7 @@
         "tsType": "string",
         "propType": "str",
         "default": "",
-        "description": "The text to convert to speech. Supports markup tags like [sigh], [laughing], [whispering], [shouting], [extremely fast] for expressive delivery. Maximum 4,000 bytes.",
+        "description": "The text to convert to speech. Supports markup tags like \"\n            \"[sigh], [laughing], [whispering], [shouting], [extremely fast] for \"\n            \"expressive delivery. Maximum 4,000 bytes.",
         "fieldType": "input",
         "required": true
       },
@@ -61482,6 +72891,362 @@
           ]
         ],
         "description": "Voice to use for speech generation"
+      }
+    ]
+  },
+  {
+    "endpointId": "inworld/realtime-tts-1.5-max",
+    "className": "Realtime_Tts_1_5_Max",
+    "moduleName": "audio-speech",
+    "docstring": "Highest-quality realtime text-to-speech with <200ms latency, emotion control, and 15-language support",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "audio_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp3",
+        "description": "Output audio format.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioFormat",
+        "enumValues": [
+          "mp3",
+          "wav",
+          "ogg_opus",
+          "flac"
+        ]
+      },
+      {
+        "name": "sample_rate",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 48000,
+        "description": "Audio sample rate in Hz.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SampleRate",
+        "enumValues": [
+          "8000",
+          "16000",
+          "22050",
+          "24000",
+          "32000",
+          "44100",
+          "48000"
+        ]
+      },
+      {
+        "name": "speaking_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Speaking speed multiplier. Set to 0 for normal speed (1.0).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1.5
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Controls randomness when generating audio. Higher values produce more expressive results, lower values are more deterministic. Set to 0 to use the model default (1.1).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text to convert to speech. Maximum 2,000 characters. Supports SSML break tags for pauses (e.g. `<break time=\"1s\" />`), emotion markups (e.g. `[happy]`, `[sad]`), and non-verbal vocalizations (e.g. `[laugh]`, `[sigh]`).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "text_normalization",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Controls whether numbers, dates, and abbreviations are expanded before synthesis. 'auto' lets the model decide, 'on' always normalizes, 'off' reads text as-is.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TextNormalization",
+        "enumValues": [
+          "auto",
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "voice_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Ashley",
+        "description": "The voice to use. Use a preset voice name (e.g. 'Ashley', 'Dennis', 'Alex') or a custom cloned voice ID.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AudioFormat",
+        "values": [
+          [
+            "MP3",
+            "mp3"
+          ],
+          [
+            "WAV",
+            "wav"
+          ],
+          [
+            "OGG_OPUS",
+            "ogg_opus"
+          ],
+          [
+            "FLAC",
+            "flac"
+          ]
+        ],
+        "description": "Output audio format."
+      },
+      {
+        "name": "SampleRate",
+        "values": [
+          [
+            "VALUE_8000",
+            "8000"
+          ],
+          [
+            "VALUE_16000",
+            "16000"
+          ],
+          [
+            "VALUE_22050",
+            "22050"
+          ],
+          [
+            "VALUE_24000",
+            "24000"
+          ],
+          [
+            "VALUE_32000",
+            "32000"
+          ],
+          [
+            "VALUE_44100",
+            "44100"
+          ],
+          [
+            "VALUE_48000",
+            "48000"
+          ]
+        ],
+        "description": "Audio sample rate in Hz."
+      },
+      {
+        "name": "TextNormalization",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ON",
+            "on"
+          ],
+          [
+            "OFF",
+            "off"
+          ]
+        ],
+        "description": "Controls whether numbers, dates, and abbreviations are expanded before synthesis. 'auto' lets the model decide, 'on' always normalizes, 'off' reads text as-is."
+      }
+    ]
+  },
+  {
+    "endpointId": "inworld/realtime-tts-1.5-mini",
+    "className": "Realtime_Tts_1_5_Mini",
+    "moduleName": "audio-speech",
+    "docstring": "Ultra-fast, cost-efficient realtime text-to-speech with ~120ms latency and 15-language support",
+    "tags": [],
+    "useCases": [],
+    "outputType": "audio",
+    "inputFields": [
+      {
+        "name": "audio_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp3",
+        "description": "Output audio format.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AudioFormat",
+        "enumValues": [
+          "mp3",
+          "wav",
+          "ogg_opus",
+          "flac"
+        ]
+      },
+      {
+        "name": "sample_rate",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 48000,
+        "description": "Audio sample rate in Hz.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SampleRate",
+        "enumValues": [
+          "8000",
+          "16000",
+          "22050",
+          "24000",
+          "32000",
+          "44100",
+          "48000"
+        ]
+      },
+      {
+        "name": "speaking_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Speaking speed multiplier. Set to 0 for normal speed (1.0).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1.5
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Controls randomness when generating audio. Higher values produce more expressive results, lower values are more deterministic. Set to 0 to use the model default (1.1).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "text",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text to convert to speech. Maximum 2,000 characters. Supports SSML break tags for pauses (e.g. `<break time=\"1s\" />`), emotion markups (e.g. `[happy]`, `[sad]`), and non-verbal vocalizations (e.g. `[laugh]`, `[sigh]`).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "text_normalization",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Controls whether numbers, dates, and abbreviations are expanded before synthesis. 'auto' lets the model decide, 'on' always normalizes, 'off' reads text as-is.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "TextNormalization",
+        "enumValues": [
+          "auto",
+          "on",
+          "off"
+        ]
+      },
+      {
+        "name": "voice_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "Ashley",
+        "description": "The voice to use. Use a preset voice name (e.g. 'Ashley', 'Dennis', 'Alex') or a custom cloned voice ID.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "AudioFormat",
+        "values": [
+          [
+            "MP3",
+            "mp3"
+          ],
+          [
+            "WAV",
+            "wav"
+          ],
+          [
+            "OGG_OPUS",
+            "ogg_opus"
+          ],
+          [
+            "FLAC",
+            "flac"
+          ]
+        ],
+        "description": "Output audio format."
+      },
+      {
+        "name": "SampleRate",
+        "values": [
+          [
+            "VALUE_8000",
+            "8000"
+          ],
+          [
+            "VALUE_16000",
+            "16000"
+          ],
+          [
+            "VALUE_22050",
+            "22050"
+          ],
+          [
+            "VALUE_24000",
+            "24000"
+          ],
+          [
+            "VALUE_32000",
+            "32000"
+          ],
+          [
+            "VALUE_44100",
+            "44100"
+          ],
+          [
+            "VALUE_48000",
+            "48000"
+          ]
+        ],
+        "description": "Audio sample rate in Hz."
+      },
+      {
+        "name": "TextNormalization",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ON",
+            "on"
+          ],
+          [
+            "OFF",
+            "off"
+          ]
+        ],
+        "description": "Controls whether numbers, dates, and abbreviations are expanded before synthesis. 'auto' lets the model decide, 'on' always normalizes, 'off' reads text as-is."
       }
     ]
   },
@@ -65309,7 +77074,7 @@
         "tsType": "boolean",
         "propType": "bool",
         "default": false,
-        "description": "Request streaming response. Defaults to False.",
+        "description": "Request streaming response.",
         "fieldType": "input",
         "required": false
       },
@@ -65353,7 +77118,7 @@
         "name": "top_k",
         "tsType": "number",
         "propType": "int",
-        "default": 50,
+        "default": 0,
         "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
         "fieldType": "input",
         "required": false
@@ -65362,7 +77127,7 @@
         "name": "top_p",
         "tsType": "number",
         "propType": "float",
-        "default": 0.9,
+        "default": 0,
         "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
         "fieldType": "input",
         "required": false
@@ -65511,7 +77276,7 @@
         "tsType": "boolean",
         "propType": "bool",
         "default": false,
-        "description": "Request streaming response. Defaults to False.",
+        "description": "Request streaming response.",
         "fieldType": "input",
         "required": false
       },
@@ -65528,7 +77293,7 @@
         "name": "temperature",
         "tsType": "number",
         "propType": "float",
-        "default": 0.2,
+        "default": 0,
         "description": "The value used to modulate the next token probabilities.",
         "fieldType": "input",
         "required": false
@@ -65537,7 +77302,7 @@
         "name": "top_k",
         "tsType": "number",
         "propType": "int",
-        "default": 50,
+        "default": 0,
         "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
         "fieldType": "input",
         "required": false
@@ -65546,10 +77311,1195 @@
         "name": "top_p",
         "tsType": "number",
         "propType": "float",
-        "default": 0.9,
+        "default": 0,
         "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
         "fieldType": "input",
         "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "anthropic/claude-fable-5",
+    "className": "Claude_Fable_5",
+    "moduleName": "text-generate",
+    "docstring": "Claude Fable 5 from Anthropic: the next generation of intelligence for the hardest knowledge work and coding problems.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional input image. Images are priced as (width px * height px)/750 input tokens",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_image_resolution",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Maximum image resolution in megapixels. Scales down image before sending it to Claude, to save time and money.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.001,
+        "max": 2
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8192,
+        "description": "Maximum number of output tokens",
+        "fieldType": "input",
+        "required": false,
+        "min": 1024,
+        "max": 128000
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Input prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "anthropic/claude-sonnet-4.6",
+    "className": "Claude_Sonnet_4_6",
+    "moduleName": "text-generate",
+    "docstring": "Claude Sonnet 4.6 from Anthropic: a full upgrade to coding, computer use, long-context reasoning, agent planning, knowledge work, and design, with a 1 million token context window in beta.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional input image. Images are priced as (width px * height px)/750 input tokens",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_image_resolution",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Maximum image resolution in megapixels. Scales down image before sending it to Claude, to save time and money.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.001,
+        "max": 2
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8192,
+        "description": "Maximum number of output tokens",
+        "fieldType": "input",
+        "required": false,
+        "min": 1024,
+        "max": 64000
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Input prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "anthropic/claude-sonnet-5",
+    "className": "Claude_Sonnet_5",
+    "moduleName": "text-generate",
+    "docstring": "Anthropic's most agentic Sonnet model, bringing frontier-level coding and tool use at Sonnet's speed and price",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "low",
+        "description": "How much thinking Claude does before responding. Higher effort improves quality on hard coding and agentic tasks, but is slower and uses more output tokens. 'low' disables thinking for the fastest, cheapest responses.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Effort",
+        "enumValues": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional input image. Images are priced as (width px * height px)/750 input tokens",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_image_resolution",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Maximum image resolution in megapixels. Scales down image before sending it to Claude, to save time and money.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.001,
+        "max": 2
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8192,
+        "description": "Maximum number of output tokens",
+        "fieldType": "input",
+        "required": false,
+        "min": 1024,
+        "max": 64000
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Input prompt",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "Effort",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ],
+          [
+            "MAX",
+            "max"
+          ]
+        ],
+        "description": "How much thinking Claude does before responding. Higher effort improves quality on hard coding and agentic tasks, but is slower and uses more output tokens. 'low' disables thinking for the fastest, cheapest responses."
+      }
+    ]
+  },
+  {
+    "endpointId": "google/gemini-3.5-flash",
+    "className": "Gemini_3_5_Flash",
+    "moduleName": "text-generate",
+    "docstring": "Google's fast multimodal model with frontier reasoning across agents, coding, and long-context tasks",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Input audio to send with the prompt (max 1 audio file, up to 8.4 hours)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Input images to send with the prompt (max 10 images, each up to 7MB)",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_output_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 65535,
+        "description": "Maximum number of tokens to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 65535
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt to send to the model",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System instruction to guide the model's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Sampling temperature between 0 and 2",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "thinking_level",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Thinking level for reasoning (low or high). Replaces thinking_budget for Gemini 3 models.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ThinkingLevel",
+        "enumValues": [
+          "none",
+          "low",
+          "high"
+        ]
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.95,
+        "description": "Nucleus sampling parameter - the model considers the results of the tokens with top_p probability mass",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "video_fps",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frame rate (frames per second) at which to sample input videos. Higher values give the model more frames to reason over (useful for fast-moving footage) but consume more tokens. Omit to use the default sampling rate (1 fps).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.1,
+        "max": 60
+      },
+      {
+        "name": "videos",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Input videos to send with the prompt (max 10 videos, each up to 45 minutes)",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ThinkingLevel",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Thinking level for reasoning (low or high). Replaces thinking_budget for Gemini 3 models."
+      }
+    ]
+  },
+  {
+    "endpointId": "ibm-granite/granite-vision-4.1-4b",
+    "className": "Granite_Vision_4_1_4b",
+    "moduleName": "text-generate",
+    "docstring": "Granite Vision 4.1 4B is a vision-language model (VLM) that delivers frontier-level performance on structured document extraction tasks — chart extraction, table extraction, and semantic key-value pair extraction — in a compact 4B parameter footprint",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "add_generation_prompt",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Add generation prompt. Passed to the chat template. Defaults to True.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A template to format the prompt with. If not specified, the chat template provided by the model will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "chat_template_kwargs",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": null,
+        "description": "Additional arguments to be passed to the chat template.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Completion API Image input.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "max_tokens is deprecated in favor of the max_completion_tokens field.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Chat completion API messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "min_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The minimum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API user prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "repetition_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Repetition penalty",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "Random seed. Leave unspecified to randomize the seed.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stop",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "A list of sequences to stop generation at. For example, [\"<end>\",\"<stop>\"] will stop generation at the first instance of \"<end>\" or \"<stop>\".",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stream",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Request streaming response.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Completion API system prompt. The chat template provides a good default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_k",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "The number of highest probability tokens to consider for generating the output. If > 0, only keep the top k tokens with highest probability (top-k filtering).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "A probability threshold for generating the output. If < 1.0, only keep the top tokens with cumulative probability >= top_p (nucleus filtering). Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751).",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputFields": [],
+    "enums": []
+  },
+  {
+    "endpointId": "openai/gpt-5.4",
+    "className": "Gpt_5_4",
+    "moduleName": "text-generate",
+    "docstring": "OpenAI's most capable frontier model for complex professional work, coding, and multi-step reasoning.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Constrains effort on reasoning for GPT-5.4. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses similar to GPT-4.1 in speed. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ]
+        ],
+        "description": "Constrains effort on reasoning for GPT-5.4. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses similar to GPT-4.1 in speed. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning)."
+      },
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-5.6-luna",
+    "className": "Gpt_5_6_Luna",
+    "moduleName": "text-generate",
+    "docstring": "OpenAI's GPT-5.6 cost-optimized tier, built for fast, high-volume, latency-sensitive workloads.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ]
+        ],
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning)."
+      },
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-5.6-sol",
+    "className": "Gpt_5_6_Sol",
+    "moduleName": "text-generate",
+    "docstring": "OpenAI's GPT-5.6 flagship tier, built for complex professional work, coding, and deep multi-step reasoning.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ]
+        ],
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning)."
+      },
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "openai/gpt-5.6-terra",
+    "className": "Gpt_5_6_Terra",
+    "moduleName": "text-generate",
+    "docstring": "OpenAI's GPT-5.6 balanced tier, tuned for everyday production work at roughly half the cost of the flagship.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "image_input",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of images to send to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_completion_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "messages",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "A JSON string representing a list of messages. For example: [{\"role\": \"user\", \"content\": \"Hello, how are you?\"}]. If provided, prompt and system_prompt are ignored.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model. Do not use if using messages.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning_effort",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "none",
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ReasoningEffort",
+        "enumValues": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to set the assistant's behavior",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "verbosity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Verbosity",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputFields": [],
+    "enums": [
+      {
+        "name": "ReasoningEffort",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ],
+          [
+            "XHIGH",
+            "xhigh"
+          ]
+        ],
+        "description": "Constrains effort on reasoning. Supported values are none, low, medium, high, and xhigh. The default none provides fast, low-latency responses. Higher reasoning efforts produce more thorough answers but use more tokens and take longer. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning)."
+      },
+      {
+        "name": "Verbosity",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive."
+      }
+    ]
+  },
+  {
+    "endpointId": "qwen/qwen3-7-plus",
+    "className": "Qwen3_7_Plus",
+    "moduleName": "text-generate",
+    "docstring": "Qwen3.7-Plus is Alibaba's cost-effective multimodal model with vision-language understanding, a 1 million token context window, and strong agentic coding and tool use.",
+    "tags": [],
+    "useCases": [],
+    "outputType": "str",
+    "inputFields": [
+      {
+        "name": "frequency_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Frequency penalty. Positive values penalize tokens proportionally to how often they have appeared, reducing repetition.",
+        "fieldType": "input",
+        "required": false,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "name": "image",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Optional list of input images for visual understanding (Qwen3.7-Plus is multimodal). Each image is sent alongside the text prompt.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2048,
+        "description": "The maximum number of tokens the model should generate as output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 65536
+      },
+      {
+        "name": "presence_penalty",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Presence penalty. Positive values penalize tokens that have already appeared, encouraging the model to talk about new topics.",
+        "fieldType": "input",
+        "required": false,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to send to the model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "You are a helpful assistant.",
+        "description": "System prompt to guide the model's behavior.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.7,
+        "description": "The value used to modulate the next token probabilities.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "top_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "A probability threshold for nucleus sampling. Only keeps the top tokens with cumulative probability >= top_p.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
       }
     ],
     "outputFields": [],

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -333,6 +333,52 @@ export class ReplicateProvider extends BaseProvider {
         id: "snowflake/snowflake-arctic-instruct",
         name: "Snowflake Arctic Instruct",
         provider: "replicate"
+      },
+      {
+        id: "anthropic/claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        provider: "replicate"
+      },
+      {
+        id: "anthropic/claude-sonnet-4.6",
+        name: "Claude Sonnet 4.6",
+        provider: "replicate"
+      },
+      {
+        id: "anthropic/claude-fable-5",
+        name: "Claude Fable 5",
+        provider: "replicate"
+      },
+      { id: "openai/gpt-5.4", name: "GPT-5.4", provider: "replicate" },
+      {
+        id: "openai/gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "replicate"
+      },
+      {
+        id: "openai/gpt-5.6-terra",
+        name: "GPT-5.6 Terra",
+        provider: "replicate"
+      },
+      {
+        id: "openai/gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "replicate"
+      },
+      {
+        id: "google/gemini-3.5-flash",
+        name: "Gemini 3.5 Flash",
+        provider: "replicate"
+      },
+      {
+        id: "qwen/qwen3-7-plus",
+        name: "Qwen3.7 Plus",
+        provider: "replicate"
+      },
+      {
+        id: "ibm-granite/granite-vision-4.1-4b",
+        name: "Granite Vision 4.1 4B",
+        provider: "replicate"
       }
     ];
   }
@@ -408,7 +454,17 @@ export class ReplicateProvider extends BaseProvider {
         name: "Chatterbox Multilingual",
         provider: "replicate"
       },
-      { id: "x-lance/f5-tts", name: "F5 TTS", provider: "replicate" }
+      { id: "x-lance/f5-tts", name: "F5 TTS", provider: "replicate" },
+      {
+        id: "inworld/realtime-tts-1.5-max",
+        name: "Inworld Realtime TTS 1.5 Max",
+        provider: "replicate"
+      },
+      {
+        id: "inworld/realtime-tts-1.5-mini",
+        name: "Inworld Realtime TTS 1.5 Mini",
+        provider: "replicate"
+      }
     ];
   }
 

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -379,6 +379,50 @@ export class ReplicateProvider extends BaseProvider {
         id: "ibm-granite/granite-vision-4.1-4b",
         name: "Granite Vision 4.1 4B",
         provider: "replicate"
+      },
+      {
+        id: "anthropic/claude-3.5-haiku",
+        name: "Claude 3.5 Haiku",
+        provider: "replicate"
+      },
+      { id: "openai/gpt-5.1", name: "GPT-5.1", provider: "replicate" },
+      { id: "openai/gpt-5-pro", name: "GPT-5 Pro", provider: "replicate" },
+      { id: "openai/o1-mini", name: "O1 Mini", provider: "replicate" },
+      {
+        id: "openai/gpt-oss-120b",
+        name: "GPT OSS 120B",
+        provider: "replicate"
+      },
+      { id: "openai/gpt-oss-20b", name: "GPT OSS 20B", provider: "replicate" },
+      {
+        id: "meta/llama-4-maverick-instruct",
+        name: "Llama 4 Maverick Instruct",
+        provider: "replicate"
+      },
+      {
+        id: "meta/llama-4-scout-instruct",
+        name: "Llama 4 Scout Instruct",
+        provider: "replicate"
+      },
+      {
+        id: "ibm-granite/granite-3.2-8b-instruct",
+        name: "Granite 3.2 8B Instruct",
+        provider: "replicate"
+      },
+      {
+        id: "ibm-granite/granite-3.3-8b-instruct",
+        name: "Granite 3.3 8B Instruct",
+        provider: "replicate"
+      },
+      {
+        id: "ibm-granite/granite-vision-3.3-2b",
+        name: "Granite Vision 3.3 2B",
+        provider: "replicate"
+      },
+      {
+        id: "lucataco/qwen2.5-omni-7b",
+        name: "Qwen2.5 Omni 7B",
+        provider: "replicate"
       }
     ];
   }
@@ -513,6 +557,16 @@ export class ReplicateProvider extends BaseProvider {
       {
         id: "thomasmol/whisper-diarization",
         name: "Whisper Diarization",
+        provider: "replicate"
+      },
+      {
+        id: "rafaelgalle/whisper-diarization-advanced",
+        name: "Whisper Diarization Advanced",
+        provider: "replicate"
+      },
+      {
+        id: "ibm-granite/granite-speech-3.3-8b",
+        name: "Granite Speech 3.3 8B",
         provider: "replicate"
       }
     ];


### PR DESCRIPTION
Stacked on #4570 — review that first. This branch is based on it because the Comment fix is what lets a media example reach its Output node at all.

## The bug

`nodetool workflows run` could execute a media graph but never produce a file:

```
ProcessingContext model interface 'createAsset' is not configured
```

`modelInterfaces` is wired in exactly one production place — `createRuntimeContext()` in `packages/websocket/src/unified-websocket-runner.ts` — and otherwise only in `packages/runtime/tests/context.test.ts`. The CLI builds its own `ProcessingContext` with storage and workspace wired, but never calls `setModelInterfaces`.

## Changes

**`--asset-output-mode <mode>`** — exposes all six modes the runtime defines: `native`, `raw`, `data_uri`, `workspace`, `storage_url`, `temp_url`. The CLI previously always used the `native` default with no way to change it. An unknown value fails immediately with the valid list.

**`createAsset` wired** via `setModelInterfaces`, mirroring the server. Assets persist to the local DB and asset store under `<userId>/<assetId>.<ext>` — the layout `storage migrate-keys` expects, so object-level RLS and bucket policies still apply.

Thumbnails are skipped: `storeAssetWithThumbnail` isn't exported from the websocket barrel, and a CLI run has no gallery to populate.

**`--workspace <dir>`**, defaulting to `./nodetool-output`. `workspace` mode writes into `<workspace>/assets`, but the CLI only had a workspace directory when running a *saved* workflow by id. A JSON or DSL file target got `null`, so the mode couldn't work at all for the most common CLI case.

## Verification

```
workflows run "Product Spot from Text.json" --asset-output-mode workspace --workspace /tmp/nt-out
→ RUN_EXIT=0
→ /tmp/nt-out/assets/<id>.mp4  (1920x1080, H.264 + AAC, 6.12s, 2.1 MB)
```

FLUX.2 [klein] and LTX-2.3 both executed against the live FAL API, with `FAL_API_KEY` taken from the environment. `npm run lint` clean; `tsc --noEmit` on packages/cli clean.

## What is *not* verified

`storage_url` and `temp_url` depend on URL resolvers this run doesn't exercise. They're plumbed and typed but untested — I'd rather say so than imply all six are proven.

## Known wart, not fixed here

In `workspace` mode the returned output URI is the `asset://` id, while the workspace copy is written under a different filename. The two don't line up. The file is produced either way, but the returned reference doesn't point at it. Worth reconciling separately — plausibly the workspace materialization should win and return the workspace URI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)