### PR TITLE
Fix comfy.* bridge request shapes to match the Python worker

### DIFF
--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -1072,14 +1072,17 @@ export abstract class PythonBridgeBase
    * would hang and the pending maps would leak.
    */
   comfyExecute(
-    prompt: Record<string, unknown>,
+    workflow: Record<string, unknown>,
     options: ComfyExecuteOptions = {},
     onEvent?: (event: ComfyEvent) => void,
     requestId: string = randomUUID()
   ): Promise<ComfyExecuteResult> {
-    const data: Record<string, unknown> = { prompt };
+    // The worker's field is `workflow`, not `prompt` — see the comfy.execute
+    // request schema in nodetool-core's docs/comfy-proxy.md.
+    const data: Record<string, unknown> = { workflow };
     if (options.blobs) data.blobs = options.blobs;
     if (options.previews) data.previews = true;
+    if (options.includeTemp) data.include_temp = true;
     if (typeof options.timeout === "number") data.timeout = options.timeout;
 
     return new Promise<ComfyExecuteResult>((resolve, reject) => {
@@ -1150,9 +1153,10 @@ export abstract class PythonBridgeBase
     bytes: Uint8Array,
     options: Record<string, unknown> = {}
   ): Promise<Record<string, unknown>> {
+    // The worker reads the payload from `data`, not `blob`.
     return this._providerCall("comfy.upload", {
       filename,
-      blob: bytes,
+      data: bytes,
       ...options
     });
   }
@@ -1165,7 +1169,12 @@ export abstract class PythonBridgeBase
   }
 
   async comfyObjectInfo(): Promise<Record<string, unknown>> {
-    return this._providerCall("comfy.object_info", {});
+    // The worker wraps the catalog as `{object_info: {...}}`; unwrap so callers
+    // get the catalog itself, as this method's contract promises.
+    const result = await this._providerCall("comfy.object_info", {});
+    return (
+      (result.object_info as Record<string, unknown> | undefined) ?? result
+    );
   }
 
   async comfySystemStats(): Promise<Record<string, unknown>> {
@@ -1182,11 +1191,11 @@ export abstract class PythonBridgeBase
   }
 
   async comfyModelsList(folder?: string): Promise<ComfyModelInfo[]> {
-    const result = await this._providerCall(
-      "comfy.models.list",
-      folder ? { folder } : {}
-    );
-    return (result as { models?: ComfyModelInfo[] }).models ?? [];
+    const result = await this._providerCall("comfy.models.list", {});
+    const models = (result as { models?: ComfyModelInfo[] }).models ?? [];
+    // The worker always returns the whole volume — there is no `folder` filter
+    // in the comfy.models.list request schema — so narrow it here.
+    return folder ? models.filter((m) => m.folder === folder) : models;
   }
 
   async comfyModelsDownload(

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -102,6 +102,12 @@ export interface ComfyStatusInfo {
   url?: string;
   /** Whether the worker could reach ComfyUI at last check (comfy.status only). */
   reachable?: boolean;
+  /** `comfy.status` only: ComfyUI's `GET /system_stats` payload. */
+  system_stats?: Record<string, unknown>;
+  /** `comfy.status` only: queue depth from ComfyUI's `GET /prompt`. */
+  queue_remaining?: number;
+  /** `comfy.status` only: why the worker could not reach ComfyUI. */
+  error?: string;
 }
 
 /**
@@ -133,11 +139,14 @@ export interface ComfyEvent {
   queue_remaining?: number;
   /** `cached`: node ids served from cache. */
   nodes?: string[];
+  /** `queued`: the worker's position in ComfyUI's queue at submission. */
+  queue_position?: number;
   /** `node_output`: the raw ComfyUI output payload for that node. */
-  output?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
   /** `preview`: raw preview image bytes (only when `previews: true`). */
-  blob?: Uint8Array;
-  mime_type?: string;
+  image?: Uint8Array;
+  /** `preview`: the image encoding — `"jpeg"`, `"png"`, or `"unknown"`. */
+  format?: string;
   [key: string]: unknown;
 }
 
@@ -151,6 +160,11 @@ export interface ComfyExecuteOptions {
   blobs?: Record<string, Uint8Array>;
   /** Request `preview` events (extra bandwidth); off by default. */
   previews?: boolean;
+  /**
+   * Also fetch `type: "temp"` outputs (preview nodes). Off by default, in which
+   * case those entries keep their metadata but carry no `blob`.
+   */
+  includeTemp?: boolean;
   /** Max seconds to wait for the ComfyUI run before the worker gives up. */
   timeout?: number;
 }
@@ -158,26 +172,48 @@ export interface ComfyExecuteOptions {
 /** Terminal `result.data` of a {@link PythonBridge.comfyExecute} call. */
 export interface ComfyExecuteResult {
   prompt_id?: string;
+  /** `"completed"`, or `"cancelled"` when the run was cancelled worker-side. */
+  status?: string;
   outputs?: Record<string, unknown>;
   blobs?: Record<string, Uint8Array>;
   [key: string]: unknown;
 }
 
+/**
+ * Where {@link PythonBridge.comfyModelsDownload} pulls the file from. The
+ * worker discriminates on `type`; a HuggingFace source resolves the token
+ * worker-side (client-supplied tokens are ignored).
+ */
+export type ComfyModelSource =
+  | {
+      type: "huggingface";
+      repo_id: string;
+      /** Path of the file within the repo. */
+      path: string;
+      /** Git revision to resolve against. Defaults to `"main"`. */
+      revision?: string;
+    }
+  | { type: "url"; url: string };
+
 /** Request payload for {@link PythonBridge.comfyModelsDownload}. */
 export interface ComfyModelDownloadRequest {
   /** Raw ComfyUI folder ("checkpoints", "loras", …) or a nodetool type string. */
   folder: string;
-  /** Direct download URL, mutually exclusive with `repo_id`. */
-  url?: string;
-  /** HuggingFace repo id, mutually exclusive with `url`. */
-  repo_id?: string;
+  /** Where to fetch the file from. */
+  source: ComfyModelSource;
+  /** Target filename on the volume. Defaults to the source basename. */
   filename?: string;
+  /** Re-download even when the file is already present. */
+  force?: boolean;
   [key: string]: unknown;
 }
 
-/** A `progress` frame from {@link PythonBridge.comfyModelsDownload}. */
+/**
+ * A `progress` frame from {@link PythonBridge.comfyModelsDownload}. `"exists"`
+ * is the fast path: the file was already on the volume and no bytes moved.
+ */
 export interface ComfyModelDownloadUpdate {
-  status: "start" | "progress" | "completed" | "error" | "cancelled";
+  status: "start" | "progress" | "completed" | "error" | "cancelled" | "exists";
   downloaded_bytes: number;
   total_bytes: number;
   error?: string;
@@ -187,8 +223,9 @@ export interface ComfyModelDownloadUpdate {
 /** One file entry from {@link PythonBridge.comfyModelsList}. */
 export interface ComfyModelInfo {
   folder: string;
+  /** Path relative to `folder` — may contain separators for nested files. */
   filename: string;
-  size?: number;
+  size_bytes?: number;
   [key: string]: unknown;
 }
 
@@ -372,7 +409,7 @@ export interface PythonBridge extends EventEmitter {
    * returned/passed `requestId`.
    */
   comfyExecute(
-    prompt: Record<string, unknown>,
+    workflow: Record<string, unknown>,
     options?: ComfyExecuteOptions,
     onEvent?: (event: ComfyEvent) => void,
     requestId?: string

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -271,12 +271,12 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
   }
 
   comfyExecute(
-    prompt: Record<string, unknown>,
+    workflow: Record<string, unknown>,
     options?: ComfyExecuteOptions,
     onEvent?: (event: ComfyEvent) => void,
     requestId?: string
   ): Promise<ComfyExecuteResult> {
-    return this._target.comfyExecute(prompt, options, onEvent, requestId);
+    return this._target.comfyExecute(workflow, options, onEvent, requestId);
   }
 
   cancelComfyExecute(requestId: string): void {

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -849,7 +849,7 @@ describe("PythonBridgeBase — models & comfy proxy RPCs", () => {
     );
     const frame = bridge.sent.find((f) => f.type === "comfy.execute")!;
     expect(frame.data).toEqual({
-      prompt: { "1": { class_type: "X" } },
+      workflow: { "1": { class_type: "X" } },
       previews: true,
       timeout: 30
     });
@@ -919,13 +919,14 @@ describe("PythonBridgeBase — models & comfy proxy RPCs", () => {
     await pCancel;
   });
 
-  it("comfyUpload sends filename + blob and merges options", async () => {
+  it("comfyUpload sends filename + data and merges options", async () => {
     const bytes = new Uint8Array([7]);
     const p = bridge.comfyUpload("f.png", bytes, { subfolder: "in" });
     const frame = bridge.sent.find((f) => f.type === "comfy.upload")!;
+    // The worker's field is `data`, not `blob`.
     expect(frame.data).toEqual({
       filename: "f.png",
-      blob: bytes,
+      data: bytes,
       subfolder: "in"
     });
     reply("comfy.upload", { name: "f.png" });
@@ -935,17 +936,35 @@ describe("PythonBridgeBase — models & comfy proxy RPCs", () => {
   it("comfyModelsList returns [] when the worker omits models", async () => {
     const p = bridge.comfyModelsList("checkpoints");
     const frame = bridge.sent.find((f) => f.type === "comfy.models.list")!;
-    expect(frame.data).toEqual({ folder: "checkpoints" });
+    // No folder filter exists on the wire — the request is always empty.
+    expect(frame.data).toEqual({});
     reply("comfy.models.list", {});
     await expect(p).resolves.toEqual([]);
   });
 
-  it("comfyModelsList sends empty data when no folder is given", async () => {
+  it("comfyModelsList narrows the worker's full listing by folder", async () => {
+    const p = bridge.comfyModelsList("checkpoints");
+    reply("comfy.models.list", {
+      models: [
+        { folder: "checkpoints", filename: "a" },
+        { folder: "loras", filename: "b" }
+      ]
+    });
+    await expect(p).resolves.toEqual([{ folder: "checkpoints", filename: "a" }]);
+  });
+
+  it("comfyModelsList returns everything when no folder is given", async () => {
     const p = bridge.comfyModelsList();
     const frame = bridge.sent.find((f) => f.type === "comfy.models.list")!;
     expect(frame.data).toEqual({});
     reply("comfy.models.list", { models: [{ name: "a" }] });
     await expect(p).resolves.toEqual([{ name: "a" }]);
+  });
+
+  it("comfyObjectInfo unwraps the worker's object_info envelope", async () => {
+    const p = bridge.comfyObjectInfo();
+    reply("comfy.object_info", { object_info: { KSampler: { input: {} } } });
+    await expect(p).resolves.toEqual({ KSampler: { input: {} } });
   });
 
   it("comfyModelsDelete coerces the deleted flag", async () => {
@@ -968,7 +987,11 @@ describe("PythonBridgeBase — models & comfy proxy RPCs", () => {
   it("comfyModelsDownload streams via the shared download engine", async () => {
     const updates: unknown[] = [];
     const p = bridge.comfyModelsDownload(
-      { folder: "checkpoints", url: "http://x", filename: "a" } as never,
+      {
+        folder: "checkpoints",
+        source: { type: "url", url: "http://x" },
+        filename: "a"
+      },
       (u) => updates.push(u),
       "cd-1"
     );

--- a/packages/runtime/tests/python-bridge-comfy.test.ts
+++ b/packages/runtime/tests/python-bridge-comfy.test.ts
@@ -92,7 +92,7 @@ describe("comfy.* bridge methods", () => {
     const frames = worker!.received("comfy.execute");
     expect(frames).toHaveLength(1);
     expect(frames[0]!.data).toEqual({
-      prompt: { "3": { class_type: "KSampler", inputs: {} } }
+      workflow: { "3": { class_type: "KSampler", inputs: {} } }
     });
 
     // No leaked pending state on either map after settle.
@@ -111,7 +111,7 @@ describe("comfy.* bridge methods", () => {
     await b.comfyExecute({ "3": {} }, { previews: true, timeout: 30 }, () => {});
     const frames = worker!.received("comfy.execute");
     expect(frames[0]!.data).toEqual({
-      prompt: { "3": {} },
+      workflow: { "3": {} },
       previews: true,
       timeout: 30
     });
@@ -203,13 +203,20 @@ describe("comfy.* bridge methods", () => {
       reachable: true
     });
 
+    // The worker has no folder filter on comfy.models.list — it always returns
+    // the whole volume, so the bridge sends an empty payload and narrows the
+    // result itself.
     const models = await b.comfyModelsList("checkpoints");
     expect(models).toEqual([
-      { folder: "checkpoints", filename: "sd_xl_base.safetensors", size: 42 }
+      {
+        folder: "checkpoints",
+        filename: "sd_xl_base.safetensors",
+        size_bytes: 42
+      }
     ]);
-    expect(worker!.received("comfy.models.list")[0]!.data).toEqual({
-      folder: "checkpoints"
-    });
+    expect(worker!.received("comfy.models.list")[0]!.data).toEqual({});
+
+    expect(await b.comfyModelsList()).toHaveLength(2);
 
     expect(await b.comfyModelsDelete("checkpoints", "sd_xl_base.safetensors")).toBe(
       true

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -102,6 +102,69 @@ export interface FakeWorkerHandle {
 }
 
 /**
+ * Validate a request against the worker's wire contract, mirroring the
+ * argument checks in nodetool-core's `worker/comfy_handler.py`. Returns the
+ * error string the real worker would answer with, or null when the request is
+ * well-formed.
+ *
+ * Without this the fake worker answers any payload, so a bridge that sends the
+ * wrong field name (`prompt` for `workflow`, `blob` for `data`, a flat model
+ * source instead of the nested `source` object) still passes every test while
+ * failing against a real worker.
+ */
+function checkWorkerContract(
+  type: string,
+  data: Record<string, unknown>
+): string | null {
+  switch (type) {
+    case "comfy.execute": {
+      const workflow = data.workflow;
+      if (
+        typeof workflow !== "object" ||
+        workflow === null ||
+        Array.isArray(workflow) ||
+        Object.keys(workflow).length === 0
+      ) {
+        return "comfy.execute requires a non-empty 'workflow' (API-format prompt JSON)";
+      }
+      return null;
+    }
+    case "comfy.upload":
+      return data.data instanceof Uint8Array
+        ? null
+        : "comfy.upload requires binary 'data'";
+    case "comfy.view":
+      return data.filename ? null : "comfy.view requires 'filename'";
+    case "comfy.cancel":
+      return data.prompt_id ? null : "comfy.cancel requires 'prompt_id'";
+    case "comfy.models.download": {
+      if (!data.folder) {
+        return "comfy.models.download requires 'folder'";
+      }
+      const source = (data.source ?? {}) as Record<string, unknown>;
+      if (source.type === "huggingface") {
+        return source.repo_id && source.path
+          ? null
+          : "huggingface source requires 'repo_id' and 'path'";
+      }
+      if (source.type === "url") {
+        return typeof source.url === "string" &&
+          /^https?:\/\//.test(source.url)
+          ? null
+          : "url source requires an http(s) 'url'";
+      }
+      return `Unknown model source type: ${JSON.stringify(source.type)} (expected 'huggingface' or 'url')`;
+    }
+    case "comfy.models.delete":
+      return data.folder && data.filename
+        ? null
+        : "comfy.models.delete requires 'folder' and 'filename'";
+    default:
+      return null;
+  }
+}
+
+/**
  * Start a fake worker on a specific port (or ephemeral when port === 0).
  * Returns once the server is listening.
  */
@@ -162,6 +225,22 @@ export function startFakeWorker(
       const send = (m: Record<string, unknown>) => {
         ws.send(pack(m));
       };
+
+      // Reject malformed requests the way the real worker does, so a bridge
+      // that sends the wrong field name fails the test instead of being
+      // silently answered. See nodetool-core docs/comfy-proxy.md.
+      const contractError = checkWorkerContract(
+        type,
+        (msg.data as Record<string, unknown>) ?? {}
+      );
+      if (contractError) {
+        send({
+          type: "error",
+          request_id: requestId,
+          data: { error: contractError }
+        });
+        return;
+      }
 
       switch (type) {
         case "discover":
@@ -361,7 +440,7 @@ export function startFakeWorker(
             event: "node_output",
             prompt_id: "p1",
             node: "9",
-            output: { images: [{ filename: "out.png" }] }
+            outputs: { images: [{ filename: "out.png" }] }
           });
           if (opts.comfyExecuteMode === "error") {
             send({
@@ -412,7 +491,12 @@ export function startFakeWorker(
             request_id: requestId,
             data: {
               models: [
-                { folder: "checkpoints", filename: "sd_xl_base.safetensors", size: 42 }
+                {
+                  folder: "checkpoints",
+                  filename: "sd_xl_base.safetensors",
+                  size_bytes: 42
+                },
+                { folder: "loras", filename: "detail.safetensors", size_bytes: 7 }
               ]
             }
           });


### PR DESCRIPTION
Found while verifying the worker protocol from both sides — the TS bridge in `packages/runtime` against `nodetool-core`'s `src/nodetool/worker/`.

Everything outside `comfy.*` checks out: framing, version negotiation, `discover`/`worker.status`, `execute`/`execute.stream`/`cancel`, and all `provider.*` and `models.*` shapes agree field-for-field. The `comfy.*` family does not — the bridge sends field names the worker never reads, so the worker's own argument validation rejects the requests.

`nodetool-core`'s `docs/comfy-proxy.md` is the authoritative wire reference (this repo's `python-bridge-types.ts` says as much), and `comfy_handler.py` matches it. This side was the one that drifted.

## Request-shape fixes

| Message | Bridge sent | Worker reads | Result before this PR |
|---|---|---|---|
| `comfy.execute` | `prompt` | `workflow` | `comfy.execute requires a non-empty 'workflow'` |
| `comfy.upload` | `blob` | `data` | `comfy.upload requires binary 'data'` |
| `comfy.models.download` | flat `{folder, url\|repo_id, filename}` | nested `source: {type, ...}` | `Unknown model source type: None` |

`comfy.execute` is the only one of these with a production caller (`ComfyWorkerWorkflowNode` in `packages/integration-nodes`), so **every ComfyUI worker run was failing**. The other two are latent — the bridge exposes them but nothing calls them yet.

Two more on the same family:

- `comfy.models.list` has no `folder` filter on the wire; the worker always returns the whole volume. The bridge now sends an empty payload and narrows client-side, so the documented filter actually applies instead of being silently dropped.
- `comfy.object_info` returns `{object_info: ...}`. Unwrapped, so the method returns the catalog its contract promises.

## Response-type fixes

These only produced `undefined` at the read site rather than throwing, because the interfaces carry index signatures:

- `ComfyEvent`: `node_output` carries `outputs` (not `output`); `preview` carries `format` + `image` (not `mime_type` + `blob`). Added `queue_position` for `queued`.
- `ComfyModelInfo`: entries carry `size_bytes`, not `size`.
- `ComfyModelDownloadUpdate`: added the `"exists"` status the worker emits on the already-downloaded fast path.
- `ComfyStatusInfo`: added the `system_stats` / `queue_remaining` / `error` fields `comfy.status` returns.
- `ComfyExecuteResult`: added `status`, which distinguishes a completed run from a worker-side cancellation.

Also exposed `include_temp` as `ComfyExecuteOptions.includeTemp` — the worker supports it, but there was no way to ask for it.

## Why the tests didn't catch this

The fake worker in `python-websocket-bridge.test-helpers.ts` answers any payload it is sent, so all three request-shape bugs passed a green suite while failing against a real worker. It now applies the same argument validation `comfy_handler.py` does and answers a matching `error` frame when a request is malformed, so a shape regression fails the suite. Its `node_output` and `comfy.models.list` responses were also emitting the wrong field names; those now mirror the worker.

## Verification

- `npx vitest run packages/runtime packages/protocol packages/integration-nodes` → 3401 passed (180 files)
- `npx tsc --build tsconfig.build.json` → clean
- `npx oxlint packages/runtime/src` → clean
- `uv run pytest tests/worker -q` in `nodetool-core` → 127 passed (unchanged; no Python edits here)

No protocol version bump: this is a client-side correction to v3, not a wire change, so `BRIDGE_PROTOCOL_VERSION` and `MIN_BRIDGE_PROTOCOL_VERSION` stay put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVSMgubQKhwLLoERBBJuhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVSMgubQKhwLLoERBBJuhx)_