### PR TITLE
fix(providers): send only the fields a model declares; add 2 video examples

### DIFF
--- a/packages/base-nodes/nodetool/examples/nodetool-base/Ad Loop from a Product Photo.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Ad Loop from a Product Photo.json
@@ -3,16 +3,16 @@
   "access": "private",
   "created_at": "2026-06-21T16:03:52.969Z",
   "updated_at": "2026-06-21T16:55:51.256Z",
-  "name": "AI Spokesperson",
+  "name": "Ad Loop from a Product Photo",
   "tool_name": null,
-  "description": "Give a presenter clip a new script. Text-to-speech voices the script, then a lip-sync model redrives the mouth in the source footage so the delivery matches. Useful for localising a take, fixing a fluffed line, or spinning one recording into many variants. Both the speech and lip-sync steps are paid per run.",
+  "description": "Turn a single product photo into a short looping ad. A prompt node writes the motion brief, Kling 2.6 on Kie animates the still, and a speed pass slows it into a hero loop. Needs a KIE_API_KEY; the video step is billed per generation.",
   "tags": [
+    "image",
     "video",
-    "audio",
     "marketing",
     "example"
   ],
-  "thumbnail": "AI Spokesperson.jpg",
+  "thumbnail": "Ad Loop from a Product Photo.jpg",
   "thumbnail_url": null,
   "graph": {
     "nodes": [
@@ -20,13 +20,11 @@
         "id": "comment-1",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "headline": "AI Spokesperson",
+          "headline": "Ad Loop from a Product Photo",
           "comment": [
-            "Re-voice an existing presenter clip without a reshoot.\n\n",
-            "1. Drop in footage of a person talking to camera.\n",
-            "2. Write the new script.\n",
-            "3. TTS voices it, then lip-sync redrives the mouth to match.\n\n",
-            "Keep the script close to the original length — lip-sync follows the audio, and a much longer script will run past the footage."
+            "One product photo in, a looping hero shot out.\n\n",
+            "Kling 2.6 animates the still, then the speed pass halves playback so the loop reads as a slow, premium reveal.\n\n",
+            "The motion brief forbids redesigning the product — the model may move the camera and the light, nothing else."
           ]
         },
         "ui_properties": {
@@ -43,12 +41,12 @@
         "dynamic_outputs": {}
       },
       {
-        "id": "in-clip",
-        "type": "nodetool.input.VideoInput",
+        "id": "in-photo",
+        "type": "nodetool.input.ImageInput",
         "data": {
-          "name": "presenter_clip",
+          "name": "product_photo",
           "value": null,
-          "description": "Footage of a person speaking to camera"
+          "description": "A clean photo of the product"
         },
         "ui_properties": {
           "position": {
@@ -58,18 +56,18 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "1  Presenter clip"
+          "title": "1  Product photo"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "in-script",
+        "id": "in-motion",
         "type": "nodetool.input.StringInput",
         "data": {
-          "name": "script",
-          "value": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
-          "description": "The new words the presenter should say"
+          "name": "motion",
+          "value": "Slow orbit around the product as a soft highlight travels across its surface",
+          "description": "How the shot should move"
         },
         "ui_properties": {
           "position": {
@@ -79,24 +77,16 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "2  New script"
+          "title": "2  Motion"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "speech",
-        "type": "nodetool.audio.TextToSpeech",
+        "id": "brief",
+        "type": "nodetool.text.Prompt",
         "data": {
-          "model": {
-            "type": "tts_model",
-            "provider": "replicate",
-            "id": "inworld/realtime-tts-1.5-max",
-            "name": "Inworld Realtime TTS 1.5 Max",
-            "path": null,
-            "voices": []
-          },
-          "speed": 1.0
+          "prompt": "Animate this product photo into a looping hero shot.\n\nMotion: {{ motion }}\n\nKeep the product's shape, colour, materials and label exactly as photographed. Move only the camera and the lighting. Keep the first and last frame close so the clip loops cleanly. No text, no logos, no hands."
         },
         "ui_properties": {
           "position": {
@@ -104,25 +94,30 @@
             "y": 380
           },
           "zIndex": 0,
-          "width": 280,
+          "width": 320,
           "selectable": true,
-          "title": "3  Voice the script"
+          "title": "Motion brief"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "sync",
-        "type": "nodetool.video.LipSync",
+        "id": "animate",
+        "type": "nodetool.video.ImageToVideo",
         "data": {
           "model": {
             "type": "video_model",
-            "provider": "fal_ai",
-            "id": "fal-ai/sync-lipsync/v2/pro",
-            "name": "Sync Lipsync v2 Pro",
+            "provider": "kie",
+            "id": "kling-2.6/image-to-video",
+            "name": "Kling 2.6 Image to Video",
             "path": null,
             "supported_tasks": []
-          }
+          },
+          "negative_prompt": "warping, melting edges, label distortion, extra objects",
+          "aspect_ratio": "16:9",
+          "resolution": "1080p",
+          "duration": 5,
+          "timeout_seconds": 0
         },
         "ui_properties": {
           "position": {
@@ -132,26 +127,45 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "4  Lip-sync to the new audio"
+          "title": "3  Animate (Kie)"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "output-clip",
-        "type": "nodetool.output.Output",
+        "id": "slow",
+        "type": "nodetool.video.SetSpeed",
         "data": {
-          "name": "revoiced_clip"
+          "speed_factor": 0.5
         },
         "ui_properties": {
           "position": {
-            "x": 1120,
-            "y": 320
+            "x": 1100,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Half speed"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "output-loop",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "ad_loop"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 1440,
+            "y": 360
           },
           "zIndex": 0,
           "width": 240,
           "selectable": true,
-          "title": "5  Re-voiced clip"
+          "title": "5  Ad loop"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -160,30 +174,37 @@
     "edges": [
       {
         "id": "e1",
-        "source": "in-script",
+        "source": "in-motion",
         "sourceHandle": "output",
-        "target": "speech",
-        "targetHandle": "text"
+        "target": "brief",
+        "targetHandle": "motion"
       },
       {
         "id": "e2",
-        "source": "in-clip",
+        "source": "in-photo",
         "sourceHandle": "output",
-        "target": "sync",
-        "targetHandle": "video"
+        "target": "animate",
+        "targetHandle": "image"
       },
       {
         "id": "e3",
-        "source": "speech",
-        "sourceHandle": "audio",
-        "target": "sync",
-        "targetHandle": "audio"
+        "source": "brief",
+        "sourceHandle": "output",
+        "target": "animate",
+        "targetHandle": "prompt"
       },
       {
         "id": "e4",
-        "source": "sync",
+        "source": "animate",
         "sourceHandle": "output",
-        "target": "output-clip",
+        "target": "slow",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e5",
+        "source": "slow",
+        "sourceHandle": "output",
+        "target": "output-loop",
         "targetHandle": "value"
       }
     ]
@@ -191,7 +212,7 @@
   "input_schema": {
     "type": "object",
     "properties": {
-      "presenter_clip": {
+      "product_photo": {
         "type": "object",
         "properties": {
           "uri": {
@@ -200,7 +221,7 @@
           },
           "type": {
             "type": "string",
-            "const": "video"
+            "const": "image"
           }
         },
         "required": [
@@ -209,21 +230,21 @@
         ],
         "label": ""
       },
-      "script": {
+      "motion": {
         "type": "string",
-        "default": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
+        "default": "Slow orbit around the product as a soft highlight travels across its surface",
         "label": ""
       }
     },
     "required": [
-      "presenter_clip",
-      "script"
+      "product_photo",
+      "motion"
     ]
   },
   "output_schema": {
     "type": "object",
     "properties": {
-      "revoiced_clip": {
+      "ad_loop": {
         "type": "object",
         "properties": {
           "uri": {
@@ -243,7 +264,7 @@
       }
     },
     "required": [
-      "revoiced_clip"
+      "ad_loop"
     ]
   },
   "settings": {},

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Score a Silent Clip.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Score a Silent Clip.json
@@ -3,16 +3,16 @@
   "access": "private",
   "created_at": "2026-06-21T16:03:52.969Z",
   "updated_at": "2026-06-21T16:55:51.256Z",
-  "name": "AI Spokesperson",
+  "name": "Score a Silent Clip",
   "tool_name": null,
-  "description": "Give a presenter clip a new script. Text-to-speech voices the script, then a lip-sync model redrives the mouth in the source footage so the delivery matches. Useful for localising a take, fixing a fluffed line, or spinning one recording into many variants. Both the speech and lip-sync steps are paid per run.",
+  "description": "Give a clip a soundtrack. Describe the mood, Stable Audio on fal.ai writes a bed to match the clip's length, and the mix is laid under the original audio. Cheaper than the video templates — one audio generation per run.",
   "tags": [
     "video",
     "audio",
-    "marketing",
+    "music",
     "example"
   ],
-  "thumbnail": "AI Spokesperson.jpg",
+  "thumbnail": "Score a Silent Clip.jpg",
   "thumbnail_url": null,
   "graph": {
     "nodes": [
@@ -20,13 +20,11 @@
         "id": "comment-1",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "headline": "AI Spokesperson",
+          "headline": "Score a Silent Clip",
           "comment": [
-            "Re-voice an existing presenter clip without a reshoot.\n\n",
-            "1. Drop in footage of a person talking to camera.\n",
-            "2. Write the new script.\n",
-            "3. TTS voices it, then lip-sync redrives the mouth to match.\n\n",
-            "Keep the script close to the original length — lip-sync follows the audio, and a much longer script will run past the footage."
+            "Put a soundtrack under a clip.\n\n",
+            "Set duration to match your clip: a bed shorter than the video leaves silence at the tail.\n\n",
+            "mix stays on so the original audio survives underneath. Turn it off to replace the track outright."
           ]
         },
         "ui_properties": {
@@ -43,12 +41,12 @@
         "dynamic_outputs": {}
       },
       {
-        "id": "in-clip",
+        "id": "in-video",
         "type": "nodetool.input.VideoInput",
         "data": {
-          "name": "presenter_clip",
+          "name": "clip",
           "value": null,
-          "description": "Footage of a person speaking to camera"
+          "description": "The clip to score"
         },
         "ui_properties": {
           "position": {
@@ -58,18 +56,18 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "1  Presenter clip"
+          "title": "1  Clip"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "in-script",
+        "id": "in-mood",
         "type": "nodetool.input.StringInput",
         "data": {
-          "name": "script",
-          "value": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
-          "description": "The new words the presenter should say"
+          "name": "mood",
+          "value": "Warm analogue synth bed, slow pulse, hopeful but restrained, no drums",
+          "description": "The mood of the score"
         },
         "ui_properties": {
           "position": {
@@ -79,50 +77,44 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "2  New script"
+          "title": "2  Mood"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "speech",
-        "type": "nodetool.audio.TextToSpeech",
+        "id": "score",
+        "type": "nodetool.audio.TextToMusic",
         "data": {
           "model": {
-            "type": "tts_model",
-            "provider": "replicate",
-            "id": "inworld/realtime-tts-1.5-max",
-            "name": "Inworld Realtime TTS 1.5 Max",
-            "path": null,
-            "voices": []
+            "type": "music_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/stable-audio-25/text-to-audio",
+            "name": "Stable Audio 2.5",
+            "path": null
           },
-          "speed": 1.0
+          "lyrics": "",
+          "duration": 12.0
         },
         "ui_properties": {
           "position": {
-            "x": 380,
+            "x": 400,
             "y": 380
           },
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "3  Voice the script"
+          "title": "3  Write the score (fal)"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "sync",
-        "type": "nodetool.video.LipSync",
+        "id": "mix",
+        "type": "nodetool.video.AddAudio",
         "data": {
-          "model": {
-            "type": "video_model",
-            "provider": "fal_ai",
-            "id": "fal-ai/sync-lipsync/v2/pro",
-            "name": "Sync Lipsync v2 Pro",
-            "path": null,
-            "supported_tasks": []
-          }
+          "volume": 0.35,
+          "mix": true
         },
         "ui_properties": {
           "position": {
@@ -132,16 +124,16 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "4  Lip-sync to the new audio"
+          "title": "4  Lay it under"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "output-clip",
+        "id": "output-scored",
         "type": "nodetool.output.Output",
         "data": {
-          "name": "revoiced_clip"
+          "name": "scored_clip"
         },
         "ui_properties": {
           "position": {
@@ -151,7 +143,7 @@
           "zIndex": 0,
           "width": 240,
           "selectable": true,
-          "title": "5  Re-voiced clip"
+          "title": "5  Scored clip"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -160,30 +152,30 @@
     "edges": [
       {
         "id": "e1",
-        "source": "in-script",
+        "source": "in-mood",
         "sourceHandle": "output",
-        "target": "speech",
-        "targetHandle": "text"
+        "target": "score",
+        "targetHandle": "prompt"
       },
       {
         "id": "e2",
-        "source": "in-clip",
+        "source": "in-video",
         "sourceHandle": "output",
-        "target": "sync",
+        "target": "mix",
         "targetHandle": "video"
       },
       {
         "id": "e3",
-        "source": "speech",
+        "source": "score",
         "sourceHandle": "audio",
-        "target": "sync",
+        "target": "mix",
         "targetHandle": "audio"
       },
       {
         "id": "e4",
-        "source": "sync",
+        "source": "mix",
         "sourceHandle": "output",
-        "target": "output-clip",
+        "target": "output-scored",
         "targetHandle": "value"
       }
     ]
@@ -191,7 +183,7 @@
   "input_schema": {
     "type": "object",
     "properties": {
-      "presenter_clip": {
+      "clip": {
         "type": "object",
         "properties": {
           "uri": {
@@ -209,21 +201,21 @@
         ],
         "label": ""
       },
-      "script": {
+      "mood": {
         "type": "string",
-        "default": "Our spring release ships today. Faster renders, sharper output, and a price that did not move.",
+        "default": "Warm analogue synth bed, slow pulse, hopeful but restrained, no drums",
         "label": ""
       }
     },
     "required": [
-      "presenter_clip",
-      "script"
+      "clip",
+      "mood"
     ]
   },
   "output_schema": {
     "type": "object",
     "properties": {
-      "revoiced_clip": {
+      "scored_clip": {
         "type": "object",
         "properties": {
           "uri": {
@@ -243,7 +235,7 @@
       }
     },
     "required": [
-      "revoiced_clip"
+      "scored_clip"
     ]
   },
   "settings": {},

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -1078,6 +1078,7 @@ export class KieProvider extends BaseProvider {
     const input: Record<string, unknown> = { prompt: params.prompt };
     if (params.aspectRatio) input.aspect_ratio = params.aspectRatio;
     this.applyVideoDuration(input, fields, params);
+    this.applyRequiredDefaults(input, fields);
 
     log.debug("Kie textToVideo", { model: modelId });
     const apiKey = this.requireApiKey();
@@ -1097,6 +1098,30 @@ export class KieProvider extends BaseProvider {
    * declared field type. A declared schema with no `duration` field sends
    * nothing; an unknown model keeps the historical numeric behavior.
    */
+  /**
+   * Fill required fields the model declares but nothing else set, using the
+   * manifest's declared default.
+   *
+   * Kie rejects a task with `500 "This field is required"` when a declared
+   * required field is absent — it does not fall back to the documented default
+   * itself. `kling-2.6/image-to-video` requires `sound` (default false), which
+   * no param maps to, so an image-to-video task failed outright.
+   *
+   * Only fields the manifest marks required AND gives a default are filled, so
+   * this cannot invent a value the model never described.
+   */
+  private applyRequiredDefaults(
+    input: Record<string, unknown>,
+    fields: ModelInputField[]
+  ): void {
+    for (const field of fields) {
+      if (!field.required) continue;
+      if (field.default === undefined) continue;
+      if (input[field.name] !== undefined) continue;
+      input[field.name] = field.default;
+    }
+  }
+
   private applyVideoDuration(
     input: Record<string, unknown>,
     fields: ModelInputField[],
@@ -1300,6 +1325,7 @@ export class KieProvider extends BaseProvider {
     if (params.prompt) input.prompt = params.prompt;
     this.applyEditOptions(input, fields, params);
     this.applyVideoDuration(input, fields, params);
+    this.applyRequiredDefaults(input, fields);
 
     log.debug("Kie imageToVideo", { model: modelId, images: imageUrls.length });
 

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -340,6 +340,35 @@ export interface ModelImageInput {
  * `uploads` (which carry the real API param name) take precedence; otherwise
  * the FAL/Replicate `inputFields` image/list[image] entries are used.
  */
+/**
+ * Input parameter names a model declares, from the generated manifest.
+ *
+ * Providers assemble a generic input bag from `*Params` (prompt,
+ * negative_prompt, strength, seed…), but each endpoint accepts only a subset.
+ * Replicate rejects the whole prediction with a validation error when it sees
+ * an undeclared field rather than ignoring it, so sending the superset fails
+ * outright — `decart/lucy-edit-2` takes neither `negative_prompt` nor
+ * `strength`.
+ *
+ * Returns an empty set when the model is missing from the manifest or declares
+ * no fields. Callers must read that as "unknown, send everything" rather than
+ * "accepts nothing", so a model absent from the manifest keeps working.
+ */
+export function getModelInputNames(
+  packageName: string,
+  exportPath: string,
+  modelId: string
+): Set<string> {
+  const entry = loadManifest(packageName, exportPath).find(
+    (n) => nodeId(n) === modelId
+  );
+  return new Set(
+    (entry?.inputFields ?? [])
+      .map((f) => f.name)
+      .filter((n): n is string => typeof n === "string" && n.length > 0)
+  );
+}
+
 export function getModelImageInputs(
   packageName: string,
   exportPath: string,

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -32,6 +32,7 @@ import type {
 } from "./types.js";
 import {
   getModelImageInputs,
+  getModelInputNames,
   loadImageModels,
   loadMusicModels,
   loadVideoModels,
@@ -927,6 +928,36 @@ export class ReplicateProvider extends BaseProvider {
     });
   }
 
+  /**
+   * Drop input fields the model does not declare in the manifest.
+   *
+   * Replicate fails the whole prediction on an undeclared field instead of
+   * ignoring it, so a generic param bag breaks any endpoint with a narrower
+   * schema. An empty declaration set means the model is not in the manifest —
+   * send everything rather than silently stripping the request bare.
+   */
+  private pruneToDeclaredInputs(
+    modelId: string,
+    input: Record<string, unknown>
+  ): Record<string, unknown> {
+    const declared = getModelInputNames(
+      "@nodetool-ai/replicate-nodes",
+      "replicate-manifest.json",
+      modelId
+    );
+    if (declared.size === 0) return input;
+    const pruned: Record<string, unknown> = {};
+    const dropped: string[] = [];
+    for (const [key, value] of Object.entries(input)) {
+      if (declared.has(key)) pruned[key] = value;
+      else dropped.push(key);
+    }
+    if (dropped.length > 0) {
+      log.debug("pruned undeclared inputs", { model: modelId, dropped });
+    }
+    return pruned;
+  }
+
   override async videoToVideo(
     video: Uint8Array,
     params: VideoToVideoParams
@@ -939,7 +970,10 @@ export class ReplicateProvider extends BaseProvider {
     if (params.strength != null) input.strength = params.strength;
     if (params.seed != null) input.seed = params.seed;
     log.debug("videoToVideo", { model: params.model.id });
-    return this.runWithInput(params.model.id, input);
+    return this.runWithInput(
+      params.model.id,
+      this.pruneToDeclaredInputs(params.model.id, input)
+    );
   }
 
   override async lipSync(
@@ -952,7 +986,10 @@ export class ReplicateProvider extends BaseProvider {
     };
     if (params.seed != null) input.seed = params.seed;
     log.debug("lipSync", { model: params.model.id });
-    return this.runWithInput(params.model.id, input);
+    return this.runWithInput(
+      params.model.id,
+      this.pruneToDeclaredInputs(params.model.id, input)
+    );
   }
 
   /**


### PR DESCRIPTION
Follow-on to #4566, #4570 and #4572 (all merged). Running the video examples end to end surfaced **two provider bugs of the same shape**: the generated manifest describes each model's inputs exactly, and neither provider read it.

## Replicate — send only declared fields

`decart/lucy-edit-2` declares `prompt`, `video`, `reference_image`, `seed`, `enhance_prompt`. The `VideoToVideo` node always sends `negative_prompt` and `strength`, and the provider forwarded them:

```
Prediction input failed validation:
  Unexpected field 'negative_prompt'
  Unexpected field 'strength'
```

Replicate **errors** on an undeclared field rather than ignoring it, so any endpoint with a narrower schema than the generic param bag failed outright.

`getModelInputNames()` reads the declared names from the manifest; `pruneToDeclaredInputs()` drops the rest. Applied to `videoToVideo` and `lipSync`. An empty declaration set means the model is absent from the manifest — send everything, so unlisted models keep working.

## Kie — fill required fields from declared defaults

`kling-2.6/image-to-video` requires `prompt`, `images`, `sound`, `duration`. The provider set three and never sent `sound`, so Kie answered `500 "This field is required"` instead of applying its own documented default.

The manifest already had it: `{"name":"sound","type":"bool","required":true,"default":false}`.

`applyRequiredDefaults()` fills any field the manifest marks **required** that also carries an explicit **default** — it cannot invent a value the model never described. Wired into image-to-video and text-to-video.

## Two new examples

**Ad Loop from a Product Photo** — the first example to use the **Kie** provider at all, despite `kie-nodes` and `kie-codegen` both shipping. Product photo, Kling 2.6 animates it, `SetSpeed` halves playback into a slow hero loop. Also the first use of `SetSpeed`.

**Score a Silent Clip** — Stable Audio 2.5 on fal writes a bed from a mood description, `AddAudio` lays it under the original at 0.35 with `mix: true` so existing audio survives.

**AI Spokesperson** switches from Replicate's `sync/lipsync-2-pro` to fal's `sync-lipsync/v2/pro`. The Replicate endpoint returned 429 on two consecutive attempts while the TTS leg succeeded both times; fal worked first try.

## Verification: every example run against the live APIs

- B-Roll Reel from a Brief — 1920x1080, 11.64s
- Video Restyle Studio — 1280x720, 6.08s (needed the Replicate fix)
- AI Spokesperson — 1920x1080, 6.12s (needed the fal swap)
- Score a Silent Clip — 5.3 MB
- Ad Loop from a Product Photo — 1920x1080, 10.0s (needed the Kie fix)

All five produce real files. `npm run lint` clean; `tsc --noEmit` on packages/runtime clean.

Both provider fixes are proven the same way: same workflow, same model, same inputs, failing before and passing after.

## Notes

- `lucy-edit-2` returns 720p from a 1080p input. Not our bug — it downscales — but worth knowing before wiring it into a pipeline that assumes resolution passes through.
- `Color Boost Video` (a shipped example) still cannot finish headlessly: `lib.image.color_grading.*` needs a WebGPU adapter. #4570 got it past graph load and it now executes `ForEachFrame` before stopping there, so that is environmental, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)