### PR TITLE
Add Claude subscription login for the Claude Agent provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,29 @@ npm run dev:nodetool -- storage migrate-keys               # Move them
 npm run dev:nodetool -- storage migrate-keys --user-id <id> --json
 ```
 
+### nodetool auth
+
+Signs in to providers that use an account instead of an API key. `auth claude`
+runs the same OAuth flow the `claude` CLI does and writes the tokens to the
+Claude Agent SDK's credential file (`$CLAUDE_CONFIG_DIR/.credentials.json`,
+default `~/.claude/.credentials.json`), so a NodeTool login and a `claude login`
+are interchangeable — the Claude Agent provider picks it up with no extra
+configuration.
+
+```bash
+npm run dev:nodetool -- auth claude login          # browser + loopback callback
+npm run dev:nodetool -- auth claude login --manual # paste the code (headless/remote)
+npm run dev:nodetool -- auth claude login --console # Console (API-billed) account
+npm run dev:nodetool -- auth claude status
+npm run dev:nodetool -- auth claude refresh --force
+npm run dev:nodetool -- auth claude logout
+```
+
+The same flow is exposed over HTTP at
+`/api/oauth/claude/{start,complete,tokens,disconnect}` and as a sign-in card on
+the **Models & Providers** settings page. Details:
+[packages/runtime/src/providers/oauth/README.md](packages/runtime/src/providers/oauth/README.md).
+
 ### nodetool secrets
 
 ```bash

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -469,6 +469,22 @@ profile since it needs a local executable. Token usage is attributed to the
 concrete dated model the CLI resolves an alias to (captured from the
 `message_start` event) so cost maps onto Anthropic pricing.
 
+### Signing in
+
+`nodetool auth claude login` runs the same OAuth flow the `claude` CLI does
+(public client, PKCE, JSON token endpoint) and writes the tokens to
+`$CLAUDE_CONFIG_DIR/.credentials.json` — the file the SDK reads — so a NodeTool
+login and a `claude login` are interchangeable. On a headless or remote host,
+`--manual` skips the loopback listener and takes the `code#state` shown in the
+browser instead. The same flow is served at
+`/api/oauth/claude/{start,complete,tokens,disconnect}` and rendered as a sign-in
+card on the Models & Providers settings page. Implementation and protocol notes:
+[packages/runtime/src/providers/oauth/README.md](../packages/runtime/src/providers/oauth/README.md).
+
+`CLAUDE_CODE_OAUTH_TOKEN` remains the alternative on hosts with no interactive
+login; it is explicitly allowlisted through the nested-session env stripping
+below.
+
 **Soft dependency.** `@anthropic-ai/claude-agent-sdk` is an *optional peer
 dependency* of `@nodetool-ai/runtime` — it is not installed by default and must
 be added with the package manager (`npm install @anthropic-ai/claude-agent-sdk`)

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,182 @@
+/**
+ * `nodetool auth claude` — sign in with a Claude subscription for the Claude
+ * Agent provider.
+ *
+ * Runs the same OAuth flow the `claude` CLI does and writes the tokens to the
+ * Claude Agent SDK's credential file (`~/.claude/.credentials.json`), so a
+ * NodeTool login and a `claude login` are interchangeable. No database, no
+ * server — the SDK reads that file directly.
+ */
+
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import {
+  ClaudeCodeLogin,
+  DefaultBrowserLauncher
+} from "@nodetool-ai/runtime/oauth";
+
+import { asJson, printKv } from "./output.js";
+
+function fail(e: unknown): never {
+  console.error(String(e instanceof Error ? e.message : e));
+  process.exit(1);
+}
+
+/** Read one line from stdin, prompting on stderr so `--json` stays pipeable. */
+async function prompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await new Promise<string>((resolve) => {
+      process.stderr.write(question);
+      rl.question("", resolve);
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+function describeExpiry(expiresAt: number | null): string {
+  if (expiresAt == null) return "never";
+  return new Date(expiresAt).toISOString();
+}
+
+export function registerAuthCommands(program: Command): void {
+  const auth = program
+    .command("auth")
+    .description(
+      "Sign in to providers that use an account instead of an API key"
+    );
+
+  const claude = auth
+    .command("claude")
+    .description("Claude subscription login for the Claude Agent provider");
+
+  claude
+    .command("login")
+    .description("Sign in with a Claude subscription and store the credentials")
+    .option("--console", "Sign in with a Console (API-billed) account")
+    .option(
+      "--manual",
+      "Skip the loopback listener and paste the code shown in the browser"
+    )
+    .option("--no-browser", "Print the URL instead of opening a browser")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        console?: boolean;
+        manual?: boolean;
+        browser?: boolean;
+        json?: boolean;
+      }) => {
+        const login = new ClaudeCodeLogin();
+        try {
+          const pending = await login.begin({
+            loginMethod: opts.console ? "console" : "claude-ai",
+            manualOnly: opts.manual
+          });
+          const url = pending.authUrl ?? pending.manualAuthUrl;
+
+          if (opts.browser !== false) {
+            await new DefaultBrowserLauncher().open(url).catch(() => {
+              // No browser on this host — the printed URL is the fallback.
+            });
+          }
+          process.stderr.write(`\nOpen this URL to sign in:\n\n  ${url}\n\n`);
+
+          let credentials;
+          if (pending.authUrl) {
+            process.stderr.write(
+              "Waiting for the browser to redirect back (Ctrl-C to cancel)...\n"
+            );
+            credentials = await pending.waitForRedirect();
+          } else {
+            const code = await prompt("Paste the code shown in the browser > ");
+            credentials = await pending.completeWithPastedCode(code);
+          }
+
+          const summary = {
+            connected: true,
+            subscription_type: credentials.subscriptionType,
+            scopes: credentials.scopes.join(" "),
+            expires_at: describeExpiry(credentials.expiresAt),
+            credentials_path: login.credentialsPath
+          };
+          if (opts.json) {
+            asJson(summary);
+            return;
+          }
+          console.log("\nSigned in to Claude.");
+          printKv(summary);
+        } catch (e) {
+          fail(e);
+        }
+      }
+    );
+
+  claude
+    .command("status")
+    .description("Show whether Claude subscription credentials are stored")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      try {
+        const status = await new ClaudeCodeLogin().status();
+        const summary = {
+          connected: status.connected,
+          expired: status.expired,
+          subscription_type: status.subscriptionType,
+          rate_limit_tier: status.rateLimitTier,
+          scopes: status.scopes.join(" "),
+          expires_at: describeExpiry(status.expiresAt),
+          credentials_path: status.credentialsPath
+        };
+        if (opts.json) {
+          asJson(summary);
+          return;
+        }
+        if (!status.connected) {
+          console.log(
+            `Not signed in. Run 'nodetool auth claude login'. (${status.credentialsPath})`
+          );
+          return;
+        }
+        printKv(summary);
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  claude
+    .command("refresh")
+    .description("Refresh the stored access token")
+    .option("--force", "Refresh even when the current token is still valid")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { force?: boolean; json?: boolean }) => {
+      try {
+        const credentials = await new ClaudeCodeLogin().refresh({
+          force: opts.force
+        });
+        const summary = { expires_at: describeExpiry(credentials.expiresAt) };
+        if (opts.json) {
+          asJson(summary);
+          return;
+        }
+        printKv(summary);
+      } catch (e) {
+        fail(e);
+      }
+    });
+
+  claude
+    .command("logout")
+    .description("Remove the stored Claude subscription credentials")
+    .action(async () => {
+      try {
+        const removed = await new ClaudeCodeLogin().logout();
+        console.log(
+          removed ? "Signed out of Claude." : "No stored Claude credentials."
+        );
+      } catch (e) {
+        fail(e);
+      }
+    });
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -74,6 +74,7 @@ import { registerEvalCommand } from "./commands/eval.js";
 import { registerAffectedCommand } from "./commands/affected.js";
 import { registerCollectionCommands } from "./commands/collections.js";
 import { registerCostsCommands } from "./commands/costs.js";
+import { registerAuthCommands } from "./commands/auth.js";
 import {
   listAllModels,
   listConfiguredProviderInfo,
@@ -2184,6 +2185,7 @@ registerEvalCommand(program);
 registerAffectedCommand(program);
 registerCollectionCommands(program);
 registerCostsCommands(program);
+registerAuthCommands(program);
 
 // ---------------------------------------------------------------------------
 

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -1060,6 +1060,57 @@ export const CODEX_CALLBACK_PORT = 1455;
 export const CODEX_CALLBACK_PATH = "/auth/callback";
 
 /**
+ * Claude Code OAuth constants — the same public client and endpoints the
+ * `claude` CLI uses to sign in with a Claude subscription. Shared across
+ * packages so the login flow (`websocket`, `cli`) and the credential store
+ * (`runtime`) agree. The client is public: there is no client secret.
+ *
+ * The resulting tokens are written to the Claude Agent SDK's own credential
+ * file, so a NodeTool login and a `claude login` are interchangeable.
+ */
+export const CLAUDE_CODE_OAUTH_CLIENT_ID =
+  "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+/** Consumer sign-in page (claude.ai subscription accounts). */
+export const CLAUDE_CODE_OAUTH_AUTHORIZATION_URL =
+  "https://claude.com/cai/oauth/authorize";
+/** Console sign-in page (API-billed org accounts). */
+export const CLAUDE_CODE_OAUTH_CONSOLE_AUTHORIZATION_URL =
+  "https://platform.claude.com/oauth/authorize";
+export const CLAUDE_CODE_OAUTH_TOKEN_URL =
+  "https://platform.claude.com/v1/oauth/token";
+/**
+ * Redirect used when no loopback listener is reachable from the browser. The
+ * console shows the user a `<code>#<state>` string to paste back.
+ */
+export const CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL =
+  "https://platform.claude.com/oauth/code/callback";
+/** Path the loopback listener serves; the port is ephemeral. */
+export const CLAUDE_CODE_CALLBACK_PATH = "/callback";
+/** Scopes requested at login. */
+export const CLAUDE_CODE_OAUTH_SCOPES = [
+  "org:create_api_key",
+  "user:profile",
+  "user:inference",
+  "user:sessions:claude_code",
+  "user:mcp_servers",
+  "user:file_upload"
+] as const;
+/**
+ * Scopes sent on refresh. Narrower than the login set — the CLI drops
+ * `org:create_api_key`, which is only needed to mint an API key at login.
+ */
+export const CLAUDE_CODE_OAUTH_REFRESH_SCOPES = [
+  "user:profile",
+  "user:inference",
+  "user:sessions:claude_code",
+  "user:mcp_servers",
+  "user:file_upload"
+] as const;
+/** Profile endpoint used to label the account (plan tier, email). */
+export const CLAUDE_CODE_OAUTH_PROFILE_URL =
+  "https://api.anthropic.com/api/oauth/profile";
+
+/**
  * Provider identifier. Resolves to a known {@link PROVIDER_IDS} value with
  * editor autocompletion, but still accepts arbitrary strings — dynamic
  * sub-providers (OpenRouter, HuggingFace inference) and Python-bridged

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -1,4 +1,11 @@
-# OpenAI OAuth authentication
+# Provider OAuth authentication
+
+Two independent flows live here: the OpenAI/Codex login (below) and the
+[Claude Code login](#claude-code-login-claude-subscription), which share the
+protocol primitives (PKCE, loopback listener, typed errors, redaction) but
+persist to different stores.
+
+## OpenAI OAuth authentication
 
 Browser-based OAuth 2.0 (Authorization Code + PKCE) for the OpenAI provider, as
 an alternative to pasting a static API key. Every request is served by a
@@ -31,7 +38,10 @@ packages/runtime/src/providers/oauth/
 ├── browser-launcher.ts          BrowserLauncher — opens the system browser
 ├── secure-credential-store.ts   SecureCredentialStore — opaque secrets (OS keychain)
 ├── token-store.ts               TokenStore — token persistence over a credential store
-└── openai-oauth-provider.ts     OpenAIOAuthProvider — orchestration + OpenAI capabilities
+├── openai-oauth-provider.ts     OpenAIOAuthProvider — orchestration + OpenAI capabilities
+├── claude-code-oauth-client.ts  ClaudeCodeOAuthClient — Anthropic's JSON token endpoint
+├── claude-code-credentials.ts   ClaudeCodeCredentialsStore — ~/.claude/.credentials.json
+└── claude-code-login.ts         ClaudeCodeLogin — orchestration (loopback + manual paste)
 
 packages/runtime/tests/providers/oauth/
 ├── pkce-helper.test.ts              unit
@@ -40,7 +50,8 @@ packages/runtime/tests/providers/oauth/
 ├── redaction.test.ts                unit
 ├── local-callback-server.test.ts    unit (real loopback sockets)
 ├── openai-oauth-provider.test.ts    unit (orchestration with injected fakes)
-└── oauth-flow.integration.test.ts   integration (full flow over real sockets)
+├── oauth-flow.integration.test.ts   integration (full flow over real sockets)
+└── claude-code-oauth.test.ts        unit + loopback integration (Claude Code flow)
 ```
 
 ### Layering
@@ -241,3 +252,92 @@ server route — the API process binds the Codex loopback listener itself:
   "OpenAI Authentication" section with **Connect with OpenAI** / **Disconnect**
   buttons that open the auth URL and poll `/api/oauth/openai/tokens` for
   completion.
+
+## Claude Code login (Claude subscription)
+
+`ClaudeCodeLogin` signs in with a Claude Pro/Max subscription using the same
+public OAuth client the `claude` CLI uses, and writes the result to the file the
+Claude Agent SDK authenticates from. A NodeTool login and a `claude login` are
+therefore interchangeable: `ClaudeAgentProvider` needs no token plumbing, because
+the SDK's bundled binary reads the credentials itself.
+
+```
+ClaudeCodeLogin                       orchestration (begin → complete → persist)
+  ├─ ClaudeCodeOAuthClient            protocol: authorize URL, exchange, refresh, profile
+  ├─ PKCEHelper                       PKCE + CSRF state       (shared)
+  ├─ LocalCallbackServer              loopback receiver       (shared)
+  ├─ BrowserLauncher                  opens the browser       (shared)
+  └─ ClaudeCodeCredentialsStore       ~/.claude/.credentials.json
+```
+
+### Three deviations from RFC 6749
+
+Anthropic's server is not a stock OAuth 2.0 provider, which is why
+`ClaudeCodeOAuthClient` is a sibling of `OAuthClient` rather than a
+configuration of it:
+
+1. The token endpoint takes a **JSON** body, not `application/x-www-form-urlencoded`.
+2. The code exchange **echoes the CSRF `state`** in that body; without it the
+   exchange is rejected.
+3. The authorization URL carries an extra **`code=true`** flag, which asks the
+   server to also display a paste-able code.
+
+Refresh also narrows the scope set: `org:create_api_key` is requested at login
+(it lets the console mint an API key) but dropped on every refresh.
+
+### Two ways to finish one authorization request
+
+`begin()` mints one PKCE pair and state, then hands back both URLs:
+
+- **Loopback** (`authUrl`) — the browser is redirected to an ephemeral
+  `127.0.0.1` listener; the registered redirect uses the `localhost` spelling,
+  matching the CLI. Only works when the browser runs on this machine.
+- **Manual** (`manualAuthUrl`) — the console shows `<code>#<state>` to paste
+  back. The only option on a headless or remote host.
+
+They differ only in `redirect_uri`, which must match between the authorization
+request and the exchange — hence `waitForRedirect()` and
+`completeWithPastedCode()` are separate completions of the same pending login.
+
+### Credential file
+
+`$CLAUDE_CONFIG_DIR/.credentials.json` (default `~/.claude/.credentials.json`),
+mode `0600`, written through a same-directory temp file so a concurrent `claude`
+process never reads a half-written file. Keys the CLI owns are preserved; only
+`claudeAiOauth` is replaced:
+
+```json
+{
+  "claudeAiOauth": {
+    "accessToken": "…",
+    "refreshToken": "…",
+    "expiresAt": 1799999999000,
+    "scopes": ["user:profile", "user:inference", "…"],
+    "subscriptionType": "max",
+    "rateLimitTier": null
+  }
+}
+```
+
+Because that file is per-machine-user rather than per-NodeTool-user, the login is
+process-wide: it is the credential the server's own `claude` subprocess will use.
+
+`refresh()` exists for callers that need a live token *outside* the SDK (status
+display, `CLAUDE_CODE_OAUTH_TOKEN`). Running the provider does not require it —
+the CLI refreshes on its own.
+
+### Entry points
+
+```bash
+nodetool auth claude login      # --console, --manual, --no-browser, --json
+nodetool auth claude status
+nodetool auth claude refresh    # --force
+nodetool auth claude logout
+```
+
+Over HTTP, `packages/websocket/src/oauth-api.ts` exposes
+`/api/oauth/claude/{start,complete,tokens,disconnect}`. `start` binds the
+loopback listener and returns both URLs plus the state; `complete` takes a pasted
+code; `tokens` reports connection status in the shape the shared
+`useOAuthConnection` hook expects. The **Models & Providers** settings page
+renders a sign-in card for it.

--- a/packages/runtime/src/providers/oauth/claude-code-credentials.ts
+++ b/packages/runtime/src/providers/oauth/claude-code-credentials.ts
@@ -1,0 +1,185 @@
+/**
+ * ClaudeCodeCredentialsStore — reads and writes the credential file the Claude
+ * Agent SDK authenticates from.
+ *
+ * The SDK spawns the bundled `claude` binary, which loads its subscription
+ * credentials from `$CLAUDE_CONFIG_DIR/.credentials.json` (defaulting to
+ * `~/.claude/.credentials.json`) under a `claudeAiOauth` key. Writing that exact
+ * shape is the whole point of this module: a NodeTool login and a `claude login`
+ * produce interchangeable credentials, and {@link ClaudeAgentProvider} needs no
+ * token plumbing of its own.
+ *
+ * The file is not NodeTool's — other keys are preserved on write, and the mode
+ * is forced to 0600 to match what the CLI does.
+ */
+
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import type { ClaudeCodeTokens } from "./claude-code-oauth-client.js";
+
+/** The `claudeAiOauth` entry, field-for-field as the CLI writes it. */
+export interface ClaudeAiOAuthCredentials {
+  accessToken: string;
+  refreshToken: string | null;
+  /** Absolute expiry, epoch ms. */
+  expiresAt: number | null;
+  scopes: string[];
+  subscriptionType: string | null;
+  rateLimitTier: string | null;
+  /** Only set when a non-default OAuth client minted the token. */
+  clientId?: string;
+}
+
+/** The subset of the credential file this module understands. */
+interface CredentialsFile {
+  claudeAiOauth?: ClaudeAiOAuthCredentials;
+  [key: string]: unknown;
+}
+
+/** Owner-only file mode, matching the CLI. */
+const FILE_MODE = 0o600;
+
+export interface ClaudeCodeCredentialsStoreOptions {
+  /** Override the config directory. Defaults to `$CLAUDE_CONFIG_DIR` or `~/.claude`. */
+  readonly configDir?: string;
+  readonly logger?: Logger;
+}
+
+/**
+ * The directory the `claude` CLI keeps its state in. `CLAUDE_CONFIG_DIR` is the
+ * CLI's own override — honouring it keeps NodeTool pointed at the same profile
+ * the user's terminal sessions use.
+ */
+export function claudeConfigDir(): string {
+  const override = process.env.CLAUDE_CONFIG_DIR;
+  return override && override.length > 0
+    ? override
+    : join(homedir(), ".claude");
+}
+
+export class ClaudeCodeCredentialsStore {
+  private readonly configDir: string;
+  private readonly logger: Logger;
+
+  constructor(options: ClaudeCodeCredentialsStoreOptions = {}) {
+    this.configDir = options.configDir ?? claudeConfigDir();
+    this.logger =
+      options.logger ??
+      createLogger("nodetool.runtime.oauth.claude-credentials");
+  }
+
+  /** Absolute path of the credential file. */
+  get path(): string {
+    return join(this.configDir, ".credentials.json");
+  }
+
+  /** The stored OAuth credentials, or null when there is no usable login. */
+  async read(): Promise<ClaudeAiOAuthCredentials | null> {
+    const file = await this.readFile();
+    const oauth = file?.claudeAiOauth;
+    return oauth && typeof oauth.accessToken === "string" ? oauth : null;
+  }
+
+  /**
+   * Merge a fresh token set into the file, preserving any keys the CLI owns
+   * (and any profile metadata a previous login recorded).
+   */
+  async save(params: {
+    tokens: ClaudeCodeTokens;
+    subscriptionType?: string | null;
+    rateLimitTier?: string | null;
+    /** Set only for a non-default OAuth client. */
+    clientId?: string;
+  }): Promise<ClaudeAiOAuthCredentials> {
+    const file = (await this.readFile()) ?? {};
+    const previous = file.claudeAiOauth;
+    const credentials: ClaudeAiOAuthCredentials = {
+      accessToken: params.tokens.accessToken,
+      refreshToken:
+        params.tokens.refreshToken ?? previous?.refreshToken ?? null,
+      expiresAt: params.tokens.expiresAt,
+      scopes: [...params.tokens.scopes],
+      subscriptionType:
+        params.subscriptionType ?? previous?.subscriptionType ?? null,
+      rateLimitTier: params.rateLimitTier ?? previous?.rateLimitTier ?? null
+    };
+    if (params.clientId) credentials.clientId = params.clientId;
+
+    await this.writeFile({ ...file, claudeAiOauth: credentials });
+    return credentials;
+  }
+
+  /**
+   * Drop the OAuth entry. Other keys survive; the file itself is removed once
+   * nothing is left in it.
+   */
+  async clear(): Promise<boolean> {
+    const file = await this.readFile();
+    if (!file?.claudeAiOauth) return false;
+    const { claudeAiOauth: _removed, ...rest } = file;
+    if (Object.keys(rest).length === 0) {
+      await unlink(this.path).catch(() => {});
+    } else {
+      await this.writeFile(rest);
+    }
+    return true;
+  }
+
+  private async readFile(): Promise<CredentialsFile | null> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path, "utf8");
+    } catch {
+      return null;
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as CredentialsFile)
+        : null;
+    } catch {
+      this.logger.warn("Claude credential file is not valid JSON", {
+        path: this.path
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Write via a temp file in the same directory, so a concurrent `claude`
+   * process never observes a half-written credential file.
+   */
+  private async writeFile(contents: CredentialsFile): Promise<void> {
+    await mkdir(this.configDir, { recursive: true });
+    const tmp = `${this.path}.${process.pid}.tmp`;
+    await writeFile(tmp, `${JSON.stringify(contents, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: FILE_MODE
+    });
+    try {
+      await rename(tmp, this.path);
+    } catch (err) {
+      await unlink(tmp).catch(() => {});
+      throw err;
+    }
+    await chmod(this.path, FILE_MODE);
+  }
+}
+
+/** True when `expiresAt` has passed (or comes within `skewMs`). */
+export function isExpired(
+  credentials: Pick<ClaudeAiOAuthCredentials, "expiresAt">,
+  now: number,
+  skewMs = 60_000
+): boolean {
+  return credentials.expiresAt != null && credentials.expiresAt - skewMs <= now;
+}

--- a/packages/runtime/src/providers/oauth/claude-code-login.ts
+++ b/packages/runtime/src/providers/oauth/claude-code-login.ts
@@ -1,0 +1,335 @@
+/**
+ * ClaudeCodeLogin — orchestration for signing in with a Claude subscription,
+ * exactly as the `claude` CLI does it, and persisting the result where the
+ * Claude Agent SDK will find it.
+ *
+ * Two completion paths share one authorization request:
+ *
+ *  - **Loopback** — the browser is redirected to an ephemeral `127.0.0.1`
+ *    listener this process binds. Works when the browser runs on the same
+ *    machine as the server (desktop, local dev).
+ *  - **Manual** — the console shows a `<code>#<state>` string the user pastes
+ *    back. The only option on a headless or remote host.
+ *
+ * The two differ only in `redirect_uri`, which must match between the
+ * authorization request and the token exchange — hence the two URLs handed back
+ * from {@link ClaudeCodeLogin.begin} and the `manual` flag carried through to
+ * completion.
+ */
+
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import {
+  CLAUDE_CODE_CALLBACK_PATH,
+  CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL
+} from "@nodetool-ai/protocol";
+import {
+  ClaudeCodeCredentialsStore,
+  isExpired,
+  type ClaudeAiOAuthCredentials
+} from "./claude-code-credentials.js";
+import {
+  ClaudeCodeOAuthClient,
+  type ClaudeCodeLoginMethod,
+  type ClaudeCodeTokens
+} from "./claude-code-oauth-client.js";
+import {
+  NotAuthenticatedError,
+  OAuthError,
+  StateMismatchError
+} from "./errors.js";
+import { LocalCallbackServer } from "./local-callback-server.js";
+import { PKCEHelper } from "./pkce-helper.js";
+import { systemClock, type Clock } from "./types.js";
+
+/** How long a started login stays completable before the listener is torn down. */
+export const CLAUDE_LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface ClaudeCodeLoginOptions {
+  /** Sign in with a claude.ai subscription (default) or a console account. */
+  readonly loginMethod?: ClaudeCodeLoginMethod;
+  /**
+   * Skip the loopback listener entirely. Set on hosts where the browser can't
+   * reach this process — only the manual paste path will be offered.
+   */
+  readonly manualOnly?: boolean;
+  /** Abort waiting for the redirect. */
+  readonly timeoutMs?: number;
+}
+
+/** Non-secret summary of a stored login. */
+export interface ClaudeCodeAuthStatus {
+  readonly connected: boolean;
+  readonly expiresAt: number | null;
+  readonly expired: boolean;
+  readonly scopes: readonly string[];
+  readonly subscriptionType: string | null;
+  readonly rateLimitTier: string | null;
+  /** Where the credentials live, so the UI can point at the right file. */
+  readonly credentialsPath: string;
+}
+
+/** A login in progress: the URLs to open, and the two ways to finish it. */
+export interface PendingClaudeCodeLogin {
+  /** Authorization URL for the loopback flow. Null when `manualOnly`. */
+  readonly authUrl: string | null;
+  /** Authorization URL whose redirect shows a paste-able `code#state`. */
+  readonly manualAuthUrl: string;
+  /** CSRF state; the caller may key the pending login on it. */
+  readonly state: string;
+  /**
+   * Wait for the browser to hit the loopback listener, then exchange and
+   * persist. Rejects if the login was started with `manualOnly`.
+   */
+  waitForRedirect(signal?: AbortSignal): Promise<ClaudeAiOAuthCredentials>;
+  /**
+   * Finish from a pasted `code#state` (or a bare code plus the state this
+   * object carries). Exchanges against the manual redirect URI and persists.
+   */
+  completeWithPastedCode(input: string): Promise<ClaudeAiOAuthCredentials>;
+  /** Tear down the listener. Idempotent; safe to call after completion. */
+  cancel(): Promise<void>;
+}
+
+export interface ClaudeCodeLoginDeps {
+  readonly client?: ClaudeCodeOAuthClient;
+  readonly credentials?: ClaudeCodeCredentialsStore;
+  readonly pkce?: PKCEHelper;
+  /** Factory so tests can supply a fake listener. */
+  readonly callbackServerFactory?: () => LocalCallbackServer;
+  readonly clock?: Clock;
+  readonly logger?: Logger;
+}
+
+export class ClaudeCodeLogin {
+  private readonly client: ClaudeCodeOAuthClient;
+  private readonly credentials: ClaudeCodeCredentialsStore;
+  private readonly pkce: PKCEHelper;
+  private readonly callbackServerFactory: () => LocalCallbackServer;
+  private readonly clock: Clock;
+  private readonly logger: Logger;
+
+  constructor(deps: ClaudeCodeLoginDeps = {}) {
+    this.logger =
+      deps.logger ?? createLogger("nodetool.runtime.oauth.claude-login");
+    this.client =
+      deps.client ?? new ClaudeCodeOAuthClient({ logger: this.logger });
+    this.credentials =
+      deps.credentials ??
+      new ClaudeCodeCredentialsStore({ logger: this.logger });
+    this.pkce = deps.pkce ?? new PKCEHelper();
+    this.callbackServerFactory =
+      deps.callbackServerFactory ??
+      (() =>
+        new LocalCallbackServer({
+          host: "127.0.0.1",
+          path: CLAUDE_CODE_CALLBACK_PATH,
+          logger: this.logger
+        }));
+    this.clock = deps.clock ?? systemClock;
+  }
+
+  /** Where the credentials the SDK reads are stored. */
+  get credentialsPath(): string {
+    return this.credentials.path;
+  }
+
+  /**
+   * Start an authorization request. Binds the loopback listener (unless
+   * `manualOnly`) and returns both authorization URLs plus the handles to
+   * finish the flow. The caller owns teardown via `cancel()`.
+   */
+  async begin(
+    options: ClaudeCodeLoginOptions = {}
+  ): Promise<PendingClaudeCodeLogin> {
+    const { verifier, challenge } = await this.pkce.createPkcePair();
+    const state = await this.pkce.createState();
+    const timeoutMs = options.timeoutMs ?? CLAUDE_LOGIN_TIMEOUT_MS;
+
+    let server: LocalCallbackServer | null = null;
+    let loopbackRedirectUri: string | null = null;
+    if (!options.manualOnly) {
+      server = this.callbackServerFactory();
+      const { port } = await server.listen();
+      // The listener binds 127.0.0.1, but the registered redirect uses the
+      // `localhost` spelling the authorization server expects from the CLI.
+      loopbackRedirectUri = `http://localhost:${port}${CLAUDE_CODE_CALLBACK_PATH}`;
+    }
+
+    const manualAuthUrl = this.client.buildAuthorizationUrl({
+      codeChallenge: challenge,
+      state,
+      redirectUri: CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL,
+      loginMethod: options.loginMethod
+    });
+    const authUrl = loopbackRedirectUri
+      ? this.client.buildAuthorizationUrl({
+          codeChallenge: challenge,
+          state,
+          redirectUri: loopbackRedirectUri,
+          loginMethod: options.loginMethod
+        })
+      : null;
+
+    const cancel = async (): Promise<void> => {
+      const current = server;
+      server = null;
+      await current?.close().catch(() => {});
+    };
+
+    return {
+      authUrl,
+      manualAuthUrl,
+      state,
+      waitForRedirect: async (signal?: AbortSignal) => {
+        if (!server || !loopbackRedirectUri) {
+          throw new OAuthError(
+            "callback_timeout",
+            "This login was started without a loopback listener; paste the code instead"
+          );
+        }
+        try {
+          const result = await server.waitForCode({
+            expectedState: state,
+            timeoutMs,
+            signal
+          });
+          return await this.exchangeAndStore({
+            code: result.code,
+            state,
+            codeVerifier: verifier,
+            redirectUri: loopbackRedirectUri,
+            signal
+          });
+        } finally {
+          await cancel();
+        }
+      },
+      completeWithPastedCode: async (input: string) => {
+        const parsed = parsePastedCode(input, state);
+        try {
+          return await this.exchangeAndStore({
+            code: parsed.code,
+            state: parsed.state,
+            codeVerifier: verifier,
+            redirectUri: CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL
+          });
+        } finally {
+          await cancel();
+        }
+      },
+      cancel
+    };
+  }
+
+  /** Non-secret summary of the stored login. */
+  async status(): Promise<ClaudeCodeAuthStatus> {
+    const stored = await this.credentials.read();
+    if (!stored) {
+      return {
+        connected: false,
+        expiresAt: null,
+        expired: false,
+        scopes: [],
+        subscriptionType: null,
+        rateLimitTier: null,
+        credentialsPath: this.credentials.path
+      };
+    }
+    return {
+      connected: true,
+      expiresAt: stored.expiresAt,
+      expired: isExpired(stored, this.clock.now()),
+      scopes: stored.scopes ?? [],
+      subscriptionType: stored.subscriptionType ?? null,
+      rateLimitTier: stored.rateLimitTier ?? null,
+      credentialsPath: this.credentials.path
+    };
+  }
+
+  /**
+   * Refresh the stored access token. Returns the credentials unchanged when
+   * they are still valid, unless `force` is set.
+   *
+   * The `claude` CLI refreshes on its own, so this is for callers that need a
+   * usable token *outside* the SDK (status display, `CLAUDE_CODE_OAUTH_TOKEN`)
+   * rather than a prerequisite for running the provider.
+   */
+  async refresh(
+    options: { force?: boolean; signal?: AbortSignal } = {}
+  ): Promise<ClaudeAiOAuthCredentials> {
+    const stored = await this.credentials.read();
+    if (!stored)
+      throw new NotAuthenticatedError("No stored Claude credentials");
+    if (!options.force && !isExpired(stored, this.clock.now())) return stored;
+    if (!stored.refreshToken) {
+      throw new NotAuthenticatedError(
+        "Stored Claude credentials have no refresh token; sign in again"
+      );
+    }
+    const tokens = await this.client.refreshAccessToken(
+      stored.refreshToken,
+      options.signal
+    );
+    return this.credentials.save({ tokens });
+  }
+
+  /** Remove the stored login. Returns false when there was nothing to remove. */
+  async logout(): Promise<boolean> {
+    return this.credentials.clear();
+  }
+
+  private async exchangeAndStore(params: {
+    code: string;
+    state: string;
+    codeVerifier: string;
+    redirectUri: string;
+    signal?: AbortSignal;
+  }): Promise<ClaudeAiOAuthCredentials> {
+    const tokens: ClaudeCodeTokens =
+      await this.client.exchangeAuthorizationCode(params);
+    const profile = await this.client.fetchProfile(
+      tokens.accessToken,
+      params.signal
+    );
+    const saved = await this.credentials.save({
+      tokens,
+      subscriptionType: profile?.subscriptionType ?? null,
+      rateLimitTier: profile?.rateLimitTier ?? null
+    });
+    this.logger.info("Claude Code login completed", {
+      subscriptionType: saved.subscriptionType,
+      scopes: saved.scopes,
+      credentialsPath: this.credentials.path
+    });
+    return saved;
+  }
+}
+
+/**
+ * Parse what the console shows after a manual authorization: `<code>#<state>`.
+ * A bare code is accepted too, falling back to the state of the login it is
+ * completing — but a mismatched state is a CSRF signal and always rejected.
+ */
+export function parsePastedCode(
+  input: string,
+  expectedState: string
+): { code: string; state: string } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new OAuthError(
+      "authorization_denied",
+      "No authorization code provided"
+    );
+  }
+  const [code, state] = trimmed.split("#", 2);
+  if (!code) {
+    throw new OAuthError(
+      "authorization_denied",
+      "No authorization code provided"
+    );
+  }
+  if (state !== undefined && state !== expectedState) {
+    throw new StateMismatchError();
+  }
+  return { code, state: expectedState };
+}

--- a/packages/runtime/src/providers/oauth/claude-code-oauth-client.ts
+++ b/packages/runtime/src/providers/oauth/claude-code-oauth-client.ts
@@ -1,0 +1,364 @@
+/**
+ * ClaudeCodeOAuthClient — the protocol layer for the Claude Code login.
+ *
+ * Anthropic's OAuth server does not follow RFC 6749's form-encoded token
+ * endpoint: the `claude` CLI posts a JSON body and echoes the CSRF `state` back
+ * in the code exchange, and the authorization URL carries an extra `code=true`
+ * flag. Those three deviations are why this is a sibling of {@link OAuthClient}
+ * rather than a configuration of it; everything else (typed errors, redaction,
+ * injected fetch/clock, never logging token material) is shared.
+ */
+
+import { createLogger, type Logger } from "@nodetool-ai/config";
+import {
+  CLAUDE_CODE_OAUTH_AUTHORIZATION_URL,
+  CLAUDE_CODE_OAUTH_CLIENT_ID,
+  CLAUDE_CODE_OAUTH_CONSOLE_AUTHORIZATION_URL,
+  CLAUDE_CODE_OAUTH_PROFILE_URL,
+  CLAUDE_CODE_OAUTH_REFRESH_SCOPES,
+  CLAUDE_CODE_OAUTH_SCOPES,
+  CLAUDE_CODE_OAUTH_TOKEN_URL
+} from "@nodetool-ai/protocol";
+import {
+  CredentialsRevokedError,
+  InvalidRefreshTokenError,
+  OAuthError,
+  OAuthNetworkError,
+  TokenExchangeError
+} from "./errors.js";
+import { redactObject } from "./redaction.js";
+import { type Clock, systemClock } from "./types.js";
+
+/** Minimal `fetch` surface this client needs — satisfied by global `fetch`. */
+export type JsonFetchLike = (
+  input: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  }
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+/** Which sign-in page the authorization URL points at. */
+export type ClaudeCodeLoginMethod = "claude-ai" | "console";
+
+/**
+ * A Claude Code token set. Shaped like the credential file's `claudeAiOauth`
+ * entry rather than {@link OAuthTokens}, because that file — not an in-memory
+ * session — is the thing this flow exists to produce.
+ */
+export interface ClaudeCodeTokens {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  /** Absolute expiry in epoch ms, or null when the server sends no expiry. */
+  readonly expiresAt: number | null;
+  readonly scopes: readonly string[];
+  /** Account/organization identity echoed by the token endpoint, if any. */
+  readonly account: ClaudeCodeTokenAccount | null;
+}
+
+export interface ClaudeCodeTokenAccount {
+  readonly uuid: string | null;
+  readonly emailAddress: string | null;
+  readonly organizationUuid: string | null;
+}
+
+/** Non-secret account metadata used to label the connection in the UI. */
+export interface ClaudeCodeProfile {
+  /** "max" | "pro" | "team" | "enterprise", or null for API-billed orgs. */
+  readonly subscriptionType: string | null;
+  readonly rateLimitTier: string | null;
+  readonly emailAddress: string | null;
+  readonly displayName: string | null;
+  readonly organizationName: string | null;
+}
+
+export interface AuthorizationUrlOptions {
+  readonly codeChallenge: string;
+  readonly state: string;
+  /**
+   * Loopback redirect the browser is sent back to. Omit for the manual flow,
+   * where the console displays a `code#state` string for the user to paste.
+   */
+  readonly redirectUri: string;
+  /** claude.ai (subscription) or the console (API billing). Default claude.ai. */
+  readonly loginMethod?: ClaudeCodeLoginMethod;
+}
+
+export interface ClaudeCodeOAuthClientOptions {
+  /** Override the published Claude Code client id. */
+  readonly clientId?: string;
+  readonly tokenEndpoint?: string;
+  readonly profileEndpoint?: string;
+  /** Injected fetch. Defaults to the global. */
+  readonly fetchFn?: JsonFetchLike;
+  readonly clock?: Clock;
+  readonly logger?: Logger;
+}
+
+/** Raw token-endpoint response. Every field is validated before use. */
+interface ClaudeTokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+  scope?: unknown;
+  account?: { uuid?: unknown; email_address?: unknown } | null;
+  organization?: { uuid?: unknown } | null;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export class ClaudeCodeOAuthClient {
+  private readonly clientId: string;
+  private readonly tokenEndpoint: string;
+  private readonly profileEndpoint: string;
+  private readonly fetchFn: JsonFetchLike;
+  private readonly clock: Clock;
+  private readonly logger: Logger;
+
+  constructor(options: ClaudeCodeOAuthClientOptions = {}) {
+    this.clientId = options.clientId ?? CLAUDE_CODE_OAUTH_CLIENT_ID;
+    this.tokenEndpoint = options.tokenEndpoint ?? CLAUDE_CODE_OAUTH_TOKEN_URL;
+    this.profileEndpoint =
+      options.profileEndpoint ?? CLAUDE_CODE_OAUTH_PROFILE_URL;
+    this.fetchFn = options.fetchFn ?? (globalThis.fetch as JsonFetchLike);
+    this.clock = options.clock ?? systemClock;
+    this.logger =
+      options.logger ?? createLogger("nodetool.runtime.oauth.claude-code");
+  }
+
+  /** Build the authorization-endpoint URL the browser should open. */
+  buildAuthorizationUrl(options: AuthorizationUrlOptions): string {
+    const base =
+      options.loginMethod === "console"
+        ? CLAUDE_CODE_OAUTH_CONSOLE_AUTHORIZATION_URL
+        : CLAUDE_CODE_OAUTH_AUTHORIZATION_URL;
+    const url = new URL(base);
+    const q = url.searchParams;
+    // `code=true` asks the server for the paste-able code display in addition
+    // to the redirect — the CLI sets it on both variants of the URL.
+    q.set("code", "true");
+    q.set("client_id", this.clientId);
+    q.set("response_type", "code");
+    q.set("redirect_uri", options.redirectUri);
+    q.set("scope", CLAUDE_CODE_OAUTH_SCOPES.join(" "));
+    q.set("code_challenge", options.codeChallenge);
+    q.set("code_challenge_method", "S256");
+    q.set("state", options.state);
+    return url.toString();
+  }
+
+  /**
+   * Exchange an authorization code for a token set. `redirectUri` must be the
+   * exact value used in the authorization request, and `state` is echoed back
+   * in the body — Anthropic's token endpoint rejects the exchange without it.
+   */
+  async exchangeAuthorizationCode(params: {
+    code: string;
+    state: string;
+    codeVerifier: string;
+    redirectUri: string;
+    signal?: AbortSignal;
+  }): Promise<ClaudeCodeTokens> {
+    return this.tokenRequest(
+      {
+        grant_type: "authorization_code",
+        code: params.code,
+        redirect_uri: params.redirectUri,
+        client_id: this.clientId,
+        code_verifier: params.codeVerifier,
+        state: params.state
+      },
+      params.signal,
+      "exchange"
+    );
+  }
+
+  /** Exchange a refresh token for a fresh access token. */
+  async refreshAccessToken(
+    refreshToken: string,
+    signal?: AbortSignal
+  ): Promise<ClaudeCodeTokens> {
+    const tokens = await this.tokenRequest(
+      {
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+        scope: CLAUDE_CODE_OAUTH_REFRESH_SCOPES.join(" ")
+      },
+      signal,
+      "refresh"
+    );
+    // The server may omit `refresh_token` on refresh; the old one stays valid.
+    return tokens.refreshToken ? tokens : { ...tokens, refreshToken };
+  }
+
+  /**
+   * Best-effort account lookup for a friendly label. Returns null when the
+   * endpoint is unreachable or the token lacks `user:profile` — a missing
+   * label must never fail a login.
+   */
+  async fetchProfile(
+    accessToken: string,
+    signal?: AbortSignal
+  ): Promise<ClaudeCodeProfile | null> {
+    try {
+      const res = await this.fetchFn(this.profileEndpoint, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: "application/json"
+        },
+        signal: signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as {
+        account?: { email_address?: unknown; display_name?: unknown } | null;
+        organization?: {
+          organization_type?: unknown;
+          rate_limit_tier?: unknown;
+          name?: unknown;
+        } | null;
+      };
+      return {
+        subscriptionType: subscriptionTypeOf(
+          body.organization?.organization_type
+        ),
+        rateLimitTier: str(body.organization?.rate_limit_tier),
+        emailAddress: str(body.account?.email_address),
+        displayName: str(body.account?.display_name),
+        organizationName: str(body.organization?.name)
+      };
+    } catch (err) {
+      this.logger.debug("Claude Code profile lookup failed", {
+        error: err instanceof Error ? err.message : String(err)
+      });
+      return null;
+    }
+  }
+
+  private async tokenRequest(
+    body: Record<string, string>,
+    signal: AbortSignal | undefined,
+    kind: "exchange" | "refresh"
+  ): Promise<ClaudeCodeTokens> {
+    let res: Awaited<ReturnType<JsonFetchLike>>;
+    try {
+      res = await this.fetchFn(this.tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json"
+        },
+        body: JSON.stringify(body),
+        signal: signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+      });
+    } catch (err) {
+      throw new OAuthNetworkError(`Network error during token ${kind}`, {
+        cause: err
+      });
+    }
+
+    let payload: ClaudeTokenResponse;
+    try {
+      payload = (await res.json()) as ClaudeTokenResponse;
+    } catch {
+      payload = {};
+    }
+
+    if (!res.ok) throw this.mapErrorResponse(res.status, payload, kind);
+    return this.normalizeTokens(payload, kind);
+  }
+
+  private mapErrorResponse(
+    status: number,
+    payload: ClaudeTokenResponse,
+    kind: string
+  ): OAuthError {
+    const code = str(payload.error);
+    // Never include the raw body in the message; log a redacted copy instead.
+    this.logger.warn("Claude token endpoint returned an error", {
+      status,
+      kind,
+      error: code,
+      body: redactObject(payload)
+    });
+
+    const message = `Token ${kind} failed: ${code ?? status}`;
+    if (code === "invalid_grant" || status === 401) {
+      return kind === "refresh"
+        ? new InvalidRefreshTokenError(message)
+        : new TokenExchangeError(
+            "Authentication failed: invalid or expired authorization code"
+          );
+    }
+    if (code === "access_denied" || code === "invalid_client") {
+      return new CredentialsRevokedError(message);
+    }
+    if (status >= 500) {
+      return new OAuthNetworkError(
+        `Token ${kind} failed: server error ${status}`
+      );
+    }
+    return new TokenExchangeError(message);
+  }
+
+  private normalizeTokens(
+    payload: ClaudeTokenResponse,
+    kind: string
+  ): ClaudeCodeTokens {
+    const accessToken = str(payload.access_token);
+    if (!accessToken) {
+      throw new TokenExchangeError(
+        `Token ${kind} response missing access_token`
+      );
+    }
+    const expiresIn =
+      typeof payload.expires_in === "number" ? payload.expires_in : null;
+    const scope = str(payload.scope);
+    const accountUuid = str(payload.account?.uuid);
+    const email = str(payload.account?.email_address);
+    const orgUuid = str(payload.organization?.uuid);
+    return {
+      accessToken,
+      refreshToken: str(payload.refresh_token),
+      expiresAt: expiresIn != null ? this.clock.now() + expiresIn * 1000 : null,
+      scopes: scope ? scope.split(" ").filter(Boolean) : [],
+      account:
+        accountUuid || email || orgUuid
+          ? {
+              uuid: accountUuid,
+              emailAddress: email,
+              organizationUuid: orgUuid
+            }
+          : null
+    };
+  }
+}
+
+/** Map the API's organization type onto the plan label the CLI displays. */
+function subscriptionTypeOf(organizationType: unknown): string | null {
+  switch (organizationType) {
+    case "claude_max":
+      return "max";
+    case "claude_pro":
+      return "pro";
+    case "claude_team":
+      return "team";
+    case "claude_enterprise":
+      return "enterprise";
+    default:
+      return null;
+  }
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/packages/runtime/src/providers/oauth/index.ts
+++ b/packages/runtime/src/providers/oauth/index.ts
@@ -67,6 +67,30 @@ export {
   type OpenAIOAuthProviderOptions,
   type LoginOptions
 } from "./openai-oauth-provider.js";
+export {
+  ClaudeCodeOAuthClient,
+  type AuthorizationUrlOptions,
+  type ClaudeCodeLoginMethod,
+  type ClaudeCodeProfile,
+  type ClaudeCodeTokenAccount,
+  type ClaudeCodeTokens,
+  type JsonFetchLike
+} from "./claude-code-oauth-client.js";
+export {
+  ClaudeCodeCredentialsStore,
+  claudeConfigDir,
+  isExpired as areClaudeCredentialsExpired,
+  type ClaudeAiOAuthCredentials
+} from "./claude-code-credentials.js";
+export {
+  ClaudeCodeLogin,
+  parsePastedCode,
+  CLAUDE_LOGIN_TIMEOUT_MS,
+  type ClaudeCodeAuthStatus,
+  type ClaudeCodeLoginDeps,
+  type ClaudeCodeLoginOptions,
+  type PendingClaudeCodeLogin
+} from "./claude-code-login.js";
 
 /**
  * Default OAuth endpoints for OpenAI. These are configuration, not contracts —

--- a/packages/runtime/tests/providers/oauth/claude-code-oauth.test.ts
+++ b/packages/runtime/tests/providers/oauth/claude-code-oauth.test.ts
@@ -1,0 +1,479 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CLAUDE_CODE_OAUTH_CLIENT_ID,
+  CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL,
+  CLAUDE_CODE_OAUTH_TOKEN_URL
+} from "@nodetool-ai/protocol";
+import {
+  ClaudeCodeOAuthClient,
+  type JsonFetchLike
+} from "../../../src/providers/oauth/claude-code-oauth-client.js";
+import {
+  ClaudeCodeCredentialsStore,
+  isExpired
+} from "../../../src/providers/oauth/claude-code-credentials.js";
+import {
+  ClaudeCodeLogin,
+  parsePastedCode
+} from "../../../src/providers/oauth/claude-code-login.js";
+import {
+  InvalidRefreshTokenError,
+  StateMismatchError,
+  TokenExchangeError
+} from "../../../src/providers/oauth/errors.js";
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** A fetch double that records calls and replays queued responses. */
+function fakeFetch(
+  responses: Array<{ ok: boolean; status: number; body: unknown }>
+): JsonFetchLike & { calls: RecordedRequest[] } {
+  const calls: RecordedRequest[] = [];
+  const fn = (async (url, init) => {
+    calls.push({
+      url,
+      method: init.method,
+      headers: init.headers,
+      body: init.body ? JSON.parse(init.body) : undefined
+    });
+    const next = responses.shift();
+    if (!next) throw new Error(`Unexpected request to ${url}`);
+    return {
+      ok: next.ok,
+      status: next.status,
+      json: async () => next.body
+    };
+  }) as JsonFetchLike & { calls: RecordedRequest[] };
+  fn.calls = calls;
+  return fn;
+}
+
+const tokenResponse = {
+  access_token: "access-1",
+  refresh_token: "refresh-1",
+  expires_in: 3600,
+  scope: "user:profile user:inference",
+  account: { uuid: "acct-1", email_address: "dev@example.com" },
+  organization: { uuid: "org-1" }
+};
+
+describe("ClaudeCodeOAuthClient", () => {
+  it("builds the authorization URL the Claude CLI sends", async () => {
+    const client = new ClaudeCodeOAuthClient({ fetchFn: fakeFetch([]) });
+    const url = new URL(
+      client.buildAuthorizationUrl({
+        codeChallenge: "challenge",
+        state: "state-1",
+        redirectUri: "http://localhost:4321/callback"
+      })
+    );
+
+    expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize");
+    expect(url.searchParams.get("code")).toBe("true");
+    expect(url.searchParams.get("client_id")).toBe(CLAUDE_CODE_OAUTH_CLIENT_ID);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:4321/callback"
+    );
+    expect(url.searchParams.get("code_challenge")).toBe("challenge");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("state-1");
+    expect(url.searchParams.get("scope")).toContain("user:inference");
+  });
+
+  it("points at the console for a console login", () => {
+    const client = new ClaudeCodeOAuthClient({ fetchFn: fakeFetch([]) });
+    const url = client.buildAuthorizationUrl({
+      codeChallenge: "c",
+      state: "s",
+      redirectUri: CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL,
+      loginMethod: "console"
+    });
+    expect(url.startsWith("https://platform.claude.com/oauth/authorize")).toBe(true);
+  });
+
+  it("posts a JSON body carrying the CSRF state on code exchange", async () => {
+    const fetchFn = fakeFetch([{ ok: true, status: 200, body: tokenResponse }]);
+    const client = new ClaudeCodeOAuthClient({
+      fetchFn,
+      clock: { now: () => 1_000 }
+    });
+
+    const tokens = await client.exchangeAuthorizationCode({
+      code: "code-1",
+      state: "state-1",
+      codeVerifier: "verifier-1",
+      redirectUri: "http://localhost:4321/callback"
+    });
+
+    const [call] = fetchFn.calls;
+    expect(call.url).toBe(CLAUDE_CODE_OAUTH_TOKEN_URL);
+    expect(call.headers["content-type"]).toBe("application/json");
+    expect(call.body).toEqual({
+      grant_type: "authorization_code",
+      code: "code-1",
+      redirect_uri: "http://localhost:4321/callback",
+      client_id: CLAUDE_CODE_OAUTH_CLIENT_ID,
+      code_verifier: "verifier-1",
+      state: "state-1"
+    });
+
+    expect(tokens.accessToken).toBe("access-1");
+    expect(tokens.refreshToken).toBe("refresh-1");
+    expect(tokens.expiresAt).toBe(1_000 + 3_600_000);
+    expect(tokens.scopes).toEqual(["user:profile", "user:inference"]);
+    expect(tokens.account).toEqual({
+      uuid: "acct-1",
+      emailAddress: "dev@example.com",
+      organizationUuid: "org-1"
+    });
+  });
+
+  it("reuses the old refresh token when the server omits one", async () => {
+    const fetchFn = fakeFetch([
+      {
+        ok: true,
+        status: 200,
+        body: { access_token: "access-2", expires_in: 60, scope: "user:inference" }
+      }
+    ]);
+    const client = new ClaudeCodeOAuthClient({ fetchFn });
+
+    const tokens = await client.refreshAccessToken("refresh-1");
+
+    expect(tokens.accessToken).toBe("access-2");
+    expect(tokens.refreshToken).toBe("refresh-1");
+    expect(fetchFn.calls[0].body).toMatchObject({
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1"
+    });
+    // `org:create_api_key` is a login-only scope; refresh must not ask for it.
+    expect(
+      (fetchFn.calls[0].body as { scope: string }).scope
+    ).not.toContain("org:create_api_key");
+  });
+
+  it("maps a 401 exchange to a token-exchange error without leaking the body", async () => {
+    const client = new ClaudeCodeOAuthClient({
+      fetchFn: fakeFetch([
+        { ok: false, status: 401, body: { error: "invalid_grant", secret: "x" } }
+      ])
+    });
+    await expect(
+      client.exchangeAuthorizationCode({
+        code: "bad",
+        state: "s",
+        codeVerifier: "v",
+        redirectUri: "http://localhost:1/callback"
+      })
+    ).rejects.toBeInstanceOf(TokenExchangeError);
+  });
+
+  it("maps a rejected refresh to InvalidRefreshTokenError", async () => {
+    const client = new ClaudeCodeOAuthClient({
+      fetchFn: fakeFetch([
+        { ok: false, status: 400, body: { error: "invalid_grant" } }
+      ])
+    });
+    await expect(client.refreshAccessToken("stale")).rejects.toBeInstanceOf(
+      InvalidRefreshTokenError
+    );
+  });
+
+  it("returns null rather than failing when the profile lookup errors", async () => {
+    const client = new ClaudeCodeOAuthClient({
+      fetchFn: fakeFetch([{ ok: false, status: 403, body: {} }])
+    });
+    expect(await client.fetchProfile("access-1")).toBeNull();
+  });
+
+  it("maps the organization type onto the plan label", async () => {
+    const client = new ClaudeCodeOAuthClient({
+      fetchFn: fakeFetch([
+        {
+          ok: true,
+          status: 200,
+          body: {
+            account: { email_address: "dev@example.com", display_name: "Dev" },
+            organization: { organization_type: "claude_max", rate_limit_tier: "t1" }
+          }
+        }
+      ])
+    });
+    expect(await client.fetchProfile("access-1")).toMatchObject({
+      subscriptionType: "max",
+      rateLimitTier: "t1",
+      emailAddress: "dev@example.com"
+    });
+  });
+});
+
+describe("ClaudeCodeCredentialsStore", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "claude-creds-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes the claudeAiOauth shape the Claude Agent SDK reads", async () => {
+    const store = new ClaudeCodeCredentialsStore({ configDir: dir });
+    await store.save({
+      tokens: {
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        expiresAt: 1_700_000_000_000,
+        scopes: ["user:inference"],
+        account: null
+      },
+      subscriptionType: "max"
+    });
+
+    const raw = JSON.parse(await readFile(join(dir, ".credentials.json"), "utf8"));
+    expect(raw).toEqual({
+      claudeAiOauth: {
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        expiresAt: 1_700_000_000_000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+        rateLimitTier: null
+      }
+    });
+  });
+
+  it("stores the file owner-only", async () => {
+    const store = new ClaudeCodeCredentialsStore({ configDir: dir });
+    await store.save({
+      tokens: {
+        accessToken: "a",
+        refreshToken: null,
+        expiresAt: null,
+        scopes: [],
+        account: null
+      }
+    });
+    const mode = (await stat(store.path)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("preserves keys the CLI owns and carries the old refresh token forward", async () => {
+    const path = join(dir, ".credentials.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        somethingElse: { keep: true },
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "refresh-1",
+          expiresAt: 1,
+          scopes: ["user:inference"],
+          subscriptionType: "pro",
+          rateLimitTier: "t1"
+        }
+      })
+    );
+
+    const store = new ClaudeCodeCredentialsStore({ configDir: dir });
+    const saved = await store.save({
+      tokens: {
+        accessToken: "new",
+        // A refresh response that omits the token must not erase the stored one.
+        refreshToken: null,
+        expiresAt: 2,
+        scopes: ["user:inference"],
+        account: null
+      }
+    });
+
+    expect(saved.refreshToken).toBe("refresh-1");
+    expect(saved.subscriptionType).toBe("pro");
+    const raw = JSON.parse(await readFile(path, "utf8"));
+    expect(raw.somethingElse).toEqual({ keep: true });
+  });
+
+  it("clears the OAuth entry and removes an otherwise-empty file", async () => {
+    const store = new ClaudeCodeCredentialsStore({ configDir: dir });
+    expect(await store.clear()).toBe(false);
+    await store.save({
+      tokens: {
+        accessToken: "a",
+        refreshToken: null,
+        expiresAt: null,
+        scopes: [],
+        account: null
+      }
+    });
+    expect(await store.clear()).toBe(true);
+    expect(await store.read()).toBeNull();
+    await expect(stat(store.path)).rejects.toThrow();
+  });
+
+  it("treats a token inside the expiry skew as expired", () => {
+    expect(isExpired({ expiresAt: 1_000 }, 0, 60_000)).toBe(true);
+    expect(isExpired({ expiresAt: 100_000 }, 0, 60_000)).toBe(false);
+    expect(isExpired({ expiresAt: null }, Number.MAX_SAFE_INTEGER)).toBe(false);
+  });
+});
+
+describe("parsePastedCode", () => {
+  it("splits the code#state the console displays", () => {
+    expect(parsePastedCode("  the-code#the-state  ", "the-state")).toEqual({
+      code: "the-code",
+      state: "the-state"
+    });
+  });
+
+  it("accepts a bare code and adopts the pending state", () => {
+    expect(parsePastedCode("the-code", "the-state")).toEqual({
+      code: "the-code",
+      state: "the-state"
+    });
+  });
+
+  it("rejects a mismatched state", () => {
+    expect(() => parsePastedCode("the-code#wrong", "the-state")).toThrow(
+      StateMismatchError
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => parsePastedCode("   ", "s")).toThrow();
+  });
+});
+
+describe("ClaudeCodeLogin", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "claude-login-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function login(
+    responses: Array<{ ok: boolean; status: number; body: unknown }>
+  ): { login: ClaudeCodeLogin; fetchFn: ReturnType<typeof fakeFetch> } {
+    const fetchFn = fakeFetch(responses);
+    return {
+      fetchFn,
+      login: new ClaudeCodeLogin({
+        client: new ClaudeCodeOAuthClient({ fetchFn }),
+        credentials: new ClaudeCodeCredentialsStore({ configDir: dir })
+      })
+    };
+  }
+
+  it("reports a disconnected status when nothing is stored", async () => {
+    const { login: flow } = login([]);
+    const status = await flow.status();
+    expect(status.connected).toBe(false);
+    expect(status.credentialsPath).toBe(join(dir, ".credentials.json"));
+  });
+
+  it("completes a manual login and persists SDK-compatible credentials", async () => {
+    const { login: flow, fetchFn } = login([
+      { ok: true, status: 200, body: tokenResponse },
+      {
+        ok: true,
+        status: 200,
+        body: { organization: { organization_type: "claude_pro" } }
+      }
+    ]);
+
+    const pending = await flow.begin({ manualOnly: true });
+    expect(pending.authUrl).toBeNull();
+    expect(pending.manualAuthUrl).toContain(
+      encodeURIComponent(CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL)
+    );
+
+    const saved = await pending.completeWithPastedCode(
+      `the-code#${pending.state}`
+    );
+
+    expect(saved.accessToken).toBe("access-1");
+    expect(saved.subscriptionType).toBe("pro");
+    // The manual path must exchange against the manual redirect URI.
+    expect(fetchFn.calls[0].body).toMatchObject({
+      redirect_uri: CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL,
+      state: pending.state
+    });
+
+    const status = await flow.status();
+    expect(status.connected).toBe(true);
+    expect(status.subscriptionType).toBe("pro");
+  });
+
+  it("completes a loopback login against the bound ephemeral port", async () => {
+    const { login: flow, fetchFn } = login([
+      { ok: true, status: 200, body: tokenResponse },
+      { ok: false, status: 404, body: {} }
+    ]);
+
+    const pending = await flow.begin();
+    const authUrl = new URL(pending.authUrl!);
+    const redirectUri = authUrl.searchParams.get("redirect_uri")!;
+    expect(redirectUri).toMatch(/^http:\/\/localhost:\d+\/callback$/);
+
+    const waiting = pending.waitForRedirect();
+    // Drive the flow the way the browser would.
+    const callback = new URL(redirectUri);
+    callback.hostname = "127.0.0.1";
+    callback.searchParams.set("code", "the-code");
+    callback.searchParams.set("state", pending.state);
+    await fetch(callback.toString());
+
+    const saved = await waiting;
+    expect(saved.accessToken).toBe("access-1");
+    expect(fetchFn.calls[0].body).toMatchObject({ redirect_uri: redirectUri });
+  });
+
+  it("refreshes only when the stored token is near expiry", async () => {
+    const store = new ClaudeCodeCredentialsStore({ configDir: dir });
+    await store.save({
+      tokens: {
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        expiresAt: Date.now() + 3_600_000,
+        scopes: ["user:inference"],
+        account: null
+      }
+    });
+
+    const fetchFn = fakeFetch([
+      {
+        ok: true,
+        status: 200,
+        body: { access_token: "access-2", expires_in: 3600, scope: "user:inference" }
+      }
+    ]);
+    const flow = new ClaudeCodeLogin({
+      client: new ClaudeCodeOAuthClient({ fetchFn }),
+      credentials: store
+    });
+
+    expect((await flow.refresh()).accessToken).toBe("access-1");
+    expect(fetchFn.calls).toHaveLength(0);
+
+    expect((await flow.refresh({ force: true })).accessToken).toBe("access-2");
+    expect((await store.read())?.refreshToken).toBe("refresh-1");
+  });
+
+  it("refuses to refresh without a stored login", async () => {
+    const { login: flow } = login([]);
+    await expect(flow.refresh()).rejects.toThrow(/No stored Claude credentials/);
+  });
+});

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -17,11 +17,13 @@ import {
 import {
   OAuthClient,
   LocalCallbackServer,
+  ClaudeCodeLogin,
   extractChatGptAccountId,
   CODEX_OAUTH_CLIENT_ID,
   CODEX_CALLBACK_PORT,
   CODEX_CALLBACK_PATH,
-  DEFAULT_CODEX_OAUTH_CONFIG
+  DEFAULT_CODEX_OAUTH_CONFIG,
+  type PendingClaudeCodeLogin
 } from "@nodetool-ai/runtime/oauth";
 
 const logger = createLogger("nodetool.websocket.oauth");
@@ -1024,6 +1026,148 @@ async function handleOpenAIDisconnect(
   return jsonResponse({ success: true, removed: credentials.length });
 }
 
+// ── Claude (subscription) Endpoints ──────────────────────────────────
+//
+// Signs in with a Claude subscription using the same public OAuth client the
+// `claude` CLI uses, and writes the tokens to the Claude Agent SDK's credential
+// file (`~/.claude/.credentials.json`). That file — not the database — is the
+// store, because the SDK spawns the `claude` binary as this process's user and
+// reads it directly; a per-user DB row would be invisible to it.
+//
+// Two ways to finish, both from the one authorization request `start` creates:
+// the browser redirects to a loopback listener this process binds (same-machine
+// hosts), or the user pastes the `code#state` the console displays (headless and
+// remote hosts). The UI reflects success by polling `/api/oauth/claude/tokens`.
+
+/** The single in-flight login, so a re-click supersedes a stale listener. */
+let activeClaudeLogin: {
+  pending: PendingClaudeCodeLogin;
+  abort: AbortController;
+} | null = null;
+
+/** Abort and tear down any in-flight Claude login. Idempotent. */
+export async function closeActiveClaudeLogin(): Promise<void> {
+  const active = activeClaudeLogin;
+  if (!active) return;
+  activeClaudeLogin = null;
+  active.abort.abort();
+  await active.pending.cancel().catch(() => {});
+}
+
+async function handleClaudeStart(request: Request): Promise<Response> {
+  if (request.method !== "GET") return errorResponse(405, "Method not allowed");
+
+  const url = new URL(request.url);
+  const loginMethod =
+    url.searchParams.get("login_method") === "console" ? "console" : "claude-ai";
+  // A remote browser can't reach this process's loopback listener; the caller
+  // says so and only the paste flow is offered.
+  const manualOnly = url.searchParams.get("manual") === "true";
+
+  await closeActiveClaudeLogin();
+
+  const login = new ClaudeCodeLogin();
+  let pending: PendingClaudeCodeLogin;
+  try {
+    pending = await login.begin({ loginMethod, manualOnly });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(500, `Could not start the Claude login: ${message}`);
+  }
+
+  const abort = new AbortController();
+  activeClaudeLogin = { pending, abort };
+
+  if (pending.authUrl) {
+    // Finish off the request path; the UI polls /tokens for success.
+    void pending
+      .waitForRedirect(abort.signal)
+      .then(() => logger.info("Claude OAuth login completed"))
+      .catch((err: unknown) => {
+        logger.warn("Claude OAuth login did not complete", {
+          error: err instanceof Error ? err.message : String(err)
+        });
+      })
+      .finally(() => {
+        if (activeClaudeLogin?.pending === pending) activeClaudeLogin = null;
+      });
+  }
+
+  return jsonResponse({
+    auth_url: pending.authUrl ?? pending.manualAuthUrl,
+    manual_auth_url: pending.manualAuthUrl,
+    state: pending.state
+  });
+}
+
+/** Complete a started login from the `code#state` the console displayed. */
+async function handleClaudeComplete(request: Request): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+
+  const active = activeClaudeLogin;
+  if (!active) {
+    return errorResponse(
+      400,
+      "No Claude login in progress. Start one and try again."
+    );
+  }
+
+  let body: { code?: unknown };
+  try {
+    body = (await request.json()) as { code?: unknown };
+  } catch {
+    return errorResponse(400, "Invalid JSON body");
+  }
+  const code = typeof body.code === "string" ? body.code : "";
+  if (!code) return errorResponse(400, "code is required");
+
+  try {
+    await active.pending.completeWithPastedCode(code);
+    logger.info("Claude OAuth login completed from a pasted code");
+    return jsonResponse({ success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(400, message);
+  } finally {
+    if (activeClaudeLogin === active) activeClaudeLogin = null;
+  }
+}
+
+/**
+ * Connection status, shaped like the other providers' `tokens` responses so the
+ * shared `useOAuthConnection` hook works unchanged. There is at most one login.
+ */
+async function handleClaudeTokens(): Promise<Response> {
+  const status = await new ClaudeCodeLogin().status();
+  return jsonResponse({
+    tokens: status.connected
+      ? [
+          {
+            provider: "claude",
+            scope: status.scopes.join(" "),
+            expires_at:
+              status.expiresAt != null
+                ? new Date(status.expiresAt).toISOString()
+                : null,
+            expired: status.expired,
+            subscription_type: status.subscriptionType,
+            rate_limit_tier: status.rateLimitTier,
+            credentials_path: status.credentialsPath
+          }
+        ]
+      : []
+  });
+}
+
+async function handleClaudeDisconnect(request: Request): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+  await closeActiveClaudeLogin();
+  const removed = await new ClaudeCodeLogin().logout();
+  return jsonResponse({ success: true, removed: removed ? 1 : 0 });
+}
+
 // ── Google Workspace Endpoints ───────────────────────────────────────
 //
 // Unlike the flows above, there is no authorization round-trip here. The user
@@ -1188,6 +1332,16 @@ export async function handleOAuthRequest(
       return handleOpenAITokens(getUserId);
     case "/api/oauth/openai/disconnect":
       return handleOpenAIDisconnect(request, getUserId);
+
+    // Claude subscription (Claude Agent SDK credentials)
+    case "/api/oauth/claude/start":
+      return handleClaudeStart(request);
+    case "/api/oauth/claude/complete":
+      return handleClaudeComplete(request);
+    case "/api/oauth/claude/tokens":
+      return handleClaudeTokens();
+    case "/api/oauth/claude/disconnect":
+      return handleClaudeDisconnect(request);
 
     // Google Workspace (token comes from the Supabase Google login)
     case "/api/oauth/google/session":

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { initTestDb, OAuthCredential } from "@nodetool-ai/models";
 import {
@@ -5,7 +8,8 @@ import {
   generateState,
   oauthStateStore,
   handleOAuthRequest,
-  closeActiveCodexCallbackServer
+  closeActiveCodexCallbackServer,
+  closeActiveClaudeLogin
 } from "../src/oauth-api.js";
 
 function getUserId(): string {
@@ -528,5 +532,189 @@ describe("OAuthCredential model CRUD", () => {
     expect(u2Creds.length).toBe(1);
     const decryptedU2 = await u2Creds[0].getDecryptedAccessToken();
     expect(decryptedU2).toBe("tok2");
+  });
+});
+
+describe("OAuth API: Claude subscription endpoints", () => {
+  // The Claude routes persist to the Claude Agent SDK's credential file rather
+  // than the database, so every test points CLAUDE_CONFIG_DIR at a scratch dir.
+  let configDir: string;
+  let previousConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    configDir = await mkdtemp(join(tmpdir(), "claude-oauth-api-"));
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    await closeActiveClaudeLogin();
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    }
+    await rm(configDir, { recursive: true, force: true });
+  });
+
+  /** Mirrors the server: the router is handed a pathname, not a full URL. */
+  function claudeRequest(
+    path: string,
+    init?: RequestInit
+  ): Promise<Response | null> {
+    const url = new URL(`http://localhost:7777${path}`);
+    return handleOAuthRequest(new Request(url, init), url.pathname, getUserId);
+  }
+
+  it("GET /api/oauth/claude/start returns both authorization URLs", async () => {
+    const response = await claudeRequest("/api/oauth/claude/start");
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(200);
+
+    const body = (await jsonBody(response!)) as {
+      auth_url: string;
+      manual_auth_url: string;
+      state: string;
+    };
+    const authUrl = new URL(body.auth_url);
+    expect(authUrl.origin + authUrl.pathname).toBe(
+      "https://claude.com/cai/oauth/authorize"
+    );
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authUrl.searchParams.get("state")).toBe(body.state);
+    // The loopback listener is bound, so the redirect points back at this process.
+    expect(authUrl.searchParams.get("redirect_uri")).toMatch(
+      /^http:\/\/localhost:\d+\/callback$/
+    );
+    expect(body.manual_auth_url).toContain(
+      encodeURIComponent("https://platform.claude.com/oauth/code/callback")
+    );
+  });
+
+  it("offers only the paste flow when the browser can't reach this process", async () => {
+    const response = await claudeRequest("/api/oauth/claude/start?manual=true");
+
+    const body = (await jsonBody(response!)) as {
+      auth_url: string;
+      manual_auth_url: string;
+    };
+    // With no listener bound, `auth_url` falls back to the manual URL.
+    expect(body.auth_url).toBe(body.manual_auth_url);
+    expect(body.auth_url).not.toContain("localhost%3A");
+  });
+
+  it("points at the console for a console login", async () => {
+    const response = await claudeRequest(
+      "/api/oauth/claude/start?login_method=console&manual=true"
+    );
+    const body = (await jsonBody(response!)) as { auth_url: string };
+    expect(body.auth_url).toContain(
+      "https://platform.claude.com/oauth/authorize"
+    );
+  });
+
+  it("GET /api/oauth/claude/tokens reports disconnected with no stored login", async () => {
+    const response = await claudeRequest("/api/oauth/claude/tokens");
+
+    expect(response!.status).toBe(200);
+    const body = (await jsonBody(response!)) as { tokens: unknown[] };
+    expect(body.tokens).toEqual([]);
+  });
+
+  it("GET /api/oauth/claude/tokens reflects a stored login", async () => {
+    await writeFile(
+      join(configDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "access-1",
+          refreshToken: "refresh-1",
+          expiresAt: Date.now() + 3_600_000,
+          scopes: ["user:profile", "user:inference"],
+          subscriptionType: "max",
+          rateLimitTier: null
+        }
+      })
+    );
+
+    const response = await claudeRequest("/api/oauth/claude/tokens");
+    const body = (await jsonBody(response!)) as {
+      tokens: Array<Record<string, unknown>>;
+    };
+
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]).toMatchObject({
+      provider: "claude",
+      scope: "user:profile user:inference",
+      expired: false,
+      subscription_type: "max"
+    });
+    // Token material must never reach the status response.
+    expect(JSON.stringify(body)).not.toContain("access-1");
+    expect(JSON.stringify(body)).not.toContain("refresh-1");
+  });
+
+  it("POST /api/oauth/claude/disconnect removes the stored login", async () => {
+    await writeFile(
+      join(configDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "access-1",
+          refreshToken: "refresh-1",
+          expiresAt: null,
+          scopes: [],
+          subscriptionType: null,
+          rateLimitTier: null
+        }
+      })
+    );
+
+    const response = await claudeRequest("/api/oauth/claude/disconnect", {
+      method: "POST"
+    });
+
+    expect(response!.status).toBe(200);
+    expect(await jsonBody(response!)).toEqual({ success: true, removed: 1 });
+
+    const after = (await jsonBody(
+      (await claudeRequest("/api/oauth/claude/tokens"))!
+    )) as { tokens: unknown[] };
+    expect(after.tokens).toEqual([]);
+  });
+
+  it("POST /api/oauth/claude/complete rejects a code with no login in progress", async () => {
+    const response = await claudeRequest("/api/oauth/claude/complete", {
+      method: "POST",
+      body: JSON.stringify({ code: "the-code#the-state" })
+    });
+
+    expect(response!.status).toBe(400);
+    expect(await jsonBody(response!)).toMatchObject({
+      detail: expect.stringContaining("No Claude login in progress")
+    });
+  });
+
+  it("POST /api/oauth/claude/complete rejects a mismatched state", async () => {
+    await claudeRequest("/api/oauth/claude/start?manual=true");
+
+    const response = await claudeRequest("/api/oauth/claude/complete", {
+      method: "POST",
+      body: JSON.stringify({ code: "the-code#not-the-state" })
+    });
+
+    expect(response!.status).toBe(400);
+    expect(await jsonBody(response!)).toMatchObject({
+      detail: expect.stringContaining("state mismatch")
+    });
+  });
+
+  it("rejects the wrong method on the mutating routes", async () => {
+    for (const path of [
+      "/api/oauth/claude/complete",
+      "/api/oauth/claude/disconnect"
+    ]) {
+      const response = await claudeRequest(path);
+      expect(response!.status).toBe(405);
+    }
   });
 });

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -83,7 +83,13 @@ interface ProviderMeta {
   /** Extra hint rendered under the description (e.g. required key scope). */
   note?: string;
   /** Provider supports OAuth sign-in in place of (or alongside) an API key. */
-  oauth?: "openai" | "hf";
+  oauth?: "openai" | "hf" | "claude";
+  /**
+   * Authentication is OAuth-only — there is no API key to store, so the card
+   * shows sign-in/sign-out and nothing else. `key` is a display id, not a
+   * secret NodeTool persists.
+   */
+  oauthOnly?: boolean;
   /** Multi-field credentials (e.g. login + password). Single-field providers omit this. */
   fields?: Array<{ key: string; label: string; secret?: boolean }>;
 }
@@ -99,6 +105,18 @@ const PROVIDER_META: ProviderMeta[] = [
     icon: openaiIcon,
     mono: true,
     oauth: "openai"
+  },
+  {
+    key: "CLAUDE_SUBSCRIPTION",
+    name: "Claude",
+    description: "Use a Claude Pro or Max subscription instead of API credits.",
+    section: "popular",
+    docsUrl: "https://code.claude.com/docs/en/overview",
+    icon: anthropicIcon,
+    mono: true,
+    note: "Signs in through Claude Code and shares its credentials.",
+    oauth: "claude",
+    oauthOnly: true
   },
   {
     key: "ANTHROPIC_API_KEY",
@@ -484,7 +502,9 @@ export const ProviderCard = memo(function ProviderCard({
 }: ProviderCardProps) {
   const theme = useTheme();
   const oauth = useOAuthConnection(meta.oauth ?? null);
-  const isConnected = secret.is_configured;
+  // OAuth-only providers have no stored secret — the sign-in itself is the
+  // connection.
+  const isConnected = meta.oauthOnly ? oauth.isConnected : secret.is_configured;
 
   const handleConnect = useCallback(() => {
     onConnect(secret);
@@ -645,7 +665,7 @@ export const ProviderCard = memo(function ProviderCard({
               {isConnected ? "Connected" : "Not connected"}
             </Caption>
           </FlexRow>
-          {oauth.isConnected && (
+          {oauth.isConnected && !meta.oauthOnly && (
             <FlexRow
               align="center"
               gap={1}
@@ -676,7 +696,9 @@ export const ProviderCard = memo(function ProviderCard({
           )}
           {!isConnected && (
             <Caption size="smaller" sx={{ opacity: 0.45, whiteSpace: "nowrap" }}>
-              Add your API key to get started.
+              {meta.oauthOnly
+                ? "Sign in to get started."
+                : "Add your API key to get started."}
             </Caption>
           )}
         </FlexColumn>
@@ -720,7 +742,7 @@ export const ProviderCard = memo(function ProviderCard({
                   </EditorButton>
                 ))}
 
-          {isConnected ? (
+          {meta.oauthOnly ? null : isConnected ? (
             <>
               <EditorButton
                 density="compact"

--- a/web/src/hooks/useOAuthConnection.ts
+++ b/web/src/hooks/useOAuthConnection.ts
@@ -5,7 +5,7 @@ import { restFetch } from "../lib/rest-fetch";
 import { isElectron } from "../lib/env";
 import { useNotificationStore } from "../stores/NotificationStore";
 
-export type OAuthProvider = "openai" | "hf";
+export type OAuthProvider = "openai" | "hf" | "claude";
 
 interface OAuthProviderConfig {
   label: string;
@@ -15,7 +15,8 @@ interface OAuthProviderConfig {
 
 const PROVIDER_CONFIG: Record<OAuthProvider, OAuthProviderConfig> = {
   openai: { label: "OpenAI", canDisconnect: true },
-  hf: { label: "HuggingFace", canDisconnect: false }
+  hf: { label: "HuggingFace", canDisconnect: false },
+  claude: { label: "Claude", canDisconnect: true }
 };
 
 interface TokensResponse {


### PR DESCRIPTION
Runs the same OAuth flow the `claude` CLI does and writes the tokens to the file the Claude Agent SDK authenticates from, so a NodeTool login and a `claude login` are interchangeable. `ClaudeAgentProvider` needs no token plumbing of its own — the SDK's bundled binary reads the credentials directly.

## Protocol

Anthropic's authorization server deviates from RFC 6749 in three ways that `OAuthClient` cannot be configured into, hence a sibling `ClaudeCodeOAuthClient`:

1. The token endpoint takes a **JSON** body, not `application/x-www-form-urlencoded`.
2. The code exchange **echoes the CSRF `state`** in that body; the exchange is rejected without it.
3. The authorization URL carries an extra **`code=true`** flag.

Refresh also narrows the scope set — `org:create_api_key` is requested at login but dropped on every refresh.

## Two completions of one authorization request

`begin()` mints one PKCE pair and state and hands back both URLs:

- **Loopback** — the browser is redirected to an ephemeral `127.0.0.1` listener; the registered redirect uses the `localhost` spelling, matching the CLI. Same-machine hosts only.
- **Manual** — the console shows `<code>#<state>` to paste back. The only option on a headless or remote host.

They differ only in `redirect_uri`, which must match between the authorization request and the exchange, so `waitForRedirect()` and `completeWithPastedCode()` are separate completions of the same pending login.

## Credential file

`$CLAUDE_CONFIG_DIR/.credentials.json` (default `~/.claude/.credentials.json`), mode `0600`, written through a same-directory temp file so a concurrent `claude` process never reads a half-written file. Keys the CLI owns are preserved; only `claudeAiOauth` is replaced.

Because that file is per-machine-user rather than per-NodeTool-user, the login is process-wide — it is the credential the server's own `claude` subprocess will use. Noted in the API handler and the README.

## Entry points

```bash
nodetool auth claude login      # --console, --manual, --no-browser, --json
nodetool auth claude status
nodetool auth claude refresh    # --force
nodetool auth claude logout
```

- HTTP: `/api/oauth/claude/{start,complete,tokens,disconnect}`. `tokens` reports status in the shape the shared `useOAuthConnection` hook already expects.
- Web: a sign-in card on **Models & Providers**. `ProviderMeta` gains `oauthOnly`, which suppresses the API-key affordances for a provider that has no key to store.

`refresh()` exists for callers that need a live token *outside* the SDK (status display, `CLAUDE_CODE_OAUTH_TOKEN`); running the provider does not require it, since the CLI refreshes on its own.

## Testing

- 22 new tests in `packages/runtime/tests/providers/oauth/claude-code-oauth.test.ts` — authorization URL shape, the JSON/state/scope deviations, error mapping, credential-file format and mode, key preservation, refresh-token carry-forward, pasted-code parsing including state mismatch, and a full loopback login over real sockets.
- `npm run lint` clean; web and electron typecheck pass (mobile typecheck fails only on uninstalled Expo deps in this sandbox, unrelated to this change).
- Existing `packages/runtime` OAuth suite (81 tests), `packages/websocket` oauth-api suite (24), and the web menus/hook suites (53) all pass.
- Smoke-tested `nodetool auth claude status --json` and `login --manual --no-browser` against a scratch `CLAUDE_CONFIG_DIR`; the generated URL matches the CLI's byte-for-byte.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vTj2uH1iBAoD3EAiRxoGX)_