### PR TITLE
feat(mini-apps): add the ten missing widget types

### DIFF
--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -172,6 +172,17 @@ ApplicationAppView   # renders the document's widget tree
   at phone width), there is no reactive-subgraph path (no browser worker, so
   every run is a full server run), and `ResourcePicker`/`ResourceGallery`
   collapse into one list of rows — a grid of tiles buys nothing at phone width.
+- **Three display widgets are cards, not previews**: `Model3D`, `Chart` and
+  `PDF`. Mobile ships no 3D renderer, no charting library and no WebView, and
+  each card names the value, shows the metadata its ref carries, and hands the
+  file to the OS instead of drawing something that only looks like it.
+  `Gallery` does render — it tiles the bound refs with the same `Image` the
+  `Image` widget uses.
+- **Path inputs are typed fields**: a phone sandbox has no user-visible
+  filesystem, and a `FilePathInput`/`FolderPathInput` value is read by the
+  machine running the workflow, not by the device. Same reasoning as
+  `DateInput`. A Hugging Face model input is a repo-id field for the same
+  reason: mobile has no hub browser.
 - **Sketch widget**: a bound sketch draws rather than being summarised.
   `components/sketch/SketchRenderer` composites it — the same compositor the
   sketch viewer screen uses — for a document bound inline and for a bare

--- a/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * The widgets added to the catalog for 3D models, charts, PDFs, galleries and
+ * the six extra input kinds.
+ *
+ * Three of them are deliberate fallbacks — mobile ships no 3D renderer, no
+ * charting library and no PDF viewer — so what is asserted there is that the
+ * card names the value and offers to open it, not that it draws it.
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  WIDGET_CATALOG,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+import ApplicationAppView from "../ApplicationAppView";
+import { RENDERERS } from "../widgets";
+
+/** A document with one widget bound to a variable holding `value`. */
+const appDoc = (
+  type: string,
+  props: Record<string, unknown>,
+  value?: unknown
+) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Catalog" } },
+    content: [{ type, props: { id: `${type}-1`, binding: "var:data", ...props } }],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-new",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    {
+      id: "data",
+      name: "data",
+      scope: "instance",
+      persist: false,
+      default: value,
+    },
+  ],
+});
+
+const makeWorkflow = (id: string): Workflow =>
+  ({
+    id,
+    name: "Catalog",
+    description: "",
+    graph: { nodes: [], edges: [] },
+  }) as unknown as Workflow;
+
+const renderApp = (id: string, doc: unknown) =>
+  render(
+    <ApplicationAppView
+      document={parseApplicationDocument(doc) as ApplicationDocument}
+      workflow={makeWorkflow(id)}
+    />
+  );
+
+describe("catalog coverage", () => {
+  it("has a native renderer for every catalog type", () => {
+    const missing = Object.keys(WIDGET_CATALOG).filter(
+      (type) => !(type in RENDERERS)
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("display fallbacks", () => {
+  it("names a 3D model and offers to open it", async () => {
+    renderApp(
+      "wf-model3d",
+      appDoc("Model3D", {}, { type: "model_3d", uri: "https://x.test/head.glb" })
+    );
+
+    expect(await screen.findByText("3D model")).toBeTruthy();
+    expect(screen.getByText("head.glb")).toBeTruthy();
+    expect(screen.getByText("Not previewable on mobile")).toBeTruthy();
+    expect(screen.getByText("Open model")).toBeTruthy();
+  });
+
+  it("shows the placeholder when nothing is bound to Model3D", () => {
+    renderApp("wf-model3d-empty", appDoc("Model3D", { placeholder: "No mesh" }));
+
+    expect(screen.getByText("No mesh")).toBeTruthy();
+  });
+
+  it("summarizes a chart's data rather than plotting it", async () => {
+    renderApp(
+      "wf-chart",
+      appDoc("Chart", { label: "Scores", chartKind: "bar" }, [1, 2, 3])
+    );
+
+    expect(await screen.findByText("Scores")).toBeTruthy();
+    expect(screen.getByText("3 points")).toBeTruthy();
+    expect(screen.getByText("Not previewable on mobile")).toBeTruthy();
+  });
+
+  it("reports a bound dataframe's shape in the chart card", async () => {
+    renderApp(
+      "wf-chart-frame",
+      appDoc("Chart", {}, {
+        type: "dataframe",
+        columns: [{ name: "x" }, { name: "y" }],
+        data: [
+          [1, 2],
+          [3, 4],
+        ],
+      })
+    );
+
+    expect(await screen.findByText("2 rows · 2 columns")).toBeTruthy();
+  });
+
+  it("names a PDF and offers to open it", async () => {
+    renderApp(
+      "wf-pdf",
+      appDoc("PDF", {}, { type: "document", uri: "https://x.test/report.pdf" })
+    );
+
+    expect(await screen.findByText("PDF")).toBeTruthy();
+    expect(screen.getByText("report.pdf")).toBeTruthy();
+    expect(screen.getByText("Open PDF")).toBeTruthy();
+  });
+
+  it("tiles a bound array of images in the gallery", async () => {
+    renderApp(
+      "wf-gallery",
+      appDoc("Gallery", { label: "Results", tileSize: 96 }, [
+        { type: "image", uri: "https://x.test/a.png" },
+        { type: "image", uri: "https://x.test/b.png" },
+      ])
+    );
+
+    expect(await screen.findByText("Results")).toBeTruthy();
+    expect(screen.getAllByTestId("gallery-tile")).toHaveLength(2);
+  });
+
+  it("shows the gallery placeholder for an empty array", () => {
+    renderApp("wf-gallery-empty", appDoc("Gallery", { placeholder: "Nothing" }, []));
+
+    expect(screen.getByText("Nothing")).toBeTruthy();
+  });
+});
+
+describe("added input widgets", () => {
+  it("writes width and height as one pair", async () => {
+    renderApp(
+      "wf-size",
+      appDoc("ImageSizeInput", { label: "Size" }, { width: 512, height: 512 })
+    );
+
+    const width = await screen.findByLabelText("width");
+    fireEvent.changeText(width, "640");
+
+    expect(screen.getByLabelText("width").props.value).toBe("640");
+    // The other half of the pair survives the edit.
+    expect(screen.getByLabelText("height").props.value).toBe("512");
+  });
+
+  it("edits a file path as text and says whose filesystem it is", async () => {
+    renderApp("wf-path", appDoc("FilePathInput", { label: "Input file" }, ""));
+
+    expect(await screen.findByText("Input file")).toBeTruthy();
+    expect(
+      screen.getByText("Path on the machine running the workflow")
+    ).toBeTruthy();
+
+    fireEvent.changeText(screen.getByPlaceholderText("/path/to/file.txt"), "/tmp/a.txt");
+    expect(screen.getByDisplayValue("/tmp/a.txt")).toBeTruthy();
+  });
+
+  it("offers a folder placeholder for the folder path input", async () => {
+    renderApp("wf-folder", appDoc("FolderPathInput", {}, ""));
+
+    expect(await screen.findByPlaceholderText("/path/to/folder")).toBeTruthy();
+  });
+
+  it("edits a text list as one entry per line", async () => {
+    renderApp(
+      "wf-textlist",
+      appDoc("MediaListInput", { listKind: "text", label: "Topics" }, [
+        "alpha",
+        "beta",
+      ])
+    );
+
+    const field = await screen.findByDisplayValue("alpha\nbeta");
+    fireEvent.changeText(field, "alpha\nbeta\ngamma");
+    expect(screen.getByDisplayValue("alpha\nbeta\ngamma")).toBeTruthy();
+  });
+
+  it("lists picked media with a remove control", async () => {
+    renderApp(
+      "wf-imagelist",
+      appDoc("MediaListInput", { listKind: "image" }, [
+        { type: "image", uri: "https://x.test/a.png" },
+      ])
+    );
+
+    expect(await screen.findByText("Add image")).toBeTruthy();
+    const remove = screen.getByLabelText("Remove image 1");
+    fireEvent.press(remove);
+    expect(screen.queryByLabelText("Remove image 1")).toBeNull();
+  });
+
+  it("edits a dataframe cell in place, keeping the ref's shape", async () => {
+    renderApp(
+      "wf-frame",
+      appDoc("DataFrameInput", { label: "Rows" }, {
+        type: "dataframe",
+        uri: "",
+        columns: [{ name: "city" }, { name: "score" }],
+        data: [["Berlin", 7]],
+      })
+    );
+
+    expect(await screen.findByText("city")).toBeTruthy();
+    expect(screen.getByText("score")).toBeTruthy();
+
+    fireEvent.changeText(screen.getByLabelText("city row 1"), "Lisbon");
+    expect(screen.getByLabelText("city row 1").props.value).toBe("Lisbon");
+    // A numeric column stays numeric.
+    fireEvent.changeText(screen.getByLabelText("score row 1"), "9");
+    expect(screen.getByLabelText("score row 1").props.value).toBe("9");
+  });
+
+  it("appends an empty row", async () => {
+    renderApp(
+      "wf-frame-add",
+      appDoc("DataFrameInput", {}, [{ city: "Berlin" }])
+    );
+
+    fireEvent.press(await screen.findByText("Add row"));
+    expect(screen.getByLabelText("city row 2")).toBeTruthy();
+  });
+
+  it("says so when there is nothing to edit", async () => {
+    renderApp("wf-frame-empty", appDoc("DataFrameInput", {}, null));
+
+    expect(await screen.findByText("No columns to edit")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * `WorkflowInput` routing: the widget renders whatever control the Input node it
+ * binds to needs. Everything the kind table declares must reach a real control —
+ * a kind that falls through to a plain text box would silently break the app
+ * (a model reference is not something anybody types).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+// The model picker's own data comes from tRPC; the routing test only cares that
+// the picker — not a text box — is what the model kinds render.
+jest.mock("../../../hooks/useModelsByProvider", () => ({
+  useModelsForType: () => ({
+    models: [
+      { type: "language_model", id: "m1", name: "Sonnet", provider: "anthropic" },
+    ],
+    providers: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+import ApplicationAppView from "../ApplicationAppView";
+
+const appDoc = {
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Inputs" } },
+    content: [
+      { type: "WorkflowInput", props: { id: "w-1", binding: "op:main/in:n1" } },
+    ],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-kinds",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [],
+};
+
+const workflowWith = (nodeType: string, data: Record<string, unknown> = {}) =>
+  ({
+    id: `wf-${nodeType}`,
+    name: "Inputs",
+    description: "",
+    graph: {
+      nodes: [{ id: "n1", type: nodeType, data: { name: "field", ...data } }],
+      edges: [],
+    },
+  }) as unknown as Workflow;
+
+const renderInput = (nodeType: string, data?: Record<string, unknown>) =>
+  render(
+    <ApplicationAppView
+      document={parseApplicationDocument(appDoc) as ApplicationDocument}
+      workflow={workflowWith(nodeType, data)}
+    />
+  );
+
+describe("WorkflowInput kind routing", () => {
+  it("renders a model picker for a language model input", async () => {
+    renderInput("nodetool.input.LanguageModelInput");
+
+    expect(await screen.findByText("Sonnet")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("owner/model")).toBeNull();
+  });
+
+  it.each([
+    "nodetool.input.ImageModelInput",
+    "nodetool.input.VideoModelInput",
+    "nodetool.input.TTSModelInput",
+    "nodetool.input.ASRModelInput",
+    "nodetool.input.EmbeddingModelInput",
+  ])("renders a model picker for %s", async (nodeType) => {
+    renderInput(nodeType);
+
+    expect(await screen.findByText("Sonnet")).toBeTruthy();
+  });
+
+  it("renders a repo field for a Hugging Face model input", async () => {
+    renderInput("nodetool.input.HuggingFaceModelInput");
+
+    expect(await screen.findByPlaceholderText("owner/model")).toBeTruthy();
+  });
+
+  it("renders a grid for a dataframe input", async () => {
+    renderInput("nodetool.input.DataFrameInput");
+
+    expect(await screen.findByText("No columns to edit")).toBeTruthy();
+  });
+
+  it("renders a path field for file and folder inputs", async () => {
+    renderInput("nodetool.input.FilePathInput");
+    expect(await screen.findByPlaceholderText("/path/to/file.txt")).toBeTruthy();
+
+    screen.unmount();
+    renderInput("nodetool.input.FolderPathInput");
+    expect(await screen.findByPlaceholderText("/path/to/folder")).toBeTruthy();
+  });
+
+  it("renders a document picker for a 3D model input", async () => {
+    renderInput("nodetool.input.Model3DInput");
+
+    expect(await screen.findByText("Choose 3D model")).toBeTruthy();
+  });
+
+  it("renders a width/height pair for an image size input", async () => {
+    renderInput("nodetool.input.ImageSizeInput");
+
+    expect(await screen.findByLabelText("width")).toBeTruthy();
+    expect(screen.getByLabelText("height")).toBeTruthy();
+  });
+
+  it.each([
+    ["nodetool.input.ImageListInput", "Add image"],
+    ["nodetool.input.VideoListInput", "Add video"],
+    ["nodetool.input.AudioListInput", "Add audio"],
+  ])("renders a media list for %s", async (nodeType, addLabel) => {
+    renderInput(nodeType);
+
+    expect(await screen.findByText(addLabel)).toBeTruthy();
+  });
+
+  it("renders a line-per-entry field for a text list input", async () => {
+    renderInput("nodetool.input.TextListInput");
+
+    expect(await screen.findByPlaceholderText("One entry per line")).toBeTruthy();
+  });
+
+  it("still renders a text box for a string input", async () => {
+    renderInput("nodetool.input.StringInput");
+
+    expect(await screen.findByText("field")).toBeTruthy();
+    expect(screen.queryByText("No columns to edit")).toBeNull();
+  });
+});

--- a/mobile/src/components/app_runtime/inputKinds.ts
+++ b/mobile/src/components/app_runtime/inputKinds.ts
@@ -27,7 +27,10 @@ export type WorkflowInputKind =
   | "image_list"
   | "video_list"
   | "audio_list"
-  | "text_list";
+  | "text_list"
+  | "model3d"
+  | "image_size"
+  | "huggingface_model";
 
 const KIND_BY_NODE_TYPE: Readonly<Record<string, WorkflowInputKind>> = {
   "nodetool.input.StringInput": "string",
@@ -43,6 +46,9 @@ const KIND_BY_NODE_TYPE: Readonly<Record<string, WorkflowInputKind>> = {
   "nodetool.input.RealtimeAudioInput": "audio",
   "nodetool.input.DocumentInput": "document",
   "nodetool.input.DataFrameInput": "dataframe",
+  "nodetool.input.Model3DInput": "model3d",
+  "nodetool.input.ImageSizeInput": "image_size",
+  "nodetool.input.HuggingFaceModelInput": "huggingface_model",
   "nodetool.input.DataframeInput": "dataframe",
   "nodetool.input.FilePathInput": "file_path",
   "nodetool.input.FolderPathInput": "folder_path",

--- a/mobile/src/components/app_runtime/mediaPicker.ts
+++ b/mobile/src/components/app_runtime/mediaPicker.ts
@@ -10,7 +10,11 @@ import * as ImagePicker from "expo-image-picker";
 
 import { apiService } from "../../services/api";
 
-export type MediaKind = "image" | "audio" | "video" | "document";
+/**
+ * `model_3d` matches the `Model3DRef` type tag a workflow's 3D input reads, so a
+ * picked mesh needs no translation on the way into the graph.
+ */
+export type MediaKind = "image" | "audio" | "video" | "document" | "model_3d";
 
 export interface MediaValue {
   type: MediaKind;
@@ -23,6 +27,7 @@ const DEFAULTS: Record<MediaKind, { ext: string; mime: string }> = {
   audio: { ext: ".wav", mime: "audio/wav" },
   video: { ext: ".mp4", mime: "video/mp4" },
   document: { ext: ".pdf", mime: "application/pdf" },
+  model_3d: { ext: ".glb", mime: "model/gltf-binary" },
 };
 
 const upload = async (

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -614,6 +614,188 @@ const DownloadWidget: React.FC<WidgetProps> = (widget) => {
   );
 };
 
+/** The file name a ref points at, for cards that can only name their value. */
+const fileNameOf = (uri: string): string => {
+  const path = uri.split("?")[0] ?? uri;
+  const last = path.slice(path.lastIndexOf("/") + 1);
+  return last || path;
+};
+
+/**
+ * The card the three non-previewable display widgets share: it names the value,
+ * lists what metadata the ref carries, and — when there is a file behind it —
+ * hands it to the OS the same way `Download` does.
+ *
+ * `Model3D`, `Chart` and `PDF` all render this instead of a preview because
+ * mobile ships none of the machinery each needs: no `three`/`expo-gl` for a
+ * mesh, no charting library for a plot, and no WebView for a paginated PDF.
+ * Pulling three renderers in for widgets a phone app rarely leads with would
+ * cost more than it buys, and drawing something that only looks like the value
+ * would lie about it. Opening the file in a viewer the device already has is
+ * the honest affordance.
+ */
+const FallbackCard: React.FC<{
+  title: string;
+  meta: string;
+  uri: string | null;
+  openLabel: string;
+  disabled?: boolean;
+}> = ({ title, meta, uri, openLabel, disabled }) => {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.documentCard, { borderColor: colors.border }]}>
+      <Text style={[styles.label, { color: colors.text }]}>{title}</Text>
+      <Text style={[styles.hint, { color: colors.textTertiary }]}>{meta}</Text>
+      <Text style={[styles.hint, { color: colors.textTertiary }]}>
+        Not previewable on mobile
+      </Text>
+      {uri ? (
+        <TouchableOpacity
+          accessibilityRole="button"
+          disabled={disabled}
+          onPress={() => {
+            void Linking.openURL(uri);
+          }}
+          style={[styles.secondaryButton, { borderColor: colors.primary }]}
+        >
+          <Text style={{ color: colors.primary }}>{openLabel}</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};
+
+/** A bound `Model3DRef`, named rather than rendered — see `FallbackCard`. */
+const Model3DWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const item = asItems(value)[0];
+  const uri = mediaUri(item);
+  if (item == null) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "No 3D model yet"}
+        colors={colors}
+      />
+    );
+  }
+  return (
+    <FallbackCard
+      title="3D model"
+      meta={uri ? fileNameOf(uri) : "In-memory mesh"}
+      uri={uri}
+      openLabel="Open model"
+      disabled={widget.disabled}
+    />
+  );
+};
+
+/** What a bound plot value amounts to, for the card that cannot draw it. */
+const chartSummary = (value: unknown): string | null => {
+  if (isRow(value) && Array.isArray((value as { data?: unknown[] }).data)) {
+    const frame = value as { data?: unknown[]; columns?: unknown };
+    const columns = Array.isArray(frame.columns) ? frame.columns.length : 0;
+    const rows = frame.data?.length ?? 0;
+    return `${rows} row${rows === 1 ? "" : "s"} · ${columns} column${
+      columns === 1 ? "" : "s"
+    }`;
+  }
+  const points = asItems(value).length;
+  if (points === 0) {return null;}
+  return `${points} point${points === 1 ? "" : "s"}`;
+};
+
+/** A bound series, summarized rather than plotted — see `FallbackCard`. */
+const ChartWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const summary = chartSummary(value);
+  if (!summary) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "No data yet"}
+        colors={colors}
+      />
+    );
+  }
+  const kind = str(widget.props.chartKind) || "line";
+  return (
+    <FallbackCard
+      title={str(widget.props.label) || `${kind} chart`}
+      meta={summary}
+      uri={null}
+      openLabel=""
+    />
+  );
+};
+
+/** A bound PDF document, named rather than paged — see `FallbackCard`. */
+const PDFWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const item = asItems(value)[0];
+  const uri = mediaUri(item);
+  if (item == null) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "No document yet"}
+        colors={colors}
+      />
+    );
+  }
+  return (
+    <FallbackCard
+      title="PDF"
+      meta={uri ? fileNameOf(uri) : "In-memory document"}
+      uri={uri}
+      openLabel="Open PDF"
+      disabled={widget.disabled}
+    />
+  );
+};
+
+/**
+ * A tiled grid of a bound array of media refs. Unlike the three cards above this
+ * one renders for real: the tiles are the same `Image` the `Image` widget draws.
+ */
+const GalleryWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const tileSize = numOr(widget.props.tileSize, 120);
+  const uris = asItems(value)
+    .map(mediaUri)
+    .filter((uri): uri is string => uri !== null);
+
+  if (uris.length === 0) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "No images yet"}
+        colors={colors}
+      />
+    );
+  }
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <View style={styles.tileGrid}>
+        {uris.map((uri, index) => (
+          <Image
+            key={`${uri}-${index}`}
+            testID="gallery-tile"
+            accessibilityRole="image"
+            source={{ uri }}
+            style={[
+              styles.tile,
+              { width: tileSize, height: tileSize, borderColor: colors.border },
+            ]}
+            resizeMode="cover"
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
 // ── Inputs ──────────────────────────────────────────────────────────────────
 
 const TextInputWidget: React.FC<WidgetProps> = (widget) => {
@@ -1012,6 +1194,15 @@ const ColorInputWidget: React.FC<WidgetProps> = (widget) => {
   );
 };
 
+/** Wording for the picker button — `model_3d` reads badly as a noun. */
+const MEDIA_LABEL: Record<MediaKind, string> = {
+  image: "image",
+  audio: "audio",
+  video: "video",
+  document: "document",
+  model_3d: "3D model",
+};
+
 const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
   kind,
   ...widget
@@ -1040,7 +1231,7 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
   return (
     <View style={styles.field}>
       <FieldLabel
-        text={str(widget.props.label) || `${kind} input`}
+        text={str(widget.props.label) || `${MEDIA_LABEL[kind]} input`}
         colors={colors}
       />
       {kind === "image" && uri ? (
@@ -1062,7 +1253,9 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
           <ActivityIndicator color={colors.primary} size="small" />
         ) : (
           <Text style={{ color: colors.primary }}>
-            {uri ? `Replace ${kind}` : `Choose ${kind}`}
+            {uri
+              ? `Replace ${MEDIA_LABEL[kind]}`
+              : `Choose ${MEDIA_LABEL[kind]}`}
           </Text>
         )}
       </TouchableOpacity>
@@ -1074,6 +1267,450 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
           {uri}
         </Text>
       ) : null}
+    </View>
+  );
+};
+
+/**
+ * A typed path rather than a browser: a phone sandbox has no user-visible
+ * filesystem to walk, and the path a `FilePathInput`/`FolderPathInput` feeds is
+ * read by the server running the workflow, not by the device. So the control is
+ * the field the value actually needs.
+ */
+const PathInputWidget: React.FC<WidgetProps & { kind: "file" | "folder" }> = ({
+  kind,
+  ...widget
+}) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  return (
+    <View style={styles.field}>
+      <FieldLabel
+        text={str(widget.props.label) || (kind === "file" ? "File path" : "Folder path")}
+        colors={colors}
+      />
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.inputBg,
+            color: colors.text,
+            borderColor: colors.border,
+          },
+        ]}
+        editable={!widget.disabled}
+        value={str(value)}
+        autoCapitalize="none"
+        autoCorrect={false}
+        placeholder={
+          str(widget.props.placeholder) ||
+          (kind === "file" ? "/path/to/file.txt" : "/path/to/folder")
+        }
+        placeholderTextColor={colors.textTertiary}
+        onChangeText={(text) => {
+          setValue(text);
+          emit("change");
+        }}
+        onBlur={() => emit("change", "commit")}
+      />
+      <Text style={[styles.hint, { color: colors.textTertiary }]}>
+        Path on the machine running the workflow
+      </Text>
+    </View>
+  );
+};
+
+/** Writes the `{width, height}` pair an image workflow's size input reads. */
+const ImageSizeInputWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const size = isRow(value) ? value : {};
+  const dimension = (key: "width" | "height"): string => {
+    const current = size[key];
+    return typeof current === "number" ? String(current) : "";
+  };
+  const write = (key: "width" | "height", text: string) => {
+    const parsed = Number(text);
+    setValue({
+      ...size,
+      [key]: text === "" || Number.isNaN(parsed) ? undefined : parsed,
+    });
+    emit("change");
+  };
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label) || "Image size"} colors={colors} />
+      <View style={styles.row}>
+        {(["width", "height"] as const).map((key) => (
+          <TextInput
+            key={key}
+            style={[
+              styles.input,
+              styles.flex,
+              {
+                backgroundColor: colors.inputBg,
+                color: colors.text,
+                borderColor: colors.border,
+              },
+            ]}
+            accessibilityLabel={key}
+            editable={!widget.disabled}
+            value={dimension(key)}
+            keyboardType="numeric"
+            placeholder={key}
+            placeholderTextColor={colors.textTertiary}
+            onChangeText={(text) => write(key, text)}
+            onBlur={() => emit("change", "commit")}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+/** Which media a `MediaListInput` collects. */
+type ListKind = "image" | "video" | "audio" | "text";
+
+const listKindOf = (value: unknown): ListKind =>
+  value === "video" || value === "audio" || value === "text"
+    ? value
+    : "image";
+
+/**
+ * Picks several values and writes them as an array — the one control behind the
+ * four list input nodes. A text list is edited as lines rather than as rows: a
+ * per-row field on a phone costs a tap per item and buys nothing.
+ */
+const MediaListInputWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const kind = listKindOf(widget.props.listKind);
+  const items = useMemo(() => (Array.isArray(value) ? value : []), [value]);
+  const [picking, setPicking] = useState(false);
+
+  const add = useCallback(async () => {
+    setPicking(true);
+    try {
+      const picked = await pickMediaValue(kind === "text" ? "document" : kind);
+      if (picked) {
+        setValue([...items, picked]);
+        emit("change");
+      }
+    } finally {
+      setPicking(false);
+    }
+  }, [emit, items, kind, setValue]);
+
+  const label = str(widget.props.label) || `${kind} list`;
+
+  if (kind === "text") {
+    return (
+      <View style={styles.field}>
+        <FieldLabel text={label} colors={colors} />
+        <TextInput
+          style={[
+            styles.input,
+            styles.inputMultiline,
+            {
+              backgroundColor: colors.inputBg,
+              color: colors.text,
+              borderColor: colors.border,
+            },
+          ]}
+          editable={!widget.disabled}
+          value={items.map(str).join("\n")}
+          multiline
+          placeholder="One entry per line"
+          placeholderTextColor={colors.textTertiary}
+          onChangeText={(text) => {
+            setValue(text === "" ? [] : text.split("\n"));
+            emit("change");
+          }}
+          onBlur={() => emit("change", "commit")}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={label} colors={colors} />
+      {items.map((item, index) => {
+        const uri = mediaUri(item);
+        return (
+          <View key={index} style={styles.row}>
+            {kind === "image" && uri ? (
+              <Image
+                accessibilityRole="image"
+                source={{ uri }}
+                style={[styles.tile, { borderColor: colors.border }]}
+                resizeMode="cover"
+              />
+            ) : (
+              <Text
+                numberOfLines={1}
+                style={[styles.hint, styles.flex, { color: colors.textTertiary }]}
+              >
+                {uri ?? `${kind} ${index + 1}`}
+              </Text>
+            )}
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel={`Remove ${kind} ${index + 1}`}
+              disabled={widget.disabled}
+              onPress={() => {
+                setValue(items.filter((_, at) => at !== index));
+                emit("change");
+              }}
+            >
+              <Text style={{ color: colors.error }}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        );
+      })}
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={widget.disabled || picking}
+        onPress={() => void add()}
+        style={[
+          styles.secondaryButton,
+          { borderColor: colors.border, backgroundColor: colors.inputBg },
+        ]}
+      >
+        {picking ? (
+          <ActivityIndicator color={colors.primary} size="small" />
+        ) : (
+          <Text style={{ color: colors.primary }}>{`Add ${kind}`}</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+/**
+ * A bound dataframe as an editable grid.
+ *
+ * Two value shapes reach this widget: the `DataframeRef` a workflow input holds
+ * (`{columns, data}`, rows as arrays) and the plain array of row objects an app
+ * variable usually carries. Both read into the same grid, and each is written
+ * back in the shape it arrived in, so editing never rewrites the value's type.
+ */
+interface Grid {
+  /** True when the value was a `DataframeRef` rather than an array of rows. */
+  frame: boolean;
+  columns: string[];
+  rows: unknown[][];
+}
+
+const readGrid = (value: unknown): Grid => {
+  if (
+    isRow(value) &&
+    (Array.isArray(value.data) || Array.isArray(value.columns))
+  ) {
+    const columns = Array.isArray(value.columns)
+      ? value.columns.map((column, index) =>
+          isRow(column) ? str(column.name) || `col ${index + 1}` : str(column)
+        )
+      : [];
+    const rows = (Array.isArray(value.data) ? value.data : []).map((row) =>
+      Array.isArray(row) ? [...row] : [row]
+    );
+    const width = Math.max(columns.length, ...rows.map((row) => row.length), 0);
+    return {
+      frame: true,
+      columns: Array.from(
+        { length: width },
+        (_, index) => columns[index] ?? `col ${index + 1}`
+      ),
+      rows,
+    };
+  }
+  if (Array.isArray(value)) {
+    const columns = tableColumns(value);
+    if (columns.length === 0) {
+      return { frame: false, columns: ["value"], rows: value.map((row) => [row]) };
+    }
+    return {
+      frame: false,
+      columns,
+      rows: value.map((row) =>
+        columns.map((column) => (isRow(row) ? row[column] : undefined))
+      ),
+    };
+  }
+  return { frame: false, columns: [], rows: [] };
+};
+
+const writeGrid = (value: unknown, grid: Grid): unknown => {
+  if (grid.frame && isRow(value)) {return { ...value, data: grid.rows };}
+  if (grid.columns.length === 1 && grid.columns[0] === "value") {
+    return grid.rows.map((row) => row[0]);
+  }
+  return grid.rows.map((row) =>
+    Object.fromEntries(grid.columns.map((column, index) => [column, row[index]]))
+  );
+};
+
+/** A cell keeps its type: a numeric column stays numeric while it parses. */
+const coerceCell = (previous: unknown, text: string): unknown => {
+  if (typeof previous !== "number") {return text;}
+  const parsed = Number(text);
+  return text !== "" && !Number.isNaN(parsed) ? parsed : text;
+};
+
+const DataFrameInputWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const grid = useMemo(() => readGrid(value), [value]);
+  const maxHeight = numOr(widget.props.maxHeight, 280);
+
+  const commit = useCallback(
+    (rows: unknown[][]) => {
+      setValue(writeGrid(value, { ...grid, rows }));
+      emit("change");
+    },
+    [emit, grid, setValue, value]
+  );
+
+  if (grid.columns.length === 0) {
+    return (
+      <View style={styles.field}>
+        <FieldLabel
+          text={str(widget.props.label) || "Data table"}
+          colors={colors}
+        />
+        <Placeholder text="No columns to edit" colors={colors} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label) || "Data table"} colors={colors} />
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <ScrollView style={{ maxHeight }} nestedScrollEnabled>
+          <View style={[styles.table, { borderColor: colors.border }]}>
+            <View style={[styles.tableRow, { backgroundColor: colors.inputBg }]}>
+              {grid.columns.map((column) => (
+                <Text
+                  key={column}
+                  numberOfLines={1}
+                  style={[styles.tableCell, styles.tableHeader, { color: colors.text }]}
+                >
+                  {column}
+                </Text>
+              ))}
+            </View>
+            {grid.rows.map((row, rowIndex) => (
+              <View
+                key={rowIndex}
+                style={[
+                  styles.tableRow,
+                  {
+                    borderTopColor: colors.border,
+                    borderTopWidth: StyleSheet.hairlineWidth,
+                  },
+                ]}
+              >
+                {grid.columns.map((column, cellIndex) => (
+                  <TextInput
+                    key={column}
+                    accessibilityLabel={`${column} row ${rowIndex + 1}`}
+                    style={[
+                      styles.tableCell,
+                      styles.cellInput,
+                      { color: colors.text },
+                    ]}
+                    editable={!widget.disabled}
+                    value={cellText(row[cellIndex])}
+                    onChangeText={(text) =>
+                      commit(
+                        grid.rows.map((current, at) =>
+                          at === rowIndex
+                            ? grid.columns.map((_, index) =>
+                                index === cellIndex
+                                  ? coerceCell(current[index], text)
+                                  : current[index]
+                              )
+                            : current
+                        )
+                      )
+                    }
+                    onBlur={() => emit("change", "commit")}
+                  />
+                ))}
+              </View>
+            ))}
+          </View>
+        </ScrollView>
+      </ScrollView>
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={widget.disabled}
+        onPress={() => commit([...grid.rows, grid.columns.map(() => "")])}
+        style={[
+          styles.secondaryButton,
+          { borderColor: colors.border, backgroundColor: colors.inputBg },
+        ]}
+      >
+        <Text style={{ color: colors.primary }}>Add row</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+/**
+ * A Hugging Face repo id, typed. Mobile has no hub browser — the models screen
+ * lists what the server already cached, not the hub — so the control is the
+ * field, and it writes the `{type, repo_id}` ref the node reads.
+ */
+const HuggingFaceModelInputWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const current = isRow(value) ? str(value.repo_id) : str(value);
+  return (
+    <View style={styles.field}>
+      <FieldLabel
+        text={str(widget.props.label) || "Hugging Face model"}
+        colors={colors}
+      />
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.inputBg,
+            color: colors.text,
+            borderColor: colors.border,
+          },
+        ]}
+        editable={!widget.disabled}
+        value={current}
+        autoCapitalize="none"
+        autoCorrect={false}
+        placeholder="owner/model"
+        placeholderTextColor={colors.textTertiary}
+        onChangeText={(text) => {
+          setValue({ type: "hf.model", repo_id: text });
+          emit("change");
+        }}
+        onBlur={() => emit("change", "commit")}
+      />
     </View>
   );
 };
@@ -1135,6 +1772,47 @@ const WorkflowInputWidget: React.FC<WidgetProps> = (widget) => {
     case "video":
     case "document":
       return <MediaInputWidget {...props} kind={input.kind} />;
+    case "model3d":
+      return <MediaInputWidget {...props} kind="model_3d" />;
+    case "image_size":
+      return <ImageSizeInputWidget {...props} />;
+    case "dataframe":
+      return <DataFrameInputWidget {...props} />;
+    case "file_path":
+      return <PathInputWidget {...props} kind="file" />;
+    case "folder_path":
+    case "folder":
+      return <PathInputWidget {...props} kind="folder" />;
+    case "image_list":
+    case "video_list":
+    case "audio_list":
+    case "text_list":
+      return (
+        <MediaListInputWidget
+          {...props}
+          props={{
+            ...props.props,
+            listKind: input.kind.replace("_list", ""),
+          }}
+        />
+      );
+    case "huggingface_model":
+      return <HuggingFaceModelInputWidget {...props} />;
+    // The six model kinds render the picker, not a text box: a model reference
+    // is `{type, id, provider, name}`, which nobody types by hand.
+    case "language_model":
+    case "image_model":
+    case "video_model":
+    case "tts_model":
+    case "asr_model":
+    case "embedding_model":
+      return (
+        <ModelSelectWidget
+          {...props}
+          props={{ ...props.props, modelKind: input.kind }}
+        />
+      );
+    case "string":
     default:
       return <TextInputWidget {...props} />;
   }
@@ -1479,7 +2157,12 @@ const slotNodes = (value: unknown): ComponentNode[] =>
       )
     : [];
 
-const RENDERERS: Record<string, React.FC<WidgetProps>> = {
+/**
+ * One entry per `WIDGET_CATALOG` type — a missing entry renders the
+ * unknown-widget hint instead of the widget, which is what
+ * `catalogWidgets.test.tsx` guards.
+ */
+export const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Heading: HeadingWidget,
   Text: TextWidget,
   Markdown: MarkdownWidget,
@@ -1498,6 +2181,10 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   KeyValue: KeyValueWidget,
   Stat: StatWidget,
   Download: DownloadWidget,
+  Model3D: Model3DWidget,
+  Chart: ChartWidget,
+  PDF: PDFWidget,
+  Gallery: GalleryWidget,
   WorkflowInput: WorkflowInputWidget,
   TextInput: TextInputWidget,
   NumberInput: NumberInputWidget,
@@ -1512,6 +2199,12 @@ const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   AudioInput: (props) => <MediaInputWidget {...props} kind="audio" />,
   VideoInput: (props) => <MediaInputWidget {...props} kind="video" />,
   DocumentInput: (props) => <MediaInputWidget {...props} kind="document" />,
+  Model3DInput: (props) => <MediaInputWidget {...props} kind="model_3d" />,
+  DataFrameInput: DataFrameInputWidget,
+  FilePathInput: (props) => <PathInputWidget {...props} kind="file" />,
+  FolderPathInput: (props) => <PathInputWidget {...props} kind="folder" />,
+  ImageSizeInput: ImageSizeInputWidget,
+  MediaListInput: MediaListInputWidget,
   ...RESOURCE_RENDERERS,
   ChatThread: ChatThreadWidget,
   ChatComposer: ChatComposerWidget,
@@ -1640,6 +2333,20 @@ const styles = StyleSheet.create({
   },
   mediaPreview: {
     height: 180,
+  },
+  tileGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  tile: {
+    width: 56,
+    height: 56,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  cellInput: {
+    fontSize: 14,
   },
   bubble: {
     maxWidth: "88%",

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -207,6 +207,45 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
       placeholder: "text"
     }
   },
+  // Renders a bound `Model3DRef` in an orbit viewer. The raw ref is `{type,
+  // uri}`, so without this a 3D result shows as an opaque object.
+  Model3D: {
+    label: "3D Model",
+    mode: "read",
+    fields: { binding: "custom", height: "number", placeholder: "text" }
+  },
+  // Plots a bound array or dataframe. `chartKind` picks the trace type rather
+  // than asking the app author for a Plotly spec.
+  Chart: {
+    label: "Chart",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      label: "text",
+      chartKind: "select",
+      height: "number",
+      placeholder: "text"
+    }
+  },
+  // Paginated PDF preview of a bound document ref. `Download` offers the same
+  // value as a file; this one renders it in place.
+  PDF: {
+    label: "PDF",
+    mode: "read",
+    fields: { binding: "custom", height: "number", placeholder: "text" }
+  },
+  // A tiled grid of a bound array of media refs — what a batch run that emits N
+  // images needs, since `Image` binds one value and `Table` renders rows.
+  Gallery: {
+    label: "Gallery",
+    mode: "read",
+    fields: {
+      binding: "custom",
+      label: "text",
+      tileSize: "number",
+      placeholder: "text"
+    }
+  },
   // Inputs
   WorkflowInput: {
     label: "Workflow Input",
@@ -349,6 +388,69 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
     trigger: "change",
     commits: false,
     fields: { binding: "custom", label: "text", events: "array" }
+  },
+  // Edits a bound dataframe as a grid. `Table` renders the same shape read-only.
+  DataFrameInput: {
+    label: "Data Table Input",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: { binding: "custom", label: "text", maxHeight: "number", events: "array" }
+  },
+  // Local filesystem paths, for apps driving a workflow that reads off disk.
+  FilePathInput: {
+    label: "File Path Input",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      placeholder: "text",
+      events: "array"
+    }
+  },
+  FolderPathInput: {
+    label: "Folder Path Input",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      placeholder: "text",
+      events: "array"
+    }
+  },
+  Model3DInput: {
+    label: "3D Model Input",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
+  },
+  // Writes an `{width, height}` pair, so an app can offer the size its image
+  // workflow reads without two coupled number fields.
+  ImageSizeInput: {
+    label: "Image Size Input",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
+  },
+  // The one widget behind the four list input nodes: `listKind` picks which,
+  // rather than four near-identical palette entries.
+  MediaListInput: {
+    label: "Media List Input",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: {
+      binding: "custom",
+      label: "text",
+      listKind: "select",
+      events: "array"
+    }
   },
   // Resource widgets address a collection through `resourceBindingId`, not the
   // `binding` token the state widgets carry.

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -105,6 +105,43 @@ describe("widget catalog", () => {
       expect(widgetMode(type)).toBe("read");
     }
   });
+
+  it("declares a display widget for every result shape a run can emit", () => {
+    // A 3D result, a plotted series, a PDF and a batch of images each used to
+    // land in Json or Output, which render them as an opaque ref.
+    for (const type of ["Model3D", "Chart", "PDF", "Gallery"]) {
+      expect(widgetMode(type)).toBe("read");
+      expect(WIDGET_CATALOG[type].trigger).toBeUndefined();
+      // None renders formattable text, so a template would replace the preview.
+      expect(WIDGET_CATALOG[type].format).toBeUndefined();
+      expect(widgetFields(type)).toHaveProperty("placeholder", "text");
+    }
+  });
+
+  it("declares an input widget for every input node kind an app can bind", () => {
+    for (const type of [
+      "DataFrameInput",
+      "FilePathInput",
+      "FolderPathInput",
+      "Model3DInput",
+      "ImageSizeInput",
+      "MediaListInput"
+    ]) {
+      expect(widgetMode(type)).toBe("write");
+      expect(WIDGET_CATALOG[type].trigger).toBe("change");
+      expect(widgetFields(type)).toHaveProperty("events", "array");
+    }
+    // The typed fields settle on blur; the pickers write a whole value at once.
+    expect(WIDGET_CATALOG.FilePathInput.commits).toBe(true);
+    expect(WIDGET_CATALOG.FolderPathInput.commits).toBe(true);
+    expect(WIDGET_CATALOG.DataFrameInput.commits).toBe(true);
+    expect(WIDGET_CATALOG.Model3DInput.commits).toBe(false);
+    expect(WIDGET_CATALOG.MediaListInput.commits).toBe(false);
+  });
+
+  it("puts the list kind on one widget rather than four palette entries", () => {
+    expect(widgetFields("MediaListInput").listKind).toBe("select");
+  });
 });
 
 describe("Table", () => {

--- a/web/src/components/appbuilder/WorkflowInputsForm.tsx
+++ b/web/src/components/appbuilder/WorkflowInputsForm.tsx
@@ -52,7 +52,10 @@ const KIND_TO_PROPERTY_TYPE: Record<
   image_list: "list",
   video_list: "list",
   audio_list: "list",
-  text_list: "list"
+  text_list: "list",
+  model3d: "model_3d",
+  image_size: "image_size",
+  huggingface_model: "hf.model"
 };
 
 const createPropertyFromDefinition = (

--- a/web/src/components/appbuilder/inputKinds.ts
+++ b/web/src/components/appbuilder/inputKinds.ts
@@ -26,7 +26,10 @@ export type WorkflowInputKind =
   | "image_list"
   | "video_list"
   | "audio_list"
-  | "text_list";
+  | "text_list"
+  | "model3d"
+  | "image_size"
+  | "huggingface_model";
 
 export const getWorkflowInputKind = (
   nodeType: string
@@ -56,6 +59,12 @@ export const getWorkflowInputKind = (
     case "nodetool.input.DataFrameInput":
     case "nodetool.input.DataframeInput":
       return "dataframe";
+    case "nodetool.input.Model3DInput":
+      return "model3d";
+    case "nodetool.input.ImageSizeInput":
+      return "image_size";
+    case "nodetool.input.HuggingFaceModelInput":
+      return "huggingface_model";
     case "nodetool.input.FilePathInput":
       return "file_path";
     case "nodetool.input.FolderPathInput":

--- a/web/src/components/appbuilder/inputProperty.ts
+++ b/web/src/components/appbuilder/inputProperty.ts
@@ -14,7 +14,8 @@ export const MODEL_INPUT_KINDS: ReadonlySet<WorkflowInputKind> = new Set([
   "video_model",
   "tts_model",
   "asr_model",
-  "embedding_model"
+  "embedding_model",
+  "huggingface_model"
 ]);
 
 const KIND_TO_PROPERTY_TYPE: Record<
@@ -44,7 +45,12 @@ const KIND_TO_PROPERTY_TYPE: Record<
   image_list: "list",
   video_list: "list",
   audio_list: "list",
-  text_list: "list"
+  text_list: "list",
+  // The node types these kinds come from: Model3DInput emits `model_3d`,
+  // ImageSizeInput `image_size`, HuggingFaceModelInput `hf.model`.
+  model3d: "model_3d",
+  image_size: "image_size",
+  huggingface_model: "hf.model"
 };
 
 const getTypeArgsForKind = (kind: WorkflowInputKind) => {

--- a/web/src/components/appbuilder/puck/ChartWidget.tsx
+++ b/web/src/components/appbuilder/puck/ChartWidget.tsx
@@ -1,0 +1,196 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Plots a bound array or dataframe.
+ *
+ * The app author picks a chart kind, not a Plotly spec: an app binds whatever
+ * its workflow emits — a dataframe, an array of records, a list of numbers — and
+ * the widget derives the axes from that shape. Plotly itself stays behind
+ * `React.lazy` (the `vendor-plotly` chunk), so the app editor never loads it
+ * until a chart actually renders.
+ */
+import React from "react";
+import type { Data } from "plotly.js";
+
+import {
+  Box,
+  Caption,
+  FlexColumn,
+  LoadingSpinner,
+  BORDER_RADIUS,
+  SPACING
+} from "../../ui_primitives";
+import { AppEvent } from "../types";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+const LazyPlotlyChart = React.lazy(
+  () => import("../../node/output/PlotlyChart")
+);
+
+/** The trace kinds a mini app can pick, and what each maps to in Plotly. */
+export const CHART_KINDS = ["line", "bar", "scatter", "pie"] as const;
+export type ChartKind = (typeof CHART_KINDS)[number];
+
+const isChartKind = (value: unknown): value is ChartKind =>
+  CHART_KINDS.includes(value as ChartKind);
+
+interface ChartTable {
+  columns: string[];
+  rows: unknown[][];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** A number the chart can plot, tolerating the numeric strings JSON carries. */
+const numeric = (value: unknown): number | null => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const fromDataframe = (value: unknown): ChartTable | null => {
+  if (!isRecord(value) || value.type !== "dataframe") return null;
+  const columns = Array.isArray(value.columns)
+    ? value.columns.map((column) =>
+        typeof column === "string"
+          ? column
+          : String((column as { name?: unknown })?.name ?? "")
+      )
+    : [];
+  const rows = Array.isArray(value.data) ? (value.data as unknown[][]) : [];
+  if (columns.length === 0 || rows.length === 0) return null;
+  return { columns, rows };
+};
+
+const fromArray = (value: unknown): ChartTable | null => {
+  const items = Array.isArray(value) ? value : value == null ? [] : [value];
+  if (items.length === 0) return null;
+
+  const records = items.filter(isRecord);
+  if (records.length === items.length) {
+    const columns: string[] = [];
+    for (const record of records) {
+      for (const key of Object.keys(record)) {
+        if (!columns.includes(key)) columns.push(key);
+      }
+    }
+    return {
+      columns,
+      rows: records.map((record) => columns.map((key) => record[key]))
+    };
+  }
+  return { columns: ["value"], rows: items.map((item) => [item]) };
+};
+
+/** A column plots as a series only when every row of it is a number. */
+const isNumericColumn = (table: ChartTable, index: number): boolean =>
+  table.rows.every((row) => numeric(row[index]) !== null);
+
+/**
+ * Turns a table into traces: the first non-numeric column is the category axis
+ * (falling back to the row number), every numeric column becomes a series.
+ */
+export const chartTraces = (value: unknown, kind: ChartKind): Data[] => {
+  const table = fromDataframe(value) ?? fromArray(value);
+  if (!table) return [];
+
+  const numericColumns = table.columns
+    .map((_, index) => index)
+    .filter((index) => isNumericColumn(table, index));
+  if (numericColumns.length === 0) return [];
+
+  const labelIndex = table.columns.findIndex(
+    (_, index) => !numericColumns.includes(index)
+  );
+  const labels =
+    labelIndex >= 0
+      ? table.rows.map((row) => String(row[labelIndex] ?? ""))
+      : table.rows.map((_, index) => String(index + 1));
+
+  if (kind === "pie") {
+    const index = numericColumns[0];
+    return [
+      {
+        type: "pie",
+        labels,
+        values: table.rows.map((row) => numeric(row[index]) ?? 0)
+      }
+    ];
+  }
+
+  return numericColumns.map((index): Data => {
+    const name = table.columns[index];
+    const y = table.rows.map((row) => numeric(row[index]));
+    if (kind === "bar") return { type: "bar", name, x: labels, y };
+    return {
+      type: "scatter",
+      mode: kind === "line" ? "lines+markers" : "markers",
+      name,
+      x: labels,
+      y
+    };
+  });
+};
+
+export interface ChartWidgetProps {
+  id: string;
+  binding?: string;
+  events?: AppEvent[];
+  disabled?: boolean;
+  label?: string;
+  chartKind?: string;
+  height?: number;
+  placeholder?: string;
+}
+
+export const ChartWidget: React.FC<ChartWidgetProps> = (props) => {
+  const { value } = useWidgetRuntime({
+    id: props.id,
+    bindingMode: "read",
+    binding: props.binding,
+    events: props.events
+  });
+  const kind = isChartKind(props.chartKind) ? props.chartKind : "line";
+  const height = props.height ?? 320;
+  const traces = React.useMemo(() => chartTraces(value, kind), [value, kind]);
+
+  const layout = React.useMemo(
+    () => ({
+      autosize: true,
+      margin: { t: 24, r: 16, b: 40, l: 48 },
+      showlegend: traces.length > 1,
+      paper_bgcolor: "transparent",
+      plot_bgcolor: "transparent"
+    }),
+    [traces.length]
+  );
+
+  if (traces.length === 0) {
+    return (
+      <Caption color="secondary">
+        {props.placeholder ?? "Nothing to plot yet"}
+      </Caption>
+    );
+  }
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <Box sx={{ width: "100%", height, borderRadius: BORDER_RADIUS.md }}>
+        <React.Suspense
+          fallback={<LoadingSpinner size="small" text="Loading chart" />}
+        >
+          <LazyPlotlyChart
+            data={traces}
+            layout={layout}
+            config={{ displayModeBar: false, responsive: true }}
+            style={{ width: "100%", height: "100%" }}
+          />
+        </React.Suspense>
+      </Box>
+    </FlexColumn>
+  );
+};

--- a/web/src/components/appbuilder/puck/MediaWidgets.tsx
+++ b/web/src/components/appbuilder/puck/MediaWidgets.tsx
@@ -1,0 +1,181 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Display widgets for the media a run emits that the plain `Image`/`Video` pair
+ * cannot show: a 3D model ref, a PDF document ref, and a whole array of media
+ * refs at once.
+ *
+ * Each ref is `{type, uri}`, so without these a 3D or PDF result lands in an app
+ * as an opaque JSON blob. The 3D and PDF viewers are the ones the asset viewer
+ * already ships, both behind their `Lazy*` wrappers so three.js and pdf.js stay
+ * out of the app editor's bundle.
+ */
+import React from "react";
+
+import {
+  Box,
+  Caption,
+  FlexColumn,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING
+} from "../../ui_primitives";
+import LazyModel3DViewer from "../../asset_viewer/LazyModel3DViewer";
+import LazyPDFViewer from "../../asset_viewer/LazyPDFViewer";
+import { AppEvent } from "../types";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+import { resolveImageSrc } from "./widgets";
+
+interface ReadWidgetProps {
+  id: string;
+  binding?: string;
+  events?: AppEvent[];
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const useReadBinding = (props: ReadWidgetProps) =>
+  useWidgetRuntime({
+    id: props.id,
+    bindingMode: "read",
+    binding: props.binding,
+    events: props.events
+  });
+
+/** A bound output holds one value or the accumulated list of streamed items. */
+const asItems = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : value == null ? [] : [value];
+
+const lastSrc = (value: unknown): string | null => {
+  const items = asItems(value);
+  return items.length > 0 ? resolveImageSrc(items[items.length - 1]) : null;
+};
+
+const Empty: React.FC<{ height: number; text: string }> = ({ height, text }) => (
+  <FlexColumn
+    align="center"
+    justify="center"
+    fullWidth
+    sx={{
+      height,
+      border: "1px dashed",
+      borderColor: "divider",
+      borderRadius: BORDER_RADIUS.md
+    }}
+  >
+    <Caption color="secondary">{text}</Caption>
+  </FlexColumn>
+);
+
+export const Model3DWidget: React.FC<
+  ReadWidgetProps & { height?: number }
+> = (props) => {
+  const { value } = useReadBinding(props);
+  const src = lastSrc(value);
+  const height = props.height ?? 320;
+  if (!src) {
+    return (
+      <Empty height={height} text={props.placeholder ?? "No 3D model yet"} />
+    );
+  }
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height,
+        borderRadius: BORDER_RADIUS.md,
+        overflow: "hidden"
+      }}
+    >
+      <LazyModel3DViewer url={src} compact />
+    </Box>
+  );
+};
+
+export const PDFWidget: React.FC<ReadWidgetProps & { height?: number }> = (
+  props
+) => {
+  const { value } = useReadBinding(props);
+  const src = lastSrc(value);
+  const height = props.height ?? 480;
+  if (!src) {
+    return <Empty height={height} text={props.placeholder ?? "No document yet"} />;
+  }
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height,
+        borderRadius: BORDER_RADIUS.md,
+        overflow: "hidden"
+      }}
+    >
+      <LazyPDFViewer url={src} />
+    </Box>
+  );
+};
+
+const TILE_SIZE = 140;
+
+/**
+ * A bound array of media refs as a tiled grid — the shape a batch run that emits
+ * N images has. Tiles match the resource gallery's look so the two read as one
+ * component.
+ */
+export const GalleryWidget: React.FC<
+  ReadWidgetProps & { label?: string; tileSize?: number }
+> = (props) => {
+  const { value } = useReadBinding(props);
+  const sources = asItems(value)
+    .map(resolveImageSrc)
+    .filter((src): src is string => src !== null);
+  const size = props.tileSize ?? TILE_SIZE;
+
+  if (sources.length === 0) {
+    return (
+      <Caption color="secondary">
+        {props.placeholder ?? "Nothing to show yet"}
+      </Caption>
+    );
+  }
+
+  return (
+    <FlexColumn gap={SPACING.xs} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <Box
+        sx={{
+          display: "grid",
+          gap: SPACING.sm,
+          width: "100%",
+          gridTemplateColumns: `repeat(auto-fill, minmax(${size}px, 1fr))`
+        }}
+      >
+        {sources.map((src, index) => (
+          <Box
+            key={index}
+            sx={{
+              height: size,
+              p: SPACING.xs,
+              borderRadius: BORDER_RADIUS.md,
+              border: "1px solid",
+              borderColor: "divider",
+              transition: MOTION.border,
+              "&:hover": { borderColor: "primary.light" }
+            }}
+          >
+            <Box
+              component="img"
+              src={src}
+              alt=""
+              sx={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                borderRadius: BORDER_RADIUS.sm
+              }}
+            />
+          </Box>
+        ))}
+      </Box>
+    </FlexColumn>
+  );
+};

--- a/web/src/components/appbuilder/puck/WorkflowInputWidget.tsx
+++ b/web/src/components/appbuilder/puck/WorkflowInputWidget.tsx
@@ -15,6 +15,7 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
 
 import {
+  Box,
   Caption,
   FlexColumn,
   TextInput,
@@ -29,6 +30,8 @@ import VideoModelSelect from "../../properties/VideoModelSelect";
 import TTSModelSelect from "../../properties/TTSModelSelect";
 import ASRModelSelect from "../../properties/ASRModelSelect";
 import EmbeddingModelSelect from "../../properties/EmbeddingModelSelect";
+import HuggingFaceModelSelect from "../../properties/HuggingFaceModelSelect";
+import type { HuggingFaceModelValueInput } from "../../../stores/ApiTypes";
 import { NodeContext } from "../../../contexts/NodeContext";
 import { AppEvent } from "../types";
 import {
@@ -69,11 +72,18 @@ const Placeholder: React.FC<{ text: string }> = ({ text }) => (
   </FlexColumn>
 );
 
+const EMPTY_HF_MODEL: HuggingFaceModelValueInput = {
+  type: "hf.model",
+  repo_id: ""
+};
+
 const ModelSelect: React.FC<{
   input: WorkflowInputIO;
-  modelId: string;
+  /** The stored reference; every select but the HF one keys off its `id`. */
+  value: unknown;
   onChange: (value: unknown) => void;
-}> = ({ input, modelId, onChange }) => {
+}> = ({ input, value, onChange }) => {
+  const modelId = (value as { id?: string } | undefined)?.id || "";
   switch (input.kind) {
     case "language_model":
       return <LanguageModelSelect onChange={onChange} value={modelId} />;
@@ -85,6 +95,18 @@ const ModelSelect: React.FC<{
       return <TTSModelSelect onChange={onChange} value={modelId} />;
     case "asr_model":
       return <ASRModelSelect onChange={onChange} value={modelId} />;
+    case "huggingface_model":
+      // A HuggingFace reference is `{type, repo_id, path}`, not an id, so this
+      // one takes the whole stored value.
+      return (
+        <HuggingFaceModelSelect
+          modelType="hf.model"
+          onChange={onChange}
+          value={
+            (value as HuggingFaceModelValueInput | undefined) ?? EMPTY_HF_MODEL
+          }
+        />
+      );
     default:
       return <EmbeddingModelSelect onChange={onChange} value={modelId} />;
   }
@@ -160,7 +182,6 @@ const InputControl: React.FC<{
   }
 
   if (MODEL_INPUT_KINDS.has(input.kind)) {
-    const modelId = (resolved as { id?: string } | undefined)?.id || "";
     return (
       <FlexColumn gap={SPACING.micro} fullWidth>
         <PropertyLabel
@@ -168,7 +189,7 @@ const InputControl: React.FC<{
           description={property.description}
           id={inputId}
         />
-        <ModelSelect input={input} modelId={modelId} onChange={handleChange} />
+        <ModelSelect input={input} value={resolved} onChange={handleChange} />
       </FlexColumn>
     );
   }
@@ -251,9 +272,9 @@ export const WorkflowInputWidget: React.FC<WorkflowInputWidgetProps> = (
 };
 
 /**
- * The model kinds a ModelSelect widget can offer. Same six the workflow input
- * form resolves, picked here by the app author instead of by a node's type —
- * an app often wants to drive an LLM node's `model` property directly.
+ * The model kinds a ModelSelect widget can offer. The same ones the workflow
+ * input form resolves, picked here by the app author instead of by a node's
+ * type — an app often wants to drive an LLM node's `model` property directly.
  */
 export const MODEL_WIDGET_KINDS = [
   "language_model",
@@ -261,7 +282,8 @@ export const MODEL_WIDGET_KINDS = [
   "video_model",
   "tts_model",
   "asr_model",
-  "embedding_model"
+  "embedding_model",
+  "huggingface_model"
 ] as const;
 
 export type ModelWidgetKind = (typeof MODEL_WIDGET_KINDS)[number];
@@ -272,7 +294,8 @@ const MODEL_KIND_NODE_TYPE: Record<ModelWidgetKind, string> = {
   video_model: "nodetool.input.VideoModelInput",
   tts_model: "nodetool.input.TTSModelInput",
   asr_model: "nodetool.input.ASRModelInput",
-  embedding_model: "nodetool.input.EmbeddingModelInput"
+  embedding_model: "nodetool.input.EmbeddingModelInput",
+  huggingface_model: "nodetool.input.HuggingFaceModelInput"
 };
 
 const isModelKind = (value: unknown): value is ModelWidgetKind =>
@@ -323,15 +346,39 @@ export const ModelSelectWidget: React.FC<ModelSelectWidgetProps> = (props) => {
 };
 
 /** Kinds exposed as standalone palette widgets alongside the auto-resolving
- * WorkflowInput — so an app authored from scratch can offer media pickers. */
-export type FixedInputKind = "image" | "audio" | "video" | "document" | "color";
+ * WorkflowInput — so an app authored from scratch can offer media pickers,
+ * paths, tables, and the media list controls. */
+export type FixedInputKind =
+  | "image"
+  | "audio"
+  | "video"
+  | "document"
+  | "color"
+  | "dataframe"
+  | "file_path"
+  | "folder_path"
+  | "model3d"
+  | "image_size"
+  | "image_list"
+  | "video_list"
+  | "audio_list"
+  | "text_list";
 
 const FIXED_KIND_NODE_TYPE: Record<FixedInputKind, string> = {
   image: "nodetool.input.ImageInput",
   audio: "nodetool.input.AudioInput",
   video: "nodetool.input.VideoInput",
   document: "nodetool.input.DocumentInput",
-  color: "nodetool.input.ColorInput"
+  color: "nodetool.input.ColorInput",
+  dataframe: "nodetool.input.DataframeInput",
+  file_path: "nodetool.input.FilePathInput",
+  folder_path: "nodetool.input.FolderPathInput",
+  model3d: "nodetool.input.Model3DInput",
+  image_size: "nodetool.input.ImageSizeInput",
+  image_list: "nodetool.input.ImageListInput",
+  video_list: "nodetool.input.VideoListInput",
+  audio_list: "nodetool.input.AudioListInput",
+  text_list: "nodetool.input.TextListInput"
 };
 
 export interface FixedInputWidgetProps {
@@ -339,12 +386,18 @@ export interface FixedInputWidgetProps {
   binding?: string;
   label?: string;
   description?: string;
+  /** Hint shown under the control — path inputs have nothing else to guide on. */
+  placeholder?: string;
   events?: AppEvent[];
 }
 
 export const FixedKindInputWidget: React.FC<
-  FixedInputWidgetProps & { kind: FixedInputKind }
-> = ({ kind, ...props }) => {
+  FixedInputWidgetProps & {
+    kind: FixedInputKind;
+    /** Caps the control's height; the grid editors grow with their rows. */
+    maxHeight?: number;
+  }
+> = ({ kind, maxHeight, ...props }) => {
   const { value, setValue, emit } = useWidgetRuntime({
     id: props.id,
     bindingMode: "write",
@@ -361,12 +414,19 @@ export const FixedKindInputWidget: React.FC<
       name: props.label || props.binding || props.id,
       label: props.label || props.binding || kind,
       kind,
-      description: props.description
+      description: props.description || props.placeholder
     }),
-    [kind, props.binding, props.description, props.id, props.label]
+    [
+      kind,
+      props.binding,
+      props.description,
+      props.id,
+      props.label,
+      props.placeholder
+    ]
   );
 
-  return (
+  const control = (
     <InputControl
       input={input}
       value={value}
@@ -375,5 +435,10 @@ export const FixedKindInputWidget: React.FC<
         emit("change");
       }}
     />
+  );
+
+  if (!maxHeight) return control;
+  return (
+    <Box sx={{ width: "100%", maxHeight, overflow: "auto" }}>{control}</Box>
   );
 };

--- a/web/src/components/appbuilder/puck/__tests__/chartWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/chartWidget.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * The Chart widget derives its traces from whatever shape the binding holds —
+ * a dataframe, an array of records, or a list of numbers — so the app author
+ * never writes a Plotly spec.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { ChartWidget, chartTraces } from "../ChartWidget";
+
+// Plotly is loaded lazily in the real widget; the test only cares that the
+// widget decided there was something to plot.
+jest.mock("../../../node/output/PlotlyChart", () => ({
+  __esModule: true,
+  default: () =>
+    require("react").createElement("div", { "data-testid": "plotly" })
+}));
+
+const OUTPUT_KEY = "main:out1";
+
+const withOutput = (value: unknown): Partial<AppInstanceState> => ({
+  outputs: {
+    [OUTPUT_KEY]: { value, invocationId: "j1", status: "done", revision: 1 }
+  }
+});
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const { wrapper: Wrapper } = makeTestRuntime(initial);
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <Wrapper>{element}</Wrapper>
+    </ThemeProvider>
+  );
+};
+
+describe("chartTraces", () => {
+  it("makes one series per numeric column of a dataframe", () => {
+    const traces = chartTraces(
+      {
+        type: "dataframe",
+        columns: [{ name: "month" }, { name: "sales" }, { name: "costs" }],
+        data: [
+          ["Jan", 10, 4],
+          ["Feb", 20, 6]
+        ]
+      },
+      "line"
+    );
+    expect(traces).toHaveLength(2);
+    expect(traces[0]).toMatchObject({
+      type: "scatter",
+      mode: "lines+markers",
+      name: "sales",
+      x: ["Jan", "Feb"],
+      y: [10, 20]
+    });
+  });
+
+  it("reads an array of records the same way", () => {
+    const traces = chartTraces(
+      [
+        { label: "a", score: 1 },
+        { label: "b", score: 2 }
+      ],
+      "bar"
+    );
+    expect(traces).toEqual([
+      { type: "bar", name: "score", x: ["a", "b"], y: [1, 2] }
+    ]);
+  });
+
+  it("numbers the rows when no column can serve as the category axis", () => {
+    expect(chartTraces([3, 5], "scatter")).toEqual([
+      { type: "scatter", mode: "markers", name: "value", x: ["1", "2"], y: [3, 5] }
+    ]);
+  });
+
+  it("turns the first numeric column into pie values", () => {
+    expect(
+      chartTraces([{ label: "a", n: 3 }, { label: "b", n: 7 }], "pie")
+    ).toEqual([{ type: "pie", labels: ["a", "b"], values: [3, 7] }]);
+  });
+
+  it("plots nothing when no column is numeric", () => {
+    expect(chartTraces([{ label: "a" }, { label: "b" }], "line")).toEqual([]);
+  });
+});
+
+describe("ChartWidget", () => {
+  it("renders the plot once the binding holds plottable data", async () => {
+    renderWidget(
+      <ChartWidget id="c1" binding="result" chartKind="bar" label="Sales" />,
+      withOutput([{ label: "a", score: 1 }])
+    );
+    expect(await screen.findByTestId("plotly")).toBeInTheDocument();
+    expect(screen.getByText("Sales")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when the binding holds nothing", () => {
+    renderWidget(
+      <ChartWidget id="c1" binding="result" placeholder="No data" />
+    );
+    expect(screen.getByText("No data")).toBeInTheDocument();
+    expect(screen.queryByTestId("plotly")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/fixedKindInputWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/fixedKindInputWidget.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * The fixed-kind palette inputs. Each synthesizes a workflow input of its kind
+ * and routes it through the editor's property resolver, so the check that
+ * matters is that a kind lands on its real editor rather than on a text box.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { getComponentForProperty } from "../../../node/PropertyInput.resolver";
+import { createPropertyForInput } from "../../inputProperty";
+import type { WorkflowInputKind } from "../../inputKinds";
+import { FixedKindInputWidget } from "../WorkflowInputWidget";
+import DataframeProperty from "../../../properties/DataframeProperty";
+import FilePathProperty from "../../../properties/FilePathProperty";
+import FolderPathProperty from "../../../properties/FolderPathProperty";
+import Model3DProperty from "../../../properties/Model3DProperty";
+import ImageSizeProperty from "../../../properties/ImageSizeProperty";
+import ImageListProperty from "../../../properties/ImageListProperty";
+import VideoListProperty from "../../../properties/VideoListProperty";
+import AudioListProperty from "../../../properties/AudioListProperty";
+import StringListProperty from "../../../properties/StringListProperty";
+
+const resolverFor = (kind: WorkflowInputKind) =>
+  getComponentForProperty(
+    createPropertyForInput({
+      nodeId: "n1",
+      nodeType: "nodetool.input.Test",
+      name: "value",
+      label: "Value",
+      kind
+    })
+  );
+
+describe("input kinds resolve to their property editor", () => {
+  it.each([
+    ["dataframe", DataframeProperty],
+    ["file_path", FilePathProperty],
+    ["folder_path", FolderPathProperty],
+    ["model3d", Model3DProperty],
+    ["image_size", ImageSizeProperty],
+    ["image_list", ImageListProperty],
+    ["video_list", VideoListProperty],
+    ["audio_list", AudioListProperty],
+    ["text_list", StringListProperty]
+  ] as const)("routes %s away from the text box", (kind, expected) => {
+    expect(resolverFor(kind)).toBe(expected);
+  });
+});
+
+describe("FixedKindInputWidget", () => {
+  it("labels a path control from the widget's own label", () => {
+    const { wrapper: Wrapper } = makeTestRuntime();
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <Wrapper>
+          <FixedKindInputWidget
+            id="f1"
+            kind="file_path"
+            label="Source file"
+            placeholder="Pick a file…"
+          />
+        </Wrapper>
+      </ThemeProvider>
+    );
+    // PropertyLabel title-cases whatever name it is given.
+    expect(screen.getByText(/Source File/i)).toBeInTheDocument();
+    expect(screen.getByText("Pick a file…")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/mediaWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/mediaWidgets.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The media display widgets: each resolves a ref (or an array of them) to a
+ * source and shows its placeholder while the binding is empty.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { GalleryWidget, Model3DWidget, PDFWidget } from "../MediaWidgets";
+
+// The real viewers pull in three.js and pdf.js; the widget's job is only to
+// hand them a resolved URL.
+jest.mock("../../../asset_viewer/LazyModel3DViewer", () => ({
+  __esModule: true,
+  default: ({ url }: { url?: string }) =>
+    require("react").createElement("div", { "data-testid": "model3d" }, url)
+}));
+
+jest.mock("../../../asset_viewer/LazyPDFViewer", () => ({
+  __esModule: true,
+  default: ({ url }: { url?: string }) =>
+    require("react").createElement("div", { "data-testid": "pdf" }, url)
+}));
+
+const OUTPUT_KEY = "main:out1";
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const { wrapper: Wrapper } = makeTestRuntime(initial);
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <Wrapper>{element}</Wrapper>
+    </ThemeProvider>
+  );
+};
+
+const withOutput = (value: unknown): Partial<AppInstanceState> => ({
+  outputs: {
+    [OUTPUT_KEY]: { value, invocationId: "j1", status: "done", revision: 1 }
+  }
+});
+
+describe("Model3DWidget", () => {
+  it("renders the bound model ref's uri in the viewer", () => {
+    renderWidget(
+      <Model3DWidget id="m1" binding="result" />,
+      withOutput({ type: "model_3d", uri: "https://cdn/model.glb" })
+    );
+    expect(screen.getByTestId("model3d")).toHaveTextContent(
+      "https://cdn/model.glb"
+    );
+  });
+
+  it("shows the placeholder when the binding holds nothing", () => {
+    renderWidget(
+      <Model3DWidget id="m1" binding="result" placeholder="No model" />
+    );
+    expect(screen.getByText("No model")).toBeInTheDocument();
+    expect(screen.queryByTestId("model3d")).not.toBeInTheDocument();
+  });
+});
+
+describe("PDFWidget", () => {
+  it("renders the bound document ref's uri in the viewer", () => {
+    renderWidget(
+      <PDFWidget id="p1" binding="result" />,
+      withOutput({ type: "document", uri: "https://cdn/report.pdf" })
+    );
+    expect(screen.getByTestId("pdf")).toHaveTextContent(
+      "https://cdn/report.pdf"
+    );
+  });
+
+  it("shows the placeholder when the binding holds nothing", () => {
+    renderWidget(<PDFWidget id="p1" binding="result" placeholder="No doc" />);
+    expect(screen.getByText("No doc")).toBeInTheDocument();
+    expect(screen.queryByTestId("pdf")).not.toBeInTheDocument();
+  });
+});
+
+describe("GalleryWidget", () => {
+  it("tiles every ref in a bound array", () => {
+    const { container } = renderWidget(
+      <GalleryWidget id="g1" binding="result" label="Results" />,
+      withOutput([
+        { type: "image", uri: "https://cdn/a.png" },
+        { type: "image", uri: "https://cdn/b.png" }
+      ])
+    );
+    const tiles = container.querySelectorAll("img");
+    expect(tiles).toHaveLength(2);
+    expect(tiles[0]).toHaveAttribute("src", "https://cdn/a.png");
+    expect(screen.getByText("Results")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when the binding holds nothing", () => {
+    const { container } = renderWidget(
+      <GalleryWidget id="g1" binding="result" placeholder="No images" />
+    );
+    expect(screen.getByText("No images")).toBeInTheDocument();
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React from "react";
-import type { Config, ArrayField } from "@puckeditor/core";
+import type { Config, ArrayField, Field } from "@puckeditor/core";
 
 import { Box, Text, FlexColumn, SPACING, SPACING_PX } from "../../ui_primitives";
 import { APP_THEMES, appThemeFrame, resolveAppTheme } from "../appThemes";
@@ -57,6 +57,8 @@ import {
 } from "./WorkflowInputWidget";
 import { ChatThreadWidget, ChatComposerWidget } from "./ChatWidgets";
 import { SketchWidget, TimelineWidget } from "./DocumentWidgets";
+import { GalleryWidget, Model3DWidget, PDFWidget } from "./MediaWidgets";
+import { ChartWidget } from "./ChartWidget";
 
 const ACTION_OPTIONS = [
   { label: "Run workflow", value: "run" },
@@ -137,20 +139,57 @@ const optionsField: ArrayField = {
   getItemSummary: (item: Record<string, unknown>) => String(item.value ?? "option")
 };
 
-/** Palette entry for a standalone media/color input of a fixed kind. */
+/**
+ * The fields every fixed-kind input shares. `extra` slots a widget's own field
+ * (a path's placeholder, a table's height) between the label and the events.
+ */
+const fixedInputFields = (extra: Record<string, Field> = {}) => ({
+  binding: bindingField("write", "Workflow input"),
+  label: { type: "text" as const, label: "Label" },
+  ...extra,
+  events: eventsField("change", { commits: false }),
+  ...conditionalFields({ format: false })
+});
+
+/** Palette entry for a standalone input of a fixed kind. */
 const fixedInputEntry = (label: string, kind: FixedInputKind) => ({
   label,
-  fields: {
-    binding: bindingField("write", "Workflow input"),
-    label: { type: "text" as const, label: "Label" },
-    events: eventsField("change", { commits: false }),
-    ...conditionalFields({ format: false })
-  },
+  fields: fixedInputFields(),
   defaultProps: { binding: "", label: "" },
   render: withConditions((props: FixedInputWidgetProps) => (
     <FixedKindInputWidget {...props} kind={kind} />
   ))
 });
+
+/** Palette entry for a path input — its placeholder becomes the control's hint. */
+const pathInputEntry = (
+  label: string,
+  kind: Extract<FixedInputKind, "file_path" | "folder_path">,
+  placeholder: string
+) => ({
+  label,
+  fields: fixedInputFields({
+    placeholder: { type: "text" as const, label: "Placeholder" }
+  }),
+  defaultProps: { binding: "", label: "", placeholder },
+  render: withConditions((props: FixedInputWidgetProps) => (
+    <FixedKindInputWidget {...props} kind={kind} />
+  ))
+});
+
+/** Which list input a MediaListInput binds. */
+const LIST_KINDS: Record<
+  string,
+  Extract<
+    FixedInputKind,
+    "image_list" | "video_list" | "audio_list" | "text_list"
+  >
+> = {
+  image_list: "image_list",
+  video_list: "video_list",
+  audio_list: "audio_list",
+  text_list: "text_list"
+};
 
 /**
  * The app page. Its theme comes from the root prop the author picked, falling
@@ -258,7 +297,13 @@ export const appConfig: Config = {
         "AudioInput",
         "VideoInput",
         "DocumentInput",
-        "ColorInput"
+        "ColorInput",
+        "DataFrameInput",
+        "FilePathInput",
+        "FolderPathInput",
+        "Model3DInput",
+        "ImageSizeInput",
+        "MediaListInput"
       ]
     },
     ai: {
@@ -286,7 +331,11 @@ export const appConfig: Config = {
         "Stat",
         "Alert",
         "CodeBlock",
-        "Download"
+        "Download",
+        "Model3D",
+        "Chart",
+        "PDF",
+        "Gallery"
       ]
     },
     layout: {
@@ -557,6 +606,71 @@ export const appConfig: Config = {
       },
       render: withConditions((props) => <DownloadWidget {...props} />)
     },
+    Model3D: {
+      label: "3D Model",
+      fields: {
+        binding: bindingField("read"),
+        height: { type: "number", label: "Height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { height: 320, placeholder: "No 3D model yet" },
+      render: withConditions((props) => <Model3DWidget {...props} />)
+    },
+    Chart: {
+      label: "Chart",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        chartKind: {
+          type: "select",
+          label: "Chart type",
+          options: [
+            { label: "Line", value: "line" },
+            { label: "Bar", value: "bar" },
+            { label: "Scatter", value: "scatter" },
+            { label: "Pie", value: "pie" }
+          ]
+        },
+        height: { type: "number", label: "Height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "",
+        chartKind: "line",
+        height: 320,
+        placeholder: "Nothing to plot yet"
+      },
+      render: withConditions((props) => <ChartWidget {...props} />)
+    },
+    PDF: {
+      label: "PDF",
+      fields: {
+        binding: bindingField("read"),
+        height: { type: "number", label: "Height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { height: 480, placeholder: "No document yet" },
+      render: withConditions((props) => <PDFWidget {...props} />)
+    },
+    Gallery: {
+      label: "Gallery",
+      fields: {
+        binding: bindingField("read"),
+        label: { type: "text", label: "Label" },
+        tileSize: { type: "number", label: "Tile size (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "",
+        tileSize: 140,
+        placeholder: "Nothing to show yet"
+      },
+      render: withConditions((props) => <GalleryWidget {...props} />)
+    },
     // ── Inputs ──
     WorkflowInput: {
       label: "Workflow Input",
@@ -826,7 +940,8 @@ export const appConfig: Config = {
             { label: "Video", value: "video_model" },
             { label: "Speech (TTS)", value: "tts_model" },
             { label: "Transcription (ASR)", value: "asr_model" },
-            { label: "Embedding", value: "embedding_model" }
+            { label: "Embedding", value: "embedding_model" },
+            { label: "Hugging Face", value: "huggingface_model" }
           ]
         },
         label: { type: "text", label: "Label" },
@@ -845,6 +960,54 @@ export const appConfig: Config = {
     VideoInput: fixedInputEntry("Video Input", "video"),
     DocumentInput: fixedInputEntry("Document Input", "document"),
     ColorInput: fixedInputEntry("Color Input", "color"),
+    Model3DInput: fixedInputEntry("3D Model Input", "model3d"),
+    ImageSizeInput: fixedInputEntry("Image Size Input", "image_size"),
+    FilePathInput: pathInputEntry(
+      "File Path Input",
+      "file_path",
+      "Pick a file…"
+    ),
+    FolderPathInput: pathInputEntry(
+      "Folder Path Input",
+      "folder_path",
+      "Pick a folder…"
+    ),
+    DataFrameInput: {
+      label: "Data Table Input",
+      fields: fixedInputFields({
+        maxHeight: { type: "number", label: "Max height (px)" }
+      }),
+      defaultProps: { binding: "", label: "", maxHeight: 320 },
+      render: withConditions(
+        (props: FixedInputWidgetProps & { maxHeight?: number }) => (
+          <FixedKindInputWidget {...props} kind="dataframe" />
+        )
+      )
+    },
+    MediaListInput: {
+      label: "Media List Input",
+      fields: fixedInputFields({
+        listKind: {
+          type: "select",
+          label: "List of",
+          options: [
+            { label: "Images", value: "image_list" },
+            { label: "Videos", value: "video_list" },
+            { label: "Audio", value: "audio_list" },
+            { label: "Text", value: "text_list" }
+          ]
+        }
+      }),
+      defaultProps: { binding: "", label: "", listKind: "image_list" },
+      render: withConditions(
+        (props: FixedInputWidgetProps & { listKind?: string }) => (
+          <FixedKindInputWidget
+            {...props}
+            kind={LIST_KINDS[props.listKind ?? ""] ?? "image_list"}
+          />
+        )
+      )
+    },
     // ── Actions ──
     Button: {
       label: "Button",


### PR DESCRIPTION
## What

Closes the gap between what a workflow can take in / emit and what a mini app can actually render.

The widget catalog had no entry for several shapes the graph already supports. On the input side those fell through to a plain text box; on the display side they landed in `Json` or `Output` and rendered as an opaque `{type, uri}`.

**New displays:** `Model3D`, `Chart`, `PDF`, `Gallery`
**New inputs:** `DataFrameInput`, `FilePathInput`, `FolderPathInput`, `Model3DInput`, `ImageSizeInput`, `MediaListInput`

`MediaListInput` carries a `listKind` select rather than splitting the four list input nodes (`ImageListInput`, `VideoListInput`, `AudioListInput`, `TextListInput`) across four near-identical palette entries.

Both `inputKinds` tables gain `model3d`, `image_size` and `huggingface_model`, so the web and mobile surfaces resolve the same node types to the same kinds.

## Why these and not others

`Map` was considered and dropped: it needs external tile servers, which the offline/CSP story doesn't support. Every other display here is backed by a library already in `web/package.json` — `three` / `@react-three/*`, `plotly.js`, `react-pdf`.

## Notes

The CLI `app debug` harness and the `app-tools` eval bridge both read `WIDGET_CATALOG` directly, so they pick the new types up with no change of their own — that was the point of consolidating the catalog. Mobile has no 3D, charting or PDF dependency and does not gain one here; those three render an explicit non-previewable card with the file affordance instead of a faked preview.

## Test plan

- [x] `packages/app-runtime` — 193 passed, incl. new catalog coverage for all ten types
- [x] `packages/cli` app-debug suites — 78 passed, catalog absorbed with no harness change
- [ ] web typecheck / lint / `appbuilder` jest
- [ ] mobile typecheck / lint / test

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xag2uaBF682TuTqeLrPbeb)_