### PR TITLE
fix(web): put the mobile app menu and panel toggle in the top row

### DIFF
--- a/web/src/components/panels/MobileRailLauncher.tsx
+++ b/web/src/components/panels/MobileRailLauncher.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import React, { useCallback } from "react";
+import MenuIcon from "@mui/icons-material/Menu";
+
+import { usePanelStore } from "../../stores/PanelStore";
+import {
+  ToolbarIconButton,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import RailAppMenu from "./RailAppMenu";
+
+const styles = (theme: Theme) =>
+  css({
+    WebkitAppRegion: "no-drag",
+    display: "flex",
+    alignItems: "center",
+    flexShrink: 0,
+    gap: getSpacingPx(SPACING.micro),
+    padding: `0 ${getSpacingPx(SPACING.xs)}`,
+    borderRight: `1px solid ${theme.vars.palette.divider}`,
+
+    "& .rail-app-logo": {
+      width: "40px",
+      height: "40px",
+      margin: 0,
+      opacity: 1
+    },
+    "& .panel-left-mobile-launcher": {
+      width: "40px",
+      height: "40px",
+      padding: 0,
+      borderRadius: BORDER_RADIUS.lg,
+      color: theme.vars.palette.text.secondary,
+      "&:hover": {
+        backgroundColor: theme.vars.palette.action.hover
+      },
+      "&.active": {
+        backgroundColor: theme.vars.palette.action.selected,
+        color: theme.vars.palette.text.primary
+      },
+      "& svg": {
+        fontSize: "var(--fontSizeBig)"
+      }
+    }
+  });
+
+export interface MobileRailLauncherProps {
+  /** Renders the logo/app menu alongside the panel toggle. */
+  showAppMenu?: boolean;
+}
+
+/**
+ * The app menu (logo) and left-panel toggle as the leading cell of the mobile
+ * top row. On desktop these live in the vertical rail, which mobile doesn't
+ * render — the top row carries them instead so they share the app chrome rather
+ * than floating over the content.
+ */
+const MobileRailLauncher: React.FC<MobileRailLauncherProps> = ({
+  showAppMenu = false
+}) => {
+  const theme = useTheme();
+  const isVisible = usePanelStore((state) => state.panel.isVisible);
+  const setVisibility = usePanelStore((state) => state.setVisibility);
+
+  const close = useCallback(() => setVisibility(false), [setVisibility]);
+  const toggle = useCallback(
+    () => setVisibility(!isVisible),
+    [setVisibility, isVisible]
+  );
+
+  return (
+    <div css={styles(theme)} className="mobile-rail-launcher">
+      {showAppMenu && <RailAppMenu onAction={close} />}
+      <ToolbarIconButton
+        className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
+        onClick={toggle}
+        ariaLabel={isVisible ? "Close panel" : "Open left panel"}
+        aria-expanded={isVisible}
+        tabIndex={-1}
+        icon={<MenuIcon />}
+      />
+    </div>
+  );
+};
+
+MobileRailLauncher.displayName = "MobileRailLauncher";
+
+export default MobileRailLauncher;

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -563,8 +563,9 @@ const mobileLauncherChrome = (theme: Theme) => ({
   }
 });
 
-// The floating cluster in the top-left corner: the app menu (logo) and the
-// panel toggle, so the app menu is reachable without opening the sheet first.
+// The floating panel toggle in the top-left corner, used on the mobile routes
+// that have no top row of their own. In the workspace shell the toggle sits in
+// the tab bar instead (MobileRailLauncher).
 const mobileLauncherBarStyles = (theme: Theme, hasHeader: boolean) =>
   css({
     position: "fixed",
@@ -573,14 +574,7 @@ const mobileLauncherBarStyles = (theme: Theme, hasHeader: boolean) =>
     zIndex: theme.zIndex.appBar,
     display: "flex",
     alignItems: "center",
-    gap: getSpacingPx(SPACING.xs),
-    "& .rail-app-logo": {
-      ...mobileLauncherChrome(theme),
-      width: "auto",
-      height: "auto",
-      margin: 0,
-      opacity: 1
-    }
+    gap: getSpacingPx(SPACING.xs)
   });
 
 const mobileLauncherStyles = (theme: Theme) =>
@@ -629,7 +623,11 @@ const MobilePanelLeft: React.FC<{
   onClose: () => void;
   onViewChange: (view: LeftPanelView) => void;
   handlePanelToggle: (view: LeftPanelView) => void;
-  showAppMenu?: boolean;
+  /**
+   * In the workspace shell the top row carries the launcher buttons
+   * (MobileRailLauncher), so this variant renders only the sheet.
+   */
+  hideLauncher?: boolean;
 }> = ({
   activeView,
   activeNodeCategory,
@@ -640,7 +638,7 @@ const MobilePanelLeft: React.FC<{
   onClose,
   onViewChange,
   handlePanelToggle,
-  showAppMenu = false
+  hideLauncher = false
 }) => {
   const theme = useTheme();
 
@@ -656,21 +654,19 @@ const MobilePanelLeft: React.FC<{
 
   return (
     <>
-      <div css={mobileLauncherBarStyles(theme, hasHeader)}>
-        {/* Settings, Help, Models, Downloads, … — on mobile the vertical
-          toolbar that carries the app menu on desktop isn't rendered, so the
-          logo sits in the floating launcher instead. */}
-        {showAppMenu && <RailAppMenu onAction={onClose} />}
-        <ToolbarIconButton
-          className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
-          css={mobileLauncherStyles(theme)}
-          onClick={isVisible ? onClose : onOpen}
-          ariaLabel={isVisible ? "Close panel" : "Open left panel"}
-          aria-expanded={isVisible}
-          tabIndex={-1}
-          icon={<MenuIcon />}
-        />
-      </div>
+      {!hideLauncher && (
+        <div css={mobileLauncherBarStyles(theme, hasHeader)}>
+          <ToolbarIconButton
+            className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
+            css={mobileLauncherStyles(theme)}
+            onClick={isVisible ? onClose : onOpen}
+            ariaLabel={isVisible ? "Close panel" : "Open left panel"}
+            aria-expanded={isVisible}
+            tabIndex={-1}
+            icon={<MenuIcon />}
+          />
+        </div>
+      )}
 
       <MobileBottomSheet
         open={isVisible}
@@ -877,7 +873,7 @@ const PanelLeft: React.FC = () => {
         onClose={handleMobileClose}
         onViewChange={onViewChange}
         handlePanelToggle={handlePanelToggle}
-        showAppMenu={isWorkspace}
+        hideLauncher={isWorkspace}
       />
     );
   }

--- a/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
+++ b/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * MobileRailLauncher tests
+ *
+ * On mobile the vertical rail isn't rendered, so the app menu (logo) and the
+ * left-panel toggle ride in the workspace top row. These tests assert both
+ * buttons are present and that the toggle flips the shared panel visibility.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import MobileRailLauncher from "../MobileRailLauncher";
+import mockTheme from "../../../__mocks__/themeMock";
+import { usePanelStore } from "../../../stores/PanelStore";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => jest.fn()
+}));
+
+jest.mock("../../content/Help/Help", () => () => null);
+jest.mock("../../Logo", () => () => <span data-testid="logo" />);
+
+jest.mock("../../../stores/KeyPressedStore", () => ({
+  useCombo: jest.fn()
+}));
+
+jest.mock("../../../stores/AppHeaderStore", () => ({
+  useAppHeaderStore: () => ({
+    helpOpen: false,
+    handleCloseHelp: jest.fn(),
+    handleOpenHelp: jest.fn(),
+    setHelpIndex: jest.fn()
+  })
+}));
+
+jest.mock("../../../stores/ModelDownloadStore", () => ({
+  useModelDownloadStore: () => ({ downloads: {}, openDialog: jest.fn() })
+}));
+
+const renderLauncher = (showAppMenu = true) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MobileRailLauncher showAppMenu={showAppMenu} />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  usePanelStore.getState().setVisibility(false);
+});
+
+it("renders the app menu next to the panel toggle", () => {
+  renderLauncher();
+
+  expect(screen.getByLabelText("Open app menu")).toBeInTheDocument();
+  expect(screen.getByLabelText("Open left panel")).toBeInTheDocument();
+});
+
+it("omits the app menu when showAppMenu is false", () => {
+  renderLauncher(false);
+
+  expect(screen.queryByLabelText("Open app menu")).not.toBeInTheDocument();
+  expect(screen.getByLabelText("Open left panel")).toBeInTheDocument();
+});
+
+it("toggles panel visibility", async () => {
+  const user = userEvent.setup();
+  renderLauncher();
+
+  await user.click(screen.getByLabelText("Open left panel"));
+  expect(usePanelStore.getState().panel.isVisible).toBe(true);
+
+  await user.click(screen.getByLabelText("Close panel"));
+  expect(usePanelStore.getState().panel.isVisible).toBe(false);
+});

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -27,6 +27,7 @@ import NotificationButton from "../panels/NotificationButton";
 import OpenMenu from "./OpenMenu";
 import WorkspaceTabItem from "./WorkspaceTabItem";
 import MobileDocumentSelector from "./MobileDocumentSelector";
+import MobileRailLauncher from "../panels/MobileRailLauncher";
 
 /** Whether a document type supports both View and Edit (vs view-only). */
 const SUPPORTS_BOTH_MODES: Record<WorkspaceTabType, boolean> = {
@@ -507,6 +508,9 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
 
   return (
     <div css={tabBarStyles} className="workspace-tabbar">
+      {/* Mobile has no vertical rail, so the app menu and panel toggle ride
+        along in the top row instead of floating over the content. */}
+      {isMobile && <MobileRailLauncher showAppMenu />}
       <button
         ref={newTabButtonRef}
         type="button"


### PR DESCRIPTION
On mobile web the logo (app menu) and the left-panel toggle floated over the content in a fixed cluster below the tab bar. They now sit as the leading cell of the workspace top row, next to **New** and the document selector, so they share the app chrome instead of covering the canvas.

## Changes

- New `web/src/components/panels/MobileRailLauncher.tsx` — the app menu (`RailAppMenu`) plus the panel toggle, sized for the 48px mobile top row, reading/writing panel visibility from `PanelStore` directly.
- `WorkspaceTabBar` renders it before the New button when `isMobile`.
- `MobilePanelLeft` drops its floating cluster inside the workspace shell (`hideLauncher`), and keeps just the panel toggle for the mobile routes that have no top row of their own (standalone chat, legacy routes). Its `showAppMenu` prop is gone — the logo now has one home per layout.

## Verification

- `npx tsc --noEmit` — no errors in the touched files (remaining errors are the pre-existing unbuilt `@nodetool-ai/*-nodes` resolution failures).
- `npx eslint` on the changed files — clean.
- `npx jest src/components/panels src/components/workspace` — 9 suites / 97 tests + 8 suites / 34 tests pass, including a new `MobileRailLauncher.test.tsx` covering both buttons rendering, the `showAppMenu={false}` case, and the visibility toggle.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FFRVTzvHTfUTw5NLxnpNr)_