### PR TITLE
fix(gemini): allow built-in tools alongside function calling

### DIFF
--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -83,7 +83,12 @@ interface GeminiRequest {
     | { codeExecution: Record<string, never> }
   >;
   toolConfig?: {
-    functionCallingConfig: { mode: "ANY"; allowedFunctionNames?: string[] };
+    functionCallingConfig?: { mode: "ANY"; allowedFunctionNames?: string[] };
+    /**
+     * Required by Gemini when a built-in tool (googleSearch, codeExecution) is
+     * sent alongside functionDeclarations — the API 400s without it.
+     */
+    includeServerSideToolInvocations?: boolean;
   };
   generationConfig?: Record<string, unknown>;
 }
@@ -696,6 +701,61 @@ export class GeminiProvider extends BaseProvider {
     };
   }
 
+  /**
+   * Fill in `tools` and `toolConfig` on a request body.
+   *
+   * Built-in tools (googleSearch, codeExecution) run server side. When they are
+   * combined with functionDeclarations, Gemini rejects the request unless
+   * `toolConfig.includeServerSideToolInvocations` is set — the built-in calls
+   * and their results have to be echoed back into the conversation for the
+   * function-calling loop to stay coherent.
+   */
+  private applyTools(
+    body: GeminiRequest,
+    tools: ProviderTool[],
+    geminiTools: Array<{ functionDeclarations: Array<Record<string, unknown>> }>,
+    nameMap: Map<string, string>,
+    toolChoice?: string | "any"
+  ): void {
+    if (geminiTools.length > 0) {
+      body.tools = geminiTools;
+    }
+
+    let hasBuiltIn = false;
+    if (tools.some((tool) => tool.name === WEB_SEARCH_TOOL_NAME)) {
+      body.tools = [...(body.tools ?? []), { googleSearch: {} }];
+      hasBuiltIn = true;
+    }
+    if (tools.some((tool) => tool.type === "code_interpreter")) {
+      body.tools = [...(body.tools ?? []), { codeExecution: {} }];
+      hasBuiltIn = true;
+    }
+
+    const toolConfig: NonNullable<GeminiRequest["toolConfig"]> = {};
+
+    if (hasBuiltIn && geminiTools.length > 0) {
+      toolConfig.includeServerSideToolInvocations = true;
+    }
+
+    if (
+      toolChoice &&
+      (toolChoice === "any" ? geminiTools.length > 0 : nameMap.has(toolChoice))
+    ) {
+      const selected =
+        toolChoice === "any"
+          ? undefined
+          : (nameMap.get(toolChoice) ?? sanitizeToolName(toolChoice));
+      toolConfig.functionCallingConfig = {
+        mode: "ANY",
+        ...(selected ? { allowedFunctionNames: [selected] } : {})
+      };
+    }
+
+    if (Object.keys(toolConfig).length > 0) {
+      body.toolConfig = toolConfig;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Non-streaming generation
   // ---------------------------------------------------------------------------
@@ -734,32 +794,7 @@ export class GeminiProvider extends BaseProvider {
       body.systemInstruction = { parts: [{ text: systemInstruction }] };
     }
 
-    if (geminiTools.length > 0) {
-      body.tools = geminiTools;
-    }
-    if (tools.some((tool) => tool.name === WEB_SEARCH_TOOL_NAME)) {
-      body.tools = [...(body.tools ?? []), { googleSearch: {} }];
-    }
-    if (tools.some((tool) => tool.type === "code_interpreter")) {
-      body.tools = [...(body.tools ?? []), { codeExecution: {} }];
-    }
-    if (
-      args.toolChoice &&
-      (args.toolChoice === "any"
-        ? geminiTools.length > 0
-        : nameMap.has(args.toolChoice))
-    ) {
-      const selected =
-        args.toolChoice === "any"
-          ? undefined
-          : (nameMap.get(args.toolChoice) ?? sanitizeToolName(args.toolChoice));
-      body.toolConfig = {
-        functionCallingConfig: {
-          mode: "ANY",
-          ...(selected ? { allowedFunctionNames: [selected] } : {})
-        }
-      };
-    }
+    this.applyTools(body, tools, geminiTools, nameMap, args.toolChoice);
 
     const generationConfig: Record<string, unknown> = {
       maxOutputTokens: maxTokens
@@ -860,32 +895,7 @@ export class GeminiProvider extends BaseProvider {
       body.systemInstruction = { parts: [{ text: systemInstruction }] };
     }
 
-    if (geminiTools.length > 0) {
-      body.tools = geminiTools;
-    }
-    if (tools.some((tool) => tool.name === WEB_SEARCH_TOOL_NAME)) {
-      body.tools = [...(body.tools ?? []), { googleSearch: {} }];
-    }
-    if (tools.some((tool) => tool.type === "code_interpreter")) {
-      body.tools = [...(body.tools ?? []), { codeExecution: {} }];
-    }
-    if (
-      args.toolChoice &&
-      (args.toolChoice === "any"
-        ? geminiTools.length > 0
-        : nameMap.has(args.toolChoice))
-    ) {
-      const selected =
-        args.toolChoice === "any"
-          ? undefined
-          : (nameMap.get(args.toolChoice) ?? sanitizeToolName(args.toolChoice));
-      body.toolConfig = {
-        functionCallingConfig: {
-          mode: "ANY",
-          ...(selected ? { allowedFunctionNames: [selected] } : {})
-        }
-      };
-    }
+    this.applyTools(body, tools, geminiTools, nameMap, args.toolChoice);
 
     const generationConfig: Record<string, unknown> = {
       maxOutputTokens: maxTokens

--- a/packages/runtime/tests/providers/gemini-provider.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider.test.ts
@@ -659,8 +659,57 @@ describe("GeminiProvider", () => {
       { googleSearch: {} }
     ]);
     expect(body.toolConfig).toEqual({
+      includeServerSideToolInvocations: true,
       functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["my_tool_"] }
     });
+  });
+
+  it("enables server-side tool invocations when built-ins ride along with function tools", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      makeFetchResponse({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }]
+      })
+    );
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" }, { fetchFn });
+    for (const builtIn of [
+      { name: "web_search" },
+      { name: "run_code", type: "code_interpreter" as const }
+    ]) {
+      fetchFn.mockClear();
+      await provider.generateMessage({
+        model: "gemini-3.5-flash",
+        messages: [{ role: "user", content: "go" }],
+        tools: [builtIn, { name: "ui_storyboard_add_shot" }]
+      });
+      const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+      expect(body.toolConfig.includeServerSideToolInvocations).toBe(true);
+    }
+  });
+
+  it("omits toolConfig when there is nothing to configure", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      makeFetchResponse({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }]
+      })
+    );
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" }, { fetchFn });
+
+    // Function tools alone — no built-in in play, so no flag.
+    await provider.generateMessage({
+      model: "gemini-3.5-flash",
+      messages: [{ role: "user", content: "go" }],
+      tools: [{ name: "ui_storyboard_add_shot" }]
+    });
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig).toBeUndefined();
+
+    // A built-in with no function declarations needs no flag either.
+    fetchFn.mockClear();
+    await provider.generateMessage({
+      model: "gemini-3.5-flash",
+      messages: [{ role: "user", content: "go" }],
+      tools: [{ name: "web_search" }]
+    });
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig).toBeUndefined();
   });
 
   it("maps code-interpreter tools to Gemini code execution", async () => {

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -290,6 +290,7 @@ describe("application invocation settlement", () => {
   /** A finished run carrying an app id and a recorded provider charge. */
   const activeJob = (status: "completed" | "failed", cost: number) => {
     const queue: Array<Record<string, unknown>> = [];
+    const listeners = new Set<() => void>();
     const now = performance.now();
     return {
       jobId: "job-settle",
@@ -310,6 +311,10 @@ describe("application invocation settlement", () => {
       context: {
         hasMessages: () => queue.length > 0,
         popMessage: () => queue.shift(),
+        addMessageListener: (listener: () => void) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
         normalizeOutputValue: vi.fn(async (v: unknown) => v),
         getNodeStatuses: () => ({}),
         getEdgeStatuses: () => ({})


### PR DESCRIPTION
## Problem

Requests to Gemini fail with a 400 whenever a built-in tool and function declarations are sent together:

> Please enable `tool_config.include_server_side_tool_invocations` to use Built-in tools with Function calling.

`GeminiProvider` maps `web_search` → `googleSearch` and `code_interpreter` → `codeExecution`, appending them to the same `tools` array that already carries `functionDeclarations`. Gemini requires an explicit opt-in for that combination, and we never sent it. Any chat turn with web search or the code interpreter enabled next to the `ui_*` editing tools (e.g. `ui_storyboard_add_shot`) was rejected before it reached the model.

This is a request-shape bug in our provider, not a server permission or environment setting — nothing about the deployment needed changing.

## Fix

Set `toolConfig.includeServerSideToolInvocations` when a built-in tool and at least one function declaration are both present. It is omitted otherwise, so requests that use only function tools, or only a built-in, keep their existing shape.

The `tools` / `toolConfig` assembly was duplicated verbatim between `generateMessage` and `generateMessages`, which is how the streaming path would have drifted from the fix. Both now call one `applyTools` helper.

`toolConfig.functionCallingConfig` becomes optional in the request type, since the flag can now be the only field set.

## Tests

`packages/runtime/tests/providers/gemini-provider.test.ts`:

- Updated the existing web-search + `toolChoice` case, which asserted the exact payload Gemini rejects.
- New: the flag is set for `googleSearch` and for `codeExecution` when function tools ride along.
- New: `toolConfig` stays absent for function tools alone and for a built-in alone.

Full runtime provider suite: 1675 passing.

## Also: an unrelated red CI leg

`Quality Gate / test-packages` was already failing on `main` (reproduced at 148d840, this PR's parent), so it is fixed here to get CI green rather than left blocking.

`application-budget-gate.test.ts` builds a fake `ProcessingContext` that never grew the `addMessageListener` that `createRelayActivityWaiter` calls. The waiter threw `context.addMessageListener is not a function` on every run; `streamJobMessages` catches any throw and forces `status = "failed"` before settling the ledger, so the settlement test saw a failed row where it expected a completed one.

Only the fixture was stale — a real `ProcessingContext` implements the method, so the production settlement path was never affected. The sibling fixture in `unified-websocket-runner-runjob-coverage.test.ts` already has this shape; this copies it.

`packages/websocket` suite: 159 files / 1940 tests passing, up from 1 failed / 1939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eopbh9WLJE2C25jKmwqmeM