### PR TITLE
fix(ci): smoke-boot the packed backend, not the staged one

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -295,16 +295,22 @@ jobs:
           npm run prepare-mcpb
           npx electron-builder --config electron-builder.json --win --x64 --dir --publish never
 
-      # Boot the staged backend before anything is signed or uploaded. The
-      # Quality Gate runs the same check, but only on Linux — the native
-      # prebuilds staged into the bundle are per-OS, so a Windows- or
-      # macOS-only staging fault is invisible until here. Smoke-launch below
-      # can't cover it: it spawns the Electron main process, which outlives a
-      # backend child that dies on import.
+      # Boot the backend out of the packed app before anything is signed or
+      # uploaded. The Quality Gate runs the same check, but only on Linux and
+      # only on the staged bundle — the native binaries are per-OS, so a
+      # Windows- or macOS-only fault is invisible until here. Smoke-launch
+      # below can't cover it either: it spawns the Electron main process, which
+      # outlives a backend child that dies on import.
+      #
+      # It must be the *packed* tree, not electron/backend-bundle: afterPack is
+      # what pins the backend's native modules to the bundled Node
+      # (NODE_RUNTIME_VERSION) and drops that Node at backend/runtime/node.
+      # electron-builder's npmRebuild leaves the workspace copies on Electron's
+      # ABI, so the staged tree is not a runnable artifact at this point.
       - name: Smoke-boot packaged backend (Windows)
         if: matrix.os == 'windows-2022'
         shell: bash -l {0}
-        run: node scripts/smoke-backend-bundle.mjs electron/backend-bundle
+        run: node scripts/smoke-backend-bundle.mjs electron/dist/win-unpacked/resources/backend
 
       - name: Resolve Windows artifacts (paths)
         if: matrix.os == 'windows-2022'
@@ -568,12 +574,26 @@ jobs:
           npm run prepare-mcpb
           npx electron-builder --config electron-builder.json --publish never
 
-      # See the Windows step above: per-OS native prebuilds mean the Linux
-      # Quality Gate run doesn't cover the macOS bundle.
+      # See the Windows step above. Only the first matching layout is booted:
+      # on macOS the x64 app is cross-built on an arm64 runner, and its bundled
+      # Node can't run natively there.
       - name: Smoke-boot packaged backend (macOS/Linux)
         if: matrix.os != 'windows-2022'
         shell: bash
-        run: node scripts/smoke-backend-bundle.mjs electron/backend-bundle
+        run: |
+          set -euo pipefail
+          for candidate in \
+            "electron/dist/mac-arm64/Nodetool.app/Contents/Resources/backend" \
+            "electron/dist/mac/Nodetool.app/Contents/Resources/backend" \
+            "electron/dist/linux-unpacked/resources/backend"; do
+            if [ -f "$candidate/server.mjs" ]; then
+              node scripts/smoke-backend-bundle.mjs "$candidate"
+              exit $?
+            fi
+          done
+          echo "::error::No packed backend found under electron/dist — nothing was smoke-booted."
+          find electron/dist -maxdepth 2 -type d | head -50
+          exit 1
 
       - name: Smoke-launch macOS .app
         if: matrix.os == 'macos-latest'

--- a/scripts/smoke-backend-bundle.mjs
+++ b/scripts/smoke-backend-bundle.mjs
@@ -15,8 +15,23 @@
  * _modules to that name), against a throwaway data dir, on a free port — then
  * polled on /health.
  *
+ * Two kinds of bundle can be passed, and the interpreter follows the bundle:
+ *
+ *   - The *staged* bundle (electron/backend-bundle), before packaging. No
+ *     bundled Node yet, so it runs on the current interpreter. This is what
+ *     the Quality Gate checks.
+ *   - The *packed* backend (…/resources/backend), after electron-builder. It
+ *     ships its own Node at runtime/node — the binary the app actually
+ *     launches the backend with (electron/src/server.ts) and the one afterPack
+ *     rebuilds better-sqlite3 against. Booting it with anything else is a
+ *     NODE_MODULE_VERSION mismatch: electron-builder's npmRebuild leaves the
+ *     workspace's native modules on Electron's ABI, which is neither the
+ *     runner's Node nor the bundled one.
+ *
  * Usage: node scripts/smoke-backend-bundle.mjs [bundleDir] [--timeout <ms>]
- *        Defaults: electron/backend-bundle, 120000 ms.
+ *                                              [--node <path>]
+ *        Defaults: electron/backend-bundle, 120000 ms, bundled Node when
+ *        present and the current interpreter otherwise.
  *        Exits 1 with the captured server output if the backend dies or never
  *        answers /health.
  */
@@ -44,6 +59,8 @@ function parseArgs(argv) {
       if (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs <= 0) {
         throw new Error(`--timeout must be a positive number of ms`);
       }
+    } else if (rest[i] === "--node") {
+      opts.nodePath = path.resolve(rest[++i]);
     } else if (rest[i].startsWith("--")) {
       throw new Error(`Unknown argument: ${rest[i]}`);
     } else {
@@ -91,12 +108,26 @@ async function withPackagedModuleLayout(bundleDir) {
   };
 }
 
-async function bootAndProbe(bundleDir, timeoutMs) {
+/**
+ * The Node the packaged app launches the backend with, when the bundle carries
+ * one. Falls back to the current interpreter for a staged (unpacked) bundle.
+ */
+function resolveNodeBinary(bundleDir, override) {
+  if (override) return override;
+  const bundled = path.join(
+    bundleDir,
+    "runtime",
+    process.platform === "win32" ? "node.exe" : "node"
+  );
+  return fs.existsSync(bundled) ? bundled : process.execPath;
+}
+
+async function bootAndProbe(bundleDir, timeoutMs, nodeBinary) {
   const port = await freePort();
   const dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "nodetool-smoke-"));
   const output = [];
 
-  const child = spawn(process.execPath, ["server.mjs"], {
+  const child = spawn(nodeBinary, ["server.mjs"], {
     cwd: bundleDir,
     env: {
       ...process.env,
@@ -152,14 +183,19 @@ async function bootAndProbe(bundleDir, timeoutMs) {
   return { healthy, exit, output: output.join(""), port, lastProbeError };
 }
 
-export async function smokeBackendBundle(bundleDir, { timeoutMs = 120_000 } = {}) {
+export async function smokeBackendBundle(
+  bundleDir,
+  { timeoutMs = 120_000, nodePath } = {}
+) {
+  const nodeBinary = resolveNodeBinary(bundleDir, nodePath);
   const restore = await withPackagedModuleLayout(bundleDir);
   let result;
   try {
-    result = await bootAndProbe(bundleDir, timeoutMs);
+    result = await bootAndProbe(bundleDir, timeoutMs, nodeBinary);
   } finally {
     await restore();
   }
+  result.nodeBinary = nodeBinary;
 
   if (result.healthy) return result;
 
@@ -171,6 +207,7 @@ export async function smokeBackendBundle(bundleDir, { timeoutMs = 120_000 } = {}
         `(last probe: ${result.lastProbeError || "no response"})`;
   throw new Error(
     `backend bundle smoke test failed: ${why}\n` +
+      `  bundle: ${bundleDir}\n  node:   ${nodeBinary}\n` +
       `--- server output ---\n${result.output.trimEnd() || "(no output)"}`
   );
 }
@@ -180,11 +217,16 @@ const isCli =
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isCli) {
-  const { bundleDir, timeoutMs } = parseArgs(process.argv);
+  const { bundleDir, timeoutMs, nodePath } = parseArgs(process.argv);
   console.log(`Smoke-testing backend bundle: ${bundleDir}`);
   try {
-    const { port } = await smokeBackendBundle(bundleDir, { timeoutMs });
-    console.log(`  OK: server.mjs booted and answered /health on :${port}`);
+    const { port, nodeBinary } = await smokeBackendBundle(bundleDir, {
+      timeoutMs,
+      nodePath,
+    });
+    console.log(
+      `  OK: server.mjs booted on ${nodeBinary} and answered /health on :${port}`
+    );
   } catch (e) {
     console.error(e.message);
     process.exit(1);


### PR DESCRIPTION
Follow-up to #4578. The release-time smoke step it added is failing on macOS ([run 30430420327](https://github.com/nodetool-ai/nodetool/actions/runs/30430420327/job/90506205039)) — the step is wrong, not the artifact.

## What failed

```
Smoke-testing backend bundle: .../electron/backend-bundle
backend bundle smoke test failed: server.mjs exited (code 1, signal null) before answering /health
--- server output ---
Database setup failed Error: The module '.../backend-bundle/node_modules/better-sqlite3/build/Release/better_sqlite3.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 137. This version of Node.js requires
NODE_MODULE_VERSION 127.
```

## Why

Neither half of that pairing is what ships.

- **The staged tree isn't runnable after packaging.** `npmRebuild` is on by default (unset in `electron-builder.json`), so `npx electron-builder` leaves the workspace's native modules on Electron 39's ABI (137). My step ran after that, against `electron/backend-bundle`.
- **The runner's Node isn't the interpreter.** The packed app ships its own Node at `backend/runtime/node` (`NODE_RUNTIME_VERSION` = 22.22.1, ABI 127) and launches the backend with it — see the production `Watchdog` branch in `electron/src/server.ts`. `after-pack.cjs` rebuilds `better-sqlite3` against *that* Node, in the packed tree only.

So the pairing that actually ships — packed binaries + bundled Node — was never what the step booted.

## Changes

- **`release.yaml`** — point both steps at the packed backend (`…/Contents/Resources/backend`, `linux-unpacked/resources/backend`, `win-unpacked/resources/backend`) instead of `electron/backend-bundle`. On macOS only the first matching layout is booted: the x64 app is cross-built on an arm64 runner and its bundled Node can't run natively there. If no packed layout is found the step fails loudly and lists `electron/dist` rather than silently passing.
- **`scripts/smoke-backend-bundle.mjs`** — pick the interpreter from the bundle: `runtime/node` when the bundle carries one, the current interpreter otherwise. `--node <path>` overrides. Failures now name both the bundle and the interpreter.

This makes the release gate stricter than it was: it boots the exact native binaries and the exact Node that ship, after `afterPack` has done its rebuild.

**The Quality Gate leg is unchanged** and stays on the staged bundle — it never runs electron-builder, so the workspace natives still match its Node. It passed on main ([job 90536686071](https://github.com/nodetool-ai/nodetool/actions/runs/30439558379/job/90536686071), 19s).

## Verification

All three interpreter paths, locally:

```
# staged bundle, no bundled Node → current interpreter
OK: server.mjs booted on /opt/node22/bin/node and answered /health on :33943

# bundle carrying runtime/node → bundled Node
OK: server.mjs booted on .../electron/backend-bundle/runtime/node and answered /health on :41237

# bad interpreter → fails with both paths named
backend bundle smoke test failed: server.mjs exited (code 1, signal null) before answering /health
  bundle: /home/user/nodetool/electron/backend-bundle
  node:   /bin/false
```

`npm run lint` passes. The macOS packed-path resolution can only be exercised by a real release run, so that's the one thing here I could not verify locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TWxwg3dUmW196rNFG2m7)_