### PR TITLE
fix(websocket): detect half-open sockets and de-synchronize reconnects

### DIFF
--- a/mobile/src/services/WebSocketManager.test.ts
+++ b/mobile/src/services/WebSocketManager.test.ts
@@ -640,16 +640,24 @@ describe('WebSocketManager', () => {
       // Set reconnectAttempt to 1 (first actual attempt)
       (manager as any).reconnectAttempt = 1;
       
-      // Access private method to test delay calculation
-      // Formula: reconnectInterval * decay^(attempt-1)
+      // Access private method to test delay calculation. The result carries
+      // half-to-full jitter, so it lands in (delay/2, delay].
+      // Formula: reconnectInterval * decay^attempt
       const delay1 = (manager as any).getReconnectDelay();
-      expect(delay1).toBe(1500); // 1000 * 1.5^1 = 1500
+      expect(delay1).toBeGreaterThan(750); // 1000 * 1.5^1 = 1500, halved
+      expect(delay1).toBeLessThanOrEqual(1500);
 
       // Simulate subsequent reconnect attempts
       (manager as any).reconnectAttempt = 3;
-      const delay3 = (manager as any).getReconnectDelay();
-      expect(delay3).toBe(3375); // 1000 * 1.5^3 = 3375
-      expect(delay3).toBeGreaterThan(delay1);
+      const delays3 = Array.from({ length: 20 }, () =>
+        (manager as any).getReconnectDelay()
+      );
+      for (const delay3 of delays3) {
+        expect(delay3).toBeGreaterThan(1687.5); // 1000 * 1.5^3 = 3375, halved
+        expect(delay3).toBeLessThanOrEqual(3375);
+      }
+      // Jitter must actually spread the attempts out.
+      expect(new Set(delays3).size).toBeGreaterThan(1);
     });
 
     it('shouldReconnect returns false for no-reconnect codes', () => {

--- a/mobile/src/services/WebSocketManager.ts
+++ b/mobile/src/services/WebSocketManager.ts
@@ -49,7 +49,10 @@ const STATE_TRANSITIONS: Record<string, { from: ConnectionState[]; to: Connectio
     to: 'reconnecting',
   },
   failed: {
-    from: ['connecting', 'reconnecting'],
+    // 'disconnected' included so a close that exhausts (or forbids) reconnects
+    // reaches the terminal state instead of being indistinguishable from an
+    // ordinary disconnect. Mirrors the web manager.
+    from: ['connecting', 'reconnecting', 'disconnected'],
     to: 'failed',
   },
 };
@@ -60,6 +63,9 @@ export class WebSocketManager {
   private state: ConnectionState = 'disconnected';
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private connectionTimer: ReturnType<typeof setTimeout> | null = null;
+  private livenessTimer: ReturnType<typeof setInterval> | null = null;
+  private lastInboundAt = 0;
+  private probeSentAt = 0;
   private reconnectAttempt = 0;
   private intentionalDisconnect = false;
   private messageQueue: WebSocketMessage[] = [];
@@ -85,6 +91,8 @@ export class WebSocketManager {
       reconnectDecay: config.reconnectDecay ?? 1.5,
       reconnectAttempts: config.reconnectAttempts ?? 10,
       timeoutInterval: config.timeoutInterval ?? 30000,
+      heartbeatInterval: config.heartbeatInterval ?? 45000,
+      heartbeatTimeout: config.heartbeatTimeout ?? 10000,
       headers: config.headers ?? {},
     };
   }
@@ -142,8 +150,15 @@ export class WebSocketManager {
    * Idempotent — safe to call from both the AppState listener and an owner.
    */
   public resumeFromBackground(): void {
+    if (this.isConnected()) {
+      // The socket may be half-open: suspended radios and cellular/wifi
+      // handoffs kill connections without an onclose, and readyState keeps
+      // saying OPEN. Make it prove otherwise.
+      this.checkLiveness();
+      return;
+    }
+
     if (
-      this.isConnected() ||
       this.intentionalDisconnect ||
       !this.config.reconnect ||
       this.state === 'connecting' ||
@@ -260,6 +275,8 @@ export class WebSocketManager {
 
     this.callbacks.onOpen?.();
 
+    this.startLivenessWatchdog();
+
     // Process queued messages
     this.processMessageQueue();
 
@@ -272,6 +289,10 @@ export class WebSocketManager {
   }
 
   private async handleMessage(event: WebSocketMessageEvent): Promise<void> {
+    // Any frame proves the socket is alive, decodable or not.
+    this.lastInboundAt = Date.now();
+    this.probeSentAt = 0;
+
     try {
       let data: unknown;
 
@@ -290,12 +311,38 @@ export class WebSocketManager {
         data = unpack(new Uint8Array(buffer));
       }
 
+      if (this.handleLivenessFrame(data)) {
+        return;
+      }
+
       console.log('[WS Receive]', data);
       this.callbacks.onMessage?.(data as WebSocketMessageData);
     } catch (error) {
       console.error('Failed to process message:', error);
       this.callbacks.onError?.(error as Error);
     }
+  }
+
+  /**
+   * Consume heartbeat frames instead of forwarding them: they carry no chat
+   * content. Returns true when the frame was a heartbeat.
+   */
+  private handleLivenessFrame(data: unknown): boolean {
+    const type =
+      data && typeof data === 'object'
+        ? (data as { type?: unknown }).type
+        : undefined;
+
+    if (type === 'ping') {
+      try {
+        this.send({ type: 'pong' });
+      } catch (error) {
+        console.log('Failed to answer server ping:', error);
+      }
+      return true;
+    }
+
+    return type === 'pong';
   }
 
   private async blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
@@ -319,6 +366,7 @@ export class WebSocketManager {
 
     this.ws = null;
     this.clearConnectionTimeout();
+    this.stopLivenessWatchdog();
 
     const wasConnecting =
       this.state === 'connecting' || this.state === 'reconnecting';
@@ -458,7 +506,110 @@ export class WebSocketManager {
         Math.pow(this.config.reconnectDecay, this.reconnectAttempt),
       30000 // Max 30 seconds
     );
-    return delay;
+    // Half-to-full jitter. Without it every client that dropped on a server
+    // restart comes back in lockstep and hammers the server as it boots.
+    return delay * (0.5 + Math.random() * 0.5);
+  }
+
+  /**
+   * Ask the socket to prove it is alive right now — used when the environment
+   * hints the connection may have died without notice (app foregrounded).
+   */
+  public checkLiveness(): void {
+    if (this.state !== 'connected') {
+      return;
+    }
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      this.handleDeadConnection('socket no longer open');
+      return;
+    }
+    this.probeLiveness();
+  }
+
+  private startLivenessWatchdog(): void {
+    this.stopLivenessWatchdog();
+    if (this.config.heartbeatInterval <= 0) {
+      return;
+    }
+
+    this.lastInboundAt = Date.now();
+    this.probeSentAt = 0;
+    // Poll well below the silence threshold so a dead socket is caught within
+    // roughly one heartbeat interval rather than two.
+    const tick = Math.max(1000, Math.floor(this.config.heartbeatInterval / 4));
+    this.livenessTimer = setInterval(() => this.checkForSilence(), tick);
+  }
+
+  private stopLivenessWatchdog(): void {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+    this.probeSentAt = 0;
+  }
+
+  private checkForSilence(): void {
+    if (this.state !== 'connected' || this.backgrounded) {
+      // A suspended app cannot service timers reliably; foregrounding runs the
+      // check explicitly through resumeFromBackground().
+      return;
+    }
+
+    if (this.probeSentAt) {
+      if (Date.now() - this.probeSentAt >= this.config.heartbeatTimeout) {
+        this.handleDeadConnection('no response to heartbeat probe');
+      }
+      return;
+    }
+
+    if (Date.now() - this.lastInboundAt >= this.config.heartbeatInterval) {
+      this.probeLiveness();
+    }
+  }
+
+  private probeLiveness(): void {
+    if (this.probeSentAt) {
+      return;
+    }
+    this.probeSentAt = Date.now();
+    try {
+      this.send({ type: 'ping' });
+    } catch (error) {
+      console.warn('Heartbeat probe failed to send:', error);
+      this.handleDeadConnection('heartbeat probe could not be sent');
+    }
+  }
+
+  /**
+   * Drop a socket the runtime still calls OPEN but that has stopped carrying
+   * traffic. `close()` alone is not enough: the closing handshake on a dead
+   * connection can hang for minutes before `onclose` fires, so detach the
+   * handlers and run the close path ourselves to get reconnect going now.
+   */
+  private handleDeadConnection(reason: string): void {
+    const dead = this.ws;
+    console.warn(`WebSocket appears dead (${reason}); reconnecting`);
+    this.stopLivenessWatchdog();
+
+    if (dead) {
+      dead.onopen = null;
+      dead.onmessage = null;
+      dead.onerror = null;
+      dead.onclose = null;
+      try {
+        dead.close();
+      } catch (error) {
+        console.log('Failed to close dead socket:', error);
+      }
+    }
+
+    this.callbacks.onError?.(
+      new Error(`WebSocket liveness check failed: ${reason}`)
+    );
+    this.handleClose({
+      code: 1006,
+      reason: 'Heartbeat timeout',
+    } as WebSocketCloseEvent);
   }
 
   private startConnectionTimeout(): void {
@@ -482,6 +633,7 @@ export class WebSocketManager {
 
   private clearTimers(): void {
     this.clearConnectionTimeout();
+    this.stopLivenessWatchdog();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/mobile/src/services/__tests__/WebSocketManager.liveness.test.ts
+++ b/mobile/src/services/__tests__/WebSocketManager.liveness.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The liveness watchdog covers the failure `onclose` never reports: a
+ * half-open socket the runtime still calls OPEN while nothing arrives. Mobile
+ * hits this constantly — suspended radios, cellular/wifi handoffs.
+ */
+import { WebSocketManager } from '../WebSocketManager';
+import type { WebSocketConfig } from '../../types/chat';
+
+jest.mock('msgpackr', () => ({
+  pack: jest.fn((msg: unknown) => msg),
+  unpack: jest.fn((buf: unknown) => buf),
+}));
+
+jest.mock('../../hooks/useAppLifecycle', () => ({
+  isAppForeground: () => true,
+  subscribeAppLifecycle: () => () => undefined,
+}));
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readyState = 0;
+  binaryType = 'arraybuffer';
+  sent: Array<Record<string, unknown>> = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(message: unknown): void {
+    this.sent.push(message as Record<string, unknown>);
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  /** Close the underlying transport without notifying the client. */
+  goHalfOpen(): void {
+    this.onclose = null;
+  }
+
+  triggerOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** The manager parses string frames as JSON, so no msgpack round-trip. */
+  deliver(message: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+
+  get pings(): Array<Record<string, unknown>> {
+    return this.sent.filter((m) => m.type === 'ping');
+  }
+}
+
+const latestSocket = (): FakeWebSocket =>
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const HEARTBEAT_INTERVAL = 4000;
+const HEARTBEAT_TIMEOUT = 1000;
+
+const createManager = (
+  overrides: Partial<WebSocketConfig> = {}
+): WebSocketManager =>
+  new WebSocketManager({
+    url: 'ws://localhost:7777/ws',
+    reconnect: false,
+    heartbeatInterval: HEARTBEAT_INTERVAL,
+    heartbeatTimeout: HEARTBEAT_TIMEOUT,
+    ...overrides,
+  });
+
+const connect = async (mgr: WebSocketManager): Promise<void> => {
+  const pending = mgr.connect();
+  latestSocket().triggerOpen();
+  await pending;
+};
+
+describe('mobile WebSocketManager liveness watchdog', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stays quiet while the server keeps sending', async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    for (let i = 0; i < 4; i++) {
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL - 500);
+      latestSocket().deliver({ type: 'chunk' });
+    }
+
+    expect(latestSocket().pings).toHaveLength(0);
+    expect(mgr.getState()).toBe('connected');
+
+    mgr.destroy();
+  });
+
+  it('probes with a ping once inbound traffic goes silent', async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL);
+
+    expect(latestSocket().pings).toHaveLength(1);
+    expect(mgr.getState()).toBe('connected');
+
+    mgr.destroy();
+  });
+
+  it('tears the socket down when the probe goes unanswered', async () => {
+    const mgr = createManager();
+    const onClose = jest.fn();
+    const mgrWithCallbacks = mgr;
+    mgrWithCallbacks.setCallbacks({ onClose });
+    await connect(mgr);
+
+    latestSocket().goHalfOpen();
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL + HEARTBEAT_TIMEOUT + 100);
+
+    expect(onClose).toHaveBeenCalledWith(1006, 'Heartbeat timeout');
+    expect(mgr.getState()).toBe('failed');
+
+    mgr.destroy();
+  });
+
+  it('keeps the connection when the probe is answered', async () => {
+    const mgr = createManager();
+    const onClose = jest.fn();
+    mgr.setCallbacks({ onClose });
+    await connect(mgr);
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL);
+    latestSocket().deliver({ type: 'pong' });
+    jest.advanceTimersByTime(HEARTBEAT_TIMEOUT + 100);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mgr.getState()).toBe('connected');
+
+    mgr.destroy();
+  });
+
+  it('answers server pings and does not surface them to subscribers', async () => {
+    const mgr = createManager();
+    const onMessage = jest.fn();
+    mgr.setCallbacks({ onMessage });
+    await connect(mgr);
+
+    latestSocket().deliver({ type: 'ping' });
+    latestSocket().deliver({ type: 'pong' });
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(latestSocket().sent.filter((m) => m.type === 'pong')).toHaveLength(1);
+
+    mgr.destroy();
+  });
+
+  it('probes instead of trusting readyState when the app foregrounds', async () => {
+    const mgr = createManager({ reconnect: true, reconnectInterval: 100 });
+    await connect(mgr);
+
+    latestSocket().goHalfOpen();
+    mgr.resumeFromBackground();
+
+    expect(latestSocket().pings).toHaveLength(1);
+
+    // Nothing answers, so the socket is dropped and a new one is opened.
+    jest.advanceTimersByTime(HEARTBEAT_TIMEOUT + 100);
+    jest.advanceTimersByTime(200);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    mgr.destroy();
+  });
+});

--- a/mobile/src/types/chat.ts
+++ b/mobile/src/types/chat.ts
@@ -120,6 +120,13 @@ export interface WebSocketConfig {
   reconnectAttempts?: number;
   timeoutInterval?: number;
   /**
+   * Inbound silence (ms) after which the connection is probed with a ping.
+   * Must stay above the server's 25s heartbeat. 0 disables the watchdog.
+   */
+  heartbeatInterval?: number;
+  /** Grace period (ms) for traffic to arrive after a probe. */
+  heartbeatTimeout?: number;
+  /**
    * Extra headers for the connection handshake (React Native native only).
    * Used to send `Authorization: Bearer <token>` so the auth token stays out
    * of the URL.

--- a/web/src/lib/websocket/GlobalWebSocketManager.ts
+++ b/web/src/lib/websocket/GlobalWebSocketManager.ts
@@ -430,6 +430,30 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
   }
 
   /**
+   * Re-establish the connection after an event that may have killed it.
+   *
+   * Waking from sleep or switching networks usually leaves the socket
+   * half-open: the browser still reports it as connected and `close` never
+   * fires, so checking `isConnected` alone would conclude there is nothing to
+   * do. Probe the socket instead, and only rebuild when it is genuinely gone.
+   */
+  private recoverConnection(trigger: string): void {
+    if (this.isConnected && this.wsManager) {
+      this.wsManager.checkLiveness();
+      return;
+    }
+    if (this.isConnecting) {
+      return;
+    }
+    this.ensureConnection().catch((err) => {
+      console.error(
+        `GlobalWebSocketManager: Failed to reconnect after ${trigger}:`,
+        err
+      );
+    });
+  }
+
+  /**
    * Set up network status monitoring to auto-reconnect on network changes
    */
   private setupNetworkListeners(): void {
@@ -441,21 +465,13 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
 
     const handleOnline = () => {
       console.info("GlobalWebSocketManager: Network came online, attempting reconnection");
-      if (!this.isConnected && !this.isConnecting) {
-        this.ensureConnection().catch((err) => {
-          console.error("GlobalWebSocketManager: Failed to reconnect after network online:", err);
-        });
-      }
+      this.recoverConnection("network online");
     };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         console.info("GlobalWebSocketManager: Tab became visible, checking connection");
-        if (!this.isConnected && !this.isConnecting) {
-          this.ensureConnection().catch((err) => {
-            console.error("GlobalWebSocketManager: Failed to reconnect after visibility change:", err);
-          });
-        }
+        this.recoverConnection("tab visible");
       }
     };
 

--- a/web/src/lib/websocket/WebSocketManager.ts
+++ b/web/src/lib/websocket/WebSocketManager.ts
@@ -5,6 +5,13 @@
  * for `open/close/message/error/reconnecting/stateChange`. Queues outbound
  * messages until connected, retries with exponential-ish backoff, and enforces
  * valid transitions to avoid double-connect/disconnect races.
+ *
+ * A liveness watchdog covers the failure mode `onclose` cannot: a half-open
+ * socket (laptop sleep, NAT/proxy drop, network switch) where the browser still
+ * reports OPEN but nothing arrives. The server heartbeats every 25s, so a
+ * longer stretch of inbound silence means the connection is suspect — we probe
+ * with a ping and, if that stays unanswered, tear the socket down so the normal
+ * reconnect path runs instead of silently dropping every run update.
  */
 import { EventEmitter } from "../EventEmitter";
 import { pack, unpack } from "msgpackr";
@@ -26,6 +33,15 @@ export interface WebSocketConfig {
   reconnectAttempts?: number;
   timeoutInterval?: number;
   binaryType?: BinaryType;
+  /**
+   * Inbound silence (ms) after which the connection is probed with a ping.
+   * Must stay above the server's 25s heartbeat. 0 disables the watchdog.
+   */
+  heartbeatInterval?: number;
+  /** Grace period (ms) for traffic to arrive after a probe. */
+  heartbeatTimeout?: number;
+  /** Cap on messages queued while offline; the oldest are dropped first. */
+  maxQueueSize?: number;
 }
 
 export interface WebSocketMessage {
@@ -88,6 +104,9 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
   private state: ConnectionState = "disconnected";
   private reconnectTimer: NodeJS.Timeout | null = null;
   private connectionTimer: NodeJS.Timeout | null = null;
+  private livenessTimer: NodeJS.Timeout | null = null;
+  private lastInboundAt = 0;
+  private probeSentAt = 0;
   private reconnectAttempt = 0;
   private intentionalDisconnect = false;
   private messageQueue: WebSocketMessage[] = [];
@@ -105,7 +124,10 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
       reconnectDecay: config.reconnectDecay ?? 1.5,
       reconnectAttempts: config.reconnectAttempts ?? 10,
       timeoutInterval: config.timeoutInterval ?? 30000,
-      binaryType: config.binaryType ?? "arraybuffer"
+      binaryType: config.binaryType ?? "arraybuffer",
+      heartbeatInterval: config.heartbeatInterval ?? 45000,
+      heartbeatTimeout: config.heartbeatTimeout ?? 10000,
+      maxQueueSize: config.maxQueueSize ?? 100
     };
   }
 
@@ -183,6 +205,11 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
       ) {
         console.debug("Queueing message while connecting");
         this.messageQueue.push(message);
+        // A long outage with a chatty caller would otherwise grow this without
+        // bound. The oldest queued messages are the least useful on recovery.
+        while (this.messageQueue.length > this.config.maxQueueSize) {
+          this.messageQueue.shift();
+        }
         return;
       }
       throw new Error(`Cannot send message in state: ${this.state}`);
@@ -221,6 +248,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
 
     this.emit("open");
 
+    this.startLivenessWatchdog();
     this.processMessageQueue();
 
     if (this.connectionResolver) {
@@ -232,6 +260,10 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
   }
 
   private async handleMessage(event: MessageEvent): Promise<void> {
+    // Any frame proves the socket is alive, decodable or not.
+    this.lastInboundAt = Date.now();
+    this.probeSentAt = 0;
+
     try {
       let data: unknown;
 
@@ -261,11 +293,38 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
         data = event.data;
       }
 
+      if (this.handleLivenessFrame(data)) {
+        return;
+      }
+
       this.emit("message", data);
     } catch (error) {
       console.error("Failed to process message:", error);
       this.emit("error", error);
     }
+  }
+
+  /**
+   * Consume heartbeat frames instead of forwarding them: they carry no routing
+   * key, so subscribers have nothing to do with them. Returns true when the
+   * frame was a heartbeat.
+   */
+  private handleLivenessFrame(data: unknown): boolean {
+    const type =
+      data && typeof data === "object"
+        ? (data as { type?: unknown }).type
+        : undefined;
+
+    if (type === "ping") {
+      try {
+        this.send({ type: "pong", ts: Date.now() / 1000 });
+      } catch (error) {
+        console.debug("Failed to answer server ping:", error);
+      }
+      return true;
+    }
+
+    return type === "pong";
   }
 
   private handleError(event: Event): void {
@@ -280,6 +339,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
 
     this.ws = null;
     this.clearConnectionTimeout();
+    this.stopLivenessWatchdog();
 
     const wasConnecting =
       this.state === "connecting" || this.state === "reconnecting";
@@ -414,7 +474,108 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
         Math.pow(this.config.reconnectDecay, this.reconnectAttempt),
       30000 // Max 30 seconds
     );
-    return delay;
+    // Half-to-full jitter. Without it every client that dropped on a server
+    // restart comes back in lockstep and hammers the server as it boots.
+    return delay * (0.5 + Math.random() * 0.5);
+  }
+
+  /**
+   * Ask the socket to prove it is alive right now. Cheap and idempotent —
+   * callers use it when the environment hints the connection may have died
+   * without notice (tab restored after sleep, network change).
+   */
+  public checkLiveness(): void {
+    if (this.state !== "connected") {
+      return;
+    }
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      this.handleDeadConnection("socket no longer open");
+      return;
+    }
+    this.probeLiveness();
+  }
+
+  private startLivenessWatchdog(): void {
+    this.stopLivenessWatchdog();
+    if (this.config.heartbeatInterval <= 0) {
+      return;
+    }
+
+    this.lastInboundAt = Date.now();
+    this.probeSentAt = 0;
+    // Poll well below the silence threshold so a dead socket is caught within
+    // roughly one heartbeat interval rather than two.
+    const tick = Math.max(1000, Math.floor(this.config.heartbeatInterval / 4));
+    this.livenessTimer = setInterval(() => this.checkForSilence(), tick);
+  }
+
+  private stopLivenessWatchdog(): void {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+    this.probeSentAt = 0;
+  }
+
+  private checkForSilence(): void {
+    if (this.state !== "connected") {
+      return;
+    }
+
+    if (this.probeSentAt) {
+      if (Date.now() - this.probeSentAt >= this.config.heartbeatTimeout) {
+        this.handleDeadConnection("no response to heartbeat probe");
+      }
+      return;
+    }
+
+    if (Date.now() - this.lastInboundAt >= this.config.heartbeatInterval) {
+      this.probeLiveness();
+    }
+  }
+
+  private probeLiveness(): void {
+    if (this.probeSentAt) {
+      return;
+    }
+    this.probeSentAt = Date.now();
+    try {
+      this.send({ type: "ping", ts: this.probeSentAt / 1000 });
+    } catch (error) {
+      console.warn("Heartbeat probe failed to send:", error);
+      this.handleDeadConnection("heartbeat probe could not be sent");
+    }
+  }
+
+  /**
+   * Drop a socket the browser still calls OPEN but that has stopped carrying
+   * traffic. `close()` alone is not enough: the closing handshake on a dead
+   * connection can hang for minutes before `onclose` fires, so detach the
+   * handlers and run the close path ourselves to get reconnect going now.
+   */
+  private handleDeadConnection(reason: string): void {
+    const dead = this.ws;
+    console.warn(`WebSocket appears dead (${reason}); reconnecting`);
+    this.stopLivenessWatchdog();
+
+    if (dead) {
+      dead.onopen = null;
+      dead.onmessage = null;
+      dead.onerror = null;
+      dead.onclose = null;
+      try {
+        dead.close();
+      } catch (error) {
+        console.debug("Failed to close dead socket:", error);
+      }
+    }
+
+    this.emit("error", new Error(`WebSocket liveness check failed: ${reason}`));
+    this.handleClose({
+      code: 1006,
+      reason: "Heartbeat timeout",
+      wasClean: false
+    } as CloseEvent);
   }
 
   private startConnectionTimeout(): void {
@@ -438,6 +599,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
 
   private clearTimers(): void {
     this.clearConnectionTimeout();
+    this.stopLivenessWatchdog();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/web/src/lib/websocket/__tests__/WebSocketManager.liveness.test.ts
+++ b/web/src/lib/websocket/__tests__/WebSocketManager.liveness.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The liveness watchdog covers the failure `onclose` never reports: a
+ * half-open socket the browser still calls OPEN while nothing arrives.
+ */
+import { WebSocketManager } from "../WebSocketManager";
+import type { WebSocketConfig } from "../WebSocketManager";
+
+jest.mock("msgpackr", () => ({
+  pack: jest.fn((msg: unknown) => msg),
+  unpack: jest.fn((buf: unknown) => buf)
+}));
+
+interface FakeCloseEvent {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readyState = 0;
+  binaryType = "arraybuffer";
+  sent: Array<Record<string, unknown>> = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: FakeCloseEvent) => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(message: unknown): void {
+    this.sent.push(message as Record<string, unknown>);
+  }
+
+  close(code = 1000, reason = ""): void {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason, wasClean: code === 1000 });
+  }
+
+  /** Close the underlying transport without notifying the client. */
+  goHalfOpen(): void {
+    this.onclose = null;
+  }
+
+  triggerOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  deliver(message: unknown): void {
+    this.onmessage?.({ data: message });
+  }
+
+  get pings(): Array<Record<string, unknown>> {
+    return this.sent.filter((m) => m.type === "ping");
+  }
+}
+
+const latestSocket = (): FakeWebSocket =>
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const HEARTBEAT_INTERVAL = 4000;
+const HEARTBEAT_TIMEOUT = 1000;
+
+const createManager = (
+  overrides: Partial<WebSocketConfig> = {}
+): WebSocketManager =>
+  new WebSocketManager({
+    url: "ws://localhost:7777/ws",
+    reconnect: false,
+    heartbeatInterval: HEARTBEAT_INTERVAL,
+    heartbeatTimeout: HEARTBEAT_TIMEOUT,
+    ...overrides
+  });
+
+const connect = async (mgr: WebSocketManager): Promise<void> => {
+  const pending = mgr.connect();
+  latestSocket().triggerOpen();
+  await pending;
+};
+
+describe("WebSocketManager liveness watchdog", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("stays quiet while the server keeps sending", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    for (let i = 0; i < 4; i++) {
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL - 500);
+      latestSocket().deliver({ type: "node_update" });
+    }
+
+    expect(latestSocket().pings).toHaveLength(0);
+    expect(mgr.getState()).toBe("connected");
+
+    mgr.destroy();
+  });
+
+  it("probes with a ping once inbound traffic goes silent", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL);
+
+    expect(latestSocket().pings).toHaveLength(1);
+    expect(mgr.getState()).toBe("connected");
+
+    mgr.destroy();
+  });
+
+  it("tears the socket down when the probe goes unanswered", async () => {
+    const mgr = createManager();
+    const closed = jest.fn();
+    mgr.on("close", closed);
+    await connect(mgr);
+
+    latestSocket().goHalfOpen();
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL + HEARTBEAT_TIMEOUT + 100);
+
+    expect(closed).toHaveBeenCalledWith(1006, "Heartbeat timeout", false);
+    expect(mgr.getState()).toBe("failed");
+
+    mgr.destroy();
+  });
+
+  it("keeps the connection when the probe is answered", async () => {
+    const mgr = createManager();
+    const closed = jest.fn();
+    mgr.on("close", closed);
+    await connect(mgr);
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL);
+    latestSocket().deliver({ type: "pong" });
+    jest.advanceTimersByTime(HEARTBEAT_TIMEOUT + 100);
+
+    expect(closed).not.toHaveBeenCalled();
+    expect(mgr.getState()).toBe("connected");
+
+    mgr.destroy();
+  });
+
+  it("reconnects after a dead connection when reconnect is enabled", async () => {
+    const mgr = createManager({ reconnect: true, reconnectInterval: 100 });
+    await connect(mgr);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    latestSocket().goHalfOpen();
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL + HEARTBEAT_TIMEOUT + 100);
+    jest.advanceTimersByTime(200);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    mgr.destroy();
+  });
+
+  it("answers server pings and does not surface them to subscribers", async () => {
+    const mgr = createManager();
+    const onMessage = jest.fn();
+    mgr.on("message", onMessage);
+    await connect(mgr);
+
+    latestSocket().deliver({ type: "ping", ts: 1 });
+    latestSocket().deliver({ type: "pong", ts: 2 });
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(latestSocket().sent.filter((m) => m.type === "pong")).toHaveLength(1);
+
+    mgr.destroy();
+  });
+
+  it("checkLiveness probes on demand", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    mgr.checkLiveness();
+
+    expect(latestSocket().pings).toHaveLength(1);
+
+    mgr.destroy();
+  });
+
+  it("checkLiveness drops a socket the browser no longer reports as open", async () => {
+    const mgr = createManager();
+    const closed = jest.fn();
+    mgr.on("close", closed);
+    await connect(mgr);
+
+    latestSocket().readyState = FakeWebSocket.CLOSED;
+    mgr.checkLiveness();
+
+    expect(closed).toHaveBeenCalledWith(1006, "Heartbeat timeout", false);
+
+    mgr.destroy();
+  });
+});
+
+describe("WebSocketManager outbound queue", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("drops the oldest messages past maxQueueSize", async () => {
+    const mgr = createManager({ reconnect: true, maxQueueSize: 3 });
+    mgr.connect().catch(() => {});
+
+    for (let i = 0; i < 6; i++) {
+      mgr.send({ type: "test", i });
+    }
+
+    latestSocket().triggerOpen();
+
+    expect(latestSocket().sent.map((m) => m.i)).toEqual([3, 4, 5]);
+
+    mgr.destroy();
+  });
+});


### PR DESCRIPTION
## The problem

Neither WebSocket client noticed a connection that died without an `onclose` — laptop sleep, NAT/proxy timeouts, a wifi/cellular handoff. The browser (and React Native) keeps reporting the socket as `OPEN`, so the manager stayed in `connected` and every workflow update, streamed chunk, and job status was silently dropped until the user reloaded the page or restarted the app.

The server already heartbeats every 25s and answers client pings with a pong (`unified-websocket-runner.ts`), but no client did anything with either frame.

Mobile's foreground handler had the same blind spot: `resumeFromBackground()` checked `isConnected()`, which a half-open socket satisfies, so waking the app from a suspended radio left a dead connection in place.

## The change

Both managers (`web/src/lib/websocket/WebSocketManager.ts` and `mobile/src/services/WebSocketManager.ts`) run a liveness watchdog:

- Any inbound frame counts as proof of life, decodable or not.
- After 45s of silence (above the server's 25s heartbeat) the client sends a ping.
- If nothing arrives within 10s, the socket is detached and run through the normal close path, so the existing reconnect/backoff logic takes over. `close()` alone is not enough — the closing handshake on a dead connection can hang for minutes before `onclose` fires.
- Both thresholds are configurable; `heartbeatInterval: 0` disables the watchdog.

Server pings are now answered with a pong, and both heartbeat frames are consumed instead of being forwarded to subscribers (they carry no routing key, so `GlobalWebSocketManager` was debug-logging one every 25s).

`checkLiveness()` is exposed so callers can probe on an environmental hint rather than waiting out the timer: the web manager runs it when the tab becomes visible or the network comes back, and mobile runs it on foreground.

Also in this area:

- **Reconnect backoff gets half-to-full jitter.** Without it every client that dropped on a server restart comes back in lockstep and hammers the server as it boots.
- **The web outbound queue is capped** (100 messages, oldest dropped). A long outage with a chatty caller grew it without bound.
- **Mobile can reach the terminal `failed` state from `disconnected`**, as the web manager already could. Previously an exhausted reconnect budget was indistinguishable from an ordinary disconnect.

## Tests

New suites cover both clients: silence probing, teardown on an unanswered probe, keeping a connection whose probe is answered, reconnecting after a dead socket, ping/pong handling, the on-demand `checkLiveness()` path, mobile's foreground probe, and the web queue cap. The mobile backoff test was updated for the jitter range.

`npm run typecheck`, `npm run lint`, and `npm run test` all pass (1043 + 63 + 72 suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3mw7hLHNkPkMN1Z2KBkWe)_