### PR TITLE
Explain opaque provider failures in node errors

### DIFF
--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -54,6 +54,7 @@ import {
   type LlmUsage
 } from "../tracing-helpers.js";
 import { logProviderRequestFailure } from "./provider-request-log.js";
+import { annotateProviderError } from "./provider-error.js";
 import { applyEntityReferences } from "./entity-references.js";
 import type { Span } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
@@ -322,6 +323,10 @@ export abstract class BaseProvider {
           try {
             return await original.apply(this, args);
           } catch (err) {
+            annotateProviderError(err, {
+              provider: this.provider,
+              model: extractModelId(args)
+            });
             if (!alreadyActive) {
               logProviderRequestFailure({
                 provider: this.provider,
@@ -632,6 +637,10 @@ export abstract class BaseProvider {
       });
       return result;
     } catch (err) {
+      annotateProviderError(err, {
+        provider: this.provider,
+        model: args.model
+      });
       error = String(err);
       logProviderRequestFailure({
         provider: this.provider,
@@ -761,6 +770,10 @@ export abstract class BaseProvider {
         model: args.model
       });
     } catch (err) {
+      annotateProviderError(err, {
+        provider: this.provider,
+        model: args.model
+      });
       error = String(err);
       logProviderRequestFailure({
         provider: this.provider,
@@ -1554,6 +1567,10 @@ async function* wrapModalityGenerator(
       yield result.value;
     }
   } catch (err) {
+    annotateProviderError(err, {
+      provider: provider.provider,
+      model: extractModelId(args)
+    });
     logProviderRequestFailure({
       provider: provider.provider,
       model: extractModelId(args),

--- a/packages/runtime/src/providers/provider-error.ts
+++ b/packages/runtime/src/providers/provider-error.ts
@@ -1,0 +1,152 @@
+/**
+ * Actionable text for opaque provider failures.
+ *
+ * Providers surface upstream HTTP errors verbatim — `403 Your request was
+ * blocked.`, `401 Incorrect API key provided`, `fetch failed` — which reaches
+ * the user as a node error with no hint of which provider failed or what to do
+ * about it. {@link annotateProviderError} appends the provider, the model, and
+ * a short remedy for the status class, leaving the original text at the front
+ * so existing message matching (rate limit, context length) still works.
+ */
+
+/** Marks an error already annotated, so nested wrappers don't stack hints. */
+const ANNOTATED = Symbol.for("nodetool.provider.errorAnnotated");
+
+interface ErrorLike {
+  status?: unknown;
+  statusCode?: unknown;
+  response?: { status?: unknown };
+  code?: unknown;
+  name?: unknown;
+  message?: unknown;
+  [ANNOTATED]?: boolean;
+}
+
+function numericStatus(value: unknown): number | null {
+  const status = typeof value === "string" ? Number(value) : value;
+  if (typeof status !== "number" || !Number.isInteger(status)) return null;
+  return status >= 100 && status <= 599 ? status : null;
+}
+
+/**
+ * HTTP status carried by a provider error: a `status`/`statusCode` field when
+ * the provider throws a typed error, otherwise a status token at the start of
+ * the message (`"403 Your request was blocked."`, the shape both the `openai`
+ * SDK and {@link OpenAICompatError} use) or after an explicit `status`/`HTTP`
+ * marker. Bare three-digit numbers elsewhere in the message are ignored — they
+ * are far more often model ids or token counts than statuses.
+ */
+export function httpStatusFromError(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as ErrorLike;
+  const direct =
+    numericStatus(candidate.status) ??
+    numericStatus(candidate.statusCode) ??
+    numericStatus(candidate.response?.status);
+  if (direct !== null) return direct;
+
+  const message =
+    typeof candidate.message === "string" ? candidate.message : "";
+  const leading = message.match(/^\s*(\d{3})\b/);
+  if (leading) return numericStatus(leading[1]);
+  const labelled = message.match(
+    /\b(?:status|http|status code)[:\s]+(\d{3})\b/i
+  );
+  return labelled ? numericStatus(labelled[1]) : null;
+}
+
+function isAbort(error: ErrorLike): boolean {
+  const name = typeof error.name === "string" ? error.name : "";
+  if (name === "AbortError" || name === "TimeoutError") return true;
+  const code = typeof error.code === "string" ? error.code : "";
+  return code === "ABORT_ERR";
+}
+
+const NETWORK_CODES = new Set([
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "CERT_HAS_EXPIRED"
+]);
+
+function isNetworkFailure(error: ErrorLike): boolean {
+  const code = typeof error.code === "string" ? error.code : "";
+  if (NETWORK_CODES.has(code)) return true;
+  const message = typeof error.message === "string" ? error.message : "";
+  return /fetch failed|network error|socket hang up/i.test(message);
+}
+
+/** Remedy for one status class, or null when the status needs no advice. */
+function hintForStatus(
+  status: number,
+  provider: string,
+  model: string
+): string | null {
+  const target = model ? `${provider}/${model}` : provider;
+  switch (status) {
+    case 401:
+      return `${target} rejected the credentials (401). Add or update the API key for ${provider} in Settings → Models & Providers.`;
+    case 403:
+      return `${target} refused the request (403). The API key may be missing access to this model, restricted to certain referrers or IPs, or blocked in your region — check it in Settings → Models & Providers.`;
+    case 402:
+      return `${target} reports the account is out of credit (402). Top up or check billing with ${provider}.`;
+    case 404:
+      return `${target} does not expose this model (404). Pick another model, or check that your ${provider} account has access to it.`;
+    case 429:
+      return `${target} is rate limiting or out of quota (429). Wait and retry, or check your ${provider} plan limits.`;
+    case 408:
+    case 504:
+      return `${target} timed out (${status}). Retry, or lower the request size.`;
+    default:
+      if (status >= 500) {
+        return `${target} is failing on its side (${status}). Retry in a moment; if it persists, check the ${provider} status page.`;
+      }
+      return null;
+  }
+}
+
+function hintFor(
+  error: ErrorLike,
+  provider: string,
+  model: string
+): string | null {
+  const status = httpStatusFromError(error);
+  if (status !== null) return hintForStatus(status, provider, model);
+  if (isNetworkFailure(error)) {
+    const target = model ? `${provider}/${model}` : provider;
+    return `Could not reach ${target}. Check your internet connection, proxy settings, and — for local providers — that the server is running.`;
+  }
+  return null;
+}
+
+/**
+ * Append provider context and a remedy to a provider failure, in place. The
+ * original message is kept as the prefix, and the error object (class, status,
+ * stack) is left intact. Aborts and already-annotated errors pass through
+ * untouched. Returns the same error so callers can `throw annotateProviderError(...)`.
+ */
+export function annotateProviderError(
+  error: unknown,
+  context: { provider: string; model?: string }
+): unknown {
+  if (!(error instanceof Error)) return error;
+  const candidate = error as Error & ErrorLike;
+  if (candidate[ANNOTATED] || isAbort(candidate)) return error;
+
+  // "unknown" is the modality wrappers' placeholder when the params carry no
+  // model id; naming it would read as a model called "unknown".
+  const model =
+    context.model && context.model !== "unknown" ? context.model : "";
+  const hint = hintFor(candidate, context.provider, model);
+  if (!hint) return error;
+
+  candidate[ANNOTATED] = true;
+  const original = candidate.message.trim();
+  candidate.message = original ? `${original} — ${hint}` : hint;
+  return error;
+}

--- a/packages/runtime/tests/providers/provider-error.test.ts
+++ b/packages/runtime/tests/providers/provider-error.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  annotateProviderError,
+  httpStatusFromError
+} from "../../src/providers/provider-error.js";
+import { BaseProvider } from "../../src/providers/base-provider.js";
+import type { Message, ProviderStreamItem } from "../../src/providers/types.js";
+
+class FailingProvider extends BaseProvider {
+  constructor(private readonly failure: Error) {
+    super("gemini");
+  }
+
+  async generateMessage(_args: {
+    messages: Message[];
+    model: string;
+  }): Promise<Message> {
+    throw this.failure;
+  }
+
+  // eslint-disable-next-line require-yield
+  async *generateMessages(_args: {
+    messages: Message[];
+    model: string;
+  }): AsyncGenerator<ProviderStreamItem> {
+    throw this.failure;
+  }
+}
+
+function httpError(status: number, message: string): Error {
+  const error = new Error(`${status} ${message}`) as Error & {
+    status: number;
+  };
+  error.status = status;
+  return error;
+}
+
+describe("httpStatusFromError", () => {
+  it("reads a numeric status field", () => {
+    expect(
+      httpStatusFromError(httpError(403, "Your request was blocked."))
+    ).toBe(403);
+  });
+
+  it("reads a leading status token when there is no status field", () => {
+    expect(httpStatusFromError(new Error("429 Rate limit reached"))).toBe(429);
+  });
+
+  it("reads a labelled status", () => {
+    expect(httpStatusFromError(new Error("request failed, HTTP 503"))).toBe(
+      503
+    );
+  });
+
+  it("ignores three-digit numbers that are not statuses", () => {
+    expect(httpStatusFromError(new Error("model gpt-4-0403 not found"))).toBe(
+      null
+    );
+    expect(httpStatusFromError("403")).toBe(null);
+  });
+});
+
+describe("annotateProviderError", () => {
+  it("explains a 403 and names the provider and model", () => {
+    const error = httpError(403, "Your request was blocked.");
+    annotateProviderError(error, { provider: "gemini", model: "gemini-3-pro" });
+    expect(error.message).toContain("403 Your request was blocked.");
+    expect(error.message).toContain("gemini/gemini-3-pro");
+    expect(error.message).toContain("Settings → Models & Providers");
+  });
+
+  it("keeps the original text first so message matching still works", () => {
+    const error = httpError(429, "Rate limit reached");
+    annotateProviderError(error, { provider: "openai", model: "gpt-5.4-mini" });
+    expect(error.message.startsWith("429 Rate limit reached")).toBe(true);
+    expect(new FailingProvider(error).isRateLimitError(error)).toBe(true);
+  });
+
+  it("annotates once, however many layers rethrow", () => {
+    const error = httpError(401, "Incorrect API key");
+    annotateProviderError(error, { provider: "openai", model: "gpt-5.4-mini" });
+    const once = error.message;
+    annotateProviderError(error, { provider: "openai", model: "gpt-5.4-mini" });
+    expect(error.message).toBe(once);
+  });
+
+  it("explains an unreachable endpoint", () => {
+    const error = new Error("fetch failed");
+    annotateProviderError(error, { provider: "ollama", model: "qwen-3.5:4b" });
+    expect(error.message).toContain("Could not reach ollama/qwen-3.5:4b");
+  });
+
+  it("leaves aborts and unclassified errors alone", () => {
+    const abort = new Error("403 blocked");
+    abort.name = "AbortError";
+    annotateProviderError(abort, { provider: "gemini" });
+    expect(abort.message).toBe("403 blocked");
+
+    const plain = new Error("model returned no items");
+    annotateProviderError(plain, { provider: "gemini" });
+    expect(plain.message).toBe("model returned no items");
+  });
+
+  it("omits the model when it is the unknown placeholder", () => {
+    const error = httpError(500, "internal error");
+    annotateProviderError(error, { provider: "fal_ai", model: "unknown" });
+    expect(error.message).not.toContain("unknown");
+  });
+});
+
+describe("BaseProvider traced wrappers", () => {
+  it("annotates streaming failures", async () => {
+    const provider = new FailingProvider(
+      httpError(403, "Your request was blocked.")
+    );
+    await expect(async () => {
+      for await (const item of provider.generateMessagesTraced({
+        messages: [{ role: "user", content: "hi" }],
+        model: "gemini-3-pro"
+      })) {
+        expect(item).toBeDefined();
+      }
+    }).rejects.toThrow(/gemini\/gemini-3-pro/);
+  });
+
+  it("annotates non-streaming failures", async () => {
+    const provider = new FailingProvider(
+      httpError(403, "Your request was blocked.")
+    );
+    await expect(
+      provider.generateMessageTraced({
+        messages: [{ role: "user", content: "hi" }],
+        model: "gemini-3-pro"
+      })
+    ).rejects.toThrow(/refused the request \(403\)/);
+  });
+});


### PR DESCRIPTION
Fixes #4582.

## Problem

The reported failure — `List Generator error: 403 Your request was blocked.` — is the upstream provider's HTTP error passed through verbatim. It names no provider, no model, and gives the user nothing to act on. Every LLM node has this shape: whatever the provider's SDK or our `OpenAICompatError` produced (`"<status> <upstream message>"`) becomes the node error text.

## Change

`BaseProvider`'s traced wrappers (`generateMessageTraced`, `generateMessagesTraced`, and the modality promise/generator wrappers) now run the error through a new `annotateProviderError` before rethrowing, right next to the existing `logProviderRequestFailure` call. The hint depends on the status class:

| status | hint |
| --- | --- |
| 401 | credentials rejected — add or update the key in Settings → Models & Providers |
| 402 | account out of credit |
| 403 | key may lack access to the model, be referrer/IP restricted, or be region-blocked |
| 404 | provider does not expose this model |
| 429 | rate limited or out of quota |
| 408 / 504 | timed out |
| 5xx | provider-side failure, retry |
| `fetch failed`, `ENOTFOUND`, … | endpoint unreachable — connection, proxy, or local server not running |

The issue's error now reads:

```
403 Your request was blocked. — gemini/gemini-3-pro refused the request (403).
The API key may be missing access to this model, restricted to certain referrers
or IPs, or blocked in your region — check it in Settings → Models & Providers.
```

Deliberately conservative:

- The original text stays at the front, so `isRateLimitError` / `isContextLengthError` and any other message matching keep working.
- The error object is mutated in place, so its class, `status`, and stack survive — no `instanceof` check downstream breaks.
- A `Symbol.for` marker makes it idempotent, so nested wrappers don't stack hints.
- Aborts, timeouts, and errors with no recognizable status pass through untouched.
- Status detection only trusts a `status`/`statusCode` field, a leading status token, or an explicit `HTTP <nnn>` marker — a bare `403` inside a model id is not a status.

## Files

- `packages/runtime/src/providers/provider-error.ts` (new) — `annotateProviderError`, `httpStatusFromError`
- `packages/runtime/src/providers/base-provider.ts` — four call sites
- `packages/runtime/tests/providers/provider-error.test.ts` (new) — 12 tests

## Verification

`packages/runtime` (2438), `agents` (1647), `llm-nodes` (491), `websocket` (1949), `kernel` (910) suites pass; `tsc --noEmit` and `oxlint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpnyDToVK9Ju2ZXNHvCYn6)_