### PR TITLE
Fix five reliability failures in workflow execution

### DIFF
--- a/packages/kernel/src/inbox.ts
+++ b/packages/kernel/src/inbox.ts
@@ -126,6 +126,12 @@ export class NodeInbox {
   /** Flag: inbox is closed (no more data accepted). */
   private _closed = false;
 
+  /**
+   * Flag: backpressure is disabled because nothing will read this inbox again
+   * (its actor finished). See {@link releaseBackpressure}.
+   */
+  private _backpressureReleased = false;
+
   /** Waiters: consumers blocking for new data. */
   private _waiters: Array<Deferred<void>> = [];
 
@@ -208,9 +214,10 @@ export class NodeInbox {
     }
 
     // Backpressure: wait if buffer is at limit
-    if (this._bufferLimit !== null) {
+    if (this._bufferLimit !== null && !this._backpressureReleased) {
       while (
         !this._closed &&
+        !this._backpressureReleased &&
         // Stryker disable next-line OptionalChaining: the buffer was auto-created above, so get(handle) is always defined here — the ?. is defensive
         (this._buffers.get(handle)?.length ?? 0) >= this._bufferLimit
       ) {
@@ -544,6 +551,25 @@ export class NodeInbox {
   async closeAll(): Promise<void> {
     this._closed = true;
     this._notifyWaiters();
+    this._notifyPutWaiters();
+  }
+
+  /**
+   * Stop applying backpressure: wake every producer parked on a full buffer and
+   * let later `put`s through without waiting.
+   *
+   * Called when the consuming actor has finished, so no one will ever drain
+   * this inbox again. Without it, an upstream actor blocked in `put()` on a
+   * full buffer waits on a `_putWaiters` deferred that only a consumer pop can
+   * resolve — the producer never returns, and the runner's `Promise.all` over
+   * all actors never settles, hanging the whole workflow.
+   *
+   * Unlike `closeAll()`, writes are still accepted and buffered, so the
+   * runner's post-run "pending inbox work" check still reports the undelivered
+   * values instead of silently dropping them.
+   */
+  releaseBackpressure(): void {
+    this._backpressureReleased = true;
     this._notifyPutWaiters();
   }
 

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -862,11 +862,48 @@ export class WorkflowRunner {
   // Node initialization
   // -----------------------------------------------------------------------
 
+  /**
+   * Initialize every node's executor before any actor runs.
+   *
+   * A failure here aborts the run before `_processGraph`, so the actors that
+   * would normally call `finalize()` never start. Finalize the executors that
+   * did initialize, otherwise whatever they opened (python bridge handles,
+   * provider clients, file descriptors) leaks for the lifetime of the process.
+   * The failure is also re-thrown with the offending node's identity attached —
+   * a bare "connect ECONNREFUSED" gives no clue which node to fix.
+   */
   private async _initializeGraph(): Promise<void> {
+    const initialized: NodeExecutor[] = [];
     for (const node of this._graph.nodes) {
       const executor = this._resolveExecutor(node);
-      if (executor.initialize) {
+      if (!executor.initialize) continue;
+      try {
         await executor.initialize();
+        initialized.push(executor);
+      } catch (err) {
+        await this._finalizeExecutors(initialized);
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Node "${node.name ?? node.id}" (${node.type}) failed to initialize: ${message}`,
+          { cause: err }
+        );
+      }
+    }
+  }
+
+  /** Finalize executors, never letting one failure hide another. */
+  private async _finalizeExecutors(
+    executors: readonly NodeExecutor[]
+  ): Promise<void> {
+    for (const executor of executors) {
+      if (!executor.finalize) continue;
+      try {
+        await executor.finalize();
+      } catch (err) {
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+        log.warn("Executor finalize failed during initialization rollback", {
+          error: err instanceof Error ? err.message : String(err)
+        });
       }
     }
   }
@@ -1133,6 +1170,8 @@ export class WorkflowRunner {
    */
   private async _processGraph(): Promise<void> {
     const actorPromises: Array<Promise<void>> = [];
+    /** Parallel to `actorPromises` — maps a settled index back to its node. */
+    const actorNodeIds: string[] = [];
 
     for (const node of this._graph.nodes) {
       // Skip input-only nodes that have no incoming edges
@@ -1177,8 +1216,14 @@ export class WorkflowRunner {
           this._signalSlotEos(sourceNodeId, slot)
       });
 
+      actorNodeIds.push(node.id);
       actorPromises.push(
         actor.run().then(async (result) => {
+          // Nothing will read this inbox again. Wake any upstream actor parked
+          // on a full buffer so it can finish instead of waiting forever for a
+          // consumer that is gone.
+          inbox.releaseBackpressure();
+
           if (result.error !== undefined) {
             this._nodeErrors.set(node.id, result.error);
           }
@@ -1244,8 +1289,26 @@ export class WorkflowRunner {
       );
     }
 
-    // Wait for all actors to complete
-    await Promise.all(actorPromises);
+    // Wait for every actor, including post-completion routing. `allSettled`
+    // rather than `all`: a throw in one actor's completion handler (EOS
+    // routing, channel bookkeeping, a message-transport failure) must not
+    // return the run while its siblings are still executing — orphaned actors
+    // would keep writing to inboxes and emitting messages after the runner
+    // reported a terminal status.
+    const settled = await Promise.allSettled(actorPromises);
+    for (const [index, outcome] of settled.entries()) {
+      if (outcome.status !== "rejected") continue;
+      const nodeId = actorNodeIds[index];
+      const message =
+        outcome.reason instanceof Error
+          ? outcome.reason.message
+          : String(outcome.reason);
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+      log.error("Actor completion handling failed", { nodeId, error: message });
+      if (!this._nodeErrors.has(nodeId)) {
+        this._nodeErrors.set(nodeId, message);
+      }
+    }
 
     // Backstop: release any reader still waiting on a channel (e.g. a writer
     // that errored before publishing). Non-cyclic graphs are already closed by
@@ -1719,13 +1782,19 @@ export class WorkflowRunner {
       );
     }
 
+    const entry: {
+      resolve: (outputs: Record<string, unknown>) => void;
+      reject: (err: Error) => void;
+    } = { resolve: () => {}, reject: () => {} };
     const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
+      entry.resolve = resolve;
+      entry.reject = reject;
       let queue = this._pendingControlResponses.get(targetNodeId);
       if (!queue) {
         queue = [];
         this._pendingControlResponses.set(targetNodeId, queue);
       }
-      queue.push({ resolve, reject });
+      queue.push(entry);
     });
 
     const event: ControlEvent = {
@@ -1733,6 +1802,26 @@ export class WorkflowRunner {
       properties
     };
     await inbox.put("__control__", event);
+
+    // The target's actor can finish between the check above and this point —
+    // its completion handler drains `_pendingControlResponses` before this
+    // waiter joined the queue, so nothing would ever settle it. Re-check after
+    // registering and reject rather than hang.
+    if (this._completedNodes.has(targetNodeId)) {
+      const queue = this._pendingControlResponses.get(targetNodeId);
+      const index = queue?.indexOf(entry) ?? -1;
+      if (queue && index >= 0) {
+        queue.splice(index, 1);
+        if (queue.length === 0) {
+          this._pendingControlResponses.delete(targetNodeId);
+        }
+        entry.reject(
+          new Error(
+            `Target node already completed and cannot handle control events: ${targetNodeId}`
+          )
+        );
+      }
+    }
 
     return promise;
   }
@@ -1901,7 +1990,20 @@ export class WorkflowRunner {
       this._messages.push(msg);
     }
     if (this._options.executionContext) {
-      this._options.executionContext.emit(msg);
+      // Message delivery is observation, not execution. A transport that fails
+      // mid-run (a closed WebSocket, a full queue) must not abort the workflow
+      // — `_emit` is called from EOS routing and actor completion handlers,
+      // where a throw would take down the run and orphan sibling actors.
+      try {
+        this._options.executionContext.emit(msg);
+      } catch (err) {
+        // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+        log.warn("Message emit failed", {
+          jobId: this.jobId,
+          type: msg.type,
+          error: err instanceof Error ? err.message : String(err)
+        });
+      }
     }
     // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
     log.debug("Message emitted", { jobId: this.jobId, type: msg.type });

--- a/packages/kernel/tests/execution-reliability.test.ts
+++ b/packages/kernel/tests/execution-reliability.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Reliability regressions in workflow execution.
+ *
+ * Each case here is a way a run used to hang, silently leak, or return a
+ * terminal status while actors were still executing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkflowRunner } from "../src/runner.js";
+import { NodeInbox } from "../src/inbox.js";
+import type {
+  NodeDescriptor,
+  Edge,
+  ProcessingMessage
+} from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { NodeExecutor } from "../src/actor.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// ---------------------------------------------------------------------------
+// Backpressure release when the consumer is gone
+// ---------------------------------------------------------------------------
+
+describe("NodeInbox.releaseBackpressure", () => {
+  it("unblocks a producer parked on a full buffer", async () => {
+    const inbox = new NodeInbox(1);
+    inbox.addUpstream("in", 1);
+    await inbox.put("in", 1);
+
+    let settled = false;
+    const blocked = inbox.put("in", 2).then(() => {
+      settled = true;
+    });
+
+    await tick();
+    expect(settled).toBe(false);
+
+    inbox.releaseBackpressure();
+    await blocked;
+    expect(settled).toBe(true);
+  });
+
+  it("still buffers the value, so pending work stays visible", async () => {
+    const inbox = new NodeInbox(1);
+    inbox.addUpstream("in", 1);
+    await inbox.put("in", 1);
+    inbox.releaseBackpressure();
+    await inbox.put("in", 2);
+
+    // Unlike closeAll(), the write is accepted — the runner's post-run
+    // "pending inbox work" check must still see undelivered values.
+    expect(inbox.hasBuffered("in")).toBe(true);
+    expect(inbox.hasPendingWork()).toBe(true);
+    expect(inbox.isClosed()).toBe(false);
+  });
+
+  it("does not apply to an inbox with no buffer limit", async () => {
+    const inbox = new NodeInbox(null);
+    inbox.addUpstream("in", 1);
+    await inbox.put("in", 1);
+    await inbox.put("in", 2);
+    expect(inbox.hasBuffered("in")).toBe(true);
+  });
+});
+
+describe("runner: a dead consumer does not deadlock its producer", () => {
+  it("completes a bufferLimit run whose consumer errors immediately", async () => {
+    // The consumer's actor dies on its first read while the streaming producer
+    // still has values to push. With a buffer limit and no backpressure
+    // release, the producer parks in put() forever waiting for a consumer that
+    // is gone, and Promise.all over the actors never settles.
+    const nodes: NodeDescriptor[] = [
+      { id: "trig", type: "test.Input", name: "trig" },
+      { id: "producer", type: "test.Streamer", is_streaming_output: true },
+      { id: "consumer", type: "test.Consumer", is_streaming_input: true }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e-trig",
+        source: "trig",
+        sourceHandle: "value",
+        target: "producer",
+        targetHandle: "start"
+      },
+      {
+        id: "e-data",
+        source: "producer",
+        sourceHandle: "value",
+        target: "consumer",
+        targetHandle: "value"
+      }
+    ];
+
+    let produced = 0;
+    const runner = new WorkflowRunner("job-backpressure", {
+      bufferLimit: 1,
+      resolveExecutor: (node) => {
+        if (node.id === "producer") {
+          return {
+            async *genProcess() {
+              for (let i = 0; i < 25; i++) {
+                produced++;
+                yield { value: i };
+              }
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        if (node.id === "consumer") {
+          return {
+            async run() {
+              throw new Error("consumer died");
+            },
+            process: async () => ({})
+          } as unknown as NodeExecutor;
+        }
+        return { process: async (i: Record<string, unknown>) => i };
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "job-backpressure", params: { trig: 0 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("consumer died");
+    // The producer ran to completion rather than parking forever.
+    expect(produced).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A failing completion handler must not orphan sibling actors
+// ---------------------------------------------------------------------------
+
+describe("runner: actor post-completion failures", () => {
+  it("waits for every actor when one completion handler throws", async () => {
+    // markChannelWriterDone runs inside the actor completion handler. When it
+    // throws, Promise.all used to reject and _runImpl returned immediately —
+    // while the slow sibling actor kept running, emitting into a run that had
+    // already reported a terminal status.
+    const nodes: NodeDescriptor[] = [
+      { id: "trig", type: "test.Input", name: "trig" },
+      {
+        id: "setvar",
+        type: "nodetool.variable.SetVariable",
+        properties: { name: "chan" }
+      },
+      { id: "slow", type: "test.Slow" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "trig",
+        sourceHandle: "value",
+        target: "setvar",
+        targetHandle: "value"
+      },
+      {
+        id: "e2",
+        source: "trig",
+        sourceHandle: "value",
+        target: "slow",
+        targetHandle: "value"
+      }
+    ];
+
+    let slowFinished = false;
+    const context = {
+      emit() {},
+      registerChannelWriters() {},
+      markChannelWriterDone() {
+        throw new Error("channel bookkeeping exploded");
+      },
+      closeAllChannels() {}
+    } as unknown as ProcessingContext;
+
+    const runner = new WorkflowRunner("job-settle", {
+      executionContext: context,
+      resolveExecutor: (node) => {
+        if (node.id === "slow") {
+          return {
+            async process() {
+              await new Promise((r) => setTimeout(r, 30));
+              slowFinished = true;
+              return { value: "done" };
+            }
+          };
+        }
+        return { process: async (i: Record<string, unknown>) => i };
+      }
+    });
+
+    const result = await runner.run(
+      { job_id: "job-settle", params: { trig: 1 } },
+      { nodes, edges }
+    );
+
+    expect(slowFinished).toBe(true);
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("channel bookkeeping exploded");
+    // The failure is attributed to the node whose handler threw.
+    expect(result.error).toContain("setvar");
+  });
+
+  it("a throwing message transport does not fail the run", async () => {
+    // A WebSocket that closes mid-run makes emit() throw. Message delivery is
+    // observation: it must not take down the workflow, which used to happen
+    // because _emit is called from EOS routing inside the actor handlers.
+    const nodes: NodeDescriptor[] = [
+      { id: "trig", type: "test.Input", name: "trig" },
+      { id: "sink", type: "test.Sink", name: "out" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "trig",
+        sourceHandle: "value",
+        target: "sink",
+        targetHandle: "value"
+      }
+    ];
+
+    let emitted = 0;
+    const context = {
+      emit(_msg: ProcessingMessage) {
+        emitted++;
+        throw new Error("socket closed");
+      }
+    } as unknown as ProcessingContext;
+
+    const runner = new WorkflowRunner("job-emit", {
+      executionContext: context,
+      resolveExecutor: () => ({
+        process: async (i: Record<string, unknown>) => i
+      })
+    });
+
+    const result = await runner.run(
+      { job_id: "job-emit", params: { trig: 7 } },
+      { nodes, edges }
+    );
+
+    expect(emitted).toBeGreaterThan(0);
+    expect(result.status).toBe("completed");
+    expect(result.outputs.out).toEqual([7]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Initialization failure must not leak initialized executors
+// ---------------------------------------------------------------------------
+
+describe("runner: initialize() failure", () => {
+  it("finalizes already-initialized executors and names the failing node", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "a", type: "test.Resource", name: "a" },
+      { id: "b", type: "test.Broken", name: "b" }
+    ];
+    const edges: Edge[] = [
+      {
+        id: "e1",
+        source: "a",
+        sourceHandle: "value",
+        target: "b",
+        targetHandle: "value"
+      }
+    ];
+
+    // Nodes initialize in graph order, so "a" opens its resource before "b"
+    // fails.
+    const finalized: string[] = [];
+    const runner = new WorkflowRunner("job-init", {
+      resolveExecutor: (node) => ({
+        async initialize() {
+          if (node.id === "b") throw new Error("port already in use");
+        },
+        async finalize() {
+          finalized.push(node.id);
+        },
+        process: async (i: Record<string, unknown>) => i
+      })
+    });
+
+    const result = await runner.run({ job_id: "job-init" }, { nodes, edges });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("port already in use");
+    expect(result.error).toContain("test.Broken");
+    expect(result.error).toContain("b");
+    // "a" initialized successfully and would otherwise hold its resource
+    // forever: no actor ever ran to finalize it.
+    expect(finalized).toEqual(["a"]);
+  });
+
+  it("a finalize failure during rollback does not mask the original error", async () => {
+    const nodes: NodeDescriptor[] = [
+      { id: "a", type: "test.Resource", name: "a" },
+      { id: "b", type: "test.Broken", name: "b" }
+    ];
+
+    const runner = new WorkflowRunner("job-init-2", {
+      resolveExecutor: (node) => ({
+        async initialize() {
+          if (node.id === "b") throw new Error("original failure");
+        },
+        async finalize() {
+          throw new Error("cleanup also failed");
+        },
+        process: async (i: Record<string, unknown>) => i
+      })
+    });
+
+    const result = await runner.run(
+      { job_id: "job-init-2" },
+      { nodes, edges: [] }
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("original failure");
+    expect(result.error).not.toContain("cleanup also failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendControlEvent races the target's completion
+// ---------------------------------------------------------------------------
+
+describe("runner: sendControlEvent completion race", () => {
+  it("rejects when the target completes while the event is in flight", async () => {
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "worker",
+        type: "test.Worker",
+        is_controlled: true,
+        outputs: { result: "int" }
+      }
+    ];
+
+    const runner = new WorkflowRunner("job-race", {
+      resolveExecutor: () => ({ process: async () => ({ result: 1 }) })
+    });
+
+    const internals = runner as unknown as {
+      _inboxes: Map<string, NodeInbox>;
+      _completedNodes: Set<string>;
+    };
+    const inbox = new NodeInbox(null);
+    inbox.addUpstream("__control__", 1);
+    internals._inboxes = new Map([["worker", inbox]]);
+    internals._completedNodes = new Set();
+
+    // Model the race precisely: the target's actor finishes *during* the
+    // awaited put(), after sendControlEvent's up-front completed check passed
+    // but before its waiter joined the pending queue. The completion handler
+    // has already drained that queue, so nothing will ever settle this waiter.
+    const realPut = inbox.put.bind(inbox);
+    inbox.put = async (handle, item, opts) => {
+      internals._completedNodes.add("worker");
+      await realPut(handle, item, opts);
+    };
+
+    await expect(runner.sendControlEvent("worker", { x: 1 })).rejects.toThrow(
+      /already completed/
+    );
+  });
+
+  it("rejects up front for an already-completed target", async () => {
+    const runner = new WorkflowRunner("job-race-2", {
+      resolveExecutor: () => ({ process: async () => ({}) })
+    });
+    const internals = runner as unknown as {
+      _inboxes: Map<string, NodeInbox>;
+      _completedNodes: Set<string>;
+    };
+    internals._inboxes = new Map([["worker", new NodeInbox(null)]]);
+    internals._completedNodes = new Set(["worker"]);
+
+    await expect(runner.sendControlEvent("worker", {})).rejects.toThrow(
+      /already completed/
+    );
+  });
+});

--- a/packages/kernel/tests/execution-reliability.test.ts
+++ b/packages/kernel/tests/execution-reliability.test.ts
@@ -330,15 +330,6 @@ describe("runner: initialize() failure", () => {
 
 describe("runner: sendControlEvent completion race", () => {
   it("rejects when the target completes while the event is in flight", async () => {
-    const nodes: NodeDescriptor[] = [
-      {
-        id: "worker",
-        type: "test.Worker",
-        is_controlled: true,
-        outputs: { result: "int" }
-      }
-    ];
-
     const runner = new WorkflowRunner("job-race", {
       resolveExecutor: () => ({ process: async () => ({ result: 1 }) })
     });


### PR DESCRIPTION
Five paths in the kernel where a run could hang, leak resources, or report a terminal status while actors were still executing. Each fix has a regression test in `packages/kernel/tests/execution-reliability.test.ts`.

## Hang: a dead consumer deadlocks its producer

With `bufferLimit` set, a producer parked in `NodeInbox.put()` on the full inbox of a consumer that already exited waited on a `_putWaiters` deferred that only a consumer pop can resolve. The producer never returned, so the runner's wait over all actors never settled and the whole workflow hung.

`NodeInbox.releaseBackpressure()` wakes parked producers and lets later puts through; the runner calls it as soon as an actor finishes. Unlike `closeAll()`, writes are still accepted and buffered, so the post-run "pending inbox work" check keeps reporting undelivered values instead of silently dropping them.

## Orphaned actors: `Promise.all` over the actor set

A throw in one actor's completion handler — EOS routing, variable-channel bookkeeping, message transport — rejected `Promise.all` and returned the run immediately, while sibling actors kept executing: still writing to inboxes and emitting messages after the runner had reported a terminal status. Now `Promise.allSettled`, with each rejection recorded as an error against the node that raised it.

## Leak: `initialize()` failure skips finalization

Executor initialization runs before `_processGraph`, so when one node's `initialize()` throws, the actors that would call `finalize()` never start — whatever earlier nodes opened (python bridge handles, provider clients, file descriptors) leaks for the process lifetime. Those executors are now finalized on the way out, and the error carries the failing node's id and type instead of a bare `connect ECONNREFUSED`.

## Hang: `sendControlEvent` races the target's completion

The target's actor can finish between the up-front `_completedNodes` check and the awaited `inbox.put()`. Its completion handler drains `_pendingControlResponses` before the new waiter joins the queue, so nothing can ever settle that promise. The state is re-checked after registering, and the waiter rejects rather than hanging.

## Abort: a failing message transport takes down the run

`_emit` is called from EOS routing and actor completion handlers, so a transport that fails mid-run (closed WebSocket, full queue) aborted the workflow. Message delivery is observation, not execution — it now logs and continues.

## Testing

- `packages/kernel` — 930 tests pass, including 10 new ones
- `npm run lint` and web/packages typecheck pass

Two pre-existing environment failures in this sandbox are unrelated to the change: `mobile` typecheck (no `mobile/node_modules`) and `packages/image-nodes` tests (`No WebGPU adapter available`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iemAHVfSTHcwXa9ZuCwur

---
_Generated by [Claude Code](https://claude.ai/code/session_019iemAHVfSTHcwXa9ZuCwur)_