### PR TITLE
fix(appbuilder): reach the agent on a narrow viewport

### DIFF
--- a/web/src/components/appbuilder/AppBuilderShell.tsx
+++ b/web/src/components/appbuilder/AppBuilderShell.tsx
@@ -1,8 +1,19 @@
 import React, { useCallback, useEffect, useState } from "react";
 import type { Data } from "@puckeditor/core";
 import { type AppDocMeta } from "@nodetool-ai/app-runtime";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import CloseIcon from "@mui/icons-material/Close";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
-import { Box, FlexColumn, FlexRow, BORDER_RADIUS } from "../ui_primitives";
+import {
+  Box,
+  CircularActionButton,
+  FlexColumn,
+  FlexRow,
+  BORDER_RADIUS,
+  SPACING,
+  Z_INDEX
+} from "../ui_primitives";
 import { Workflow } from "../../stores/ApiTypes";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import FrontendToolRuntimeSync from "../panels/FrontendToolRuntimeSync";
@@ -34,6 +45,15 @@ export interface AppBuilderShellProps {
   onClose?: () => void;
 }
 
+/**
+ * Puck folds its header actions — the "Ask Agent" and "App Data" toggles among
+ * them — into a chevron menu below 638px, so on a phone the only way to reach
+ * the agent is to find that menu. Below that width the shell surfaces the agent
+ * behind a floating button of its own, and the panel covers the whole surface:
+ * docking a 360px panel beside the canvas leaves too little of either.
+ */
+const NARROW_QUERY = "(max-width: 637.98px)";
+
 /** Shared framing for the panels that dock beside the canvas. */
 const sidePanelSx = {
   width: { xs: "min(100vw, 360px)", lg: 420 },
@@ -43,6 +63,18 @@ const sidePanelSx = {
   borderColor: "divider",
   overflow: "hidden",
   borderTopLeftRadius: BORDER_RADIUS.lg
+} as const;
+
+/** The same panel, covering the canvas instead of docking beside it. */
+const overlayPanelSx = {
+  ...sidePanelSx,
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  borderLeft: "none",
+  borderTopLeftRadius: 0,
+  backgroundColor: "background.default",
+  zIndex: Z_INDEX.overlay
 } as const;
 
 /**
@@ -86,6 +118,8 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
   }));
   const [agentOpen, setAgentOpen] = useState(false);
   const toggleAgent = useCallback(() => setAgentOpen((open) => !open), []);
+  const narrow = useMediaQuery(NARROW_QUERY);
+  const panelSx = narrow ? overlayPanelSx : sidePanelSx;
   const [dataOpen, setDataOpen] = useState(false);
   const toggleData = useCallback(() => setDataOpen((open) => !open), []);
 
@@ -120,7 +154,10 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
   );
 
   return (
-    <FlexRow gap={0} sx={{ width: "100%", height: "100%", minHeight: 0 }}>
+    <FlexRow
+      gap={0}
+      sx={{ width: "100%", height: "100%", minHeight: 0, position: "relative" }}
+    >
       {/* Syncs workflow tools to this workflow so the agent can edit the graph. */}
       <FrontendToolRuntimeSync />
       <FlexColumn sx={{ flex: 1, minWidth: 0, height: "100%", minHeight: 0 }}>
@@ -143,7 +180,7 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
         </Box>
       </FlexColumn>
       {dataOpen && (
-        <Box sx={sidePanelSx}>
+        <Box sx={panelSx}>
           <AppDataPanel
             meta={meta}
             onChange={setMeta}
@@ -153,12 +190,26 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
         </Box>
       )}
       {agentOpen && agentWorkflowId && (
-        <Box sx={sidePanelSx}>
+        <Box sx={panelSx}>
           <AppBuilderAgentPanel
             applicationId={applicationId}
             workflowId={agentWorkflowId}
           />
         </Box>
+      )}
+      {narrow && agentWorkflowId && (
+        <CircularActionButton
+          icon={agentOpen ? <CloseIcon /> : <AutoAwesomeIcon />}
+          onClick={toggleAgent}
+          ariaLabel={agentOpen ? "Close agent" : "Ask Agent"}
+          tooltip={agentOpen ? "Close agent" : "Ask Agent"}
+          tooltipPlacement="top"
+          size={48}
+          position="absolute"
+          bottom={SPACING.xl}
+          right={SPACING.xl}
+          zIndex={Z_INDEX.overlay + 1}
+        />
       )}
     </FlexRow>
   );

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -111,7 +111,10 @@ the existing worker path.
   documents.
 - `AppBuilderShell.tsx` — the editing surface, independent of storage: it seeds
   Puck from a document, holds the operations/resources/variables beside it, and
-  emits the **whole** document on save.
+  emits the **whole** document on save. Below 638px — where Puck folds its
+  header actions, the **Ask Agent** toggle included, into a chevron menu — the
+  shell renders its own floating agent toggle and the panels cover the canvas
+  instead of docking beside it.
 - `ApplicationAppBuilder.tsx` — the container over an `applications` record:
   loads with `applications.get`, saves with `applications.update` carrying
   `baseUpdatedAt`. A lost compare-and-swap raises an alert and a banner with a

--- a/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
 import type { Data } from "@puckeditor/core";
 import type { AppDocMeta } from "@nodetool-ai/app-runtime";
 
+import mockTheme from "../../../__mocks__/themeMock";
 import type { Workflow } from "../../../stores/ApiTypes";
 import type { AppDocument } from "../appData";
 
@@ -137,18 +139,47 @@ const document: AppDocument = {
 
 const renderShell = (onSave = jest.fn()) => {
   render(
-    <AppBuilderShell
-      applicationId="app-1"
-      document={document}
-      workflow={workflow}
-      agentWorkflowId="wf-1"
-      onSave={onSave}
-    />
+    <ThemeProvider theme={mockTheme}>
+      <AppBuilderShell
+        applicationId="app-1"
+        document={document}
+        workflow={workflow}
+        agentWorkflowId="wf-1"
+        onSave={onSave}
+      />
+    </ThemeProvider>
   );
   return onSave;
 };
 
-beforeEach(() => jest.clearAllMocks());
+/** The toggle Puck draws in its header — hidden behind a menu on narrow screens. */
+const headerAgentToggle = () =>
+  screen.getAllByRole("button", { name: "Ask Agent" })[0];
+
+const originalMatchMedia = window.matchMedia;
+
+/** Reports every query as matching (or not), standing in for the viewport width. */
+const setNarrowViewport = (narrow: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: narrow,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setNarrowViewport(false);
+});
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
 
 describe("AppBuilderShell", () => {
   it("saves the whole document, not just the layout", async () => {
@@ -189,19 +220,45 @@ describe("AppBuilderShell", () => {
     const user = userEvent.setup();
     renderShell();
 
-    await user.click(screen.getByRole("button", { name: "Ask Agent" }));
+    await user.click(headerAgentToggle());
 
     expect(screen.getByTestId("agent-panel")).toHaveTextContent("wf-1");
   });
 
+  it("opens the agent from its own toggle on a narrow viewport", async () => {
+    // Puck folds its header actions into a chevron menu below 638px, so the
+    // shell renders a floating toggle that stays reachable there.
+    setNarrowViewport(true);
+    const user = userEvent.setup();
+    renderShell();
+
+    const toggles = screen.getAllByRole("button", { name: "Ask Agent" });
+    expect(toggles).toHaveLength(2);
+
+    await user.click(toggles[1]);
+
+    expect(screen.getByTestId("agent-panel")).toHaveTextContent("wf-1");
+    expect(
+      screen.getByRole("button", { name: "Close agent" })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the floating toggle off wide viewports, where Puck shows its own", () => {
+    renderShell();
+
+    expect(screen.getAllByRole("button", { name: "Ask Agent" })).toHaveLength(1);
+  });
+
   it("hides the agent when no workflow is bound", () => {
     render(
-      <AppBuilderShell
-        applicationId="app-1"
-        document={document}
-        workflow={workflow}
-        onSave={jest.fn()}
-      />
+      <ThemeProvider theme={mockTheme}>
+        <AppBuilderShell
+          applicationId="app-1"
+          document={document}
+          workflow={workflow}
+          onSave={jest.fn()}
+        />
+      </ThemeProvider>
     );
 
     expect(


### PR DESCRIPTION
## Problem

The **Ask Agent** button is missing from the app builder on mobile web.

The toggle lives in Puck's `headerActions` override (`PuckAppEditor.tsx`). Puck folds those actions into a `MenuBar` that is `display: none` below 638px, revealed only by a chevron button in the header — so on a phone the agent is unreachable unless you happen to find that menu.

A second problem sits behind it: even once opened, `AppBuilderShell` docks the agent as a `flexShrink: 0`, 360px-wide side panel next to the canvas. On a 390px phone that leaves ~30px of canvas and a squeezed panel.

## Change

`AppBuilderShell` now watches `(max-width: 637.98px)` — the width at which Puck collapses its header:

- Below it, the shell renders its own floating agent toggle (bottom-right, `CircularActionButton`), which switches to a close icon while the panel is open. Above it, the button is not mounted; Puck's header toggle is visible there and is the only one.
- Below it, the agent and App Data panels cover the canvas (`position: absolute; inset: 0`) instead of docking beside it.

The toggle is still gated on `agentWorkflowId`, so an app with no workflow bound shows no agent — unchanged.

## Tests

`AppBuilderShell.test.tsx` now wraps in a `ThemeProvider` and stubs `window.matchMedia` to stand in for viewport width, with two new cases: the floating toggle opens the agent on a narrow viewport, and it is absent on a wide one. Existing cases unchanged in intent.

```
web: jest src/components/appbuilder + ApplicationSurface — 35 suites, 351 tests pass
web: eslint (changed files) — clean
web: tsc --noEmit — no errors in appbuilder
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019fG93vz99k9iYHvf65pCfp)_