### PR TITLE
Harden the WebSocket protocol against drops and stalled peers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,12 @@ Security notes:
 | `NODETOOL_WS_RATE_LIMIT_DISABLED` | Disable the per-connection WebSocket inbound message cap | no | Cap is **on** by default |
 | `NODETOOL_WS_RATE_LIMIT_MAX` | Max inbound WS messages per window per connection | no | Default `200`; over-cap clients are closed with code `1008` |
 | `NODETOOL_WS_RATE_LIMIT_WINDOW_MS` | WebSocket rate-limit window length (ms) | no | Default `1000` (1 second) |
+| `NODETOOL_WS_HEALTH_DISABLED` | Disable the per-connection ping / idle-timeout watchdog | no | Watchdog is **on** by default; it terminates half-open peers that never sent a close frame |
+| `NODETOOL_WS_PING_INTERVAL_MS` | How often each WebSocket peer is pinged | no | Default `20000` |
+| `NODETOOL_WS_IDLE_TIMEOUT_MS` | Peer silence before the connection is terminated | no | Default `70000`; keep above the client's own 45s liveness threshold |
+| `NODETOOL_WS_MAX_BUFFERED_BYTES` | Outbound buffer per connection before sends wait for drain | no | Default `8388608` (8 MiB) |
+| `NODETOOL_WS_DRAIN_TIMEOUT_MS` | How long a send waits for a slow reader before it is dropped | no | Default `30000`; the drop uses code `1001` so clients reconnect |
+| `NODETOOL_WS_MAX_QUEUED_FRAMES` | Undelivered inbound frames per connection before it is closed | no | Default `2000`; closes with code `1008` |
 | `NODETOOL_DISABLE_TRIGGERS` | Skip trigger ingestion on this process (no dispatcher, scheduler, file watcher, or webhook route) | no | Ingestion is **on** by default. Set to `1` when a second server shares one database, or for an embedded server that must not start background work |
 | `LOG_LEVEL` / `NODETOOL_LOG_LEVEL` | Logging level | no | Defaults to `info` (`NODETOOL_LOG_LEVEL` takes precedence) |
 | `SECRETS_MASTER_KEY` | Master key for secret encryption | yes | See [Secret Storage and Master Key](#secret-storage-and-master-key) |

--- a/packages/websocket/src/lib/ws-connection-health.ts
+++ b/packages/websocket/src/lib/ws-connection-health.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-connection health limits for the long-lived `/ws` socket.
+ *
+ * Two failure modes these bound, both invisible to `close` handlers:
+ *
+ *   Half-open peer — a client that vanished without a close frame (laptop
+ *   sleep, NAT rebind, killed browser). The socket stays "open" forever, and
+ *   with it the runner, its observers, its timers and its running jobs. A
+ *   protocol-level ping plus an idle deadline turns that into a real close.
+ *
+ *   Slow consumer — a client that reads slower than the server streams. `send`
+ *   buffers in memory with no upper bound, so one stalled reader can grow the
+ *   server's heap until it dies. Sends wait for the buffer to drain, and a peer
+ *   that never drains is dropped.
+ *
+ * Tunable via:
+ *
+ *   NODETOOL_WS_HEALTH_DISABLED         Set truthy to disable ping/idle checks.
+ *   NODETOOL_WS_PING_INTERVAL_MS        Ping cadence (default 20000).
+ *   NODETOOL_WS_IDLE_TIMEOUT_MS         Silence before the peer is dropped (default 70000).
+ *   NODETOOL_WS_MAX_BUFFERED_BYTES      Outbound buffer before sends wait (default 8388608).
+ *   NODETOOL_WS_DRAIN_TIMEOUT_MS        How long a send waits for drain (default 30000).
+ *   NODETOOL_WS_MAX_QUEUED_FRAMES       Undelivered inbound frames before close (default 2000).
+ */
+import { parseIntEnv, parseBoolEnv } from "./env-config.js";
+
+export interface WsConnectionHealthConfig {
+  enabled: boolean;
+  pingIntervalMs: number;
+  idleTimeoutMs: number;
+  maxBufferedBytes: number;
+  drainTimeoutMs: number;
+  maxQueuedFrames: number;
+}
+
+export function getWsConnectionHealthConfig(): WsConnectionHealthConfig {
+  return {
+    enabled: !parseBoolEnv("NODETOOL_WS_HEALTH_DISABLED"),
+    pingIntervalMs: parseIntEnv("NODETOOL_WS_PING_INTERVAL_MS", 20_000),
+    // Above the client's own 45s silence threshold, so the client gets to
+    // notice and reconnect on its own before the server gives up on it.
+    idleTimeoutMs: parseIntEnv("NODETOOL_WS_IDLE_TIMEOUT_MS", 70_000),
+    maxBufferedBytes: parseIntEnv("NODETOOL_WS_MAX_BUFFERED_BYTES", 8 * 1024 * 1024),
+    drainTimeoutMs: parseIntEnv("NODETOOL_WS_DRAIN_TIMEOUT_MS", 30_000),
+    maxQueuedFrames: parseIntEnv("NODETOOL_WS_MAX_QUEUED_FRAMES", 2000)
+  };
+}

--- a/packages/websocket/src/ws-adapter.ts
+++ b/packages/websocket/src/ws-adapter.ts
@@ -1,6 +1,10 @@
 import type { WebSocket } from "@fastify/websocket";
 import type { WebSocketConnection } from "./unified-websocket-runner.js";
 import { WsMessageRateLimiter } from "./lib/ws-rate-limit.js";
+import {
+  getWsConnectionHealthConfig,
+  type WsConnectionHealthConfig
+} from "./lib/ws-connection-health.js";
 
 type WsFrame = {
   type: string;
@@ -10,6 +14,12 @@ type WsFrame = {
 
 /**
  * Adapts a ws WebSocket to the WebSocketConnection interface used by UnifiedWebSocketRunner.
+ *
+ * Beyond the plumbing it enforces the per-connection health limits described in
+ * `lib/ws-connection-health.ts`: a ping/idle deadline that closes half-open
+ * peers, a bounded outbound buffer that makes `sendBytes`/`sendText` wait on a
+ * slow reader instead of growing the heap, and a cap on undelivered inbound
+ * frames.
  */
 export class WsAdapter implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -18,24 +28,26 @@ export class WsAdapter implements WebSocketConnection {
   private queue: WsFrame[] = [];
   private waiters: Array<(frame: WsFrame) => void> = [];
   private disconnected = false;
+  private readonly health: WsConnectionHealthConfig;
+  private lastActivityAt = Date.now();
+  private healthTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private socket: WebSocket,
-    private rateLimiter: WsMessageRateLimiter = new WsMessageRateLimiter()
+    private rateLimiter: WsMessageRateLimiter = new WsMessageRateLimiter(),
+    health: WsConnectionHealthConfig = getWsConnectionHealthConfig()
   ) {
+    this.health = health;
+
     socket.on(
       "message",
       (raw: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
         if (this.disconnected) return;
+        this.lastActivityAt = Date.now();
         // Cap inbound message rate per connection — a flooding client is
         // disconnected with a policy-violation code instead of being serviced.
         if (!this.rateLimiter.allow()) {
-          try {
-            this.socket.close(1008, "Message rate limit exceeded");
-          } catch {
-            // socket already closing/closed
-          }
-          this.markDisconnected();
+          this.closeWith(1008, "Message rate limit exceeded");
           return;
         }
         const bytes =
@@ -44,13 +56,42 @@ export class WsAdapter implements WebSocketConnection {
           ? { type: "websocket.message", bytes }
           : { type: "websocket.message", text: bytes.toString() };
         const waiter = this.waiters.shift();
-        if (waiter) waiter(frame);
-        else this.queue.push(frame);
+        if (waiter) {
+          waiter(frame);
+          return;
+        }
+        // Nothing is reading. Frames pile up only if the runner's receive loop
+        // has stalled; past this depth the client is better served by a close
+        // it can reconnect from than by an ever-growing queue.
+        if (this.queue.length >= this.health.maxQueuedFrames) {
+          this.closeWith(1008, "Inbound queue overflow");
+          return;
+        }
+        this.queue.push(frame);
       }
     );
 
+    // Any traffic proves the peer is alive: data frames, protocol pongs, and
+    // the pings browsers send on their own.
+    socket.on("pong", () => this.markActivity());
+    socket.on("ping", () => this.markActivity());
     socket.on("error", () => this.markDisconnected());
     socket.on("close", () => this.markDisconnected());
+
+    this.startHealthWatchdog();
+  }
+
+  private markActivity(): void {
+    this.lastActivityAt = Date.now();
+  }
+
+  private closeWith(code: number, reason: string): void {
+    try {
+      this.socket.close(code, reason);
+    } catch {
+      // socket already closing/closed
+    }
+    this.markDisconnected();
   }
 
   /**
@@ -65,12 +106,56 @@ export class WsAdapter implements WebSocketConnection {
     this.disconnected = true;
     this.clientState = "disconnected";
     this.applicationState = "disconnected";
+    this.stopHealthWatchdog();
     const frame: WsFrame = { type: "websocket.disconnect" };
     if (this.waiters.length > 0) {
       for (const waiter of this.waiters) waiter(frame);
       this.waiters.length = 0;
     } else {
       this.queue.push(frame);
+    }
+  }
+
+  /**
+   * Probe the peer on a timer and give up on it once it has been silent past
+   * the idle deadline.
+   *
+   * `close()` is not enough for a peer that is already gone — the closing
+   * handshake has nobody to answer it and the socket can linger for minutes —
+   * so the connection is terminated outright once the deadline passes.
+   */
+  private startHealthWatchdog(): void {
+    if (!this.health.enabled || this.health.pingIntervalMs <= 0) return;
+
+    this.healthTimer = setInterval(() => {
+      if (this.disconnected) return;
+
+      if (Date.now() - this.lastActivityAt >= this.health.idleTimeoutMs) {
+        this.markDisconnected();
+        try {
+          this.socket.terminate?.();
+        } catch {
+          // socket already gone
+        }
+        return;
+      }
+
+      try {
+        this.socket.ping?.();
+      } catch {
+        // A ping that cannot even be queued means the socket is finished.
+        this.markDisconnected();
+      }
+    }, this.health.pingIntervalMs);
+
+    // Never hold the process open for a watchdog.
+    this.healthTimer.unref?.();
+  }
+
+  private stopHealthWatchdog(): void {
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = null;
     }
   }
 
@@ -83,11 +168,52 @@ export class WsAdapter implements WebSocketConnection {
   }
 
   async sendBytes(data: Uint8Array): Promise<void> {
-    this.socket.send(data);
+    await this.send(data);
   }
 
   async sendText(data: string): Promise<void> {
-    this.socket.send(data);
+    await this.send(data);
+  }
+
+  /**
+   * Write one frame, waiting first if the peer is behind.
+   *
+   * The runner serializes sends behind a lock, so waiting here propagates
+   * backpressure all the way up to whatever is producing messages instead of
+   * letting them accumulate in the socket's buffer.
+   */
+  private async send(data: Uint8Array | string): Promise<void> {
+    if (this.disconnected) return;
+    await this.awaitDrain();
+    if (this.disconnected) return;
+    try {
+      this.socket.send(data);
+    } catch {
+      // The peer went away between the drain check and the write.
+      this.markDisconnected();
+    }
+  }
+
+  private async awaitDrain(): Promise<void> {
+    const { maxBufferedBytes, drainTimeoutMs } = this.health;
+    if (maxBufferedBytes <= 0) return;
+    if (this.bufferedAmount() < maxBufferedBytes) return;
+
+    const deadline = Date.now() + drainTimeoutMs;
+    while (!this.disconnected && this.bufferedAmount() >= maxBufferedBytes) {
+      if (Date.now() >= deadline) {
+        // 1001 rather than a policy code: the client should treat this as a
+        // routine drop and reconnect.
+        this.closeWith(1001, "Client too slow to receive");
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  private bufferedAmount(): number {
+    const buffered = (this.socket as { bufferedAmount?: number }).bufferedAmount;
+    return typeof buffered === "number" ? buffered : 0;
   }
 
   async close(code?: number, reason?: string): Promise<void> {

--- a/packages/websocket/tests/ws-connection-health.test.ts
+++ b/packages/websocket/tests/ws-connection-health.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Per-connection health limits: the half-open peer the OS never reports, the
+ * slow reader whose backlog would otherwise live in the server's heap, and the
+ * inbound backlog a stalled runner leaves behind.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import {
+  getWsConnectionHealthConfig,
+  type WsConnectionHealthConfig
+} from "../src/lib/ws-connection-health.js";
+import { WsAdapter } from "../src/ws-adapter.js";
+import { WsMessageRateLimiter } from "../src/lib/ws-rate-limit.js";
+
+const HEALTH_ENV_VARS = [
+  "NODETOOL_WS_HEALTH_DISABLED",
+  "NODETOOL_WS_PING_INTERVAL_MS",
+  "NODETOOL_WS_IDLE_TIMEOUT_MS",
+  "NODETOOL_WS_MAX_BUFFERED_BYTES",
+  "NODETOOL_WS_DRAIN_TIMEOUT_MS",
+  "NODETOOL_WS_MAX_QUEUED_FRAMES"
+] as const;
+
+function clearHealthEnv(): void {
+  for (const key of HEALTH_ENV_VARS) delete process.env[key];
+}
+
+const health = (
+  overrides: Partial<WsConnectionHealthConfig> = {}
+): WsConnectionHealthConfig => ({
+  enabled: true,
+  pingIntervalMs: 1000,
+  idleTimeoutMs: 5000,
+  maxBufferedBytes: 1024,
+  drainTimeoutMs: 2000,
+  maxQueuedFrames: 3,
+  ...overrides
+});
+
+function makeSocket() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    send: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    ping: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+    bufferedAmount: number;
+  };
+  emitter.send = vi.fn();
+  emitter.close = vi.fn();
+  emitter.ping = vi.fn();
+  emitter.terminate = vi.fn();
+  emitter.bufferedAmount = 0;
+  return emitter;
+}
+
+const noLimit = () =>
+  new WsMessageRateLimiter({
+    enabled: false,
+    maxMessages: 0,
+    windowMs: 1000
+  });
+
+describe("getWsConnectionHealthConfig", () => {
+  afterEach(clearHealthEnv);
+
+  it("returns sane defaults", () => {
+    clearHealthEnv();
+    expect(getWsConnectionHealthConfig()).toEqual({
+      enabled: true,
+      pingIntervalMs: 20_000,
+      idleTimeoutMs: 70_000,
+      maxBufferedBytes: 8 * 1024 * 1024,
+      drainTimeoutMs: 30_000,
+      maxQueuedFrames: 2000
+    });
+  });
+
+  it("reads overrides from the environment", () => {
+    process.env.NODETOOL_WS_HEALTH_DISABLED = "true";
+    process.env.NODETOOL_WS_PING_INTERVAL_MS = "500";
+    process.env.NODETOOL_WS_IDLE_TIMEOUT_MS = "1500";
+    process.env.NODETOOL_WS_MAX_BUFFERED_BYTES = "2048";
+    process.env.NODETOOL_WS_DRAIN_TIMEOUT_MS = "100";
+    process.env.NODETOOL_WS_MAX_QUEUED_FRAMES = "7";
+    expect(getWsConnectionHealthConfig()).toEqual({
+      enabled: false,
+      pingIntervalMs: 500,
+      idleTimeoutMs: 1500,
+      maxBufferedBytes: 2048,
+      drainTimeoutMs: 100,
+      maxQueuedFrames: 7
+    });
+  });
+});
+
+describe("WsAdapter half-open peer detection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("pings the peer on the configured cadence", () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    new WsAdapter(socket as never, noLimit(), health());
+
+    vi.advanceTimersByTime(3500);
+
+    expect(socket.ping).toHaveBeenCalledTimes(3);
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates a peer that has gone silent past the idle deadline", async () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    vi.advanceTimersByTime(6000);
+
+    expect(socket.terminate).toHaveBeenCalled();
+    expect(adapter.clientState).toBe("disconnected");
+    expect((await adapter.receive()).type).toBe("websocket.disconnect");
+  });
+
+  it("treats a protocol pong as proof of life", () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    // Answer every probe just before the deadline would expire.
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(4000);
+      socket.emit("pong");
+    }
+
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(adapter.clientState).toBe("connected");
+  });
+
+  it("treats inbound data as proof of life", async () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(4000);
+      socket.emit("message", Buffer.from("hi"), false);
+      await adapter.receive();
+    }
+
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(adapter.clientState).toBe("connected");
+  });
+
+  it("stops probing once the socket is gone", () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    new WsAdapter(socket as never, noLimit(), health());
+
+    socket.emit("close");
+    vi.advanceTimersByTime(10_000);
+
+    expect(socket.ping).not.toHaveBeenCalled();
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  it("does not probe when health checks are disabled", () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    new WsAdapter(socket as never, noLimit(), health({ enabled: false }));
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(socket.ping).not.toHaveBeenCalled();
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+});
+
+describe("WsAdapter outbound backpressure", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends straight through while the peer keeps up", async () => {
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    await adapter.sendBytes(new Uint8Array([1, 2, 3]));
+    await adapter.sendText("hello");
+
+    expect(socket.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for a full buffer to drain before writing", async () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+    socket.bufferedAmount = 4096;
+
+    const pending = adapter.sendText("blocked");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(socket.send).not.toHaveBeenCalled();
+
+    socket.bufferedAmount = 0;
+    await vi.advanceTimersByTimeAsync(100);
+    await pending;
+
+    expect(socket.send).toHaveBeenCalledWith("blocked");
+  });
+
+  it("drops a peer that never drains, with a code the client reconnects from", async () => {
+    vi.useFakeTimers();
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+    socket.bufferedAmount = 4096;
+
+    const pending = adapter.sendText("blocked");
+    await vi.advanceTimersByTimeAsync(2500);
+    await pending;
+
+    expect(socket.close).toHaveBeenCalledWith(1001, "Client too slow to receive");
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(adapter.clientState).toBe("disconnected");
+  });
+
+  it("swallows a write that races the peer going away", async () => {
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+    socket.send.mockImplementation(() => {
+      throw new Error("WebSocket is not open");
+    });
+
+    await expect(adapter.sendText("doomed")).resolves.toBeUndefined();
+    expect(adapter.clientState).toBe("disconnected");
+  });
+});
+
+describe("WsAdapter inbound queue cap", () => {
+  it("closes the connection when undelivered frames pile up", async () => {
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    // Nothing is calling receive(), so every frame queues.
+    for (let i = 0; i < 4; i++) {
+      socket.emit("message", Buffer.from(String(i)), false);
+    }
+
+    expect(socket.close).toHaveBeenCalledWith(1008, "Inbound queue overflow");
+    expect(adapter.clientState).toBe("disconnected");
+  });
+
+  it("does not count frames a reader has already taken", async () => {
+    const socket = makeSocket();
+    const adapter = new WsAdapter(socket as never, noLimit(), health());
+
+    for (let i = 0; i < 8; i++) {
+      socket.emit("message", Buffer.from(String(i)), false);
+      expect((await adapter.receive()).type).toBe("websocket.message");
+    }
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(adapter.clientState).toBe("connected");
+  });
+});

--- a/web/src/lib/websocket/GlobalWebSocketManager.ts
+++ b/web/src/lib/websocket/GlobalWebSocketManager.ts
@@ -51,7 +51,6 @@ interface GlobalWebSocketEvents {
 
 type GlobalWebSocketEvent = keyof GlobalWebSocketEvents;
 
-const MAX_RECONNECT_ATTEMPTS = 10;
 const RECONNECT_INTERVAL_MS = 1000;
 
 /**
@@ -59,9 +58,10 @@ const RECONNECT_INTERVAL_MS = 1000;
  *
  * Establishes a single shared WebSocket to the unified backend and
  * multiplexes messages by job_id or thread_id. Consumers subscribe with a
- * routing key and receive only their messages. Built-in reconnect with up to
- * 5 attempts/1s backoff; `ensureConnection` blocks until connected and reuses
- * Supabase auth when available.
+ * routing key and receive only their messages. Reconnects indefinitely with
+ * backoff, and cuts the backoff short when the network or the tab comes back;
+ * `ensureConnection` blocks until connected and reuses Supabase auth when
+ * available.
  */
 class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
   private static instance: GlobalWebSocketManager | null = null;
@@ -149,8 +149,7 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
         url: wsUrl,
         binaryType: "arraybuffer",
         reconnect: true,
-        reconnectInterval: RECONNECT_INTERVAL_MS,
-        reconnectAttempts: MAX_RECONNECT_ATTEMPTS
+        reconnectInterval: RECONNECT_INTERVAL_MS
       });
 
       this.wsManager.on("open", () => {
@@ -440,6 +439,13 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
   private recoverConnection(trigger: string): void {
     if (this.isConnected && this.wsManager) {
       this.wsManager.checkLiveness();
+      return;
+    }
+    // Already retrying: the manager owns the socket, so let it keep it — but
+    // cut short whatever backoff it is sitting in, since the thing it was
+    // waiting for (network, wake) has just happened.
+    if (this.wsManager && this.isManagerBusy()) {
+      this.wsManager.retryNow();
       return;
     }
     if (this.isConnecting) {

--- a/web/src/lib/websocket/WebSocketManager.ts
+++ b/web/src/lib/websocket/WebSocketManager.ts
@@ -3,8 +3,10 @@
  *
  * Exposes a small state machine (`ConnectionState`) plus EventEmitter events
  * for `open/close/message/error/reconnecting/stateChange`. Queues outbound
- * messages until connected, retries with exponential-ish backoff, and enforces
- * valid transitions to avoid double-connect/disconnect races.
+ * messages for the whole time a reconnect is pending — including the backoff
+ * window, which is when callers are most likely to send — retries with
+ * exponential backoff and jitter for as long as it takes, and enforces valid
+ * transitions to avoid double-connect/disconnect races.
  *
  * A liveness watchdog covers the failure mode `onclose` cannot: a half-open
  * socket (laptop sleep, NAT/proxy drop, network switch) where the browser still
@@ -30,7 +32,14 @@ export interface WebSocketConfig {
   reconnect?: boolean;
   reconnectInterval?: number;
   reconnectDecay?: number;
+  /**
+   * Cap on consecutive reconnect attempts. Defaults to `Infinity`: a client
+   * that stops retrying stays dark until something else (a tab focus, a network
+   * event) happens to rebuild it, which for a background tab may be never.
+   */
   reconnectAttempts?: number;
+  /** Ceiling on the exponential backoff delay. */
+  maxReconnectInterval?: number;
   timeoutInterval?: number;
   binaryType?: BinaryType;
   /**
@@ -61,6 +70,14 @@ interface WebSocketManagerEvents {
     newState: ConnectionState,
     previousState: ConnectionState
   ) => void;
+}
+
+/**
+ * Heartbeat frames are about the socket that carried them, so replaying one
+ * queued during an outage would only answer a question nobody is still asking.
+ */
+function isLivenessFrame(message: WebSocketMessage): boolean {
+  return message.type === "ping" || message.type === "pong";
 }
 
 interface ConnectionStateTransition {
@@ -108,6 +125,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
   private lastInboundAt = 0;
   private probeSentAt = 0;
   private reconnectAttempt = 0;
+  private reconnectPending = false;
   private intentionalDisconnect = false;
   private messageQueue: WebSocketMessage[] = [];
   private connectionPromise: Promise<void> | null = null;
@@ -122,7 +140,8 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
       reconnect: config.reconnect ?? true,
       reconnectInterval: config.reconnectInterval ?? 1000,
       reconnectDecay: config.reconnectDecay ?? 1.5,
-      reconnectAttempts: config.reconnectAttempts ?? 10,
+      reconnectAttempts: config.reconnectAttempts ?? Infinity,
+      maxReconnectInterval: config.maxReconnectInterval ?? 30000,
       timeoutInterval: config.timeoutInterval ?? 30000,
       binaryType: config.binaryType ?? "arraybuffer",
       heartbeatInterval: config.heartbeatInterval ?? 45000,
@@ -183,6 +202,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
 
   public disconnect(): void {
     this.intentionalDisconnect = true;
+    this.reconnectPending = false;
     this.clearTimers();
     this.messageQueue = [];
 
@@ -199,11 +219,8 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
 
   public send(message: WebSocketMessage): void {
     if (!this.isConnected()) {
-      if (
-        this.config.reconnect &&
-        (this.state === "connecting" || this.state === "reconnecting")
-      ) {
-        console.debug("Queueing message while connecting");
+      if (this.canQueue() && !isLivenessFrame(message)) {
+        console.debug(`Queueing message while ${this.state}`);
         this.messageQueue.push(message);
         // A long outage with a chatty caller would otherwise grow this without
         // bound. The oldest queued messages are the least useful on recovery.
@@ -226,6 +243,25 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
     }
   }
 
+  /**
+   * Whether an outbound message can wait for the socket to come back.
+   *
+   * The backoff window between a drop and the next attempt sits in the
+   * `disconnected` state, and it is exactly when a caller is most likely to
+   * send: the run they just started, the chat message they just typed. Dropping
+   * those on the floor is what makes a blip look like a broken app.
+   */
+  private canQueue(): boolean {
+    if (!this.config.reconnect || this.intentionalDisconnect) {
+      return false;
+    }
+    return (
+      this.state === "connecting" ||
+      this.state === "reconnecting" ||
+      (this.state === "disconnected" && this.reconnectPending)
+    );
+  }
+
   private setupEventHandlers(): void {
     if (!this.ws) {return;}
 
@@ -241,6 +277,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
     console.info("WebSocket connection opened");
     this.clearConnectionTimeout();
     this.reconnectAttempt = 0;
+    this.reconnectPending = false;
 
     if (!this.transitionTo("connected")) {
       return;
@@ -357,12 +394,15 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
       this.connectionPromise = null;
     }
 
-    this.emit("close", event.code, event.reason, event.wasClean);
-
     const shouldReconnect = this.shouldReconnect(event);
     console.info(
       `Should reconnect: ${shouldReconnect}, attempts: ${this.reconnectAttempt}/${this.config.reconnectAttempts}`
     );
+
+    // Decided before the event fires: a listener that sends from its `close`
+    // handler must see the same queueing window as one that sends a tick later.
+    this.reconnectPending = shouldReconnect;
+    this.emit("close", event.code, event.reason, event.wasClean);
 
     if (shouldReconnect) {
       this.scheduleReconnect();
@@ -380,12 +420,14 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
     // 4. Specific error codes that shouldn't trigger reconnection
     const noReconnectCodes = [
       // Note: 1001 (Going away) is intentionally NOT blocked to allow reconnect
-      // when servers restart or proxies roll connections. We still avoid
-      // reconnecting on policy/auth/server errors.
+      // when servers restart or proxies roll connections. Nor is 1011 (Internal
+      // server error): a server that fell over is the case reconnect exists
+      // for, and backoff keeps a genuinely broken one from being hammered.
+      // What stays terminal is what retrying cannot fix — a rejected client, a
+      // frame this client would only send again, a missing extension.
       1008, // Policy violation
       1009, // Message too big
       1010, // Mandatory extension
-      1011, // Internal server error
       4000, // Custom: Authentication required
       4001, // Custom: Unauthorized
       4003 // Custom: Forbidden
@@ -472,7 +514,7 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
     const delay = Math.min(
       this.config.reconnectInterval *
         Math.pow(this.config.reconnectDecay, this.reconnectAttempt),
-      30000 // Max 30 seconds
+      this.config.maxReconnectInterval
     );
     // Half-to-full jitter. Without it every client that dropped on a server
     // restart comes back in lockstep and hammers the server as it boots.
@@ -493,6 +535,28 @@ export class WebSocketManager extends EventEmitter<WebSocketManagerEvents> {
       return;
     }
     this.probeLiveness();
+  }
+
+  /**
+   * Collapse a pending backoff wait and retry immediately.
+   *
+   * Backoff assumes nothing has changed since the last failure. When the
+   * environment says otherwise — the network came back, the tab woke up — the
+   * remaining wait is dead time, and at the 30s ceiling that is 30s of a UI
+   * that looks broken for no reason.
+   */
+  public retryNow(): void {
+    if (!this.reconnectTimer) {
+      return;
+    }
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    // Restart the backoff ladder — the failures it was counting are stale.
+    this.reconnectAttempt = 1;
+    if (this.intentionalDisconnect) {
+      return;
+    }
+    void this.reconnect();
   }
 
   private startLivenessWatchdog(): void {

--- a/web/src/lib/websocket/__tests__/WebSocketManager.resilience.test.ts
+++ b/web/src/lib/websocket/__tests__/WebSocketManager.resilience.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Outage behaviour: what the manager does between a drop and the socket coming
+ * back — how long it keeps trying, what happens to messages sent meanwhile, and
+ * how it responds when the environment says the wait is over.
+ */
+import { WebSocketManager } from "../WebSocketManager";
+import type { WebSocketConfig } from "../WebSocketManager";
+
+jest.mock("msgpackr", () => ({
+  pack: jest.fn((msg: unknown) => msg),
+  unpack: jest.fn((buf: unknown) => buf)
+}));
+
+interface FakeCloseEvent {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readyState = 0;
+  binaryType = "arraybuffer";
+  sent: unknown[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: FakeCloseEvent) => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(message: unknown): void {
+    this.sent.push(message);
+  }
+
+  close(code = 1000, reason = ""): void {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason, wasClean: code === 1000 });
+  }
+
+  triggerOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Drop the transport the way a network failure does. */
+  drop(): void {
+    this.close(1006, "Abnormal closure");
+  }
+}
+
+const latestSocket = (): FakeWebSocket =>
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const createManager = (
+  overrides: Partial<WebSocketConfig> = {}
+): WebSocketManager =>
+  new WebSocketManager({
+    url: "ws://localhost:7777/ws",
+    reconnect: true,
+    reconnectInterval: 100,
+    heartbeatInterval: 0,
+    ...overrides
+  });
+
+const connect = async (mgr: WebSocketManager): Promise<void> => {
+  const pending = mgr.connect();
+  latestSocket().triggerOpen();
+  await pending;
+};
+
+describe("WebSocketManager outage resilience", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    jest.useFakeTimers();
+    jest.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("keeps retrying past the old ten-attempt cap", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    for (let attempt = 0; attempt < 15; attempt++) {
+      latestSocket().drop();
+      // Backoff is capped at 30s; one full ceiling covers every attempt.
+      jest.advanceTimersByTime(31_000);
+    }
+
+    expect(mgr.getState()).toBe("reconnecting");
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(15);
+
+    mgr.destroy();
+  });
+
+  it("caps the backoff at maxReconnectInterval", async () => {
+    const mgr = createManager({ maxReconnectInterval: 5000 });
+    await connect(mgr);
+
+    for (let attempt = 0; attempt < 12; attempt++) {
+      latestSocket().drop();
+      jest.advanceTimersByTime(5000);
+    }
+
+    expect(FakeWebSocket.instances.length).toBe(13);
+
+    mgr.destroy();
+  });
+
+  it("still gives up when reconnect is disabled", async () => {
+    const mgr = createManager({ reconnect: false });
+    await connect(mgr);
+
+    latestSocket().drop();
+    jest.advanceTimersByTime(60_000);
+
+    expect(mgr.getState()).toBe("failed");
+
+    mgr.destroy();
+  });
+
+  it("reconnects after the server reports an internal error", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    latestSocket().close(1011, "Internal server error");
+    jest.advanceTimersByTime(200);
+
+    expect(mgr.getState()).toBe("reconnecting");
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    mgr.destroy();
+  });
+
+  it("does not reconnect after a policy close", async () => {
+    const mgr = createManager();
+    await connect(mgr);
+
+    latestSocket().close(1008, "Message rate limit exceeded");
+    jest.advanceTimersByTime(60_000);
+
+    expect(mgr.getState()).toBe("failed");
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    mgr.destroy();
+  });
+
+  describe("sending during the backoff window", () => {
+    it("queues and flushes on reconnect instead of throwing", async () => {
+      const mgr = createManager();
+      await connect(mgr);
+
+      latestSocket().drop();
+      expect(mgr.getState()).toBe("disconnected");
+
+      expect(() => mgr.send({ type: "run_job" })).not.toThrow();
+
+      jest.advanceTimersByTime(200);
+      latestSocket().triggerOpen();
+
+      expect(latestSocket().sent).toContainEqual({ type: "run_job" });
+
+      mgr.destroy();
+    });
+
+    it("drops heartbeat frames rather than replaying them", async () => {
+      const mgr = createManager();
+      await connect(mgr);
+
+      latestSocket().drop();
+
+      expect(() => mgr.send({ type: "ping", ts: 1 })).toThrow(
+        "Cannot send message in state: disconnected"
+      );
+
+      jest.advanceTimersByTime(200);
+      latestSocket().triggerOpen();
+
+      expect(latestSocket().sent).toHaveLength(0);
+
+      mgr.destroy();
+    });
+
+    it("throws once the manager has given up for good", async () => {
+      const mgr = createManager({ reconnect: false });
+      await connect(mgr);
+
+      latestSocket().drop();
+
+      expect(() => mgr.send({ type: "run_job" })).toThrow(
+        "Cannot send message in state: failed"
+      );
+
+      mgr.destroy();
+    });
+
+    it("drops the queue on an intentional disconnect", async () => {
+      const mgr = createManager();
+      await connect(mgr);
+
+      latestSocket().drop();
+      mgr.send({ type: "run_job" });
+      mgr.disconnect();
+
+      expect(() => mgr.send({ type: "run_job" })).toThrow();
+
+      mgr.destroy();
+    });
+  });
+
+  describe("retryNow", () => {
+    it("connects immediately instead of waiting out the backoff", async () => {
+      const mgr = createManager({ reconnectInterval: 30_000 });
+      await connect(mgr);
+
+      latestSocket().drop();
+      expect(FakeWebSocket.instances).toHaveLength(1);
+
+      mgr.retryNow();
+
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      expect(mgr.getState()).toBe("reconnecting");
+
+      mgr.destroy();
+    });
+
+    it("is a no-op when no reconnect is pending", async () => {
+      const mgr = createManager();
+      await connect(mgr);
+
+      mgr.retryNow();
+
+      expect(FakeWebSocket.instances).toHaveLength(1);
+      expect(mgr.getState()).toBe("connected");
+
+      mgr.destroy();
+    });
+
+    it("restarts the backoff ladder from the bottom", async () => {
+      const mgr = createManager({ reconnectInterval: 1000, maxReconnectInterval: 30_000 });
+      await connect(mgr);
+
+      // Climb the ladder until the delay is pinned at the ceiling.
+      for (let attempt = 0; attempt < 10; attempt++) {
+        latestSocket().drop();
+        jest.advanceTimersByTime(31_000);
+      }
+      const beforeRetry = FakeWebSocket.instances.length;
+
+      latestSocket().drop();
+      mgr.retryNow();
+      latestSocket().drop();
+
+      // Back at the bottom of the ladder: the next attempt lands in ~1.5s,
+      // not the 30s the pre-retry counter would have asked for.
+      jest.advanceTimersByTime(2000);
+      expect(FakeWebSocket.instances.length).toBe(beforeRetry + 2);
+
+      mgr.destroy();
+    });
+  });
+});

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -664,7 +664,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
             "reconnecting",
             (attempt: number, maxAttempts: number) => {
               set({
-                statusMessage: `Reconnecting... (attempt ${attempt}/${maxAttempts})`
+                statusMessage: Number.isFinite(maxAttempts)
+                  ? `Reconnecting... (attempt ${attempt}/${maxAttempts})`
+                  : `Reconnecting... (attempt ${attempt})`
               });
             }
           )


### PR DESCRIPTION
Reliability work on the `/ws` protocol, on both ends. Nothing here changes the message format — it's all about what happens when a connection misbehaves.

## Server — `WsAdapter`

Three per-connection limits, none of which existed before:

- **Half-open peer detection.** The runner sent an app-level `ping` every 25s but never checked that anyone answered. A client that vanished without a close frame — laptop sleep, NAT rebind, killed browser — kept its socket "open" forever, and with it the runner, its observers, its timers and its running jobs. The adapter now pings on a timer and `terminate()`s the socket once the peer has been silent past an idle deadline. Any traffic counts as proof of life: data frames, protocol pongs, client-initiated pings.
- **Outbound backpressure.** `sendBytes`/`sendText` called `socket.send()` and returned. A client reading slower than the server streams buffered in memory with no ceiling, so one stalled reader could grow the heap until the process died. Sends now wait for the buffer to drain (which propagates backpressure up through the runner's send lock to the producers), and a peer that never drains is dropped with code `1001` so it reconnects rather than treating the close as terminal.
- **Inbound queue cap.** Frames queued without limit when nothing was calling `receive()`. Past a generous depth the connection is closed with `1008`.

All three are tunable via `NODETOOL_WS_*` env vars — see the new rows in `docs/configuration.md`.

## Client — `WebSocketManager`

- **Reconnect indefinitely.** The ten-attempt cap gave up after roughly 80 seconds and parked the manager in `failed`, where it stayed until a tab focus or `online` event happened to rebuild it — for a background tab, possibly never. Backoff still climbs to a 30s ceiling with jitter, now via a configurable `maxReconnectInterval`.
- **Queue across the whole backoff window.** Sends were only queued while a socket was being established; the gap between a drop and the next attempt sits in `disconnected`, where `send()` threw. That gap is exactly when a caller sends the run they just started or the message they just typed. Heartbeat frames are excluded — replaying a stale `ping` answers a question nobody is still asking.
- **`retryNow()`**, called from the `online` and `visibilitychange` handlers. Backoff assumes nothing has changed since the last failure; when the network comes back or the tab wakes, the remaining wait is dead time, and at the ceiling that's 30 seconds of a UI that looks broken for no reason.
- **Reconnect on close code `1011`.** A server that fell over is the case reconnect exists for. `1008`/`1009`/`1010` and the auth codes stay terminal — retrying can't fix a rejected client or a missing extension.

## Tests

- `packages/websocket/tests/ws-connection-health.test.ts` — 14 tests: ping cadence, termination on idle, each proof-of-life signal, drain-then-send, the slow-peer drop and its close code, the write that races the peer going away, the inbound cap.
- `web/src/lib/websocket/__tests__/WebSocketManager.resilience.test.ts` — 12 tests: retrying past the old cap, the backoff ceiling, queueing and flushing during backoff, heartbeat frames not being replayed, the terminal cases still being terminal, and `retryNow` short-circuiting the wait and restarting the ladder.

## Verification

- `packages/websocket` vitest: 160 files, 1963 tests pass
- `web` jest: 1044 suites, 12353 tests pass
- `npm run lint` passes; `npm run typecheck` passes for web and electron (mobile can't typecheck in this container — its `node_modules` aren't installed, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQ1MmcD1gAzNcrQqQ95nb6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ1MmcD1gAzNcrQqQ95nb6)_